### PR TITLE
Create ADCS feature flag and wrap associated code

### DIFF
--- a/cmd/api/src/analysis/ad/post.go
+++ b/cmd/api/src/analysis/ad/post.go
@@ -145,7 +145,7 @@ func PostLocalGroups(ctx context.Context, db graph.Database, localGroupExpansion
 	}
 }
 
-func Post(ctx context.Context, db graph.Database) (*analysis.AtomicPostProcessingStats, error) {
+func Post(ctx context.Context, db graph.Database, adcsEnabled bool) (*analysis.AtomicPostProcessingStats, error) {
 	aggregateStats := analysis.NewAtomicPostProcessingStats()
 	if stats, err := analysis.DeleteTransitEdges(ctx, db, ad.Entity, ad.Entity, adAnalysis.PostProcessedRelationships()...); err != nil {
 		return &aggregateStats, err
@@ -157,7 +157,7 @@ func Post(ctx context.Context, db graph.Database) (*analysis.AtomicPostProcessin
 		return &aggregateStats, err
 	} else if localGroupStats, err := PostLocalGroups(ctx, db, groupExpansions); err != nil {
 		return &aggregateStats, err
-	} else if adcsStats, err := adAnalysis.PostADCS(ctx, db, groupExpansions); err != nil {
+	} else if adcsStats, err := adAnalysis.PostADCS(ctx, db, groupExpansions, adcsEnabled); err != nil {
 		return &aggregateStats, err
 	} else {
 		aggregateStats.Merge(stats)

--- a/cmd/api/src/api/middleware/middleware.go
+++ b/cmd/api/src/api/middleware/middleware.go
@@ -240,6 +240,11 @@ func SecureHandlerMiddleware(cfg config.Configuration, contentSecurityPolicy str
 	}).Handler
 }
 
+// FeatureFlagMiddleware is a middleware that enables or disables a given endpoint based on the status of the passed feature flag.
+// It is intended to be attached directly to endpoints that should be affected by the feature flag. The feature flag determining the
+// endpoint's availability should be specified in flagKey.
+//
+// If the flag is enabled, the endpoint will work as intended. If the flag is disabled, a 404 will be returned to the user.
 func FeatureFlagMiddleware(db database.Database, flagKey string) mux.MiddlewareFunc {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {

--- a/cmd/api/src/api/middleware/middleware.go
+++ b/cmd/api/src/api/middleware/middleware.go
@@ -249,7 +249,7 @@ func FeatureFlagMiddleware(db database.Database, flagKey string) mux.MiddlewareF
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
 			if flag, err := db.GetFlagByKey(flagKey); err != nil {
-
+				api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusInternalServerError, fmt.Sprintf("error retrieving %s feature flag: %s", flagKey, err), request), response)
 			} else if flag.Enabled {
 				next.ServeHTTP(response, request)
 			} else {

--- a/cmd/api/src/api/registration/v2.go
+++ b/cmd/api/src/api/registration/v2.go
@@ -30,6 +30,7 @@ import (
 	"github.com/specterops/bloodhound/src/auth"
 	"github.com/specterops/bloodhound/src/config"
 	"github.com/specterops/bloodhound/src/database"
+	"github.com/specterops/bloodhound/src/model/appcfg"
 )
 
 func samlWriteAPIErrorResponse(request *http.Request, response http.ResponseWriter, statusCode int, message string) {
@@ -213,24 +214,24 @@ func NewV2API(cfg config.Configuration, resources v2.Resources, routerInst *rout
 		routerInst.GET(fmt.Sprintf("/api/v2/gpos/{%s}/ous", api.URIPathVariableObjectID), resources.ListADGPOAffectedContainers).RequirePermissions(permissions.GraphDBRead),
 
 		// AIACA Entity API
-		routerInst.GET(fmt.Sprintf("/api/v2/aiacas/{%s}", api.URIPathVariableObjectID), resources.GetAIACAEntityInfo).RequirePermissions(permissions.GraphDBRead),
-		routerInst.GET(fmt.Sprintf("/api/v2/aiacas/{%s}/controllers", api.URIPathVariableObjectID), resources.ListADEntityControllers).RequirePermissions(permissions.GraphDBRead),
+		routerInst.GET(fmt.Sprintf("/api/v2/aiacas/{%s}", api.URIPathVariableObjectID), resources.GetAIACAEntityInfo).RequirePermissions(permissions.GraphDBRead).CheckFeatureFlag(resources.DB, appcfg.FeatureAdcs),
+		routerInst.GET(fmt.Sprintf("/api/v2/aiacas/{%s}/controllers", api.URIPathVariableObjectID), resources.ListADEntityControllers).RequirePermissions(permissions.GraphDBRead).CheckFeatureFlag(resources.DB, appcfg.FeatureAdcs),
 
 		// RootCA Entity API
-		routerInst.GET(fmt.Sprintf("/api/v2/rootcas/{%s}", api.URIPathVariableObjectID), resources.GetRootCAEntityInfo).RequirePermissions(permissions.GraphDBRead),
-		routerInst.GET(fmt.Sprintf("/api/v2/rootcas/{%s}/controllers", api.URIPathVariableObjectID), resources.ListADEntityControllers).RequirePermissions(permissions.GraphDBRead),
+		routerInst.GET(fmt.Sprintf("/api/v2/rootcas/{%s}", api.URIPathVariableObjectID), resources.GetRootCAEntityInfo).RequirePermissions(permissions.GraphDBRead).CheckFeatureFlag(resources.DB, appcfg.FeatureAdcs),
+		routerInst.GET(fmt.Sprintf("/api/v2/rootcas/{%s}/controllers", api.URIPathVariableObjectID), resources.ListADEntityControllers).RequirePermissions(permissions.GraphDBRead).CheckFeatureFlag(resources.DB, appcfg.FeatureAdcs),
 
 		// EnterpriseCA Entity API
-		routerInst.GET(fmt.Sprintf("/api/v2/enterprisecas/{%s}", api.URIPathVariableObjectID), resources.GetEnterpriseCAEntityInfo).RequirePermissions(permissions.GraphDBRead),
-		routerInst.GET(fmt.Sprintf("/api/v2/enterprisecas/{%s}/controllers", api.URIPathVariableObjectID), resources.ListADEntityControllers).RequirePermissions(permissions.GraphDBRead),
+		routerInst.GET(fmt.Sprintf("/api/v2/enterprisecas/{%s}", api.URIPathVariableObjectID), resources.GetEnterpriseCAEntityInfo).RequirePermissions(permissions.GraphDBRead).CheckFeatureFlag(resources.DB, appcfg.FeatureAdcs),
+		routerInst.GET(fmt.Sprintf("/api/v2/enterprisecas/{%s}/controllers", api.URIPathVariableObjectID), resources.ListADEntityControllers).RequirePermissions(permissions.GraphDBRead).CheckFeatureFlag(resources.DB, appcfg.FeatureAdcs),
 
 		// NTAuthStore Entity API
-		routerInst.GET(fmt.Sprintf("/api/v2/ntauthstores/{%s}", api.URIPathVariableObjectID), resources.GetNTAuthStoreEntityInfo).RequirePermissions(permissions.GraphDBRead),
-		routerInst.GET(fmt.Sprintf("/api/v2/ntauthstores/{%s}/controllers", api.URIPathVariableObjectID), resources.ListADEntityControllers).RequirePermissions(permissions.GraphDBRead),
+		routerInst.GET(fmt.Sprintf("/api/v2/ntauthstores/{%s}", api.URIPathVariableObjectID), resources.GetNTAuthStoreEntityInfo).RequirePermissions(permissions.GraphDBRead).CheckFeatureFlag(resources.DB, appcfg.FeatureAdcs),
+		routerInst.GET(fmt.Sprintf("/api/v2/ntauthstores/{%s}/controllers", api.URIPathVariableObjectID), resources.ListADEntityControllers).RequirePermissions(permissions.GraphDBRead).CheckFeatureFlag(resources.DB, appcfg.FeatureAdcs),
 
 		// CertTemplate Entity API
-		routerInst.GET(fmt.Sprintf("/api/v2/certtemplates/{%s}", api.URIPathVariableObjectID), resources.GetCertTemplateEntityInfo).RequirePermissions(permissions.GraphDBRead),
-		routerInst.GET(fmt.Sprintf("/api/v2/certtemplates/{%s}/controllers", api.URIPathVariableObjectID), resources.ListADEntityControllers).RequirePermissions(permissions.GraphDBRead),
+		routerInst.GET(fmt.Sprintf("/api/v2/certtemplates/{%s}", api.URIPathVariableObjectID), resources.GetCertTemplateEntityInfo).RequirePermissions(permissions.GraphDBRead).CheckFeatureFlag(resources.DB, appcfg.FeatureAdcs),
+		routerInst.GET(fmt.Sprintf("/api/v2/certtemplates/{%s}/controllers", api.URIPathVariableObjectID), resources.ListADEntityControllers).RequirePermissions(permissions.GraphDBRead).CheckFeatureFlag(resources.DB, appcfg.FeatureAdcs),
 
 		// OU Entity API
 		routerInst.GET(fmt.Sprintf("/api/v2/ous/{%s}", api.URIPathVariableObjectID), resources.GetOUEntityInfo).RequirePermissions(permissions.GraphDBRead),

--- a/cmd/api/src/api/router/router.go
+++ b/cmd/api/src/api/router/router.go
@@ -1,17 +1,17 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 package router
@@ -23,6 +23,7 @@ import (
 	"github.com/specterops/bloodhound/src/api/middleware"
 	"github.com/specterops/bloodhound/src/auth"
 	"github.com/specterops/bloodhound/src/config"
+	"github.com/specterops/bloodhound/src/database"
 	"github.com/specterops/bloodhound/src/model"
 )
 
@@ -79,6 +80,11 @@ func (s *Route) AuthorizeUserManagementAccess() *Route {
 
 func (s *Route) RequireUserId() *Route {
 	s.handler.Use(middleware.RequireUserId())
+	return s
+}
+
+func (s *Route) CheckFeatureFlag(db database.Database, flagKey string) *Route {
+	s.handler.Use(middleware.FeatureFlagMiddleware(db, flagKey))
 	return s
 }
 

--- a/cmd/api/src/daemons/datapipe/analysis.go
+++ b/cmd/api/src/daemons/datapipe/analysis.go
@@ -28,6 +28,7 @@ import (
 	"github.com/specterops/bloodhound/src/analysis/azure"
 	"github.com/specterops/bloodhound/src/config"
 	"github.com/specterops/bloodhound/src/database"
+	"github.com/specterops/bloodhound/src/model/appcfg"
 	"github.com/specterops/bloodhound/src/services/agi"
 	"github.com/specterops/bloodhound/src/services/dataquality"
 )
@@ -61,7 +62,9 @@ func RunAnalysisOperations(ctx context.Context, db database.Database, graphDB gr
 		collector.Collect(fmt.Errorf("azure tier zero tagging failed: %w", err))
 	}
 
-	if stats, err := ad.Post(ctx, graphDB); err != nil {
+	if adcsFlag, err := db.GetFlagByKey(appcfg.FeatureAdcs); err != nil {
+		collector.Collect(fmt.Errorf("error retrieving ADCS feature flag: %w", err))
+	} else if stats, err := ad.Post(ctx, graphDB, adcsFlag.Enabled); err != nil {
 		collector.Collect(fmt.Errorf("error during ad post: %w", err))
 	} else {
 		stats.LogStats()

--- a/cmd/api/src/daemons/datapipe/convertors.go
+++ b/cmd/api/src/daemons/datapipe/convertors.go
@@ -21,7 +21,7 @@ import (
 	"github.com/specterops/bloodhound/graphschema/ad"
 )
 
-func convertComputerData(data []ein.Computer) ConvertedData {
+func convertComputerData(data []ein.Computer, adcsEnabled bool) ConvertedData {
 	converted := ConvertedData{}
 
 	for _, computer := range data {
@@ -57,7 +57,9 @@ func convertComputerData(data []ein.Computer) ConvertedData {
 			}
 		}
 
-		converted.NodeProps = append(converted.NodeProps, ein.ParseDCRegistryData(computer))
+		if adcsEnabled {
+			converted.NodeProps = append(converted.NodeProps, ein.ParseDCRegistryData(computer))
+		}
 
 		converted.NodeProps = append(converted.NodeProps, baseNodeProp)
 	}

--- a/cmd/api/src/model/appcfg/flag.go
+++ b/cmd/api/src/model/appcfg/flag.go
@@ -1,17 +1,17 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 package appcfg
@@ -25,6 +25,7 @@ const (
 	FeatureAzureSupport        = "azure_support"
 	FeatureReconciliation      = "reconciliation"
 	FeatureEntityPanelCaching  = "entity_panel_cache"
+	FeatureAdcs                = "adcs"
 )
 
 // AvailableFlags returns a FeatureFlagSet of expected feature flags. Feature flag defaults introduced here will become the initial
@@ -71,6 +72,13 @@ func AvailableFlags() FeatureFlagSet {
 			Name:          "Enable application level caching",
 			Description:   "Enables the use of application level caching for entity panel queries",
 			Enabled:       true,
+			UserUpdatable: false,
+		},
+		FeatureAdcs: {
+			Key:           FeatureAdcs,
+			Name:          "Enable collection and processing of ADCS data",
+			Description:   "Enables the ability to analyze ADCS data for creating ADCS attack paths",
+			Enabled:       false,
 			UserUpdatable: false,
 		},
 	}


### PR DESCRIPTION
## Description

This PR creates a new feature flag for enabling ADCS related endpoints, ingest logic, and post-processing logic. The feature flag is disabled by default to enable limited testing for specific scenarios. This should prevent widespread errors if there are unknown bugs in the new feature code.

A new middleware was added to allow easy addition of feature flag checking logic to any endpoint in the BloodHound API. The middleware just needs to be added to the registration of the protected endpoints, passing in the flag that controls the behavior. If the flag is disabled, a 404 will be returned to the requester.

## Motivation and Context

* This should help prevent breaking everyone's BloodHound instance if there are unknown bugs in the new ADCS code.

## How Has This Been Tested?

* Verified the feature flag is set to `enabled=false` on a fresh instance.
* Verified the ADCS endpoints are unreachable when the flag is set to `false`.
* Verified no ADCS data is ingested or post-processed when the flag is set to `false`.
* Verified the above functionality works as expected when the flag is set to `true`.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] My changes include a database migration.
