### PR TITLE
feat: add partnertier2support and members to tier-zero/high-value dur…

### DIFF
--- a/packages/go/analysis/azure/queries.go
+++ b/packages/go/analysis/azure/queries.go
@@ -88,14 +88,14 @@ func FetchAzureAttackPathRoots(tx graph.Transaction, tenant *graph.Node) (graph.
 		attackPathRoots.AddSets(customTierZeroNodes)
 	}
 
-	// The CompanyAdministratorRole, PrivilegedRoleAdministratorRole tenant roles are critical attack path roots
+	// The CompanyAdministratorRole, PrivilegedRoleAdministratorRole, PrivilegedAuthenticationAdministratorRole, PartnerTier2SupportRole tenant roles are critical attack path roots
 	if adminRoles, err := TenantRoles(tx, tenant, azure.CompanyAdministratorRole, azure.PrivilegedRoleAdministratorRole, azure.PrivilegedAuthenticationAdministratorRole, azure.PartnerTier2SupportRole); err != nil {
 		return nil, err
 	} else {
 		attackPathRoots.AddSets(adminRoles)
 	}
 
-	// Find users that have CompanyAdministratorRole, PrivilegedRoleAdministratorRole
+	// Find users that have CompanyAdministratorRole, PrivilegedRoleAdministratorRole, PrivilegedAuthenticationAdministratorRole, PartnerTier2SupportRole
 	if adminRoleMembers, err := RoleMembersWithGrants(tx, tenant, azure.CompanyAdministratorRole, azure.PrivilegedRoleAdministratorRole, azure.PrivilegedAuthenticationAdministratorRole, azure.PartnerTier2SupportRole); err != nil {
 		return nil, err
 	} else {

--- a/packages/go/analysis/azure/queries.go
+++ b/packages/go/analysis/azure/queries.go
@@ -18,6 +18,8 @@ package azure
 
 import (
 	"context"
+	"strings"
+
 	"github.com/RoaringBitmap/roaring/roaring64"
 	"github.com/specterops/bloodhound/dawgs/graph"
 	"github.com/specterops/bloodhound/dawgs/ops"
@@ -26,7 +28,6 @@ import (
 	"github.com/specterops/bloodhound/graphschema/azure"
 	"github.com/specterops/bloodhound/graphschema/common"
 	"github.com/specterops/bloodhound/log"
-	"strings"
 )
 
 func FetchCollectedTenants(tx graph.Transaction) (graph.NodeSet, error) {
@@ -88,14 +89,14 @@ func FetchAzureAttackPathRoots(tx graph.Transaction, tenant *graph.Node) (graph.
 	}
 
 	// The CompanyAdministratorRole, PrivilegedRoleAdministratorRole tenant roles are critical attack path roots
-	if adminRoles, err := TenantRoles(tx, tenant, azure.CompanyAdministratorRole, azure.PrivilegedRoleAdministratorRole, azure.PrivilegedAuthenticationAdministratorRole); err != nil {
+	if adminRoles, err := TenantRoles(tx, tenant, azure.CompanyAdministratorRole, azure.PrivilegedRoleAdministratorRole, azure.PrivilegedAuthenticationAdministratorRole, azure.PartnerTier2SupportRole); err != nil {
 		return nil, err
 	} else {
 		attackPathRoots.AddSets(adminRoles)
 	}
 
 	// Find users that have CompanyAdministratorRole, PrivilegedRoleAdministratorRole
-	if adminRoleMembers, err := RoleMembersWithGrants(tx, tenant, azure.CompanyAdministratorRole, azure.PrivilegedRoleAdministratorRole, azure.PrivilegedAuthenticationAdministratorRole); err != nil {
+	if adminRoleMembers, err := RoleMembersWithGrants(tx, tenant, azure.CompanyAdministratorRole, azure.PrivilegedRoleAdministratorRole, azure.PrivilegedAuthenticationAdministratorRole, azure.PartnerTier2SupportRole); err != nil {
 		return nil, err
 	} else {
 		for _, adminRoleMember := range adminRoleMembers {


### PR DESCRIPTION
…ing analysis

## Description

<!--- Describe your changes in detail -->

- Adds the PartnerTier2Support role to the tier zero asset group
- Adds members with the PartnerTier2Support role to the tier zero asset group

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The PartnerTier2Support role grants trusted access to 3rd parties that allows critical actions to be taken against tier-zero. 

## How Has This Been Tested?

Exercised dataset from test tenant in BHE and BHCE

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
