### PR TITLE
Add EnterpriseCA registry properties

### DIFF
--- a/cmd/api/src/daemons/datapipe/convertors.go
+++ b/cmd/api/src/daemons/datapipe/convertors.go
@@ -219,6 +219,7 @@ func convertEnterpriseCAData(data []ein.EnterpriseCA) ConvertedData {
 
 	for _, enterpriseca := range data {
 		converted.NodeProps = append(converted.NodeProps, ein.ConvertObjectToNode(enterpriseca.IngestBase, ad.EnterpriseCA))
+		converted.NodeProps = append(converted.NodeProps, ein.ParseCARegistryProperties(enterpriseca))
 		converted.RelProps = append(converted.RelProps, ein.ParseEnterpriseCAMiscData(enterpriseca)...)
 
 		if rel := ein.ParseObjectContainer(enterpriseca.IngestBase, ad.EnterpriseCA); rel.IsValid() {

--- a/cmd/ui/src/ducks/entityinfo/types.ts
+++ b/cmd/ui/src/ducks/entityinfo/types.ts
@@ -137,7 +137,8 @@ export interface EnterpriseCAInfo extends EntityInfo {
         enrollmentagentrestrictionscollected: boolean;
         flags: 10;
         hasbasicconstraints: boolean;
-        isuserspecifiessanenabled: boolean;
+        hasenrollmentagentrestrictions?: boolean;
+        isuserspecifiessanenabled?: boolean;
         isuserspecifiessanenabledcollected: boolean;
         description?: string;
     };

--- a/packages/cue/bh/ad/ad.cue
+++ b/packages/cue/bh/ad/ad.cue
@@ -69,11 +69,25 @@ CASecurityCollected: types.#StringEnum & {
 	representation: "casecuritycollected"
 }
 
+HasEnrollmentAgentRestrictions: types.#StringEnum & {
+	symbol: 		"HasEnrollmentAgentRestrictions"
+	schema: 		"ad"
+	name:           "Has Enrollment Agent Restrictions"
+	representation: "hasenrollmentagentrestrictions"
+}
+
 EnrollmentAgentRestrictionsCollected: types.#StringEnum & {
 	symbol: 		"EnrollmentAgentRestrictionsCollected"
 	schema: 		"ad"
 	name:           "Enrollment Agent Restrictions Collected"
 	representation: "enrollmentagentrestrictionscollected"
+}
+
+IsUserSpecifiesSanEnabled: types.#StringEnum & {
+	symbol: 		"IsUserSpecifiesSanEnabled"
+	schema: 		"ad"
+	name:           "Is User Specifies San Enabled"
+	representation: "isuserspecifiessanenabled"
 }
 
 IsUserSpecifiesSanEnabledCollected: types.#StringEnum & {
