### PR TITLE
chore: move entity content file to shared ui and update icon colors in bh graph go file

### DIFF
--- a/cmd/api/src/api/bloodhoundgraph/bloodhoundgraph.go
+++ b/cmd/api/src/api/bloodhoundgraph/bloodhoundgraph.go
@@ -258,7 +258,7 @@ func (s *BloodHoundGraphNode) SetIcon(nType string) {
 		}
 	case "EnterpriseCA":
 		s.FontIcon = &BloodHoundGraphFontIcon{
-			Text: "fa-box",
+			Text: "fa-building",
 		}
 	case "NTAuthStore":
 		s.FontIcon = &BloodHoundGraphFontIcon{
@@ -340,15 +340,15 @@ func (s *BloodHoundGraphNode) SetBackground(nType string) {
 	case "GPO":
 		s.BloodHoundGraphItem.Color = "#998EFD"
 	case "AIACA":
-		s.BloodHoundGraphItem.Color = "#763AAD"
+		s.BloodHoundGraphItem.Color = "#9769F0"
 	case "RootCA":
-		s.BloodHoundGraphItem.Color = "#763AAD"
+		s.BloodHoundGraphItem.Color = "#6968E8"
 	case "EnterpriseCA":
-		s.BloodHoundGraphItem.Color = "#25724B"
+		s.BloodHoundGraphItem.Color = "#4696E9"
 	case "NTAuthStore":
-		s.BloodHoundGraphItem.Color = "#763AAD"
+		s.BloodHoundGraphItem.Color = "#D575F5"
 	case "CertTemplate":
-		s.BloodHoundGraphItem.Color = "#FDA1FF"
+		s.BloodHoundGraphItem.Color = "#B153F3"
 	case "Meta":
 		s.BloodHoundGraphItem.Color = "#000"
 	default:

--- a/cmd/ui/src/ducks/entityinfo/types.ts
+++ b/cmd/ui/src/ducks/entityinfo/types.ts
@@ -14,9 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { GraphNodeTypes } from 'src/ducks/graph/types';
-
-import { AzureNodeKind } from 'bh-shared-ui';
+import { AzureNodeKind, EntityKinds } from 'bh-shared-ui';
 
 // --- AIACA
 export interface AIACAInfo extends EntityInfo {
@@ -274,12 +272,6 @@ export interface UserInfo extends EntityInfo {
 // --- Meta
 export type MetaInfoGraph = GraphInfo;
 
-export const EntityInfoEndpoints = {
-    GetInfo: (type: GraphNodeTypes, id: string) => {
-        return `/api/v1/entities/${type.toLowerCase()}/${id}`;
-    },
-};
-
 // --- Azure Entities
 export interface AZAppInfo extends AZEntityInfo {
     props: BasicInfo & {
@@ -431,7 +423,7 @@ export interface EntityInfo {
 }
 
 export interface AZEntityInfo {
-    kind: GraphNodeTypes;
+    kind: EntityKinds;
     props: BasicInfo;
 }
 
@@ -465,7 +457,7 @@ interface SetEntityInfoOpenAction {
 
 export type SelectedNode = {
     id: string;
-    type: GraphNodeTypes;
+    type: EntityKinds;
     name: string;
     graphId?: string;
 };

--- a/cmd/ui/src/ducks/searchbar/types.ts
+++ b/cmd/ui/src/ducks/searchbar/types.ts
@@ -14,7 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { GraphNodeTypes } from 'src/ducks/graph/types';
+import { EntityKinds } from 'bh-shared-ui';
 import { EdgeCheckboxType } from 'src/views/Explore/ExploreSearch/EdgeFilteringDialog';
 
 const SEARCH_RESET = 'app/search/RESET';
@@ -60,7 +60,7 @@ export interface SearchBarState {
 }
 export interface SearchNodeType {
     objectid: string;
-    type: GraphNodeTypes;
+    type: EntityKinds;
     name: string;
 }
 

--- a/cmd/ui/src/views/Explore/EntityInfo/EntityInfoContent.test.tsx
+++ b/cmd/ui/src/views/Explore/EntityInfo/EntityInfoContent.test.tsx
@@ -17,9 +17,9 @@
 import EntityInfoContent from './EntityInfoContent';
 import { EntityInfoPanelContextProvider } from './EntityInfoPanelContextProvider';
 import { render, screen, waitForElementToBeRemoved } from 'src/test-utils';
-import { GraphNodeTypes } from 'src/ducks/graph/types';
 import { rest } from 'msw';
 import { setupServer } from 'msw/node';
+import { AzureNodeKind } from 'bh-shared-ui';
 
 const server = setupServer(
     rest.get('/api/v2/azure/roles', (req, res, ctx) => {
@@ -46,7 +46,7 @@ describe('EntityInfoContent', () => {
 
         render(
             <EntityInfoPanelContextProvider>
-                <EntityInfoContent id={testId} nodeType={GraphNodeTypes.AZRole} />
+                <EntityInfoContent id={testId} nodeType={AzureNodeKind.Role} />
             </EntityInfoPanelContextProvider>
         );
         await waitForElementToBeRemoved(() => screen.getByText('Loading...'));

--- a/cmd/ui/src/views/Explore/EntityInfo/EntityInfoContent.tsx
+++ b/cmd/ui/src/views/Explore/EntityInfo/EntityInfoContent.tsx
@@ -15,16 +15,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Box } from '@mui/material';
+import { allSections, entityInformationEndpoints, EntityKinds } from 'bh-shared-ui';
 import React from 'react';
 import { useQuery } from 'react-query';
-import { GraphNodeTypes } from 'src/ducks/graph/types';
-import { allSections, entityInformationEndpoints } from './content';
 import EntityInfoDataTableList from './EntityInfoDataTableList';
 import EntityObjectInformation from './EntityObjectInformation';
 
 export interface EntityInfoContentProps {
     id: string;
-    nodeType: GraphNodeTypes;
+    nodeType: EntityKinds;
 }
 
 const EntityInfoContent: React.FC<EntityInfoContentProps> = ({ id, nodeType }) => {

--- a/cmd/ui/src/views/Explore/EntityInfo/EntityInfoDataTable.test.tsx
+++ b/cmd/ui/src/views/Explore/EntityInfo/EntityInfoDataTable.test.tsx
@@ -18,13 +18,12 @@ import { render, screen } from 'src/test-utils';
 import userEvent from '@testing-library/user-event';
 import { rest, RequestHandler } from 'msw';
 import { setupServer } from 'msw/node';
-import { ActiveDirectoryNodeKind } from 'bh-shared-ui';
+import { ActiveDirectoryNodeKind, allSections } from 'bh-shared-ui';
 import EntityInfoDataTable from './EntityInfoDataTable';
 import { EntityInfoPanelContextProvider } from './EntityInfoPanelContextProvider';
-import { allSections } from './content';
 
 const objectId = 'fake-object-id';
-const sections = allSections[ActiveDirectoryNodeKind.GPO](objectId);
+const sections = allSections[ActiveDirectoryNodeKind.GPO]!(objectId);
 
 const queryCount = {
     controllers: {

--- a/cmd/ui/src/views/Explore/EntityInfo/EntityInfoDataTable.tsx
+++ b/cmd/ui/src/views/Explore/EntityInfo/EntityInfoDataTable.tsx
@@ -14,33 +14,15 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+import { EntityInfoDataTableProps, InfiniteScrollingTable, abortEntitySectionRequest } from 'bh-shared-ui';
 import { useQuery } from 'react-query';
 import { useDispatch } from 'react-redux';
-import { InfiniteScrollingTable } from 'bh-shared-ui';
+import { NODE_GRAPH_RENDER_LIMIT } from 'src/constants';
 import { putGraphData, putGraphError, saveResponseForExport, setGraphLoading } from 'src/ducks/explore/actions';
 import { addSnackbar } from 'src/ducks/global/actions';
 import { sourceNodeSelected } from 'src/ducks/searchbar/actions';
-import { abortRequest } from 'src/views/Explore/utils';
-import EntityInfoCollapsibleSection from './EntityInfoCollapsibleSection';
-import { NODE_GRAPH_RENDER_LIMIT } from 'src/constants';
 import { transformFlatGraphResponse } from 'src/utils';
-
-export interface EntityInfoDataTableProps {
-    id: string;
-    label: string;
-    endpoint?: ({
-        counts,
-        skip,
-        limit,
-        type,
-    }: {
-        counts?: boolean;
-        skip?: number;
-        limit?: number;
-        type?: string;
-    }) => Promise<any>;
-    sections?: EntityInfoDataTableProps[];
-}
+import EntityInfoCollapsibleSection from './EntityInfoCollapsibleSection';
 
 const EntityInfoDataTable: React.FC<EntityInfoDataTableProps> = ({ id, label, endpoint, sections }) => {
     const dispatch = useDispatch();
@@ -61,7 +43,7 @@ const EntityInfoDataTable: React.FC<EntityInfoDataTableProps> = ({ id, label, en
         if (!endpoint) return;
 
         if (isOpen && countQuery.data?.count < NODE_GRAPH_RENDER_LIMIT) {
-            abortRequest();
+            abortEntitySectionRequest();
 
             dispatch(setGraphLoading(true));
 

--- a/cmd/ui/src/views/Explore/EntityInfo/EntityInfoDataTableList.tsx
+++ b/cmd/ui/src/views/Explore/EntityInfo/EntityInfoDataTableList.tsx
@@ -15,9 +15,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Box, Divider } from '@mui/material';
+import { EntityInfoDataTableProps } from 'bh-shared-ui';
 import React from 'react';
-import EntityInfoDataTable, { EntityInfoDataTableProps } from './EntityInfoDataTable';
-
+import EntityInfoDataTable from './EntityInfoDataTable';
 export interface EntityInfoDataTableListProps {
     tables: EntityInfoDataTableProps[];
 }

--- a/cmd/ui/src/views/Explore/EntityInfo/EntityInfoHeader.tsx
+++ b/cmd/ui/src/views/Explore/EntityInfo/EntityInfoHeader.tsx
@@ -17,15 +17,14 @@
 import { faAngleDoubleUp, faMinus, faPlus } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Typography } from '@mui/material';
-import { Icon, NodeIcon } from 'bh-shared-ui';
+import { Icon, NodeIcon, EntityKinds } from 'bh-shared-ui';
 import React from 'react';
-import { GraphNodeTypes } from 'src/ducks/graph/types';
 import { useEntityInfoPanelContext } from 'src/views/Explore/EntityInfo/EntityInfoPanelContext';
 import useHeaderStyles from 'src/views/Explore/InfoStyles/Header';
 
 interface HeaderProps {
     name?: string;
-    nodeType?: GraphNodeTypes;
+    nodeType?: EntityKinds;
     onToggleExpanded: (expanded: boolean) => void;
     expanded: boolean;
 }

--- a/cmd/ui/src/views/Explore/ExploreSearchCombobox/ExploreSearchCombobox.test.tsx
+++ b/cmd/ui/src/views/Explore/ExploreSearchCombobox/ExploreSearchCombobox.test.tsx
@@ -19,7 +19,7 @@ import { rest } from 'msw';
 import { setupServer } from 'msw/node';
 import { act, render, screen, within } from 'src/test-utils';
 import ExploreSearchCombobox from '.';
-import { GraphNodeTypes } from 'src/ducks/graph/types';
+import { ActiveDirectoryNodeKind } from 'bh-shared-ui';
 
 const testSearchResults = {
     data: [
@@ -131,7 +131,7 @@ describe('icon rendering', () => {
                     inputValue=''
                     handleNodeEdited={vi.fn()}
                     handleNodeSelected={vi.fn()}
-                    selectedItem={{ type: GraphNodeTypes.Computer, objectid: '1', name: 'Computer a' }}
+                    selectedItem={{ type: ActiveDirectoryNodeKind.Computer, objectid: '1', name: 'Computer a' }}
                 />
             );
         });

--- a/cmd/ui/src/views/Explore/fragments.tsx
+++ b/cmd/ui/src/views/Explore/fragments.tsx
@@ -15,11 +15,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Alert, Box, CircularProgress, Typography } from '@mui/material';
-import { EntityField, NodeIcon, format } from 'bh-shared-ui';
+import { AzureNodeKind, EntityField, EntityKinds, NodeIcon, format } from 'bh-shared-ui';
 import isEmpty from 'lodash/isEmpty';
 import React, { PropsWithChildren } from 'react';
 import { TIER_ZERO_TAG } from 'src/constants';
-import { GraphNodeTypes } from 'src/ducks/graph/types';
 import { sourceNodeSelected } from 'src/ducks/searchbar/actions';
 
 import { useAppDispatch } from 'src/store';
@@ -160,7 +159,7 @@ interface BasicObjectInfoFieldsProps {
     name?: string;
 }
 
-const RelatedKindField = (fieldLabel: string, relatedKind: GraphNodeTypes, id: string, name?: string) => {
+const RelatedKindField = (fieldLabel: string, relatedKind: EntityKinds, id: string, name?: string) => {
     const dispatch = useAppDispatch();
     return (
         <Box padding={1}>
@@ -200,14 +199,14 @@ export const BasicObjectInfoFields: React.FC<BasicObjectInfoFieldsProps> = (prop
             {props.service_principal_id &&
                 RelatedKindField(
                     'Service Principal ID:',
-                    GraphNodeTypes.AZServicePrincipal,
+                    AzureNodeKind.ServicePrincipal,
                     props.service_principal_id,
                     props.name
                 )}
             {props.noderesourcegroupid &&
                 RelatedKindField(
                     'Node Resource Group ID:',
-                    GraphNodeTypes.AZResourceGroup,
+                    AzureNodeKind.ResourceGroup,
                     props.noderesourcegroupid,
                     props.name
                 )}

--- a/cmd/ui/src/views/Explore/utils.ts
+++ b/cmd/ui/src/views/Explore/utils.ts
@@ -34,13 +34,6 @@ import { GlyphLocation } from 'src/rendering/programs/node.glyphs';
 import { EdgeDirection, EdgeParams, NodeParams } from 'src/utils';
 import { NODE_ICON, GLYPHS, UNKNOWN_ICON } from './svgIcons';
 
-export let controller = new AbortController();
-
-export const abortRequest = () => {
-    controller.abort();
-    controller = new AbortController();
-};
-
 export const formatObjectInfoFields = (props: any): EntityField[] => {
     let mappedFields: EntityField[] = [];
     const propKeys = Object.keys(props);

--- a/cmd/ui/src/views/QA/index.tsx
+++ b/cmd/ui/src/views/QA/index.tsx
@@ -1,3 +1,19 @@
+// Copyright 2023 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import QA from './QA';
 
 export default QA;

--- a/cmd/ui/src/views/QA/index.tsx
+++ b/cmd/ui/src/views/QA/index.tsx
@@ -14,6 +14,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import QA from './QA';
+import QualityAssurance from './QA';
 
-export default QA;
+export default QualityAssurance;

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/ADCSESC1/Composition.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/ADCSESC1/Composition.tsx
@@ -16,7 +16,7 @@
 
 import { FC } from 'react';
 import { Alert, Box, Skeleton, Typography } from '@mui/material';
-import { apiClient } from '../../..';
+import { apiClient } from '../../../utils/api';
 import { EdgeInfoProps } from '..';
 import { useQuery } from 'react-query';
 import VirtualizedNodeList, { VirtualizedNodeListItem } from '../../VirtualizedNodeList';

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/GoldenCert/Composition.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/GoldenCert/Composition.tsx
@@ -16,7 +16,7 @@
 
 import { FC } from 'react';
 import { Alert, Box, Skeleton, Typography } from '@mui/material';
-import { apiClient } from '../../..';
+import { apiClient } from '../../../utils/api';
 import { EdgeInfoProps } from '..';
 import { useQuery } from 'react-query';
 import VirtualizedNodeList, { VirtualizedNodeListItem } from '../../VirtualizedNodeList';

--- a/packages/javascript/bh-shared-ui/src/components/HighlightedText/HighlightedText.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HighlightedText/HighlightedText.test.tsx
@@ -55,7 +55,7 @@ describe('HighlightedText', () => {
         render(<HighlightedText text='(TESTLAB.LOCAL)+SOME@TEXT$![-[\]{}()*+?' search='CAL)+SOME@TEXT$!' />);
         expect(screen.getByText(/\(TESTLAB\.LO/)).toBeInTheDocument();
         expect(screen.getByText(/CAL\)\+SOME@TEXT\$!/)).toBeInTheDocument();
-        expect(screen.getByText(/\[\-\[\\\]\{\}\(\)\*\+\?/)).toBeInTheDocument();
+        expect(screen.getByText(/\[-\[\\\]\{\}\(\)\*\+\?/)).toBeInTheDocument();
         expect(screen.getByText(/CAL\)\+SOME@TEXT\$!/)).toHaveAttribute('style', 'font-weight: bold;');
     });
 });

--- a/packages/javascript/bh-shared-ui/src/components/VirtualizedNodeList.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/VirtualizedNodeList.tsx
@@ -16,7 +16,7 @@
 
 import { List, ListItemButton, Tooltip } from '@mui/material';
 import { FixedSizeList, ListChildComponentProps } from 'react-window';
-import { NodeIcon } from '.';
+import NodeIcon from './NodeIcon';
 
 export type VirtualizedNodeListItem = {
     name: string;

--- a/packages/javascript/bh-shared-ui/src/hooks/useDataQualityStats.tsx
+++ b/packages/javascript/bh-shared-ui/src/hooks/useDataQualityStats.tsx
@@ -16,7 +16,7 @@
 
 import { useQuery } from 'react-query';
 import { DateTime } from 'luxon';
-import { apiClient } from '..';
+import { apiClient } from '../utils/api';
 
 export type Domain = {
     type: string;

--- a/packages/javascript/bh-shared-ui/src/utils/content.ts
+++ b/packages/javascript/bh-shared-ui/src/utils/content.ts
@@ -15,7 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { ActiveDirectoryNodeKind, AzureNodeKind } from '../graphSchema';
-import { apiClient } from '.';
+import { apiClient } from './api';
 import { RequestOptions } from 'js-client-library';
 
 type EntitySectionEndpointParams = {
@@ -140,7 +140,7 @@ export const entityInformationEndpoints: Partial<
     [ActiveDirectoryNodeKind.RootCA]: (id: string, options?: RequestOptions) =>
         apiClient.getRootCAV2(id, false, options),
     [ActiveDirectoryNodeKind.User]: (id: string, options?: RequestOptions) => apiClient.getUserV2(id, false, options),
-    ['Meta']: apiClient.getMetaV2,
+    Meta: apiClient.getMetaV2,
 };
 
 export const allSections: Partial<Record<EntityKinds, (id: string) => EntityInfoDataTableProps[]>> = {
@@ -1948,5 +1948,5 @@ export const allSections: Partial<Record<EntityKinds, (id: string) => EntityInfo
                     .then((res) => res.data),
         },
     ],
-    ['Meta']: () => [],
+    Meta: () => [],
 };

--- a/packages/javascript/bh-shared-ui/src/utils/entityInfoDisplay.ts
+++ b/packages/javascript/bh-shared-ui/src/utils/entityInfoDisplay.ts
@@ -36,7 +36,7 @@ export enum ADSpecificTimeProperties {
 
 // Map containing all properties that should display as bitwise integers in the entity panel.
 // The key is the property string, the value is the amount of significant digits the hex value should display with.
-export var BitwiseInts = new Map([['certificatemappingmethodsraw', 2]]);
+const BitwiseInts = new Map([['certificatemappingmethodsraw', 2]]);
 
 //These times are handled differently specifically for these properties as they are collected and ingested to match these values
 //Here is some related documentation:

--- a/packages/javascript/bh-shared-ui/src/utils/index.ts
+++ b/packages/javascript/bh-shared-ui/src/utils/index.ts
@@ -15,6 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 export * from './api';
+export * from './content';
 export * from './datetime';
 export * from './exportGraphData';
 export * from './entityInfoDisplay';


### PR DESCRIPTION
## Description
This moves the content file for the entity info sections to the shared ui.
<!--- Describe your changes in detail -->

## Motivation and Context
These views should be available in BHE and this changeset consolidates the content.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
This is mostly code reorganization. The app builds and functions as before.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
