### PR TITLE
Update unsupported OS cypher query to include Server 2012

### DIFF
--- a/packages/javascript/bh-shared-ui/src/commonSearches.tsx
+++ b/packages/javascript/bh-shared-ui/src/commonSearches.tsx
@@ -61,11 +61,11 @@ export const CommonSearches = [
             },
             {
                 description: 'Users with foreign domain group membership',
-                cypher: `MATCH p=(n:User)-[:MemberOf]->(m:Group)\nWHERE m.domain<>n.domain\nRETURN p`,
+                cypher: `MATCH p=(n:User)-[:MemberOf]->(m:Group)\nWHERE m.domainsid<>n.domainsid\nRETURN p`,
             },
             {
                 description: 'Groups with foreign domain group membership',
-                cypher: `MATCH p=(n:Group)-[:MemberOf]->(m:Group)\nWHERE m.domain<>n.domain AND n.name<>m.name\nRETURN p`,
+                cypher: `MATCH p=(n:Group)-[:MemberOf]->(m:Group)\nWHERE m.domainsid<>n.domainsid AND n.name<>m.name\nRETURN p`,
             },
             {
                 description: 'Computers where Domain Users are local administrators',

--- a/packages/javascript/bh-shared-ui/src/commonSearches.tsx
+++ b/packages/javascript/bh-shared-ui/src/commonSearches.tsx
@@ -43,7 +43,7 @@ export const CommonSearches = [
             },
             {
                 description: 'Computers with unsupported operating systems',
-                cypher: `MATCH (n:Computer)\nWHERE n.operatingsystem =~ "(?i).*(2000|2003|2008|xp|vista|7|me).*"\nRETURN n`,
+                cypher: `MATCH (n:Computer)\nWHERE n.operatingsystem =~ "(?i).*(2000|2003|2008|2012|xp|vista|7|me).*"\nRETURN n`,
             },
             {
                 description: 'Locations of high value/Tier Zero objects',


### PR DESCRIPTION
## Description

Adds Server 2012 to list of unsupported operating systems cypher query.

## Motivation and Context

Server 2012 is EOL.

## How Has This Been Tested?

Tested query in dev environment.

## Screenshots (if appropriate):

n/a

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ X ] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] My changes include a database migration.
