### PR TITLE
Add "Update Asset Group Selectors" endpoint

### DIFF
--- a/cmd/api/src/api/agi_test.go
+++ b/cmd/api/src/api/agi_test.go
@@ -1,29 +1,44 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 package api_test
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
-	"github.com/specterops/bloodhound/src/api"
-	"github.com/specterops/bloodhound/src/model"
-	"github.com/stretchr/testify/require"
+	"github.com/gorilla/mux"
 	"github.com/specterops/bloodhound/graphschema/ad"
 	"github.com/specterops/bloodhound/graphschema/azure"
+	"github.com/specterops/bloodhound/headers"
+	"github.com/specterops/bloodhound/mediatypes"
+	"github.com/specterops/bloodhound/src/api"
+	v2 "github.com/specterops/bloodhound/src/api/v2"
+	"github.com/specterops/bloodhound/src/auth"
+	"github.com/specterops/bloodhound/src/ctx"
+	datapipeMocks "github.com/specterops/bloodhound/src/daemons/datapipe/mocks"
+	dbMocks "github.com/specterops/bloodhound/src/database/mocks"
+	"github.com/specterops/bloodhound/src/model"
+	"github.com/specterops/bloodhound/src/test/must"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 )
 
 func TestAssetGroupMembers_SortBy(t *testing.T) {
@@ -380,4 +395,151 @@ func TestAssetGroupMembers_BuildFilteringConditional_Error(t *testing.T) {
 	_, err = input.BuildFilteringConditional("asset_group_id", model.Equals, "abcd")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), api.ErrorResponseDetailsBadQueryParameterFilters)
