### PR TITLE
fix: gorm override column names for domain_collection_results

### DIFF
--- a/cmd/api/src/model/jobs.go
+++ b/cmd/api/src/model/jobs.go
@@ -191,11 +191,11 @@ type DomainCollectionResult struct {
 	GPOCount          int    `json:"gpo_count"`
 	OUCount           int    `json:"ou_count"`
 	ContainerCount    int    `json:"container_count"`
-	AIACACount        int    `json:"aiaca_count"`
-	RootCACount       int    `json:"rootca_count"`
-	EnterpriseCACount int    `json:"enterpriseca_count"`
-	NTAuthStoreCount  int    `json:"ntauthstore_count"`
-	CertTemplateCount int    `json:"certtemplate_count"`
+	AIACACount        int    `json:"aiaca_count" gorm:"column:aiaca_count"`
+	RootCACount       int    `json:"rootca_count" gorm:"column:rootca_count"`
+	EnterpriseCACount int    `json:"enterpriseca_count" gorm:"column:enterpriseca_count"`
+	NTAuthStoreCount  int    `json:"ntauthstore_count" gorm:"column:ntauthstore_count"`
+	CertTemplateCount int    `json:"certtemplate_count" gorm:"column:certtemplate_count"`
 	DeletedCount      int    `json:"deleted_count"`
 
 	BigSerial


### PR DESCRIPTION
## Description
The column names in the domain_collection_results table are set to be overridden.
<!--- Describe your changes in detail -->

## Motivation and Context
Gorm uses snake case to relate structs to tables but our migration was not in that form so writing the data point resulted in an error. 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
A collection was run with the updated changes and the error observed originally was no longer logging.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] My changes include a database migration.
