### PR TITLE
feat: enable literal scrubbed user query logging

### DIFF
--- a/packages/go/cypher/frontend/format_test.go
+++ b/packages/go/cypher/frontend/format_test.go
@@ -1,0 +1,21 @@
+package frontend
+
+import (
+	"bytes"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestCypherEmitter_StripLiterals(t *testing.T) {
+	var (
+		buffer            = &bytes.Buffer{}
+		regularQuery, err = ParseCypher(DefaultCypherContext(), "match (n {value: 'PII'}) where n.other = 'more pii' and n.number = 411 return n.name, n")
+		emitter           = CypherEmitter{
+			StripLiterals: true,
+		}
+	)
+
+	require.Nil(t, err)
+	require.Nil(t, emitter.Write(regularQuery, buffer))
+	require.Equal(t, "match (n {value: $STRIPPED}) where n.other = $STRIPPED and n.number = $STRIPPED return n.name, n", buffer.String())
+}

--- a/packages/go/cypher/frontend/parse.go
+++ b/packages/go/cypher/frontend/parse.go
@@ -1,17 +1,17 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 package frontend
@@ -36,7 +36,18 @@ func CypherToCypher(ctx *Context, input string) (string, error) {
 	if query, err := ParseCypher(ctx, input); err != nil {
 		return "", err
 	} else {
-		return FormatRegularQuery(query)
+		var (
+			output  = &bytes.Buffer{}
+			emitter = CypherEmitter{
+				StripLiterals: false,
+			}
+		)
+
+		if err := emitter.Write(query, output); err != nil {
+			return "", err
+		}
+
+		return output.String(), nil
 	}
 }
 

--- a/packages/go/dawgs/query/neo4j/neo4j.go
+++ b/packages/go/dawgs/query/neo4j/neo4j.go
@@ -1,22 +1,23 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 package neo4j
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 
@@ -379,5 +380,11 @@ func (s *QueryBuilder) PrepareAllShortestPaths() error {
 }
 
 func (s *QueryBuilder) Render() (string, error) {
-	return frontend.FormatRegularQuery(s.query)
+	buffer := &bytes.Buffer{}
+
+	if err := frontend.NewCypherEmitter(false).Write(s.query, buffer); err != nil {
+		return "", err
+	} else {
+		return buffer.String(), nil
+	}
 }


### PR DESCRIPTION
## Description

This changeset improves the openCypher front end by adding an emitter type that can contain output configuration information. This type is used to add a switch in the format functions for stripping literals when outputting openCypher from the query model.

Stripped literals are replaced with a parameter named `$STRIPPED`. This allows the query to remain syntactically correct while removing any sensitive information contained in the literal values.

Property names and other syntax elements are currently not considered sensitive.

### Output Example

```json
{"level":"info","query":"match p = ()-[:HasSession]->(n)-[]->() where n.pii = $STRIPPED return p","time":"2023-08-14T09:38:22.575719651-07:00","message":"Executing user cypher query"}
```

### Other Changes

* Refactor the emitter type to output to the `io.Writer` type for flexibility.
* Refactor GraphQuery to output user queries into the application structured log.

## Motivation and Context

It's very hard to trace what queries may be problematic from the BH application log. In order to enable log output for user queries we need to first scrub any literal data in it.

## How Has This Been Tested?

Added unit tests to cover the new path.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [x] I have added and/or updated tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] My changes include a database migration.
