### PR TITLE
Warning when disabling MFA

### DIFF
--- a/cmd/ui/src/views/Users/Users.tsx
+++ b/cmd/ui/src/views/Users/Users.tsx
@@ -347,7 +347,6 @@ const Users = () => {
                 secret={disable2FASecret}
                 onSecretChange={(e: any) => setDisable2FASecret(e.target.value)}
                 contentText='Are you sure you want to disable MFA for this user? Please enter your password to confirm.'
-                displayWarning
             />
             <PasswordDialog
                 open={resetUserPasswordDialogOpen}

--- a/cmd/ui/src/views/Users/Users.tsx
+++ b/cmd/ui/src/views/Users/Users.tsx
@@ -347,6 +347,7 @@ const Users = () => {
                 secret={disable2FASecret}
                 onSecretChange={(e: any) => setDisable2FASecret(e.target.value)}
                 contentText='Are you sure you want to disable MFA for this user? Please enter your password to confirm.'
+                displayWarning
             />
             <PasswordDialog
                 open={resetUserPasswordDialogOpen}

--- a/packages/javascript/bh-shared-ui/src/components/Disable2FADialog/Disable2FADialog.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/Disable2FADialog/Disable2FADialog.test.tsx
@@ -92,23 +92,7 @@ describe('Enable2FADialog', () => {
         ).toBeInTheDocument();
     });
 
-    it('does not display security wanrning when displayWarning is NOT passed', () => {
-        expect(screen.queryByTestId('ReportProblemOutlinedIcon')).not.toBeInTheDocument();
-    });
-
-    it('displays security warning when displayWarning is passed as a prop', () => {
-        render(
-            <Disable2FADialog
-                open={true}
-                onCancel={testOnCancel}
-                onClose={testOnClose}
-                onSave={testOnSave}
-                secret=''
-                onSecretChange={testSetSecret}
-                contentText=''
-                displayWarning // <-- testing this prop
-            />
-        );
+    it('displays security warning ', () => {
         expect(screen.queryByTestId('ReportProblemOutlinedIcon')).toBeInTheDocument();
     });
 

--- a/packages/javascript/bh-shared-ui/src/components/Disable2FADialog/Disable2FADialog.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/Disable2FADialog/Disable2FADialog.test.tsx
@@ -92,6 +92,26 @@ describe('Enable2FADialog', () => {
         ).toBeInTheDocument();
     });
 
+    it('does not display security wanrning when displayWarning is NOT passed', () => {
+        expect(screen.queryByTestId('ReportProblemOutlinedIcon')).not.toBeInTheDocument();
+    });
+
+    it('displays security warning when displayWarning is passed as a prop', () => {
+        render(
+            <Disable2FADialog
+                open={true}
+                onCancel={testOnCancel}
+                onClose={testOnClose}
+                onSave={testOnSave}
+                secret=''
+                onSecretChange={testSetSecret}
+                contentText=''
+                displayWarning // testing this field
+            />
+        );
+        expect(screen.queryByTestId('ReportProblemOutlinedIcon')).toBeInTheDocument();
+    });
+
     describe('user clicks "Cancel" button', () => {
         beforeEach(async () => {
             await user.click(screen.getByRole('button', { name: 'Cancel' }));

--- a/packages/javascript/bh-shared-ui/src/components/Disable2FADialog/Disable2FADialog.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/Disable2FADialog/Disable2FADialog.test.tsx
@@ -106,7 +106,7 @@ describe('Enable2FADialog', () => {
                 secret=''
                 onSecretChange={testSetSecret}
                 contentText=''
-                displayWarning // testing this field
+                displayWarning // <-- testing this prop
             />
         );
         expect(screen.queryByTestId('ReportProblemOutlinedIcon')).toBeInTheDocument();

--- a/packages/javascript/bh-shared-ui/src/components/Disable2FADialog/Disable2FADialog.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/Disable2FADialog/Disable2FADialog.tsx
@@ -35,7 +35,7 @@ const Disable2FADialog: React.FC<{
     secret: string;
     onSecretChange: (e: any) => void;
     contentText: string;
-    displayWarning: boolean;
+    displayWarning?: boolean;
 }> = ({ open, onClose, onCancel, onSave, error, secret, onSecretChange, contentText, displayWarning = false }) => {
     const handleOnSave: React.FormEventHandler = (e) => {
         e.preventDefault();

--- a/packages/javascript/bh-shared-ui/src/components/Disable2FADialog/Disable2FADialog.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/Disable2FADialog/Disable2FADialog.tsx
@@ -14,7 +14,16 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { Button, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle, TextField } from '@mui/material';
+import {
+    Alert,
+    Button,
+    Dialog,
+    DialogActions,
+    DialogContent,
+    DialogContentText,
+    DialogTitle,
+    TextField,
+} from '@mui/material';
 import React from 'react';
 
 const Disable2FADialog: React.FC<{
@@ -26,7 +35,8 @@ const Disable2FADialog: React.FC<{
     secret: string;
     onSecretChange: (e: any) => void;
     contentText: string;
-}> = ({ open, onClose, onCancel, onSave, error, secret, onSecretChange, contentText }) => {
+    displayWarning: boolean;
+}> = ({ open, onClose, onCancel, onSave, error, secret, onSecretChange, contentText, displayWarning = false }) => {
     const handleOnSave: React.FormEventHandler = (e) => {
         e.preventDefault();
         onSave(secret);
@@ -37,6 +47,12 @@ const Disable2FADialog: React.FC<{
             <DialogTitle>Disable Multi-Factor Authentication?</DialogTitle>
             <form onSubmit={handleOnSave}>
                 <DialogContent>
+                    {displayWarning && (
+                        <Alert severity='warning' style={{ marginBottom: '10px', alignItems: 'center' }}>
+                            Disabling MFA increases the risk of unauthorized access. For optimal account security, we
+                            highly recommend keeping MFA enabled.
+                        </Alert>
+                    )}
                     <DialogContentText>{contentText}</DialogContentText>
 
                     <TextField

--- a/packages/javascript/bh-shared-ui/src/components/Disable2FADialog/Disable2FADialog.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/Disable2FADialog/Disable2FADialog.tsx
@@ -35,8 +35,7 @@ const Disable2FADialog: React.FC<{
     secret: string;
     onSecretChange: (e: any) => void;
     contentText: string;
-    displayWarning?: boolean;
-}> = ({ open, onClose, onCancel, onSave, error, secret, onSecretChange, contentText, displayWarning = false }) => {
+}> = ({ open, onClose, onCancel, onSave, error, secret, onSecretChange, contentText }) => {
     const handleOnSave: React.FormEventHandler = (e) => {
         e.preventDefault();
         onSave(secret);
@@ -47,12 +46,10 @@ const Disable2FADialog: React.FC<{
             <DialogTitle>Disable Multi-Factor Authentication?</DialogTitle>
             <form onSubmit={handleOnSave}>
                 <DialogContent>
-                    {displayWarning && (
-                        <Alert severity='warning' style={{ marginBottom: '10px', alignItems: 'center' }}>
-                            Disabling MFA increases the risk of unauthorized access. For optimal account security, we
-                            highly recommend keeping MFA enabled.
-                        </Alert>
-                    )}
+                    <Alert severity='warning' style={{ marginBottom: '10px', alignItems: 'center' }}>
+                        Disabling MFA increases the risk of unauthorized access. For optimal account security, we highly
+                        recommend keeping MFA enabled.
+                    </Alert>
                     <DialogContentText>{contentText}</DialogContentText>
 
                     <TextField


### PR DESCRIPTION
## Description
Adds a warning message as to potential vulnerabilities when MFA is disabled. This warning is **only** present in the `Disable2FADialog` found at admin -> Manage Users -> hamburger menu for users with MFA enabled -> disable MFA. Not present on the user's profile page when going to turn off MFA, however, we can add it there if necessary.

## Motivation and Context
Sufficiently warn the admin before disabling a user's MFA.

## How Has This Been Tested?
Tested BHE, BHCE for the warning to be present from the admin perspective and NOT from the user profile perspective.

## Screenshots (if appropriate):
![Screenshot 2023-11-17 at 2 47 14 PM](https://github.com/SpecterOps/BloodHound/assets/66393111/d77525fa-7651-4f34-a003-c2101b098abb)

## Types of changes
-   [x] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
-   [ ] Documentation updates are needed, and have been made accordingly.
-   [x] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
