### PR TITLE
DO NOT MERGE add gorm constraint on asset_group_selectors

### DIFF
--- a/cmd/api/src/database/migration/gorm.go
+++ b/cmd/api/src/database/migration/gorm.go
@@ -68,10 +68,6 @@ func ListBHModels() []any {
 
 func (s *Migrator) gormAutoMigrate(models []any) error {
 	return s.db.Transaction(func(tx *gorm.DB) error {
-		if result := tx.Exec(`alter table if exists asset_group_selectors drop constraint if exists idx_asset_group_selectors_name;`); result.Error != nil {
-			return result.Error
-		}
-
 		for _, currentModel := range models {
 			if err := tx.Migrator().AutoMigrate(currentModel); err != nil {
 				return fmt.Errorf("failed to migrate model %T: %w", currentModel, err)

--- a/cmd/api/src/model/agi.go
+++ b/cmd/api/src/model/agi.go
@@ -24,7 +24,7 @@ import (
 
 type AssetGroupSelector struct {
 	AssetGroupID   int32  `json:"asset_group_id"`
-	Name           string `json:"name"`
+	Name           string `json:"name" gorm:"unique"`
 	Selector       string `json:"selector"`
 	SystemSelector bool   `json:"system_selector"`
 


### PR DESCRIPTION
## Description
MERGE AFTER https://github.com/SpecterOps/BloodHound/pull/90 IS RELEASED
This adds a uniqueness constraint on the `name` column in `AssetGroupSelectors` through GORM. This will be essential for newly spun up environments since these will not run the manual migrations created in https://github.com/SpecterOps/BloodHound/pull/90

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] My changes include a database migration.
