### PR TITLE
Revert ip bind to 0.0.0.0

### DIFF
--- a/local-harnesses/build.config.json.template
+++ b/local-harnesses/build.config.json.template
@@ -1,8 +1,8 @@
 {
     "version": 1,
-    "bind_addr": "localhost:8080",
+    "bind_addr": "0.0.0.0:8080",
     "metrics_port": "localhost:2112",
-    "root_url": "http://localhost:8080/",
+    "root_url": "http://0.0.0.0:8080/",
     "work_dir": "/bhapi/work",
     "collectors_base_path": "/bhapi/collectors",
     "log_level": "INFO",


### PR DESCRIPTION
https://github.com/SpecterOps/BloodHound/commit/7787b6baf17b54536411b626fd40ba517c27f023 breaks the development build (just bh-dev). 
The traefik proxy can't connect to the api when the service is only listening on localhost.