### PR TITLE
feat: update azresetpassword processing to start from role nodes inst…

### DIFF
--- a/packages/go/analysis/azure/post.go
+++ b/packages/go/analysis/azure/post.go
@@ -18,9 +18,12 @@ package azure
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
+	"github.com/RoaringBitmap/roaring"
 	"github.com/RoaringBitmap/roaring/roaring64"
+	"github.com/bloodhoundad/azurehound/v2/constants"
 	"github.com/specterops/bloodhound/dawgs/graph"
 	"github.com/specterops/bloodhound/dawgs/ops"
 	"github.com/specterops/bloodhound/dawgs/query"
@@ -28,6 +31,7 @@ import (
 	"github.com/specterops/bloodhound/graphschema/azure"
 	"github.com/specterops/bloodhound/graphschema/common"
 	"github.com/specterops/bloodhound/log"
+	"github.com/specterops/bloodhound/slices"
 
 	"github.com/specterops/bloodhound/analysis"
 )
@@ -48,6 +52,19 @@ func AddMemberGroupNotRoleAssignableTargetRoles() []string {
 		azure.IntuneServiceAdministratorRole,
 		azure.KnowledgeAdministratorRole,
 		azure.KnowledgeManagerRole,
+	}
+}
+
+func ResetPasswordRoleIDs() []string {
+	return []string{
+		constants.GlobalAdministratorRoleID,
+		constants.PrivilegedAuthenticationAdministratorRoleID,
+		constants.PartnerTier2SupportRoleID,
+		constants.HelpdeskAdministratorRoleID,
+		constants.AuthenticationAdministratorRoleID,
+		constants.UserAdministratorRoleID,
+		constants.PasswordAdministratorRoleID,
+		constants.PartnerTier1SupportRoleID,
 	}
 }
 
@@ -146,100 +163,134 @@ func (s RoleAssignmentMap) HasRole(id graph.ID, roleTemplateIDs ...string) bool 
 }
 
 type RoleAssignments struct {
-	Nodes         graph.NodeKindSet
-	AssignmentMap RoleAssignmentMap
+	Principals graph.NodeKindSet
+	RoleMap    map[string]*roaring.Bitmap
 }
 
