### PR TITLE
remove ingest endpoint from community documentation

### DIFF
--- a/cmd/api/src/docs/json/paths/v2/ingestion.json
+++ b/cmd/api/src/docs/json/paths/v2/ingestion.json
@@ -4,7 +4,6 @@
             "description": "Ingests data from the user interface or clients",
             "tags": [
                 "Ingestion",
-                "Community",
                 "Enterprise"
             ],
             "summary": "Endpoint for data ingestion",


### PR DESCRIPTION
## Description

The api/v2/ingest endpoint is not available on BH CE, but was showing as available. The documentation has been updated to be accurate.


## How Has This Been Tested?
Verified on local dev that the icon has been updated:

![Screenshot 2023-10-26 at 11 32 50 AM](https://github.com/SpecterOps/BloodHound/assets/24904109/07dcd56d-5f6e-4015-bc52-21bfc5c92bd3)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
