### PR TITLE
feat: handle dc reg values not existing

### DIFF
--- a/packages/go/ein/ad.go
+++ b/packages/go/ein/ad.go
@@ -566,6 +566,8 @@ const (
 
 // Prettified definitions for DCRegistryData
 const (
+	RegValNotExisting                               = "Registry value does not exist"
+
 	PrettyCertMappingManyToOne                      = "0x01: Many-to-one (issuer certificate)"
 	PrettyCertMappingOneToOne                       = "0x02: One-to-one (subject/issuer)"
 	PrettyCertMappingUserPrincipalName              = "0x04: User principal name (UPN/SAN)"
@@ -581,40 +583,50 @@ func ParseDCRegistryData(computer Computer) IngestibleNode {
 	var ()
 	propMap := make(map[string]any)
 
-	if computer.DCRegistryData.CertificateMappingMethods.Collected && computer.DCRegistryData.CertificateMappingMethods.Value >= 0 {
+	if computer.DCRegistryData.CertificateMappingMethods.Collected {
 		propMap[ad.CertificateMappingMethodsRaw.String()] = computer.DCRegistryData.CertificateMappingMethods.Value
 
-		var prettyMappings []string
+		if computer.DCRegistryData.CertificateMappingMethods.Value == -1 {
+			propMap[ad.CertificateMappingMethods.String()] = RegValNotExisting
 
-		if computer.DCRegistryData.CertificateMappingMethods.Value&int(CertificateMappingManytoMany) != 0 {
-			prettyMappings = append(prettyMappings, PrettyCertMappingManyToOne)
-		}
-		if computer.DCRegistryData.CertificateMappingMethods.Value&int(CertificateMappingOneToOne) != 0 {
-			prettyMappings = append(prettyMappings, PrettyCertMappingOneToOne)
-		}
-		if computer.DCRegistryData.CertificateMappingMethods.Value&int(CertificateMappingUserPrincipalName) != 0 {
-			prettyMappings = append(prettyMappings, PrettyCertMappingUserPrincipalName)
-		}
-		if computer.DCRegistryData.CertificateMappingMethods.Value&int(CertificateMappingKerberosS4UCertificate) != 0 {
-			prettyMappings = append(prettyMappings, PrettyCertMappingKerberosS4UCertificate)
-		}
-		if computer.DCRegistryData.CertificateMappingMethods.Value&int(CertificateMappingKerberosS4UExplicitCertificate) != 0 {
-			prettyMappings = append(prettyMappings, PrettyCertMappingKerberosS4UExplicitCertificate)
-		}
+		} else if computer.DCRegistryData.CertificateMappingMethods.Value >= 0 {
+			var prettyMappings []string
 
-		propMap[ad.CertificateMappingMethods.String()] = prettyMappings
+			if computer.DCRegistryData.CertificateMappingMethods.Value&int(CertificateMappingManytoMany) != 0 {
+				prettyMappings = append(prettyMappings, PrettyCertMappingManyToOne)
+			}
+			if computer.DCRegistryData.CertificateMappingMethods.Value&int(CertificateMappingOneToOne) != 0 {
+				prettyMappings = append(prettyMappings, PrettyCertMappingOneToOne)
+			}
+			if computer.DCRegistryData.CertificateMappingMethods.Value&int(CertificateMappingUserPrincipalName) != 0 {
+				prettyMappings = append(prettyMappings, PrettyCertMappingUserPrincipalName)
+			}
+			if computer.DCRegistryData.CertificateMappingMethods.Value&int(CertificateMappingKerberosS4UCertificate) != 0 {
+				prettyMappings = append(prettyMappings, PrettyCertMappingKerberosS4UCertificate)
+			}
+			if computer.DCRegistryData.CertificateMappingMethods.Value&int(CertificateMappingKerberosS4UExplicitCertificate) != 0 {
+				prettyMappings = append(prettyMappings, PrettyCertMappingKerberosS4UExplicitCertificate)
+			}
+
+			propMap[ad.CertificateMappingMethods.String()] = prettyMappings
+		}
 	}
 
-	if computer.DCRegistryData.StrongCertificateBindingEnforcement.Collected && computer.DCRegistryData.StrongCertificateBindingEnforcement.Value >= 0 {
+	if computer.DCRegistryData.StrongCertificateBindingEnforcement.Collected {
 		propMap[ad.StrongCertificateBindingEnforcementRaw.String()] = computer.DCRegistryData.StrongCertificateBindingEnforcement.Value
 
-		switch computer.DCRegistryData.StrongCertificateBindingEnforcement.Value {
-		case 0:
-			propMap[ad.StrongCertificateBindingEnforcement.String()] = PrettyStrongCertBindingEnforcementDisabled
-		case 1:
-			propMap[ad.StrongCertificateBindingEnforcement.String()] = PrettyStrongCertBindingEnforcementCompatibility
-		case 2:
-			propMap[ad.StrongCertificateBindingEnforcement.String()] = PrettyStrongCertBindingEnforcementFull
+		if computer.DCRegistryData.StrongCertificateBindingEnforcement.Value == -1 {
+			propMap[ad.StrongCertificateBindingEnforcement.String()] = RegValNotExisting
+
+		} else if computer.DCRegistryData.StrongCertificateBindingEnforcement.Value >= 0 {
+			switch computer.DCRegistryData.StrongCertificateBindingEnforcement.Value {
+			case 0:
+				propMap[ad.StrongCertificateBindingEnforcement.String()] = PrettyStrongCertBindingEnforcementDisabled
+			case 1:
+				propMap[ad.StrongCertificateBindingEnforcement.String()] = PrettyStrongCertBindingEnforcementCompatibility
+			case 2:
+				propMap[ad.StrongCertificateBindingEnforcement.String()] = PrettyStrongCertBindingEnforcementFull
+			}
 		}
 	}
 

--- a/packages/go/ein/ad.go
+++ b/packages/go/ein/ad.go
@@ -585,13 +585,11 @@ func ParseDCRegistryData(computer Computer) IngestibleNode {
 
 	if computer.DCRegistryData.CertificateMappingMethods.Collected {
 		propMap[ad.CertificateMappingMethodsRaw.String()] = computer.DCRegistryData.CertificateMappingMethods.Value
+		var prettyMappings []string
 
 		if computer.DCRegistryData.CertificateMappingMethods.Value == -1 {
-			propMap[ad.CertificateMappingMethods.String()] = RegValNotExisting
-
-		} else if computer.DCRegistryData.CertificateMappingMethods.Value >= 0 {
-			var prettyMappings []string
-
+			prettyMappings = append(prettyMappings, RegValNotExisting)
+		} else {
 			if computer.DCRegistryData.CertificateMappingMethods.Value&int(CertificateMappingManytoMany) != 0 {
 				prettyMappings = append(prettyMappings, PrettyCertMappingManyToOne)
 			}
@@ -607,26 +605,23 @@ func ParseDCRegistryData(computer Computer) IngestibleNode {
 			if computer.DCRegistryData.CertificateMappingMethods.Value&int(CertificateMappingKerberosS4UExplicitCertificate) != 0 {
 				prettyMappings = append(prettyMappings, PrettyCertMappingKerberosS4UExplicitCertificate)
 			}
-
-			propMap[ad.CertificateMappingMethods.String()] = prettyMappings
 		}
+
+		propMap[ad.CertificateMappingMethods.String()] = prettyMappings		
 	}
 
 	if computer.DCRegistryData.StrongCertificateBindingEnforcement.Collected {
 		propMap[ad.StrongCertificateBindingEnforcementRaw.String()] = computer.DCRegistryData.StrongCertificateBindingEnforcement.Value
 
-		if computer.DCRegistryData.StrongCertificateBindingEnforcement.Value == -1 {
-			propMap[ad.StrongCertificateBindingEnforcement.String()] = RegValNotExisting
-
-		} else if computer.DCRegistryData.StrongCertificateBindingEnforcement.Value >= 0 {
-			switch computer.DCRegistryData.StrongCertificateBindingEnforcement.Value {
+		switch computer.DCRegistryData.StrongCertificateBindingEnforcement.Value {
+		    case -1:
+				propMap[ad.StrongCertificateBindingEnforcement.String()] = RegValNotExisting
 			case 0:
 				propMap[ad.StrongCertificateBindingEnforcement.String()] = PrettyStrongCertBindingEnforcementDisabled
 			case 1:
 				propMap[ad.StrongCertificateBindingEnforcement.String()] = PrettyStrongCertBindingEnforcementCompatibility
 			case 2:
 				propMap[ad.StrongCertificateBindingEnforcement.String()] = PrettyStrongCertBindingEnforcementFull
-			}
 		}
 	}
 


### PR DESCRIPTION
## Description

Handle when DC registry values do not exist.

It is possible that the registry values we want to collect do not exist. Sharphound will return -1 for integer values in this case.
We will store the value as is and make the user aware that the value does not exist: 
![image](https://github.com/SpecterOps/BloodHound/assets/12843299/5dd03cd3-dcc2-446c-87c5-6844d7a7de2b)

## How Has This Been Tested?

Uploaded positive int values, 0 values, and -1 values.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] My changes include a database migration.
