### PR TITLE
Env fixes and docs

### DIFF
--- a/cmd/api/src/config/config_test.go
+++ b/cmd/api/src/config/config_test.go
@@ -1,17 +1,17 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 package config_test
@@ -51,21 +51,6 @@ func TestSetValuesFromEnv(t *testing.T) {
 	assert.Equal(t, "https://example.com/?q=query_test", cfg.RootURL.String())
 	assert.Equal(t, "0.0.0.0", cfg.BindAddress)
 	assert.Equal(t, uint32(10), cfg.Crypto.Argon2.MemoryKibibytes)
-}
-
-func TestWritableConfiguration_SetValue(t *testing.T) {
-	var cfg config.Configuration
-
-	assert.Nil(t, config.SetValue(&cfg, "bind_addr", "0.0.0.0"))
-	assert.Equal(t, "0.0.0.0", cfg.BindAddress)
-
-	assert.Nil(t, config.SetValue(&cfg, "crypto_argon2_memory_kibibytes", "10"))
-	assert.Equal(t, uint32(10), cfg.Crypto.Argon2.MemoryKibibytes)
-
-	assert.NotNil(t, config.SetValue(&cfg, "crypto_argon2_memory_kibibytes", "string"))
-	assert.Nil(t, config.SetValue(&cfg, "crypto_fake", "string"))
-	assert.NotNil(t, config.SetValue(&cfg, "", "string"))
-	assert.NotNil(t, config.SetValue(cfg, "", "string"))
 }
 
 func TestDatabaseConfiguration(t *testing.T) {

--- a/cmd/api/src/config/reflect.go
+++ b/cmd/api/src/config/reflect.go
@@ -262,9 +262,8 @@ func SetValue(target any, path, value string) error {
 		found := false
 		for _, taggedField := range taggedFields {
 			taggedFieldName := taggedField.Tag.Name()
-			taggedFieldCompName := strings.Replace(taggedFieldName, "_", "", -1)
 
-			if taggedFieldCompName == nextPathPart {
+			if taggedFieldName == nextPathPart {
 				cursor = cursor.Field(taggedField.Field)
 				found = true
 				break
@@ -273,7 +272,7 @@ func SetValue(target any, path, value string) error {
 			if idx+1 < len(pathParts) {
 				remainingFullPath := strings.Join(append([]string{nextPathPart}, pathParts[idx+1:]...), "_")
 
-				if taggedFieldCompName == remainingFullPath {
+				if taggedFieldName == remainingFullPath {
 					cursor = cursor.Field(taggedField.Field)
 
 					if !cursor.CanAddr() {

--- a/cmd/api/src/config/reflect.go
+++ b/cmd/api/src/config/reflect.go
@@ -1,17 +1,17 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 package config
@@ -24,8 +24,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/specterops/bloodhound/src/serde"
 	"github.com/specterops/bloodhound/log"
+	"github.com/specterops/bloodhound/src/serde"
 )
 
 var structTagRegex = regexp.MustCompile(`(\w+):"([^"]+)"`)
@@ -262,8 +262,9 @@ func SetValue(target any, path, value string) error {
 		found := false
 		for _, taggedField := range taggedFields {
 			taggedFieldName := taggedField.Tag.Name()
+			taggedFieldCompName := strings.Replace(taggedFieldName, "_", "", -1)
 
-			if taggedFieldName == nextPathPart {
+			if taggedFieldCompName == nextPathPart {
 				cursor = cursor.Field(taggedField.Field)
 				found = true
 				break
@@ -272,7 +273,7 @@ func SetValue(target any, path, value string) error {
 			if idx+1 < len(pathParts) {
 				remainingFullPath := strings.Join(append([]string{nextPathPart}, pathParts[idx+1:]...), "_")
 
-				if taggedFieldName == remainingFullPath {
+				if taggedFieldCompName == remainingFullPath {
 					cursor = cursor.Field(taggedField.Field)
 
 					if !cursor.CanAddr() {

--- a/cmd/api/src/config/reflect_test.go
+++ b/cmd/api/src/config/reflect_test.go
@@ -1,0 +1,37 @@
+package config_test
+
+import (
+	"testing"
+
+	"github.com/specterops/bloodhound/src/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSetValue(t *testing.T) {
+	var cfg config.Configuration
+
+	t.Run("basic top level key with underscore", func(t *testing.T) {
+		assert.Nil(t, config.SetValue(&cfg, "bind_addr", "0.0.0.0"))
+		assert.Equal(t, "0.0.0.0", cfg.BindAddress)
+	})
+
+	t.Run("two level path with underscore in both keys", func(t *testing.T) {
+		assert.Nil(t, config.SetValue(&cfg, "default_admin_expire_now", "true"))
+		assert.Equal(t, true, cfg.DefaultAdmin.ExpireNow)
+	})
+
+	t.Run("three level path with underscore in bottom key", func(t *testing.T) {
+		assert.Nil(t, config.SetValue(&cfg, "crypto_argon2_memory_kibibytes", "10"))
+		assert.Equal(t, uint32(10), cfg.Crypto.Argon2.MemoryKibibytes)
+	})
+
+	t.Run("attempting to set a value to an unknown field should not fail", func(t *testing.T) {
+		assert.Nil(t, config.SetValue(&cfg, "crypto_fake", "string"))
+	})
+
+	t.Run("edge cases", func(t *testing.T) {
+		assert.NotNil(t, config.SetValue(&cfg, "crypto_argon2_memory_kibibytes", "string"))
+		assert.NotNil(t, config.SetValue(&cfg, "", "string"))
+		assert.NotNil(t, config.SetValue(cfg, "", "string"))
+	})
+}


### PR DESCRIPTION
## Description

- Fix a problem with configuration values with underscores when provided as environment variables.
- Document our environment variables and how to use them to provide sensitive properties instead of putting those properties in the `bloodhound.config.json`.

## Motivation and Context

https://github.com/SpecterOps/BloodHound/issues/9

While we have always supported configuring BHCE through environment variables, there is a distinct lack of documentation. Furthermore, while preparing the documentation, a bug was found in how we parse our environment variables that prevented a few of them from actually working. This PR seeks to resolve both gaps.

## How Has This Been Tested?

- Manually tested by adding various environment variables to our dev docker compose and ensuring they worked properly
- Added a new regression test case for the patched environment variable parsing bug

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] Documentation updates are needed, and have been made accordingly.
-   [x] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
