### PR TITLE
fix: disable_cypher_qc and other 3+ segment JSON keys

### DIFF
--- a/cmd/api/src/config/config.go
+++ b/cmd/api/src/config/config.go
@@ -19,6 +19,7 @@ package config
 import (
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -240,7 +241,9 @@ func SetValuesFromEnv(varPrefix string, target any, env []string) error {
 			if formattedPrefix := formatEnvironmentVariablePrefix(varPrefix); strings.HasPrefix(key, formattedPrefix) {
 				cfgKeyPath := strings.TrimPrefix(key, formattedPrefix)
 
-				if err := SetValue(target, cfgKeyPath, valueStr); err != nil {
+				if err := SetValue(target, cfgKeyPath, valueStr); errors.Is(err, InvalidConfigurationPathError) {
+					log.Warnf("%s", err)
+				} else if err != nil {
 					return err
 				}
 			}

--- a/cmd/api/src/config/reflect.go
+++ b/cmd/api/src/config/reflect.go
@@ -17,6 +17,7 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 	"regexp"
@@ -24,11 +25,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/specterops/bloodhound/log"
 	"github.com/specterops/bloodhound/src/serde"
 )
 
 var structTagRegex = regexp.MustCompile(`(\w+):"([^"]+)"`)
+var InvalidConfigurationPathError = errors.New("Unable to find a configuration element by path")
 
 // taggedField represents a struct field by its index and a parsed representation of any tags associated with the
 // struct field.
@@ -270,10 +271,12 @@ func SetValue(target any, path, value string) error {
 				break
 			}
 
-			lookahead := idx + 1
+			base := idx
+			lookahead := base
 
 			for lookahead < len(pathParts) {
-				remainingFullPath := strings.Join(append([]string{nextPathPart}, pathParts[lookahead]), "_")
+				// Make sure to add one to lookahead, as we want to get the range starting at base and going 1 or more indexes beyond it
+				remainingFullPath := strings.Join(pathParts[base:lookahead+1], "_")
 
 				if taggedFieldName == remainingFullPath {
 					cursor = cursor.Field(taggedField.Field)
@@ -291,8 +294,7 @@ func SetValue(target any, path, value string) error {
 		}
 
 		if !found {
-			log.Warnf("Unable to find a configuration element by path: %s", path)
-			return nil
+			return fmt.Errorf("%w: %s", InvalidConfigurationPathError, path)
 		}
 	}
 

--- a/cmd/api/src/config/reflect.go
+++ b/cmd/api/src/config/reflect.go
@@ -271,12 +271,11 @@ func SetValue(target any, path, value string) error {
 				break
 			}
 
-			base := idx
-			lookahead := base
+			lookahead := idx
 
 			for lookahead < len(pathParts) {
 				// Make sure to add one to lookahead, as we want to get the range starting at base and going 1 or more indexes beyond it
-				remainingFullPath := strings.Join(pathParts[base:lookahead+1], "_")
+				remainingFullPath := strings.Join(pathParts[idx:lookahead+1], "_")
 
 				if taggedFieldName == remainingFullPath {
 					cursor = cursor.Field(taggedField.Field)

--- a/cmd/api/src/config/reflect_test.go
+++ b/cmd/api/src/config/reflect_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/specterops/bloodhound/src/config"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSetValue(t *testing.T) {
@@ -41,8 +42,14 @@ func TestSetValue(t *testing.T) {
 		assert.Equal(t, uint32(10), cfg.Crypto.Argon2.MemoryKibibytes)
 	})
 
-	t.Run("attempting to set a value to an unknown field should not fail", func(t *testing.T) {
-		assert.Nil(t, config.SetValue(&cfg, "crypto_fake", "string"))
+	t.Run("key with two underscores", func(t *testing.T) {
+		require.Nil(t, config.SetValue(&cfg, "disable_cypher_qc", "true"))
+		assert.Equal(t, true, cfg.DisableCypherQC)
+	})
+
+	t.Run("key with three underscores", func(t *testing.T) {
+		require.Nil(t, config.SetValue(&cfg, "max_graphdb_cache_size", "0"))
+		assert.Equal(t, 0, cfg.MaxGraphQueryCacheSize)
 	})
 
 	t.Run("edge cases", func(t *testing.T) {


### PR DESCRIPTION
## Description

Fixes a bug that caused config keys with more than one underscore to not be parsed.

Regression tests have been added to avoid further issues

## Motivation and Context

The previous env var fixes introduced a bug when attempting to find the end of a key when the key contains multiple underscores

## How Has This Been Tested?

Additional tests have been added and various configurations with varying numbers of underscores and path segments were reviewed to ensure we have coverage for variations of path sizes and variations of multiple underscores per key.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [x] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
