### PR TITLE
chore: remove unnecessary complexity in the data pipeline

### DIFF
--- a/cmd/api/src/api/v2/file_uploads.go
+++ b/cmd/api/src/api/v2/file_uploads.go
@@ -153,10 +153,9 @@ func (s Resources) EndFileUploadJob(response http.ResponseWriter, request *http.
 		api.HandleDatabaseError(request, response, err)
 	} else if fileUploadJob.Status != model.JobStatusRunning {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, "job must be in running status to end", request), response)
-	} else if fileUploadJob, err := fileupload.EndFileUploadJob(s.DB, fileUploadJob); err != nil {
+	} else if err := fileupload.EndFileUploadJob(s.DB, fileUploadJob); err != nil {
 		api.HandleDatabaseError(request, response, err)
 	} else {
-		s.TaskNotifier.NotifyOfFileUploadJobStatus(fileUploadJob)
 		response.WriteHeader(http.StatusOK)
 	}
 }

--- a/cmd/api/src/api/v2/file_uploads_test.go
+++ b/cmd/api/src/api/v2/file_uploads_test.go
@@ -1,17 +1,17 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 package v2_test
@@ -216,7 +216,6 @@ func TestResources_EndFileUploadJob(t *testing.T) {
 						Status: model.JobStatusRunning,
 					}, nil)
 					mockDB.EXPECT().UpdateFileUploadJob(gomock.Any()).Return(nil)
