### PR TITLE
chore: do not log context timeouts from traversal workers

### DIFF
--- a/packages/go/dawgs/traversal/id.go
+++ b/packages/go/dawgs/traversal/id.go
@@ -1,17 +1,17 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 package traversal
@@ -109,11 +109,11 @@ func (s IDTraversal) BreadthFirst(ctx context.Context, plan IDPlan) error {
 						return nil
 					}
 				}
-			}); err != nil {
-				errors.Add(fmt.Errorf("reader %d failed: %w", workerID, err))
-
-				// A worker encountered an error, kill the traversal context
+			}); err != nil && err != graph.ErrContextTimedOut {
+				// A worker encountered a fatal error, kill the traversal context
 				doneFunc()
+
+				errors.Add(fmt.Errorf("reader %d failed: %w", workerID, err))
 			}
 		}(workerID)
 	}

--- a/packages/go/dawgs/traversal/traversal.go
+++ b/packages/go/dawgs/traversal/traversal.go
@@ -1,17 +1,17 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 package traversal
@@ -115,11 +115,11 @@ func (s Traversal) BreadthFirst(ctx context.Context, plan Plan) error {
 						return nil
 					}
 				}
-			}); err != nil {
-				errors.Add(fmt.Errorf("reader %d failed: %w", workerID, err))
-
-				// A worker encountered an error, kill the traversal context
+			}); err != nil && err != graph.ErrContextTimedOut {
+				// A worker encountered a fatal error, kill the traversal context
 				doneFunc()
+
+				errors.Add(fmt.Errorf("reader %d failed: %w", workerID, err))
 			}
 		}(workerID)
 	}


### PR DESCRIPTION
## Description

In a parallel BFS traversal, it's possible that some workers are unable to start due to connection slots being unavailable. This can result in a situation where the traversal naturally finishes but because workers are locked into waiting for a connection slot, they surface the context cancellation as a failure.

## Motivation and Context

Log noise and better behaved traversal.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
