### PR TITLE
Relationship Information Properties

### DIFF
--- a/cmd/api/src/api/v2/cypher_search.go
+++ b/cmd/api/src/api/v2/cypher_search.go
@@ -1,17 +1,17 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 package v2
@@ -25,7 +25,8 @@ import (
 )
 
 type CypherSearch struct {
-	Query string `json:"query"`
+	Query             string `json:"query"`
+	IncludeProperties bool   `json:"include_properties,omitempty"`
 }
 
 func (s Resources) CypherSearch(response http.ResponseWriter, request *http.Request) {
@@ -36,7 +37,7 @@ func (s Resources) CypherSearch(response http.ResponseWriter, request *http.Requ
 			request.Context(),
 			api.BuildErrorResponse(http.StatusBadRequest, "JSON malformed.", request), response,
 		)
-	} else if graphResponse, err := s.GraphQuery.RawCypherSearch(request.Context(), payload.Query); err != nil {
+	} else if graphResponse, err := s.GraphQuery.RawCypherSearch(request.Context(), payload.Query, payload.IncludeProperties); err != nil {
 		if queries.IsQueryError(err) {
 			api.WriteErrorResponse(
 				request.Context(),

--- a/cmd/api/src/api/v2/pathfinding.go
+++ b/cmd/api/src/api/v2/pathfinding.go
@@ -59,14 +59,16 @@ func writeShortestPathsResult(paths graph.PathSet, response http.ResponseWriter,
 		graphResponse := model.NewUnifiedGraph()
 
 		for _, n := range paths.AllNodes() {
-			graphResponse.Nodes[n.ID.String()] = model.FromDAWGSNode(n)
+			graphResponse.Nodes[n.ID.String()] = model.FromDAWGSNode(n, false)
 		}
 
 		edges := slices.FlatMap(paths, func(path graph.Path) []model.UnifiedEdge {
-			return slices.Map(path.Edges, model.FromDAWGSRelationship)
+			return slices.Map(path.Edges, model.FromDAWGSRelationship(false))
 		})
 
-		graphResponse.Edges = slices.Unique(edges)
+		graphResponse.Edges = slices.UniqueBy(edges, func(edge model.UnifiedEdge) string {
+			return edge.Source + edge.Kind + edge.Target
+		})
 
 		api.WriteBasicResponse(request.Context(), graphResponse, http.StatusOK, response)
 	}

--- a/cmd/api/src/docs/json/definitions/graphs.json
+++ b/cmd/api/src/docs/json/definitions/graphs.json
@@ -32,14 +32,21 @@
                     "kind": "User",
                     "objectId": "abc123",
                     "isTierZero": true,
-                    "lastSeen": "2022-12-07T15:09:51.474Z"
+                    "lastSeen": "2022-12-07T15:09:51.474Z",
+                    "properties": {
+                            "lastseen": "2023-02-03T22:54:21.728Z",
+                            "system_tags": "admin_tier_0"
+                    }
                 },
                 "node2": {
                     "label": "DOMAIN USERS@TESTLAB.LOCAL",
                     "kind": "Group",
                     "objectId": "xyz789",
                     "isTierZero": false,
-                    "lastSeen": "2022-12-07T15:09:51.474Z"
+                    "lastSeen": "2022-12-07T15:09:51.474Z",
+                    "properties": {
+                        "lastseen": "2023-02-03T22:54:21.728Z"
+                    }
                 }
             },
             "edges": [
@@ -48,7 +55,11 @@
                     "target": "node2",
                     "label": "MemberOf",
                     "kind": "MemberOf",
-                    "lastSeen": "2022-12-07T15:09:51.474Z"
+                    "lastSeen": "2022-12-07T15:09:51.474Z",
+                    "properties": {
+                        "lastseen": "2023-02-03T22:54:21.728Z",
+                        "isacl": false
+                    }
                 }
             ]
         }
@@ -76,6 +87,10 @@
                 "type": "string",
                 "format": "date-time",
                 "description": "The RFC-3339 datetime of the last time BloodHound was notified of the node's existance."
+            },
+            "properties": {
+                "type": "object",
+                "description": "The node's properties that are stored in the graph database"
             }
         }
     },
@@ -99,6 +114,10 @@
             },
             "lastSeen": {
                 "$ref": "#/definitions/properties.LastSeen"
+            },
+            "properties": {
+                "type": "object",
+                "description": "The edge's properties that are stored in the graph database"
             }
         }
     }

