### PR TITLE
Make sure that only valid labels are displayed

### DIFF
--- a/packages/go/analysis/analysis.go
+++ b/packages/go/analysis/analysis.go
@@ -72,7 +72,7 @@ func GetNodeKind(node *graph.Node) graph.Kind {
 			if resultKind.String() == NodeKindUnknown {
 				resultKind = kind
 			}
-		} else {
+		} else if _, err := ParseKind(kind.String()); err == nil {
 			resultKind = kind
 		}
 	}

--- a/packages/go/analysis/analysis_test.go
+++ b/packages/go/analysis/analysis_test.go
@@ -1,17 +1,17 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 package analysis_test
@@ -19,11 +19,11 @@ package analysis_test
 import (
 	"testing"
 
-	"github.com/stretchr/testify/require"
 	"github.com/specterops/bloodhound/analysis"
 	"github.com/specterops/bloodhound/dawgs/graph"
 	"github.com/specterops/bloodhound/graphschema/ad"
 	"github.com/specterops/bloodhound/graphschema/azure"
+	"github.com/stretchr/testify/assert"
 )
 
 type kindStr string
@@ -44,11 +44,14 @@ func (s kindStr) Is(others ...graph.Kind) bool {
 
 func TestGetNodeKindDisplayLabel(t *testing.T) {
 	const unsupportedKind = kindStr("Unsupported Kind")
+	assert := assert.New(t)
 
-	require.Equal(t, ad.User.String(), analysis.GetNodeKindDisplayLabel(graph.PrepareNode(graph.NewProperties(), ad.Entity, ad.User)))
-	require.Equal(t, ad.Group.String(), analysis.GetNodeKindDisplayLabel(graph.PrepareNode(graph.NewProperties(), ad.Entity, ad.Group, ad.LocalGroup)))
-	require.Equal(t, ad.LocalGroup.String(), analysis.GetNodeKindDisplayLabel(graph.PrepareNode(graph.NewProperties(), ad.Entity, ad.LocalGroup)))
-	require.Equal(t, azure.Group.String(), analysis.GetNodeKindDisplayLabel(graph.PrepareNode(graph.NewProperties(), azure.Entity, azure.Group)))
-	require.Equal(t, unsupportedKind.String(), analysis.GetNodeKindDisplayLabel(graph.PrepareNode(graph.NewProperties(), unsupportedKind)))
-	require.Equal(t, "Unknown", analysis.GetNodeKindDisplayLabel(graph.PrepareNode(graph.NewProperties())))
+	assert.Equal(ad.Entity.String(), analysis.GetNodeKindDisplayLabel(graph.PrepareNode(graph.NewProperties(), ad.Entity)), "should return base kind if no other valid kinds are present")
+	assert.Equal(ad.User.String(), analysis.GetNodeKindDisplayLabel(graph.PrepareNode(graph.NewProperties(), ad.Entity, ad.User)), "should return valid AD kind when base and kind are present")
+	assert.Equal(ad.Group.String(), analysis.GetNodeKindDisplayLabel(graph.PrepareNode(graph.NewProperties(), ad.Entity, ad.Group, ad.LocalGroup)), "should return valid kind other than LocalGroup if one is present")
+	assert.Equal(ad.LocalGroup.String(), analysis.GetNodeKindDisplayLabel(graph.PrepareNode(graph.NewProperties(), ad.Entity, ad.LocalGroup)), "should return LocalGroup if no other valid kinds are present")
+	assert.Equal(azure.Group.String(), analysis.GetNodeKindDisplayLabel(graph.PrepareNode(graph.NewProperties(), azure.Entity, azure.Group)), "should return valid Azure kind when base and kind are present")
+	assert.Equal(analysis.NodeKindUnknown, analysis.GetNodeKindDisplayLabel(graph.PrepareNode(graph.NewProperties(), unsupportedKind)), "should return Unknown when only an unsupported kind is present")
+	assert.Equal(ad.Entity.String(), analysis.GetNodeKindDisplayLabel(graph.PrepareNode(graph.NewProperties(), ad.Entity, unsupportedKind)), "should return valid kind if one is preseneven if an unsupported kind is also present")
+	assert.Equal(analysis.NodeKindUnknown, analysis.GetNodeKindDisplayLabel(graph.PrepareNode(graph.NewProperties())), "should return Unknown if no node has no kinds on it")
 }


### PR DESCRIPTION
## Description

If you add additional labels to the nodes after the import (e.g. for some advanced APOC queries), these are added at a random position within the label list. With Bloodhound, the last label in the list is always selected and displayed into the GUI, even if it cannot be rendered. 

Here is an example:

A node with the following labels
![Clipboard_2024-01-07-21-23-38](https://github.com/SpecterOps/BloodHound/assets/6979616/9c02998f-1e17-4ddb-b399-2a14a24428ac)

results in the following GUI node:
![Clipboard_2024-01-07-21-23-47](https://github.com/SpecterOps/BloodHound/assets/6979616/a0bc73f1-3001-4193-a89c-5cec97223d0e)


## Motivation and Context
The change ensures that nodes can only be assigned to valid types so that they are subsequently rendered correctly in the GUI. 

## How Has This Been Tested?
A new container with a customized code was created and verified.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
