### PR TITLE
chore: wire up post processing for currently existing adcs handlers

### DIFF
--- a/cmd/api/src/analysis/ad/post.go
+++ b/cmd/api/src/analysis/ad/post.go
@@ -27,33 +27,7 @@ import (
 	"github.com/specterops/bloodhound/dawgs/util/channels"
 	"github.com/specterops/bloodhound/graphschema/ad"
 	"github.com/specterops/bloodhound/log"
-	"github.com/specterops/bloodhound/src/model/appcfg"
 )
-
-func PostProcessedRelationships(localGroupPostProcessingFlag appcfg.FeatureFlag) []graph.Kind {
-	if localGroupPostProcessingFlag.Enabled {
-		return []graph.Kind{
-			ad.DCSync,
-			ad.SyncLAPSPassword,
-			ad.CanRDP,
-			ad.AdminTo,
-			ad.CanPSRemote,
-			ad.ExecuteDCOM,
-			ad.ADCSESC1,
-			ad.ADCSESC2,
-			ad.ADCSESC3,
-			ad.ADCSESC4,
-			ad.ADCSESC5,
-			ad.ADCSESC6,
-			ad.ADCSESC7,
-		}
-	}
-
-	return []graph.Kind{
-		ad.SyncLAPSPassword,
-		ad.DCSync,
-	}
-}
 
 func PostLocalGroups(ctx context.Context, db graph.Database) (*analysis.AtomicPostProcessingStats, error) {
 	var (
@@ -183,11 +157,14 @@ func Post(ctx context.Context, db graph.Database) (*analysis.AtomicPostProcessin
 		return &aggregateStats, err
 	} else if localGroupStats, err := PostLocalGroups(ctx, db); err != nil {
 		return &aggregateStats, err
+	} else if adcsStats, err := adAnalysis.PostADCS(ctx, db); err != nil {
+		return &aggregateStats, err
 	} else {
 		aggregateStats.Merge(stats)
 		aggregateStats.Merge(syncLAPSStats)
 		aggregateStats.Merge(dcSyncStats)
 		aggregateStats.Merge(localGroupStats)
+		aggregateStats.Merge(adcsStats)
 		return &aggregateStats, nil
 	}
 }

--- a/packages/cue/bh/ad/ad.cue
+++ b/packages/cue/bh/ad/ad.cue
@@ -27,70 +27,77 @@ PathfindingRelationships: [...types.#Kind]
 
 // Property name enumerations
 
-CertChain: types.#Kind & {
+CertChain: types.#StringEnum & {
 	symbol: 		"CertChain"
 	schema: 		"ad"
 	name:           "Certificate Chain"
 	representation: "certchain"
 }
 
-CertName: types.#Kind & {
+CertName: types.#StringEnum & {
 	symbol: 		"CertName"
 	schema: 		"ad"
 	name:           "Certificate Name"
 	representation: "certname"
 }
 
-CertThumbprint: types.#Kind & {
+CertThumbprint: types.#StringEnum & {
 	symbol: 		"CertThumbprint"
 	schema: 		"ad"
 	name:           "Certificate Thumbprint"
 	representation: "certthumbprint"
 }
 
-CAName: types.#Kind & {
+CertThumbprints: types.#StringEnum & {
+	symbol: 		"CertThumbprints"
+	schema: 		"ad"
+	name:           "Certificate Thumbprints"
+	representation: "certthumbprints"
+}
+
+CAName: types.#StringEnum & {
 	symbol: 		"CAName"
 	schema: 		"ad"
 	name:           "CA Name"
 	representation: "caname"
 }
 
-CASecurityCollected: types.#Kind & {
+CASecurityCollected: types.#StringEnum & {
 	symbol: 		"CASecurityCollected"
 	schema: 		"ad"
 	name:           "CA Security Collected"
 	representation: "casecuritycollected"
 }
 
-EnrollmentAgentRestrictionsCollected: types.#Kind & {
+EnrollmentAgentRestrictionsCollected: types.#StringEnum & {
 	symbol: 		"EnrollmentAgentRestrictionsCollected"
 	schema: 		"ad"
 	name:           "Enrollment Agent Restrictions Collected"
 	representation: "enrollmentagentrestrictionscollected"
 }
 
