### PR TITLE
draft: built in groups get filtered out 

### DIFF
--- a/cmd/api/src/queries/graph.go
+++ b/cmd/api/src/queries/graph.go
@@ -276,12 +276,15 @@ func searchNodeByKindAndEqualsName(kind graph.Kind, name string) graph.Criteria 
 			query.Equals(query.NodeProperty(common.Name.String()), name),
 			query.Equals(query.NodeProperty(common.ObjectID.String()), name),
 		),
-		query.Not(query.KindIn(query.Node(), ad.LocalGroup)),
+		query.Not(
+			query.And(
+				query.Kind(query.Node(), ad.LocalGroup),
+				query.Not(query.Kind(query.Node(), ad.Group)),
+			)),
 	)
 }
 
 func searchNodeByKindAndContainsName(kind graph.Kind, name string) graph.Criteria {
-
 	return query.And(
 		query.Kind(query.Node(), kind),
 		query.Or(
@@ -290,8 +293,11 @@ func searchNodeByKindAndContainsName(kind graph.Kind, name string) graph.Criteri
 		),
 		query.Not(query.Equals(query.NodeProperty(common.Name.String()), name)),
 		query.Not(query.Equals(query.NodeProperty(common.ObjectID.String()), name)),
-		query.Not(query.KindIn(query.Node(), ad.LocalGroup)),
-	)
+		query.Not(
+			query.And(
+				query.Kind(query.Node(), ad.LocalGroup),
+				query.Not(query.Kind(query.Node(), ad.Group)),
+			)))
 }
 
 func formatSearchResults(exactResults []model.SearchResult, fuzzyResults []model.SearchResult, limit, skip int) []model.SearchResult {

--- a/cmd/api/src/queries/graph.go
+++ b/cmd/api/src/queries/graph.go
@@ -269,6 +269,15 @@ func (s *GraphQuery) GetAllShortestPaths(ctx context.Context, startNodeID string
 	})
 }
 
+// the following negation clause matches nodes that have both ADLocalGroup and Group labels, but excludes nodes that only have the ADLocalGroup label.
+// equivalent cypher: MATCH (n) WHERE NOT (n:ADLocalGroup AND NOT n:Group)
+var groupFilter = query.Not(
+	query.And(
+		query.Kind(query.Node(), ad.LocalGroup),
+		query.Not(query.Kind(query.Node(), ad.Group)),
+	),
+)
+
 func searchNodeByKindAndEqualsName(kind graph.Kind, name string) graph.Criteria {
 	return query.And(
 		query.Kind(query.Node(), kind),
@@ -276,11 +285,7 @@ func searchNodeByKindAndEqualsName(kind graph.Kind, name string) graph.Criteria 
 			query.Equals(query.NodeProperty(common.Name.String()), name),
 			query.Equals(query.NodeProperty(common.ObjectID.String()), name),
 		),
-		query.Not(
-			query.And(
-				query.Kind(query.Node(), ad.LocalGroup),
-				query.Not(query.Kind(query.Node(), ad.Group)),
-			)),
+		groupFilter,
 	)
 }
 
@@ -293,11 +298,8 @@ func searchNodeByKindAndContainsName(kind graph.Kind, name string) graph.Criteri
 		),
 		query.Not(query.Equals(query.NodeProperty(common.Name.String()), name)),
 		query.Not(query.Equals(query.NodeProperty(common.ObjectID.String()), name)),
-		query.Not(
-			query.And(
-				query.Kind(query.Node(), ad.LocalGroup),
-				query.Not(query.Kind(query.Node(), ad.Group)),
-			)))
+		groupFilter,
+	)
 }
 
 func formatSearchResults(exactResults []model.SearchResult, fuzzyResults []model.SearchResult, limit, skip int) []model.SearchResult {

--- a/cmd/api/src/queries/graph_integration_test.go
+++ b/cmd/api/src/queries/graph_integration_test.go
@@ -129,7 +129,7 @@ func TestSearchNodesByName_GroupLocalGroupCorrect(t *testing.T) {
 			results, err := graphQuery.SearchNodesByName(context.Background(), graph.Kinds{azure.Entity, ad.Entity}, userWanted, skip, limit)
 
 			require.Nil(t, err)
-			require.Equal(t, 1, len(results), "ADLocalGroup nodes should return if they are also group nodes")
+			require.Equal(t, 1, len(results), ":ADLocalGroup nodes should return if they are also :Group nodes")
 
 			return nil
 		})

