### PR TITLE
chore: bump available SharpHound version to 2.3.1

### DIFF
--- a/dockerfiles/bloodhound.Dockerfile
+++ b/dockerfiles/bloodhound.Dockerfile
@@ -17,7 +17,7 @@
 ########
 # Global build args
 ################
-ARG SHARPHOUND_VERSION=v2.3.0
+ARG SHARPHOUND_VERSION=v2.3.1
 ARG AZUREHOUND_VERSION=v2.1.6
 
 ########

--- a/tools/docker-compose/api.Dockerfile
+++ b/tools/docker-compose/api.Dockerfile
@@ -17,7 +17,7 @@
 ########
 # Global build args
 ################
-ARG SHARPHOUND_VERSION=v2.3.0
+ARG SHARPHOUND_VERSION=v2.3.1
 ARG AZUREHOUND_VERSION=v2.1.6
 
 


### PR DESCRIPTION
## Description

This change makes SharpHound version 2.3.1 available for download via BloodHound Community Edition.