### PR TITLE
increase dawgs memory limit to 2gb

### DIFF
--- a/cmd/api/src/config/default.go
+++ b/cmd/api/src/config/default.go
@@ -49,7 +49,7 @@ func NewDefaultConfiguration() (Configuration, error) {
 			DisableAnalysis:        false,
 			DisableCypherQC:        false,
 			DisableMigrations:      false,
-			TraversalMemoryLimit:   1, // 1 GiB by default
+			TraversalMemoryLimit:   2, // 2 GiB by default
 			TLS:                    TLSConfiguration{},
 			SAML:                   SAMLConfiguration{},
 			Database: DatabaseConfiguration{

--- a/local-harnesses/build.config.json.template
+++ b/local-harnesses/build.config.json.template
@@ -22,6 +22,5 @@
         "first_name": "BloodHound",
         "last_name": "Dev",
         "expire_now": false
-    },
-    "traversal_memory_limit": 1
+    }
 }

--- a/packages/go/dawgs/drivers/neo4j/transaction.go
+++ b/packages/go/dawgs/drivers/neo4j/transaction.go
@@ -115,7 +115,7 @@ func (s *neo4jTransaction) UpdateNodeBy(update graph.NodeUpdate) error {
 
 func newTransaction(ctx context.Context, session neo4j_core.Session, cfg graph.TransactionConfig, writeFlushSize int, batchWriteSize int, traversalMemoryLimit size.Size) *neo4jTransaction {
 	if traversalMemoryLimit == 0 {
-		traversalMemoryLimit = size.Gibibyte
+		traversalMemoryLimit = 2 * size.Gibibyte
 	}
 
 	return &neo4jTransaction{


### PR DESCRIPTION
## Description

Increase dawgs query limit to 2GB since enterprise customers are running into the limits too often.


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
