### PR TITLE
drop all unused keys

### DIFF
--- a/cmd/api/src/database/migration/migrations/v5.3.0.sql
+++ b/cmd/api/src/database/migration/migrations/v5.3.0.sql
@@ -14,11 +14,9 @@
 --
 -- SPDX-License-Identifier: Apache-2.0
 
+-- drop any known existing keys
 ALTER TABLE IF EXISTS ONLY asset_group_selectors
   DROP CONSTRAINT IF EXISTS asset_group_selectors_name_key;
-
-ALTER TABLE IF EXISTS ONLY asset_group_selectors
-  ADD CONSTRAINT asset_group_selectors_name_assetgroupid_key UNIQUE (name, asset_group_id);
 
 ALTER TABLE IF EXISTS ONLY asset_group_selectors
   DROP CONSTRAINT IF EXISTS asset_group_selectors_unique_name;
@@ -37,3 +35,7 @@ ALTER TABLE IF EXISTS ONLY asset_group_selectors
 
 ALTER TABLE IF EXISTS ONLY asset_group_selectors
   DROP CONSTRAINT IF EXISTS asset_group_selectors_name_assetgroupid_key;
+
+-- create the only key we care about
+ALTER TABLE IF EXISTS ONLY asset_group_selectors
+  ADD CONSTRAINT asset_group_selectors_name_assetgroupid_key UNIQUE (name, asset_group_id);

--- a/cmd/api/src/database/migration/migrations/v5.3.0.sql
+++ b/cmd/api/src/database/migration/migrations/v5.3.0.sql
@@ -22,9 +22,6 @@ ALTER TABLE IF EXISTS ONLY asset_group_selectors
   DROP CONSTRAINT IF EXISTS asset_group_selectors_unique_name;
 
 ALTER TABLE IF EXISTS ONLY asset_group_selectors
-  DROP CONSTRAINT IF EXISTS asset_group_selectors_name_key;
-
-ALTER TABLE IF EXISTS ONLY asset_group_selectors
   DROP CONSTRAINT IF EXISTS idx_asset_group_selectors_name;
 
 ALTER TABLE IF EXISTS ONLY asset_group_selectors

--- a/cmd/api/src/database/migration/migrations/v5.3.0.sql
+++ b/cmd/api/src/database/migration/migrations/v5.3.0.sql
@@ -19,3 +19,21 @@ ALTER TABLE IF EXISTS ONLY asset_group_selectors
 
 ALTER TABLE IF EXISTS ONLY asset_group_selectors
   ADD CONSTRAINT asset_group_selectors_name_assetgroupid_key UNIQUE (name, asset_group_id);
+
+ALTER TABLE IF EXISTS ONLY asset_group_selectors
+  DROP CONSTRAINT IF EXISTS asset_group_selectors_unique_name;
+
+ALTER TABLE IF EXISTS ONLY asset_group_selectors
+  DROP CONSTRAINT IF EXISTS asset_group_selectors_name_key;
+
+ALTER TABLE IF EXISTS ONLY asset_group_selectors
+  DROP CONSTRAINT IF EXISTS idx_asset_group_selectors_name;
+
+ALTER TABLE IF EXISTS ONLY asset_group_selectors
+  DROP CONSTRAINT IF EXISTS idx_asset_group_selectors_deleted_at;
+
+ALTER TABLE IF EXISTS ONLY asset_group_selectors
+  DROP CONSTRAINT IF EXISTS asset_group_selectors_name_unique;
+
+ALTER TABLE IF EXISTS ONLY asset_group_selectors
+  DROP CONSTRAINT IF EXISTS asset_group_selectors_name_assetgroupid_key;

--- a/cmd/api/src/database/migration/migrations/v5.3.0.sql
+++ b/cmd/api/src/database/migration/migrations/v5.3.0.sql
@@ -14,7 +14,7 @@
 --
 -- SPDX-License-Identifier: Apache-2.0
 
--- drop any known existing keys
+-- drop any keys known to exist
 ALTER TABLE IF EXISTS ONLY asset_group_selectors
   DROP CONSTRAINT IF EXISTS asset_group_selectors_name_key;
 
@@ -36,6 +36,6 @@ ALTER TABLE IF EXISTS ONLY asset_group_selectors
 ALTER TABLE IF EXISTS ONLY asset_group_selectors
   DROP CONSTRAINT IF EXISTS asset_group_selectors_name_assetgroupid_key;
 
--- create the only key we care about
+-- create the key we care about
 ALTER TABLE IF EXISTS ONLY asset_group_selectors
   ADD CONSTRAINT asset_group_selectors_name_assetgroupid_key UNIQUE (name, asset_group_id);


### PR DESCRIPTION
## Description
Remove unused indexes auto created by GORM.

## Motivation and Context
Clean up extra constraints on `asset_group_selectors` and only use `asset_group_selectors_name_assetgroupid_key UNIQUE (name, asset_group_id)`

## How Has This Been Tested?
`just test -a`

## Types of changes
-   [x] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] My changes include a database migration.
