### PR TITLE
fix: stepwise was making new migrations on every restart

### DIFF
--- a/cmd/api/src/database/migration/stepwise.go
+++ b/cmd/api/src/database/migration/stepwise.go
@@ -156,6 +156,8 @@ func (s *Migrator) executeStepwiseMigrations() error {
 		}
 	}
 
+	currentVersionMigration := model.NewMigration(version.GetVersion())
+
 	if migrationFilenames, err := s.MigrationFilenames(); err != nil {
 		return err
 	} else if manifest, err := NewManifest(migrationFilenames); err != nil {
@@ -164,8 +166,9 @@ func (s *Migrator) executeStepwiseMigrations() error {
 		return fmt.Errorf("could not get latest migration: %w", err)
 	} else if err := s.ExecuteMigrations(manifest.After(lastMigration.Version())); err != nil {
 		return fmt.Errorf("could not execute migrations: %w", err)
-	} else {
-		currentVersionMigration := model.NewMigration(version.GetVersion())
+	} else if lastMigration != currentVersionMigration {
 		return s.db.Create(&currentVersionMigration).Error
+	} else {
+		return nil
 	}
 }


### PR DESCRIPTION
## Description

This will prevent the stepwise migrator from adding additional entries for the same version

## Motivation and Context

Due to how the stepwise migrator runs, we were stamping a new version in the migrations database on every app restart, even if that version already existed. This change will ensure it only stamps the new version if the last migration and the current version aren't the same.

## How Has This Been Tested?

Validated locally with test harness

## Types of changes

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
