### PR TITLE
fix: remove BHE schema from schema file

### DIFF
--- a/cmd/api/src/database/migration/migrations/schema.sql
+++ b/cmd/api/src/database/migration/migrations/schema.sql
@@ -247,98 +247,6 @@ CREATE SEQUENCE IF NOT EXISTS azure_data_quality_stats_id_seq
     CACHE 1;
 ALTER SEQUENCE azure_data_quality_stats_id_seq OWNED BY azure_data_quality_stats.id;
 
-CREATE TABLE IF NOT EXISTS client_ingest_tasks (
-    file_name text,
-    request_guid text,
-    task_id bigint,
-    id bigint NOT NULL,
-    created_at timestamp with time zone,
-    updated_at timestamp with time zone
-);
-
-CREATE SEQUENCE IF NOT EXISTS client_ingest_tasks_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-ALTER SEQUENCE client_ingest_tasks_id_seq OWNED BY client_ingest_tasks.id;
-
-CREATE TABLE IF NOT EXISTS client_scheduled_jobs (
-    client_id text,
-    client_name text,
-    client_schedule_id integer,
-    execution_time timestamp with time zone,
-    status bigint,
-    status_message text,
-    start_time timestamp with time zone,
-    end_time timestamp with time zone,
-    log_path text,
-    session_collection boolean,
-    local_group_collection boolean,
-    ad_structure_collection boolean,
-    all_trusted_domains boolean,
-    domain_controller text,
-    event_title text,
-    last_ingest timestamp with time zone,
-    ous text[],
-    domains text[],
-    id bigint NOT NULL,
-    created_at timestamp with time zone,
-    updated_at timestamp with time zone
-);
-
-CREATE SEQUENCE IF NOT EXISTS client_scheduled_jobs_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-ALTER SEQUENCE client_scheduled_jobs_id_seq OWNED BY client_scheduled_jobs.id;
-
-CREATE TABLE IF NOT EXISTS client_schedules (
-    client_id text,
-    rrule text,
-    session_collection boolean,
-    local_group_collection boolean,
-    ad_structure_collection boolean,
-    all_trusted_domains boolean,
-    next_scheduled_at timestamp with time zone,
-    deleted_at timestamp with time zone,
-    ous text[],
-    domains text[],
-    id integer NOT NULL,
-    created_at timestamp with time zone,
-    updated_at timestamp with time zone
-);
-
-CREATE SEQUENCE IF NOT EXISTS client_schedules_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-ALTER SEQUENCE client_schedules_id_seq OWNED BY client_schedules.id;
-
-CREATE TABLE IF NOT EXISTS clients (
-    name text,
-    ip_address text,
-    hostname text,
-    configured_user text,
-    last_checkin timestamp with time zone,
-    current_job_id bigint,
-    completed_job_count integer,
-    domain_controller text,
-    version text,
-    user_sid text,
-    deleted_at timestamp with time zone,
-    type text,
-    id text NOT NULL,
-    created_at timestamp with time zone,
-    updated_at timestamp with time zone
-);
-
 CREATE TABLE IF NOT EXISTS domain_collection_results (
     job_id bigint,
     domain_name text,
@@ -363,13 +271,6 @@ CREATE SEQUENCE IF NOT EXISTS domain_collection_results_id_seq
     NO MAXVALUE
     CACHE 1;
 ALTER SEQUENCE domain_collection_results_id_seq OWNED BY domain_collection_results.id;
-
-CREATE TABLE IF NOT EXISTS domain_details (
-    name text,
-    object_id text NOT NULL,
-    "exists" boolean,
-    type text
-);
 
 CREATE TABLE IF NOT EXISTS feature_flags (
     id integer NOT NULL,
@@ -435,35 +336,6 @@ CREATE TABLE IF NOT EXISTS installations (
     updated_at timestamp with time zone
 );
 
-CREATE TABLE IF NOT EXISTS list_findings (
-    principal text,
-    principal_kind text,
-    finding text,
-    domain_sid text,
-    props jsonb,
-    accepted_until timestamp with time zone,
-    id integer NOT NULL,
-    created_at timestamp with time zone,
-    updated_at timestamp with time zone
-);
-
-CREATE SEQUENCE IF NOT EXISTS list_findings_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-ALTER SEQUENCE list_findings_id_seq OWNED BY list_findings.id;
-
-CREATE TABLE IF NOT EXISTS ou_details (
-    name text,
-    object_id text NOT NULL,
-    "exists" boolean,
-    distinguished_name text,
-    type text
-);
-
 CREATE TABLE IF NOT EXISTS parameters (
     key text,
     name text,
@@ -499,70 +371,6 @@ CREATE SEQUENCE IF NOT EXISTS permissions_id_seq
     NO MAXVALUE
     CACHE 1;
 ALTER SEQUENCE permissions_id_seq OWNED BY permissions.id;
-
-CREATE TABLE IF NOT EXISTS relationship_findings (
-    from_principal text,
-    to_principal text,
-    from_principal_props jsonb,
-    from_principal_kind text,
-    to_principal_props jsonb,
-    to_principal_kind text,
-    rel_props jsonb,
-    combo_graph_relation_id bigint,
-    finding text,
-    domain_sid text,
-    principals_hash text,
-    accepted_until timestamp with time zone,
-    id integer NOT NULL,
-    created_at timestamp with time zone,
-    updated_at timestamp with time zone
-);
-
-CREATE SEQUENCE IF NOT EXISTS relationship_findings_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-ALTER SEQUENCE relationship_findings_id_seq OWNED BY relationship_findings.id;
-
-CREATE TABLE IF NOT EXISTS risk_counts (
-    composite_risk bigint,
-    finding_count bigint,
-    impacted_asset_count bigint,
-    domain_sid text,
-    finding text,
-    id bigint NOT NULL,
-    created_at timestamp with time zone,
-    updated_at timestamp with time zone
-);
-
-CREATE SEQUENCE IF NOT EXISTS risk_counts_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-ALTER SEQUENCE risk_counts_id_seq OWNED BY risk_counts.id;
-
-CREATE TABLE IF NOT EXISTS risk_posture_stats (
-    domain_sid text,
-    exposure_index numeric,
-    tier_zero_count bigint,
-    critical_risk_count bigint,
-    id bigint NOT NULL,
-    created_at timestamp with time zone,
-    updated_at timestamp with time zone
-);
-
-CREATE SEQUENCE IF NOT EXISTS risk_posture_stats_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-ALTER SEQUENCE risk_posture_stats_id_seq OWNED BY risk_posture_stats.id;
 
 CREATE TABLE IF NOT EXISTS roles (
     name text,
@@ -671,19 +479,12 @@ ALTER TABLE ONLY audit_logs ALTER COLUMN id SET DEFAULT nextval('audit_logs_id_s
 ALTER TABLE ONLY auth_secrets ALTER COLUMN id SET DEFAULT nextval('auth_secrets_id_seq'::regclass);
 ALTER TABLE ONLY azure_data_quality_aggregations ALTER COLUMN id SET DEFAULT nextval('azure_data_quality_aggregations_id_seq'::regclass);
 ALTER TABLE ONLY azure_data_quality_stats ALTER COLUMN id SET DEFAULT nextval('azure_data_quality_stats_id_seq'::regclass);
-ALTER TABLE ONLY client_ingest_tasks ALTER COLUMN id SET DEFAULT nextval('client_ingest_tasks_id_seq'::regclass);
-ALTER TABLE ONLY client_scheduled_jobs ALTER COLUMN id SET DEFAULT nextval('client_scheduled_jobs_id_seq'::regclass);
-ALTER TABLE ONLY client_schedules ALTER COLUMN id SET DEFAULT nextval('client_schedules_id_seq'::regclass);
 ALTER TABLE ONLY domain_collection_results ALTER COLUMN id SET DEFAULT nextval('domain_collection_results_id_seq'::regclass);
 ALTER TABLE ONLY feature_flags ALTER COLUMN id SET DEFAULT nextval('feature_flags_id_seq'::regclass);
 ALTER TABLE ONLY file_upload_jobs ALTER COLUMN id SET DEFAULT nextval('file_upload_jobs_id_seq'::regclass);
 ALTER TABLE ONLY ingest_tasks ALTER COLUMN id SET DEFAULT nextval('ingest_tasks_id_seq'::regclass);
-ALTER TABLE ONLY list_findings ALTER COLUMN id SET DEFAULT nextval('list_findings_id_seq'::regclass);
 ALTER TABLE ONLY parameters ALTER COLUMN id SET DEFAULT nextval('parameters_id_seq'::regclass);
 ALTER TABLE ONLY permissions ALTER COLUMN id SET DEFAULT nextval('permissions_id_seq'::regclass);
-ALTER TABLE ONLY relationship_findings ALTER COLUMN id SET DEFAULT nextval('relationship_findings_id_seq'::regclass);
-ALTER TABLE ONLY risk_counts ALTER COLUMN id SET DEFAULT nextval('risk_counts_id_seq'::regclass);
-ALTER TABLE ONLY risk_posture_stats ALTER COLUMN id SET DEFAULT nextval('risk_posture_stats_id_seq'::regclass);
 ALTER TABLE ONLY roles ALTER COLUMN id SET DEFAULT nextval('roles_id_seq'::regclass);
 ALTER TABLE ONLY saml_providers ALTER COLUMN id SET DEFAULT nextval('saml_providers_id_seq'::regclass);
 ALTER TABLE ONLY saved_queries ALTER COLUMN id SET DEFAULT nextval('saved_queries_id_seq'::regclass);
@@ -712,18 +513,8 @@ ALTER TABLE ONLY azure_data_quality_aggregations
     ADD CONSTRAINT azure_data_quality_aggregations_pkey PRIMARY KEY (id);
 ALTER TABLE ONLY azure_data_quality_stats
     ADD CONSTRAINT azure_data_quality_stats_pkey PRIMARY KEY (id);
-ALTER TABLE ONLY client_ingest_tasks
-    ADD CONSTRAINT client_ingest_tasks_pkey PRIMARY KEY (id);
-ALTER TABLE ONLY client_scheduled_jobs
-    ADD CONSTRAINT client_scheduled_jobs_pkey PRIMARY KEY (id);
-ALTER TABLE ONLY client_schedules
-    ADD CONSTRAINT client_schedules_pkey PRIMARY KEY (id);
-ALTER TABLE ONLY clients
-    ADD CONSTRAINT clients_pkey PRIMARY KEY (id);
 ALTER TABLE ONLY domain_collection_results
     ADD CONSTRAINT domain_collection_results_pkey PRIMARY KEY (id);
-ALTER TABLE ONLY domain_details
-    ADD CONSTRAINT domain_details_pkey PRIMARY KEY (object_id);
 ALTER TABLE ONLY feature_flags
     ADD CONSTRAINT feature_flags_key_key UNIQUE (key);
 ALTER TABLE ONLY feature_flags
@@ -736,22 +527,12 @@ ALTER TABLE ONLY ingest_tasks
     ADD CONSTRAINT ingest_tasks_pkey PRIMARY KEY (id);
 ALTER TABLE ONLY installations
     ADD CONSTRAINT installations_pkey PRIMARY KEY (id);
-ALTER TABLE ONLY list_findings
-    ADD CONSTRAINT list_findings_pkey PRIMARY KEY (id);
-ALTER TABLE ONLY ou_details
-    ADD CONSTRAINT ou_details_pkey PRIMARY KEY (object_id);
 ALTER TABLE ONLY parameters
     ADD CONSTRAINT parameters_key_key UNIQUE (key);
 ALTER TABLE ONLY parameters
     ADD CONSTRAINT parameters_pkey PRIMARY KEY (id);
 ALTER TABLE ONLY permissions
     ADD CONSTRAINT permissions_pkey PRIMARY KEY (id);
-ALTER TABLE ONLY relationship_findings
-    ADD CONSTRAINT relationship_findings_pkey PRIMARY KEY (id);
-ALTER TABLE ONLY risk_counts
-    ADD CONSTRAINT risk_counts_pkey PRIMARY KEY (id);
-ALTER TABLE ONLY risk_posture_stats
-    ADD CONSTRAINT risk_posture_stats_pkey PRIMARY KEY (id);
 ALTER TABLE ONLY roles_permissions
     ADD CONSTRAINT roles_permissions_pkey PRIMARY KEY (role_id, permission_id);
 ALTER TABLE ONLY roles
@@ -778,16 +559,6 @@ CREATE INDEX IF NOT EXISTS idx_audit_logs_actor_id ON audit_logs USING btree (ac
 CREATE INDEX IF NOT EXISTS idx_audit_logs_created_at ON audit_logs USING btree (created_at);
 CREATE INDEX IF NOT EXISTS idx_azure_data_quality_aggregations_run_id ON azure_data_quality_aggregations USING btree (run_id);
 CREATE INDEX IF NOT EXISTS idx_azure_data_quality_stats_run_id ON azure_data_quality_stats USING btree (run_id);
-CREATE INDEX IF NOT EXISTS idx_client_schedules_deleted_at ON client_schedules USING btree (deleted_at);
-CREATE INDEX IF NOT EXISTS idx_clients_deleted_at ON clients USING btree (deleted_at);
-CREATE INDEX IF NOT EXISTS idx_list_findings_domain_s_id ON list_findings USING btree (domain_sid);
-CREATE INDEX IF NOT EXISTS idx_list_findings_finding ON list_findings USING btree (finding);
-CREATE INDEX IF NOT EXISTS idx_list_findings_principal ON list_findings USING btree (principal);
-CREATE INDEX IF NOT EXISTS idx_relationship_findings_domain_s_id ON relationship_findings USING btree (domain_sid);
-CREATE INDEX IF NOT EXISTS idx_relationship_findings_finding ON relationship_findings USING btree (finding);
-CREATE INDEX IF NOT EXISTS idx_relationship_findings_principals_hash ON relationship_findings USING btree (principals_hash);
-CREATE INDEX IF NOT EXISTS idx_risk_counts_domain_s_id ON risk_counts USING btree (domain_sid);
-CREATE INDEX IF NOT EXISTS idx_risk_counts_finding ON risk_counts USING btree (finding);
 CREATE INDEX IF NOT EXISTS idx_saml_providers_name ON saml_providers USING btree (name);
 CREATE UNIQUE INDEX IF NOT EXISTS idx_saved_queries_composite_index ON saved_queries USING btree (user_id, name);
 CREATE INDEX IF NOT EXISTS idx_users_principal_name ON users USING btree (principal_name);
@@ -798,8 +569,6 @@ ALTER TABLE ONLY asset_group_collections
     ADD CONSTRAINT fk_asset_groups_collections FOREIGN KEY (asset_group_id) REFERENCES asset_groups(id) ON DELETE CASCADE;
 ALTER TABLE ONLY asset_group_selectors
     ADD CONSTRAINT fk_asset_groups_selectors FOREIGN KEY (asset_group_id) REFERENCES asset_groups(id) ON DELETE CASCADE;
-ALTER TABLE ONLY client_schedules
-    ADD CONSTRAINT fk_clients_schedules FOREIGN KEY (client_id) REFERENCES clients(id);
 ALTER TABLE ONLY file_upload_jobs
     ADD CONSTRAINT fk_file_upload_jobs_user FOREIGN KEY (user_id) REFERENCES users(id);
 ALTER TABLE ONLY roles_permissions


### PR DESCRIPTION
## Description

Remove BHE schema from BHCE

## Motivation and Context

When fixing Gorm automigrate, we accidentally included BHE specific schema in our main schema file. This resolves the issue and allows us to release the next BHCE version without making unnecessary tables for users

## How Has This Been Tested?

Migrations run correctly with the missing tables. Spot checked all references to the removed schema by hand.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