@@ -462,7 +476,9 @@ Properties: [
 	CertName,
 	CertThumbprint,
 	CertThumbprints,
+	HasEnrollmentAgentRestrictions,
 	EnrollmentAgentRestrictionsCollected,
+	IsUserSpecifiesSanEnabled,
 	IsUserSpecifiesSanEnabledCollected,
 	HasBasicConstraints,
 	BasicConstraintPathLength,

--- a/packages/go/ein/ad.go
+++ b/packages/go/ein/ad.go
@@ -407,6 +407,31 @@ func ParseUserRightData(userRight UserRightsAssignmentAPIResult, computer Comput
 	return relationships
 }
 
+func ParseCARegistryProperties(enterpriseCA EnterpriseCA) IngestibleNode {
+	propMap := make(map[string]any)
+
+	// HasEnrollmentAgentRestrictions
+	if enterpriseCA.CARegistryData.EnrollmentAgentRestrictions.Collected {
+
+		if len(enterpriseCA.CARegistryData.EnrollmentAgentRestrictions.Restrictions) > 0 {
+			propMap[ad.HasEnrollmentAgentRestrictions.String()] = true
+		} else {
+			propMap[ad.HasEnrollmentAgentRestrictions.String()] = false
+		}
+	}
+
+	// IsUserSpecifiesSanEnabled
+	if enterpriseCA.CARegistryData.IsUserSpecifiesSanEnabled.Collected {
+		propMap[ad.IsUserSpecifiesSanEnabled.String()] = enterpriseCA.CARegistryData.IsUserSpecifiesSanEnabled.Value
+	}
+
+	return IngestibleNode{
+		ObjectID:    enterpriseCA.ObjectIdentifier,
+		PropertyMap: propMap,
+		Label:       ad.EnterpriseCA,
+	}
+}
+
 func ParseEnterpriseCAMiscData(enterpriseCA EnterpriseCA) []IngestibleRelationship {
 	var (
 		relationships        = make([]IngestibleRelationship, 0)

--- a/packages/go/graphschema/ad/ad.go
+++ b/packages/go/graphschema/ad/ad.go
@@ -110,7 +110,9 @@ const (
 	CertName                               Property = "certname"
 	CertThumbprint                         Property = "certthumbprint"
 	CertThumbprints                        Property = "certthumbprints"
+	HasEnrollmentAgentRestrictions         Property = "hasenrollmentagentrestrictions"
 	EnrollmentAgentRestrictionsCollected   Property = "enrollmentagentrestrictionscollected"
+	IsUserSpecifiesSanEnabled              Property = "isuserspecifiessanenabled"
 	IsUserSpecifiesSanEnabledCollected     Property = "isuserspecifiessanenabledcollected"
 	HasBasicConstraints                    Property = "hasbasicconstraints"
 	BasicConstraintPathLength              Property = "basicconstraintpathlength"
@@ -167,7 +169,7 @@ const (
 )
 
 func AllProperties() []Property {
-	return []Property{AdminCount, CASecurityCollected, CAName, CertChain, CertName, CertThumbprint, CertThumbprints, EnrollmentAgentRestrictionsCollected, IsUserSpecifiesSanEnabledCollected, HasBasicConstraints, BasicConstraintPathLength, DNSHostname, CrossCertificatePair, DistinguishedName, DomainFQDN, DomainSID, Sensitive, HighValue, BlocksInheritance, IsACL, IsACLProtected, IsDeleted, Enforced, Department, HasCrossCertificatePair, HasSPN, UnconstrainedDelegation, LastLogon, LastLogonTimestamp, IsPrimaryGroup, HasLAPS, DontRequirePreAuth, LogonType, HasURA, PasswordNeverExpires, PasswordNotRequired, FunctionalLevel, TrustType, SidFiltering, TrustedToAuth, SamAccountName, CertificateMappingMethodsRaw, CertificateMappingMethods, StrongCertificateBindingEnforcementRaw, StrongCertificateBindingEnforcement, EKUs, SubjectAltRequireUPN, AuthorizedSignatures, ApplicationPolicies, SchemaVersion, RequiresManagerApproval, AuthenticationEnabled, EnrolleeSuppliesSubject, CertificateApplicationPolicy, CertificateNameFlag, EffectiveEKUs, EnrollmentFlag, NoSecurityExtension, RenewalPeriod, ValidityPeriod, OID}
+	return []Property{AdminCount, CASecurityCollected, CAName, CertChain, CertName, CertThumbprint, CertThumbprints, HasEnrollmentAgentRestrictions, EnrollmentAgentRestrictionsCollected, IsUserSpecifiesSanEnabled, IsUserSpecifiesSanEnabledCollected, HasBasicConstraints, BasicConstraintPathLength, DNSHostname, CrossCertificatePair, DistinguishedName, DomainFQDN, DomainSID, Sensitive, HighValue, BlocksInheritance, IsACL, IsACLProtected, IsDeleted, Enforced, Department, HasCrossCertificatePair, HasSPN, UnconstrainedDelegation, LastLogon, LastLogonTimestamp, IsPrimaryGroup, HasLAPS, DontRequirePreAuth, LogonType, HasURA, PasswordNeverExpires, PasswordNotRequired, FunctionalLevel, TrustType, SidFiltering, TrustedToAuth, SamAccountName, CertificateMappingMethodsRaw, CertificateMappingMethods, StrongCertificateBindingEnforcementRaw, StrongCertificateBindingEnforcement, EKUs, SubjectAltRequireUPN, AuthorizedSignatures, ApplicationPolicies, SchemaVersion, RequiresManagerApproval, AuthenticationEnabled, EnrolleeSuppliesSubject, CertificateApplicationPolicy, CertificateNameFlag, EffectiveEKUs, EnrollmentFlag, NoSecurityExtension, RenewalPeriod, ValidityPeriod, OID}
 }
 func ParseProperty(source string) (Property, error) {
 	switch source {
@@ -185,8 +187,12 @@ func ParseProperty(source string) (Property, error) {
 		return CertThumbprint, nil
 	case "certthumbprints":
 		return CertThumbprints, nil
+	case "hasenrollmentagentrestrictions":
+		return HasEnrollmentAgentRestrictions, nil
 	case "enrollmentagentrestrictionscollected":
 		return EnrollmentAgentRestrictionsCollected, nil
+	case "isuserspecifiessanenabled":
+		return IsUserSpecifiesSanEnabled, nil
 	case "isuserspecifiessanenabledcollected":
 		return IsUserSpecifiesSanEnabledCollected, nil
 	case "hasbasicconstraints":
@@ -313,8 +319,12 @@ func (s Property) String() string {
 		return string(CertThumbprint)
 	case CertThumbprints:
 		return string(CertThumbprints)
+	case HasEnrollmentAgentRestrictions:
+		return string(HasEnrollmentAgentRestrictions)
 	case EnrollmentAgentRestrictionsCollected:
 		return string(EnrollmentAgentRestrictionsCollected)
+	case IsUserSpecifiesSanEnabled:
+		return string(IsUserSpecifiesSanEnabled)
 	case IsUserSpecifiesSanEnabledCollected:
 		return string(IsUserSpecifiesSanEnabledCollected)
 	case HasBasicConstraints:
@@ -441,8 +451,12 @@ func (s Property) Name() string {
 		return "Certificate Thumbprint"
 	case CertThumbprints:
 		return "Certificate Thumbprints"
+	case HasEnrollmentAgentRestrictions:
+		return "Has Enrollment Agent Restrictions"
 	case EnrollmentAgentRestrictionsCollected:
 		return "Enrollment Agent Restrictions Collected"
+	case IsUserSpecifiesSanEnabled:
+		return "Is User Specifies San Enabled"
 	case IsUserSpecifiesSanEnabledCollected:
 		return "Is User Specifies San Enabled Collected"
 	case HasBasicConstraints:

--- a/packages/javascript/bh-shared-ui/src/graphSchema.ts
+++ b/packages/javascript/bh-shared-ui/src/graphSchema.ts
@@ -258,7 +258,9 @@ export enum ActiveDirectoryKindProperties {
     CertName = 'certname',
     CertThumbprint = 'certthumbprint',
     CertThumbprints = 'certthumbprints',
+    HasEnrollmentAgentRestrictions = 'hasenrollmentagentrestrictions',
     EnrollmentAgentRestrictionsCollected = 'enrollmentagentrestrictionscollected',
+    IsUserSpecifiesSanEnabled = 'isuserspecifiessanenabled',
     IsUserSpecifiesSanEnabledCollected = 'isuserspecifiessanenabledcollected',
     HasBasicConstraints = 'hasbasicconstraints',
     BasicConstraintPathLength = 'basicconstraintpathlength',
@@ -329,8 +331,12 @@ export function ActiveDirectoryKindPropertiesToDisplay(value: ActiveDirectoryKin
             return 'Certificate Thumbprint';
         case ActiveDirectoryKindProperties.CertThumbprints:
             return 'Certificate Thumbprints';
+        case ActiveDirectoryKindProperties.HasEnrollmentAgentRestrictions:
+            return 'Has Enrollment Agent Restrictions';
         case ActiveDirectoryKindProperties.EnrollmentAgentRestrictionsCollected:
             return 'Enrollment Agent Restrictions Collected';
+        case ActiveDirectoryKindProperties.IsUserSpecifiesSanEnabled:
+            return 'Is User Specifies San Enabled';
         case ActiveDirectoryKindProperties.IsUserSpecifiesSanEnabledCollected:
             return 'Is User Specifies San Enabled Collected';
         case ActiveDirectoryKindProperties.HasBasicConstraints:


### PR DESCRIPTION
## Description

Add properties `IsUserSpecifiesSanEnabled` and `HasEnrollmentAgentRestrictions` to EnterpriseCA nodes.

## Motivation and Context

We currently only store if these properties are collected, but not their values. We need these EnterpriseCA attributes as properties so we can check them in the post-processing logic for ESC3 and ESC6.

## How Has This Been Tested?

Ingested data from my lab with two EnterpriseCAs - one where these properties are collected and one where they are not.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

![image](https://github.com/SpecterOps/BloodHound/assets/12843299/d7cd4957-1310-464f-9862-abae15aed79b)
![image](https://github.com/SpecterOps/BloodHound/assets/12843299/feb3e3b8-8a08-4344-a5da-553bda27e16a)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] My changes include a database migration.
