### PR TITLE
Update unsupported OS cypher query to include Windows 8 and Windows NT, and remove false positives

### DIFF
--- a/packages/javascript/bh-shared-ui/src/commonSearches.tsx
+++ b/packages/javascript/bh-shared-ui/src/commonSearches.tsx
@@ -43,7 +43,7 @@ export const CommonSearches = [
             },
             {
                 description: 'Computers with unsupported operating systems',
-                cypher: `MATCH (n:Computer)\nWHERE n.operatingsystem =~ "(?i).* (2000|2003|2008|2012|xp|vista|7|8|me|nt).*"\nRETURN n`,
+                cypher: `MATCH (n:Computer)\nWHERE n.operatingsystem =~ "(?i).*Windows.* (2000|2003|2008|2012|xp|vista|7|8|me|nt).*"\nRETURN n`,
             },
             {
                 description: 'Locations of high value/Tier Zero objects',

--- a/packages/javascript/bh-shared-ui/src/commonSearches.tsx
+++ b/packages/javascript/bh-shared-ui/src/commonSearches.tsx
@@ -43,7 +43,7 @@ export const CommonSearches = [
             },
             {
                 description: 'Computers with unsupported operating systems',
-                cypher: `MATCH (n:Computer)\nWHERE n.operatingsystem =~ "(?i).*(2000|2003|2008|2012|xp|vista|7|me).*"\nRETURN n`,
+                cypher: `MATCH (n:Computer)\nWHERE n.operatingsystem =~ "(?i).* (2000|2003|2008|2012|xp|vista|7|8|me|nt).*"\nRETURN n`,
             },
             {
                 description: 'Locations of high value/Tier Zero objects',


### PR DESCRIPTION
## Description

- Added '8' to match Windows 8.
- Added 'nt' to match Windows NT.
  - "NT" is also seen in many community-made Cypher and PowerShell queries searching for unsupported OS.
- Added a space before the version number, to not match false-positives containing "nt" like "Windows 2022 Datacenter"
- Added a requirement of "Windows" before the version number to remove false positives, as some non-Windows OS will have a version number starting with 8, 7, etc.
  - This may filter out true-positives of non-Windows OS versions with the years 2010, 2012, etc. These are most likely out of date too, for example "Mandriva Linux 2010". However, I believe this Cypher query was never thought to catch such guesswork cases.

## Motivation and Context

- Windows 8, 8.1, and NT are EOL.
- I have before seen false-positives when using the query.

## How Has This Been Tested?

- Tested in multiple production environments.
- Anecdotally, I have never seen a Windows OS having a version number in OperatingSystem which didn't include "Windows".

## Screenshots (if appropriate):

False positive (Ubuntu) in old query, when did not including "Windows":
![image](https://github.com/SpecterOps/BloodHound/assets/2473497/a82595bf-4632-4faa-b4fd-1a45cb528283)

False positive (SUSE Linux) in old query, when not including a space before version number:
![image](https://github.com/SpecterOps/BloodHound/assets/2473497/34c583d1-f627-4a19-964a-dacf2d6d90c6)

Finding Windows 8.1 with new query:
![image](https://github.com/SpecterOps/BloodHound/assets/2473497/a5b38cf6-3bb5-4db3-a002-337ffa70c4dc)

## Types of changes

-   [ x ] Chore (a change that does not modify the application functionality)
-   [ x ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] My changes include a database migration.
