### PR TITLE
fix: update role assignments to not delete existing relprops

### DIFF
--- a/cmd/api/src/daemons/datapipe/azure_convertors.go
+++ b/cmd/api/src/daemons/datapipe/azure_convertors.go
@@ -1,17 +1,17 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 package datapipe
@@ -310,7 +310,6 @@ func convertAzureGroupOwner(raw json.RawMessage, converted *ConvertedAzureData) 
 	if err := json.Unmarshal(raw, &data); err != nil {
 		log.Errorf(SerialError, "azure group owners", err)
 	} else {
-
 		converted.RelProps = append(converted.RelProps, ein.ConvertAzureGroupOwnerToRels(data)...)
 	}
 }
@@ -666,7 +665,7 @@ func convertAzureContainerRegistryRoleAssignment(raw json.RawMessage, converted 
 	if err := json.Unmarshal(raw, &data); err != nil {
 		log.Errorf(SerialError, "azure container registry role assignments", err)
 	} else {
-		converted.RelProps = ein.ConvertAzureContainerRegistryRoleAssignment(data)
+		converted.RelProps = append(converted.RelProps, ein.ConvertAzureContainerRegistryRoleAssignment(data)...)
 	}
 }
 
@@ -676,7 +675,7 @@ func convertAzureWebAppRoleAssignment(raw json.RawMessage, converted *ConvertedA
 	if err := json.Unmarshal(raw, &data); err != nil {
 		log.Errorf(SerialError, "azure web app role assignments", err)
 	} else {
-		converted.RelProps = ein.ConvertAzureWebAppRoleAssignment(data)
+		converted.RelProps = append(converted.RelProps, ein.ConvertAzureWebAppRoleAssignment(data)...)
 	}
 }
 

--- a/cmd/api/src/daemons/datapipe/ingest.go
+++ b/cmd/api/src/daemons/datapipe/ingest.go
@@ -1,17 +1,17 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 package datapipe

--- a/packages/go/ein/azure.go
+++ b/packages/go/ein/azure.go
@@ -1,17 +1,17 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 package ein
@@ -683,6 +683,8 @@ func ConvertAzureRoleAssignmentToRels(roleAssignment azure2.UnifiedRoleAssignmen
 
 	if CanAddSecret(roleAssignment.RoleDefinitionId) && roleAssignment.DirectoryScopeId != "/" {
 		if relType, err := GetAddSecretRoleKind(roleAssignment.RoleDefinitionId); err != nil {
+			log.Errorf("Error processing role assignment for role %s: %v", roleObjectId, err)
+		} else {
 			relationships = append(relationships, IngestibleRelationship{
 				Source:     strings.ToUpper(roleAssignment.PrincipalId),
 				SourceType: azure.Entity,
@@ -691,8 +693,6 @@ func ConvertAzureRoleAssignmentToRels(roleAssignment azure2.UnifiedRoleAssignmen
 				RelProps:   map[string]any{},
 				RelType:    relType,
 			})
-		} else {
-			log.Errorf("Error processing role assignment for role %s: %v", roleObjectId, err)
 		}
 	}
 


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

- update Container Registry & WebApp Role Assignments role assignments to not delete other relationships that are ready for ingest

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Several Azure relationships were not being ingested into the dataset due to several logic errors.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
