### PR TITLE
fix: remove aggressive timeout context setting middleware

### DIFF
--- a/cmd/api/src/api/marshalling.go
+++ b/cmd/api/src/api/marshalling.go
@@ -1,17 +1,17 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 package api
@@ -25,13 +25,13 @@ import (
 	"strings"
 	"time"
 
-	"github.com/specterops/bloodhound/src/api/stream"
-	"github.com/specterops/bloodhound/src/model"
-	"github.com/specterops/bloodhound/src/utils"
 	"github.com/specterops/bloodhound/errors"
 	"github.com/specterops/bloodhound/headers"
 	"github.com/specterops/bloodhound/log"
 	"github.com/specterops/bloodhound/mediatypes"
+	"github.com/specterops/bloodhound/src/api/stream"
+	"github.com/specterops/bloodhound/src/model"
+	"github.com/specterops/bloodhound/src/utils"
 )
 
 const (
@@ -73,11 +73,6 @@ type ResponseWrapper struct {
 }
 
 func WriteErrorResponse(ctx context.Context, untypedError any, response http.ResponseWriter) {
-	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
-		log.Warnf("Writing API Error. Context Deadline Exceeded while writing error response.")
-		return
-	}
-
 	switch typedError := untypedError.(type) {
 	case *ErrorResponse: // V1 error handling
 		log.Warnf("Writing API Error. Status: %v. Message: %v", typedError.HTTPStatus, typedError.Error)

--- a/cmd/api/src/api/middleware/logging.go
+++ b/cmd/api/src/api/middleware/logging.go
@@ -1,17 +1,17 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 package middleware
@@ -22,13 +22,13 @@ import (
 	"runtime/debug"
 	"time"
 
+	"github.com/gofrs/uuid"
+	"github.com/specterops/bloodhound/headers"
+	"github.com/specterops/bloodhound/log"
 	"github.com/specterops/bloodhound/src/api"
 	"github.com/specterops/bloodhound/src/auth"
 	"github.com/specterops/bloodhound/src/config"
 	"github.com/specterops/bloodhound/src/ctx"
-	"github.com/gofrs/uuid"
-	"github.com/specterops/bloodhound/headers"
-	"github.com/specterops/bloodhound/log"
 )
 
 // PanicHandler is a middleware func that sets up a defer-recovery trap to capture any unhandled panics that bubble

--- a/cmd/api/src/api/middleware/middleware_internal_test.go
+++ b/cmd/api/src/api/middleware/middleware_internal_test.go
@@ -1,17 +1,17 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 package middleware
@@ -24,8 +24,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
 	"github.com/specterops/bloodhound/headers"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetScheme(t *testing.T) {
@@ -73,9 +73,10 @@ func TestRequestWaitDuration(t *testing.T) {
 	req.Header.Set(headers.Prefer.String(), "wait=1")
 	req.URL.RawQuery = q.Encode()
 
-	timeout, err := requestWaitDuration(req, 30*time.Second)
+	requestedWaitDuration, err := requestWaitDuration(req, 30*time.Second)
 	require.Nil(t, err)
-	require.Equal(t, 1*time.Second, timeout)
+	require.Equal(t, 1*time.Second, requestedWaitDuration.Value)
+	require.True(t, requestedWaitDuration.UserSet)
 }
 
 func TestParsePreferHeaderWait(t *testing.T) {

--- a/cmd/api/src/api/middleware/middleware_test.go
+++ b/cmd/api/src/api/middleware/middleware_test.go
@@ -1,17 +1,17 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 package middleware_test
@@ -24,41 +24,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/specterops/bloodhound/src/api"
-	"github.com/stretchr/testify/require"
 	"github.com/specterops/bloodhound/headers"
 	"github.com/specterops/bloodhound/mediatypes"
+	"github.com/specterops/bloodhound/src/api"
+	"github.com/stretchr/testify/require"
 
 	"github.com/specterops/bloodhound/src/api/middleware"
 )
-
-func TestServeHTTP_ContextTimeout(t *testing.T) {
-	handlerResponse := "success"
-	handlerFunc := http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
-		time.Sleep(2 * time.Second)
-		api.WriteBasicResponse(request.Context(), handlerResponse, http.StatusOK, response)
-	})
-	wrapper := middleware.NewWrapper(handlerFunc)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
-	defer cancel()
-	req, err := http.NewRequestWithContext(ctx, "GET", "foo/bar", nil)
-	require.Nil(t, err)
-
-	req.Header.Set(headers.ContentType.String(), mediatypes.ApplicationJson.String())
-	response := httptest.NewRecorder()
-
-	wrapper.ServeHTTP(response, req)
-
-	// simulate the goroutine continuing to work after context timeout.
-	time.Sleep(2 * time.Second)
-
-	require.Equal(t, http.StatusGatewayTimeout, response.Code)
-	require.Contains(t, response.Body.String(), middleware.ErrorResponseContextDeadlineExceeded)
-
-	// The response structure must only contain the context timeout body, not the handler response body
-	require.NotContains(t, response.Body.String(), handlerResponse)
-}
 
 func TestServeHTTP_Success(t *testing.T) {
 	handlerFunc := http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {

--- a/cmd/api/src/ctx/ctx.go
+++ b/cmd/api/src/ctx/ctx.go
@@ -1,17 +1,17 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 package ctx
@@ -32,9 +32,15 @@ type CtxKey string
 
 const ValueKey = CtxKey("ctx.bhe")
 
+type RequestedWaitDuration struct {
+	Value   time.Duration
+	UserSet bool
+}
+
 // Context holds contextual data that is passed around to functions. This is an extension to Golang's built in context.
 type Context struct {
 	StartTime time.Time
+	Timeout   RequestedWaitDuration
 	RequestID string
 	AuthCtx   auth.Context
 	Host      *url.URL
@@ -77,6 +83,11 @@ func Get(ctx context.Context) *Context {
 	} else {
 		return bhCtx
 	}
+}
+
+// Set takes the given golang context and stores the given bh context struct inside it using a well known key
+func Set(ctx context.Context, bhCtx *Context) context.Context {
+	return context.WithValue(ctx, ValueKey, bhCtx)
 }
 
 // RequestID returns the request ID of the HTTP request

--- a/packages/go/dawgs/graph/path.go
+++ b/packages/go/dawgs/graph/path.go
@@ -1,17 +1,17 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 package graph

--- a/packages/go/dawgs/ops/ops.go
+++ b/packages/go/dawgs/ops/ops.go
@@ -1,17 +1,17 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 package ops


### PR DESCRIPTION
## Description

Remove a bunch of experimental machinery around controlling request context timeouts. This style of control leads to strange double-commit scenarios for the `http.Response` type and results in incorrect `504` responses where the client is behaving but behind a slow connection.

This changeset addresses https://github.com/SpecterOps/BloodHound/issues/13.

## Motivation and Context

There's a long history of debug attempts related to the code being cleaned up here. To save everyone a long read, the gist is that this was an experiment in aggressively trying to preserve UX for multi-user, single-tenant instances that back BloodHound Enterprise.

## How Has This Been Tested?

Integration test passes to validate that request handling operates as expected. One negative test harness written in Python that won't be committed.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [x] I have added and/or updated tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] My changes include a database migration.
