### PR TITLE
feat: incorporate esc3 in ui pathfinding default and add filter checkbox

### DIFF
--- a/cmd/api/src/api/registration/v2.go
+++ b/cmd/api/src/api/registration/v2.go
@@ -150,7 +150,7 @@ func NewV2API(cfg config.Configuration, resources v2.Resources, routerInst *rout
 
 		routerInst.GET("/api/v2/pathfinding", resources.GetPathfindingResult).Queries("start_node", "{start_node}", "end_node", "{end_node}").RequirePermissions(permissions.GraphDBRead),
 		routerInst.GET("/api/v2/graphs/shortest-path", resources.GetShortestPath).Queries(params.StartNode.String(), params.StartNode.RouteMatcher(), params.EndNode.String(), params.EndNode.RouteMatcher()).RequirePermissions(permissions.GraphDBRead),
-		routerInst.GET("/api/v2/graphs/edge-composition", resources.GetEdgeComposition).RequirePermissions(permissions.GraphDBRead).CheckFeatureFlag(resources.DB, appcfg.FeatureAdcs),
+		routerInst.GET("/api/v2/graphs/edge-composition", resources.GetEdgeComposition).RequirePermissions(permissions.GraphDBRead).CheckFeatureFlag(resources.DB, appcfg.FeatureAdcs), // TODO: Cleanup #ADCSFeatureFlag after full launch.
 
 		// TODO discuss if this should be a post endpoint
 		routerInst.GET("/api/v2/graph-search", resources.GetSearchResult).RequirePermissions(permissions.GraphDBRead),

--- a/cmd/api/src/docs/json/paths/v2/jobs.json
+++ b/cmd/api/src/docs/json/paths/v2/jobs.json
@@ -659,7 +659,7 @@
                 "Error": {
                     "$ref": "#/components/responses/defaultError"
                 }
-            }  
+            }
         }
     },
     "/api/v2/jobs/{job_id}/log": {

--- a/packages/javascript/bh-shared-ui/src/commonSearches.tsx
+++ b/packages/javascript/bh-shared-ui/src/commonSearches.tsx
@@ -19,11 +19,8 @@ import { ActiveDirectoryPathfindingEdges, AzurePathfindingEdges } from './graphS
 const categoryAD = 'Active Directory';
 const categoryAzure = 'Azure';
 
-// Join all elements with "|" but the last element, then append last element
-// produces element1|element2|element3
-const azureTransitEdgeTypes = AzurePathfindingEdges().slice(0, -1).join('|') + AzurePathfindingEdges().slice(-1);
-const adTransitEdgeTypes =
-    ActiveDirectoryPathfindingEdges().slice(0, -1).join('|') + '|' + ActiveDirectoryPathfindingEdges().slice(-1);
+const azureTransitEdgeTypes = AzurePathfindingEdges().join('|');
+const adTransitEdgeTypes = ActiveDirectoryPathfindingEdges().join('|');
 
 const highPrivilegedRoleDisplayNameRegex =
     'Global Administrator.*|User Administrator.*|Cloud Application Administrator.*|Authentication Policy Administrator.*|Exchange Administrator.*|Helpdesk Administrator.*|Privileged Authentication Administrator.*';

--- a/packages/javascript/bh-shared-ui/src/views/Explore/ExploreSearch/edgeTypes.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/Explore/ExploreSearch/edgeTypes.tsx
@@ -88,7 +88,11 @@ export const AllEdgeTypes: Category[] = [
             },
             {
                 name: 'Active Directory Certificate Services',
-                edgeTypes: [ActiveDirectoryRelationshipKind.ADCSESC1, ActiveDirectoryRelationshipKind.GoldenCert],
+                edgeTypes: [
+                    ActiveDirectoryRelationshipKind.GoldenCert,
+                    ActiveDirectoryRelationshipKind.ADCSESC1,
+                    ActiveDirectoryRelationshipKind.ADCSESC3,
+                ],
             },
         ],
     },


### PR DESCRIPTION
## Description
ESC3 is added to the filter options for pathfinding searches via the UI. Adding this checkbox also adds it to the default list of traversed edges during pathfinding. 
<!--- Describe your changes in detail -->

## Motivation and Context
These options support ESC 3 edge incorporation. 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

![image](https://github.com/SpecterOps/BloodHound/assets/16910931/d55fd855-063b-44f9-ad91-4234dda723e1)

![image](https://github.com/SpecterOps/BloodHound/assets/16910931/e74974ec-4af5-42b3-973f-1260ef6bc8ed)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] My changes include a database migration.
