### PR TITLE
Store raw CertificateMappingMethods integer value

### DIFF
--- a/packages/cue/bh/ad/ad.cue
+++ b/packages/cue/bh/ad/ad.cue
@@ -307,13 +307,6 @@ SamAccountName: types.#StringEnum & {
 	representation: "samaccountname"
 }
 
-CertificateMappingMethodsCollected: types.#StringEnum & {
-	symbol:         "CertificateMappingMethodsCollected"
-	schema:         "ad"
-	name:           "Certificate Mapping Methods Collected"
-	representation: "certificatemappingmethodscollected"
-}
-
 CertificateMappingMethodsRaw: types.#StringEnum & {
 	symbol:         "CertificateMappingMethodsRaw"
 	schema:         "ad"
@@ -324,15 +317,8 @@ CertificateMappingMethodsRaw: types.#StringEnum & {
 CertificateMappingMethods: types.#StringEnum & {
 	symbol:         "CertificateMappingMethods"
 	schema:         "ad"
-	name:           "Certificate Mapping Methods Pretty"
-	representation: "certificatemappingmethodspretty"
-}
-
-StrongCertificateBindingEnforcementCollected: types.#StringEnum & {
-	symbol:         "StrongCertificateBindingEnforcementCollected"
-	schema:         "ad"
-	name:           "Strong Certificate Binding Enforcement Collected"
-	representation: "strongcertificatebindingenforcementcollected"
+	name:           "Certificate Mapping Methods"
+	representation: "certificatemappingmethods"
 }
 
 StrongCertificateBindingEnforcementRaw: types.#StringEnum & {
@@ -433,10 +419,8 @@ Properties: [
 	SidFiltering,
 	TrustedToAuth,
 	SamAccountName,
-	CertificateMappingMethodsCollected,
 	CertificateMappingMethodsRaw,
 	CertificateMappingMethods,
-	StrongCertificateBindingEnforcementCollected,
 	StrongCertificateBindingEnforcementRaw,
 	StrongCertificateBindingEnforcement,
 	EKUs,

--- a/packages/cue/bh/ad/ad.cue
+++ b/packages/cue/bh/ad/ad.cue
@@ -314,15 +314,15 @@ CertificateMappingMethodsCollected: types.#StringEnum & {
 	representation: "certificatemappingmethodscollected"
 }
 
-CertificateMappingMethodsHex: types.#StringEnum & {
-	symbol:         "CertificateMappingMethodsHex"
+CertificateMappingMethodsRaw: types.#StringEnum & {
+	symbol:         "CertificateMappingMethodsRaw"
 	schema:         "ad"
-	name:           "Certificate Mapping Methods Hex"
-	representation: "certificatemappingmethodshex"
+	name:           "Certificate Mapping Methods (Raw)"
+	representation: "certificatemappingmethodsraw"
 }
 
-CertificateMappingMethodsPretty: types.#StringEnum & {
-	symbol:         "CertificateMappingMethodsPretty"
+CertificateMappingMethods: types.#StringEnum & {
+	symbol:         "CertificateMappingMethods"
 	schema:         "ad"
 	name:           "Certificate Mapping Methods Pretty"
 	representation: "certificatemappingmethodspretty"
@@ -335,18 +335,18 @@ StrongCertificateBindingEnforcementCollected: types.#StringEnum & {
 	representation: "strongcertificatebindingenforcementcollected"
 }
 
-StrongCertificateBindingEnforcementInt: types.#StringEnum & {
-	symbol:         "StrongCertificateBindingEnforcementInt"
+StrongCertificateBindingEnforcementRaw: types.#StringEnum & {
+	symbol:         "StrongCertificateBindingEnforcementRaw"
 	schema:         "ad"
-	name:           "Strong Certificate Binding Enforcement Int"
-	representation: "strongcertificatebindingenforcementint"
+	name:           "Strong Certificate Binding Enforcement (Raw)"
+	representation: "strongcertificatebindingenforcementraw"
 }
 
-StrongCertificateBindingEnforcementPretty: types.#StringEnum & {
-	symbol:         "StrongCertificateBindingEnforcementPretty"
+StrongCertificateBindingEnforcement: types.#StringEnum & {
+	symbol:         "StrongCertificateBindingEnforcement"
 	schema:         "ad"
-	name:           "Strong Certificate Binding Enforcement Pretty"
-	representation: "strongcertificatebindingenforcementpretty"
+	name:           "Strong Certificate Binding Enforcement"
+	representation: "strongcertificatebindingenforcement"
 }
 
 CrossCertificatePair: types.#StringEnum & {
