### PR TITLE
Support SharpHound flag for collecting ADCS data

### DIFF
--- a/cmd/api/src/database/migration/migrations/v5.3.0.sql
+++ b/cmd/api/src/database/migration/migrations/v5.3.0.sql
@@ -14,6 +14,22 @@
 --
 -- SPDX-License-Identifier: Apache-2.0
 
+-- Data Quality Stats for new node types
+ALTER TABLE ad_data_quality_stats
+ADD COLUMN IF NOT EXISTS aiacas BIGINT DEFAULT 0,
+ADD COLUMN IF NOT EXISTS rootcas BIGINT DEFAULT 0,
+ADD COLUMN IF NOT EXISTS enterprisecas BIGINT DEFAULT 0,
+ADD COLUMN IF NOT EXISTS ntauthstores BIGINT DEFAULT 0,
+ADD COLUMN IF NOT EXISTS certtemplates BIGINT DEFAULT 0;
+
+ALTER TABLE ad_data_quality_aggregations
+ADD COLUMN IF NOT EXISTS aiacas BIGINT DEFAULT 0,
+ADD COLUMN IF NOT EXISTS rootcas BIGINT DEFAULT 0,
+ADD COLUMN IF NOT EXISTS enterprisecas BIGINT DEFAULT 0,
+ADD COLUMN IF NOT EXISTS ntauthstores BIGINT DEFAULT 0,
+ADD COLUMN IF NOT EXISTS certtemplates BIGINT DEFAULT 0;
+
+-- New columns for ADCS collection flags via SharpHound Service
 ALTER TABLE client_schedules
 ADD COLUMN IF NOT EXISTS adcs_collection BOOLEAN DEFAULT false;
 

--- a/cmd/api/src/database/migration/migrations/v5.3.0.sql
+++ b/cmd/api/src/database/migration/migrations/v5.3.0.sql
@@ -1,0 +1,21 @@
+-- Copyright 2023 Specter Ops, Inc.
+--
+-- Licensed under the Apache License, Version 2.0
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- SPDX-License-Identifier: Apache-2.0
+
+ALTER TABLE client_schedules
+ADD COLUMN IF NOT EXISTS adcs_collection BOOLEAN DEFAULT false;
+
+ALTER TABLE client_scheduled_jobs
+ADD COLUMN IF NOT EXISTS adcs_collection BOOLEAN DEFAULT false;

--- a/packages/javascript/js-client-library/src/types.ts
+++ b/packages/javascript/js-client-library/src/types.ts
@@ -59,6 +59,7 @@ export interface CreateScheduledJobRequest {
     session_collection: boolean;
     ad_structure_collection: boolean;
     local_group_collection: boolean;
+    adcs_collection: boolean;
     domain_controller?: string;
     ous: string[];
     domains: string[];
@@ -82,6 +83,7 @@ export interface CreateSharpHoundEventRequest {
     session_collection: boolean;
     ad_structure_collection: boolean;
     local_group_collection: boolean;
+    adcs_collection: boolean;
     ous: string[];
     domains: string[];
     all_trusted_domains: boolean;
@@ -98,6 +100,7 @@ export interface UpdateSharpHoundEventRequest {
     session_collection: boolean;
     ad_structure_collection: boolean;
     local_group_collection: boolean;
+    adcs_collection: boolean;
     ous: string[];
     domains: string[];
     all_trusted_domains: boolean;


### PR DESCRIPTION
## Description

This PR makes a couple of changes to support ADCS collection via SharpHound in BloodHound Enterprise. A new migration is added to create the new column on the `client_schedules` and `client_scheduled_jobs` tables. Also, necessary updates were made to the UI data models to support the new attribute.

This PR also contains migrations for the `ad_data_quality_stats` and `ad_data_quality_aggregations` tables. These attributes were added via Gorm in a previous commit for the `adcs-poc` branch. Gorm auto-migrate was removed in #159 which means we now need explicit stepwise migrations for these columns.

## Motivation and Context
- We want to give people the option of collecting ADCS data via SharpHound Service clients.

## How Has This Been Tested?
- Verified the migration successfully applies the new columns and that existing records default to `false`

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [x] My changes include a database migration.