-IsUserSpecifiesSanEnabledCollected: types.#Kind & {
+IsUserSpecifiesSanEnabledCollected: types.#StringEnum & {
 	symbol: 		"IsUserSpecifiesSanEnabledCollected"
 	schema: 		"ad"
 	name:           "Is User Specifies San Enabled Collected"
 	representation: "isuserspecifiessanenabledcollected"
 }
 
-HasBasicConstraints: types.#Kind & {
+HasBasicConstraints: types.#StringEnum & {
 	symbol: 		"HasBasicConstraints"
 	schema: 		"ad"
 	name:           "Has Basic Constraints"
 	representation: "hasbasicconstraints"
 }
 
-BasicConstraintPathLength: types.#Kind & {
+BasicConstraintPathLength: types.#StringEnum & {
 	symbol: 		"BasicConstraintPathLength"
 	schema: 		"ad"
 	name:           "Basic Constraint Path Length"
 	representation: "basicconstraintpathlength"
 }
 
-DNSHostname: types.#Kind & {
+DNSHostname: types.#StringEnum & {
 	symbol: 		"DNSHostname"
 	schema: 		"ad"
 	name:           "DNS Hostname"
@@ -356,6 +363,7 @@ Properties: [
 	CertChain,
 	CertName,
 	CertThumbprint,
+	CertThumbprints,
 	EnrollmentAgentRestrictionsCollected,
 	IsUserSpecifiesSanEnabledCollected,
 	HasBasicConstraints,

--- a/packages/go/analysis/ad/post.go
+++ b/packages/go/analysis/ad/post.go
@@ -40,6 +40,9 @@ func PostProcessedRelationships() []graph.Kind {
 		ad.AdminTo,
 		ad.CanPSRemote,
 		ad.ExecuteDCOM,
+		ad.TrustedForNTAuth,
+		ad.IssuedSignedBy,
+		ad.EnterpriseCAFor,
 		ad.ADCSESC1,
 		ad.ADCSESC2,
 		ad.ADCSESC3,
@@ -136,6 +139,22 @@ func FetchComputers(ctx context.Context, db graph.Database) (*roaring64.Bitmap, 
 
 			return nil
 		})
+	})
+}
+
+func FetchNodesByKind(ctx context.Context, db graph.Database, kinds ...graph.Kind) ([]*graph.Node, error) {
+	var nodes []*graph.Node
+	return nodes, db.ReadTransaction(ctx, func(tx graph.Transaction) error {
+		var err error
+		if nodes, err = ops.FetchNodes(tx.Nodes().Filterf(func() graph.Criteria {
+			return query.And(
+				query.KindIn(query.Node(), kinds...),
+			)
+		})); err != nil {
+			return err
+		} else {
+			return nil
+		}
 	})
 }
 

