### PR TITLE
chore: add build to init

### DIFF
--- a/justfile
+++ b/justfile
@@ -21,7 +21,7 @@ init:
     cp ./local-harnesses/build.config.json.template ./local-harnesses/build.config.json
   elif [[ -f "./local-harnesses/build.config.json" ]]; then
     echo "Not copying build.config.json since it already exists"
-  else \
+  else
     cp ./local-harnesses/build.config.json.template ./local-harnesses/build.config.json
   fi
 
@@ -30,12 +30,19 @@ init:
     cp ./local-harnesses/integration.config.json.template ./local-harnesses/integration.config.json
   elif [[ -f "./local-harnesses/integration.config.json" ]]; then
     echo "Not copying integration.config.json since it already exists"
-  else \
+  else
     cp ./local-harnesses/integration.config.json.template ./local-harnesses/integration.config.json
   fi
 
   echo "Install additional Go tools"
   go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.52.2
+
+  echo "Check that a go.work.sum file exists and run a local build if not"
+  if [[ ! -f "go.work.sum" ]]; then
+    just build -v
+  fi
+
+  echo "Init Complete"
 
 # Show available targets for this context.
 show *FLAGS:


### PR DESCRIPTION
## Description

Adds a `just build -v` step to our `just init` when a `go.work.sum` file isn't available yet (nothing has been built or run in the project)

## Motivation and Context

After working with a few people on getting their dev environments sane, I realized that having `just init` run an initial build if you don't already have a `go.work.sum` would help solve an annoying error for people starting fresh with the dev docker compose.

## How Has This Been Tested?

Ran init again locally with my `go.work.sum` removed

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
