### PR TITLE
Fix query for 'Shortest paths from Kerberoastable users'

### DIFF
--- a/packages/javascript/bh-shared-ui/src/commonSearches.tsx
+++ b/packages/javascript/bh-shared-ui/src/commonSearches.tsx
@@ -138,7 +138,7 @@ export const CommonSearches: CommonSearchType[] = [
             },
             {
                 description: 'Shortest paths from Kerberoastable users',
-                cypher: `MATCH p=shortestPath((n)-[:${adTransitEdgeTypes}*1..]->(m:Computer))\nWHERE m.unconstraineddelegation = true AND n<>m\nRETURN p`,
+                cypher: `MATCH p=shortestPath((n:User)-[:${adTransitEdgeTypes}*1..]->(m:Computer))\nWHERE n.hasspn = true AND n<>m\nRETURN p`,
             },
             {
                 description: 'Shortest paths to Domain Admins from Kerberoastable users',


### PR DESCRIPTION
## Description
Fixed the cypher query for 'Shortest paths from Kerberoastable users', which was returning incorrect results.
Actually, it was the same as 'Shortest paths to systems trusted for unconstrained delegation'.


## Motivation and Context
The query returned 'Shortest paths to systems trusted for unconstrained delegation' instead of 'Shortest paths from Kerberoastable users'.

## How Has This Been Tested?
Run the query and obtained expected results.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
