### PR TITLE
Fix import of relationships with wrong casing

### DIFF
--- a/packages/go/ein/azure.go
+++ b/packages/go/ein/azure.go
@@ -42,6 +42,8 @@ const (
 	KeyVaultPermissionGet string = "Get"
 )
 
+var resourceGroupLevel, _ = regexp.Compile("^[\\w\\d\\-\\/]*/resourceGroups/[0-9a-zA-Z]+$")
+
 func ConvertAZAppToNode(app models.App) IngestibleNode {
 	return IngestibleNode{
 		PropertyMap: map[string]any{
@@ -1488,8 +1490,8 @@ func ResourceWithinScope(resource, scope string) bool {
 	if strings.EqualFold(resource, scope) {
 		return true
 	}
-	resourceGroupLevel, _ := regexp.MatchString("^[\\w\\d\\-\\/]*/resourceGroups/[0-9a-zA-Z]+$", resource)
-	if resourceGroupLevel && strings.HasPrefix(strings.ToLower(resource), strings.ToLower(scope)) {
+
+	if resourceGroupLevel.MatchString(scope) && strings.HasPrefix(strings.ToLower(resource), strings.ToLower(scope)) {
 		return true
 	}
 	return false

--- a/packages/go/ein/azure.go
+++ b/packages/go/ein/azure.go
@@ -42,7 +42,7 @@ const (
 	KeyVaultPermissionGet string = "Get"
 )
 
-var resourceGroupLevel, _ = regexp.Compile("^[\\w\\d\\-\\/]*/resourceGroups/[0-9a-zA-Z]+$")
+var resourceGroupLevel = regexp.MustCompile("^[\\w\\d\\-\\/]*/resourceGroups/[0-9a-zA-Z]+$")
 
 func ConvertAZAppToNode(app models.App) IngestibleNode {
 	return IngestibleNode{


### PR DESCRIPTION
## Description

Added function to check if a resource belongs to a scope either by full ID or inherited by resource group.
This check uses case-insensitive matching due to reasons explained below.
It also checks if the scope is at resource group level and will grant inherited relationship if the resource is prefixed with the scope.

## Motivation and Context

When importing data from AzureHound, the virtual machine ID sometimes does not match the casing of the scope which results in relationships such as AZVMAdminLogin is not registered.

Additionally, relationships were only registered if a direct role assignment to the resource was added and ignored resource group inheritance.

From [docs](https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules):
> Resource and resource group names are case-insensitive unless specifically noted in the valid characters column.
> 
> When using various APIs to retrieve the name for a resource or resource group, the returned value may have different casing than what you originally specified for the name. The returned value may even display different case values than what is listed in the valid characters table.
> 
> Always perform a case-insensitive comparison of names.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

This change only abstracts away the resource<->scope matching and will be tested by existing tests.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