--- a/cmd/api/src/docs/json/paths/v2/graphs.json
+++ b/cmd/api/src/docs/json/paths/v2/graphs.json
@@ -1,105 +1,98 @@
 {
-    "/api/v2/graphs/shortest-path": {
-        "get": {
-            "security": [],
-            "description": "Returns the shortest path between two nodes in the graph",
-            "tags": [
-                "Graphs",
-                "Community",
-                "Enterprise"
-            ],
-            "summary": "Get the shortest path graph",
-            "parameters": [
-                {
-                    "$ref": "#/definitions/parameters.PreferHeader"
-                },
-                {
-                    "name": "start_node",
-                    "description": "The start node objectId",
-                    "in": "query",
-                    "required": true
-                },
-                {
-                    "name": "end_node",
-                    "description": "The end node objectId",
-                    "in": "query",
-                    "required": true
-                },
-                {
-                    "name": "relationship_kinds",
-                    "description": "Filter the kinds of relationships traversed between the start node and the end node.",
-                    "in": "query",
-                    "required": false,
-                    "schema": {
-                        "$ref": "#/components/schemas/predicates.ContainsPredicate"
-                    },
-                    "examples": {
-                        "in": {
-                            "value": "in:Contains,GetChangesAll,MemberOf",
-                            "summary": "Only traverse specific kinds of relationships"
-                        },
-                        "nin": {
-                            "value": "nin:LocalToComputer,MemberOfLocalGroup",
-                            "summary": "Exclude traversing specific kinds of relationships"
-                        }
-                    }
-                }
-            ],
-            "responses": {
-                "200": {
-                    "description": "A graph of the shortest path from `start_node` to `end_node`.",
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/definitions/graphs.GraphResponse"
-                            }
-                        }
-                    }
-                },
-                "Error": {
-                    "$ref": "#/components/responses/defaultError"
-                }
-            }
-        }
-    },
-    "/api/v2/graphs/cypher": {
-        "post": {
-            "security": [],
-            "description": "Runs a manual cypher query directly against the database",
-            "tags": [
-                "Graphs",
-                "Community",
-                "Enterprise"
-            ],
-            "summary": "Runs a manual cypher query directly against the database",
-            "requestBody": {
-                "content": {
-                    "application/json": {
-                        "schema": {
-                            "properties": {
-                                "query": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    }
-                }
+  "/api/v2/graphs/shortest-path": {
+    "get": {
+      "security": [],
+      "description": "Returns graph data related to the cypher query sent in the response body that contains a collection of nodes and edges",
+      "tags": ["Graphs", "Community", "Enterprise"],
+      "summary": "Get the shortest path graph",
+      "parameters": [
+        {
+          "$ref": "#/definitions/parameters.PreferHeader"
+        },
+        {
+          "name": "start_node",
+          "description": "The start node objectId",
+          "in": "query",
+          "required": true
+        },
+        {
+          "name": "end_node",
+          "description": "The end node objectId",
+          "in": "query",
+          "required": true
+        },
+        {
+          "name": "relationship_kinds",
+          "description": "Filter the kinds of relationships traversed between the start node and the end node.",
+          "in": "query",
+          "required": false,
+          "schema": {
+            "$ref": "#/components/schemas/predicates.ContainsPredicate"
+          },
+          "examples": {
+            "in": {
+              "value": "in:Contains,GetChangesAll,MemberOf",
+              "summary": "Only traverse specific kinds of relationships"
             },
-            "responses": {
-                "200": {
-                    "description": "A graph of the shortest path from `start_node` to `end_node`.",
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/definitions/graphs.GraphResponse"
-                            }
-                        }
-                    }
-                },
-                "Error": {
-                    "$ref": "#/components/responses/defaultError"
-                }
+            "nin": {
+              "value": "nin:LocalToComputer,MemberOfLocalGroup",
+              "summary": "Exclude traversing specific kinds of relationships"
             }
+          }
         }
+      ],
+      "responses": {
+        "200": {
+          "description": "A graph of the shortest path from `start_node` to `end_node`.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/definitions/graphs.GraphResponse"
+              }
+            }
+          }
+        },
+        "Error": {
+          "$ref": "#/components/responses/defaultError"
+        }
+      }
     }
+  },
+  "/api/v2/graphs/cypher": {
+    "post": {
+      "security": [],
+      "description": "Runs a manual cypher query directly against the database",
+      "tags": ["Graphs", "Community", "Enterprise"],
+      "summary": "Runs a manual cypher query directly against the database",
+      "requestBody": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "properties": {
+                "query": {
+                  "type": "string"
+                },
+                "include_properties": { "type": "boolean" }
+              }
+            }
+          }
+        }
+      },
+      "responses": {
+        "200": {
+          "description": "A graph of the shortest path from `start_node` to `end_node`.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/definitions/graphs.GraphResponse"
+              }
+            }
+          }
+        },
+        "Error": {
+          "$ref": "#/components/responses/defaultError"
+        }
+      }
+    }
+  }
 }

