### PR TITLE
Fix empty request_id and incorrect elapsed time in logs

### DIFF
--- a/cmd/api/src/api/registration/registration.go
+++ b/cmd/api/src/api/registration/registration.go
@@ -17,6 +17,8 @@
 package registration
 
 import (
+	"net/http"
+
 	"github.com/specterops/bloodhound/cache"
 	"github.com/specterops/bloodhound/dawgs/graph"
 	"github.com/specterops/bloodhound/src/api"
@@ -28,18 +30,17 @@ import (
 	"github.com/specterops/bloodhound/src/config"
 	"github.com/specterops/bloodhound/src/daemons/datapipe"
 	"github.com/specterops/bloodhound/src/database"
-	"net/http"
 )
 
 func RegisterFossGlobalMiddleware(routerInst *router.Router, cfg config.Configuration, identityResolver auth.IdentityResolver, authenticator api.Authenticator) {
-	// Set up logging
-	if cfg.EnableAPILogging {
-		routerInst.UsePrerouting(middleware.LoggingMiddleware(cfg, identityResolver))
-	}
-
 	// Set up the middleware stack
 	routerInst.UsePrerouting(middleware.ContextMiddleware)
 	routerInst.UsePrerouting(middleware.CORSMiddleware())
+
+	// Set up logging. This must be done after ContextMiddleware is initialized so the context can be accessed in the log logic
+	if cfg.EnableAPILogging {
+		routerInst.UsePrerouting(middleware.LoggingMiddleware(cfg, identityResolver))
+	}
 
 	routerInst.UsePostrouting(
 		middleware.PanicHandler,


### PR DESCRIPTION
## Description

This PR fixes the order middleware is initialized so that the request context can be accessed within the `LoggingMiddleware`. The `LoggingMiddleware` was previously initialized before `ContextMiddleware`, causing `request.Context()` to be empty inside of the log middleware.

Two of the log fields, `request_id` and `elapsed` relied on values in the request context to generate properly. With this fix these fields should now be populated in log lines.

## Motivation and Context

* Ensure `request_id` and `elapsed` have correct values in the logs
* Make `request.Context()` accessible in `LoggingMiddleware` so it can be used for other calculations

## How Has This Been Tested?

* Verified that those two fields are correctly populated in my dev environment's logs

## Screenshots (if appropriate):

Before:
```
bh-api-1        | {"level":"info","remote_addr":"172.23.0.4:57916","proto":"HTTP/1.1","referer":"http://bloodhound.localhost/ui/explore","user_agent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36","request_id":"","request_bytes":0,"response_bytes":35,"status":200,"elapsed":9223372036854.775,"time":"2024-01-17T16:02:29.557790384Z","message":"GET /api/v2/available-domains"}
bh-api-1        | {"level":"info","remote_addr":"172.23.0.4:57916","proto":"HTTP/1.1","referer":"http://bloodhound.localhost/ui/administration/file-ingest","user_agent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36","request_id":"","request_bytes":0,"response_bytes":62,"status":200,"elapsed":9223372036854.775,"time":"2024-01-17T16:02:31.826450635Z","message":"GET /api/v2/file-upload?skip=0&limit=10&sort_by=-id"}
bh-api-1        | {"level":"info","remote_addr":"172.23.0.4:57916","proto":"HTTP/1.1","referer":"http://bloodhound.localhost/ui/administration/manage-users","user_agent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36","request_id":"","request_bytes":0,"response_bytes":781,"status":200,"elapsed":9223372036854.775,"time":"2024-01-17T16:02:33.898107095Z","message":"GET /api/v2/self"}
bh-api-1        | {"level":"info","remote_addr":"172.23.0.4:57920","proto":"HTTP/1.1","referer":"http://bloodhound.localhost/ui/administration/manage-users","user_agent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36","request_id":"","request_bytes":0,"response_bytes":54,"status":200,"elapsed":9223372036854.775,"time":"2024-01-17T16:02:33.909819345Z","message":"GET /api/v2/saml"}
```

After:
```
bh-api-1        | {"level":"info","remote_addr":"172.20.0.6:38788","proto":"HTTP/1.1","referer":"http://bloodhound.localhost/ui/mockServiceWorker.js","user_agent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36","request_id":"","request_bytes":0,"response_bytes":54,"status":200,"elapsed":9223372036854.775,"time":"2024-01-17T18:10:57.743804001Z","message":"GET /api/v2/saml"}
bh-api-1        | {"level":"info","remote_addr":"172.20.0.6:52450","proto":"HTTP/1.1","referer":"http://bloodhound.localhost/ui/mockServiceWorker.js","user_agent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36","request_id":"","request_bytes":0,"response_bytes":2019,"status":200,"elapsed":9223372036854.775,"time":"2024-01-17T18:10:57.747877001Z","message":"GET /api/v2/bloodhound-users"}
bh-api-1        | {"level":"info","remote_addr":"172.20.0.6:38788","proto":"HTTP/1.1","referer":"http://bloodhound.localhost/ui/mockServiceWorker.js","user_agent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36","request_id":"","request_bytes":0,"response_bytes":54,"status":200,"elapsed":9223372036854.775,"time":"2024-01-17T18:10:59.218940918Z","message":"GET /api/v2/saml"}
bh-api-1        | {"level":"info","remote_addr":"172.20.0.6:52450","proto":"HTTP/1.1","referer":"http://bloodhound.localhost/ui/mockServiceWorker.js","user_agent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36","request_id":"","request_bytes":0,"response_bytes":735,"status":200,"elapsed":9223372036854.775,"time":"2024-01-17T18:10:59.22112596Z","message":"GET /api/v2/roles"}
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] My changes include a database migration.