@@ -434,11 +434,11 @@ Properties: [
 	TrustedToAuth,
 	SamAccountName,
 	CertificateMappingMethodsCollected,
-	CertificateMappingMethodsHex,
-	CertificateMappingMethodsPretty,
+	CertificateMappingMethodsRaw,
+	CertificateMappingMethods,
 	StrongCertificateBindingEnforcementCollected,
-	StrongCertificateBindingEnforcementInt,
-	StrongCertificateBindingEnforcementPretty,
+	StrongCertificateBindingEnforcementRaw,
+	StrongCertificateBindingEnforcement,
 	EKUs,
 	SubjectAltRequireUPN,
 	AuthorizedSignatures,

--- a/packages/go/ein/ad.go
+++ b/packages/go/ein/ad.go
@@ -582,7 +582,6 @@ func ParseDCRegistryData(computer Computer) IngestibleNode {
 	propMap := make(map[string]any)
 
 	if computer.DCRegistryData.CertificateMappingMethods.Collected && computer.DCRegistryData.CertificateMappingMethods.Value >= 0 {
-		propMap[ad.CertificateMappingMethodsCollected.String()] = true
 		propMap[ad.CertificateMappingMethodsRaw.String()] = computer.DCRegistryData.CertificateMappingMethods.Value
 
 		var prettyMappings []string
@@ -607,7 +606,6 @@ func ParseDCRegistryData(computer Computer) IngestibleNode {
 	}
 
 	if computer.DCRegistryData.StrongCertificateBindingEnforcement.Collected && computer.DCRegistryData.StrongCertificateBindingEnforcement.Value >= 0 {
-		propMap[ad.StrongCertificateBindingEnforcementCollected.String()] = true
 		propMap[ad.StrongCertificateBindingEnforcementRaw.String()] = computer.DCRegistryData.StrongCertificateBindingEnforcement.Value
 
 		switch computer.DCRegistryData.StrongCertificateBindingEnforcement.Value {

--- a/packages/go/ein/ad.go
+++ b/packages/go/ein/ad.go
@@ -17,7 +17,6 @@
 package ein
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/specterops/bloodhound/analysis"
@@ -573,9 +572,9 @@ const (
 	PrettyCertMappingKerberosS4UCertificate         = "0x08: Kerberos service-for-user (S4U) certificate"
 	PrettyCertMappingKerberosS4UExplicitCertificate = "0x10: Kerberos service-for-user (S4U) explicit certificate"
 
-	PrettyStrongCertBindingEnforcementDisabled      = "0: Disabled"
-	PrettyStrongCertBindingEnforcementCompatibility = "1: Compatibility mode"
-	PrettyStrongCertBindingEnforcementFull          = "2: Full enforcement mode"
+	PrettyStrongCertBindingEnforcementDisabled      = "Disabled"
+	PrettyStrongCertBindingEnforcementCompatibility = "Compatibility mode"
+	PrettyStrongCertBindingEnforcementFull          = "Full enforcement mode"
 )
 
 func ParseDCRegistryData(computer Computer) IngestibleNode {
@@ -584,7 +583,7 @@ func ParseDCRegistryData(computer Computer) IngestibleNode {
 
 	if computer.DCRegistryData.CertificateMappingMethods.Collected && computer.DCRegistryData.CertificateMappingMethods.Value >= 0 {
 		propMap[ad.CertificateMappingMethodsCollected.String()] = true
-		propMap[ad.CertificateMappingMethodsHex.String()] = fmt.Sprintf("0x%02x", computer.DCRegistryData.CertificateMappingMethods.Value)
+		propMap[ad.CertificateMappingMethodsRaw.String()] = computer.DCRegistryData.CertificateMappingMethods.Value
 
 		var prettyMappings []string
 
@@ -604,20 +603,20 @@ func ParseDCRegistryData(computer Computer) IngestibleNode {
 			prettyMappings = append(prettyMappings, PrettyCertMappingKerberosS4UExplicitCertificate)
 		}
 
-		propMap[ad.CertificateMappingMethodsPretty.String()] = prettyMappings
+		propMap[ad.CertificateMappingMethods.String()] = prettyMappings
 	}
 
-	if computer.DCRegistryData.StrongCertificateBindingEnforcement.Collected {
+	if computer.DCRegistryData.StrongCertificateBindingEnforcement.Collected && computer.DCRegistryData.StrongCertificateBindingEnforcement.Value >= 0 {
 		propMap[ad.StrongCertificateBindingEnforcementCollected.String()] = true
-		propMap[ad.StrongCertificateBindingEnforcementInt.String()] = computer.DCRegistryData.StrongCertificateBindingEnforcement.Value
+		propMap[ad.StrongCertificateBindingEnforcementRaw.String()] = computer.DCRegistryData.StrongCertificateBindingEnforcement.Value
 
 		switch computer.DCRegistryData.StrongCertificateBindingEnforcement.Value {
 		case 0:
-			propMap[ad.StrongCertificateBindingEnforcementPretty.String()] = PrettyStrongCertBindingEnforcementDisabled
+			propMap[ad.StrongCertificateBindingEnforcement.String()] = PrettyStrongCertBindingEnforcementDisabled
 		case 1:
-			propMap[ad.StrongCertificateBindingEnforcementPretty.String()] = PrettyStrongCertBindingEnforcementCompatibility
+			propMap[ad.StrongCertificateBindingEnforcement.String()] = PrettyStrongCertBindingEnforcementCompatibility
 		case 2:
-			propMap[ad.StrongCertificateBindingEnforcementPretty.String()] = PrettyStrongCertBindingEnforcementFull
+			propMap[ad.StrongCertificateBindingEnforcement.String()] = PrettyStrongCertBindingEnforcementFull
 		}
 	}
 

--- a/packages/go/graphschema/ad/ad.go
+++ b/packages/go/graphschema/ad/ad.go
@@ -146,11 +146,11 @@ const (
 	TrustedToAuth                                Property = "trustedtoauth"
 	SamAccountName                               Property = "samaccountname"
 	CertificateMappingMethodsCollected           Property = "certificatemappingmethodscollected"
-	CertificateMappingMethodsHex                 Property = "certificatemappingmethodshex"
-	CertificateMappingMethodsPretty              Property = "certificatemappingmethodspretty"
+	CertificateMappingMethodsRaw                 Property = "certificatemappingmethodsraw"
+	CertificateMappingMethods                    Property = "certificatemappingmethodspretty"
 	StrongCertificateBindingEnforcementCollected Property = "strongcertificatebindingenforcementcollected"
-	StrongCertificateBindingEnforcementInt       Property = "strongcertificatebindingenforcementint"
-	StrongCertificateBindingEnforcementPretty    Property = "strongcertificatebindingenforcementpretty"
+	StrongCertificateBindingEnforcementRaw       Property = "strongcertificatebindingenforcementraw"
+	StrongCertificateBindingEnforcement          Property = "strongcertificatebindingenforcement"
 	EKUs                                         Property = "ekus"
 	SubjectAltRequireUPN                         Property = "subjectaltrequireupn"
 	AuthorizedSignatures                         Property = "authorizedsignatures"
@@ -159,7 +159,7 @@ const (
 )
 
 func AllProperties() []Property {
-	return []Property{AdminCount, CASecurityCollected, CAName, CertChain, CertName, CertThumbprint, CertThumbprints, EnrollmentAgentRestrictionsCollected, IsUserSpecifiesSanEnabledCollected, HasBasicConstraints, BasicConstraintPathLength, DNSHostname, CrossCertificatePair, DistinguishedName, DomainFQDN, DomainSID, Sensitive, HighValue, BlocksInheritance, IsACL, IsACLProtected, IsDeleted, Enforced, Department, HasCrossCertificatePair, HasSPN, UnconstrainedDelegation, LastLogon, LastLogonTimestamp, IsPrimaryGroup, HasLAPS, DontRequirePreAuth, LogonType, HasURA, PasswordNeverExpires, PasswordNotRequired, FunctionalLevel, TrustType, SidFiltering, TrustedToAuth, SamAccountName, CertificateMappingMethodsCollected, CertificateMappingMethodsHex, CertificateMappingMethodsPretty, StrongCertificateBindingEnforcementCollected, StrongCertificateBindingEnforcementInt, StrongCertificateBindingEnforcementPretty, EKUs, SubjectAltRequireUPN, AuthorizedSignatures, ApplicationPolicies, SchemaVersion}
+	return []Property{AdminCount, CASecurityCollected, CAName, CertChain, CertName, CertThumbprint, CertThumbprints, EnrollmentAgentRestrictionsCollected, IsUserSpecifiesSanEnabledCollected, HasBasicConstraints, BasicConstraintPathLength, DNSHostname, CrossCertificatePair, DistinguishedName, DomainFQDN, DomainSID, Sensitive, HighValue, BlocksInheritance, IsACL, IsACLProtected, IsDeleted, Enforced, Department, HasCrossCertificatePair, HasSPN, UnconstrainedDelegation, LastLogon, LastLogonTimestamp, IsPrimaryGroup, HasLAPS, DontRequirePreAuth, LogonType, HasURA, PasswordNeverExpires, PasswordNotRequired, FunctionalLevel, TrustType, SidFiltering, TrustedToAuth, SamAccountName, CertificateMappingMethodsCollected, CertificateMappingMethodsRaw, CertificateMappingMethods, StrongCertificateBindingEnforcementCollected, StrongCertificateBindingEnforcementRaw, StrongCertificateBindingEnforcement, EKUs, SubjectAltRequireUPN, AuthorizedSignatures, ApplicationPolicies, SchemaVersion}
 }
 func ParseProperty(source string) (Property, error) {
 	switch source {
@@ -247,16 +247,16 @@ func ParseProperty(source string) (Property, error) {
 		return SamAccountName, nil
 	case "certificatemappingmethodscollected":
 		return CertificateMappingMethodsCollected, nil
-	case "certificatemappingmethodshex":
-		return CertificateMappingMethodsHex, nil
+	case "certificatemappingmethodsraw":
+		return CertificateMappingMethodsRaw, nil
 	case "certificatemappingmethodspretty":
-		return CertificateMappingMethodsPretty, nil
+		return CertificateMappingMethods, nil
 	case "strongcertificatebindingenforcementcollected":
 		return StrongCertificateBindingEnforcementCollected, nil
-	case "strongcertificatebindingenforcementint":
-		return StrongCertificateBindingEnforcementInt, nil
-	case "strongcertificatebindingenforcementpretty":
-		return StrongCertificateBindingEnforcementPretty, nil
+	case "strongcertificatebindingenforcementraw":
+		return StrongCertificateBindingEnforcementRaw, nil
+	case "strongcertificatebindingenforcement":
+		return StrongCertificateBindingEnforcement, nil
 	case "ekus":
 		return EKUs, nil
 	case "subjectaltrequireupn":
@@ -357,16 +357,16 @@ func (s Property) String() string {
 		return string(SamAccountName)
 	case CertificateMappingMethodsCollected:
 		return string(CertificateMappingMethodsCollected)
-	case CertificateMappingMethodsHex:
-		return string(CertificateMappingMethodsHex)
-	case CertificateMappingMethodsPretty:
-		return string(CertificateMappingMethodsPretty)
+	case CertificateMappingMethodsRaw:
+		return string(CertificateMappingMethodsRaw)
+	case CertificateMappingMethods:
+		return string(CertificateMappingMethods)
 	case StrongCertificateBindingEnforcementCollected:
 		return string(StrongCertificateBindingEnforcementCollected)
-	case StrongCertificateBindingEnforcementInt:
-		return string(StrongCertificateBindingEnforcementInt)
-	case StrongCertificateBindingEnforcementPretty:
-		return string(StrongCertificateBindingEnforcementPretty)
+	case StrongCertificateBindingEnforcementRaw:
+		return string(StrongCertificateBindingEnforcementRaw)
+	case StrongCertificateBindingEnforcement:
+		return string(StrongCertificateBindingEnforcement)
 	case EKUs:
 		return string(EKUs)
 	case SubjectAltRequireUPN:
@@ -467,16 +467,16 @@ func (s Property) Name() string {
 		return "SAM Account Name"
 	case CertificateMappingMethodsCollected:
 		return "Certificate Mapping Methods Collected"
-	case CertificateMappingMethodsHex:
-		return "Certificate Mapping Methods Hex"
-	case CertificateMappingMethodsPretty:
+	case CertificateMappingMethodsRaw:
+		return "Certificate Mapping Methods (Raw)"
+	case CertificateMappingMethods:
 		return "Certificate Mapping Methods Pretty"
 	case StrongCertificateBindingEnforcementCollected:
 		return "Strong Certificate Binding Enforcement Collected"
-	case StrongCertificateBindingEnforcementInt:
-		return "Strong Certificate Binding Enforcement Int"
-	case StrongCertificateBindingEnforcementPretty:
-		return "Strong Certificate Binding Enforcement Pretty"
+	case StrongCertificateBindingEnforcementRaw:
+		return "Strong Certificate Binding Enforcement (Raw)"
+	case StrongCertificateBindingEnforcement:
+		return "Strong Certificate Binding Enforcement"
 	case EKUs:
 		return "EKUs"
 	case SubjectAltRequireUPN:

--- a/packages/go/graphschema/ad/ad.go
+++ b/packages/go/graphschema/ad/ad.go
@@ -104,62 +104,60 @@ var (
 type Property string
 
 const (
-	AdminCount                                   Property = "admincount"
-	CASecurityCollected                          Property = "casecuritycollected"
-	CAName                                       Property = "caname"
-	CertChain                                    Property = "certchain"
-	CertName                                     Property = "certname"
-	CertThumbprint                               Property = "certthumbprint"
-	CertThumbprints                              Property = "certthumbprints"
-	EnrollmentAgentRestrictionsCollected         Property = "enrollmentagentrestrictionscollected"
-	IsUserSpecifiesSanEnabledCollected           Property = "isuserspecifiessanenabledcollected"
-	HasBasicConstraints                          Property = "hasbasicconstraints"
-	BasicConstraintPathLength                    Property = "basicconstraintpathlength"
-	DNSHostname                                  Property = "dnshostname"
-	CrossCertificatePair                         Property = "crosscertificatepair"
-	DistinguishedName                            Property = "distinguishedname"
-	DomainFQDN                                   Property = "domain"
-	DomainSID                                    Property = "domainsid"
-	Sensitive                                    Property = "sensitive"
-	HighValue                                    Property = "highvalue"
-	BlocksInheritance                            Property = "blocksinheritance"
-	IsACL                                        Property = "isacl"
-	IsACLProtected                               Property = "isaclprotected"
-	IsDeleted                                    Property = "isdeleted"
-	Enforced                                     Property = "enforced"
-	Department                                   Property = "department"
-	HasCrossCertificatePair                      Property = "hascrosscertificatepair"
-	HasSPN                                       Property = "hasspn"
-	UnconstrainedDelegation                      Property = "unconstraineddelegation"
-	LastLogon                                    Property = "lastlogon"
-	LastLogonTimestamp                           Property = "lastlogontimestamp"
-	IsPrimaryGroup                               Property = "isprimarygroup"
-	HasLAPS                                      Property = "haslaps"
-	DontRequirePreAuth                           Property = "dontreqpreauth"
-	LogonType                                    Property = "logontype"
-	HasURA                                       Property = "hasura"
-	PasswordNeverExpires                         Property = "pwdneverexpires"
-	PasswordNotRequired                          Property = "passwordnotreqd"
-	FunctionalLevel                              Property = "functionallevel"
-	TrustType                                    Property = "trusttype"
-	SidFiltering                                 Property = "sidfiltering"
-	TrustedToAuth                                Property = "trustedtoauth"
-	SamAccountName                               Property = "samaccountname"
-	CertificateMappingMethodsCollected           Property = "certificatemappingmethodscollected"
-	CertificateMappingMethodsRaw                 Property = "certificatemappingmethodsraw"
-	CertificateMappingMethods                    Property = "certificatemappingmethodspretty"
-	StrongCertificateBindingEnforcementCollected Property = "strongcertificatebindingenforcementcollected"
-	StrongCertificateBindingEnforcementRaw       Property = "strongcertificatebindingenforcementraw"
-	StrongCertificateBindingEnforcement          Property = "strongcertificatebindingenforcement"
-	EKUs                                         Property = "ekus"
-	SubjectAltRequireUPN                         Property = "subjectaltrequireupn"
-	AuthorizedSignatures                         Property = "authorizedsignatures"
-	ApplicationPolicies                          Property = "applicationpolicies"
-	SchemaVersion                                Property = "schemaversion"
+	AdminCount                             Property = "admincount"
+	CASecurityCollected                    Property = "casecuritycollected"
+	CAName                                 Property = "caname"
+	CertChain                              Property = "certchain"
+	CertName                               Property = "certname"
+	CertThumbprint                         Property = "certthumbprint"
+	CertThumbprints                        Property = "certthumbprints"
+	EnrollmentAgentRestrictionsCollected   Property = "enrollmentagentrestrictionscollected"
+	IsUserSpecifiesSanEnabledCollected     Property = "isuserspecifiessanenabledcollected"
+	HasBasicConstraints                    Property = "hasbasicconstraints"
+	BasicConstraintPathLength              Property = "basicconstraintpathlength"
+	DNSHostname                            Property = "dnshostname"
+	CrossCertificatePair                   Property = "crosscertificatepair"
+	DistinguishedName                      Property = "distinguishedname"
+	DomainFQDN                             Property = "domain"
+	DomainSID                              Property = "domainsid"
+	Sensitive                              Property = "sensitive"
+	HighValue                              Property = "highvalue"
+	BlocksInheritance                      Property = "blocksinheritance"
+	IsACL                                  Property = "isacl"
+	IsACLProtected                         Property = "isaclprotected"
+	IsDeleted                              Property = "isdeleted"
+	Enforced                               Property = "enforced"
+	Department                             Property = "department"
+	HasCrossCertificatePair                Property = "hascrosscertificatepair"
+	HasSPN                                 Property = "hasspn"
+	UnconstrainedDelegation                Property = "unconstraineddelegation"
+	LastLogon                              Property = "lastlogon"
+	LastLogonTimestamp                     Property = "lastlogontimestamp"
+	IsPrimaryGroup                         Property = "isprimarygroup"
+	HasLAPS                                Property = "haslaps"
+	DontRequirePreAuth                     Property = "dontreqpreauth"
+	LogonType                              Property = "logontype"
+	HasURA                                 Property = "hasura"
+	PasswordNeverExpires                   Property = "pwdneverexpires"
+	PasswordNotRequired                    Property = "passwordnotreqd"
+	FunctionalLevel                        Property = "functionallevel"
+	TrustType                              Property = "trusttype"
+	SidFiltering                           Property = "sidfiltering"
+	TrustedToAuth                          Property = "trustedtoauth"
+	SamAccountName                         Property = "samaccountname"
+	CertificateMappingMethodsRaw           Property = "certificatemappingmethodsraw"
+	CertificateMappingMethods              Property = "certificatemappingmethods"
+	StrongCertificateBindingEnforcementRaw Property = "strongcertificatebindingenforcementraw"
+	StrongCertificateBindingEnforcement    Property = "strongcertificatebindingenforcement"
+	EKUs                                   Property = "ekus"
+	SubjectAltRequireUPN                   Property = "subjectaltrequireupn"
+	AuthorizedSignatures                   Property = "authorizedsignatures"
+	ApplicationPolicies                    Property = "applicationpolicies"
+	SchemaVersion                          Property = "schemaversion"
 )
 
 func AllProperties() []Property {
-	return []Property{AdminCount, CASecurityCollected, CAName, CertChain, CertName, CertThumbprint, CertThumbprints, EnrollmentAgentRestrictionsCollected, IsUserSpecifiesSanEnabledCollected, HasBasicConstraints, BasicConstraintPathLength, DNSHostname, CrossCertificatePair, DistinguishedName, DomainFQDN, DomainSID, Sensitive, HighValue, BlocksInheritance, IsACL, IsACLProtected, IsDeleted, Enforced, Department, HasCrossCertificatePair, HasSPN, UnconstrainedDelegation, LastLogon, LastLogonTimestamp, IsPrimaryGroup, HasLAPS, DontRequirePreAuth, LogonType, HasURA, PasswordNeverExpires, PasswordNotRequired, FunctionalLevel, TrustType, SidFiltering, TrustedToAuth, SamAccountName, CertificateMappingMethodsCollected, CertificateMappingMethodsRaw, CertificateMappingMethods, StrongCertificateBindingEnforcementCollected, StrongCertificateBindingEnforcementRaw, StrongCertificateBindingEnforcement, EKUs, SubjectAltRequireUPN, AuthorizedSignatures, ApplicationPolicies, SchemaVersion}
+	return []Property{AdminCount, CASecurityCollected, CAName, CertChain, CertName, CertThumbprint, CertThumbprints, EnrollmentAgentRestrictionsCollected, IsUserSpecifiesSanEnabledCollected, HasBasicConstraints, BasicConstraintPathLength, DNSHostname, CrossCertificatePair, DistinguishedName, DomainFQDN, DomainSID, Sensitive, HighValue, BlocksInheritance, IsACL, IsACLProtected, IsDeleted, Enforced, Department, HasCrossCertificatePair, HasSPN, UnconstrainedDelegation, LastLogon, LastLogonTimestamp, IsPrimaryGroup, HasLAPS, DontRequirePreAuth, LogonType, HasURA, PasswordNeverExpires, PasswordNotRequired, FunctionalLevel, TrustType, SidFiltering, TrustedToAuth, SamAccountName, CertificateMappingMethodsRaw, CertificateMappingMethods, StrongCertificateBindingEnforcementRaw, StrongCertificateBindingEnforcement, EKUs, SubjectAltRequireUPN, AuthorizedSignatures, ApplicationPolicies, SchemaVersion}
 }
 func ParseProperty(source string) (Property, error) {
 	switch source {
@@ -245,14 +243,10 @@ func ParseProperty(source string) (Property, error) {
 		return TrustedToAuth, nil
 	case "samaccountname":
 		return SamAccountName, nil
-	case "certificatemappingmethodscollected":
-		return CertificateMappingMethodsCollected, nil
 	case "certificatemappingmethodsraw":
 		return CertificateMappingMethodsRaw, nil
-	case "certificatemappingmethodspretty":
+	case "certificatemappingmethods":
 		return CertificateMappingMethods, nil
-	case "strongcertificatebindingenforcementcollected":
-		return StrongCertificateBindingEnforcementCollected, nil
 	case "strongcertificatebindingenforcementraw":
 		return StrongCertificateBindingEnforcementRaw, nil
 	case "strongcertificatebindingenforcement":
@@ -355,14 +349,10 @@ func (s Property) String() string {
 		return string(TrustedToAuth)
 	case SamAccountName:
 		return string(SamAccountName)
-	case CertificateMappingMethodsCollected:
-		return string(CertificateMappingMethodsCollected)
 	case CertificateMappingMethodsRaw:
 		return string(CertificateMappingMethodsRaw)
 	case CertificateMappingMethods:
 		return string(CertificateMappingMethods)
-	case StrongCertificateBindingEnforcementCollected:
-		return string(StrongCertificateBindingEnforcementCollected)
 	case StrongCertificateBindingEnforcementRaw:
 		return string(StrongCertificateBindingEnforcementRaw)
 	case StrongCertificateBindingEnforcement:
@@ -465,14 +455,10 @@ func (s Property) Name() string {
 		return "Trusted For Constrained Delegation"
 	case SamAccountName:
 		return "SAM Account Name"
-	case CertificateMappingMethodsCollected:
-		return "Certificate Mapping Methods Collected"
 	case CertificateMappingMethodsRaw:
 		return "Certificate Mapping Methods (Raw)"
 	case CertificateMappingMethods:
-		return "Certificate Mapping Methods Pretty"
-	case StrongCertificateBindingEnforcementCollected:
-		return "Strong Certificate Binding Enforcement Collected"
+		return "Certificate Mapping Methods"
 	case StrongCertificateBindingEnforcementRaw:
 		return "Strong Certificate Binding Enforcement (Raw)"
 	case StrongCertificateBindingEnforcement:

--- a/packages/javascript/bh-shared-ui/src/graphSchema.ts
+++ b/packages/javascript/bh-shared-ui/src/graphSchema.ts
@@ -296,11 +296,11 @@ export enum ActiveDirectoryKindProperties {
     TrustedToAuth = 'trustedtoauth',
     SamAccountName = 'samaccountname',
     CertificateMappingMethodsCollected = 'certificatemappingmethodscollected',
-    CertificateMappingMethodsHex = 'certificatemappingmethodshex',
-    CertificateMappingMethodsPretty = 'certificatemappingmethodspretty',
+    CertificateMappingMethodsRaw = 'certificatemappingmethodsraw',
+    CertificateMappingMethods = 'certificatemappingmethodspretty',
     StrongCertificateBindingEnforcementCollected = 'strongcertificatebindingenforcementcollected',
-    StrongCertificateBindingEnforcementInt = 'strongcertificatebindingenforcementint',
-    StrongCertificateBindingEnforcementPretty = 'strongcertificatebindingenforcementpretty',
+    StrongCertificateBindingEnforcementRaw = 'strongcertificatebindingenforcementraw',
+    StrongCertificateBindingEnforcement = 'strongcertificatebindingenforcement',
     EKUs = 'ekus',
     SubjectAltRequireUPN = 'subjectaltrequireupn',
     AuthorizedSignatures = 'authorizedsignatures',
@@ -393,16 +393,16 @@ export function ActiveDirectoryKindPropertiesToDisplay(value: ActiveDirectoryKin
             return 'SAM Account Name';
         case ActiveDirectoryKindProperties.CertificateMappingMethodsCollected:
             return 'Certificate Mapping Methods Collected';
-        case ActiveDirectoryKindProperties.CertificateMappingMethodsHex:
-            return 'Certificate Mapping Methods Hex';
-        case ActiveDirectoryKindProperties.CertificateMappingMethodsPretty:
+        case ActiveDirectoryKindProperties.CertificateMappingMethodsRaw:
+            return 'Certificate Mapping Methods (Raw)';
+        case ActiveDirectoryKindProperties.CertificateMappingMethods:
             return 'Certificate Mapping Methods Pretty';
         case ActiveDirectoryKindProperties.StrongCertificateBindingEnforcementCollected:
             return 'Strong Certificate Binding Enforcement Collected';
-        case ActiveDirectoryKindProperties.StrongCertificateBindingEnforcementInt:
-            return 'Strong Certificate Binding Enforcement Int';
-        case ActiveDirectoryKindProperties.StrongCertificateBindingEnforcementPretty:
-            return 'Strong Certificate Binding Enforcement Pretty';
+        case ActiveDirectoryKindProperties.StrongCertificateBindingEnforcementRaw:
+            return 'Strong Certificate Binding Enforcement (Raw)';
+        case ActiveDirectoryKindProperties.StrongCertificateBindingEnforcement:
+            return 'Strong Certificate Binding Enforcement';
         case ActiveDirectoryKindProperties.EKUs:
             return 'EKUs';
         case ActiveDirectoryKindProperties.SubjectAltRequireUPN:

--- a/packages/javascript/bh-shared-ui/src/graphSchema.ts
+++ b/packages/javascript/bh-shared-ui/src/graphSchema.ts
@@ -295,10 +295,8 @@ export enum ActiveDirectoryKindProperties {
     SidFiltering = 'sidfiltering',
     TrustedToAuth = 'trustedtoauth',
     SamAccountName = 'samaccountname',
-    CertificateMappingMethodsCollected = 'certificatemappingmethodscollected',
     CertificateMappingMethodsRaw = 'certificatemappingmethodsraw',
-    CertificateMappingMethods = 'certificatemappingmethodspretty',
-    StrongCertificateBindingEnforcementCollected = 'strongcertificatebindingenforcementcollected',
+    CertificateMappingMethods = 'certificatemappingmethods',
     StrongCertificateBindingEnforcementRaw = 'strongcertificatebindingenforcementraw',
     StrongCertificateBindingEnforcement = 'strongcertificatebindingenforcement',
     EKUs = 'ekus',
@@ -391,14 +389,10 @@ export function ActiveDirectoryKindPropertiesToDisplay(value: ActiveDirectoryKin
             return 'Trusted For Constrained Delegation';
         case ActiveDirectoryKindProperties.SamAccountName:
             return 'SAM Account Name';
-        case ActiveDirectoryKindProperties.CertificateMappingMethodsCollected:
-            return 'Certificate Mapping Methods Collected';
         case ActiveDirectoryKindProperties.CertificateMappingMethodsRaw:
             return 'Certificate Mapping Methods (Raw)';
         case ActiveDirectoryKindProperties.CertificateMappingMethods:
-            return 'Certificate Mapping Methods Pretty';
-        case ActiveDirectoryKindProperties.StrongCertificateBindingEnforcementCollected:
-            return 'Strong Certificate Binding Enforcement Collected';
+            return 'Certificate Mapping Methods';
         case ActiveDirectoryKindProperties.StrongCertificateBindingEnforcementRaw:
             return 'Strong Certificate Binding Enforcement (Raw)';
         case ActiveDirectoryKindProperties.StrongCertificateBindingEnforcement:

--- a/packages/javascript/bh-shared-ui/src/utils/entityInfoDisplay.test.ts
+++ b/packages/javascript/bh-shared-ui/src/utils/entityInfoDisplay.test.ts
@@ -72,6 +72,13 @@ describe('Formatting number properties', () => {
         //A value of 0 will not be held by azure property whencreated but this demonstrated handling the values differently
         expect(formatNumber(0, 'az', 'whencreated')).toEqual('0');
     });
+
+    it('properly displays bitwise integers', () => {
+        // Base happy path
+        expect(formatNumber(31, 'ad', 'certificatemappingmethodsraw')).toEqual('31 (0x1F)');
+        // Honors specified padding
+        expect(formatNumber(4, 'ad', 'certificatemappingmethodsraw')).toEqual('4 (0x04)');
+    });
 });
 
 describe('Formatting boolean properties', () => {

--- a/packages/javascript/bh-shared-ui/src/utils/entityInfoDisplay.ts
+++ b/packages/javascript/bh-shared-ui/src/utils/entityInfoDisplay.ts
@@ -36,9 +36,7 @@ export enum ADSpecificTimeProperties {
 
 // Map containing all properties that should display as bitwise integers in the entity panel.
 // The key is the property string, the value is the amount of significant digits the hex value should display with.
-export var BitwiseInts = new Map([
-    ['certificatemappingmethodsraw', 2]
-])
+export var BitwiseInts = new Map([['certificatemappingmethodsraw', 2]]);
 
 //These times are handled differently specifically for these properties as they are collected and ingested to match these values
 //Here is some related documentation:
@@ -70,16 +68,15 @@ export const formatADSpecificTime = (timeValue: number, keyprop: ADSpecificTimeP
 
 export const formatBitwiseInt = (value: number, padding: number): string => {
     return `${value} (0x${value.toString(16).padStart(padding, '0').toUpperCase()})`;
-}
+};
 
 export const formatNumber = (value: number, kind?: EntityPropertyKind, keyprop?: string): string => {
     const isAmbiguousTimeValue =
         kind === 'ad' && Object.values(ADSpecificTimeProperties).includes(keyprop as ADSpecificTimeProperties);
-    const isBitwiseInt =
-        kind === 'ad' && BitwiseInts.has(keyprop as ActiveDirectoryKindProperties)
+    const isBitwiseInt = kind === 'ad' && BitwiseInts.has(keyprop as ActiveDirectoryKindProperties);
 
     if (isAmbiguousTimeValue) return formatADSpecificTime(value, keyprop as ADSpecificTimeProperties);
-    if (isBitwiseInt) return formatBitwiseInt(value, 2)
+    if (isBitwiseInt) return formatBitwiseInt(value, 2);
 
     //315536400 = January 1st, 1980. Seems like a safe bet
     const secondsLowerBound = 315536400;

--- a/packages/javascript/bh-shared-ui/src/utils/entityInfoDisplay.ts
+++ b/packages/javascript/bh-shared-ui/src/utils/entityInfoDisplay.ts
@@ -16,6 +16,7 @@
 
 import { DateTime } from 'luxon';
 import { LuxonFormat } from './datetime';
+import { ActiveDirectoryKindProperties } from '..';
 
 export type EntityPropertyKind = 'ad' | 'az' | 'cm' | null;
 
@@ -32,6 +33,12 @@ export enum ADSpecificTimeProperties {
     LAST_LOGON_TIMESTAMP = 'lastlogontimestamp',
     PASSWORD_LAST_SET = 'pwdlastset',
 }
+
+// Map containing all properties that should display as bitwise integers in the entity panel.
+// The key is the property string, the value is the amount of significant digits the hex value should display with.
+export var BitwiseInts = new Map([
+    ['certificatemappingmethodsraw', 2]
+])
 
 //These times are handled differently specifically for these properties as they are collected and ingested to match these values
 //Here is some related documentation:
@@ -61,11 +68,18 @@ export const formatADSpecificTime = (timeValue: number, keyprop: ADSpecificTimeP
     }
 };
 
+export const formatBitwiseInt = (value: number, padding: number): string => {
+    return `${value} (0x${value.toString(16).padStart(padding, '0').toUpperCase()})`;
+}
+
 export const formatNumber = (value: number, kind?: EntityPropertyKind, keyprop?: string): string => {
     const isAmbiguousTimeValue =
         kind === 'ad' && Object.values(ADSpecificTimeProperties).includes(keyprop as ADSpecificTimeProperties);
+    const isBitwiseInt =
+        kind === 'ad' && BitwiseInts.has(keyprop as ActiveDirectoryKindProperties)
 
     if (isAmbiguousTimeValue) return formatADSpecificTime(value, keyprop as ADSpecificTimeProperties);
+    if (isBitwiseInt) return formatBitwiseInt(value, 2)
 
     //315536400 = January 1st, 1980. Seems like a safe bet
     const secondsLowerBound = 315536400;

--- a/packages/javascript/bh-shared-ui/src/utils/entityInfoDisplay.ts
+++ b/packages/javascript/bh-shared-ui/src/utils/entityInfoDisplay.ts
@@ -73,7 +73,7 @@ export const formatBitwiseInt = (value: number, padding: number): string => {
 export const formatNumber = (value: number, kind?: EntityPropertyKind, keyprop?: string): string => {
     const isAmbiguousTimeValue =
         kind === 'ad' && Object.values(ADSpecificTimeProperties).includes(keyprop as ADSpecificTimeProperties);
-    const isBitwiseInt = kind === 'ad' && BitwiseInts.has(keyprop as ActiveDirectoryKindProperties);
+    const isBitwiseInt = BitwiseInts.has(keyprop as ActiveDirectoryKindProperties);
 
     if (isAmbiguousTimeValue) return formatADSpecificTime(value, keyprop as ADSpecificTimeProperties);
     if (isBitwiseInt) return formatBitwiseInt(value, 2);


### PR DESCRIPTION
## Description

This PR alters the data we are storing for the Computer property `CertificateMappingMethods`. When implemented we were storing this as a string that contained the hexadecimal representation of the integer that is stored in the registry. This  format was difficult to work with in code, so we are making the change to store it as the raw integer instead.

We still want to be sure to display the hex value as that is a better representation of how the setting is used. I added some additional formatting to the Entity Panel formatting to display both the int value and hex value in special circumstances like this.

## Motivation and Context

* Make the `CertificateMappingMethods` value more useful on the code side while still preserving the hex value in the Entity Panel

## How Has This Been Tested?

* Locally verified that the property is displaying correctly

## Screenshots (if appropriate):

![Screenshot 2023-10-18 at 3 40 08 PM](https://github.com/SpecterOps/BloodHound/assets/885166/ac271813-addc-421a-931b-8814acabfa74)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] My changes include a database migration.