-					mockTasker.EXPECT().NotifyOfFileUploadJobStatus(gomock.Any())
 				},
 				Test: func(output apitest.Output) {
 					apitest.StatusCode(output, http.StatusOK)

--- a/cmd/api/src/daemons/datapipe/jobs.go
+++ b/cmd/api/src/daemons/datapipe/jobs.go
@@ -17,6 +17,7 @@
 package datapipe
 
 import (
+	"context"
 	"os"
 
 	"github.com/specterops/bloodhound/dawgs/graph"
@@ -26,49 +27,87 @@ import (
 )
 
 func (s *Daemon) failJobsUnderAnalysis() {
-	for _, jobID := range s.fileUploadJobsUnderAnalysisByID {
-		if err := fileupload.FailFileUploadJob(s.db, jobID, "Analysis failed"); err != nil {
-			log.Errorf("Failed updating job %d to failed status: %v", jobID, err)
+	if fileUploadJobsUnderAnalysis, err := s.db.GetFileUploadJobsWithStatus(model.JobStatusAnalyzing); err != nil {
+		log.Errorf("Failed to load file upload jobs under analysis: %v", err)
+	} else {
+		for _, job := range fileUploadJobsUnderAnalysis {
+			if err := fileupload.FailFileUploadJob(s.db, job.ID, "Analysis failed"); err != nil {
+				log.Errorf("Failed updating file upload job %d to failed status: %v", job.ID, err)
+			}
 		}
 	}
 }
 
-func (s *Daemon) processCompletedFileUploadJobs() {
-	if completedFileUploadJobs, err := s.db.GetFileUploadJobsWithStatus(model.JobStatusIngesting); err != nil {
+func (s *Daemon) completeJobsUnderAnalysis() {
+	if fileUploadJobsUnderAnalysis, err := s.db.GetFileUploadJobsWithStatus(model.JobStatusAnalyzing); err != nil {
+		log.Errorf("Failed to load file upload jobs under analysis: %v", err)
+	} else {
+		for _, job := range fileUploadJobsUnderAnalysis {
+			if err := fileupload.UpdateFileUploadJobStatus(s.db, job, model.JobStatusComplete, "Complete"); err != nil {
+				log.Errorf("Error updating fileupload job %d: %v", job.ID, err)
+			}
+		}
+	}
+}
+
+func (s *Daemon) processIngestedFileUploadJobs() {
+	if ingestedFileUploadJobs, err := s.db.GetFileUploadJobsWithStatus(model.JobStatusIngesting); err != nil {
 		log.Errorf("Failed to look up finished file upload jobs: %v", err)
 	} else {
-		for _, completedFileUploadJob := range completedFileUploadJobs {
-			if err := fileupload.UpdateFileUploadJobStatus(s.db, completedFileUploadJob.ID, model.JobStatusComplete, "Complete"); err != nil {
-				log.Errorf("Error updating fileupload job %d: %v", completedFileUploadJob.ID, err)
+		for _, ingestedFileUploadJob := range ingestedFileUploadJobs {
+			if err := fileupload.UpdateFileUploadJobStatus(s.db, ingestedFileUploadJob, model.JobStatusAnalyzing, "Analyzing"); err != nil {
+				log.Errorf("Error updating fileupload job %d: %v", ingestedFileUploadJob.ID, err)
 			}
-
-			s.fileUploadJobsUnderAnalysisByID = append(s.fileUploadJobsUnderAnalysisByID, completedFileUploadJob.ID)
 		}
 	}
 }
 
-func (s *Daemon) processIngestTasks(ingestTasks model.IngestTasks) {
-	s.status.Update(model.DatapipeStatusIngesting, false)
-	defer s.status.Update(model.DatapipeStatusIdle, false)
+// clearFileTask removes a generic file upload task for ingested data.
+func (s *Daemon) clearFileTask(ingestTask model.IngestTask) {
+	if err := s.db.DeleteIngestTask(ingestTask); err != nil {
+		log.Errorf("Error removing file upload task from db: %v", err)
+	}
+}
 
-	for _, ingestTask := range ingestTasks {
-		jsonFile, err := os.Open(ingestTask.FileName)
-		if err != nil {
-			log.Errorf("Error reading file for ingest task %v: %v", ingestTask.ID, err)
-		}
+func (s *Daemon) processIngestFile(ctx context.Context, path string) error {
+	if jsonFile, err := os.Open(path); err != nil {
+		return err
+	} else {
+		defer func() {
+			if err := jsonFile.Close(); err != nil {
+				log.Errorf("Failed closing ingest file %s: %v", path, err)
+			}
+		}()
 
-		if err = s.graphdb.BatchOperation(s.ctx, func(batch graph.Batch) error {
+		return s.graphdb.BatchOperation(ctx, func(batch graph.Batch) error {
 			if err := s.ReadWrapper(batch, jsonFile); err != nil {
 				return err
 			} else {
 				return nil
 			}
-		}); err != nil {
-			log.Errorf("Error processing ingest task %v: %v", ingestTask.ID, err)
+		})
+	}
+}
+
+// processIngestTasks covers the generic file upload case for ingested data.
+func (s *Daemon) processIngestTasks(ctx context.Context, ingestTasks model.IngestTasks) {
+	s.status.Update(model.DatapipeStatusIngesting, false)
+	defer s.status.Update(model.DatapipeStatusIdle, false)
+
+	for _, ingestTask := range ingestTasks {
+		// Check the context to see if we should continue processing ingest tasks. This has to be explicit since error
+		// handling assumes that all failures should be logged and not returned.
+		select {
+		case <-ctx.Done():
+			return
+		default:
 		}
 
-		s.clearTask(ingestTask)
-		jsonFile.Close()
+		if err := s.processIngestFile(ctx, ingestTask.FileName); err != nil {
+			log.Errorf("Failed processing ingest task %d with file %s: %v", ingestTask.ID, ingestTask.FileName, err)
+		}
+
+		s.clearFileTask(ingestTask)
 	}
 }
 

--- a/cmd/api/src/daemons/datapipe/mocks/mock.go
+++ b/cmd/api/src/daemons/datapipe/mocks/mock.go
@@ -64,18 +64,6 @@ func (mr *MockTaskerMockRecorder) GetStatus() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStatus", reflect.TypeOf((*MockTasker)(nil).GetStatus))
 }
 
-// NotifyOfFileUploadJobStatus mocks base method.
-func (m *MockTasker) NotifyOfFileUploadJobStatus(arg0 model.FileUploadJob) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "NotifyOfFileUploadJobStatus", arg0)
-}
-
-// NotifyOfFileUploadJobStatus indicates an expected call of NotifyOfFileUploadJobStatus.
-func (mr *MockTaskerMockRecorder) NotifyOfFileUploadJobStatus(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NotifyOfFileUploadJobStatus", reflect.TypeOf((*MockTasker)(nil).NotifyOfFileUploadJobStatus), arg0)
-}
-
 // RequestAnalysis mocks base method.
 func (m *MockTasker) RequestAnalysis() {
 	m.ctrl.T.Helper()

--- a/cmd/api/src/model/jobs.go
+++ b/cmd/api/src/model/jobs.go
@@ -116,6 +116,7 @@ const (
 	JobStatusTimedOut  JobStatus = 4
 	JobStatusFailed    JobStatus = 5
 	JobStatusIngesting JobStatus = 6
+	JobStatusAnalyzing JobStatus = 7
 )
 
 func allJobStatuses() []JobStatus {
@@ -128,6 +129,7 @@ func allJobStatuses() []JobStatus {
 		JobStatusTimedOut,
 		JobStatusFailed,
 		JobStatusIngesting,
+		JobStatusAnalyzing,
 	}
 }
 
@@ -165,6 +167,9 @@ func (s JobStatus) String() string {
 
 	case JobStatusIngesting:
 		return "INGESTING"
+
+	case JobStatusAnalyzing:
+		return "ANALYZING"
 
 	default:
 		return "INVALIDSTATUS"

--- a/cmd/api/src/services/fileupload/file_upload.go
+++ b/cmd/api/src/services/fileupload/file_upload.go
@@ -110,13 +110,14 @@ func TouchFileUploadJobLastIngest(db FileUploadData, fileUploadJob model.FileUpl
 	return db.UpdateFileUploadJob(fileUploadJob)
 }
 
-func EndFileUploadJob(db FileUploadData, job model.FileUploadJob) (model.FileUploadJob, error) {
+func EndFileUploadJob(db FileUploadData, job model.FileUploadJob) error {
 	job.Status = model.JobStatusIngesting
+
 	if err := db.UpdateFileUploadJob(job); err != nil {
-		return job, fmt.Errorf("error ending file upload job: %w", err)
-	} else {
-		return job, nil
+		return fmt.Errorf("error ending file upload job: %w", err)
 	}
+
+	return nil
 }
 
 func UpdateFileUploadJobStatus(db FileUploadData, jobID int64, status model.JobStatus, message string) error {

--- a/cmd/api/src/services/fileupload/file_upload.go
+++ b/cmd/api/src/services/fileupload/file_upload.go
@@ -120,20 +120,12 @@ func EndFileUploadJob(db FileUploadData, job model.FileUploadJob) error {
 	return nil
 }
 
-func UpdateFileUploadJobStatus(db FileUploadData, jobID int64, status model.JobStatus, message string) error {
-	if job, err := db.GetFileUploadJob(jobID); err != nil {
-		return err
-	} else {
-		job.Status = status
-		job.StatusMessage = message
-		job.EndTime = time.Now().UTC()
+func UpdateFileUploadJobStatus(db FileUploadData, fileUploadJob model.FileUploadJob, status model.JobStatus, message string) error {
+	fileUploadJob.Status = status
+	fileUploadJob.StatusMessage = message
+	fileUploadJob.EndTime = time.Now().UTC()
 
-		return db.UpdateFileUploadJob(job)
-	}
-}
-
-func CompleteFileUploadJob(db FileUploadData, jobID int64) (model.FileUploadJob, error) {
-	return model.FileUploadJob{}, nil
+	return db.UpdateFileUploadJob(fileUploadJob)
 }
 
 func TimeOutUploadJob(db FileUploadData, jobID int64, message string) error {

--- a/packages/javascript/bh-shared-ui/src/components/FinishedIngestLog/types.ts
+++ b/packages/javascript/bh-shared-ui/src/components/FinishedIngestLog/types.ts
@@ -34,7 +34,9 @@ export enum FileUploadJobStatus {
     TIMED_OUT = 4,
     FAILED = 5,
     INGESTING = 6,
+    ANALYZING = 7,
 }
+
 export const FileUploadJobStatusToString: Record<FileUploadJobStatus, string> = {
     [-1]: 'Invalid',
     0: 'Ready',
@@ -44,4 +46,5 @@ export const FileUploadJobStatusToString: Record<FileUploadJobStatus, string> = 
     4: 'Timed Out',
     5: 'Failed',
     6: 'Ingesting',
+    7: 'Analyzing',
 };


### PR DESCRIPTION
## Description

This changeset removes several unnecessary components of the data pipeline. The original intent for the in-memory retention of completed file upload jobs was to trigger analysis immediately upon completion of file-upload. However, addition of configuration for the loop ticker and a clearer path for triggering a data pipeline loop run removes the need for this complexity.

This also removes a gap where a timed out file upload job could have its status overwritten later on during analysis.

## Motivation and Context

The data pipeline is already complex enough, as-is. Let's not make it harder on ourselves to maintain this part of the system.

## How Has This Been Tested?

Updated unit tests.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
