### PR TITLE
Fix ADCS post-processing bug

### DIFF
--- a/packages/go/analysis/ad/adcs.go
+++ b/packages/go/analysis/ad/adcs.go
@@ -414,8 +414,6 @@ func PostADCS(ctx context.Context, db graph.Database, groupExpansions impact.Pat
 									log.Errorf("failed post processing for %s: %w", ad.GoldenCert.String(), err)
 								} else if err := PostADCSESC1(ctx, tx, outC, db, groupExpansions, enterpriseCertAuthorities, certTemplates, enterpriseCA, innerDomain); err != nil {
 									log.Errorf("failed post processing for %s: %w", ad.ADCSESC1.String(), err)
-								} else {
-									return nil
 								}
 							}
 						}


### PR DESCRIPTION
## Description

This PR fixes a bug in ADCS post-processing that caused it to exit the loop after successfully post-processing the first `EnterpriseCA`.

## Motivation and Context

* Fix the bug to allow all `EnterpriseCAs` to be post-processed.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] My changes include a database migration.