--- a/packages/go/graphschema/ad/ad.go
+++ b/packages/go/graphschema/ad/ad.go
@@ -110,6 +110,7 @@ const (
 	CertChain                                    Property = "certchain"
 	CertName                                     Property = "certname"
 	CertThumbprint                               Property = "certthumbprint"
+	CertThumbprints                              Property = "certthumbprints"
 	EnrollmentAgentRestrictionsCollected         Property = "enrollmentagentrestrictionscollected"
 	IsUserSpecifiesSanEnabledCollected           Property = "isuserspecifiessanenabledcollected"
 	HasBasicConstraints                          Property = "hasbasicconstraints"
@@ -153,7 +154,7 @@ const (
 )
 
 func AllProperties() []Property {
-	return []Property{AdminCount, CASecurityCollected, CAName, CertChain, CertName, CertThumbprint, EnrollmentAgentRestrictionsCollected, IsUserSpecifiesSanEnabledCollected, HasBasicConstraints, BasicConstraintPathLength, DNSHostname, CrossCertificatePair, DistinguishedName, DomainFQDN, DomainSID, Sensitive, HighValue, BlocksInheritance, IsACL, IsACLProtected, IsDeleted, Enforced, Department, HasCrossCertificatePair, HasSPN, UnconstrainedDelegation, LastLogon, LastLogonTimestamp, IsPrimaryGroup, HasLAPS, DontRequirePreAuth, LogonType, HasURA, PasswordNeverExpires, PasswordNotRequired, FunctionalLevel, TrustType, SidFiltering, TrustedToAuth, SamAccountName, CertificateMappingMethodsCollected, CertificateMappingMethodsHex, CertificateMappingMethodsPretty, StrongCertificateBindingEnforcementCollected, StrongCertificateBindingEnforcementInt, StrongCertificateBindingEnforcementPretty}
+	return []Property{AdminCount, CASecurityCollected, CAName, CertChain, CertName, CertThumbprint, CertThumbprints, EnrollmentAgentRestrictionsCollected, IsUserSpecifiesSanEnabledCollected, HasBasicConstraints, BasicConstraintPathLength, DNSHostname, CrossCertificatePair, DistinguishedName, DomainFQDN, DomainSID, Sensitive, HighValue, BlocksInheritance, IsACL, IsACLProtected, IsDeleted, Enforced, Department, HasCrossCertificatePair, HasSPN, UnconstrainedDelegation, LastLogon, LastLogonTimestamp, IsPrimaryGroup, HasLAPS, DontRequirePreAuth, LogonType, HasURA, PasswordNeverExpires, PasswordNotRequired, FunctionalLevel, TrustType, SidFiltering, TrustedToAuth, SamAccountName, CertificateMappingMethodsCollected, CertificateMappingMethodsHex, CertificateMappingMethodsPretty, StrongCertificateBindingEnforcementCollected, StrongCertificateBindingEnforcementInt, StrongCertificateBindingEnforcementPretty}
 }
 func ParseProperty(source string) (Property, error) {
 	switch source {
@@ -169,6 +170,8 @@ func ParseProperty(source string) (Property, error) {
 		return CertName, nil
 	case "certthumbprint":
 		return CertThumbprint, nil
+	case "certthumbprints":
+		return CertThumbprints, nil
 	case "enrollmentagentrestrictionscollected":
 		return EnrollmentAgentRestrictionsCollected, nil
 	case "isuserspecifiessanenabledcollected":
@@ -267,6 +270,8 @@ func (s Property) String() string {
 		return string(CertName)
 	case CertThumbprint:
 		return string(CertThumbprint)
+	case CertThumbprints:
+		return string(CertThumbprints)
 	case EnrollmentAgentRestrictionsCollected:
 		return string(EnrollmentAgentRestrictionsCollected)
 	case IsUserSpecifiesSanEnabledCollected:
@@ -365,6 +370,8 @@ func (s Property) Name() string {
 		return "Certificate Name"
 	case CertThumbprint:
 		return "Certificate Thumbprint"
+	case CertThumbprints:
+		return "Certificate Thumbprints"
 	case EnrollmentAgentRestrictionsCollected:
 		return "Enrollment Agent Restrictions Collected"
 	case IsUserSpecifiesSanEnabledCollected:

--- a/packages/javascript/bh-shared-ui/src/graphSchema.ts
+++ b/packages/javascript/bh-shared-ui/src/graphSchema.ts
@@ -260,6 +260,7 @@ export enum ActiveDirectoryKindProperties {
     CertChain = 'certchain',
     CertName = 'certname',
     CertThumbprint = 'certthumbprint',
+    CertThumbprints = 'certthumbprints',
     EnrollmentAgentRestrictionsCollected = 'enrollmentagentrestrictionscollected',
     IsUserSpecifiesSanEnabledCollected = 'isuserspecifiessanenabledcollected',
     HasBasicConstraints = 'hasbasicconstraints',
@@ -315,6 +316,8 @@ export function ActiveDirectoryKindPropertiesToDisplay(value: ActiveDirectoryKin
             return 'Certificate Name';
         case ActiveDirectoryKindProperties.CertThumbprint:
             return 'Certificate Thumbprint';
+        case ActiveDirectoryKindProperties.CertThumbprints:
+            return 'Certificate Thumbprints';
         case ActiveDirectoryKindProperties.EnrollmentAgentRestrictionsCollected:
             return 'Enrollment Agent Restrictions Collected';
         case ActiveDirectoryKindProperties.IsUserSpecifiesSanEnabledCollected:


### PR DESCRIPTION
## Description
The handlers that were created for post processing TrustedForNTAuth, IssuedSignedBy, and EnterpriseCAFor have been wired up to actually run during post processing.
<!--- Describe your changes in detail -->

## Motivation and Context
This moves us closer to integrating all of the ADCS post processing logic.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Analysis was initiated on the dataset collected for the esc1 environment. No analysis errors were logged but we may need to insure the expected edges are being created.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] My changes include a database migration.
