### PR TITLE
Better hygiene on asset group members endpoint

### DIFF
--- a/cmd/api/src/api/v2/agi.go
+++ b/cmd/api/src/api/v2/agi.go
@@ -441,7 +441,7 @@ func parseAGMembersFromNodes(nodes graph.NodeSet, selectors model.AssetGroupSele
 
 		if node.Kinds.ContainsOneOf(azure.Entity) {
 			if tenantID, err := node.Properties.Get(azure.TenantID.String()).String(); err != nil {
-				log.Warnf("%s is missing for node %d, skipping AG Membership...", azure.Tenant.String(), node.ID)
+				log.Warnf("%s is missing for node %d, skipping AG Membership...", azure.TenantID.String(), node.ID)
 				continue
 			} else {
 				agMember.EnvironmentKind = azure.Tenant.String()

--- a/cmd/api/src/api/v2/agi.go
+++ b/cmd/api/src/api/v2/agi.go
@@ -1,17 +1,17 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 package v2
@@ -23,10 +23,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/specterops/bloodhound/src/api"
-	"github.com/specterops/bloodhound/src/ctx"
-	"github.com/specterops/bloodhound/src/model"
-	"github.com/specterops/bloodhound/src/utils"
 	"github.com/gorilla/mux"
 	"github.com/specterops/bloodhound/analysis"
 	"github.com/specterops/bloodhound/dawgs/graph"
@@ -34,7 +30,12 @@ import (
 	"github.com/specterops/bloodhound/graphschema/azure"
 	"github.com/specterops/bloodhound/graphschema/common"
 	"github.com/specterops/bloodhound/headers"
+	"github.com/specterops/bloodhound/log"
 	"github.com/specterops/bloodhound/slices"
+	"github.com/specterops/bloodhound/src/api"
+	"github.com/specterops/bloodhound/src/ctx"
+	"github.com/specterops/bloodhound/src/model"
+	"github.com/specterops/bloodhound/src/utils"
 )
 
 // CreateAssetGroupRequest holds data required to create an asset group
@@ -403,27 +404,52 @@ func parseAGMembersFromNodes(nodes graph.NodeSet, selectors model.AssetGroupSele
 		isCustomMember := false
 		// a member is custom if at least one selector exists for that object ID
 		for _, agSelector := range selectors {
-			if agSelector.Selector == node.Properties.Map[common.ObjectID.String()].(string) {
+			if objectId, ok := node.Properties.Map[common.ObjectID.String()].(string); !ok {
+				log.Warnf("objectid is missing for node %d", node.ID)
+			} else if agSelector.Selector == objectId {
 				isCustomMember = true
 			}
 		}
 
+		var (
+			memberObjectId string
+			memberName     string
+		)
+
+		if objectId, ok := node.Properties.Map[common.ObjectID.String()].(string); ok {
+			memberObjectId = objectId
+		} else {
+			log.Warnf("objectid is missing for node %d", node.ID)
+			memberObjectId = ""
+		}
+
+		if name, ok := node.Properties.Map[common.Name.String()].(string); !ok {
+			memberName = name
+		} else {
+			log.Warnf("name is missing for node %d", node.ID)
+			memberName = ""
+		}
+
 		agMember := api.AssetGroupMember{
 			AssetGroupID: assetGroupID,
-			ObjectID:     node.Properties.Map[common.ObjectID.String()].(string),
+			ObjectID:     memberObjectId,
 			PrimaryKind:  analysis.GetNodeKindDisplayLabel(node),
 			Kinds:        node.Kinds.Strings(),
-			Name:         node.Properties.Map[common.Name.String()].(string),
+			Name:         memberName,
 			CustomMember: isCustomMember,
 		}
 
 		if tenantID := node.Properties.Map[azure.TenantID.String()]; tenantID != nil {
 			agMember.EnvironmentID = tenantID.(string)
 			agMember.EnvironmentKind = azure.Tenant.String()
+		} else if domainSID, ok := node.Properties.Map[ad.DomainSID.String()].(string); !ok {
+			log.Warnf("domainsid is missing for node %d", node.ID)
+			domainSID = ""
 		} else {
-			agMember.EnvironmentID = node.Properties.Map[ad.DomainSID.String()].(string)
+			agMember.EnvironmentID = domainSID
 			agMember.EnvironmentKind = ad.Domain.String()
 		}
+
 		agMembers = append(agMembers, agMember)
 	}
 	return agMembers

--- a/cmd/api/src/api/v2/agi.go
+++ b/cmd/api/src/api/v2/agi.go
@@ -404,7 +404,7 @@ func parseAGMembersFromNodes(nodes graph.NodeSet, selectors model.AssetGroupSele
 		isCustomMember := false
 		// a member is custom if at least one selector exists for that object ID
 		for _, agSelector := range selectors {
-			if objectId, ok := node.Properties.Map[common.ObjectID.String()].(string); !ok {
+			if objectId, err := node.Properties.Get(common.ObjectID.String()).String(); err != nil {
 				log.Warnf("objectid is missing for node %d", node.ID)
 			} else if agSelector.Selector == objectId {
 				isCustomMember = true
@@ -416,14 +416,14 @@ func parseAGMembersFromNodes(nodes graph.NodeSet, selectors model.AssetGroupSele
 			memberName     string
 		)
 
-		if objectId, ok := node.Properties.Map[common.ObjectID.String()].(string); !ok {
+		if objectId, err := node.Properties.Get(common.ObjectID.String()).String(); err != nil {
 			log.Warnf("objectid is missing for node %d", node.ID)
 			memberObjectId = ""
 		} else {
 			memberObjectId = objectId
 		}
 
-		if name, ok := node.Properties.Map[common.Name.String()].(string); !ok {
+		if name, err := node.Properties.Get(common.Name.String()).String(); err != nil {
 			log.Warnf("name is missing for node %d", node.ID)
 			memberName = ""
 		} else {
@@ -439,10 +439,10 @@ func parseAGMembersFromNodes(nodes graph.NodeSet, selectors model.AssetGroupSele
 			CustomMember: isCustomMember,
 		}
 
-		if tenantID := node.Properties.Map[azure.TenantID.String()]; tenantID != nil {
-			agMember.EnvironmentID = tenantID.(string)
+		if tenantID, err := node.Properties.Get(azure.TenantID.String()).String(); err == nil {
+			agMember.EnvironmentID = tenantID
 			agMember.EnvironmentKind = azure.Tenant.String()
-		} else if domainSID, ok := node.Properties.Map[ad.DomainSID.String()].(string); !ok {
+		} else if domainSID, err := node.Properties.Get(ad.DomainSID.String()).String(); err != nil {
 			log.Warnf("domainsid is missing for node %d", node.ID)
 			domainSID = ""
 		} else {

--- a/cmd/api/src/api/v2/agi.go
+++ b/cmd/api/src/api/v2/agi.go
@@ -456,7 +456,7 @@ func parseAGMembersFromNodes(nodes graph.NodeSet, selectors model.AssetGroupSele
 				agMember.EnvironmentID = domainSID
 			}
 		} else {
-			log.Warnf("Node %d is missing valid base entity, skipping AG Membership...")
+			log.Warnf("Node %d is missing valid base entity, skipping AG Membership...", node.ID)
 			continue
 		}
 

--- a/cmd/api/src/api/v2/agi.go
+++ b/cmd/api/src/api/v2/agi.go
@@ -416,18 +416,18 @@ func parseAGMembersFromNodes(nodes graph.NodeSet, selectors model.AssetGroupSele
 			memberName     string
 		)
 
-		if objectId, ok := node.Properties.Map[common.ObjectID.String()].(string); ok {
-			memberObjectId = objectId
-		} else {
+		if objectId, ok := node.Properties.Map[common.ObjectID.String()].(string); !ok {
 			log.Warnf("objectid is missing for node %d", node.ID)
 			memberObjectId = ""
+		} else {
+			memberObjectId = objectId
 		}
 
 		if name, ok := node.Properties.Map[common.Name.String()].(string); !ok {
-			memberName = name
-		} else {
 			log.Warnf("name is missing for node %d", node.ID)
 			memberName = ""
+		} else {
+			memberName = name
 		}
 
 		agMember := api.AssetGroupMember{

--- a/cmd/api/src/api/v2/agi_internal_test.go
+++ b/cmd/api/src/api/v2/agi_internal_test.go
@@ -1,17 +1,17 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 package v2
@@ -20,13 +20,13 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/specterops/bloodhound/src/api"
-	"github.com/specterops/bloodhound/src/model"
-	"github.com/stretchr/testify/require"
 	"github.com/specterops/bloodhound/dawgs/graph"
 	"github.com/specterops/bloodhound/graphschema/ad"
 	"github.com/specterops/bloodhound/graphschema/azure"
 	"github.com/specterops/bloodhound/graphschema/common"
+	"github.com/specterops/bloodhound/src/api"
+	"github.com/specterops/bloodhound/src/model"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetLatestQueryParameter_LatestMalformed(t *testing.T) {
@@ -96,4 +96,32 @@ func TestParseAGMembersFromNodes_(t *testing.T) {
 
 	require.Equal(t, customMembersExpected, customMembersFound)
 	require.Equal(t, azureNodesExpected, azureNodesFound)
+}
+
+func TestParseAGMembersFromNodes_MissingNodeProperties(t *testing.T) {
+	nodes := graph.NodeSet{
+		// the parse fn should handle a node with nil values for name, objectid, and domainsid
+		1: &graph.Node{
+			ID:    1,
+			Kinds: graph.Kinds{ad.Domain},
+			Properties: &graph.Properties{
+				Map: map[string]any{},
+			},
+		},
+	}
+
+	members := parseAGMembersFromNodes(nodes,
+		model.AssetGroupSelectors{model.AssetGroupSelector{
+			AssetGroupID:   1,
+			Name:           "a",
+			Selector:       "a",
+			SystemSelector: false,
+		}}, 1)
+
+	require.Equal(t, 1, len(members))
+
+	require.Equal(t, members[0].EnvironmentID, "")
+	require.Equal(t, members[0].ObjectID, "")
+	require.Equal(t, members[0].Name, "")
+
 }

--- a/cmd/api/src/api/v2/agi_internal_test.go
+++ b/cmd/api/src/api/v2/agi_internal_test.go
@@ -55,21 +55,21 @@ func TestParseAGMembersFromNodes_(t *testing.T) {
 	nodes := graph.NodeSet{
 		1: &graph.Node{
 			ID:    1,
-			Kinds: graph.Kinds{ad.Domain},
+			Kinds: graph.Kinds{ad.Entity, ad.Domain},
 			Properties: &graph.Properties{
 				Map: map[string]any{common.ObjectID.String(): "a", common.Name.String(): "a", ad.DomainSID.String(): "a"},
 			},
 		},
 		2: &graph.Node{
 			ID:    2,
-			Kinds: graph.Kinds{azure.Tenant},
+			Kinds: graph.Kinds{azure.Entity, azure.Tenant},
 			Properties: &graph.Properties{
 				Map: map[string]any{common.ObjectID.String(): "b", common.Name.String(): "b", azure.TenantID.String(): "b"},
 			},
 		},
 		3: &graph.Node{
 			ID:    3,
-			Kinds: graph.Kinds{ad.Domain},
+			Kinds: graph.Kinds{ad.Entity, ad.Domain},
 			Properties: &graph.Properties{
 				Map: map[string]any{common.ObjectID.String(): "c", common.Name.String(): "c", ad.DomainSID.String(): "c"},
 			},
@@ -103,7 +103,7 @@ func TestParseAGMembersFromNodes_MissingNodeProperties(t *testing.T) {
 		// the parse fn should handle a node with nil values for name, objectid, and domainsid
 		1: &graph.Node{
 			ID:    1,
-			Kinds: graph.Kinds{ad.Domain},
+			Kinds: graph.Kinds{ad.Entity, ad.Domain},
 			Properties: &graph.Properties{
 				Map: map[string]any{},
 			},

--- a/cmd/api/src/api/v2/agi_internal_test.go
+++ b/cmd/api/src/api/v2/agi_internal_test.go
@@ -100,10 +100,17 @@ func TestParseAGMembersFromNodes_(t *testing.T) {
 
 func TestParseAGMembersFromNodes_MissingNodeProperties(t *testing.T) {
 	nodes := graph.NodeSet{
-		// the parse fn should handle a node with nil values for name, objectid, and domainsid
+		// the parse fn should handle nodes with missing name and missing properties with warnings and no output
 		1: &graph.Node{
 			ID:    1,
 			Kinds: graph.Kinds{ad.Entity, ad.Domain},
+			Properties: &graph.Properties{
+				Map: map[string]any{},
+			},
+		},
+		2: &graph.Node{
+			ID:    2,
+			Kinds: graph.Kinds{azure.Entity, azure.Tenant},
 			Properties: &graph.Properties{
 				Map: map[string]any{},
 			},
@@ -118,10 +125,5 @@ func TestParseAGMembersFromNodes_MissingNodeProperties(t *testing.T) {
 			SystemSelector: false,
 		}}, 1)
 
-	require.Equal(t, 1, len(members))
-
-	require.Equal(t, members[0].EnvironmentID, "")
-	require.Equal(t, members[0].ObjectID, "")
-	require.Equal(t, members[0].Name, "")
-
+	require.Equal(t, 0, len(members))
 }

--- a/cmd/api/src/api/v2/agi_test.go
+++ b/cmd/api/src/api/v2/agi_test.go
@@ -1,17 +1,17 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 package v2_test
@@ -24,6 +24,11 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/gorilla/mux"
+	"github.com/specterops/bloodhound/dawgs/graph"
+	"github.com/specterops/bloodhound/errors"
+	"github.com/specterops/bloodhound/graphschema/ad"
+	"github.com/specterops/bloodhound/graphschema/common"
 	"github.com/specterops/bloodhound/src/api"
 	v2 "github.com/specterops/bloodhound/src/api/v2"
 	"github.com/specterops/bloodhound/src/api/v2/apitest"
@@ -32,13 +37,8 @@ import (
 	"github.com/specterops/bloodhound/src/model"
 	queriesMocks "github.com/specterops/bloodhound/src/queries/mocks"
 	"github.com/specterops/bloodhound/src/utils/test"
-	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
-	"github.com/specterops/bloodhound/dawgs/graph"
-	"github.com/specterops/bloodhound/errors"
-	"github.com/specterops/bloodhound/graphschema/ad"
-	"github.com/specterops/bloodhound/graphschema/common"
 )
 
 func TestCreateAssetGroupRequest_AuditData(t *testing.T) {
@@ -897,14 +897,14 @@ func TestResources_ListAssetGroupMembers(t *testing.T) {
 						Return(graph.NodeSet{
 							1: &graph.Node{
 								ID:    1,
-								Kinds: graph.Kinds{ad.Domain},
+								Kinds: graph.Kinds{ad.Entity, ad.Domain},
 								Properties: &graph.Properties{
 									Map: map[string]any{common.ObjectID.String(): "a", common.Name.String(): "a", ad.DomainSID.String(): "a"},
 								},
 							},
 							2: &graph.Node{
 								ID:    2,
-								Kinds: graph.Kinds{ad.Domain},
+								Kinds: graph.Kinds{ad.Entity, ad.Domain},
 								Properties: &graph.Properties{
 									Map: map[string]any{common.ObjectID.String(): "b", common.Name.String(): "b", ad.DomainSID.String(): "b"},
 								},
@@ -974,21 +974,21 @@ func TestResources_ListAssetGroupMembers(t *testing.T) {
 						Return(graph.NodeSet{
 							1: &graph.Node{
 								ID:    1,
-								Kinds: graph.Kinds{ad.Domain},
+								Kinds: graph.Kinds{ad.Entity, ad.Domain},
 								Properties: &graph.Properties{
 									Map: map[string]any{common.ObjectID.String(): "a", common.Name.String(): "a", ad.DomainSID.String(): "a"},
 								},
 							},
 							2: &graph.Node{
 								ID:    2,
-								Kinds: graph.Kinds{ad.Domain},
+								Kinds: graph.Kinds{ad.Entity, ad.Domain},
 								Properties: &graph.Properties{
 									Map: map[string]any{common.ObjectID.String(): "b", common.Name.String(): "b", ad.DomainSID.String(): "b"},
 								},
 							},
 							3: &graph.Node{
 								ID:    3,
-								Kinds: graph.Kinds{ad.Domain},
+								Kinds: graph.Kinds{ad.Entity, ad.Domain},
 								Properties: &graph.Properties{
 									Map: map[string]any{common.ObjectID.String(): "c", common.Name.String(): "c", ad.DomainSID.String(): "c"},
 								},
@@ -1017,14 +1017,14 @@ func TestResources_ListAssetGroupMembers(t *testing.T) {
 						Return(graph.NodeSet{
 							1: &graph.Node{
 								ID:    1,
-								Kinds: graph.Kinds{ad.Domain},
+								Kinds: graph.Kinds{ad.Entity, ad.Domain},
 								Properties: &graph.Properties{
 									Map: map[string]any{common.ObjectID.String(): "a", common.Name.String(): "a", ad.DomainSID.String(): "a"},
 								},
 							},
 							2: &graph.Node{
 								ID:    2,
-								Kinds: graph.Kinds{ad.Domain},
+								Kinds: graph.Kinds{ad.Entity, ad.Domain},
 								Properties: &graph.Properties{
 									Map: map[string]any{common.ObjectID.String(): "b", common.Name.String(): "b", ad.DomainSID.String(): "b"},
 								},
@@ -1052,14 +1052,14 @@ func TestResources_ListAssetGroupMembers(t *testing.T) {
 						Return(graph.NodeSet{
 							1: &graph.Node{
 								ID:    1,
-								Kinds: graph.Kinds{ad.Domain},
+								Kinds: graph.Kinds{ad.Entity, ad.Domain},
 								Properties: &graph.Properties{
 									Map: map[string]any{common.ObjectID.String(): "a", common.Name.String(): "a", ad.DomainSID.String(): "a"},
 								},
 							},
 							2: &graph.Node{
 								ID:    2,
-								Kinds: graph.Kinds{ad.Domain},
+								Kinds: graph.Kinds{ad.Entity, ad.Domain},
 								Properties: &graph.Properties{
 									Map: map[string]any{common.ObjectID.String(): "b", common.Name.String(): "b", ad.DomainSID.String(): "b"},
 								},


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

The /api/v2/asset-groups/:assetGroupId/members endpoint was returning an empty response in some environments due to a panic caused by type conversions of the form 

`somevar := someval.(string)` .  

The offending type conversions in the `GetAssetGroupNodes` function are covered by this PR

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [x] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
