### PR TITLE
fix for extra scrollbar in current search results

### DIFF
--- a/packages/javascript/bh-shared-ui/src/components/SearchCurrentNodes/SearchCurrentNodes.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/SearchCurrentNodes/SearchCurrentNodes.tsx
@@ -62,7 +62,7 @@ const SearchCurrentNodes: FC<{
     useEffect(() => {
         const resultsHeight = LIST_ITEM_HEIGHT * items.length;
         if (resultsHeight > MAX_CONTAINER_HEIGHT) {
-            setVirtualizationHeight(400);
+            setVirtualizationHeight(MAX_CONTAINER_HEIGHT - 10);
         } else {
             setVirtualizationHeight(resultsHeight);
         }
@@ -97,7 +97,7 @@ const SearchCurrentNodes: FC<{
 
     const Row = ({ index, style }: any) => {
         return (
-            <Box style={style}>
+            <Box style={style} overflow={"hidden"}>
                 <SearchResultItem
                     item={items[index]}
                     index={index}


### PR DESCRIPTION
## Description
- Under some conditions, two vertical scroll bars are visible in the results display for the new current search feature. This PR adjusts the height of our virtualization window to prevent the unintended overflow.

## Motivation and Context
- This is a quick fix for an issue caused by [https://github.com/SpecterOps/BloodHound/pull/61](https://github.com/SpecterOps/BloodHound/pull/61)

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes
-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
