### PR TITLE
chore: add skip to TestSizeOfProperties as it is too flakey

### DIFF
--- a/packages/go/dawgs/graph/properties_test.go
+++ b/packages/go/dawgs/graph/properties_test.go
@@ -1,17 +1,17 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 package graph_test
@@ -20,8 +20,8 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/stretchr/testify/require"
 	"github.com/specterops/bloodhound/dawgs/graph"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewProperties(t *testing.T) {
@@ -64,6 +64,7 @@ func TestNewProperties(t *testing.T) {
 }
 
 func TestSizeOfProperties(t *testing.T) {
+	t.Skip("Skipping SizeOf due to flake")
 	properties := graph.NewProperties()
 
 	require.Equal(t, 24, int(properties.SizeOf()))


### PR DESCRIPTION
## Description

Skips the TestSizeOfProperties test since the size determination in DAWGS is best effort and not guaranteed to be 100% accurate.

## Motivation and Context

Tests have been failing more frequently due to this test flapping, and it's causing too much noise.

## How Has This Been Tested?

Attempted to run test locally and got the appropriate skip message

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
