### PR TITLE
fix: ensure that nested IssuedSignedBy relationships expand in adcs e…

### DIFF
--- a/packages/go/analysis/ad/ad.go
+++ b/packages/go/analysis/ad/ad.go
@@ -513,7 +513,7 @@ func ADCSESC1Path1Pattern(domainID graph.ID) traversal.PatternContinuation {
 			),
 		)).
 		Outbound(query.And(
-			query.KindIn(query.Relationship(), ad.PublishedTo),
+			query.KindIn(query.Relationship(), ad.PublishedTo, ad.IssuedSignedBy),
 			query.Kind(query.End(), ad.EnterpriseCA),
 		)).
 		Outbound(query.And(


### PR DESCRIPTION
## Description

Fixes a missed expansion for ADCS ESC1 composition.

## Motivation and Context

This allows ADCS1 ESC1 composition to correctly return for nested `IssuedSignedBy` edges such as:

`(:CertTemplate)-[:PublishedTo]->(:EnterpriseCA)-[:IssuedSignedBy]->(:EnterpriseCA)-[:EnterpriseCAFor]->(:RootCA)`

## How Has This Been Tested?

Local instance testing.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] My changes include a database migration.
