### PR TITLE
fix: env shouldn't use non-default options by default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,8 @@ WEB_PORT=80
 TRAEFIK_PORT=8000
 DEBUG_PORT=3456
 BH_CONFIG_FILE=build.config.json
-#AIR_FLAGS="-build.poll true" # This will enable polling mode for Air, which can help with virtualized filesystems like Docker on Mac
+# This will enable polling mode for Air, which can help with virtualized filesystems like Docker on Mac
+#AIR_FLAGS="-build.poll true"
 
 # BloodHound API
 BH_HOSTNAME=bloodhound.localhost

--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,7 @@ WEB_PORT=80
 TRAEFIK_PORT=8000
 DEBUG_PORT=3456
 BH_CONFIG_FILE=build.config.json
-AIR_FLAGS="-build.poll true" # This will enable polling mode for Air, which can help with virtualized filesystems like Docker on Mac
+#AIR_FLAGS="-build.poll true" # This will enable polling mode for Air, which can help with virtualized filesystems like Docker on Mac
 
 # BloodHound API
 BH_HOSTNAME=bloodhound.localhost


### PR DESCRIPTION
## Description

Comment out non-default env option to make `.env-example` align with actual defaults

## Motivation and Context

Discovered that the .env-example provided sets a non-default value by default

## How Has This Been Tested?

Just cleanup, no-op change

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
