### PR TITLE
obey user_updatable for flag toggling

### DIFF
--- a/cmd/api/src/api/v2/flag.go
+++ b/cmd/api/src/api/v2/flag.go
@@ -1,28 +1,29 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 package v2
 
 import (
+	"fmt"
 	"net/http"
 	"strconv"
 
+	"github.com/gorilla/mux"
 	"github.com/specterops/bloodhound/src/api"
 	"github.com/specterops/bloodhound/src/model/appcfg"
-	"github.com/gorilla/mux"
 )
 
 type ListFlagsResponse struct {
@@ -48,6 +49,8 @@ func (s Resources) ToggleFlag(response http.ResponseWriter, request *http.Reques
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, api.ErrorResponseDetailsIDMalformed, request), response)
 	} else if featureFlag, err := s.DB.GetFlag(int32(featureID)); err != nil {
 		api.HandleDatabaseError(request, response, err)
+	} else if !featureFlag.UserUpdatable {
+		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusForbidden, fmt.Sprintf("Feature flag %s(%d) is not user updatable.", featureFlag.Key, featureID), request), response)
 	} else {
 		featureFlag.Enabled = !featureFlag.Enabled
 

--- a/cmd/api/src/api/v2/flag_test.go
+++ b/cmd/api/src/api/v2/flag_test.go
@@ -1,17 +1,17 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 package v2_test
@@ -22,12 +22,12 @@ import (
 
 	"go.uber.org/mock/gomock"
 
+	"github.com/specterops/bloodhound/errors"
 	"github.com/specterops/bloodhound/src/api"
 	v2 "github.com/specterops/bloodhound/src/api/v2"
 	"github.com/specterops/bloodhound/src/database/mocks"
 	"github.com/specterops/bloodhound/src/model/appcfg"
 	"github.com/specterops/bloodhound/src/utils/test"
-	"github.com/specterops/bloodhound/errors"
 )
 
 func TestResources_GetFlags(t *testing.T) {
@@ -72,16 +72,22 @@ func TestResources_ToggleFlag(t *testing.T) {
 		mockDB       = mocks.NewMockDatabase(mockCtrl)
 		resources    = v2.Resources{DB: mockDB}
 		requestSetup = test.Request(t).
-			WithMethod(http.MethodGet).
-			WithURL("/api/v2/features/%s/toggle", featureIDStr).
-			WithURLPathVars(map[string]string{api.URIPathVariableFeatureID: featureIDStr}).
-			OnHandlerFunc(resources.ToggleFlag)
+				WithMethod(http.MethodGet).
+				WithURL("/api/v2/features/%s/toggle", featureIDStr).
+				WithURLPathVars(map[string]string{api.URIPathVariableFeatureID: featureIDStr}).
+				OnHandlerFunc(resources.ToggleFlag)
 	)
 
 	defer mockCtrl.Finish()
 
 	mockDB.EXPECT().GetFlag(featureID).Return(appcfg.FeatureFlag{
 		UserUpdatable: false,
+	}, nil)
+
+	requestSetup.Require().ResponseStatusCode(http.StatusForbidden)
+
+	mockDB.EXPECT().GetFlag(featureID).Return(appcfg.FeatureFlag{
+		UserUpdatable: true,
 	}, nil)
 	mockDB.EXPECT().SetFlag(gomock.Any()).Return(nil)
 


### PR DESCRIPTION
## Description

Flags that are not user-updatable are currently still able to get updated through the toggle flags endpoint. This code changes that to obey said field.

## How Has This Been Tested?
Added unit test case

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [x] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
