### PR TITLE
fix: remove blanket 15m timeout for transactions

### DIFF
--- a/packages/go/dawgs/drivers/neo4j/neo4j.go
+++ b/packages/go/dawgs/drivers/neo4j/neo4j.go
@@ -1,34 +1,35 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 package neo4j
 
 import (
 	"fmt"
-	"net/url"
-	"time"
-
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/specterops/bloodhound/dawgs"
 	"github.com/specterops/bloodhound/dawgs/graph"
 	"github.com/specterops/bloodhound/dawgs/util/channels"
+	"math"
+	"net/url"
 )
 
 const (
-	defaultNeo4jTransactionTimeout = time.Minute * 15
+	// defaultNeo4jTransactionTimeout is set to math.MinInt as this is what the core neo4j library defaults to when
+	// left unset. It is recommended that users set this for time-sensitive operations
+	defaultNeo4jTransactionTimeout = math.MinInt
 )
 
 func newNeo4jDB(connectionURLStr string) (graph.Database, error) {


### PR DESCRIPTION
## Description

This was ill-advised in implementation. We use timeouts for query quality control but not all paths expect a 15m timeout application. Instead we should resort to how the neo4j core library sets this value.

## Motivation and Context

Seeing some transient failures occur for valid operations that take longer than 15m.

## How Has This Been Tested?

Integration tests.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] My changes include a database migration.
