### PR TITLE
Fix environment variable for postgres database

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,14 +30,14 @@ BH_NEO4J_WEB_PORT=7575
 # BloodHound Postgres
 BH_POSTGRES_USER=bloodhound
 BH_POSTGRES_PASSWORD=bloodhoundcommunityedition
-BH_POSTGRES_DATABASE=bloodhound
+BH_POSTGRES_DB=bloodhound
 BH_POSTGRES_VOLUME=bh-postgres-data
 BH_POSTGRES_PORT=6543
 
 # Integration Postgres
 INTEGRATION_POSTGRES_USER=bloodhound
 INTEGRATION_POSTGRES_PASSWORD=bloodhoundcommunityedition
-INTEGRATION_POSTGRES_DATABASE=bloodhound
+INTEGRATION_POSTGRES_DB=bloodhound
 INTEGRATION_POSTGRES_PORT=65432
 
 # Integration Neo4j

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -36,7 +36,7 @@ services:
     environment:
       - POSTGRES_USER=${BH_POSTGRES_USER:-bloodhound}
       - POSTGRES_PASSWORD=${BH_POSTGRES_PASSWORD:-bloodhoundcommunityedition}
-      - POSTGRES_DATABASE=${BH_POSTGRES_DATABASE:-bloodhound}
+      - POSTGRES_DB=${BH_POSTGRES_DB:-bloodhound}
     ports:
       - ${BH_POSTGRES_PORT:-5432}:5432
     volumes:
@@ -45,7 +45,7 @@ services:
       test:
         [
           "CMD-SHELL",
-          "pg_isready -U ${BH_POSTGRES_USER:-bloodhound} -d 'dbname=${BH_POSTGRES_DATABASE:-bloodhound}' -h 127.0.0.1 -p 5432"
+          "pg_isready -U ${BH_POSTGRES_USER:-bloodhound} -d 'dbname=${BH_POSTGRES_DB:-bloodhound}' -h 127.0.0.1 -p 5432"
         ]
       interval: 10s
       timeout: 5s

--- a/docker-compose.testing.yml
+++ b/docker-compose.testing.yml
@@ -22,7 +22,7 @@ services:
     environment:
       - POSTGRES_USER=bloodhound
       - POSTGRES_PASSWORD=bloodhoundcommunityedition
-      - POSTGRES_DATABASE=bloodhound
+      - POSTGRES_DB=bloodhound
     ports:
       - 65432:5432
     volumes:

--- a/examples/docker-compose/.env.example
+++ b/examples/docker-compose/.env.example
@@ -4,7 +4,7 @@ BLOODHOUND_TAG=latest
 # Postgres auth configuration
 POSTGRES_USER=bloodhound
 POSTGRES_PASSWORD=bloodhoundcommunityedition
-POSTGRES_DATABASE=bloodhound
+POSTGRES_DB=bloodhound
 
 # Auth string for NEO4J credentials
 NEO4J_AUTH=neo4j/bloodhoundcommunityedition

--- a/examples/docker-compose/docker-compose.yml
+++ b/examples/docker-compose/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     environment:
       - POSTGRES_USER=${POSTGRES_USER:-bloodhound}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-bloodhoundcommunityedition}
-      - POSTGRES_DATABASE=${POSTGRES_DATABASE:-bloodhound}
+      - POSTGRES_DB=${POSTGRES_DB:-bloodhound}
     # Database ports are disabled by default. Please change your database password to something secure before uncommenting
     # ports:
     #   - ${POSTGRES_PORT:-5432}:5432
@@ -31,7 +31,7 @@ services:
       test:
         [
           "CMD-SHELL",
-          "pg_isready -U ${POSTGRES_USER:-bloodhound} -d ${POSTGRES_DATABASE:-bloodhound} -h 127.0.0.1 -p 5432"
+          "pg_isready -U ${POSTGRES_USER:-bloodhound} -d ${POSTGRES_DB:-bloodhound} -h 127.0.0.1 -p 5432"
         ]
       interval: 10s
       timeout: 5s


### PR DESCRIPTION
## Description

In the current scripts a wrong environment variable is used for the postgres database and therefore the current variable has no influence on the name of the postgres database. When creating the postgres database, the default behavior of postgres is currently applied (username as database name).

## Motivation and Context

The pull request simply replaces the incorrect variable `POSTGRES_DATABASE` with the correct `POSTGRES_DB` (See https://hub.docker.com/_/postgres) so that this functionality can be used correctly. 

## How Has This Been Tested?
A new container with a customized database name was created and verified within the container.

## Screenshots (if appropriate):

## Types of changes

-   [x] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
