### PR TITLE
Entity info count fallback

### DIFF
--- a/cmd/ui/src/views/Explore/EntityInfo/EntityInfoDataTable.test.tsx
+++ b/cmd/ui/src/views/Explore/EntityInfo/EntityInfoDataTable.test.tsx
@@ -1,0 +1,115 @@
+import { render, screen } from 'src/test-utils';
+import userEvent from '@testing-library/user-event';
+import { rest, RequestHandler } from 'msw';
+import { setupServer } from 'msw/node';
+import EntityInfoDataTable from './EntityInfoDataTable';
+import { EntityInfoPanelContextProvider } from './EntityInfoPanelContextProvider';
+import { allSections } from './content';
+import { ActiveDirectoryNodeKind } from 'bh-shared-ui';
+
+const objectId = 'fake-object-id';
+const sections = allSections[ActiveDirectoryNodeKind.GPO](objectId);
+
+const queryCount = {
+    controllers: {
+        count: 0,
+        limit: 128,
+        skip: 0,
+        data: [],
+    },
+    ous: {
+        count: 8,
+        limit: 128,
+        skip: 0,
+        data: [],
+    },
+    computers: {
+        count: 3003,
+        limit: 128,
+        skip: 0,
+        data: [],
+    },
+    users: {
+        count: 1998,
+        limit: 128,
+        skip: 0,
+        data: [],
+    },
+    'tier-zero': {
+        count: 55,
+        limit: 128,
+        skip: 0,
+        data: [],
+    },
+} as const;
+
+const handlers: Array<RequestHandler> = [
+    rest.get(`api/v2/gpos/${objectId}/:asset`, (req, res, ctx) => {
+        const asset = req.params.asset as keyof typeof queryCount;
+        return res(ctx.json(queryCount[asset]));
+    }),
+];
+
+const server = setupServer(...handlers);
+
+describe('EntityInfoDataTable', () => {
+    describe('Node count', () => {
+        beforeAll(() => server.listen());
+        afterEach(() => server.resetHandlers());
+        afterAll(() => server.close());
+
+        it('sums nested section node counts', async () => {
+            render(
+                <EntityInfoPanelContextProvider>
+                    <EntityInfoDataTable {...sections[0]} />
+                </EntityInfoPanelContextProvider>
+            );
+            const sum = await screen.findByText('5,064');
+            expect(sum).not.toBeNull();
+        });
+
+        it('displays ! icon when one of the Affected Object calls fail', async () => {
+            console.error = vi.fn();
+            server.use(
+                rest.get(`api/v2/gpos/${objectId}/ous`, (req, res, ctx) => {
+                    return res(ctx.status(500));
+                })
+            );
+
+            render(
+                <EntityInfoPanelContextProvider>
+                    <EntityInfoDataTable {...sections[0]} />
+                </EntityInfoPanelContextProvider>
+            );
+
+            const errorIcon = await screen.findByTestId('ErrorOutlineIcon');
+
+            expect(errorIcon).not.toBeNull();
+        });
+
+        it('displays 0 when a given sections returns empty, and sums the rest of the sections correctly', async () => {
+            server.use(
+                rest.get(`api/v2/gpos/${objectId}/ous`, (req, res, ctx) => {
+                    const _ous = { ...queryCount.ous, count: undefined };
+                    return res(ctx.json(_ous));
+                })
+            );
+
+            const user = userEvent.setup();
+            render(
+                <EntityInfoPanelContextProvider>
+                    <EntityInfoDataTable {...sections[0]} />
+                </EntityInfoPanelContextProvider>
+            );
+
+            const sum = await screen.findAllByText('5,056');
+            expect(sum).not.toBeNull();
+
+            const button = await screen.findByRole('button');
+            await user.click(button);
+
+            const zero = await screen.findByText('0');
+            expect(zero.textContent).toBe('0');
+        });
+    });
+});

--- a/cmd/ui/src/views/Explore/EntityInfo/EntityInfoDataTable.test.tsx
+++ b/cmd/ui/src/views/Explore/EntityInfo/EntityInfoDataTable.test.tsx
@@ -18,10 +18,10 @@ import { render, screen } from 'src/test-utils';
 import userEvent from '@testing-library/user-event';
 import { rest, RequestHandler } from 'msw';
 import { setupServer } from 'msw/node';
+import { ActiveDirectoryNodeKind } from 'bh-shared-ui';
 import EntityInfoDataTable from './EntityInfoDataTable';
 import { EntityInfoPanelContextProvider } from './EntityInfoPanelContextProvider';
 import { allSections } from './content';
-import { ActiveDirectoryNodeKind } from 'bh-shared-ui';
 
 const objectId = 'fake-object-id';
 const sections = allSections[ActiveDirectoryNodeKind.GPO](objectId);

--- a/cmd/ui/src/views/Explore/EntityInfo/EntityInfoDataTable.test.tsx
+++ b/cmd/ui/src/views/Explore/EntityInfo/EntityInfoDataTable.test.tsx
@@ -1,3 +1,19 @@
+// Copyright 2023 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { render, screen } from 'src/test-utils';
 import userEvent from '@testing-library/user-event';
 import { rest, RequestHandler } from 'msw';

--- a/cmd/ui/src/views/Explore/EntityInfo/EntityInfoDataTable.tsx
+++ b/cmd/ui/src/views/Explore/EntityInfo/EntityInfoDataTable.tsx
@@ -105,10 +105,11 @@ const EntityInfoDataTable: React.FC<EntityInfoDataTableProps> = ({ id, label, en
     let count: number | undefined;
     if (Array.isArray(countQuery.data)) {
         count = countQuery.data.reduce((acc, val) => {
-            return acc + val.count;
+            const count = val.count ?? 0;
+            return acc + count;
         }, 0);
     } else if (countQuery.data) {
-        count = countQuery.data.count;
+        count = countQuery.data.count ?? 0;
     }
 
     return (


### PR DESCRIPTION
## Description

Fallback to 0 for `EntityInfoDataTable` count when `countQuery` returns empty.

## Motivation and Context

Previously when the count query returned empty for a given node, and that node was in a group of other Node Kinds, the sum of all counts return `NaN`. Preferably if a count is empty, it should be counted and displayed as 0 and not block other node counts from being summed.

## How Has This Been Tested?

Manual tests:
- empty `countQuery` response, 
- failed network requests, 
- countQuery returning results

Added integration test to cover the different states a node count can be in.

## Screenshots (if appropriate):
### happy:
![Screenshot 2023-11-08 at 10 36 29 AM](https://github.com/SpecterOps/BloodHound/assets/66393111/a32143fc-5c38-4448-9e82-b98cae2f842a)

### error:
![Screenshot 2023-11-08 at 10 29 06 AM](https://github.com/SpecterOps/BloodHound/assets/66393111/edf98b2b-68be-48d6-8c9c-1f7b62272e5a)


### empty returns:
![Screenshot 2023-11-08 at 10 36 01 AM](https://github.com/SpecterOps/BloodHound/assets/66393111/33a5b493-f9c9-436a-a1d1-564acca4a11a)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [x] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
