### PR TITLE
fix: Unmark the python installation as externally managed when buildi…

### DIFF
--- a/dockerfiles/bloodhound.Dockerfile
+++ b/dockerfiles/bloodhound.Dockerfile
@@ -32,6 +32,7 @@ ENV CHECKOUT_HASH=${checkout_hash}
 WORKDIR /bloodhound
 
 RUN apk add --update --no-cache python3 git go
+RUN rm /usr/lib/python3.11/EXTERNALLY-MANAGED
 RUN python3 -m ensurepip
 RUN pip3 install --no-cache --upgrade pip setuptools
 


### PR DESCRIPTION
Unmarks the python installation as externally managed when building `dockerfiles/bloodhound.Dockerfile`.

This configuration was causing build errors, for example:
https://github.com/SpecterOps/BloodHound/actions/runs/7176399446

For more information:
https://packaging.python.org/en/latest/specifications/externally-managed-environments/