+}
+
+func TestResources_UpdateAssetGroupSelectors_GetAssetGroupError(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	payload := []model.AssetGroupSelectorSpec{
+		{
+			SelectorName:   "test",
+			EntityObjectID: "1",
+		},
+	}
+
+	req, err := http.NewRequest("POST", "/api/v2/asset-groups/1/selectors", must.MarshalJSONReader(payload))
+	require.Nil(t, err)
+
+	req.Header.Set(headers.ContentType.String(), mediatypes.ApplicationJson.String())
+	req = mux.SetURLVars(req, map[string]string{api.URIPathVariableAssetGroupID: "1"})
+
+	mockDB := dbMocks.NewMockDatabase(mockCtrl)
+	mockDB.EXPECT().GetAssetGroup(gomock.Any()).Return(model.AssetGroup{}, fmt.Errorf("test error"))
+	handlers := v2.Resources{DB: mockDB}
+
+	response := httptest.NewRecorder()
+	handler := http.HandlerFunc(handlers.UpdateAssetGroupSelectors)
+
+	handler.ServeHTTP(response, req)
+	require.Equal(t, http.StatusInternalServerError, response.Code)
+	require.Contains(t, response.Body.String(), api.ErrorResponseDetailsInternalServerError)
+}
+
+func TestResources_UpdateAssetGroupSelectors_PayloadError(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	payload := "INVALID PAYLOAD"
+
+	req, err := http.NewRequest("POST", "/api/v2/asset-groups/1/selectors", must.MarshalJSONReader(payload))
+	require.Nil(t, err)
+
+	req.Header.Set(headers.ContentType.String(), mediatypes.ApplicationJson.String())
+	req = mux.SetURLVars(req, map[string]string{api.URIPathVariableAssetGroupID: "1"})
+
+	assetGroup := model.AssetGroup{
+		Name:        "test group",
+		Tag:         "test tag",
+		SystemGroup: false,
+	}
+
+	mockDB := dbMocks.NewMockDatabase(mockCtrl)
+	mockDB.EXPECT().GetAssetGroup(gomock.Any()).Return(assetGroup, nil)
+	handlers := v2.Resources{DB: mockDB}
+
+	response := httptest.NewRecorder()
+	handler := http.HandlerFunc(handlers.UpdateAssetGroupSelectors)
+
+	handler.ServeHTTP(response, req)
+	require.Equal(t, http.StatusBadRequest, response.Code)
+	require.Contains(t, response.Body.String(), api.ErrorResponsePayloadUnmarshalError)
+}
+
+func TestResources_UpdateAssetGroupSelectors_Success(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	payload := []model.AssetGroupSelectorSpec{
+		{
+			SelectorName:   "test",
+			EntityObjectID: "1",
+			Action:         model.SelectorSpecActionAdd,
+		},
+		{
+			SelectorName:   "test2",
+			EntityObjectID: "2",
+			Action:         model.SelectorSpecActionRemove,
+		},
+	}
+
+	req, err := http.NewRequest("POST", "/api/v2/asset-groups/1/selectors", must.MarshalJSONReader(payload))
+	require.Nil(t, err)
+
+	req.Header.Set(headers.ContentType.String(), mediatypes.ApplicationJson.String())
+
+	bheCtx := ctx.Context{
+		RequestID: "requestID",
+		AuthCtx: auth.Context{
+			Owner:   model.User{},
+			Session: model.UserSession{},
+		},
+	}
+	req = req.WithContext(context.WithValue(context.Background(), ctx.ValueKey, bheCtx.WithRequestID("requestID")))
+	req = mux.SetURLVars(req, map[string]string{api.URIPathVariableAssetGroupID: "1"})
+
+	assetGroup := model.AssetGroup{
+		Name:        "test group",
+		Tag:         "test tag",
+		SystemGroup: false,
+	}
+
+	expectedResult := map[string]model.AssetGroupSelectors{
+		"added_selectors": {
+			model.AssetGroupSelector{
+				AssetGroupID: assetGroup.ID,
+				Name:         payload[0].SelectorName,
+				Selector:     payload[0].EntityObjectID,
+			},
+		},
+		"removed_selectors": {
+			model.AssetGroupSelector{
+				AssetGroupID: assetGroup.ID,
+				Name:         payload[1].SelectorName,
+				Selector:     payload[1].EntityObjectID,
+			},
+		},
+	}
+
+	mockDB := dbMocks.NewMockDatabase(mockCtrl)
+	mockDB.EXPECT().GetAssetGroup(gomock.Any()).Return(assetGroup, nil)
+	mockDB.EXPECT().UpdateAssetGroupSelectors(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(expectedResult, nil)
+
+	mockTasker := datapipeMocks.NewMockTasker(mockCtrl)
+	mockTasker.EXPECT().RequestAnalysis()
+
+	handlers := v2.Resources{
+		DB:           mockDB,
+		TaskNotifier: mockTasker,
+	}
+
+	response := httptest.NewRecorder()
+	handler := http.HandlerFunc(handlers.UpdateAssetGroupSelectors)
+
+	handler.ServeHTTP(response, req)
+	require.Equal(t, http.StatusOK, response.Code)
+
+	resp := api.ResponseWrapper{}
+	err = json.Unmarshal(response.Body.Bytes(), &resp)
+	require.Nil(t, err)
+
+	dataJSON, err := json.Marshal(resp.Data)
+	require.Nil(t, err)
+
+	data := make(map[string][]model.AssetGroupSelector, 0)
+	err = json.Unmarshal(dataJSON, &data)
+	require.Nil(t, err)
+
+	require.Equal(t, expectedResult["added_selectors"][0].Name, data["added_selectors"][0].Name)
+	require.Equal(t, expectedResult["removed_selectors"][0].Name, data["removed_selectors"][0].Name)
 }

--- a/cmd/api/src/api/registration/v2.go
+++ b/cmd/api/src/api/registration/v2.go
@@ -137,6 +137,7 @@ func NewV2API(cfg config.Configuration, resources v2.Resources, routerInst *rout
 		routerInst.GET(fmt.Sprintf("/api/v2/asset-groups/{%s}/custom-selectors", api.URIPathVariableAssetGroupID), resources.GetAssetGroupCustomMemberCount).RequirePermissions(permissions.GraphDBRead),
 		routerInst.DELETE(fmt.Sprintf("/api/v2/asset-groups/{%s}", api.URIPathVariableAssetGroupID), resources.DeleteAssetGroup).RequirePermissions(permissions.GraphDBWrite),
 		routerInst.PUT(fmt.Sprintf("/api/v2/asset-groups/{%s}", api.URIPathVariableAssetGroupID), resources.UpdateAssetGroup).RequirePermissions(permissions.GraphDBWrite),
+		routerInst.POST(fmt.Sprintf("/api/v2/asset-groups/{%s}/selectors", api.URIPathVariableAssetGroupID), resources.UpdateAssetGroupSelectors).RequirePermissions(permissions.GraphDBWrite),
 		routerInst.DELETE(fmt.Sprintf("/api/v2/asset-groups/{%s}/selectors/{%s}", api.URIPathVariableAssetGroupID, api.URIPathVariableAssetGroupSelectorID), resources.DeleteAssetGroupSelector).RequirePermissions(permissions.GraphDBWrite),
 		routerInst.GET(fmt.Sprintf("/api/v2/asset-groups/{%s}/collections", api.URIPathVariableAssetGroupID), resources.ListAssetGroupCollections).RequirePermissions(permissions.GraphDBRead),
 		routerInst.GET(fmt.Sprintf("/api/v2/asset-groups/{%s}/members", api.URIPathVariableAssetGroupID), resources.ListAssetGroupMembers).RequirePermissions(permissions.GraphDBRead),

--- a/cmd/api/src/docs/json/definitions/models.json
+++ b/cmd/api/src/docs/json/definitions/models.json
@@ -40,6 +40,9 @@
       "deleted_at": {
         "$ref": "#/definitions/sql.NullTime"
       },
+      "asset_group_id": {
+        "type": "integer"
+      },
       "id": {
         "type": "integer"
       },
@@ -60,8 +63,12 @@
   "model.AssetGroupSelectorSpec": {
     "type": "object",
     "properties": {
-      "node_label": {
-        "type": "string"
+      "action": {
+        "type": "string",
+        "enum": [
+          "add",
+          "remove"
+        ]
       },
       "selector_name": {
         "type": "string"
@@ -826,54 +833,54 @@
       }
     }
   },
-    "model.DomainCollectionResult": {
-        "type": "object",
-        "properties": {
-            "job_id": {
-                "type": "integer"
-            },
-            "domain_name": {
-                "description": "Name of the domain that was enumerated",
-                "type": "string"
-            },
-            "message": {
-                "description": "A status message for a domain enumeration result",
-                "type": "string"
-            },
-            "success": {
-                "description": "A boolean value indicating whether the domain enumeration succeeded",
-                "type": "boolean"
-            },
-            "user_count": {
-                "Description": "A count of users enumerated",
-                "type": "integer"
-            },
-            "group_count": {
-                "Description": "A count of groups enumerated",
-                "type": "integer"
-            },
-            "computers": {
-                "Description": "A count of computers enumerated",
-                "type": "integer"
-            },
-            "containers": {
-                "Description": "A count of containers enumerated",
-                "type": "integer"
-            },
-            "gpos": {
-                "Description": "A count of gpos enumerated",
-                "type": "integer"
-            },
-            "ous": {
-                "Description": "A count of ous enumerated",
-                "type": "integer"
-            },
-            "deleted": {
-                "Description": "A count of deleted objects enumerated",
-                "type": "integer"
-            }
-        }
-    },
+  "model.DomainCollectionResult": {
+    "type": "object",
+    "properties": {
+      "job_id": {
+        "type": "integer"
+      },
+      "domain_name": {
+        "description": "Name of the domain that was enumerated",
+        "type": "string"
+      },
+      "message": {
+        "description": "A status message for a domain enumeration result",
+        "type": "string"
+      },
+      "success": {
+        "description": "A boolean value indicating whether the domain enumeration succeeded",
+        "type": "boolean"
+      },
+      "user_count": {
+        "Description": "A count of users enumerated",
+        "type": "integer"
+      },
+      "group_count": {
+        "Description": "A count of groups enumerated",
+        "type": "integer"
+      },
+      "computers": {
+        "Description": "A count of computers enumerated",
+        "type": "integer"
+      },
+      "containers": {
+        "Description": "A count of containers enumerated",
+        "type": "integer"
+      },
+      "gpos": {
+        "Description": "A count of gpos enumerated",
+        "type": "integer"
+      },
+      "ous": {
+        "Description": "A count of ous enumerated",
+        "type": "integer"
+      },
+      "deleted": {
+        "Description": "A count of deleted objects enumerated",
+        "type": "integer"
+      }
+    }
+  },
   "model.DisplayClientScheduledJob": {
     "type": "object",
     "properties": {

--- a/cmd/api/src/docs/json/definitions/models.json
+++ b/cmd/api/src/docs/json/definitions/models.json
@@ -65,10 +65,7 @@
     "properties": {
       "action": {
         "type": "string",
-        "enum": [
-          "add",
-          "remove"
-        ]
+        "enum": ["add", "remove"]
       },
       "selector_name": {
         "type": "string"
@@ -833,54 +830,54 @@
       }
     }
   },
-  "model.DomainCollectionResult": {
-    "type": "object",
-    "properties": {
-      "job_id": {
-        "type": "integer"
-      },
-      "domain_name": {
-        "description": "Name of the domain that was enumerated",
-        "type": "string"
-      },
-      "message": {
-        "description": "A status message for a domain enumeration result",
-        "type": "string"
-      },
-      "success": {
-        "description": "A boolean value indicating whether the domain enumeration succeeded",
-        "type": "boolean"
-      },
-      "user_count": {
-        "Description": "A count of users enumerated",
-        "type": "integer"
-      },
-      "group_count": {
-        "Description": "A count of groups enumerated",
-        "type": "integer"
-      },
-      "computers": {
-        "Description": "A count of computers enumerated",
-        "type": "integer"
-      },
-      "containers": {
-        "Description": "A count of containers enumerated",
-        "type": "integer"
-      },
-      "gpos": {
-        "Description": "A count of gpos enumerated",
-        "type": "integer"
-      },
-      "ous": {
-        "Description": "A count of ous enumerated",
-        "type": "integer"
-      },
-      "deleted": {
-        "Description": "A count of deleted objects enumerated",
-        "type": "integer"
-      }
-    }
-  },
+    "model.DomainCollectionResult": {
+        "type": "object",
+        "properties": {
+            "job_id": {
+                "type": "integer"
+            },
+            "domain_name": {
+                "description": "Name of the domain that was enumerated",
+                "type": "string"
+            },
+            "message": {
+                "description": "A status message for a domain enumeration result",
+                "type": "string"
+            },
+            "success": {
+                "description": "A boolean value indicating whether the domain enumeration succeeded",
+                "type": "boolean"
+            },
+            "user_count": {
+                "Description": "A count of users enumerated",
+                "type": "integer"
+            },
+            "group_count": {
+                "Description": "A count of groups enumerated",
+                "type": "integer"
+            },
+            "computers": {
+                "Description": "A count of computers enumerated",
+                "type": "integer"
+            },
+            "containers": {
+                "Description": "A count of containers enumerated",
+                "type": "integer"
+            },
+            "gpos": {
+                "Description": "A count of gpos enumerated",
+                "type": "integer"
+            },
+            "ous": {
+                "Description": "A count of ous enumerated",
+                "type": "integer"
+            },
+            "deleted": {
+                "Description": "A count of deleted objects enumerated",
+                "type": "integer"
+            }
+        }
+    },
   "model.DisplayClientScheduledJob": {
     "type": "object",
     "properties": {

--- a/cmd/api/src/docs/json/definitions/v2.json
+++ b/cmd/api/src/docs/json/definitions/v2.json
@@ -73,6 +73,27 @@
       }
     }
   },
+  "v2.CreateAssetGroupSelectorResponse": {
+    "properties": {
+      "data": {
+        "type": "object",
+        "properties": {
+          "addedMembers": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/model.AssetGroupSelector"
+            }
+          },
+          "removedMembers": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/model.AssetGroupSelector"
+            }
+          }
+        }
+      }
+    }
+  },
   "v2.ClientCreateRequest": {
     "type": "object",
     "required": [

--- a/cmd/api/src/docs/json/paths/v2/asset-isolation.json
+++ b/cmd/api/src/docs/json/paths/v2/asset-isolation.json
@@ -339,7 +339,10 @@
                 "content": {
                     "application/json": {
                         "schema": {
-                            "$ref": "#/definitions/model.AssetGroupSelectorSpec"
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/model.AssetGroupSelectorSpec"
+                            }
                         }
                     }
                 }

--- a/cmd/api/src/docs/json/paths/v2/asset-isolation.json
+++ b/cmd/api/src/docs/json/paths/v2/asset-isolation.json
@@ -321,20 +321,20 @@
             }
         ],
         "post": {
-            "description": "Creates an asset group selector",
+            "description": "Updates asset group selectors",
             "tags": [
                 "Asset Isolation",
                 "Community",
                 "Enterprise"
             ],
-            "summary": "Create an asset group selector",
+            "summary": "Update asset group selectors",
             "parameters": [
                 {
                     "$ref": "#/definitions/parameters.PreferHeader"
                 }
             ],
             "requestBody": {
-                "description": "The request body for creating an asset group selector",
+                "description": "The request body for updating asset group selectors",
                 "required": true,
                 "content": {
                     "application/json": {

--- a/cmd/api/src/docs/json/paths/v2/asset-isolation.json
+++ b/cmd/api/src/docs/json/paths/v2/asset-isolation.json
@@ -350,7 +350,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "#/definitions/api.ResponseWrapper"
+                                "$ref": "#/definitions/v2.CreateAssetGroupSelectorResponse"
                             }
                         }
                     }


### PR DESCRIPTION
## Description
- Adds the `POST /v2/asset-groups/{asset_group_id}/selectors` endpoint into BHCE
- Fixes a bug that caused this endpoint to always return empty lists of selectors
- Updates the documentation to reflect the correct request/response types for this endpoint

## Motivation and Context
We are building a new asset group management page, which will need the ability to add and remove asset group selectors.

## How Has This Been Tested?
- This handler has existing tests that were ported over along with it

## Screenshots (if appropriate):
![Screenshot 2023-10-11 at 2 53 25 PM](https://github.com/SpecterOps/BloodHound/assets/16313351/56b6ef83-d89c-4d31-9ae1-0f8d52c87f12)

## Types of changes
-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
-   [x] Documentation updates are needed, and have been made accordingly.
-   [x] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
