### PR TITLE
Update ADCS icon colors

### DIFF
--- a/cmd/ui/src/icons.ts
+++ b/cmd/ui/src/icons.ts
@@ -101,12 +101,12 @@ export const NODE_ICON: IconDictionary = {
 
     [ActiveDirectoryNodeKind.AIACA]: {
         icon: faArrowsLeftRightToLine,
-        color: '#763AAD',
+        color: '#A561AA',
     },
 
     [ActiveDirectoryNodeKind.RootCA]: {
         icon: faLandmark,
-        color: '#763AAD',
+        color: '#A561AA',
     },
 
     [ActiveDirectoryNodeKind.EnterpriseCA]: {
@@ -116,7 +116,7 @@ export const NODE_ICON: IconDictionary = {
 
     [ActiveDirectoryNodeKind.NTAuthStore]: {
         icon: faStore,
-        color: '#763AAD',
+        color: '#A561AA',
     },
 
     [ActiveDirectoryNodeKind.CertTemplate]: {

--- a/packages/javascript/bh-shared-ui/src/components/NodeIcon/constants.ts
+++ b/packages/javascript/bh-shared-ui/src/components/NodeIcon/constants.ts
@@ -71,12 +71,12 @@ export const NODE_ICON: { [index: string]: { icon: IconDefinition; color: string
 
     AIACA: {
         icon: faArrowsLeftRightToLine,
-        color: '#763AAD',
+        color: '#A561AA',
     },
 
     RootCA: {
         icon: faLandmark,
-        color: '#763AAD',
+        color: '#A561AA',
     },
 
     EnterpriseCA: {
@@ -86,7 +86,7 @@ export const NODE_ICON: { [index: string]: { icon: IconDefinition; color: string
 
     NTAuthStore: {
         icon: faStore,
-        color: '#763AAD',
+        color: '#A561AA',
     },
 
     CertTemplate: {


### PR DESCRIPTION
## Description

I think the purple icons are too dark. It is too difficult to distinguish the three node types. We use it for three node types because they are the same object class in AD. 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

Before:
![image](https://github.com/SpecterOps/BloodHound/assets/12843299/52297b80-e138-4975-9691-8afdfe9a3d26)

After:
![image](https://github.com/SpecterOps/BloodHound/assets/12843299/61d290b4-5fc8-4596-b34a-015c6ee86aa0)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [X] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] My changes include a database migration.