--- a/cmd/api/src/queries/graph_integration_test.go
+++ b/cmd/api/src/queries/graph_integration_test.go
@@ -1,17 +1,17 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build integration
@@ -24,18 +24,18 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/specterops/bloodhound/src/api"
-	"github.com/specterops/bloodhound/src/api/bloodhoundgraph"
-	"github.com/specterops/bloodhound/src/queries"
-	"github.com/specterops/bloodhound/src/test/integration"
-	"github.com/specterops/bloodhound/cache"
-	"github.com/stretchr/testify/require"
 	adAnalysis "github.com/specterops/bloodhound/analysis/ad"
+	"github.com/specterops/bloodhound/cache"
 	"github.com/specterops/bloodhound/dawgs/graph"
 	"github.com/specterops/bloodhound/dawgs/query"
 	"github.com/specterops/bloodhound/graphschema/ad"
 	"github.com/specterops/bloodhound/graphschema/azure"
 	"github.com/specterops/bloodhound/graphschema/common"
+	"github.com/specterops/bloodhound/src/api"
+	"github.com/specterops/bloodhound/src/api/bloodhoundgraph"
+	"github.com/specterops/bloodhound/src/queries"
+	"github.com/specterops/bloodhound/src/test/integration"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSearchNodesByName_ExactMatch(t *testing.T) {
@@ -106,6 +106,30 @@ func TestSearchNodesByName_NoADLocalGroup(t *testing.T) {
 
 			require.Nil(t, err)
 			require.Equal(t, 0, len(results), "No ADLocalGroup nodes should be returned ")
+
+			return nil
+		})
+}
+
+func TestSearchNodesByName_GroupLocalGroupCorrect(t *testing.T) {
+	testContext := integration.NewGraphTestContext(t)
+
+	testContext.DatabaseTestWithSetup(
+		func(harness *integration.HarnessDetails) {
+			harness.SearchHarness.Setup(testContext)
+		},
+		func(harness integration.HarnessDetails, db graph.Database) error {
+			var (
+				userWanted = "Account Op"
+				skip       = 0
+				limit      = 10
+				graphQuery = queries.NewGraphQuery(testContext.GraphDB, cache.Cache{}, 0, false)
+			)
+
+			results, err := graphQuery.SearchNodesByName(context.Background(), graph.Kinds{azure.Entity, ad.Entity}, userWanted, skip, limit)
+
+			require.Nil(t, err)
+			require.Equal(t, 1, len(results), "ADLocalGroup nodes should return if they are also group nodes")
 
 			return nil
 		})

--- a/cmd/api/src/test/integration/harnesses.go
+++ b/cmd/api/src/test/integration/harnesses.go
@@ -1074,7 +1074,9 @@ func (s *SearchHarness) Setup(graphTestContext *GraphTestContext) {
 	s.User3 = graphTestContext.NewActiveDirectoryUser("USER NUMBER THREE", graphTestContext.Harness.RootADHarness.ActiveDirectoryDomainSID)
 	s.User4 = graphTestContext.NewActiveDirectoryUser("USER NUMBER FOUR", graphTestContext.Harness.RootADHarness.ActiveDirectoryDomainSID)
 	s.User5 = graphTestContext.NewActiveDirectoryUser("USER NUMBER FIVE", graphTestContext.Harness.RootADHarness.ActiveDirectoryDomainSID)
+
 	s.LocalGroup = graphTestContext.NewActiveDirectoryLocalGroup("REMOTE DESKTOP USERS", graphTestContext.Harness.RootADHarness.ActiveDirectoryDomainSID)
+
 	s.GroupLocalGroup = graphTestContext.NewActiveDirectoryLocalGroup("ACCOUNT OPERATORS", graphTestContext.Harness.RootADHarness.ActiveDirectoryDomainSID)
 	s.GroupLocalGroup.AddKinds(ad.Group)
 	graphTestContext.UpdateNode(s.GroupLocalGroup)

--- a/cmd/api/src/test/integration/harnesses.go
+++ b/cmd/api/src/test/integration/harnesses.go
@@ -1,17 +1,17 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 package integration
@@ -1059,12 +1059,13 @@ func (s *AZInboundControlHarness) Setup(testCtx *GraphTestContext) {
 }
 
 type SearchHarness struct {
-	User1      *graph.Node
-	User2      *graph.Node
-	User3      *graph.Node
-	User4      *graph.Node
-	User5      *graph.Node
-	LocalGroup *graph.Node
+	User1           *graph.Node
+	User2           *graph.Node
+	User3           *graph.Node
+	User4           *graph.Node
+	User5           *graph.Node
+	LocalGroup      *graph.Node
+	GroupLocalGroup *graph.Node
 }
 
 func (s *SearchHarness) Setup(graphTestContext *GraphTestContext) {
@@ -1074,6 +1075,9 @@ func (s *SearchHarness) Setup(graphTestContext *GraphTestContext) {
 	s.User4 = graphTestContext.NewActiveDirectoryUser("USER NUMBER FOUR", graphTestContext.Harness.RootADHarness.ActiveDirectoryDomainSID)
 	s.User5 = graphTestContext.NewActiveDirectoryUser("USER NUMBER FIVE", graphTestContext.Harness.RootADHarness.ActiveDirectoryDomainSID)
 	s.LocalGroup = graphTestContext.NewActiveDirectoryLocalGroup("REMOTE DESKTOP USERS", graphTestContext.Harness.RootADHarness.ActiveDirectoryDomainSID)
+	s.GroupLocalGroup = graphTestContext.NewActiveDirectoryLocalGroup("ACCOUNT OPERATORS", graphTestContext.Harness.RootADHarness.ActiveDirectoryDomainSID)
+	s.GroupLocalGroup.AddKinds(ad.Group)
+	graphTestContext.UpdateNode(s.GroupLocalGroup)
 }
 
 type RootADHarness struct {

--- a/packages/go/cypher/frontend/format.go
+++ b/packages/go/cypher/frontend/format.go
@@ -493,11 +493,15 @@ func (s CypherEmitter) formatLiteral(output io.Writer, literal *model.Literal) e
 func (s CypherEmitter) WriteExpression(output io.Writer, expression model.Expression) error {
 	switch typedExpression := expression.(type) {
 	case *model.Negation:
-		if _, err := io.WriteString(output, "not "); err != nil {
+		if _, err := io.WriteString(output, "not ("); err != nil {
 			return err
 		}
 
 		if err := s.WriteExpression(output, typedExpression.Expression); err != nil {
+			return err
+		}
+
+		if _, err := io.WriteString(output, ")"); err != nil {
 			return err
 		}
 

--- a/packages/go/cypher/frontend/format.go
+++ b/packages/go/cypher/frontend/format.go
@@ -493,16 +493,25 @@ func (s CypherEmitter) formatLiteral(output io.Writer, literal *model.Literal) e
 func (s CypherEmitter) WriteExpression(output io.Writer, expression model.Expression) error {
 	switch typedExpression := expression.(type) {
 	case *model.Negation:
-		if _, err := io.WriteString(output, "not ("); err != nil {
+		if _, err := io.WriteString(output, "not "); err != nil {
 			return err
 		}
 
-		if err := s.WriteExpression(output, typedExpression.Expression); err != nil {
-			return err
-		}
-
-		if _, err := io.WriteString(output, ")"); err != nil {
-			return err
+		switch innerExpression := typedExpression.Expression.(type) {
+		case *model.Parenthetical:
+			if err := s.WriteExpression(output, innerExpression); err != nil {
+				return err
+			}
+		default:
+			if _, err := io.WriteString(output, "("); err != nil {
+				return err
+			}
+			if err := s.WriteExpression(output, innerExpression); err != nil {
+				return err
+			}
+			if _, err := io.WriteString(output, ")"); err != nil {
+				return err
+			}
 		}
 
 	case *model.IDInCollection:

--- a/packages/go/cypher/test/cases/positive_tests.json
+++ b/packages/go/cypher/test/cases/positive_tests.json
@@ -469,7 +469,7 @@
             "name": "Find nodes with no relationships",
             "type": "string_match",
             "details": {
-                "query": "match (b) where not (b)<-[]->() return b",
+                "query": "match (b) where not ((b)<-[]->()) return b",
                 "complexity": 11.0
             }
         },
@@ -854,7 +854,7 @@
             "name": "Find all shortest paths to workstations where Domain Users can RDP",
             "type": "string_match",
             "details": {
-                "query": "match p = allShortestPaths((g:Group {name: 'DOMAIN USERS@DOMAIN.PAIN'})-[:CanRDP]->(c:Computer)) where not c.operatingsystem contains 'Server' return p",
+                "query": "match p = allShortestPaths((g:Group {name: 'DOMAIN USERS@DOMAIN.PAIN'})-[:CanRDP]->(c:Computer)) where not (c.operatingsystem contains 'Server') return p",
                 "complexity": 4.0
             }
         },
@@ -862,7 +862,7 @@
             "name": "Find Workstations where Domain Users can RDP",
             "type": "string_match",
             "details": {
-                "query": "match p = (g:Group {name: 'DOMAIN USERS@DOMAIN.PAIN'})-[:CanRDP]->(c:Computer) where not c.operatingsystem contains 'Server' return p",
+                "query": "match p = (g:Group {name: 'DOMAIN USERS@DOMAIN.PAIN'})-[:CanRDP]->(c:Computer) where not (c.operatingsystem contains 'Server') return p",
                 "complexity": 2.0
             }
         },
@@ -886,7 +886,7 @@
             "name": "Find Domain Admins Logons to non-Domain Controllers",
             "type": "string_match",
             "details": {
-                "query": "match (dc)-[r:MemberOf*0..]->(g:Group) where g.objectid ends with '-516' with collect(dc) as exclude match p = (c:Computer)-[n:HasSession]->(u:User)-[r2:MemberOf*1..]->(g:Group) where g.objectid ends with '-512' and not c in exclude return p",
+                "query": "match (dc)-[r:MemberOf*0..]->(g:Group) where g.objectid ends with '-516' with collect(dc) as exclude match p = (c:Computer)-[n:HasSession]->(u:User)-[r2:MemberOf*1..]->(g:Group) where g.objectid ends with '-512' and not (c in exclude) return p",
                 "complexity": 17.0
             }
         },
@@ -974,7 +974,7 @@
             "name": "Shortest Paths to Unconstrained Delegation Systems",
             "type": "string_match",
             "details": {
-                "query": "match p = shortestPath((n)-[:HasSession|AdminTo|Contains|AZLogicAppContributor*1..]->(m:Computer {unconstraineddelegation: true})) where not n = m return p",
+                "query": "match p = shortestPath((n)-[:HasSession|AdminTo|Contains|AZLogicAppContributor*1..]->(m:Computer {unconstraineddelegation: true})) where not (n = m) return p",
                 "complexity": 9.0
             }
         },
@@ -982,7 +982,7 @@
             "name": "Shortest Paths from Kerberoastable Users",
             "type": "string_match",
             "details": {
-                "query": "match p = shortestPath((n)-[:HasSession|AdminTo|Contains|AZLogicAppContributor*1..]->(m:Computer {unconstraineddelegation: true})) where not n = m return p",
+                "query": "match p = shortestPath((n)-[:HasSession|AdminTo|Contains|AZLogicAppContributor*1..]->(m:Computer {unconstraineddelegation: true})) where not (n = m) return p",
                 "complexity": 9.0
             }
         },
@@ -1030,7 +1030,7 @@
             "name": "Find Shortest Paths to Domain Admins",
             "type": "string_match",
             "details": {
-                "query": "match p = shortestPath((n)-[:HasSession|AdminTo|Contains|AZLogicAppContributor*1..]->(m:Group {name: 'DOMAIN ADMINS@DOMAIN.PAIN'})) where not n = m return p",
+                "query": "match p = shortestPath((n)-[:HasSession|AdminTo|Contains|AZLogicAppContributor*1..]->(m:Group {name: 'DOMAIN ADMINS@DOMAIN.PAIN'})) where not (n = m) return p",
                 "complexity": 9.0
             }
         },

--- a/packages/go/dawgs/query/neo4j/neo4j_test.go
+++ b/packages/go/dawgs/query/neo4j/neo4j_test.go
@@ -1,17 +1,17 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 package neo4j_test
@@ -25,8 +25,8 @@ import (
 	"github.com/specterops/bloodhound/dawgs/query"
 	"github.com/specterops/bloodhound/dawgs/query/neo4j"
 
-	"github.com/stretchr/testify/require"
 	"github.com/specterops/bloodhound/dawgs/graph"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -495,7 +495,7 @@ func TestQueryBuilder_Render(t *testing.T) {
 		query.Returning(
 			query.Node(),
 		),
-	), "match (n) where not (n)<-[]->() return n"))
+	), "match (n) where not ((n)<-[]->()) return n"))
 
 	t.Run("Node Datetime Before", assertQueryResult(query.SinglePartQuery(
 		query.Where(
@@ -1015,7 +1015,7 @@ func TestQueryBuilder_Render(t *testing.T) {
 		query.Returning(
 			query.Count(query.Node()),
 		),
-	), "match (n) where (not n.system_tags contains $0 or n.system_tags is null) return count(n)"))
+	), "match (n) where (not (n.system_tags contains $0) or n.system_tags is null) return count(n)"))
 
 	t.Run("Is Not Null", assertQueryResult(query.SinglePartQuery(
 		query.Where(


### PR DESCRIPTION


## Description

<!--- Describe your changes in detail -->

some of the built in groups were not searchable from the explore page because of the way the dawgs query was written in `queries.SearchNodesByName()`.  The dawgs query had a filter that excluded any nodes with a label of `:Group`, but there are cases when we want to return nodes with the labels `:Group:ADLocalGroup`.  This PR updates the dawgs query to express this logic

the equivalent cypher we want to express in dawgs is:
```MATCH (n) WHERE NOT (n:ADLocalGroup AND NOT n:Group)```

this query will match nodes like `(n:AdLocalGroup:Group)` but WON'T match `(n:Group)`

i also updated the query formatter in the cypher frontend package to wrap negation clauses in parens.  

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

the test suite for the cypher parser has been updated so that test cases with negation clauses are now correctly wrapped in parens

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] My changes include a database migration.
