### PR TITLE
Move edgeTypes to shared UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,12 @@ original BloodHound was created by [@_wald0](https://www.twitter.com/_wald0), [@
 The easiest way to get up and running is to use our pre-configured Docker Compose setup. The following steps will get BloodHound CE up and running with the least amount of effort.
   
   1. Install Docker Compose. This should be included with the [Docker Desktop](https://www.docker.com/products/docker-desktop/) installation
-  2. Run `curl https://raw.githubusercontent.com/SpecterOps/bloodhound/main/examples/docker-compose/docker-compose.yml | docker compose -f - up `
+  2. Run `curl -L https://ghst.ly/getbhce | docker compose -f - up`
   3. Locate the randomly generated password in the terminal output of Docker Compose
   4. In a browser, navigate to `http://localhost:8080/ui/login`. Login with a username of `admin` and the randomly generated password from the logs
 ## Useful Links
 
+- [BloodHound Slack](https://ghst.ly/BHSlack)
 - [Wiki](https://github.com/SpecterOps/BloodHound/wiki)
 - [Contributors](./CONTRIBUTORS.md)
 - [Docker Compose Example](./examples/docker-compose/README.md)
@@ -40,6 +41,7 @@ The easiest way to get up and running is to use our pre-configured Docker Compos
 ## Contact
 
 Please check out the [Contact page](https://github.com/SpecterOps/BloodHound/wiki/Contact) in our wiki for details on how to reach out with questions and suggestions.
+
 ## Licensing
 
 ```

--- a/cmd/api/src/api/v2/saved_queries_test.go
+++ b/cmd/api/src/api/v2/saved_queries_test.go
@@ -17,6 +17,7 @@
 package v2_test
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -47,8 +48,10 @@ func TestResources_ListSavedQueries_SortingError(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	endpoint := "/api/v2/saved-queries"
+	userId, err := uuid2.NewV4()
+	require.Nil(t, err)
 
-	if req, err := http.NewRequest("GET", endpoint, nil); err != nil {
+	if req, err := http.NewRequestWithContext(createContextWithOwnerId(userId), "GET", endpoint, nil); err != nil {
 		t.Fatal(err)
 	} else {
 		q := url.Values{}
@@ -76,8 +79,10 @@ func TestResources_ListSavedQueries_InvalidFilterColumn(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	endpoint := "/api/v2/saved-queries"
+	userId, err := uuid2.NewV4()
+	require.Nil(t, err)
 
-	if req, err := http.NewRequest("GET", endpoint, nil); err != nil {
+	if req, err := http.NewRequestWithContext(createContextWithOwnerId(userId), "GET", endpoint, nil); err != nil {
 		t.Fatal(err)
 	} else {
 		q := url.Values{}
@@ -105,8 +110,10 @@ func TestResources_ListSavedQueries_InvalidFilterPredicate(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	endpoint := "/api/v2/saved-queries"
+	userId, err := uuid2.NewV4()
+	require.Nil(t, err)
 
-	if req, err := http.NewRequest("GET", endpoint, nil); err != nil {
+	if req, err := http.NewRequestWithContext(createContextWithOwnerId(userId), "GET", endpoint, nil); err != nil {
 		t.Fatal(err)
 	} else {
 		q := url.Values{}
@@ -133,8 +140,10 @@ func TestResources_ListSavedQueries_InvalidSkip(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	endpoint := "/api/v2/saved-queries"
+	userId, err := uuid2.NewV4()
+	require.Nil(t, err)
 
-	if req, err := http.NewRequest("GET", endpoint, nil); err != nil {
+	if req, err := http.NewRequestWithContext(createContextWithOwnerId(userId), "GET", endpoint, nil); err != nil {
 		t.Fatal(err)
 	} else {
 		q := url.Values{}
@@ -161,8 +170,10 @@ func TestResources_ListSavedQueries_InvalidLimit(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	endpoint := "/api/v2/saved-queries"
+	userId, err := uuid2.NewV4()
+	require.Nil(t, err)
 
-	if req, err := http.NewRequest("GET", endpoint, nil); err != nil {
+	if req, err := http.NewRequestWithContext(createContextWithOwnerId(userId), "GET", endpoint, nil); err != nil {
 		t.Fatal(err)
 	} else {
 		q := url.Values{}
@@ -193,24 +204,11 @@ func TestResources_ListSavedQueries_DBError(t *testing.T) {
 	userId, err := uuid2.NewV4()
 	require.Nil(t, err)
 
-	bhCtx := ctx.Context{
-		RequestID: "",
-		AuthCtx: auth.Context{
-			Session: model.UserSession{
-				User:   model.User{},
-				UserID: userId,
-			},
-		},
-		Host: nil,
-	}
-	goContext := bhCtx.ConstructGoContext()
-
 	mockDB.EXPECT().ListSavedQueries(userId, "", model.SQLFilter{}, 0, 10000).Return(model.SavedQueries{}, 0, fmt.Errorf("foo"))
 
-	if req, err := http.NewRequest("GET", endpoint, nil); err != nil {
+	if req, err := http.NewRequestWithContext(createContextWithOwnerId(userId), "GET", endpoint, nil); err != nil {
 		t.Fatal(err)
 	} else {
-		req = req.WithContext(goContext)
 		req.Header.Set(headers.ContentType.String(), mediatypes.ApplicationJson.String())
 
 		router := mux.NewRouter()
@@ -235,18 +233,6 @@ func TestResources_ListSavedQueries(t *testing.T) {
 	userId, err := uuid2.NewV4()
 	require.Nil(t, err)
 
-	bhCtx := ctx.Context{
-		RequestID: "",
-		AuthCtx: auth.Context{
-			Session: model.UserSession{
-				User:   model.User{},
-				UserID: userId,
-			},
-		},
-		Host: nil,
-	}
-	goContext := bhCtx.ConstructGoContext()
-
 	mockDB.EXPECT().ListSavedQueries(userId, gomock.Any(), gomock.Any(), 1, 10).Return(model.SavedQueries{
 		{
 			UserID: userId.String(),
@@ -255,10 +241,9 @@ func TestResources_ListSavedQueries(t *testing.T) {
 		},
 	}, 1, nil)
 
-	if req, err := http.NewRequest("GET", endpoint, nil); err != nil {
+	if req, err := http.NewRequestWithContext(createContextWithOwnerId(userId), "GET", endpoint, nil); err != nil {
 		t.Fatal(err)
 	} else {
-		req = req.WithContext(goContext)
 		q := url.Values{}
 		q.Add("sort_by", "-name")
 		q.Add("name", "eq:myQuery")
@@ -289,24 +274,11 @@ func TestResources_CreateSavedQuery_InvalidBody(t *testing.T) {
 	userId, err := uuid2.NewV4()
 	require.Nil(t, err)
 
-	bhCtx := ctx.Context{
-		RequestID: "",
-		AuthCtx: auth.Context{
-			Session: model.UserSession{
-				User:   model.User{},
-				UserID: userId,
-			},
-		},
-		Host: nil,
-	}
-	goContext := bhCtx.ConstructGoContext()
-
 	payload := "foobar"
 
-	req, err := http.NewRequest("POST", endpoint, must.MarshalJSONReader(payload))
+	req, err := http.NewRequestWithContext(createContextWithOwnerId(userId), "POST", endpoint, must.MarshalJSONReader(payload))
 	require.Nil(t, err)
 
-	req = req.WithContext(goContext)
 	req.Header.Set(headers.ContentType.String(), mediatypes.ApplicationJson.String())
 
 	router := mux.NewRouter()
@@ -329,24 +301,11 @@ func TestResources_CreateSavedQuery_EmptyBody(t *testing.T) {
 	userId, err := uuid2.NewV4()
 	require.Nil(t, err)
 
-	bhCtx := ctx.Context{
-		RequestID: "",
-		AuthCtx: auth.Context{
-			Session: model.UserSession{
-				User:   model.User{},
-				UserID: userId,
-			},
-		},
-		Host: nil,
-	}
-	goContext := bhCtx.ConstructGoContext()
-
 	payload := v2.CreateSavedQueryRequest{}
 
-	req, err := http.NewRequest("POST", endpoint, must.MarshalJSONReader(payload))
+	req, err := http.NewRequestWithContext(createContextWithOwnerId(userId), "POST", endpoint, must.MarshalJSONReader(payload))
 	require.Nil(t, err)
 
-	req = req.WithContext(goContext)
 	req.Header.Set(headers.ContentType.String(), mediatypes.ApplicationJson.String())
 
 	router := mux.NewRouter()
@@ -370,18 +329,6 @@ func TestResources_CreateSavedQuery_DuplicateName(t *testing.T) {
 	userId, err := uuid2.NewV4()
 	require.Nil(t, err)
 
-	bhCtx := ctx.Context{
-		RequestID: "",
-		AuthCtx: auth.Context{
-			Session: model.UserSession{
-				User:   model.User{},
-				UserID: userId,
-			},
-		},
-		Host: nil,
-	}
-	goContext := bhCtx.ConstructGoContext()
-
 	mockDB.EXPECT().CreateSavedQuery(gomock.Any(), gomock.Any(), gomock.Any()).Return(model.SavedQuery{}, fmt.Errorf("duplicate key value violates unique constraint \"idx_saved_queries_composite_index\""))
 
 	payload := v2.CreateSavedQueryRequest{
@@ -389,10 +336,9 @@ func TestResources_CreateSavedQuery_DuplicateName(t *testing.T) {
 		Name:  "myQuery",
 	}
 
-	req, err := http.NewRequest("POST", endpoint, must.MarshalJSONReader(payload))
+	req, err := http.NewRequestWithContext(createContextWithOwnerId(userId), "POST", endpoint, must.MarshalJSONReader(payload))
 	require.Nil(t, err)
 
-	req = req.WithContext(goContext)
 	req.Header.Set(headers.ContentType.String(), mediatypes.ApplicationJson.String())
 
 	router := mux.NewRouter()
@@ -416,18 +362,6 @@ func TestResources_CreateSavedQuery_CreateFailure(t *testing.T) {
 	userId, err := uuid2.NewV4()
 	require.Nil(t, err)
 
-	bhCtx := ctx.Context{
-		RequestID: "",
-		AuthCtx: auth.Context{
-			Session: model.UserSession{
-				User:   model.User{},
-				UserID: userId,
-			},
-		},
-		Host: nil,
-	}
-	goContext := bhCtx.ConstructGoContext()
-
 	payload := v2.CreateSavedQueryRequest{
 		Query: "Match(n) return n",
 		Name:  "myCustomQuery1",
@@ -435,10 +369,9 @@ func TestResources_CreateSavedQuery_CreateFailure(t *testing.T) {
 
 	mockDB.EXPECT().CreateSavedQuery(userId, payload.Name, payload.Query).Return(model.SavedQuery{}, fmt.Errorf("foo"))
 
-	req, err := http.NewRequest("POST", endpoint, must.MarshalJSONReader(payload))
+	req, err := http.NewRequestWithContext(createContextWithOwnerId(userId), "POST", endpoint, must.MarshalJSONReader(payload))
 	require.Nil(t, err)
 
-	req = req.WithContext(goContext)
 	req.Header.Set(headers.ContentType.String(), mediatypes.ApplicationJson.String())
 
 	router := mux.NewRouter()
@@ -461,18 +394,6 @@ func TestResources_CreateSavedQuery(t *testing.T) {
 	userId, err := uuid2.NewV4()
 	require.Nil(t, err)
 
-	bhCtx := ctx.Context{
-		RequestID: "",
-		AuthCtx: auth.Context{
-			Session: model.UserSession{
-				User:   model.User{},
-				UserID: userId,
-			},
-		},
-		Host: nil,
-	}
-	goContext := bhCtx.ConstructGoContext()
-
 	payload := v2.CreateSavedQueryRequest{
 		Query: "Match(n) return n",
 		Name:  "myCustomQuery1",
@@ -484,10 +405,9 @@ func TestResources_CreateSavedQuery(t *testing.T) {
 		Query:  payload.Query,
 	}, nil)
 
-	req, err := http.NewRequest("POST", endpoint, must.MarshalJSONReader(payload))
+	req, err := http.NewRequestWithContext(createContextWithOwnerId(userId), "POST", endpoint, must.MarshalJSONReader(payload))
 	require.Nil(t, err)
 
-	req = req.WithContext(goContext)
 	req.Header.Set(headers.ContentType.String(), mediatypes.ApplicationJson.String())
 
 	router := mux.NewRouter()
@@ -509,22 +429,9 @@ func TestResources_DeleteSavedQuery_IDMalformed(t *testing.T) {
 	userId, err := uuid2.NewV4()
 	require.Nil(t, err)
 
-	bhCtx := ctx.Context{
-		RequestID: "",
-		AuthCtx: auth.Context{
-			Session: model.UserSession{
-				User:   model.User{},
-				UserID: userId,
-			},
-		},
-		Host: nil,
-	}
-	goContext := bhCtx.ConstructGoContext()
-
-	req, err := http.NewRequest("DELETE", "/api/v2/saved-queries/-1", nil)
+	req, err := http.NewRequestWithContext(createContextWithOwnerId(userId), "DELETE", "/api/v2/saved-queries/-1", nil)
 	require.Nil(t, err)
 
-	req = req.WithContext(goContext)
 	req.Header.Set(headers.ContentType.String(), mediatypes.ApplicationJson.String())
 
 	router := mux.NewRouter()
@@ -547,23 +454,12 @@ func TestResources_DeleteSavedQuery_DBError(t *testing.T) {
 	userId, err := uuid2.NewV4()
 	require.Nil(t, err)
 
-	bhCtx := ctx.Context{
-		RequestID: "",
-		AuthCtx: auth.Context{
-			Session: model.UserSession{
-				User:   model.User{},
-				UserID: userId,
-			},
-		},
-		Host: nil,
-	}
-	goContext := bhCtx.ConstructGoContext()
 	endpoint := "/api/v2/saved-queries/%s"
 	savedQueryId := "1"
 
 	mockDB.EXPECT().SavedQueryBelongsToUser(gomock.Any(), gomock.Any()).Return(false, fmt.Errorf("foo"))
 
-	req, err := http.NewRequestWithContext(goContext, "DELETE", fmt.Sprintf(endpoint, savedQueryId), nil)
+	req, err := http.NewRequestWithContext(createContextWithOwnerId(userId), "DELETE", fmt.Sprintf(endpoint, savedQueryId), nil)
 	require.Nil(t, err)
 
 	req.Header.Set(headers.ContentType.String(), mediatypes.ApplicationJson.String())
@@ -587,23 +483,12 @@ func TestResources_DeleteSavedQuery_QueryDoesNotBelongToUser(t *testing.T) {
 	userId, err := uuid2.NewV4()
 	require.Nil(t, err)
 
-	bhCtx := ctx.Context{
-		RequestID: "",
-		AuthCtx: auth.Context{
-			Session: model.UserSession{
-				User:   model.User{},
-				UserID: userId,
-			},
-		},
-		Host: nil,
-	}
-	goContext := bhCtx.ConstructGoContext()
 	endpoint := "/api/v2/saved-queries/%s"
 	savedQueryId := "1"
 
 	mockDB.EXPECT().SavedQueryBelongsToUser(gomock.Any(), gomock.Any()).Return(false, nil)
 
-	req, err := http.NewRequestWithContext(goContext, "DELETE", fmt.Sprintf(endpoint, savedQueryId), nil)
+	req, err := http.NewRequestWithContext(createContextWithOwnerId(userId), "DELETE", fmt.Sprintf(endpoint, savedQueryId), nil)
 	require.Nil(t, err)
 
 	req.Header.Set(headers.ContentType.String(), mediatypes.ApplicationJson.String())
@@ -628,23 +513,12 @@ func TestResources_DeleteSavedQuery_RecordNotFound(t *testing.T) {
 	userId, err := uuid2.NewV4()
 	require.Nil(t, err)
 
-	bhCtx := ctx.Context{
-		RequestID: "",
-		AuthCtx: auth.Context{
-			Session: model.UserSession{
-				User:   model.User{},
-				UserID: userId,
-			},
-		},
-		Host: nil,
-	}
-	goContext := bhCtx.ConstructGoContext()
 	endpoint := "/api/v2/saved-queries/%s"
 	savedQueryId := "1"
 
 	mockDB.EXPECT().SavedQueryBelongsToUser(gomock.Any(), gomock.Any()).Return(false, database.ErrNotFound)
 
-	req, err := http.NewRequestWithContext(goContext, "DELETE", fmt.Sprintf(endpoint, savedQueryId), nil)
+	req, err := http.NewRequestWithContext(createContextWithOwnerId(userId), "DELETE", fmt.Sprintf(endpoint, savedQueryId), nil)
 	require.Nil(t, err)
 
 	req.Header.Set(headers.ContentType.String(), mediatypes.ApplicationJson.String())
@@ -669,24 +543,13 @@ func TestResources_DeleteSavedQuery_RecordNotFound_EdgeCase(t *testing.T) {
 	userId, err := uuid2.NewV4()
 	require.Nil(t, err)
 
-	bhCtx := ctx.Context{
-		RequestID: "",
-		AuthCtx: auth.Context{
-			Session: model.UserSession{
-				User:   model.User{},
-				UserID: userId,
-			},
-		},
-		Host: nil,
-	}
-	goContext := bhCtx.ConstructGoContext()
 	endpoint := "/api/v2/saved-queries/%s"
 	savedQueryId := "1"
 
 	mockDB.EXPECT().SavedQueryBelongsToUser(gomock.Any(), gomock.Any()).Return(true, nil)
 	mockDB.EXPECT().DeleteSavedQuery(gomock.Any()).Return(database.ErrNotFound)
 
-	req, err := http.NewRequestWithContext(goContext, "DELETE", fmt.Sprintf(endpoint, savedQueryId), nil)
+	req, err := http.NewRequestWithContext(createContextWithOwnerId(userId), "DELETE", fmt.Sprintf(endpoint, savedQueryId), nil)
 	require.Nil(t, err)
 
 	req.Header.Set(headers.ContentType.String(), mediatypes.ApplicationJson.String())
@@ -711,24 +574,13 @@ func TestResources_DeleteSavedQuery_DeleteError(t *testing.T) {
 	userId, err := uuid2.NewV4()
 	require.Nil(t, err)
 
-	bhCtx := ctx.Context{
-		RequestID: "",
-		AuthCtx: auth.Context{
-			Session: model.UserSession{
-				User:   model.User{},
-				UserID: userId,
-			},
-		},
-		Host: nil,
-	}
-	goContext := bhCtx.ConstructGoContext()
 	endpoint := "/api/v2/saved-queries/%s"
 	savedQueryId := "1"
 
 	mockDB.EXPECT().SavedQueryBelongsToUser(gomock.Any(), gomock.Any()).Return(true, nil)
 	mockDB.EXPECT().DeleteSavedQuery(gomock.Any()).Return(fmt.Errorf("foo"))
 
-	req, err := http.NewRequestWithContext(goContext, "DELETE", fmt.Sprintf(endpoint, savedQueryId), nil)
+	req, err := http.NewRequestWithContext(createContextWithOwnerId(userId), "DELETE", fmt.Sprintf(endpoint, savedQueryId), nil)
 	require.Nil(t, err)
 
 	req.Header.Set(headers.ContentType.String(), mediatypes.ApplicationJson.String())
@@ -753,24 +605,13 @@ func TestResources_DeleteSavedQuery(t *testing.T) {
 	userId, err := uuid2.NewV4()
 	require.Nil(t, err)
 
-	bhCtx := ctx.Context{
-		RequestID: "",
-		AuthCtx: auth.Context{
-			Session: model.UserSession{
-				User:   model.User{},
-				UserID: userId,
-			},
-		},
-		Host: nil,
-	}
-	goContext := bhCtx.ConstructGoContext()
 	endpoint := "/api/v2/saved-queries/%s"
 	savedQueryId := "1"
 
 	mockDB.EXPECT().SavedQueryBelongsToUser(gomock.Any(), gomock.Any()).Return(true, nil)
 	mockDB.EXPECT().DeleteSavedQuery(gomock.Any()).Return(nil)
 
-	req, err := http.NewRequestWithContext(goContext, "DELETE", fmt.Sprintf(endpoint, savedQueryId), nil)
+	req, err := http.NewRequestWithContext(createContextWithOwnerId(userId), "DELETE", fmt.Sprintf(endpoint, savedQueryId), nil)
 	require.Nil(t, err)
 
 	req.Header.Set(headers.ContentType.String(), mediatypes.ApplicationJson.String())
@@ -781,4 +622,19 @@ func TestResources_DeleteSavedQuery(t *testing.T) {
 
 	handler.ServeHTTP(response, req)
 	require.Equal(t, http.StatusNoContent, response.Code)
+}
+
+func createContextWithOwnerId(id uuid2.UUID) context.Context {
+	bhCtx := ctx.Context{
+		RequestID: "",
+		AuthCtx: auth.Context{
+			Owner: model.User{
+				Unique: model.Unique{
+					ID: id,
+				},
+			},
+		},
+		Host: nil,
+	}
+	return bhCtx.ConstructGoContext()
 }

--- a/cmd/api/src/database/migration/migrations/v5.3.1.sql
+++ b/cmd/api/src/database/migration/migrations/v5.3.1.sql
@@ -1,0 +1,19 @@
+-- Copyright 2023 Specter Ops, Inc.
+--
+-- Licensed under the Apache License, Version 2.0
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- SPDX-License-Identifier: Apache-2.0
+DELETE FROM
+    saved_queries
+WHERE
+    user_id = '00000000-0000-0000-0000-000000000000'

--- a/cmd/ui/src/ducks/searchbar/reducer.ts
+++ b/cmd/ui/src/ducks/searchbar/reducer.ts
@@ -18,14 +18,14 @@ import { produce } from 'immer';
 import cloneDeep from 'lodash/cloneDeep';
 import * as types from 'src/ducks/searchbar/types';
 import { EdgeCheckboxType } from 'src/views/Explore/ExploreSearch/EdgeFilteringDialog';
-import { AllEdgeTypes } from 'src/views/Explore/ExploreSearch/edgeTypes';
+import { AllEdgeTypes, Category, Subcategory } from 'bh-shared-ui';
 
 // by default: all checkboxes are selected
 const initialPathFilters: EdgeCheckboxType[] = [];
 
-AllEdgeTypes.forEach((category) => {
-    category.subcategories.forEach((subcategory) => {
-        subcategory.edgeTypes.forEach((edgeType) => {
+AllEdgeTypes.forEach((category: Category) => {
+    category.subcategories.forEach((subcategory: Subcategory) => {
+        subcategory.edgeTypes.forEach((edgeType: string) => {
             initialPathFilters.push({
                 category: category.categoryName,
                 subcategory: subcategory.name,

--- a/cmd/ui/src/views/Explore/ExploreSearch/EdgeFilteringDialog.test.tsx
+++ b/cmd/ui/src/views/Explore/ExploreSearch/EdgeFilteringDialog.test.tsx
@@ -18,7 +18,7 @@ import { act } from 'react-dom/test-utils';
 import { render, screen } from 'src/test-utils';
 import userEvent from '@testing-library/user-event';
 import EdgeFilteringDialog from './EdgeFilteringDialog';
-import { AllEdgeTypes } from './edgeTypes';
+import { AllEdgeTypes } from 'bh-shared-ui';
 
 describe('Pathfinding', () => {
     beforeEach(async () => {

--- a/cmd/ui/src/views/Explore/ExploreSearch/EdgeFilteringDialog.tsx
+++ b/cmd/ui/src/views/Explore/ExploreSearch/EdgeFilteringDialog.tsx
@@ -171,7 +171,7 @@ const SubcategoryListItem = ({ subcategory, checked, setChecked }: SubcategoryLi
             setChecked={setChecked}
             collapsibleContent={
                 <List sx={{ pl: 4 }}>
-                    <ListItem>
+                    <ListItem sx={{ display: 'block'}}>
                         <EdgesView edgeTypes={edgeTypes} checked={checked} setChecked={setChecked} />
                     </ListItem>
                 </List>

--- a/cmd/ui/src/views/Explore/ExploreSearch/EdgeFilteringDialog.tsx
+++ b/cmd/ui/src/views/Explore/ExploreSearch/EdgeFilteringDialog.tsx
@@ -41,7 +41,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faChevronDown, faChevronUp } from '@fortawesome/free-solid-svg-icons';
 import { useSelector } from 'react-redux';
 import { pathFiltersSaved } from 'src/ducks/searchbar/actions';
-import { AllEdgeTypes, Category, Subcategory } from './edgeTypes';
+import { AllEdgeTypes, Category, Subcategory } from 'bh-shared-ui';
 import { AppState, useAppDispatch } from 'src/store';
 
 interface EdgeFilteringDialogProps {

--- a/cmd/ui/src/views/Explore/fragments.tsx
+++ b/cmd/ui/src/views/Explore/fragments.tsx
@@ -26,6 +26,8 @@ import useCollapsibleSectionStyles from 'src/views/Explore/InfoStyles/Collapsibl
 
 const exclusionList = [
     'gid',
+    'admin_rights_count',
+    'admin_rights_risk_percent',
     'hasspn',
     'system_tags',
     'user_tags',

--- a/packages/javascript/bh-shared-ui/src/commonSearches.tsx
+++ b/packages/javascript/bh-shared-ui/src/commonSearches.tsx
@@ -90,11 +90,11 @@ export const CommonSearches: CommonSearchType[] = [
             },
             {
                 description: 'Workstations where Domain Users can RDP',
-                cypher: `MATCH p=(m:Group)-[:CanRDP]->(c:Computer)\nWHERE m.objectid ENDS WITH "-513" AND NOT c.operatingsystem CONTAINS "Server"\nRETURN p`,
+                cypher: `MATCH p=(m:Group)-[:CanRDP]->(c:Computer)\nWHERE m.objectid ENDS WITH "-513" AND NOT toUpper(c.operatingsystem) CONTAINS "Server"\nRETURN p`,
             },
             {
                 description: 'Servers where Domain Users can RDP',
-                cypher: `MATCH p=(m:Group)-[:CanRDP]->(c:Computer)\nWHERE m.objectid ENDS WITH "-513" AND c.operatingsystem CONTAINS "Server"\nRETURN p`,
+                cypher: `MATCH p=(m:Group)-[:CanRDP]->(c:Computer)\nWHERE m.objectid ENDS WITH "-513" AND toUpper(c.operatingsystem) CONTAINS "Server"\nRETURN p`,
             },
             {
                 description: 'Dangerous privileges for Domain Users groups',

--- a/packages/javascript/bh-shared-ui/src/components/Disable2FADialog/Disable2FADialog.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/Disable2FADialog/Disable2FADialog.test.tsx
@@ -92,6 +92,10 @@ describe('Enable2FADialog', () => {
         ).toBeInTheDocument();
     });
 
+    it('displays security warning ', () => {
+        expect(screen.queryByTestId('ReportProblemOutlinedIcon')).toBeInTheDocument();
+    });
+
     describe('user clicks "Cancel" button', () => {
         beforeEach(async () => {
             await user.click(screen.getByRole('button', { name: 'Cancel' }));

--- a/packages/javascript/bh-shared-ui/src/components/Disable2FADialog/Disable2FADialog.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/Disable2FADialog/Disable2FADialog.tsx
@@ -14,7 +14,16 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { Button, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle, TextField } from '@mui/material';
+import {
+    Alert,
+    Button,
+    Dialog,
+    DialogActions,
+    DialogContent,
+    DialogContentText,
+    DialogTitle,
+    TextField,
+} from '@mui/material';
 import React from 'react';
 
 const Disable2FADialog: React.FC<{
@@ -37,6 +46,10 @@ const Disable2FADialog: React.FC<{
             <DialogTitle>Disable Multi-Factor Authentication?</DialogTitle>
             <form onSubmit={handleOnSave}>
                 <DialogContent>
+                    <Alert severity='warning' style={{ marginBottom: '10px', alignItems: 'center' }}>
+                        Disabling MFA increases the risk of unauthorized access. For optimal account security, we highly
+                        recommend keeping MFA enabled.
+                    </Alert>
                     <DialogContentText>{contentText}</DialogContentText>
 
                     <TextField

--- a/packages/javascript/bh-shared-ui/src/views/Explore/ExploreSearch/edgeTypes.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/Explore/ExploreSearch/edgeTypes.tsx
@@ -14,7 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { ActiveDirectoryRelationshipKind, AzureRelationshipKind } from 'bh-shared-ui';
+import { ActiveDirectoryRelationshipKind, AzureRelationshipKind } from "../../..";
 
 export type Category = {
     categoryName: string;

--- a/packages/javascript/bh-shared-ui/src/views/Explore/ExploreSearch/edgeTypes.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/Explore/ExploreSearch/edgeTypes.tsx
@@ -14,7 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { ActiveDirectoryRelationshipKind, AzureRelationshipKind } from "../../..";
+import { ActiveDirectoryRelationshipKind, AzureRelationshipKind } from '../../../graphSchema';
 
 export type Category = {
     categoryName: string;
@@ -88,10 +88,7 @@ export const AllEdgeTypes: Category[] = [
             },
             {
                 name: 'Active Directory Certificate Services',
-                edgeTypes: [
-                    ActiveDirectoryRelationshipKind.ADCSESC1,
-                    ActiveDirectoryRelationshipKind.GoldenCert,
-                ],
+                edgeTypes: [ActiveDirectoryRelationshipKind.ADCSESC1, ActiveDirectoryRelationshipKind.GoldenCert],
             },
         ],
     },

--- a/packages/javascript/bh-shared-ui/src/views/Explore/ExploreSearch/edgeTypes.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/Explore/ExploreSearch/edgeTypes.tsx
@@ -90,7 +90,6 @@ export const AllEdgeTypes: Category[] = [
                 name: 'Active Directory Certificate Services',
                 edgeTypes: [
                     ActiveDirectoryRelationshipKind.ADCSESC1,
-                    ActiveDirectoryRelationshipKind.HostsCAService,
                     ActiveDirectoryRelationshipKind.GoldenCert,
                 ],
             },

--- a/packages/javascript/bh-shared-ui/src/views/Explore/ExploreSearch/index.ts
+++ b/packages/javascript/bh-shared-ui/src/views/Explore/ExploreSearch/index.ts
@@ -14,8 +14,4 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-export { default as UserProfile } from './UserProfile';
-
-export * from './DataQuality';
-
-export * from './Explore/ExploreSearch';
+export * from './edgeTypes';


### PR DESCRIPTION
## Description

This PR moves the `edgeTypes` definitions out of version-specific UI code and into `bh-shared-ui`. They are the same in both versions of BloodHound.

## Motivation and Context

* Desire to stop making the same updates in multiple places

## How Has This Been Tested?

* Updated tests where needed
* Verified in the UI that the correct edge types are showing in the Edge Filter

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
