### PR TITLE
fix: add necessary indexes for table optimization

### DIFF
--- a/cmd/api/src/database/migration/migrations/v5.3.1.sql
+++ b/cmd/api/src/database/migration/migrations/v5.3.1.sql
@@ -1,0 +1,9 @@
+CREATE INDEX IF NOT EXISTS idx_asset_group_collections_asset_group_id ON asset_group_collections USING btree (asset_group_id);
+CREATE INDEX IF NOT EXISTS idx_asset_group_collections_created_at ON asset_group_collections USING btree (created_at);
+CREATE INDEX IF NOT EXISTS idx_asset_group_collections_updated_at ON asset_group_collections USING btree (updated_at);
+
+CREATE INDEX IF NOT EXISTS idx_asset_group_collection_entries_asset_group_collection_id ON asset_group_collection_entries USING btree (asset_group_collection_id);
+CREATE INDEX IF NOT EXISTS idx_asset_group_collection_entries_created_at ON asset_group_collection_entries USING btree (created_at);
+CREATE INDEX IF NOT EXISTS idx_asset_group_collection_entries_updated_at ON asset_group_collection_entries USING btree (updated_at);
+
+TRUNCATE asset_group_collection_entries;


### PR DESCRIPTION
## Description

A hotfix migration to add necessary indexes to `asset_group_collections` and `asset_group_collection_entries`, allowing them to scale to larger data sets. This migration will also truncate `asset_group_collection_entries` to reset table size in live environments.

## Motivation and Context

We sometimes see these tables get large enough that operations on them slow way down due to lack of good indexes. This migration aims to add indexes for fields that are likely to be referenced during normal application operation.

## How Has This Been Tested?

Migrations were tested for expected results locally. This was done by spinning up local dev, removing the v5.3.1 entry (since it was created during development) and restarting the API (saving the file was enough to kick off a hot reload). Migration gave no errors and expected indexes and truncation occurred without incident.

Existing migration testing also found no issues.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
