### PR TITLE
allow asset group selectors with the same name to exist under different asset groups

### DIFF
--- a/cmd/api/src/database/migration/migrations/schema.sql
+++ b/cmd/api/src/database/migration/migrations/schema.sql
@@ -715,7 +715,7 @@ ALTER TABLE ONLY asset_group_collection_entries
 ALTER TABLE ONLY asset_group_collections
     ADD CONSTRAINT asset_group_collections_pkey PRIMARY KEY (id);
 ALTER TABLE ONLY asset_group_selectors
-    ADD CONSTRAINT asset_group_selectors_name_assetgroupid_key UNIQUE (name, asset_group_id);
+    ADD CONSTRAINT asset_group_selectors_name_key UNIQUE (name);
 ALTER TABLE ONLY asset_group_selectors
     ADD CONSTRAINT asset_group_selectors_pkey PRIMARY KEY (id);
 ALTER TABLE ONLY asset_groups

--- a/cmd/api/src/database/migration/migrations/v5.2.1.sql
+++ b/cmd/api/src/database/migration/migrations/v5.2.1.sql
@@ -14,8 +14,8 @@
 --
 -- SPDX-License-Identifier: Apache-2.0
 
-ALTER TABLE ONLY asset_group_selectors
-  DROP CONSTRAINT asset_group_selectors_name_key;
+ALTER TABLE IF EXISTS ONLY asset_group_selectors
+  DROP CONSTRAINT IF EXISTS asset_group_selectors_name_key;
 
-ALTER TABLE ONLY asset_group_selectors
+ALTER TABLE IF EXISTS ONLY asset_group_selectors
   ADD CONSTRAINT asset_group_selectors_name_assetgroupid_key UNIQUE (name, asset_group_id);


### PR DESCRIPTION
## Description

Currently, the name field of an asset group selector needs to be unique regardless of the asset group. This prevents custom “High Value” nodes from being added to the “Owned” group and vice versa in BHCE, and would cause further problems if we want to add additional groups in the future. Trying to add a duplicate selector causes an error.

This story drops that constraint and creates a new uniqueness constraint on both the name and asset_group_id columns, thereby allowing a selector to exist under both Owned as well as HVT asset groups.

## How Has This Been Tested?
I spun up a database on the main branch to simulate an existing DB. The selectors table has a constraint on the name column here:

<img width="274" alt="existing constraints" src="https://github.com/SpecterOps/BloodHound/assets/24904109/34f803ee-21ae-494f-a2b5-3914e1bde5a8">

Then I restarted the environment to have the migration applied:

<img width="971" alt="existing migration execution" src="https://github.com/SpecterOps/BloodHound/assets/24904109/fbe36ef1-3df9-4a21-9d5d-0a2954961c1c">

Verified that the constraint has been updated (the new constraint name contains both column names in it):

<img width="378" alt="existing constraints after" src="https://github.com/SpecterOps/BloodHound/assets/24904109/2770b296-0ad0-439a-8d78-77fc48482bd0">

Then I created 2 selectors with the same name but belonging to the 2 different asset groups via postman:

<img width="661" alt="existing owned" src="https://github.com/SpecterOps/BloodHound/assets/24904109/807c45b2-7cc3-44a2-9e3a-8f679e1d2cc5">

<img width="661" alt="existing t0" src="https://github.com/SpecterOps/BloodHound/assets/24904109/37cc509e-881f-4a88-9848-aa683b09d5bb">

And verified through the database that both the selectors were created:

<img width="991" alt="existing db" src="https://github.com/SpecterOps/BloodHound/assets/24904109/d44a1ad0-7f61-4689-9f82-2d8f7ec32c78">




Next, I wiped out my database and re-created it to verify that any fresh installs will have the right constraint set up, and then repeated the selecor creation via postman to verify that multiple selectors can exist with the same name:

<img width="616" alt="fresh owned" src="https://github.com/SpecterOps/BloodHound/assets/24904109/01b26749-215a-49b7-9ba6-17d1e171586c">


<img width="616" alt="fresh t0" src="https://github.com/SpecterOps/BloodHound/assets/24904109/f40938b1-f261-47d2-92f1-8b05718b336e">


<img width="997" alt="fresh db" src="https://github.com/SpecterOps/BloodHound/assets/24904109/be030626-96c0-4f40-9108-e3c67696786a">


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] My changes include a database migration.
