### PR TITLE
fix: optionally add accepted param to request instead of defaulting t…

### DIFF
--- a/packages/javascript/js-client-library/src/client.ts
+++ b/packages/javascript/js-client-library/src/client.ts
@@ -407,21 +407,25 @@ class BHEAPIClient {
         limit: number,
         filterAccepted?: boolean,
         options?: types.RequestOptions
-    ) =>
-        this.baseClient.get(
+    ) => {
+        const params: types.RiskDetailsRequest = {
+            finding: finding,
+            skip: skip,
+            limit: limit,
+        };
+
+        if (typeof filterAccepted === 'boolean') params.Accepted = `eq:${filterAccepted}`;
+
+        return this.baseClient.get(
             `/api/v2/domains/${domainId}/details`,
             Object.assign(
                 {
-                    params: {
-                        finding,
-                        skip,
-                        limit,
-                        Accepted: `eq:${filterAccepted ? filterAccepted : false}`,
-                    },
+                    params: params,
                 },
                 options
             )
         );
+    };
 
     getRiskSparklineValues = (
         domainId: string,

--- a/packages/javascript/js-client-library/src/types.ts
+++ b/packages/javascript/js-client-library/src/types.ts
@@ -148,6 +148,13 @@ export type PostureRequest = {
     sort_by?: string;
 };
 
+export type RiskDetailsRequest = {
+    finding: string;
+    skip: number;
+    limit: number;
+    Accepted?: string;
+};
+
 export type GraphNode = {
     label: string;
     kind: string;


### PR DESCRIPTION
## Description
Changes the sent request parameters to be optionally added to the risk details endpoint.
<!--- Describe your changes in detail -->

## Motivation and Context
Fixes a bug in bhe.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
