### PR TITLE
fix: adapt node radius size to account for zoom ratio in rendering programs

### DIFF
--- a/cmd/ui/src/components/GraphEdgeEvents.tsx
+++ b/cmd/ui/src/components/GraphEdgeEvents.tsx
@@ -1,17 +1,17 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 import { useSigma } from '@react-sigma/core';
@@ -31,12 +31,12 @@ import {
 const GraphEdgeEvents: FC = () => {
     const dispatch = useAppDispatch();
     const graphState = useSelector((state: AppState) => state.explore);
-    const canvasRef = useRef<HTMLCanvasElement | null>(document.querySelector('#sigma-container'));
 
     const sigma = useSigma();
     const camera = sigma.getCamera();
     const ratio = camera.getState().ratio;
     const canvases = sigma.getCanvases();
+    const sigmaContainer = document.getElementById('sigma-container');
     const mouseCanvas = canvases.mouse;
     const edgeLabelsCanvas = canvases.edgeLabels;
     const { height, width } = mouseCanvas.style;
@@ -133,7 +133,7 @@ const GraphEdgeEvents: FC = () => {
                             onClickEdge(edge);
                         } else {
                             //Hover the edge label
-                            if (canvasRef.current) canvasRef.current.style.cursor = 'pointer';
+                            if (sigmaContainer) sigmaContainer.style.cursor = 'pointer';
                         }
                         //Return early so as not to propagate the event to sigma handlers
                         return;
@@ -141,8 +141,8 @@ const GraphEdgeEvents: FC = () => {
                 }
             }
 
-            if (canvasRef.current && canvasRef.current.style.cursor === 'pointer')
-                canvasRef.current.style.cursor = 'default';
+            if (sigmaContainer && sigmaContainer.style.cursor === 'pointer') sigmaContainer.style.cursor = 'default';
+
             const customEvent = new Event(event.type, { bubbles: true });
             Object.assign(customEvent, {
                 clientX: event.clientX,

--- a/cmd/ui/src/components/GraphEvents.tsx
+++ b/cmd/ui/src/components/GraphEvents.tsx
@@ -1,17 +1,17 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 import { useRegisterEvents, useSetSettings, useSigma } from '@react-sigma/core';
@@ -44,7 +44,6 @@ export const GraphEvents: FC<GraphEventProps> = ({
     const sigma = useSigma();
     const registerEvents = useRegisterEvents();
     const setSettings = useSetSettings();
-    const edgeEventsCanvasRef = useRef<HTMLCanvasElement | null>(document.querySelector('#sigma-container'));
 
     const [hoveredNode, setHoveredNode] = useState<string | null>(null);
     const [draggedNode, setDraggedNode] = useState<string | null>(null);
@@ -56,6 +55,8 @@ export const GraphEvents: FC<GraphEventProps> = ({
     const clickTimerRef = useRef<ReturnType<typeof setTimeout>>();
     const prevent = useRef(false);
 
+    const sigmaContainer = document.getElementById('sigma-container');
+
     const clearDraggedNode = () => {
         setDraggedNode(null);
         setIsDragging(false);
@@ -66,11 +67,11 @@ export const GraphEvents: FC<GraphEventProps> = ({
     useEffect(() => {
         registerEvents({
             enterNode: (event) => {
-                if (edgeEventsCanvasRef.current) edgeEventsCanvasRef.current.style.cursor = 'grab';
+                if (sigmaContainer) sigmaContainer.style.cursor = 'grab';
                 setHoveredNode(event.node);
             },
             leaveNode: () => {
-                if (edgeEventsCanvasRef.current) edgeEventsCanvasRef.current.style.cursor = 'default';
+                if (sigmaContainer) sigmaContainer.style.cursor = 'default';
                 setHoveredNode(null);
             },
             downNode: (event) => {

--- a/cmd/ui/src/components/SigmaChart.tsx
+++ b/cmd/ui/src/components/SigmaChart.tsx
@@ -27,7 +27,7 @@ import { RankDirection } from 'src/hooks/useLayoutDagre/useLayoutDagre';
 import drawEdgeLabel from 'src/rendering/programs/edge-label';
 import EdgeArrowProgram from 'src/rendering/programs/edge.arrow';
 import CurvedEdgeArrowProgram from 'src/rendering/programs/edge.curvedArrow';
-import drawHover from 'src/rendering/programs/hover';
+import drawHover from 'src/rendering/programs/node-hover';
 import drawLabel from 'src/rendering/programs/node-label';
 import getNodeCombinedProgram from 'src/rendering/programs/node.combined';
 import getNodeGlyphsProgram from 'src/rendering/programs/node.glyphs';
@@ -78,6 +78,8 @@ const SigmaChart: FC<Partial<SigmaChartProps>> = ({
                 renderEdgeLabels: true,
                 hoverRenderer: drawHover,
                 edgeLabelRenderer: drawEdgeLabel,
+                edgeLabelSize: 12,
+                labelSize: 12,
                 labelFont: 'Roboto',
                 labelRenderer: drawLabel,
                 maxCameraRatio: MAX_CAMERA_RATIO,

--- a/cmd/ui/src/rendering/programs/edge.arrow.ts
+++ b/cmd/ui/src/rendering/programs/edge.arrow.ts
@@ -1,17 +1,17 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 /**
@@ -23,8 +23,8 @@
  * @module
  */
 import { createEdgeCompoundProgram } from 'sigma/rendering/webgl/programs/common/edge';
-import EdgeArrowHeadProgram from './edge.arrowHead';
-import EdgeClampedProgram from 'sigma/rendering/webgl/programs/edge.clamped';
+import EdgeArrowHeadProgram from 'src/rendering/programs/edge.arrowHead';
+import EdgeClampedProgram from 'src/rendering/programs/edge.clamped';
 
 const EdgeArrowProgram = createEdgeCompoundProgram([EdgeClampedProgram, EdgeArrowHeadProgram]);
 

--- a/cmd/ui/src/rendering/programs/edge.arrowHead.ts
+++ b/cmd/ui/src/rendering/programs/edge.arrowHead.ts
@@ -1,17 +1,17 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 /**
@@ -22,12 +22,14 @@
  * This is pulled directly from Sigma, we are just using different shaders
  * @module
  */
-import { EdgeDisplayData, NodeDisplayData } from 'sigma/types';
-import { floatColor } from 'sigma/utils';
-import { vertexShaderSource } from '../shaders/edge.arrowHead.vert';
-import { fragmentShaderSource } from '../shaders/edge.arrowHead.frag';
 import { AbstractEdgeProgram } from 'sigma/rendering/webgl/programs/common/edge';
 import { RenderParams } from 'sigma/rendering/webgl/programs/common/program';
+import { NodeDisplayData } from 'sigma/types';
+import { floatColor } from 'sigma/utils';
+import { CurvedEdgeDisplayData } from 'src/rendering/programs/edge.curvedArrow';
+import { fragmentShaderSource } from 'src/rendering/shaders/edge.arrowHead.frag';
+import { vertexShaderSource } from 'src/rendering/shaders/edge.arrowHead.vert';
+import { getNodeRadius } from 'src/rendering/utils/utils';
 
 const POINTS = 3,
     ATTRIBUTES = 9,
@@ -126,7 +128,7 @@ export default class EdgeArrowHeadProgram extends AbstractEdgeProgram {
     process(
         sourceData: NodeDisplayData,
         targetData: NodeDisplayData,
-        data: EdgeDisplayData,
+        data: CurvedEdgeDisplayData,
         hidden: boolean,
         offset: number
     ): void {
@@ -136,13 +138,14 @@ export default class EdgeArrowHeadProgram extends AbstractEdgeProgram {
             return;
         }
 
+        const inverseSqrtZoomRatio = data.inverseSqrtZoomRatio || 1;
         const thickness = data.size || 1,
-            radius = targetData.size || 1,
             x1 = sourceData.x,
             y1 = sourceData.y,
             x2 = targetData.x,
             y2 = targetData.y,
             color = floatColor(data.color);
+        const radius = getNodeRadius(targetData.highlighted, inverseSqrtZoomRatio, targetData.size);
 
         // Computing normals
         const dx = x2 - x1,
@@ -155,8 +158,8 @@ export default class EdgeArrowHeadProgram extends AbstractEdgeProgram {
         if (len) {
             len = 1 / Math.sqrt(len);
 
-            n1 = -dy * len * thickness;
-            n2 = dx * len * thickness;
+            n1 = -dy * len * thickness * 1.2;
+            n2 = dx * len * thickness * 1.2;
         }
 
         let i = POINTS * ATTRIBUTES * offset;

--- a/cmd/ui/src/rendering/programs/edge.arrowHead.ts
+++ b/cmd/ui/src/rendering/programs/edge.arrowHead.ts
@@ -158,8 +158,8 @@ export default class EdgeArrowHeadProgram extends AbstractEdgeProgram {
         if (len) {
             len = 1 / Math.sqrt(len);
 
-            n1 = -dy * len * thickness * 1.2;
-            n2 = dx * len * thickness * 1.2;
+            n1 = -dy * len * thickness;
+            n2 = dx * len * thickness;
         }
 
         let i = POINTS * ATTRIBUTES * offset;

--- a/cmd/ui/src/rendering/programs/edge.curvedArrow.ts
+++ b/cmd/ui/src/rendering/programs/edge.curvedArrow.ts
@@ -1,17 +1,17 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 /**
@@ -25,9 +25,16 @@
 import { createEdgeCompoundProgram } from 'sigma/rendering/webgl/programs/common/edge';
 import EdgeCurvedArrowHeadProgram from './edge.curvedArrowHead';
 import EdgeCurvedProgram from './edge.curved';
-import { EdgeDisplayData } from 'sigma/types';
+import { EdgeDisplayData, Coordinates } from 'sigma/types';
+import { EdgeDirection } from 'src/utils';
 
-export type CurvedEdgeDisplayData = EdgeDisplayData & { groupSize?: number; groupPosition?: number };
+export type CurvedEdgeDisplayData = EdgeDisplayData & {
+    groupSize?: number;
+    groupPosition?: number;
+    direction?: EdgeDirection;
+    control?: Coordinates;
+    inverseSqrtZoomRatio?: number;
+};
 
 const EdgeArrowProgram = createEdgeCompoundProgram([EdgeCurvedProgram, EdgeCurvedArrowHeadProgram]);
 

--- a/cmd/ui/src/rendering/programs/edge.curvedArrowHead.ts
+++ b/cmd/ui/src/rendering/programs/edge.curvedArrowHead.ts
@@ -175,8 +175,8 @@ export default class EdgeArrowHeadProgram extends AbstractEdgeProgram {
         const normal = bezier.getNormals(control, end);
 
         const vOffset = {
-            x: normal.x * thickness * 1.2,
-            y: -normal.y * thickness * 1.2,
+            x: normal.x * thickness,
+            y: -normal.y * thickness,
         };
 
         let i = POINTS * ATTRIBUTES * offset;

--- a/cmd/ui/src/rendering/programs/edge.curvedArrowHead.ts
+++ b/cmd/ui/src/rendering/programs/edge.curvedArrowHead.ts
@@ -1,17 +1,17 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 /**
@@ -21,14 +21,15 @@
  * Program rendering direction arrows as a simple triangle.
  * @module
  */
-import { NodeDisplayData } from 'sigma/types';
-import { floatColor } from 'sigma/utils';
-import { vertexShaderSource } from '../shaders/edge.arrowHead.vert';
-import { fragmentShaderSource } from '../shaders/edge.arrowHead.frag';
 import { AbstractEdgeProgram } from 'sigma/rendering/webgl/programs/common/edge';
 import { RenderParams } from 'sigma/rendering/webgl/programs/common/program';
-import { CurvedEdgeDisplayData } from './edge.curvedArrow';
-import { bezier } from '../utils/bezier';
+import { NodeDisplayData } from 'sigma/types';
+import { floatColor } from 'sigma/utils';
+import { CurvedEdgeDisplayData } from 'src/rendering/programs/edge.curvedArrow';
+import { fragmentShaderSource } from 'src/rendering/shaders/edge.arrowHead.frag';
+import { vertexShaderSource } from 'src/rendering/shaders/edge.arrowHead.vert';
+import { bezier } from 'src/rendering/utils/bezier';
+import { getNodeRadius } from 'src/rendering/utils/utils';
 
 const POINTS = 3,
     ATTRIBUTES = 9,
@@ -149,10 +150,11 @@ export default class EdgeArrowHeadProgram extends AbstractEdgeProgram {
             return;
         }
 
+        const inverseSqrtZoomRatio = data.inverseSqrtZoomRatio || 1;
         const start = { x: sourceData.x, y: sourceData.y };
         const end = { x: targetData.x, y: targetData.y };
         const thickness = data.size || 1;
-        const radius = targetData.size || 1;
+        const radius = getNodeRadius(targetData.highlighted, inverseSqrtZoomRatio, targetData.size);
         const color = floatColor(data.color);
 
         // We are going to try and approximate the intersection here
@@ -169,13 +171,12 @@ export default class EdgeArrowHeadProgram extends AbstractEdgeProgram {
             adjustedHeight *= -1;
         }
 
-        const midpoint = bezier.getMidpoint(start, end);
-        const control = bezier.getOffsetVertex(start, end, midpoint, adjustedHeight);
+        const control = bezier.getControlAtMidpoint(adjustedHeight, start, end);
         const normal = bezier.getNormals(control, end);
 
         const vOffset = {
-            x: normal.x * thickness,
-            y: -normal.y * thickness,
+            x: normal.x * thickness * 1.2,
+            y: -normal.y * thickness * 1.2,
         };
 
         let i = POINTS * ATTRIBUTES * offset;

--- a/cmd/ui/src/rendering/programs/node-hover.ts
+++ b/cmd/ui/src/rendering/programs/node-hover.ts
@@ -1,23 +1,27 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 import { Settings } from 'sigma/settings';
 import { NodeDisplayData, PartialButFor } from 'sigma/types';
 import drawLabel from 'src/rendering/programs/node-label';
-import { HIGHLIGHTED_LABEL_BACKGROUND_COLOR, HIGHLIGHTED_LABEL_FONT_COLOR } from 'src/rendering/utils/utils';
+import {
+    HIGHLIGHTED_LABEL_BACKGROUND_COLOR,
+    HIGHLIGHTED_LABEL_FONT_COLOR,
+    getNodeRadius,
+} from 'src/rendering/utils/utils';
 
 export default function drawHover(
     context: CanvasRenderingContext2D,
@@ -34,7 +38,8 @@ export default function drawHover(
     context.fillStyle = HIGHLIGHTED_LABEL_BACKGROUND_COLOR;
 
     const PADDING = 2;
-    const radius = data.size * inverseSqrtZoomRatio + (PADDING + 2) * inverseSqrtZoomRatio;
+    const radius = getNodeRadius(true, inverseSqrtZoomRatio, data.size);
+
     const nodeLabelExists = typeof data.label === 'string';
 
     if (nodeLabelExists) {

--- a/cmd/ui/src/rendering/programs/node.glyphs.ts
+++ b/cmd/ui/src/rendering/programs/node.glyphs.ts
@@ -1,17 +1,17 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 /**
@@ -28,13 +28,13 @@
  *
  * @module
  */
-import { Coordinates, Dimensions, NodeDisplayData } from 'sigma/types';
-import { floatColor } from 'sigma/utils';
-import { vertexShaderSource } from '../shaders/node.glyphs.vert';
-import { fragmentShaderSource } from '../shaders/node.glyphs.frag';
 import { AbstractNodeProgram } from 'sigma/rendering/webgl/programs/common/node';
 import { RenderParams } from 'sigma/rendering/webgl/programs/common/program';
 import Sigma from 'sigma/sigma';
+import { Coordinates, Dimensions, NodeDisplayData } from 'sigma/types';
+import { floatColor } from 'sigma/utils';
+import { fragmentShaderSource } from 'src/rendering/shaders/node.glyphs.frag';
+import { vertexShaderSource } from 'src/rendering/shaders/node.glyphs.vert';
 
 const POINTS = 3,
     /*

--- a/cmd/ui/src/rendering/utils/utils.test.ts
+++ b/cmd/ui/src/rendering/utils/utils.test.ts
@@ -1,0 +1,43 @@
+// Copyright 2023 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { getNodeRadius } from 'src/rendering/utils/utils';
+
+describe('Getting the node radius for use in our rendering programs', () => {
+    const inverseSqrtZoomRatio = 1;
+    test('If for some reason the node size is not defined return 1 as a default', () => {
+        const nodeSize = undefined;
+
+        // The default is not dependent on whether the node is highlighted
+        expect(getNodeRadius(true, inverseSqrtZoomRatio, nodeSize)).toBe(1);
+        expect(getNodeRadius(false, inverseSqrtZoomRatio, nodeSize)).toBe(1);
+    });
+
+    test('The node radius is adjusted for nodes that have their "highlighted" property set to true since the highlight adds some padding', () => {
+        const nodeSize = 10;
+
+        expect(getNodeRadius(true, inverseSqrtZoomRatio, nodeSize)).toBeGreaterThan(
+            getNodeRadius(false, inverseSqrtZoomRatio, nodeSize)
+        );
+    });
+
+    test('The node radius is adjusted to take into account the current camera zoom ratio', () => {
+        const nodeSize = 10;
+
+        expect(getNodeRadius(true, 1, nodeSize)).not.toEqual(getNodeRadius(true, 0.5, nodeSize));
+        expect(getNodeRadius(false, 1, nodeSize)).not.toEqual(getNodeRadius(false, 0.5, nodeSize));
+    });
+});

--- a/cmd/ui/src/rendering/utils/utils.ts
+++ b/cmd/ui/src/rendering/utils/utils.ts
@@ -1,18 +1,30 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 export const HIGHLIGHTED_LABEL_BACKGROUND_COLOR = '#FF6D66';
 export const HIGHLIGHTED_LABEL_FONT_COLOR = '#FFF';
+
+export const getNodeRadius = (highlighted: boolean, inverseSqrtZoomRatio: number, size?: number): number => {
+    const PADDING = 2;
+    let radius = 1;
+
+    if (!size) return radius;
+
+    if (highlighted) radius = size * inverseSqrtZoomRatio + (PADDING + 2) * inverseSqrtZoomRatio;
+    else radius = size * inverseSqrtZoomRatio;
+
+    return radius;
+};


### PR DESCRIPTION
## Description
The existing rendering programs have been updated to uniformly account for the zoom ratio when handling calculations involving node radii. 
<!--- Describe your changes in detail -->

## Motivation and Context
Design choices made in the sigma repository cause node sizes to adjust to the zoom ratio so that nodes stay relatively the same size regardless of the zoom ratio. These size adaptations have undesired side effects for our use case such as edge arrowheads becoming hidden when zoomed in too close and so a factor is applied in this changeset to avoid such behavior.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
A unit test was added for the `getNodeRadius` utility function. Zoom behavior was verified in a local instance. See the screen captures below

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

Previous undesired behavior

https://github.com/SpecterOps/BloodHound/assets/16910931/565da243-6c12-48ef-9078-aaac602c711c


Fixed behavior

https://github.com/SpecterOps/BloodHound/assets/16910931/2e65bbee-912c-475c-bb89-b87259adcc42


Node highlight taken into account

https://github.com/SpecterOps/BloodHound/assets/16910931/4518d809-569b-4798-af5c-44b8b365f244


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [x] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
