### PR TITLE
fix asset group error, add integration test

### DIFF
--- a/cmd/api/src/database/migration/agi.go
+++ b/cmd/api/src/database/migration/agi.go
@@ -65,7 +65,7 @@ func (s *Migrator) updateAssetGroups() error {
 			}
 		}
 
-		if _, hasOwned := systemAssetGroups.FindByName(model.OwnedAssetGroupTag); !hasOwned {
+		if _, hasOwned := systemAssetGroups.FindByName(model.OwnedAssetGroupName); !hasOwned {
 			log.Infof("Missing the default Owned asset group. Creating it now.")
 
 			ownedAG := model.AssetGroup{

--- a/cmd/api/src/database/migration/agi_integration_test.go
+++ b/cmd/api/src/database/migration/agi_integration_test.go
@@ -1,0 +1,40 @@
+// Copyright 2023 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build serial_integration
+// +build serial_integration
+
+package migration_test
+
+import (
+	"github.com/specterops/bloodhound/src/model"
+	"github.com/specterops/bloodhound/src/test/integration"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestMigration_AssetGroups(t *testing.T) {
+	// We expect a new DB to have the T0 group and the Owned group
+	expectedNumAssetGroups := 2
+	dbInst := integration.OpenDatabase(t)
+	if err := integration.Prepare(dbInst); err != nil {
+		t.Fatalf("Failed preparing DB: %v", err)
+	}
+
+	assetGroups, err := dbInst.GetAllAssetGroups("", model.SQLFilter{})
+	require.Nil(t, err)
+	require.Equal(t, expectedNumAssetGroups, len(assetGroups))
+}


### PR DESCRIPTION
## Description

A bug was introduced in https://github.com/SpecterOps/BloodHound/pull/164 where the existence of the `Owned` asset group was incorrectly being checked, resulting in bad data being set up in the database. This MR fixes that bug, and adds an integration test to prevent such regressions.

## How Has This Been Tested?

Added integration test

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [x] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
