### PR TITLE
Update the 'Computers where Domain Users can read LAPS passwords' Query

### DIFF
--- a/packages/javascript/bh-shared-ui/src/commonSearches.tsx
+++ b/packages/javascript/bh-shared-ui/src/commonSearches.tsx
@@ -82,7 +82,7 @@ export const CommonSearches: CommonSearchType[] = [
             },
             {
                 description: 'Computers where Domain Users can read LAPS passwords',
-                cypher: `MATCH p=(m:Group)-[:AllExtendedRights|ReadLAPSPassword]->(n:Computer)\nWHERE m.objectid ENDS WITH "-513"\nRETURN p`,
+                cypher: `MATCH p=(m:Group)-[:AllExtendedRights|ReadLAPSPassword]->(n:Computer)\nRETURN p`,
             },
             {
                 description: 'Paths from Domain Users to high value/Tier Zero targets',


### PR DESCRIPTION
## Description
It is better to leave the "Computers where Domain Users can read LAPS passwords" Query unconstrained regarding Domain Group membership to avoid false negative results.

<!--- Describe your changes in detail -->
## Motivation and Context
The previous query limits the results in cases where Domain Users belong to Domain Groups that are not members of the "Domain Users" Group.

## How Has This Been Tested?
I have experienced engagements where Users belong to the default "Domain Users" Group and a custom "LAPS" Domain Group. The default query would first find membership to the "LAPS" Domain Group and then stop querying for membership in the "Domain Users" Group, resulting in showing no results. However, those Users had the target permission.

## Types of changes
Removed `WHERE m.objectid ENDS WITH "-513"\n` from the query.