### PR TITLE
chore: partition collection methods to split out ldap source in its own option

### DIFF
--- a/cmd/api/src/daemons/datapipe/models.go
+++ b/cmd/api/src/daemons/datapipe/models.go
@@ -140,6 +140,8 @@ const (
 	CollectionMethodPSRemote      CollectionMethod = 1 << 14
 	CollectionMethodUserRights    CollectionMethod = 1 << 15
 	CollectionMethodCARegistry    CollectionMethod = 1 << 16
+	CollectionMethodDCRegistry    CollectionMethod = 1 << 17
+	CollectionMethodCertServices  CollectionMethod = 1 << 18
 )
 
 func AllCollectionMethods() []CollectionMethod {
@@ -161,6 +163,8 @@ func AllCollectionMethods() []CollectionMethod {
 		CollectionMethodPSRemote,
 		CollectionMethodUserRights,
 		CollectionMethodCARegistry,
+		CollectionMethodDCRegistry,
+		CollectionMethodCertServices,
 	}
 }
 


### PR DESCRIPTION
## Description
The collection methods available ADCS are being split a little more than originally defined. This changeset updates our collection method definitions in the API to reflect these updates.
<!--- Describe your changes in detail -->

## Motivation and Context
It was desired to split out the collection methods for ADCS so that there is an option to isolate data retrieved from LDAP into it's own collection method, CertServices, rather than combining it into CA Registry Collection.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Associated changes made on the collector side are not available yet. 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] My changes include a database migration.
