### PR TITLE
add ESC6a to edge finding

### DIFF
--- a/packages/javascript/bh-shared-ui/src/views/Explore/ExploreSearch/edgeTypes.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/Explore/ExploreSearch/edgeTypes.tsx
@@ -92,6 +92,7 @@ export const AllEdgeTypes: Category[] = [
                     ActiveDirectoryRelationshipKind.GoldenCert,
                     ActiveDirectoryRelationshipKind.ADCSESC1,
                     ActiveDirectoryRelationshipKind.ADCSESC3,
+                    ActiveDirectoryRelationshipKind.ADCSESC6a,
                     ActiveDirectoryRelationshipKind.ADCSESC9a,
                 ],
             },


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
this small change adds the ESC6a to the edge filtering dialog, which can be accessed from the pathfinding search box on the explore page.  like other edges, it is checked by default.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
we want the new ESC6a edge to be included in pathfinding searches by default.  the way to do that is by adding an edge to `edgeTypes.tsx`.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
the 9A edge appearing in the dialog, default checked:
<img width="862" alt="Screenshot 2024-01-24 at 8 03 49 AM" src="https://github.com/SpecterOps/BloodHound/assets/23143242/dc8c23ec-8ca7-4d01-872a-2ce8a462ae12">


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
