### PR TITLE
fix: use root path instead of relative path for img src

### DIFF
--- a/cmd/ui/src/components/Header.tsx
+++ b/cmd/ui/src/components/Header.tsx
@@ -124,7 +124,7 @@ const Header: React.FC = () => {
                 <Box height='100%' paddingY='6px' boxSizing='border-box'>
                     <Link component={RouterLink} to={routes.ROUTE_HOME} data-testid='global_header_nav-home'>
                         <img
-                            src={'img/logo-transparent-banner.svg'}
+                            src={'/img/logo-transparent-banner.svg'}
                             alt='BloodHound CE Home'
                             style={{
                                 height: '100%',

--- a/cmd/ui/src/components/LoginPage.tsx
+++ b/cmd/ui/src/components/LoginPage.tsx
@@ -28,7 +28,7 @@ const LoginPage: React.FC<LoginPageProps> = ({ children }) => {
                     <Paper sx={{ px: 8, pb: 8, pt: 4 }}>
                         <Box height='100%' width='auto' textAlign='center' boxSizing='content-box' padding='64px'>
                             <img
-                                src={'img/logo-transparent-full.svg'}
+                                src={'/img/logo-transparent-full.svg'}
                                 alt='BloodHound'
                                 style={{
                                     width: '100%',

--- a/cmd/ui/src/views/Explore/ExploreSearch/CypherInput.tsx
+++ b/cmd/ui/src/views/Explore/ExploreSearch/CypherInput.tsx
@@ -191,7 +191,7 @@ const CypherInput = () => {
                 /*What is graphed will never die*/ toggle && (
                     <div style={{ display: 'block', position: 'relative', bottom: 0, left: 0 }}>
                         <img
-                            src={'img/logo-animated.gif'}
+                            src={'/img/logo-animated.gif'}
                             alt='What is graphed will never die'
                             style={{ width: '200px' }}
                         />


### PR DESCRIPTION
## Description
This changeset updates img src url's to use the root path.
<!--- Describe your changes in detail -->

## Motivation and Context
The `src` attribute for some `img` tags were using a relative path instead of the root path which would point to the wrong location when moving to different pages, most notably pages within the administration page. 

Here is some documentation related to these resources that are held in the public folder:

https://vitejs.dev/guide/assets.html#the-public-directory
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
The cache was cleared and the outbound request was inspected to check that the image was pulling from the correct location.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
