### PR TITLE
Improve Cypher queries for foreign groups and users

### DIFF
--- a/packages/javascript/bh-shared-ui/src/commonSearches.tsx
+++ b/packages/javascript/bh-shared-ui/src/commonSearches.tsx
@@ -61,11 +61,11 @@ export const CommonSearches = [
             },
             {
                 description: 'Users with foreign domain group membership',
-                cypher: `MATCH p=(n:User)-[:MemberOf]->(m:Group)\nWHERE m.domain<>n.domain\nRETURN p`,
+                cypher: `MATCH p=(n:User)-[:MemberOf]->(m:Group)\nWHERE m.domainsid<>n.domainsid\nRETURN p`,
             },
             {
                 description: 'Groups with foreign domain group membership',
-                cypher: `MATCH p=(n:Group)-[:MemberOf]->(m:Group)\nWHERE m.domain<>n.domain AND n.name<>m.name\nRETURN p`,
+                cypher: `MATCH p=(n:Group)-[:MemberOf]->(m:Group)\nWHERE m.domainsid<>n.domainsid AND n.name<>m.name\nRETURN p`,
             },
             {
                 description: 'Computers where Domain Users are local administrators',


### PR DESCRIPTION
Update "Users" and "Groups with foreign domain group membership" Cypher queries to more accurately specify "domainsid" instead of "domain" in the WHERE clause. This resolves an issue where returned results incorrectly included non-foreign domain groups or users

## Description

`Groups with foreign domain group membership` and `Users with foreign domain group membership` can incorrectly return results that include domain local objects.

## Motivation and Context

This changes the queries to specify `domainsid` rather than `domain`.

## How Has This Been Tested?

Tested in a BHCE dev environment and BHE environments.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ X ] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] My changes include a database migration.
