### PR TITLE
Asset group mock endpoint

### DIFF
--- a/cmd/ui/src/views/Explore/ContextMenu/AssetGroupMenuItem.test.tsx
+++ b/cmd/ui/src/views/Explore/ContextMenu/AssetGroupMenuItem.test.tsx
@@ -70,7 +70,7 @@ describe('AssetGroupMenuItem', async () => {
                     return res(ctx.json({}));
                 }
             }),
-            rest.post('/api/v2/asset-groups/:assetGroupId/selectors', (req, res, ctx) => {
+            rest.put('/api/v2/asset-groups/:assetGroupId/selectors', (req, res, ctx) => {
                 return res(ctx.json({}));
             })
         );
@@ -183,7 +183,7 @@ describe('AssetGroupMenuItem', async () => {
                     return res(ctx.json({}));
                 }
             }),
-            rest.post('/api/v2/asset-groups/:assetGroupId/selectors', (req, res, ctx) => {
+            rest.put('/api/v2/asset-groups/:assetGroupId/selectors', (req, res, ctx) => {
                 return res(ctx.json({}));
             })
         );

--- a/cmd/ui/src/views/Explore/ContextMenu/AssetGroupMenuItem.test.tsx
+++ b/cmd/ui/src/views/Explore/ContextMenu/AssetGroupMenuItem.test.tsx
@@ -35,7 +35,7 @@ describe('AssetGroupMenuItem', async () => {
             },
         },
     });
-    console.log('just testing commit');
+
     const getAssetGroupTestProps = ({ isTierZero }: { isTierZero: boolean }) => ({
         assetgroups: {
             assetGroups: isTierZero

--- a/cmd/ui/src/views/Explore/ContextMenu/AssetGroupMenuItem.test.tsx
+++ b/cmd/ui/src/views/Explore/ContextMenu/AssetGroupMenuItem.test.tsx
@@ -35,7 +35,7 @@ describe('AssetGroupMenuItem', async () => {
             },
         },
     });
-
+    console.log('just testing commit');
     const getAssetGroupTestProps = ({ isTierZero }: { isTierZero: boolean }) => ({
         assetgroups: {
             assetGroups: isTierZero


### PR DESCRIPTION
## Description
Updates `AssetGroupMenuItem` tests to mock the PUT endpoint instead of the previous POST endpoint

## Motivation and Context
POST `/api/v2/asset-groups/:assetGroupId/selectors` was deprecated and replaced with a PUT endpoint in this PR: https://github.com/SpecterOps/BloodHound/pull/268

## How Has This Been Tested?
Manual and automated tests

## Types of changes
- [x] Chore (a change that does not modify the application functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Documentation updates are needed, and have been made accordingly.
- [ ] I have added and/or updated tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] My changes include a database migration.