### PR TITLE
fix: update test to only check major/minor/patch

### DIFF
--- a/cmd/api/src/database/migration/stepwise_internal_integration_test.go
+++ b/cmd/api/src/database/migration/stepwise_internal_integration_test.go
@@ -209,6 +209,8 @@ func TestMigrator_Migrate(t *testing.T) {
 
 		ver, err := testMigrator.LatestMigration()
 		require.Nil(t, err)
-		assert.Equal(t, version.GetVersion(), ver.Version())
+		assert.Equal(t, version.GetVersion().Major, ver.Version().Major)
+		assert.Equal(t, version.GetVersion().Minor, ver.Version().Minor)
+		assert.Equal(t, version.GetVersion().Patch, ver.Version().Patch)
 	})
 }


### PR DESCRIPTION
## Description

Fixes the new stepwise test to test only the parts of the built version that the migrations table tracks

## Motivation and Context

Migrations table doesn't track prerelease portion of version, so we should explicitly check the bits that it does track

## How Has This Been Tested?

Test continues to pass locally

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
