### PR TITLE
fix: handle special characters in highlightedtext component for explo…

### DIFF
--- a/packages/javascript/bh-shared-ui/src/components/HighlightedText/HighlightedText.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HighlightedText/HighlightedText.test.tsx
@@ -46,8 +46,16 @@ describe('HighlightedText', () => {
     });
 
     it('should render when search string matches text entirely', () => {
-        render(<HighlightedText text='test string' search='test string' />);
+        render(<HighlightedText text='test string' search='test string' />).debug();
         expect(screen.getByText(/test string/)).toBeInTheDocument();
         expect(screen.getByText(/test string/)).toHaveAttribute('style', 'font-weight: bold;');
+    });
+
+    it('should handle special characters', () => {
+        render(<HighlightedText text='(TESTLAB.LOCAL)+SOME@TEXT$![-[\]{}()*+?' search='CAL)+SOME@TEXT$!' />);
+        expect(screen.getByText(/\(TESTLAB\.LO/)).toBeInTheDocument();
+        expect(screen.getByText(/CAL\)\+SOME@TEXT\$!/)).toBeInTheDocument();
+        expect(screen.getByText(/\[\-\[\\\]\{\}\(\)\*\+\?/)).toBeInTheDocument();
+        expect(screen.getByText(/CAL\)\+SOME@TEXT\$!/)).toHaveAttribute('style', 'font-weight: bold;');
     });
 });

--- a/packages/javascript/bh-shared-ui/src/components/HighlightedText/HighlightedText.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HighlightedText/HighlightedText.test.tsx
@@ -46,7 +46,7 @@ describe('HighlightedText', () => {
     });
 
     it('should render when search string matches text entirely', () => {
-        render(<HighlightedText text='test string' search='test string' />).debug();
+        render(<HighlightedText text='test string' search='test string' />);
         expect(screen.getByText(/test string/)).toBeInTheDocument();
         expect(screen.getByText(/test string/)).toHaveAttribute('style', 'font-weight: bold;');
     });

--- a/packages/javascript/bh-shared-ui/src/components/HighlightedText/HighlightedText.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HighlightedText/HighlightedText.tsx
@@ -15,26 +15,30 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';
+import { Typography } from '@mui/material';
+
+const escapeSpecialCharacters = (text: string) => text.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&');
 
 const HighlightedText: React.FC<{ text: string; search: string }> = ({ text, search }) => {
-    const regex = new RegExp(`(.*?)(${search})(.*)`, 'mi');
+    const escapedSearch = escapeSpecialCharacters(search);
+    const regex = new RegExp(`(.*?)(${escapedSearch})(.*)`, 'mi');
     const groups = text.match(regex);
     if (groups === null || groups.length === 1) return <>{text}</>;
 
     const parts = groups.slice(1);
 
     return (
-        <span>
+        <Typography variant='body2' component={'span'}>
             {parts.map((part, i) => {
                 if (part.toLowerCase() === search.toLowerCase())
                     return (
-                        <span key={i} style={{ fontWeight: 'bold' }}>
+                        <Typography variant='body2' component={'span'} style={{ fontWeight: 'bold' }} key={i}>
                             {part}
-                        </span>
+                        </Typography>
                     );
                 return <React.Fragment key={i}>{part}</React.Fragment>;
             })}
-        </span>
+        </Typography>
     );
 };
 


### PR DESCRIPTION
## Description
Special character escaping is now done in the logic for the highlightedtext component.
<!--- Describe your changes in detail -->

## Motivation and Context
Typing a special character into search input in the explore page would result in an unhandled error related to trying to use regex to match and highlight the keyword search within the results. Some nodes contain special characters so it is important to handle this.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
A unit test was added to the highlighted text component and the fix was tried locally.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [x] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
