### PR TITLE
Fix: Healthcheck neo4j don't keep output file of wget

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,7 +88,7 @@ services:
       - traefik.http.routers.neo4jbrowser.service=neo4jbrowser
       - traefik.http.services.neo4jbrowser.loadbalancer.server.port=7474
     healthcheck:
-      test: [ "CMD-SHELL", "wget http://localhost:7474 || exit 1" ]
+      test: [ "CMD-SHELL", "wget -O /dev/null -o /dev/null http://localhost:7474 || exit 1" ]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,7 +88,7 @@ services:
       - traefik.http.routers.neo4jbrowser.service=neo4jbrowser
       - traefik.http.services.neo4jbrowser.loadbalancer.server.port=7474
     healthcheck:
-      test: [ "CMD-SHELL", "wget -O /dev/null -o /dev/null http://localhost:7474 || exit 1" ]
+      test: [ "CMD-SHELL", "wget -O /dev/null -q http://localhost:7474 || exit 1" ]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/examples/docker-compose/docker-compose.yml
+++ b/examples/docker-compose/docker-compose.yml
@@ -52,7 +52,7 @@ services:
       test:
         [
           "CMD-SHELL",
-          "wget -O /dev/null -o /dev/null http://localhost:${NEO4J_WEB_PORT:-7474} || exit 1"
+          "wget -O /dev/null -q http://localhost:${NEO4J_WEB_PORT:-7474} || exit 1"
         ]
       interval: 10s
       timeout: 5s

--- a/examples/docker-compose/docker-compose.yml
+++ b/examples/docker-compose/docker-compose.yml
@@ -52,7 +52,7 @@ services:
       test:
         [
           "CMD-SHELL",
-          "wget http://localhost:${NEO4J_WEB_PORT:-7474} || exit 1"
+          "wget -O /dev/null -o /dev/null http://localhost:${NEO4J_WEB_PORT:-7474} || exit 1"
         ]
       interval: 10s
       timeout: 5s


### PR DESCRIPTION
## Description

## Motivation and Context

Docker healthcheck creates a new file in the neo4j docker every 10 seconds. To avoid filling the `/var/lib/neo4j` folder with thousands of files, the commit redirects the output of `wget` to `/dev/null`.

## How Has This Been Tested?

The docker containers was removed to trigger `docker compose up` and check if the docker is in the `healthy` status

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] My changes include a database migration.
