### PR TITLE
log missing azure tenant ids during analysis

### DIFF
--- a/cmd/api/src/daemons/datapipe/agi.go
+++ b/cmd/api/src/daemons/datapipe/agi.go
@@ -69,6 +69,13 @@ func ParallelTagAzureTierZero(ctx context.Context, db graph.Database) error {
 			readerWG = &sync.WaitGroup{}
 		)
 
+		// log missing tenant IDs for easier debugging
+		for _, tenant := range tenants {
+			if _, err = tenant.Properties.Get(azure.TenantID.String()).String(); err != nil {
+				log.Errorf("Error getting tenant id for tenant %d: %v", tenant.ID, err)
+			}
+		}
+
 		readerWG.Add(1)
 
 		go func() {

--- a/cmd/api/src/daemons/datapipe/analysis.go
+++ b/cmd/api/src/daemons/datapipe/analysis.go
@@ -1,17 +1,17 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 package datapipe
@@ -20,19 +20,19 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/specterops/bloodhound/analysis"
+	adAnalysis "github.com/specterops/bloodhound/analysis/ad"
+	"github.com/specterops/bloodhound/dawgs/graph"
+	"github.com/specterops/bloodhound/errors"
 	"github.com/specterops/bloodhound/src/analysis/ad"
 	"github.com/specterops/bloodhound/src/analysis/azure"
 	"github.com/specterops/bloodhound/src/config"
 	"github.com/specterops/bloodhound/src/database"
 	"github.com/specterops/bloodhound/src/services/agi"
 	"github.com/specterops/bloodhound/src/services/dataquality"
-	"github.com/specterops/bloodhound/analysis"
-	adAnalysis "github.com/specterops/bloodhound/analysis/ad"
-	"github.com/specterops/bloodhound/dawgs/graph"
-	"github.com/specterops/bloodhound/errors"
 )
 
-func RunAnalysisOperations(ctx context.Context, db database.Database, graphDB graph.Database, cfg config.Configuration) error {
+func RunAnalysisOperations(ctx context.Context, db database.Database, graphDB graph.Database, _ config.Configuration) error {
 	var (
 		collector = &errors.ErrorCollector{}
 	)


### PR DESCRIPTION
## Description

When performing analysis on an AD domain, if the domain node is missing the domainsid attribute, we will log that as an error.
While Azure analysis follows the same logic with the tenantid property on the tenant node, this error is not surfaced into our logging infrastructure, making troubleshooting more difficult than necessary.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