--- a/cmd/api/src/docs/json/paths/v2/graphs.json
+++ b/cmd/api/src/docs/json/paths/v2/graphs.json
@@ -2,7 +2,7 @@
   "/api/v2/graphs/shortest-path": {
     "get": {
       "security": [],
-      "description": "Returns graph data related to the cypher query sent in the response body that contains a collection of nodes and edges",
+      "description": "A graph of the shortest path from `start_node` to `end_node`.",
       "tags": ["Graphs", "Community", "Enterprise"],
       "summary": "Get the shortest path graph",
       "parameters": [
@@ -80,7 +80,7 @@
       },
       "responses": {
         "200": {
-          "description": "A graph of the shortest path from `start_node` to `end_node`.",
+          "description": "Returns graph data related to the cypher query sent in the response body that contains a collection of nodes and edges",
           "content": {
             "application/json": {
               "schema": {

--- a/cmd/api/src/model/unified_graph.go
+++ b/cmd/api/src/model/unified_graph.go
@@ -1,17 +1,17 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 package model
@@ -42,29 +42,36 @@ func NewUnifiedGraph() UnifiedGraph {
 
 // UnifiedNode represents a single node in a graph containing a minimal set of attributes for graph rendering
 type UnifiedNode struct {
-	Label      string    `json:"label"`
-	Kind       string    `json:"kind"`
-	ObjectId   string    `json:"objectId"`
-	IsTierZero bool      `json:"isTierZero"`
-	LastSeen   time.Time `json:"lastSeen"`
+	Label      string         `json:"label"`
+	Kind       string         `json:"kind"`
+	ObjectId   string         `json:"objectId"`
+	IsTierZero bool           `json:"isTierZero"`
+	LastSeen   time.Time      `json:"lastSeen"`
+	Properties map[string]any `json:"properties,omitempty"`
 }
 
 // UnifiedEdge represents a single path segment in a graph containing a minimal set of attributes for graph rendering
 type UnifiedEdge struct {
-	Source   string    `json:"source"`
-	Target   string    `json:"target"`
-	Label    string    `json:"label"`
-	Kind     string    `json:"kind"`
-	LastSeen time.Time `json:"lastSeen"`
+	Source     string         `json:"source"`
+	Target     string         `json:"target"`
+	Label      string         `json:"label"`
+	Kind       string         `json:"kind"`
+	LastSeen   time.Time      `json:"lastSeen"`
+	Properties map[string]any `json:"properties,omitempty"`
 }
 
-func FromDAWGSNode(node *graph.Node) UnifiedNode {
+func FromDAWGSNode(node *graph.Node, includeProperties bool) UnifiedNode {
 	var (
 		objectId   = getTypedPropertyOrDefault(node.Properties, common.ObjectID.String(), "")
 		label      = getTypedPropertyOrDefault(node.Properties, common.Name.String(), objectId)
 		systemTags = getTypedPropertyOrDefault(node.Properties, common.SystemTags.String(), "")
 		lastSeen   = getTypedPropertyOrDefault(node.Properties, common.LastSeen.String(), time.Now())
+		properties map[string]any
 	)
+
+	if includeProperties {
+		properties = node.Properties.Map
+	}
 
 	return UnifiedNode{
 		Label:      label,
@@ -72,37 +79,48 @@ func FromDAWGSNode(node *graph.Node) UnifiedNode {
 		ObjectId:   objectId,
 		IsTierZero: strings.Contains(systemTags, ad.AdminTierZero),
 		LastSeen:   lastSeen,
+		Properties: properties,
 	}
 }
 
-func FromDAWGSRelationship(rel *graph.Relationship) UnifiedEdge {
-	return UnifiedEdge{
-		Source:   rel.StartID.String(),
-		Target:   rel.EndID.String(),
-		Kind:     rel.Kind.String(),
-		Label:    rel.Kind.String(),
-		LastSeen: getTypedPropertyOrDefault(rel.Properties, common.LastSeen.String(), time.Now()),
+// This is being used with slices.Map so it is necessary to return a closure
+func FromDAWGSRelationship(includeProperties bool) func(*graph.Relationship) UnifiedEdge {
+	return func(rel *graph.Relationship) UnifiedEdge {
+		var properties map[string]any
+
+		if includeProperties {
+			properties = rel.Properties.Map
+		}
+
+		return UnifiedEdge{
+			Source:     rel.StartID.String(),
+			Target:     rel.EndID.String(),
+			Kind:       rel.Kind.String(),
+			Label:      rel.Kind.String(),
+			LastSeen:   getTypedPropertyOrDefault(rel.Properties, common.LastSeen.String(), time.Now()),
+			Properties: properties,
+		}
 	}
 }
 
-func (s *UnifiedGraph) AddRelationship(rel *graph.Relationship) {
-	formattedRelationship := FromDAWGSRelationship(rel)
+func (s *UnifiedGraph) AddRelationship(rel *graph.Relationship, includeProperties bool) {
+	formattedRelationship := FromDAWGSRelationship(includeProperties)(rel)
 	s.Edges = append(s.Edges, formattedRelationship)
 }
 
-func (s *UnifiedGraph) AddNode(node *graph.Node) {
-	formattedNode := FromDAWGSNode(node)
+func (s *UnifiedGraph) AddNode(node *graph.Node, includeProperties bool) {
+	formattedNode := FromDAWGSNode(node, includeProperties)
 	s.Nodes[node.ID.String()] = formattedNode
 }
 
-func (s *UnifiedGraph) AddPathSet(paths graph.PathSet) {
+func (s *UnifiedGraph) AddPathSet(paths graph.PathSet, includeProperties bool) {
 	for _, path := range paths.Paths() {
 		for _, node := range path.Nodes {
-			s.AddNode(node)
+			s.AddNode(node, includeProperties)
 		}
 
 		for _, edge := range path.Edges {
-			s.AddRelationship(edge)
+			s.AddRelationship(edge, includeProperties)
 		}
 	}
 }

--- a/cmd/api/src/queries/graph.go
+++ b/cmd/api/src/queries/graph.go
@@ -139,7 +139,7 @@ type Graph interface {
 	FetchNodesByObjectIDs(ctx context.Context, objectIDs ...string) (graph.NodeSet, error)
 	ValidateOUs(ctx context.Context, ous []string) ([]string, error)
 	BatchNodeUpdate(ctx context.Context, nodeUpdate graph.NodeUpdate) error
-	RawCypherSearch(ctx context.Context, rawCypher string) (model.UnifiedGraph, error)
+	RawCypherSearch(ctx context.Context, rawCypher string, includeProperties bool) (model.UnifiedGraph, error)
 }
 
 type GraphQuery struct {
@@ -390,7 +390,7 @@ func (s *GraphQuery) prepareGraphQuery(rawCypher string, disableCypherQC bool) (
 	return graphQuery, nil
 }
 
-func (s *GraphQuery) RawCypherSearch(ctx context.Context, rawCypher string) (model.UnifiedGraph, error) {
+func (s *GraphQuery) RawCypherSearch(ctx context.Context, rawCypher string, includeProperties bool) (model.UnifiedGraph, error) {
 	var (
 		graphResponse = model.NewUnifiedGraph()
 		bhCtxInst     = bhCtx.Get(ctx)
@@ -407,7 +407,7 @@ func (s *GraphQuery) RawCypherSearch(ctx context.Context, rawCypher string) (mod
 			if pathSet, err := ops.FetchPathSetByQuery(tx, preparedQuery.cypher); err != nil {
 				return err
 			} else {
-				graphResponse.AddPathSet(pathSet)
+				graphResponse.AddPathSet(pathSet, includeProperties)
 			}
 
 			return nil

--- a/cmd/api/src/queries/graph_test.go
+++ b/cmd/api/src/queries/graph_test.go
@@ -19,13 +19,14 @@ package queries_test
 import (
 	"context"
 	"fmt"
-	"github.com/specterops/bloodhound/src/auth"
-	bhCtx "github.com/specterops/bloodhound/src/ctx"
-	"github.com/specterops/bloodhound/src/test/must"
 	"net/http"
 	"net/url"
 	"testing"
 	"time"
+
+	"github.com/specterops/bloodhound/src/auth"
+	bhCtx "github.com/specterops/bloodhound/src/ctx"
+	"github.com/specterops/bloodhound/src/test/must"
 
 	"github.com/gorilla/mux"
 	"github.com/specterops/bloodhound/cache"
@@ -81,7 +82,7 @@ func TestGraphQuery_RawCypherSearch(t *testing.T) {
 		return nil
 	})
 
-	_, err := gq.RawCypherSearch(outerBHCtxInst.ConstructGoContext(), "match (n) return n;")
+	_, err := gq.RawCypherSearch(outerBHCtxInst.ConstructGoContext(), "match (n) return n;", false)
 	require.Nil(t, err)
 
 	// Validate that query complexity controls are working
@@ -104,14 +105,14 @@ func TestGraphQuery_RawCypherSearch(t *testing.T) {
 	outerBHCtxInst.Timeout.UserSet = false
 	outerBHCtxInst.Timeout.Value = time.Minute
 
-	_, err = gq.RawCypherSearch(outerBHCtxInst.ConstructGoContext(), "match ()-[:HasSession*..]->()-[:MemberOf*..]->() return n;")
+	_, err = gq.RawCypherSearch(outerBHCtxInst.ConstructGoContext(), "match ()-[:HasSession*..]->()-[:MemberOf*..]->() return n;", false)
 	require.Nil(t, err)
 
 	// Prove that overriding QC with a user-preference works
 	outerBHCtxInst.Timeout.UserSet = true
 	outerBHCtxInst.Timeout.Value = time.Second * 20
 
-	_, err = gq.RawCypherSearch(outerBHCtxInst.ConstructGoContext(), "match ()-[:HasSession*..]->()-[:MemberOf*..]->() return n;")
+	_, err = gq.RawCypherSearch(outerBHCtxInst.ConstructGoContext(), "match ()-[:HasSession*..]->()-[:MemberOf*..]->() return n;", false)
 	require.Nil(t, err)
 }
 

--- a/cmd/api/src/queries/mocks/graph.go
+++ b/cmd/api/src/queries/mocks/graph.go
@@ -217,18 +217,18 @@ func (mr *MockGraphMockRecorder) GetNodesByKind(arg0 interface{}, arg1 ...interf
 }
 
 // RawCypherSearch mocks base method.
-func (m *MockGraph) RawCypherSearch(arg0 context.Context, arg1 string) (model.UnifiedGraph, error) {
+func (m *MockGraph) RawCypherSearch(arg0 context.Context, arg1 string, arg2 bool) (model.UnifiedGraph, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RawCypherSearch", arg0, arg1)
+	ret := m.ctrl.Call(m, "RawCypherSearch", arg0, arg1, arg2)
 	ret0, _ := ret[0].(model.UnifiedGraph)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // RawCypherSearch indicates an expected call of RawCypherSearch.
-func (mr *MockGraphMockRecorder) RawCypherSearch(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockGraphMockRecorder) RawCypherSearch(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RawCypherSearch", reflect.TypeOf((*MockGraph)(nil).RawCypherSearch), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RawCypherSearch", reflect.TypeOf((*MockGraph)(nil).RawCypherSearch), arg0, arg1, arg2)
 }
 
 // SearchByNameOrObjectID mocks base method.

--- a/cmd/ui/src/components/GraphEdgeEvents.tsx
+++ b/cmd/ui/src/components/GraphEdgeEvents.tsx
@@ -54,8 +54,18 @@ const GraphEdgeEvents: FC = () => {
                     id: id,
                     name: selectedItem.label?.text || '',
                     data: selectedItem.data,
-                    sourceNode: graphState.chartProps.items?.[selectedItem.id1],
-                    targetNode: graphState.chartProps.items?.[selectedItem.id2],
+                    sourceNode: {
+                        name: graphState.chartProps.items?.[selectedItem.id1].data.name,
+                        id: selectedItem.id1,
+                        objectId: graphState.chartProps.items?.[selectedItem.id1].data.objectid,
+                        type: graphState.chartProps.items?.[selectedItem.id1].data.nodetype,
+                    },
+                    targetNode: {
+                        name: graphState.chartProps.items?.[selectedItem.id1].data.name,
+                        id: selectedItem.id1,
+                        objectId: graphState.chartProps.items?.[selectedItem.id1].data.objectid,
+                        type: graphState.chartProps.items?.[selectedItem.id1].data.nodetype,
+                    },
                 })
             );
         },

--- a/cmd/ui/src/components/GraphEdgeEvents.tsx
+++ b/cmd/ui/src/components/GraphEdgeEvents.tsx
@@ -61,10 +61,10 @@ const GraphEdgeEvents: FC = () => {
                         type: graphState.chartProps.items?.[selectedItem.id1].data.nodetype,
                     },
                     targetNode: {
-                        name: graphState.chartProps.items?.[selectedItem.id1].data.name,
-                        id: selectedItem.id1,
-                        objectId: graphState.chartProps.items?.[selectedItem.id1].data.objectid,
-                        type: graphState.chartProps.items?.[selectedItem.id1].data.nodetype,
+                        name: graphState.chartProps.items?.[selectedItem.id2].data.name,
+                        id: selectedItem.id2,
+                        objectId: graphState.chartProps.items?.[selectedItem.id2].data.objectid,
+                        type: graphState.chartProps.items?.[selectedItem.id2].data.nodetype,
                     },
                 })
             );

--- a/cmd/ui/src/utils.ts
+++ b/cmd/ui/src/utils.ts
@@ -182,6 +182,15 @@ export type EdgeParams = {
     forceLabel?: boolean;
 };
 
+const getEdgeLastSeenValue = (edge: any) => {
+    let lastSeen = undefined;
+
+    if (edge.lastSeen) lastSeen = edge.lastSeen;
+    if (edge.data && edge.data.lastSeen) lastSeen = edge.data.lastSeen;
+
+    return lastSeen;
+};
+
 export const transformFlatGraphResponse = (graph: FlatGraphResponse): GraphData => {
     const result: GraphData = {
         nodes: {},
@@ -206,7 +215,7 @@ export const transformFlatGraphResponse = (graph: FlatGraphResponse): GraphData 
                 target: edge.id2,
                 label: edge.label.text || '',
                 kind: edge.label.text || '',
-                lastSeen: edge.data ? edge.data.lastSeen : undefined,
+                lastSeen: getEdgeLastSeenValue(edge),
                 exploreGraphId: key || `${edge.id1}_${edge.label.text}_${edge.id2}`,
                 data: edge.data,
             });
@@ -238,6 +247,7 @@ export const transformToFlatGraphResponse = (graph: GraphResponse) => {
             label: {
                 text: edge.label,
             },
+            lastSeen: edge.lastSeen,
             data: edge.data,
         };
     }

--- a/cmd/ui/src/utils.ts
+++ b/cmd/ui/src/utils.ts
@@ -182,13 +182,14 @@ export type EdgeParams = {
     forceLabel?: boolean;
 };
 
-const getEdgeLastSeenValue = (edge: any) => {
-    let lastSeen = undefined;
+const getLastSeenValue = (object: any): string => {
+    if (object.lastSeen) return object.lastSeen;
+    if (object.data) {
+        if (object.data.lastSeen) return object.data.lastSeen;
+        if (object.data.lastseen) return object.data.lastseen;
+    }
 
-    if (edge.lastSeen) lastSeen = edge.lastSeen;
-    if (edge.data && edge.data.lastSeen) lastSeen = edge.data.lastSeen;
-
-    return lastSeen;
+    return '';
 };
 
 export const transformFlatGraphResponse = (graph: FlatGraphResponse): GraphData => {
@@ -200,24 +201,26 @@ export const transformFlatGraphResponse = (graph: FlatGraphResponse): GraphData 
     for (const [key, item] of Object.entries(graph)) {
         if (isNode(item)) {
             const node = item as StyledGraphNode;
+            const lastSeen = getLastSeenValue(node);
             result.nodes[key] = {
                 label: node.label.text || '',
                 kind: node.data.nodetype,
                 objectId: node.data.objectid,
                 isTierZero: !!(node.data.system_tags && node.data.system_tags.indexOf('admin_tier_0') !== -1),
-                lastSeen: node.data.lastSeen || undefined,
+                lastSeen: lastSeen,
             };
         } else if (isLink(item)) {
             const edge = item as StyledGraphEdge;
+            const lastSeen = getLastSeenValue(edge);
             result.edges.push({
                 impactPercent: edge.data ? edge.data.composite_risk_impact_percent : undefined,
                 source: edge.id1,
                 target: edge.id2,
                 label: edge.label.text || '',
                 kind: edge.label.text || '',
-                lastSeen: getEdgeLastSeenValue(edge),
+                lastSeen: lastSeen,
                 exploreGraphId: key || `${edge.id1}_${edge.label.text}_${edge.id2}`,
-                data: edge.data,
+                data: { ...edge.data, lastseen: lastSeen },
             });
         }
     }
@@ -228,6 +231,7 @@ export const transformFlatGraphResponse = (graph: FlatGraphResponse): GraphData 
 export const transformToFlatGraphResponse = (graph: GraphResponse) => {
     const result: any = {};
     for (const [key, value] of Object.entries(graph.data.nodes)) {
+        const lastSeen = getLastSeenValue(value);
         result[key] = {
             label: {
                 text: value.label,
@@ -237,18 +241,20 @@ export const transformToFlatGraphResponse = (graph: GraphResponse) => {
                 name: value.label,
                 objectid: value.objectId,
                 system_tags: value.isTierZero ? 'admin_tier_0' : undefined,
+                lastseen: lastSeen,
             },
         };
     }
     for (const edge of graph.data.edges) {
+        const lastSeen = getLastSeenValue(edge);
         result[`${edge.source}_${edge.kind}_${edge.target}`] = {
             id1: edge.source,
             id2: edge.target,
             label: {
                 text: edge.label,
             },
-            lastSeen: edge.lastSeen,
-            data: edge.data,
+            lastSeen: lastSeen,
+            data: { ...edge.data, lastseen: lastSeen },
         };
     }
     return result;

--- a/cmd/ui/src/views/Explore/EdgeInfo/EdgeInfoContent.test.tsx
+++ b/cmd/ui/src/views/Explore/EdgeInfo/EdgeInfoContent.test.tsx
@@ -24,8 +24,13 @@ describe('EdgeInfoContent', () => {
             id: '1',
             name: 'CustomEdge',
             data: { isACL: false },
-            sourceNode: { data: { name: 'source node' } },
-            targetNode: { data: { name: 'target node' } },
+            sourceNode: {
+                name: 'source node',
+                id: '1',
+                objectId: '1',
+                type: 'User',
+            },
+            targetNode: { name: 'target node', id: '2', objectId: '2', type: 'User' },
         };
 
         render(<EdgeInfoContent selectedEdge={selectedEdge} />);

--- a/cmd/ui/src/views/Explore/EdgeInfo/EdgeInfoContent.test.tsx
+++ b/cmd/ui/src/views/Explore/EdgeInfo/EdgeInfoContent.test.tsx
@@ -15,25 +15,58 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { SelectedEdge } from 'bh-shared-ui';
-import { render, screen } from 'src/test-utils';
 import EdgeInfoContent from 'src/views/Explore/EdgeInfo/EdgeInfoContent';
+import { rest } from 'msw';
+import { setupServer } from 'msw/node';
+import { render, screen } from 'src/test-utils';
+
+const server = setupServer(
+    rest.post(`/api/v2/graphs/cypher`, (req, res, ctx) => {
+        return res(
+            ctx.json({
+                data: {
+                    nodes: {},
+                    edges: [
+                        {
+                            source: '1',
+                            target: '2',
+                            label: 'CustomEdge',
+                            kind: 'CustomEdge',
+                            lastSeen: '2023-09-07T11:10:33.664596893Z',
+                            properties: {
+                                lastseen: '2023-09-07T11:10:33.664596893Z',
+                                isacl: false,
+                            },
+                        },
+                    ],
+                },
+            })
+        );
+    })
+);
+
+const selectedEdge: SelectedEdge = {
+    id: '1',
+    name: 'CustomEdge',
+    data: { isACL: false },
+    sourceNode: {
+        name: 'source node',
+        id: '1',
+        objectId: '1',
+        type: 'User',
+    },
+    targetNode: { name: 'target node', id: '2', objectId: '2', type: 'User' },
+};
+
+beforeAll(() => server.listen());
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
 
 describe('EdgeInfoContent', () => {
-    test('Trying to view the edge info does not crash the app when selecting an unrecognized edge', () => {
-        const selectedEdge: SelectedEdge = {
-            id: '1',
-            name: 'CustomEdge',
-            data: { isACL: false },
-            sourceNode: {
-                name: 'source node',
-                id: '1',
-                objectId: '1',
-                type: 'User',
-            },
-            targetNode: { name: 'target node', id: '2', objectId: '2', type: 'User' },
-        };
-
+    test('Trying to view the edge info does not crash the app when selecting an unrecognized edge', async () => {
         render(<EdgeInfoContent selectedEdge={selectedEdge} />);
+
+        expect(await screen.findByText(/source node/)).toBeInTheDocument();
 
         //The text is broken up into different elements because of the span that bolds the custom edge so these assertions are broken up to match that
         //The assertions use regex to avoid having to match on the white space
@@ -47,6 +80,7 @@ describe('EdgeInfoContent', () => {
         expect(screen.getByText(/Source Node:/)).toBeInTheDocument();
         expect(screen.getByText(/Target Node:/)).toBeInTheDocument();
         expect(screen.getByText(/Is ACL:/)).toBeInTheDocument();
+        expect(screen.getByText(/Last Collected by BloodHound:/)).toBeInTheDocument();
 
         //The whole app does not crash and require a refresh
         expect(

--- a/cmd/ui/src/views/Explore/EdgeInfo/EdgeInfoContent.tsx
+++ b/cmd/ui/src/views/Explore/EdgeInfo/EdgeInfoContent.tsx
@@ -40,12 +40,12 @@ const EdgeInfoContent: FC<{ selectedEdge: NonNullable<SelectedEdge> }> = ({ sele
                                 </Box>
                                 <EdgeInfoCollapsibleSection section={section[0] as keyof typeof EdgeSections}>
                                     <Section
-                                        sourceName={sourceNode.data.name}
-                                        sourceType={sourceNode.data.nodetype}
-                                        targetName={targetNode.data.name}
-                                        targetType={targetNode.data.nodetype}
-                                        targetId={targetNode.data.objectid}
-                                        haslaps={!!targetNode.data.haslaps}
+                                        sourceName={sourceNode.name}
+                                        sourceType={sourceNode.type}
+                                        targetName={targetNode.name}
+                                        targetType={targetNode.type}
+                                        targetId={targetNode.objectId}
+                                        haslaps={!!targetNode.haslaps}
                                     />
                                 </EdgeInfoCollapsibleSection>
                             </Fragment>

--- a/cmd/ui/src/views/Explore/EdgeInfo/EdgeObjectInformation.test.tsx
+++ b/cmd/ui/src/views/Explore/EdgeInfo/EdgeObjectInformation.test.tsx
@@ -1,0 +1,113 @@
+// Copyright 2023 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { SelectedEdge } from 'bh-shared-ui';
+import EdgeObjectInformation from 'src/views/Explore/EdgeInfo/EdgeObjectInformation';
+import { rest } from 'msw';
+import { setupServer } from 'msw/node';
+import { render, screen } from 'src/test-utils';
+
+const server = setupServer();
+
+const selectedEdge: SelectedEdge = {
+    id: '1',
+    name: 'DCSync',
+    data: { lastseen: '2023-09-07T11:10:33.664596893Z' },
+    sourceNode: {
+        name: 'source_node',
+        id: '1',
+        objectId: '1',
+        type: 'User',
+    },
+    targetNode: { name: 'target_node', id: '2', objectId: '2', type: 'User' },
+};
+
+beforeAll(() => server.listen());
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+describe('EdgeObjectInformation', () => {
+    test('The edge properties are fetched through a cypher search which includes lastseen', async () => {
+        server.use(
+            rest.post(`/api/v2/graphs/cypher`, (req, res, ctx) => {
+                return res(
+                    ctx.json({
+                        data: {
+                            nodes: {},
+                            edges: [
+                                {
+                                    source: '48297',
+                                    target: '1238',
+                                    label: 'DCSync',
+                                    kind: 'DCSync',
+                                    lastSeen: '2023-09-07T11:10:33.664596893Z',
+                                    properties: {
+                                        lastseen: '2023-09-07T11:10:33.664596893Z',
+                                        isacl: false,
+                                    },
+                                },
+                            ],
+                        },
+                    })
+                );
+            })
+        );
+
+        render(<EdgeObjectInformation selectedEdge={selectedEdge} />);
+
+        expect(await screen.findByText(/source_node/)).toBeInTheDocument();
+
+        //Display the information obtained from the cypher query for all edge properties
+        expect(screen.getByText(/Source Node:/)).toBeInTheDocument();
+        expect(screen.getByText(/source_node/)).toBeInTheDocument();
+        expect(screen.getByText(/Target Node:/)).toBeInTheDocument();
+        expect(screen.getByText(/target_node/)).toBeInTheDocument();
+        expect(screen.getByText(/Is ACL:/)).toBeInTheDocument();
+        expect(screen.getByText(/FALSE/)).toBeInTheDocument();
+        expect(screen.getByText(/Last Collected by BloodHound:/)).toBeInTheDocument();
+    });
+
+    test('Error handling for fetching edge information', async () => {
+        console.error = vi.fn();
+        server.use(
+            rest.get(`/api/v2/graphs/cypher`, (req, res, ctx) => {
+                return res(
+                    ctx.status(500),
+                    ctx.json({
+                        errorMessage: `Internal Server Error`,
+                    })
+                );
+            })
+        );
+
+        render(<EdgeObjectInformation selectedEdge={selectedEdge} />);
+
+        expect(await screen.findByText(/source_node/)).toBeInTheDocument();
+
+        //These fields are all obtainable from the original graph response information
+        //so if there is an error we can still display at least this information
+        expect(screen.getByText(/Source Node:/)).toBeInTheDocument();
+        expect(screen.getByText(/source_node/)).toBeInTheDocument();
+        expect(screen.getByText(/Target Node:/)).toBeInTheDocument();
+        expect(screen.getByText(/target_node/)).toBeInTheDocument();
+        expect(screen.getByText(/Last Collected by BloodHound:/)).toBeInTheDocument();
+
+        //These are extra fields that don't come with the graph response
+        //so if there is an error with the edge query they will not be displayed
+        expect(screen.queryByText(/Is ACL:/)).toBeNull();
+        expect(screen.queryByText(/FALSE/)).toBeNull();
+    });
+});

--- a/cmd/ui/src/views/Explore/EdgeInfo/EdgeObjectInformation.tsx
+++ b/cmd/ui/src/views/Explore/EdgeInfo/EdgeObjectInformation.tsx
@@ -14,7 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { Box, Skeleton, Typography } from '@mui/material';
+import { Skeleton } from '@mui/material';
 import { SelectedEdge, apiClient } from 'bh-shared-ui';
 import { FC } from 'react';
 import { useQuery } from 'react-query';
@@ -38,21 +38,13 @@ const EdgeObjectInformation: FC<{ selectedEdge: NonNullable<SelectedEdge> }> = (
                 { signal }
             )
             .then((result) => {
-                if (!result.data.data) return [];
+                if (!result.data.data) return { nodes: {}, edges: [] };
                 return result.data.data;
             });
     });
 
     if (isLoading) {
         return <Skeleton variant='rectangular' sx={{}} />;
-    }
-
-    if (isError) {
-        return (
-            <Box>
-                <Typography>Unable to fetch edge information</Typography>
-            </Box>
-        );
     }
 
     const sourceNodeField: EntityField = {
@@ -65,11 +57,19 @@ const EdgeObjectInformation: FC<{ selectedEdge: NonNullable<SelectedEdge> }> = (
         value: selectedEdge.targetNode.name,
     };
 
-    const formattedObjectFields: EntityField[] = [
-        sourceNodeField,
-        targetNodeField,
-        ...formatObjectInfoFields(cypherResponse.edges[0].properties || {}),
-    ];
+    let formattedObjectFields: EntityField[] = [sourceNodeField, targetNodeField];
+
+    if (isError) {
+        formattedObjectFields = [
+            ...formattedObjectFields,
+            ...formatObjectInfoFields({ lastseen: selectedEdge.data.lastseen }),
+        ];
+    } else {
+        formattedObjectFields = [
+            ...formattedObjectFields,
+            ...formatObjectInfoFields(cypherResponse.edges[0]?.properties || {}),
+        ];
+    }
 
     return (
         <EdgeInfoCollapsibleSection section={'data'}>

--- a/cmd/ui/src/views/Explore/EdgeInfo/EdgeObjectInformation.tsx
+++ b/cmd/ui/src/views/Explore/EdgeInfo/EdgeObjectInformation.tsx
@@ -14,27 +14,61 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { SelectedEdge } from 'bh-shared-ui';
+import { Box, Skeleton, Typography } from '@mui/material';
+import { SelectedEdge, apiClient } from 'bh-shared-ui';
 import { FC } from 'react';
+import { useQuery } from 'react-query';
 import EdgeInfoCollapsibleSection from 'src/views/Explore/EdgeInfo/EdgeInfoCollapsibleSection';
 import { EntityField, FieldsContainer, ObjectInfoFields } from 'src/views/Explore/fragments';
 import { formatObjectInfoFields } from 'src/views/Explore/utils';
 
+const selectedEdgeCypherQuery = (sourceId: string | number, targetId: string | number, edgeKind: string): string =>
+    `MATCH (s)-[r:${edgeKind}]-(t) WHERE ID(s) = ${sourceId} AND ID(t) = ${targetId} RETURN r LIMIT 1`;
+
 const EdgeObjectInformation: FC<{ selectedEdge: NonNullable<SelectedEdge> }> = ({ selectedEdge }) => {
+    const {
+        data: cypherResponse,
+        isLoading,
+        isError,
+    } = useQuery([selectedEdge.id], ({ signal }) => {
+        return apiClient
+            .cypherSearch(
+                selectedEdgeCypherQuery(selectedEdge.sourceNode.id, selectedEdge.targetNode.id, selectedEdge.name),
+                true,
+                { signal }
+            )
+            .then((result) => {
+                if (!result.data.data) return [];
+                return result.data.data;
+            });
+    });
+
+    if (isLoading) {
+        return <Skeleton variant='rectangular' sx={{}} />;
+    }
+
+    if (isError) {
+        return (
+            <Box>
+                <Typography>Unable to fetch edge information</Typography>
+            </Box>
+        );
+    }
+
     const sourceNodeField: EntityField = {
         label: 'Source Node:',
-        value: selectedEdge.sourceNode.data.name,
+        value: selectedEdge.sourceNode.name,
     };
 
     const targetNodeField: EntityField = {
         label: 'Target Node:',
-        value: selectedEdge.targetNode.data.name,
+        value: selectedEdge.targetNode.name,
     };
 
     const formattedObjectFields: EntityField[] = [
         sourceNodeField,
         targetNodeField,
-        ...formatObjectInfoFields(selectedEdge.data || {}),
+        ...formatObjectInfoFields(cypherResponse.edges[0].properties || {}),
     ];
 
     return (

--- a/cmd/ui/src/views/Explore/GraphView.tsx
+++ b/cmd/ui/src/views/Explore/GraphView.tsx
@@ -229,7 +229,7 @@ const GraphView: FC = () => {
 };
 
 const GridItems = () => {
-    const columnsDefault = { xs: 6, md: 5, lg: 4, xl: 4 };
+    const columnsDefault = { xs: 6, md: 5, lg: 4, xl: 3 };
     const cypherSearchColumns = { xs: 6, md: 6, lg: 6, xl: 4 };
 
     const [columns, setColumns] = useState(columnsDefault);
@@ -246,7 +246,7 @@ const GridItems = () => {
         <Grid item xs={xs} md={md} lg={lg} xl={xl} sx={{ height: '100%' }} key={'exploreSearch'}>
             <ExploreSearch handleColumns={handleCypherTab} />
         </Grid>,
-        <Grid item xs={6} md={5} lg={4} sx={{ height: '100%' }} key={'info'}>
+        <Grid item xs={6} md={5} lg={4} xl={3} sx={{ height: '100%' }} key={'info'}>
             {edgeInfoState.open ? <EdgeInfoPane selectedEdge={edgeInfoState.selectedEdge} /> : <EntityInfoPanel />}
         </Grid>,
     ];

--- a/cmd/ui/src/views/Explore/fragments.tsx
+++ b/cmd/ui/src/views/Explore/fragments.tsx
@@ -14,76 +14,17 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { Alert, Box, CircularProgress, Theme, Typography } from '@mui/material';
-import makeStyles from '@mui/styles/makeStyles';
+import { Alert, Box, CircularProgress, Typography } from '@mui/material';
+import { NodeIcon } from 'bh-shared-ui';
 import isEmpty from 'lodash/isEmpty';
 import React, { PropsWithChildren } from 'react';
-import { NodeIcon } from 'bh-shared-ui';
 import { TIER_ZERO_TAG } from 'src/constants';
 import { GraphNodeTypes } from 'src/ducks/graph/types';
 import { setSearchValue, startSearchSelected } from 'src/ducks/searchbar/actions';
 import { PRIMARY_SEARCH, SEARCH_TYPE_EXACT } from 'src/ducks/searchbar/types';
 import { useAppDispatch } from 'src/store';
 import { format } from 'src/utils';
-
-const useStyles = makeStyles((theme: Theme) => ({
-    accordionRoot: {
-        backgroundColor: 'inherit',
-        margin: 0,
-        '&.Mui-disabled': {
-            backgroundColor: 'inherit',
-        },
-        '&.Mui-expanded': {
-            margin: 0,
-        },
-    },
-    accordionSummary: {
-        padding: theme.spacing(0, 2),
-        margin: theme.spacing(0, -2),
-        '&:hover': {
-            backgroundColor: theme.palette.action.hover,
-        },
-    },
-    accordionDetails: {
-        padding: theme.spacing(1, 0),
-    },
-    accordionCount: {
-        display: 'flex',
-        justifyContent: 'center',
-        alignItems: 'center',
-        fontWeight: 'bold',
-        fontSize: '0.9rem',
-        backgroundColor: '#d7dee3',
-        minWidth: '3rem',
-        height: '1.6rem',
-        lineHeight: '1.6em',
-        paddingX: '0.5rem',
-        borderRadius: theme.shape.borderRadius,
-    },
-    title: {
-        marginLeft: theme.spacing(2),
-        lineHeight: '3em',
-        fontSize: theme.typography.fontSize,
-    },
-    fieldsContainer: {
-        borderRadius: theme.shape.borderRadius,
-        fontSize: '0.75rem',
-        '& > :nth-child(even)': {
-            backgroundColor: theme.palette.grey[200],
-        },
-    },
-    alertRoot: {
-        display: 'flex',
-        justifyContent: 'center',
-        padding: 0,
-        minWidth: '3rem',
-        borderRadius: theme.shape.borderRadius,
-    },
-    alertIcon: {
-        padding: '4px',
-        margin: 0,
-    },
-}));
+import useCollapsibleSectionStyles from 'src/views/Explore/InfoStyles/CollapsibleSection';
 
 const exclusionList = [
     'gid',
@@ -130,7 +71,7 @@ export const SubHeader: React.FC<{ label: string; count?: number; isLoading?: bo
     isLoading = false,
     isError = false,
 }) => {
-    const styles = useStyles();
+    const styles = useCollapsibleSectionStyles();
     return (
         <Box display='flex' justifyContent='space-between' alignItems='center' width='100%'>
             <Typography variant='h6' className={styles.title}>
@@ -156,7 +97,7 @@ export const SubHeader: React.FC<{ label: string; count?: number; isLoading?: bo
 };
 
 export const FieldsContainer: React.FC<PropsWithChildren> = ({ children }) => {
-    const styles = useStyles();
+    const styles = useCollapsibleSectionStyles();
     return <div className={styles.fieldsContainer}>{children}</div>;
 };
 

--- a/packages/go/slices/slices.go
+++ b/packages/go/slices/slices.go
@@ -1,17 +1,17 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 package slices
@@ -56,6 +56,25 @@ func Unique[T comparable](slice []T) []T {
 	for _, value := range slice {
 		if _, ok := existsMap[value]; !ok {
 			existsMap[value] = exists
+			out = append(out, value)
+		}
+	}
+
+	return out
+}
+
+// UniqueBy returns a new slice that is free of any duplicate values in the original
+func UniqueBy[T any, U comparable](slice []T, fn func(T) U) []T {
+	var (
+		exists    = struct{}{}
+		existsMap = map[U]struct{}{}
+		out       = make([]T, 0)
+	)
+
+	for _, value := range slice {
+		key := fn(value)
+		if _, ok := existsMap[key]; !ok {
+			existsMap[key] = exists
 			out = append(out, value)
 		}
 	}

--- a/packages/javascript/bh-shared-ui/src/components/Disable2FADialog/Disable2FADialog.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/Disable2FADialog/Disable2FADialog.test.tsx
@@ -59,7 +59,17 @@ describe('Enable2FADialog', () => {
     const testSetSecret = vi.fn();
 
     beforeEach(() => {
-        render(<Disable2FADialog open={true} onCancel={testOnCancel} onClose={testOnClose} onSave={testOnSave} secret='' setSecret={testSetSecret} contentText=''/>);
+        render(
+            <Disable2FADialog
+                open={true}
+                onCancel={testOnCancel}
+                onClose={testOnClose}
+                onSave={testOnSave}
+                secret=''
+                onSecretChange={testSetSecret}
+                contentText=''
+            />
+        );
     });
 
     it('should display "Disable Multi-Factor Authentication?" title', () => {

--- a/packages/javascript/bh-shared-ui/src/providers/NotificationProvider/reducer.ts
+++ b/packages/javascript/bh-shared-ui/src/providers/NotificationProvider/reducer.ts
@@ -18,7 +18,7 @@ import { ActionType, NotificationAction } from './actions';
 import { Notification } from './model';
 
 export const notificationsReducer = (state: Notification[], action: NotificationAction): Notification[] => {
-    if (action.type == ActionType.Add) {
+    if (action.type === ActionType.Add) {
         return [...state, action.value];
     } else if (action.type === ActionType.Dismiss) {
         return state.map((notification) => {

--- a/packages/javascript/bh-shared-ui/src/store/edgeinfo/edgeSlice.ts
+++ b/packages/javascript/bh-shared-ui/src/store/edgeinfo/edgeSlice.ts
@@ -26,8 +26,8 @@ export type SelectedEdge = {
     id: string;
     name: string;
     data: Record<string, any>;
-    sourceNode: Record<string, any>;
-    targetNode: Record<string, any>;
+    sourceNode: { name: string; id: string | number; objectId: string; type: string; haslaps?: boolean };
+    targetNode: { name: string; id: string | number; objectId: string; type: string; haslaps?: boolean };
 } | null;
 
 export type ExpandedEdgeSections = Record<keyof typeof EdgeSections, boolean>;

--- a/packages/javascript/js-client-library/src/client.ts
+++ b/packages/javascript/js-client-library/src/client.ts
@@ -53,8 +53,8 @@ class BHEAPIClient {
         );
     };
 
-    cypherSearch = (query: string, options?: types.RequestOptions) => {
-        return this.baseClient.post('/api/v2/graphs/cypher', { query }, options);
+    cypherSearch = (query: string, includeProperties?: boolean, options?: types.RequestOptions) => {
+        return this.baseClient.post('/api/v2/graphs/cypher', { query, include_properties: includeProperties }, options);
     };
 
     getAvailableDomains = (options?: types.RequestOptions) => this.baseClient.get('/api/v2/available-domains', options);


### PR DESCRIPTION
## Description
All of the edge information that is collected into BloodHound will now display in the Edge Info Pane under Relationship Information section when selecting an edge.

The changes here have enhanced the `api/v2/graphs/cypher/` endpoint to allow requesting full hydration of the properties for the nodes and edges returned from the results of the cypher query by passing a field in the JSON body for include_properties with a boolean value that defaults to false. This allows doing an internal cypher query for the selected edge's properties that are sure to be hydrated regardless of the data that was returned with the response for rendering the graph.
<!--- Describe your changes in detail -->

## Motivation and Context
Since there are various ways to initiate rendering a graph in the UI and because different ways route through different endpoints, not all of the graph responses were being handled correctly since they vary in format or amount of information returned depending on what endpoint is being used to get data for graph rendering. 

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
UI unit tests were updated. Saw full enumeration of properties in display in local env.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

![Screenshot 2023-09-07 at 12 16 30 PM](https://github.com/SpecterOps/BloodHound/assets/16910931/16a931c3-b33a-40f1-8f8d-7ce1c0fab641)

![Screenshot 2023-09-07 at 12 36 13 PM](https://github.com/SpecterOps/BloodHound/assets/16910931/5dfdf618-5507-42f4-a5b5-9764040187c4)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] Documentation updates are needed, and have been made accordingly.
-   [x] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
