### PR TITLE
fix: make saml login root a var so we can set it for each app context

### DIFF
--- a/cmd/api/src/auth/bhsaml/provider.go
+++ b/cmd/api/src/auth/bhsaml/provider.go
@@ -1,17 +1,17 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 package bhsaml
@@ -24,22 +24,24 @@ import (
 	"net/url"
 	"path"
 
+	"github.com/crewjam/saml"
+	"github.com/crewjam/saml/samlsp"
+	dsig "github.com/russellhaering/goxmldsig"
+	"github.com/specterops/bloodhound/crypto"
+	"github.com/specterops/bloodhound/log"
 	"github.com/specterops/bloodhound/src/api"
 	"github.com/specterops/bloodhound/src/api/stream"
 	"github.com/specterops/bloodhound/src/config"
 	bhCtx "github.com/specterops/bloodhound/src/ctx"
 	"github.com/specterops/bloodhound/src/database"
 	"github.com/specterops/bloodhound/src/model"
-	"github.com/crewjam/saml"
-	"github.com/crewjam/saml/samlsp"
-	dsig "github.com/russellhaering/goxmldsig"
-	"github.com/specterops/bloodhound/crypto"
-	"github.com/specterops/bloodhound/log"
+)
+
+var (
+	SAMLAPILoginRoot = "api/v2/login/saml"
 )
 
 const (
-	SAMLAPILoginRoot = "api/v2/login/saml"
-
 	SSODescriptorUseSigning    string = "signing"
 	SSODescriptorUseEncryption string = "encryption"
 )


### PR DESCRIPTION
## Description

This updates the SAML API root constant to be mutable. Until we have a better way of negotiating the different URL paths for SAML from the old enterprise V1 API this is best-effort.

## Motivation and Context

Unblock old SAML registrations in the enterprise build.

## How Has This Been Tested?

Local testing with Auth0.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] My changes include a database migration.
