### PR TITLE
fix: Filter out group nodes from GPO affected T0 queries

### DIFF
--- a/packages/go/analysis/ad/filters.go
+++ b/packages/go/analysis/ad/filters.go
@@ -163,6 +163,9 @@ func SelectComputersCandidateFilter(node *graph.Node) bool {
 func SelectGPOTierZeroCandidateFilter(node *graph.Node) bool {
 	if tags, err := node.Properties.Get(common.SystemTags.String()).String(); err != nil {
 		return false
+	} else if node.Kinds.ContainsOneOf(ad.Group) {
+		// GPOs don’t apply to groups.
+		return false
 	} else {
 		return strings.Contains(tags, ad.AdminTierZero)
 	}

--- a/packages/go/analysis/ad/filters_test.go
+++ b/packages/go/analysis/ad/filters_test.go
@@ -1,0 +1,38 @@
+// Copyright 2023 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package ad_test
+
+import (
+	ad2 "github.com/specterops/bloodhound/analysis/ad"
+	"github.com/specterops/bloodhound/dawgs/graph"
+	"github.com/specterops/bloodhound/graphschema/ad"
+	"github.com/specterops/bloodhound/graphschema/common"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestSelectGPOContainerCandidateFilter(t *testing.T) {
+	var (
+		computer = graph.NewNode(0, graph.NewProperties(), ad.Computer)
+		group    = graph.NewNode(1, graph.NewProperties().Set(common.SystemTags.String(), ad.AdminTierZero), ad.Group)
+		user     = graph.NewNode(2, graph.NewProperties().Set(common.SystemTags.String(), ad.AdminTierZero), ad.User)
+	)
+
+	assert.False(t, ad2.SelectGPOContainerCandidateFilter(computer))
+	assert.False(t, ad2.SelectGPOTierZeroCandidateFilter(group))
+	assert.True(t, ad2.SelectGPOTierZeroCandidateFilter(user))
+}


### PR DESCRIPTION
## Description

GPOs don’t apply to groups.  Groups can be used as filters for GPOs but you can’t take control over a group through a GPO.  Our entity panel for GPOs incorrectly shows Groups when expanding the affected objects accordion, then expanding Tier Zero objects.  The query for this should only account for the following objects: Domains, Users, Computers, OUs. 

## Motivation and Context

Fix query to properly filter groups.

## How Has This Been Tested?

Before and after change was compared against local data that reproduced this behavior.
A unit test verifying logic paths was added.

## Types of changes

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [x] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
