### PR TITLE
Migrate data quality tables for new ADCS nodes

### DIFF
--- a/cmd/api/src/database/migration/migrations/v5.3.0.sql
+++ b/cmd/api/src/database/migration/migrations/v5.3.0.sql
@@ -1,0 +1,30 @@
+-- Copyright 2023 Specter Ops, Inc.
+--
+-- Licensed under the Apache License, Version 2.0
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- SPDX-License-Identifier: Apache-2.0
+
+-- Data Quality Stats for new ADCS node types
+ALTER TABLE ad_data_quality_stats
+ADD COLUMN IF NOT EXISTS aiacas BIGINT DEFAULT 0,
+ADD COLUMN IF NOT EXISTS rootcas BIGINT DEFAULT 0,
+ADD COLUMN IF NOT EXISTS enterprisecas BIGINT DEFAULT 0,
+ADD COLUMN IF NOT EXISTS ntauthstores BIGINT DEFAULT 0,
+ADD COLUMN IF NOT EXISTS certtemplates BIGINT DEFAULT 0;
+
+ALTER TABLE ad_data_quality_aggregations
+ADD COLUMN IF NOT EXISTS aiacas BIGINT DEFAULT 0,
+ADD COLUMN IF NOT EXISTS rootcas BIGINT DEFAULT 0,
+ADD COLUMN IF NOT EXISTS enterprisecas BIGINT DEFAULT 0,
+ADD COLUMN IF NOT EXISTS ntauthstores BIGINT DEFAULT 0,
+ADD COLUMN IF NOT EXISTS certtemplates BIGINT DEFAULT 0;


### PR DESCRIPTION
## Description

This PR adds additional columns to the `ad_data_quality_stats` and `ad_data_quality_aggregations` tables to support collecting stats for new nodes being collected from ADCS. This migration is necessary as Gorm auto-migrations were removed as part of #159.

## Motivation and Context

* These columns are used to store counts of the new node types that are now being collected for ADCS

## How Has This Been Tested?

* Verified the migration successfully adds the new columns.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] My changes include a database migration.
