### PR TITLE
fix: More EnrollOnBehalfOf to self scenarios

### DIFF
--- a/cmd/api/src/analysis/ad/adcs_integration_test.go
+++ b/cmd/api/src/analysis/ad/adcs_integration_test.go
@@ -242,7 +242,7 @@ func TestEnrollOnBehalfOf(t *testing.T) {
 			results, err := ad2.EnrollOnBehalfOfVersionOne(tx, v1Templates, certTemplates)
 			require.Nil(t, err)
 
-			require.Len(t, results, 2)
+			require.Len(t, results, 3)
 
 			require.Contains(t, results, analysis.CreatePostRelationshipJob{
 				FromID: harness.EnrollOnBehalfOfHarnessOne.CertTemplate11.ID,
@@ -252,6 +252,12 @@ func TestEnrollOnBehalfOf(t *testing.T) {
 
 			require.Contains(t, results, analysis.CreatePostRelationshipJob{
 				FromID: harness.EnrollOnBehalfOfHarnessOne.CertTemplate13.ID,
+				ToID:   harness.EnrollOnBehalfOfHarnessOne.CertTemplate12.ID,
+				Kind:   ad.EnrollOnBehalfOf,
+			})
+
+			require.Contains(t, results, analysis.CreatePostRelationshipJob{
+				FromID: harness.EnrollOnBehalfOfHarnessOne.CertTemplate12.ID,
 				ToID:   harness.EnrollOnBehalfOfHarnessOne.CertTemplate12.ID,
 				Kind:   ad.EnrollOnBehalfOf,
 			})
@@ -286,16 +292,6 @@ func TestEnrollOnBehalfOf(t *testing.T) {
 			require.Contains(t, results, analysis.CreatePostRelationshipJob{
 				FromID: harness.EnrollOnBehalfOfHarnessTwo.CertTemplate21.ID,
 				ToID:   harness.EnrollOnBehalfOfHarnessTwo.CertTemplate23.ID,
-				Kind:   ad.EnrollOnBehalfOf,
-			})
-
-			results, err = ad2.EnrollOnBehalfOfSelfControl(tx, v1Templates)
-			require.Nil(t, err)
-
-			require.Len(t, results, 1)
-			require.Contains(t, results, analysis.CreatePostRelationshipJob{
-				FromID: harness.EnrollOnBehalfOfHarnessTwo.CertTemplate25.ID,
-				ToID:   harness.EnrollOnBehalfOfHarnessTwo.CertTemplate25.ID,
 				Kind:   ad.EnrollOnBehalfOf,
 			})
 

--- a/packages/go/analysis/ad/adcs.go
+++ b/packages/go/analysis/ad/adcs.go
@@ -200,20 +200,6 @@ func PostEnrollOnBehalfOf(certTemplates []*graph.Node, operation analysis.StatTr
 		}
 	})
 
-	operation.Operation.SubmitReader(func(ctx context.Context, tx graph.Transaction, outC chan<- analysis.CreatePostRelationshipJob) error {
-		if results, err := EnrollOnBehalfOfSelfControl(tx, versionOneTemplates); err != nil {
-			return err
-		} else {
-			for _, result := range results {
-				if !channels.Submit(ctx, outC, result) {
-					return nil
-				}
-			}
-
-			return nil
-		}
-	})
-
 	return nil
 }
 
@@ -269,9 +255,7 @@ func EnrollOnBehalfOfVersionOne(tx graph.Transaction, versionOneCertTemplates []
 
 	for _, certTemplateOne := range allCertTemplates {
 		//prefilter as much as we can first
-		if slices.Contains(versionOneCertTemplates, certTemplateOne) {
-			continue
-		} else if hasEku, err := certTemplateHasEkuOrAll(certTemplateOne, EkuCertRequestAgent, EkuAnyPurpose); err != nil {
+		if hasEku, err := certTemplateHasEkuOrAll(certTemplateOne, EkuCertRequestAgent, EkuAnyPurpose); err != nil {
 			log.Errorf("Error checking ekus for certtemplate %d: %w", certTemplateOne.ID, err)
 		} else if !hasEku {
 			continue
@@ -283,9 +267,7 @@ func EnrollOnBehalfOfVersionOne(tx graph.Transaction, versionOneCertTemplates []
 			continue
 		} else {
 			for _, certTemplateTwo := range versionOneCertTemplates {
-				if certTemplateTwo.ID == certTemplateOne.ID {
-					continue
-				} else if hasPath, err := DoesCertTemplateLinkToDomain(tx, certTemplateTwo, domainNode); err != nil {
+				if hasPath, err := DoesCertTemplateLinkToDomain(tx, certTemplateTwo, domainNode); err != nil {
 					log.Errorf("Error getting domain node for certtemplate %d: %w", certTemplateTwo.ID, err)
 				} else if !hasPath {
 					continue
@@ -311,35 +293,6 @@ func getDomainForCertTemplate(tx graph.Transaction, certTemplate *graph.Node) (*
 	} else {
 		return domainNode, nil
 	}
-}
-
-func EnrollOnBehalfOfSelfControl(tx graph.Transaction, versionOneCertTemplates []*graph.Node) ([]analysis.CreatePostRelationshipJob, error) {
-	results := make([]analysis.CreatePostRelationshipJob, 0)
-	for _, certTemplate := range versionOneCertTemplates {
-		if hasEku, err := certTemplateHasEkuOrAll(certTemplate, EkuAnyPurpose); err != nil {
-			log.Errorf("Error checking ekus for certtemplate %d: %w", certTemplate.ID, err)
-		} else if !hasEku {
-			continue
-		} else if subjectRequireUpn, err := certTemplate.Properties.Get(ad.SubjectAltRequireUPN.String()).Bool(); err != nil {
-			log.Errorf("Error getting subjectAltRequireUPN for certtemplate %d: %w", certTemplate.ID, err)
-		} else if !subjectRequireUpn {
-			continue
-		} else if domainNode, err := getDomainForCertTemplate(tx, certTemplate); err != nil {
-			log.Errorf("Error getting domain for certtemplate %d: %w", certTemplate.ID, err)
-		} else if doesLink, err := DoesCertTemplateLinkToDomain(tx, certTemplate, domainNode); err != nil {
-			log.Errorf("Error fetching paths from certtemplate %d to domain: %w", certTemplate.ID, err)
-		} else if !doesLink {
-			continue
-		} else {
-			results = append(results, analysis.CreatePostRelationshipJob{
-				FromID: certTemplate.ID,
-				ToID:   certTemplate.ID,
-				Kind:   ad.EnrollOnBehalfOf,
-			})
-		}
-	}
-
-	return results, nil
 }
 
 func certTemplateHasEkuOrAll(certTemplate *graph.Node, targetEkus ...string) (bool, error) {


### PR DESCRIPTION
## Description

Remove special requirements for CertTemplate of schema version 1 to get an EnrollOnBehalfOf edge to itself.

## Motivation and Context

There are no specific requirements for CertTemplate of version 1 to have an EnrollOnBehalfOf edge to itself except that it has the enrollment agent EKU. We can remove the checks we have in place that prevent the creation of the edge to the same CertTemplate of version 1, and we can delete the code that checks for the specific scenario that we currently for this edge type. 

## How Has This Been Tested?

Tested with my lab data.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

Getting the expected edges:
![image](https://github.com/SpecterOps/BloodHound/assets/12843299/214f0e3a-a600-472e-a4d2-9116ecf8badf)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] My changes include a database migration.