-func (s RoleAssignments) UsersWithoutRoles() graph.NodeSet {
-	users := graph.NewNodeSet()
-
-	for _, user := range s.Nodes.Get(azure.User) {
-		if !s.AssignmentMap.UserHasRoles(user) {
-			users.Add(user)
-		}
+func (s RoleAssignments) GetNodeKindSet(bm *roaring.Bitmap) graph.NodeKindSet {
+	var (
+		result = graph.NewNodeKindSet()
+		iter   = bm.Iterator()
+	)
+	for iter.HasNext() {
+		node := s.Principals.GetNode(graph.ID(iter.Next()))
+		result.Add(node)
 	}
-
-	return users
+	return result
 }
 
-func (s RoleAssignments) NodesWithRole(roleTemplateIDs ...string) graph.NodeKindSet {
-	members := graph.NewNodeKindSet()
+func (s RoleAssignments) GetNodeSet(bm *roaring.Bitmap) graph.NodeSet {
+	return s.GetNodeKindSet(bm).AllNodes()
+}
 
-	for userID, roleAssignments := range s.AssignmentMap {
-		for _, roleTemplateID := range roleTemplateIDs {
-			if _, hasRole := roleAssignments[roleTemplateID]; hasRole {
-				members.Add(s.Nodes.GetNode(userID))
-				break
-			}
+func (s RoleAssignments) Users() *roaring.Bitmap {
+	return s.Principals.Get(azure.User).IDBitmap()
+}
+
+func (s RoleAssignments) UsersWithAnyRole() *roaring.Bitmap {
+	users := s.Users()
+
+	principalsWithRoles := roaring.New()
+	for _, bitmap := range s.RoleMap {
+		principalsWithRoles.Or(bitmap)
+	}
+	principalsWithRoles.And(users)
+	return principalsWithRoles
+}
+
+func (s RoleAssignments) UsersWithoutRoles() *roaring.Bitmap {
+	result := s.Users()
+	result.AndNot(s.UsersWithAnyRole())
+	return result
+}
+
+func (s RoleAssignments) UsersWithRole(roleTemplateIDs ...string) *roaring.Bitmap {
+	result := s.PrincipalsWithRole(roleTemplateIDs...)
+	result.And(s.Users())
+	return result
+}
+
+func (s RoleAssignments) UsersWithRolesExclusive(roleTemplateIDs ...string) *roaring.Bitmap {
+	result := s.PrincipalsWithRolesExclusive(roleTemplateIDs...)
+	result.And(s.Users())
+	return result
+}
+
+// PrincipalsWithRole returns a roaring bitmap of principals that have been assigned one or more of the matching roles from list of role template IDs
+func (s RoleAssignments) PrincipalsWithRole(roleTemplateIDs ...string) *roaring.Bitmap {
+	result := roaring.New()
+	for _, roleTemplateID := range roleTemplateIDs {
+		if bitmap, ok := s.RoleMap[roleTemplateID]; ok {
+			result.Or(bitmap)
 		}
 	}
+	return result
+}
 
-	return members
+// PrincipalsWithRole returns a roaring bitmap of principals that have been assigned one or more of the matching roles from list of role template IDs but excluding principals with non-matching roles
+func (s RoleAssignments) PrincipalsWithRolesExclusive(roleTemplateIDs ...string) *roaring.Bitmap {
+	var (
+		result             = roaring.New()
+		excludedPrincipals = roaring.New()
+	)
+	for roleID, bitmap := range s.RoleMap {
+		if slices.Contains(roleTemplateIDs, roleID) {
+			result.Or(bitmap)
+		} else {
+			excludedPrincipals.Or(bitmap)
+		}
+	}
+	result.AndNot(excludedPrincipals)
+	return result
 }
 
 // NodesWithRolesExclusive will return nodes that *only* have a role/roles listed and exclude nodes that have other roles
 func (s RoleAssignments) NodesWithRolesExclusive(roleTemplateIDs ...string) graph.NodeKindSet {
-	var (
-		members = graph.NewNodeKindSet()
-		roleMap = make(map[string]struct{})
-	)
-	for _, roleTemplateID := range roleTemplateIDs {
-		roleMap[roleTemplateID] = struct{}{}
-	}
-
-	for nodeID, roleAssignments := range s.AssignmentMap {
-		var (
-			hasIncludedRole = false
-			hasExcludedRole = false
-		)
-		for assignment := range roleAssignments {
-			if _, hasRole := roleMap[assignment]; hasRole {
-				hasIncludedRole = true
-			} else {
-				hasExcludedRole = true
-			}
-		}
-		if hasIncludedRole && !hasExcludedRole {
-			members.Add(s.Nodes.GetNode(nodeID))
-		}
-	}
-
-	return members
+	bm := s.PrincipalsWithRolesExclusive(roleTemplateIDs...)
+	return s.GetNodeKindSet(bm)
 }
 
 func (s RoleAssignments) NodeHasRole(id graph.ID, roleTemplateIDs ...string) bool {
-	return s.AssignmentMap.HasRole(id, roleTemplateIDs...)
+	for _, roleID := range roleTemplateIDs {
+		if bm, ok := s.RoleMap[roleID]; ok {
+			if bm.Contains(uint32(id)) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
+// TenantRoles returns the NodeSet of roles for a given tenant that match one of the given role template IDs. If no role template ID is provided, then all of the tenant role nodes are returned in the NodeSet.
 func TenantRoles(tx graph.Transaction, tenant *graph.Node, roleTemplateIDs ...string) (graph.NodeSet, error) {
+	if !IsTenantNode(tenant) {
+		return nil, fmt.Errorf("cannot fetch tenant roles - node %d must be of kind %s", tenant.ID, azure.Tenant)
+	}
+
+	conditions := []graph.Criteria{
+		query.Equals(query.StartID(), tenant.ID),
+		query.Kind(query.Relationship(), azure.Contains),
+		query.Kind(query.End(), azure.Role),
+	}
+
+	if len(roleTemplateIDs) > 0 {
+		conditions = append(conditions, query.In(query.EndProperty(azure.RoleTemplateID.String()), roleTemplateIDs))
+	}
+
 	return ops.FetchEndNodes(tx.Relationships().Filterf(func() graph.Criteria {
-		return query.And(
-			query.Equals(query.StartID(), tenant.ID),
-			query.Kind(query.Relationship(), azure.Contains),
-			query.Kind(query.End(), azure.Role),
-			query.In(query.EndProperty(azure.RoleTemplateID.String()), roleTemplateIDs),
-		)
+		return query.And(conditions...)
 	}))
 }
 
 func initTenantRoleAssignments(tx graph.Transaction, tenant *graph.Node) (RoleAssignments, error) {
-	if tenantID, err := tenant.Properties.Get(azure.TenantID.String()).String(); err != nil {
-		if graph.IsErrPropertyNotFound(err) {
-			log.Errorf("Node %d is missing property %s", tenant.ID, azure.TenantID)
-		}
-
-		return RoleAssignments{}, err
-	} else if roleMembers, err := ops.FetchNodeSet(tx.Nodes().Filterf(func() graph.Criteria {
-		return query.And(
-			query.Equals(query.NodeProperty(azure.TenantID.String()), tenantID),
-			query.KindIn(query.Node(), azure.User, azure.Group, azure.ServicePrincipal),
-		)
-	})); err != nil && !graph.IsErrNotFound(err) {
+	if !IsTenantNode(tenant) {
+		return RoleAssignments{}, fmt.Errorf("cannot initialize tenant role assignments - node %d must be of kind %s", tenant.ID, azure.Tenant)
+	} else if roleMembers, err := TenantPrincipals(tx, tenant); err != nil && !graph.IsErrNotFound(err) {
 		return RoleAssignments{}, err
 	} else {
 		return RoleAssignments{
-			Nodes:         roleMembers.KindSet(),
-			AssignmentMap: make(RoleAssignmentMap),
+			Principals: roleMembers.KindSet(),
+			RoleMap:    make(map[string]*roaring.Bitmap),
 		}, nil
 	}
 }
@@ -300,38 +351,21 @@ func TenantRoleAssignments(ctx context.Context, db graph.Database, tenant *graph
 	return roleAssignments, db.ReadTransaction(ctx, func(tx graph.Transaction) error {
 		if fetchedRoleAssignments, err := initTenantRoleAssignments(tx, tenant); err != nil {
 			return err
+		} else if roles, err := TenantRoles(tx, tenant); err != nil {
+			return err
 		} else {
-			return fetchedRoleAssignments.Nodes.EachNode(func(node *graph.Node) error {
-				traversalPlan := ops.TraversalPlan{
-					Root:      node,
-					Direction: graph.DirectionOutbound,
-					BranchQuery: func() graph.Criteria {
-						return query.KindIn(query.Relationship(), azure.MemberOf, azure.HasRole)
-					},
-					DescentFilter: roleDescentFilter,
-					PathFilter: func(ctx *ops.TraversalContext, segment *graph.PathSegment) bool {
-						return segment.Node.Kinds.ContainsOneOf(azure.Role)
-					},
-				}
-
-				if roles, err := ops.AcyclicTraverseTerminals(tx, traversalPlan); err != nil {
-					return err
-				} else {
-					roleTemplateIDs := make(map[string]struct{}, roles.Len())
-
-					for _, roleNode := range roles {
-						if rollTemplateID, err := roleNode.Properties.Get(azure.RoleTemplateID.String()).String(); err != nil {
-							if !graph.IsErrPropertyNotFound(err) {
-								return err
-							}
-						} else {
-							roleTemplateIDs[rollTemplateID] = struct{}{}
-						}
+			return roles.KindSet().EachNode(func(node *graph.Node) error {
+				if roleTemplateID, err := node.Properties.Get(azure.RoleTemplateID.String()).String(); err != nil {
+					if !graph.IsErrPropertyNotFound(err) {
+						return err
 					}
-
-					fetchedRoleAssignments.AssignmentMap[node.ID] = roleTemplateIDs
+				} else if members, err := RoleMembers(tx, tenant, roleTemplateID); err != nil {
+					if !graph.IsErrNotFound(err) {
+						return err
+					}
+				} else {
+					fetchedRoleAssignments.RoleMap[roleTemplateID] = members.IDBitmap()
 				}
-
 				roleAssignments = fetchedRoleAssignments
 				return nil
 			})
@@ -993,26 +1027,63 @@ func ExecuteCommand(ctx context.Context, db graph.Database) (*analysis.AtomicPos
 	}
 }
 
-func resetPassword(ctx context.Context, db graph.Database, operation analysis.StatTrackedOperation[analysis.CreatePostRelationshipJob], roleAssignments RoleAssignments) error {
-	usersWithoutRoles := roleAssignments.UsersWithoutRoles()
+func resetPassword(ctx context.Context, db graph.Database, operation analysis.StatTrackedOperation[analysis.CreatePostRelationshipJob], tenant *graph.Node, roleAssignments RoleAssignments) error {
+	return operation.Operation.SubmitReader(func(ctx context.Context, tx graph.Transaction, outC chan<- analysis.CreatePostRelationshipJob) error {
+		if pwResetRoles, err := TenantRoles(tx, tenant, ResetPasswordRoleIDs()...); err != nil {
+			return err
+		} else {
+			for _, role := range pwResetRoles {
+				if roleTemplateIDProp := role.Properties.Get(azure.RoleTemplateID.String()); roleTemplateIDProp.IsNil() {
+					log.Errorf("unable to process azresetpassword for role node %d - missing property %s", role.ID, azure.RoleTemplateID)
+				} else if roleTemplateID, err := roleTemplateIDProp.String(); err != nil {
+					log.Errorf("unable to process azresetpassword for role node %d - property %s is not a string", role.ID, azure.RoleTemplateID)
+				} else {
+					targets := roaring.New()
+					switch roleTemplateID {
+					case constants.GlobalAdministratorRoleID, constants.PrivilegedAuthenticationAdministratorRoleID, constants.PartnerTier2SupportRoleID:
+						targets.Or(roleAssignments.Users())
+					case constants.UserAdministratorRoleID:
+						targets.Or(roleAssignments.UsersWithoutRoles())
+						targets.Or(roleAssignments.UsersWithRolesExclusive(UserAdministratorPasswordResetTargetRoles()...))
+					case constants.HelpdeskAdministratorRoleID:
+						targets.Or(roleAssignments.UsersWithoutRoles())
+						targets.Or(roleAssignments.UsersWithRolesExclusive(HelpdeskAdministratorPasswordResetTargetRoles()...))
+					case constants.AuthenticationAdministratorRoleID:
+						targets.Or(roleAssignments.UsersWithoutRoles())
+						targets.Or(roleAssignments.UsersWithRolesExclusive(AuthenticationAdministratorPasswordResetTargetRoles()...))
+					case constants.PasswordAdministratorRoleID:
+						targets.Or(roleAssignments.UsersWithoutRoles())
+						targets.Or(roleAssignments.UsersWithRolesExclusive(PasswordAdministratorPasswordResetTargetRoles()...))
+					case constants.PartnerTier1SupportRoleID:
+						targets.Or(roleAssignments.UsersWithoutRoles())
+					default:
+						log.Errorf("unable to process azresetpassword for role node %d - encountered unhandled role template id '%s'", role.ID, roleTemplateID)
+					}
 
-	if securityGroupOwners, err := getRoleEligibleSecurityGroupUsers(ctx, db, roleAssignments); err != nil {
-		return err
-	} else {
-		for _, userID := range roleAssignments.Nodes.AllNodeIDs() {
-			if err := resetPasswordCases(roleAssignments, operation, userID, usersWithoutRoles, securityGroupOwners); err != nil {
-				log.Errorf("Unable to process AZResetPassword for node %d: %v", userID, err)
+					iter := targets.Iterator()
+					for iter.HasNext() {
+						nextJob := analysis.CreatePostRelationshipJob{
+							FromID: role.ID,
+							ToID:   graph.ID(iter.Next()),
+							Kind:   azure.ResetPassword,
+						}
+
+						if !channels.Submit(ctx, outC, nextJob) {
+							return nil
+						}
+
+					}
+				}
 			}
 		}
-
 		return nil
-	}
+	})
 }
 
 // getRoleEligibleSecurityGroupUsers finds Users who own or are members of a role eligible security group
 func getRoleEligibleSecurityGroupUsers(ctx context.Context, db graph.Database, roleAssignments RoleAssignments) (*roaring64.Bitmap, error) {
 	var (
-		tenantGroups   = roleAssignments.Nodes.Get(azure.Group)
+		tenantGroups   = roleAssignments.Principals.Get(azure.Group)
 		securityGroups = make([]graph.ID, 0)
 		groupUsers     = roaring64.New()
 	)
@@ -1034,7 +1105,7 @@ func getRoleEligibleSecurityGroupUsers(ctx context.Context, db graph.Database, r
 		// find users that own or are a member of role eligible groups
 		return tx.Relationships().Filterf(func() graph.Criteria {
 			return query.And(
-				query.InIDs(query.StartID(), roleAssignments.Nodes.Get(azure.User).IDs()...),
+				query.InIDs(query.StartID(), roleAssignments.Principals.Get(azure.User).IDs()...),
 				query.KindIn(query.Relationship(), azure.Owns, azure.MemberOf),
 				query.Kind(query.End(), azure.Group),
 				query.InIDs(query.EndID(), securityGroups...))
@@ -1051,7 +1122,7 @@ func resetPasswordCases(roleAssignments RoleAssignments, operation analysis.Stat
 	if roleAssignments.NodeHasRole(userID, azure.CompanyAdministratorRole, azure.PrivilegedAuthenticationAdministratorRole, azure.PartnerTier2SupportRole) {
 		// GA, PAA, and PT2S roles can reset all user passwords in the tenant
 		operation.Operation.SubmitReader(func(ctx context.Context, tx graph.Transaction, outC chan<- analysis.CreatePostRelationshipJob) error {
-			for targetID := range roleAssignments.Nodes.Get(azure.User) {
+			for targetID := range roleAssignments.Principals.Get(azure.User) {
 				if userID == targetID {
 					continue
 				}
@@ -1254,9 +1325,10 @@ func resetPasswordCases(roleAssignments RoleAssignments, operation analysis.Stat
 
 func globalAdmins(roleAssignments RoleAssignments, tenant *graph.Node, operation analysis.StatTrackedOperation[analysis.CreatePostRelationshipJob]) {
 	operation.Operation.SubmitReader(func(ctx context.Context, tx graph.Transaction, outC chan<- analysis.CreatePostRelationshipJob) error {
-		for _, roleMember := range roleAssignments.NodesWithRole(azure.CompanyAdministratorRole).GetCombined(azure.User, azure.ServicePrincipal, azure.Group) {
+		iter := roleAssignments.PrincipalsWithRole(constants.GlobalAdministratorRoleID).Iterator()
+		for iter.HasNext() {
 			nextJob := analysis.CreatePostRelationshipJob{
-				FromID: roleMember.ID,
+				FromID: graph.ID(iter.Next()),
 				ToID:   tenant.ID,
 				Kind:   azure.GlobalAdmin,
 			}
@@ -1264,17 +1336,18 @@ func globalAdmins(roleAssignments RoleAssignments, tenant *graph.Node, operation
 			if !channels.Submit(ctx, outC, nextJob) {
 				return nil
 			}
-		}
 
+		}
 		return nil
 	})
 }
 
 func privilegedRoleAdmins(roleAssignments RoleAssignments, tenant *graph.Node, operation analysis.StatTrackedOperation[analysis.CreatePostRelationshipJob]) {
 	operation.Operation.SubmitReader(func(ctx context.Context, tx graph.Transaction, outC chan<- analysis.CreatePostRelationshipJob) error {
-		for _, roleMember := range roleAssignments.NodesWithRole(azure.PrivilegedRoleAdministratorRole).GetCombined(azure.User, azure.ServicePrincipal, azure.Group) {
+		iter := roleAssignments.PrincipalsWithRole(constants.PrivilegedRoleAdministratorRoleID).Iterator()
+		for iter.HasNext() {
 			nextJob := analysis.CreatePostRelationshipJob{
-				FromID: roleMember.ID,
+				FromID: graph.ID(iter.Next()),
 				ToID:   tenant.ID,
 				Kind:   azure.PrivilegedRoleAdmin,
 			}
@@ -1282,17 +1355,18 @@ func privilegedRoleAdmins(roleAssignments RoleAssignments, tenant *graph.Node, o
 			if !channels.Submit(ctx, outC, nextJob) {
 				return nil
 			}
-		}
 
+		}
 		return nil
 	})
 }
 
 func privilegedAuthAdmins(roleAssignments RoleAssignments, tenant *graph.Node, operation analysis.StatTrackedOperation[analysis.CreatePostRelationshipJob]) {
 	operation.Operation.SubmitReader(func(ctx context.Context, tx graph.Transaction, outC chan<- analysis.CreatePostRelationshipJob) error {
-		for _, roleMember := range roleAssignments.NodesWithRole(azure.PrivilegedAuthenticationAdministratorRole).GetCombined(azure.User, azure.ServicePrincipal, azure.Group) {
+		iter := roleAssignments.PrincipalsWithRole(constants.PrivilegedAuthenticationAdministratorRoleID).Iterator()
+		for iter.HasNext() {
 			nextJob := analysis.CreatePostRelationshipJob{
-				FromID: roleMember.ID,
+				FromID: graph.ID(iter.Next()),
 				ToID:   tenant.ID,
 				Kind:   azure.PrivilegedAuthAdmin,
 			}
@@ -1300,6 +1374,7 @@ func privilegedAuthAdmins(roleAssignments RoleAssignments, tenant *graph.Node, o
 			if !channels.Submit(ctx, outC, nextJob) {
 				return nil
 			}
+
 		}
 
 		return nil
@@ -1307,15 +1382,16 @@ func privilegedAuthAdmins(roleAssignments RoleAssignments, tenant *graph.Node, o
 }
 
 func addMembers(roleAssignments RoleAssignments, operation analysis.StatTrackedOperation[analysis.CreatePostRelationshipJob]) {
-	tenantGroups := roleAssignments.Nodes.Get(azure.Group)
+	tenantGroups := roleAssignments.Principals.Get(azure.Group)
 
 	for tenantGroupID, tenantGroup := range tenantGroups {
 		innerGroupID := tenantGroupID
 		innerGroup := tenantGroup
 		operation.Operation.SubmitReader(func(ctx context.Context, tx graph.Transaction, outC chan<- analysis.CreatePostRelationshipJob) error {
-			for _, tenantUser := range roleAssignments.NodesWithRole(AddMemberAllGroupsTargetRoles()...).Get(azure.User) {
+			iter := roleAssignments.UsersWithRole(AddMemberAllGroupsTargetRoles()...).Iterator()
+			for iter.HasNext() {
 				nextJob := analysis.CreatePostRelationshipJob{
-					FromID: tenantUser.ID,
+					FromID: graph.ID(iter.Next()),
 					ToID:   innerGroupID,
 					Kind:   azure.AddMembers,
 				}
@@ -1323,8 +1399,8 @@ func addMembers(roleAssignments RoleAssignments, operation analysis.StatTrackedO
 				if !channels.Submit(ctx, outC, nextJob) {
 					return nil
 				}
-			}
 
+			}
 			return nil
 		})
 
@@ -1336,9 +1412,10 @@ func addMembers(roleAssignments RoleAssignments, operation analysis.StatTrackedO
 					return err
 				}
 			} else if !isRoleAssignable {
-				for _, tenantUser := range roleAssignments.NodesWithRole(AddMemberGroupNotRoleAssignableTargetRoles()...).Get(azure.User) {
+				iter := roleAssignments.UsersWithRole(AddMemberGroupNotRoleAssignableTargetRoles()...).Iterator()
+				for iter.HasNext() {
 					nextJob := analysis.CreatePostRelationshipJob{
-						FromID: tenantUser.ID,
+						FromID: graph.ID(iter.Next()),
 						ToID:   innerGroupID,
 						Kind:   azure.AddMembers,
 					}
@@ -1346,6 +1423,7 @@ func addMembers(roleAssignments RoleAssignments, operation analysis.StatTrackedO
 					if !channels.Submit(ctx, outC, nextJob) {
 						return nil
 					}
+
 				}
 			}
 
@@ -1364,7 +1442,7 @@ func UserRoleAssignments(ctx context.Context, db graph.Database) (*analysis.Atom
 				operation.Done()
 				return &analysis.AtomicPostProcessingStats{}, err
 			} else {
-				if err := resetPassword(ctx, db, operation, roleAssignments); err != nil {
+				if err := resetPassword(ctx, db, operation, tenant, roleAssignments); err != nil {
 					operation.Done()
 					return &analysis.AtomicPostProcessingStats{}, err
 				} else {

--- a/packages/go/analysis/azure/post.go
+++ b/packages/go/analysis/azure/post.go
@@ -1034,7 +1034,7 @@ func resetPassword(ctx context.Context, db graph.Database, operation analysis.St
 		} else {
 			for _, role := range pwResetRoles {
 				if targets, err := resetPasswordEndNodeBitmapForRole(role, roleAssignments); err != nil {
-					return fmt.Errorf("unable to continue processing azresetpassword for tenant node %d", tenant.ID, err)
+					return fmt.Errorf("unable to continue processing azresetpassword for tenant node %d: %w", tenant.ID, err)
 				} else {
 					iter := targets.Iterator()
 					for iter.HasNext() {

--- a/packages/go/analysis/azure/post_test.go
+++ b/packages/go/analysis/azure/post_test.go
@@ -20,9 +20,10 @@ import (
 	"context"
 	"testing"
 
+	"github.com/RoaringBitmap/roaring"
 	"github.com/bloodhoundad/azurehound/v2/constants"
 	"github.com/specterops/bloodhound/dawgs/graph"
-	"github.com/specterops/bloodhound/dawgs/graph/mocks"
+	graph_mocks "github.com/specterops/bloodhound/dawgs/graph/mocks"
 	"github.com/specterops/bloodhound/dawgs/util/size"
 	azschema "github.com/specterops/bloodhound/graphschema/azure"
 	"github.com/stretchr/testify/assert"
@@ -42,14 +43,21 @@ var (
 // setupRoleAssignments is used to create a testable RoleAssignments struct. It is used in all RoleAssignments tests
 // and may require adjusting tests if modified
 func setupRoleAssignments() azure.RoleAssignments {
+	roleMap := map[string]*roaring.Bitmap{
+		constants.GlobalAdministratorRoleID:   roaring.New(),
+		constants.ReportsReaderRoleID:         roaring.New(),
+		constants.HelpdeskAdministratorRoleID: roaring.New(),
+		constants.PartnerTier1SupportRoleID:   roaring.New(),
+	}
+	roleMap[constants.GlobalAdministratorRoleID].Add(user.ID.Uint32())
+	roleMap[constants.ReportsReaderRoleID].Add(group.ID.Uint32())
+	roleMap[constants.HelpdeskAdministratorRoleID].Add(group.ID.Uint32())
+	roleMap[constants.PartnerTier1SupportRoleID].Add(app.ID.Uint32())
+
 	return azure.RoleAssignments{
 		// user2 has no roles! this is intentional
-		Nodes: graph.NewNodeSet(user, user2, group, app).KindSet(),
-		AssignmentMap: map[graph.ID]map[string]struct{}{
-			user.ID:  {azschema.CompanyAdministratorRole: struct{}{}},
-			group.ID: {azschema.ReportsReaderRole: struct{}{}, azschema.HelpdeskAdministratorRole: struct{}{}},
-			app.ID:   {azschema.PartnerTier1SupportRole: struct{}{}},
-		},
+		Principals: graph.NewNodeSet(user, user2, group, app).KindSet(),
+		RoleMap:    roleMap,
 	}
 }
 
@@ -64,16 +72,16 @@ func TestRoleAssignments_NodeHasRole(t *testing.T) {
 
 func TestRoleAssignments_UsersWithoutRoles(t *testing.T) {
 	assignments := setupRoleAssignments()
-	assert.NotEqual(t, user, assignments.UsersWithoutRoles().Get(user.ID))
-	assert.Equal(t, user2, assignments.UsersWithoutRoles().Get(user2.ID))
+	assert.False(t, assignments.UsersWithoutRoles().Contains(uint32(user.ID)))
+	assert.True(t, assignments.UsersWithoutRoles().Contains(uint32(user2.ID)))
 }
 
 func TestRoleAssignments_NodesWithRole(t *testing.T) {
 	assignments := setupRoleAssignments()
-	assert.Equal(t, user, assignments.NodesWithRole(azschema.ReportsReaderRole, azschema.CompanyAdministratorRole).Get(azschema.User).Get(user.ID))
-	assert.Equal(t, group, assignments.NodesWithRole(azschema.ReportsReaderRole, azschema.CompanyAdministratorRole).Get(azschema.Group).Get(group.ID))
-	assert.Equal(t, group, assignments.NodesWithRole(azschema.ReportsReaderRole, azschema.HelpdeskAdministratorRole).Get(azschema.Group).Get(group.ID))
-	assert.Equal(t, graph.EmptyNodeSet().Get(0), assignments.NodesWithRole(azschema.ReportsReaderRole).Get(azschema.User).Get(user.ID))
+	assert.True(t, assignments.PrincipalsWithRole(constants.ReportsReaderRoleID, constants.GlobalAdministratorRoleID).Contains(uint32(user.ID)))
+	assert.True(t, assignments.PrincipalsWithRole(constants.ReportsReaderRoleID, constants.GlobalAdministratorRoleID).Contains(uint32(group.ID)))
+	assert.True(t, assignments.PrincipalsWithRole(constants.ReportsReaderRoleID, constants.HelpdeskAdministratorRoleID).Contains(uint32(group.ID)))
+	assert.False(t, assignments.PrincipalsWithRole(constants.ReportsReaderRoleID).Contains(uint32(user.ID)))
 }
 
 func TestRoleAssignments_NodesWithRolesExclusive(t *testing.T) {

--- a/packages/go/analysis/azure/post_test.go
+++ b/packages/go/analysis/azure/post_test.go
@@ -49,10 +49,10 @@ func setupRoleAssignments() azure.RoleAssignments {
 		constants.HelpdeskAdministratorRoleID: roaring.New(),
 		constants.PartnerTier1SupportRoleID:   roaring.New(),
 	}
-	roleMap[constants.GlobalAdministratorRoleID].Add(user.ID.Uint32())
-	roleMap[constants.ReportsReaderRoleID].Add(group.ID.Uint32())
-	roleMap[constants.HelpdeskAdministratorRoleID].Add(group.ID.Uint32())
-	roleMap[constants.PartnerTier1SupportRoleID].Add(app.ID.Uint32())
+	roleMap[constants.GlobalAdministratorRoleID].Add(uint32(user.ID))
+	roleMap[constants.ReportsReaderRoleID].Add(uint32(group.ID))
+	roleMap[constants.HelpdeskAdministratorRoleID].Add(uint32(group.ID))
+	roleMap[constants.PartnerTier1SupportRoleID].Add(uint32(app.ID))
 
 	return azure.RoleAssignments{
 		// user2 has no roles! this is intentional

--- a/packages/go/analysis/azure/role.go
+++ b/packages/go/analysis/azure/role.go
@@ -1,17 +1,17 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 package azure
@@ -45,7 +45,6 @@ func RoleEntityDetails(ctx context.Context, db graph.Database, objectID string, 
 }
 
 func PopulateRoleEntityDetailsCounts(tx graph.Transaction, node *graph.Node, details RoleDetails) (RoleDetails, error) {
-
 	if activeAssignments, err := FetchEntityActiveAssignments(tx, node, 0, 0); err != nil {
 		return details, err
 	} else {

--- a/packages/go/analysis/azure/tenant.go
+++ b/packages/go/analysis/azure/tenant.go
@@ -68,7 +68,7 @@ func PopulateTenantEntityDetailsCounts(tx graph.Transaction, node *graph.Node, d
 
 // TenantPrincipals returns the complete set of User, Group, and Service Principal nodes contained by the given Tenant node
 func TenantPrincipals(tx graph.Transaction, tenant *graph.Node) (graph.NodeSet, error) {
-	if !tenant.Kinds.ContainsOneOf(azure.Tenant) {
+	if !IsTenantNode(tenant) {
 		return nil, fmt.Errorf("node %d must contain kind %s", tenant.ID, azure.Tenant)
 	} else {
 		return ops.FetchEndNodes(tx.Relationships().Filterf(func() graph.Criteria {

--- a/packages/go/analysis/azure/tenant.go
+++ b/packages/go/analysis/azure/tenant.go
@@ -1,25 +1,28 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 package azure
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/specterops/bloodhound/dawgs/graph"
+	"github.com/specterops/bloodhound/dawgs/ops"
+	"github.com/specterops/bloodhound/dawgs/query"
 	"github.com/specterops/bloodhound/graphschema/azure"
 )
 
@@ -46,7 +49,7 @@ func TenantEntityDetails(db graph.Database, objectID string, hydrateCounts bool)
 }
 
 func PopulateTenantEntityDetailsCounts(tx graph.Transaction, node *graph.Node, details TenantDetails) (TenantDetails, error) {
-	var descendentKinds = GetDescendentKinds(azure.Tenant)
+	descendentKinds := GetDescendentKinds(azure.Tenant)
 
 	if descendents, err := FetchEntityDescendentCounts(tx, node, 0, 0, descendentKinds...); err != nil {
 		return details, err
@@ -61,4 +64,23 @@ func PopulateTenantEntityDetailsCounts(tx graph.Transaction, node *graph.Node, d
 	}
 
 	return details, nil
+}
+
+// TenantPrincipals returns the complete set of User, Group, and Service Principal nodes contained by the given Tenant node
+func TenantPrincipals(tx graph.Transaction, tenant *graph.Node) (graph.NodeSet, error) {
+	if !tenant.Kinds.ContainsOneOf(azure.Tenant) {
+		return nil, fmt.Errorf("node %d must contain kind %s", tenant.ID, azure.Tenant)
+	} else {
+		return ops.FetchEndNodes(tx.Relationships().Filterf(func() graph.Criteria {
+			return query.And(
+				query.Equals(query.StartID(), tenant.ID),
+				query.Kind(query.Relationship(), azure.Contains),
+				query.KindIn(query.End(), azure.User, azure.Group, azure.ServicePrincipal),
+			)
+		}))
+	}
+}
+
+func IsTenantNode(node *graph.Node) bool {
+	return node.Kinds.ContainsOneOf(azure.Tenant)
 }


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

- Update AZResetPassword post-processing to start at AZRole nodes and end at AZUser nodes
- Misc. performance refactors and others
- Updated post-processing tests

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The existing approach in which AZResetPassword edges are processed creates an unwieldy number of edges in the graph which impacts analysis time significantly and creates a poor user experience in the case where misconfiguration leads to every user having an AZResetPassword edge to every other user.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Updated the existing post-processing tests to account for the new requirements.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [x] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
