### PR TITLE
feat: static analysis plumbing for BHCE

### DIFF
--- a/.github/workflows/static-code-analysis.yml
+++ b/.github/workflows/static-code-analysis.yml
@@ -14,7 +14,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-name: Run Tests
+name: Static Code Analysis
 
 on:
   push:
@@ -24,7 +24,7 @@ on:
 
     
 jobs:
-  run-tests:
+  run-analysis:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/static-code-analysis.yml
+++ b/.github/workflows/static-code-analysis.yml
@@ -1,0 +1,50 @@
+# Copyright 2024 Specter Ops, Inc.
+#
+# Licensed under the Apache License, Version 2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: Run Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, synchronize]
+
+    
+jobs:
+  run-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout source code for this repository
+      uses: actions/checkout@v3
+
+    - name: Install Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: '^1.21.0'
+
+    - name: Install Node
+      uses: actions/setup-node@v4
+      with:
+        node-version: 18
+
+    - name: Install Yarn
+      run: |
+        npm install --global yarn
+
+    - name: Run Analysis
+      run: |
+        go run github.com/specterops/bloodhound/packages/go/stbernard analysis

--- a/.golangci.json
+++ b/.golangci.json
@@ -14,24 +14,18 @@
     "max-same-issues": 0,
     "exclude-rules": [
       {
-        "path": "hyperloglog_bench_test\\.go",
-        "text": "SA6002:"
-      },
-      {
-        "path": "cache_test\\.go",
-        "text": "SA1026:"
-      },
-      {
-        "path": "foldr_test\\.go",
-        "text": "SA4000:"
-      },
-      {
         "path": ".go",
         "text": "((neo4j(.+)(NewDriver|Result))|Id|database.Database|(.+)Deprecated) is deprecated"
       },
       {
-        "path": "expected_ingest.go",
-        "text": "ST1022:"
+        "path": "cache_test\\.go",
+        "text": "SA1026:",
+        "severity": "warning"
+      },
+      {
+        "path": "foldr_test\\.go",
+        "text": "SA4000:",
+        "severity": "warning"
       }
     ]
   },
@@ -49,6 +43,16 @@
     "rules": [
       {
         "text": "(ST\\d{4}|S\\d{4}|SA1019)",
+        "severity": "warning"
+      },
+      {
+        "path": "hyperloglog_bench_test\\.go",
+        "text": "SA6002:",
+        "severity": "warning"
+      },
+      {
+        "path": "expected_ingest.go",
+        "text": "ST1022:",
         "severity": "warning"
       }
     ]

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,6 +6,8 @@
     "go.testEnvVars": {
         "INTEGRATION_CONFIG_PATH": "${workspaceFolder}/local-harnesses/integration.config.json"
     },
+    "go.formatTool": "goimports",
+    "go.lintTool": "golangci-lint",
     "[python]": {
         "editor.defaultFormatter": "ms-python.black-formatter"
     },

--- a/cmd/api/src/analysis/ad/adcs_integration_test.go
+++ b/cmd/api/src/analysis/ad/adcs_integration_test.go
@@ -600,6 +600,7 @@ func TestADCSESC6a(t *testing.T) {
 		certTemplates, err := ad2.FetchNodesByKind(context.Background(), db, ad.CertTemplate)
 		require.Nil(t, err)
 		domains, err := ad2.FetchNodesByKind(context.Background(), db, ad.Domain)
+		require.Nil(t, err)
 
 		cache := ad2.NewADCSCache()
 		cache.BuildCache(context.Background(), db, enterpriseCertAuthorities, certTemplates)
@@ -655,6 +656,7 @@ func TestADCSESC6a(t *testing.T) {
 		certTemplates, err := ad2.FetchNodesByKind(context.Background(), db, ad.CertTemplate)
 		require.Nil(t, err)
 		domains, err := ad2.FetchNodesByKind(context.Background(), db, ad.Domain)
+		require.Nil(t, err)
 
 		cache := ad2.NewADCSCache()
 		cache.BuildCache(context.Background(), db, enterpriseCertAuthorities, certTemplates)
@@ -709,6 +711,7 @@ func TestADCSESC6a(t *testing.T) {
 		certTemplates, err := ad2.FetchNodesByKind(context.Background(), db, ad.CertTemplate)
 		require.Nil(t, err)
 		domains, err := ad2.FetchNodesByKind(context.Background(), db, ad.Domain)
+		require.Nil(t, err)
 
 		cache := ad2.NewADCSCache()
 		cache.BuildCache(context.Background(), db, enterpriseCertAuthorities, certTemplates)
@@ -767,6 +770,7 @@ func TestADCSESC6a(t *testing.T) {
 		certTemplates, err := ad2.FetchNodesByKind(context.Background(), db, ad.CertTemplate)
 		require.Nil(t, err)
 		domains, err := ad2.FetchNodesByKind(context.Background(), db, ad.Domain)
+		require.Nil(t, err)
 
 		cache := ad2.NewADCSCache()
 		cache.BuildCache(context.Background(), db, enterpriseCertAuthorities, certTemplates)

--- a/cmd/api/src/test/integration/harnesses/utils.go
+++ b/cmd/api/src/test/integration/harnesses/utils.go
@@ -1,3 +1,19 @@
+// Copyright 2024 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package harnesses
 
 import (

--- a/docker-compose.watch.yml
+++ b/docker-compose.watch.yml
@@ -1,3 +1,19 @@
+# Copyright 2024 Specter Ops, Inc.
+#
+# Licensed under the Apache License, Version 2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 version: '3'
 
 services:

--- a/justfile
+++ b/justfile
@@ -138,15 +138,9 @@ prune-my-branches nuclear='no':
   echo "Remaining Git Branches:"
   git --no-pager branch
 
-# run linting for all Go modules
-go-lint:
-  #!/usr/bin/env bash
-  echo 'ensuring golangci-lint@{{golangci-lint-version}} is installed'
-  go install -v github.com/golangci/golangci-lint/cmd/golangci-lint@{{golangci-lint-version}}
-  echo 'running golangci-lint on all detected modules in your go.work'
-  # grab all the module locations from go.work and run golangci-lint on each
-  golangci-lint run $(cat go.work | { cat | grep -E '\./' | awk 'NF{print $0 "/..."}'; } | tr '\n' ' ')
-  echo 'done'
+# Run all analyzers (requires jq to be installed locally)
+analyze:
+  go run github.com/specterops/bloodhound/packages/go/stbernard analysis | jq 'sort_by(.severity) | .[] | {"severity": .severity, "description": .description, "location": "\(.location.path):\(.location.lines.begin)"}' 
 
 # run docker compose commands for the BH dev profile (Default: up)
 bh-dev *ARGS='up':


### PR DESCRIPTION
## Description

- Adds a new static analysis pipeline to GitHub Actions to enforce our static analysis rules going forward
- Resets the static analysis config to sane defaults. This includes moving some ignored rules to warnings so they can eventually be tackled.
- Adds `just analyze` command using St Bernard. The results are filtered and prettified by `jq` for better local dev ergonomics (you can click the links to go directly to the line)
- Includes fixes for triggered error rules

## Motivation and Context

No broken windows

## How Has This Been Tested?

- Local runs of the analyzer match expectations and complete as expected
- Pipeline tested several times to ensure consistent results

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Chore (a change that does not modify the application functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Documentation updates are needed, and have been made accordingly.
- [ ] I have added and/or updated tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] My changes include a database migration.