### PR TITLE
feat: esc6a edge composition

### DIFF
--- a/cmd/api/src/analysis/ad/adcs_integration_test.go
+++ b/cmd/api/src/analysis/ad/adcs_integration_test.go
@@ -839,6 +839,58 @@ func TestADCSESC6a(t *testing.T) {
 				require.Contains(t, names, "Group1", "Group2")
 			}
 
+			if edge, err := tx.Relationships().Filterf(func() graph.Criteria {
+				return query.And(
+					query.Kind(query.Relationship(), ad.ADCSESC6a),
+					query.Equals(query.StartProperty(common.Name.String()), "Group1"),
+				)
+			}).First(); err != nil {
+				t.Fatalf("error fetching esc6a edges in integration test; %v", err)
+			} else {
+				composition, err := ad2.GetADCSESC6aEdgeComposition(context.Background(), db, edge)
+				require.Nil(t, err)
+				names := []string{}
+				for _, node := range composition.AllNodes() {
+					name, _ := node.Properties.Get(common.Name.String()).String()
+					names = append(names, name)
+				}
+				require.Equal(t, 8, len(composition.AllNodes()))
+				require.Contains(t, names, "Group1")
+				require.Contains(t, names, "Group0")
+				require.Contains(t, names, "CertTemplate1")
+				require.Contains(t, names, "EnterpriseCA")
+				require.Contains(t, names, "RootCA")
+				require.Contains(t, names, "NTAuthStore")
+				require.Contains(t, names, "DC")
+				require.Contains(t, names, "Domain")
+			}
+
+			if edge, err := tx.Relationships().Filterf(func() graph.Criteria {
+				return query.And(
+					query.Kind(query.Relationship(), ad.ADCSESC6a),
+					query.Equals(query.StartProperty(common.Name.String()), "Group2"),
+				)
+			}).First(); err != nil {
+				t.Fatalf("error fetching esc6a edges in integration test; %v", err)
+			} else {
+				composition, err := ad2.GetADCSESC6aEdgeComposition(context.Background(), db, edge)
+				require.Nil(t, err)
+				names := []string{}
+				for _, node := range composition.AllNodes() {
+					name, _ := node.Properties.Get(common.Name.String()).String()
+					names = append(names, name)
+				}
+				require.Equal(t, 8, len(composition.AllNodes()))
+				require.Contains(t, names, "Group2")
+				require.Contains(t, names, "Group0")
+				require.Contains(t, names, "CertTemplate2")
+				require.Contains(t, names, "EnterpriseCA")
+				require.Contains(t, names, "RootCA")
+				require.Contains(t, names, "NTAuthStore")
+				require.Contains(t, names, "DC")
+				require.Contains(t, names, "Domain")
+			}
+
 			return nil
 		})
 	})

--- a/cmd/api/src/test/integration/harnesses.go
+++ b/cmd/api/src/test/integration/harnesses.go
@@ -2109,7 +2109,7 @@ func initHarnessNodeProperties(c *GraphTestContext, nodeMap map[string]*graph.No
 		}
 
 		//This is an exception for schemaVersion which should not be a boolean
-		if value == "1" || value == "0" {
+		if value == "1" || value == "0" || value == "2" {
 			intValue, _ := strconv.ParseInt(value, 10, 32)
 			nodeMap[node.ID].Properties.Set(strings.ToLower(key), float64(intValue))
 		} else if boolValue, err := strconv.ParseBool(value); err != nil {

--- a/cmd/ui/src/views/Explore/EdgeInfo/EdgeInfoContent.tsx
+++ b/cmd/ui/src/views/Explore/EdgeInfo/EdgeInfoContent.tsx
@@ -73,7 +73,9 @@ const EdgeInfoContent: FC<{ selectedEdge: NonNullable<SelectedEdge> }> = ({ sele
                         const sendOnChange =
                             (selectedEdge.name === 'GoldenCert' ||
                                 selectedEdge.name === 'ADCSESC1' ||
-                                selectedEdge.name === 'ADCSESC3' || selectedEdge.name === 'ADCSESC9a') &&
+                                selectedEdge.name === 'ADCSESC3' ||
+                                selectedEdge.name === 'ADCSESC6a' ||
+                                selectedEdge.name === 'ADCSESC9a') &&
                             section[0] === 'composition';
 
                         return (

--- a/cmd/ui/src/views/Explore/ExploreSearchCombobox/ExploreSearchCombobox.tsx
+++ b/cmd/ui/src/views/Explore/ExploreSearchCombobox/ExploreSearchCombobox.tsx
@@ -81,7 +81,13 @@ const ExploreSearchCombobox: React.FC<{
                     },
                     startAdornment: selectedItem?.type && <NodeIcon nodeType={selectedItem?.type} />,
                 }}
-                {...getInputProps({ onFocus: openMenu, refKey: 'inputRef', onChange: (e) => {handleNodeEdited(e.currentTarget.value)} })}
+                {...getInputProps({
+                    onFocus: openMenu,
+                    refKey: 'inputRef',
+                    onChange: (e) => {
+                        handleNodeEdited(e.currentTarget.value);
+                    },
+                })}
                 data-testid='explore_search_input-search'
             />
             <div

--- a/packages/go/analysis/ad/ad.go
+++ b/packages/go/analysis/ad/ad.go
@@ -19,12 +19,13 @@ package ad
 import (
 	"context"
 	"fmt"
-	"github.com/specterops/bloodhound/analysis"
-	"github.com/specterops/bloodhound/dawgs/traversal"
 	"sort"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/specterops/bloodhound/analysis"
+	"github.com/specterops/bloodhound/dawgs/traversal"
 
 	"github.com/specterops/bloodhound/analysis/impact"
 	"github.com/specterops/bloodhound/dawgs/cardinality"
@@ -549,6 +550,12 @@ func GetEdgeCompositionPath(ctx context.Context, db graph.Database, edge *graph.
 			} else {
 				pathSet = results
 			}
+		} else if edge.Kind == ad.ADCSESC6a {
+			if results, err := GetADCSESC6aEdgeComposition(ctx, db, edge); err != nil {
+				return err
+			} else {
+				pathSet = results
+			}
 		} else if edge.Kind == ad.ADCSESC9a {
 			if results, err := GetADCSESC9aEdgeComposition(ctx, db, edge); err != nil {
 				return err
@@ -632,6 +639,284 @@ func ADCSESC3Path3Pattern() traversal.PatternContinuation {
 			query.KindIn(query.End(), ad.EnterpriseCA),
 			query.KindIn(query.Relationship(), ad.Enroll),
 		))
+}
+
+func ADCSESC6aPath1Pattern() traversal.PatternContinuation {
+	return traversal.NewPattern().
+		Outbound(query.And(
+			query.Kind(query.Relationship(), ad.MemberOf),
+			query.Kind(query.End(), ad.Group),
+		)).
+		Outbound(query.And(
+			query.KindIn(query.End(), ad.EnterpriseCA),
+			query.Equals(query.EndProperty(ad.IsUserSpecifiesSanEnabled.String()), true),
+			query.KindIn(query.Relationship(), ad.Enroll),
+		))
+}
+
+func ADCSESC6aPath2Pattern(domainId graph.ID, enterpriseCAs cardinality.Duplex[uint32]) traversal.PatternContinuation {
+	return traversal.NewPattern().
+		Outbound(query.And(
+			query.Kind(query.Relationship(), ad.MemberOf),
+			query.Kind(query.End(), ad.Group),
+		)).
+		Outbound(query.And(
+			query.KindIn(query.Relationship(), ad.GenericAll, ad.Enroll, ad.AllExtendedRights),
+			query.Kind(query.End(), ad.CertTemplate),
+			query.And(
+				query.Equals(query.EndProperty(ad.RequiresManagerApproval.String()), false),
+				query.Equals(query.EndProperty(ad.NoSecurityExtension.String()), true),
+				query.Equals(query.EndProperty(ad.AuthenticationEnabled.String()), true),
+				query.Or(
+					query.Equals(query.EndProperty(ad.SchemaVersion.String()), 1),
+					query.And(
+						query.GreaterThan(query.EndProperty(ad.SchemaVersion.String()), 1),
+						query.Equals(query.EndProperty(ad.AuthorizedSignatures.String()), 0),
+					),
+				),
+			),
+		)).
+		Outbound(query.And(
+			query.KindIn(query.Relationship(), ad.PublishedTo),
+			query.InIDs(query.End(), cardinality.DuplexToGraphIDs(enterpriseCAs)...),
+			query.Kind(query.End(), ad.EnterpriseCA),
+		)).
+		Outbound(query.And(
+			query.KindIn(query.Relationship(), ad.IssuedSignedBy, ad.EnterpriseCAFor),
+			query.Kind(query.End(), ad.RootCA),
+		)).
+		Outbound(query.And(
+			query.KindIn(query.Relationship(), ad.RootCAFor),
+			query.Equals(query.EndID(), domainId),
+		))
+}
+
+func ADCSESC6aPath3Pattern(domainId graph.ID, enterpriseCAs, candidateTemplates cardinality.Duplex[uint32]) traversal.PatternContinuation {
+	return traversal.NewPattern().
+		Outbound(query.And(
+			query.Kind(query.Relationship(), ad.MemberOf),
+			query.Kind(query.End(), ad.Group),
+		)).
+		Outbound(query.And(
+			query.KindIn(query.Relationship(), ad.GenericAll, ad.Enroll, ad.AllExtendedRights),
+			query.KindIn(query.End(), ad.CertTemplate),
+			query.InIDs(query.EndID(), cardinality.DuplexToGraphIDs(candidateTemplates)...),
+		)).
+		Outbound(query.And(
+			query.KindIn(query.Relationship(), ad.PublishedTo),
+			query.KindIn(query.End(), ad.EnterpriseCA),
+			query.InIDs(query.End(), cardinality.DuplexToGraphIDs(enterpriseCAs)...))).
+		Outbound(query.And(
+			query.KindIn(query.Relationship(), ad.TrustedForNTAuth),
+			query.Kind(query.End(), ad.NTAuthStore),
+		)).
+		Outbound(query.And(
+			query.KindIn(query.Relationship(), ad.NTAuthStoreFor),
+			query.Equals(query.EndID(), domainId),
+		))
+}
+
+func ADCSESC6aPath4Pattern(domainId graph.ID, enterpriseCAs cardinality.Duplex[uint32]) traversal.PatternContinuation {
+	return traversal.NewPattern().
+		Outbound(query.Or(
+			query.And(
+				query.Kind(query.Relationship(), ad.MemberOf),
+				query.Kind(query.End(), ad.Group),
+			),
+			query.And(
+				query.KindIn(query.Relationship(), ad.Enroll),
+				query.KindIn(query.End(), ad.EnterpriseCA),
+				query.InIDs(query.End(), cardinality.DuplexToGraphIDs(enterpriseCAs)...)),
+		)).
+		Outbound(query.And(
+			query.KindIn(query.Relationship(), ad.CanAbuseWeakCertBinding),
+			query.KindIn(query.End(), ad.Computer),
+		)).
+		Outbound(query.And(
+			query.KindIn(query.Relationship(), ad.DCFor),
+			query.Equals(query.EndID(), domainId),
+		))
+}
+
+func GetADCSESC6aEdgeComposition(ctx context.Context, db graph.Database, edge *graph.Relationship) (graph.PathSet, error) {
+	var (
+		startNode            *graph.Node
+		traversalInst        = traversal.New(db, analysis.MaximumDatabaseParallelWorkers)
+		lock                 = &sync.Mutex{}
+		paths                = graph.PathSet{}
+		certTemplateSegments = map[graph.ID][]*graph.PathSegment{}
+		enterpriseCASegments = map[graph.ID][]*graph.PathSegment{}
+		certTemplates        = cardinality.NewBitmap32()
+		enterpriseCAs        = cardinality.NewBitmap32()
+		path1EnterpriseCAs   = cardinality.NewBitmap32()
+	)
+
+	if err := db.ReadTransaction(ctx, func(tx graph.Transaction) error {
+		if node, err := ops.FetchNode(tx, edge.StartID); err != nil {
+			return err
+		} else {
+			startNode = node
+			return nil
+		}
+	}); err != nil {
+		return nil, err
+	}
+
+	if err := traversalInst.BreadthFirst(ctx, traversal.Plan{
+		Root: startNode,
+		Driver: ADCSESC6aPath1Pattern().Do(func(terminal *graph.PathSegment) error {
+			enterpriseCA := terminal.Search(func(nextSegment *graph.PathSegment) bool {
+				return nextSegment.Node.Kinds.ContainsOneOf(ad.EnterpriseCA)
+			})
+
+			lock.Lock()
+			path1EnterpriseCAs.Add(enterpriseCA.ID.Uint32())
+			lock.Unlock()
+
+			return nil
+		}),
+	}); err != nil {
+		return nil, err
+	}
+
+	if err := traversalInst.BreadthFirst(ctx, traversal.Plan{
+		Root: startNode,
+		Driver: ADCSESC6aPath2Pattern(edge.EndID, path1EnterpriseCAs).Do(func(terminal *graph.PathSegment) error {
+			certTemplate := terminal.Search(func(nextSegment *graph.PathSegment) bool {
+				return nextSegment.Node.Kinds.ContainsOneOf(ad.CertTemplate)
+			})
+
+			lock.Lock()
+			certTemplateSegments[certTemplate.ID] = append(certTemplateSegments[certTemplate.ID], terminal)
+			certTemplates.Add(certTemplate.ID.Uint32())
+			lock.Unlock()
+
+			return nil
+		})}); err != nil {
+		return nil, err
+	}
+	log.Infof("certtemplates %v", certTemplates.Slice())
+
+	if err := traversalInst.BreadthFirst(ctx, traversal.Plan{
+		Root: startNode,
+		Driver: ADCSESC6aPath3Pattern(edge.EndID, path1EnterpriseCAs, certTemplates).Do(func(terminal *graph.PathSegment) error {
+			certTemplate := terminal.Search(func(nextSegment *graph.PathSegment) bool {
+				return nextSegment.Node.Kinds.ContainsOneOf(ad.CertTemplate)
+			})
+
+			lock.Lock()
+			certTemplateSegments[certTemplate.ID] = append(certTemplateSegments[certTemplate.ID], terminal)
+			certTemplates.Add(certTemplate.ID.Uint32())
+			lock.Unlock()
+
+			return nil
+		})}); err != nil {
+		return nil, err
+	}
+
+	if err := traversalInst.BreadthFirst(ctx, traversal.Plan{
+		Root: startNode,
+		Driver: ADCSESC6aPath4Pattern(edge.EndID, path1EnterpriseCAs).Do(func(terminal *graph.PathSegment) error {
+			enterpriseCA := terminal.Search(func(nextSegment *graph.PathSegment) bool {
+				return nextSegment.Node.Kinds.ContainsOneOf(ad.EnterpriseCA)
+			})
+
+			lock.Lock()
+			paths.AddPath(terminal.Path())
+			enterpriseCASegments[enterpriseCA.ID] = append(enterpriseCASegments[enterpriseCA.ID], terminal)
+			enterpriseCAs.Add(enterpriseCA.ID.Uint32())
+			lock.Unlock()
+
+			return nil
+		}),
+	}); err != nil {
+		return nil, err
+	}
+
+	email, err := startNode.Properties.Get(common.Email.String()).String()
+	if err != nil {
+		log.Warnf("unable to access property %s for node with id %d: %v", common.Email.String(), startNode.ID, err)
+	}
+
+	if err := certTemplates.Each(func(value uint32) (bool, error) {
+
+		var certTemplate *graph.Node
+
+		if err := db.ReadTransaction(ctx, func(tx graph.Transaction) error {
+			if node, err := ops.FetchNode(tx, graph.ID(value)); err != nil {
+				return err
+			} else {
+				certTemplate = node
+				return nil
+			}
+		}); err != nil {
+			return false, err
+		}
+
+		schemaVersion, err := certTemplate.Properties.Get(ad.SchemaVersion.String()).Float64()
+		if err != nil {
+			log.Warnf("unable to access property %s for certTemplate with id %d: %v", ad.SchemaVersion.String(), certTemplate.ID, err)
+		}
+		subjectAltRequireEmail, err := certTemplate.Properties.Get(ad.SubjectAltRequireEmail.String()).Bool()
+		if err != nil {
+			log.Warnf("unable to access property %s for certTemplate with id %d: %v", ad.SubjectAltRequireEmail.String(), certTemplate.ID, err)
+		}
+		subjectRequireEmail, err := certTemplate.Properties.Get(ad.SubjectRequireEmail.String()).Bool()
+		if err != nil {
+			log.Warnf("unable to access property %s for certTemplate with id %d: %v", ad.SubjectRequireEmail.String(), certTemplate.ID, err)
+		}
+		subjectAltRequireDNS, err := certTemplate.Properties.Get(ad.SubjectAltRequireDNS.String()).Bool()
+		if err != nil {
+			log.Warnf("unable to access property %s for certTemplate with id %d: %v", ad.SubjectAltRequireDNS.String(), certTemplate.ID, err)
+		}
+		subjectAltRequireDomainDNS, err := certTemplate.Properties.Get(ad.SubjectAltRequireDomainDNS.String()).Bool()
+		if err != nil {
+			log.Warnf("unable to access property %s for certTemplate with id %d: %v", ad.SubjectAltRequireDomainDNS.String(), certTemplate.ID, err)
+		}
+
+		for _, segment := range certTemplateSegments[graph.ID(value)] {
+
+			if startNode.Kinds.ContainsOneOf(ad.User) {
+				if subjectAltRequireDNS || subjectAltRequireDomainDNS {
+					continue
+				} else if email == "" && !((!subjectAltRequireEmail && !subjectRequireEmail) || schemaVersion == 1) {
+					continue
+				} else {
+					log.Infof("Found ESC6a Path: %s", graph.FormatPathSegment(segment))
+					paths.AddPath(segment.Path())
+				}
+			} else if startNode.Kinds.ContainsOneOf(ad.Computer) {
+				if email == "" && !((!subjectAltRequireEmail && !subjectRequireEmail) || schemaVersion == 1) {
+					continue
+				} else {
+					log.Infof("Found ESC6a Path: %s", graph.FormatPathSegment(segment))
+					paths.AddPath(segment.Path())
+				}
+			} else {
+				log.Infof("Found ESC6a Path: %s", graph.FormatPathSegment(segment))
+				paths.AddPath(segment.Path())
+			}
+
+		}
+
+		return true, nil
+	}); err != nil {
+		return paths, err
+	}
+
+	if paths.Len() > 0 {
+		if err := enterpriseCAs.Each(func(value uint32) (bool, error) {
+			for _, segment := range enterpriseCASegments[graph.ID(value)] {
+				paths.AddPath(segment.Path())
+			}
+			return true, nil
+
+		}); err != nil {
+			return paths, err
+		}
+	}
+
+	return paths, nil
 }
 
 func GetADCSESC3EdgeComposition(ctx context.Context, db graph.Database, edge *graph.Relationship) (graph.PathSet, error) {

--- a/packages/go/analysis/ad/ad.go
+++ b/packages/go/analysis/ad/ad.go
@@ -643,7 +643,7 @@ func ADCSESC3Path3Pattern() traversal.PatternContinuation {
 
 func ADCSESC6aPath1Pattern() traversal.PatternContinuation {
 	return traversal.NewPattern().
-		Outbound(query.And(
+		OutboundWithDepth(0, 0, query.And(
 			query.Kind(query.Relationship(), ad.MemberOf),
 			query.Kind(query.End(), ad.Group),
 		)).
@@ -656,7 +656,7 @@ func ADCSESC6aPath1Pattern() traversal.PatternContinuation {
 
 func ADCSESC6aPath2Pattern(domainId graph.ID, enterpriseCAs cardinality.Duplex[uint32]) traversal.PatternContinuation {
 	return traversal.NewPattern().
-		Outbound(query.And(
+		OutboundWithDepth(0, 0, query.And(
 			query.Kind(query.Relationship(), ad.MemberOf),
 			query.Kind(query.End(), ad.Group),
 		)).
@@ -693,7 +693,7 @@ func ADCSESC6aPath2Pattern(domainId graph.ID, enterpriseCAs cardinality.Duplex[u
 
 func ADCSESC6aPath3Pattern(domainId graph.ID, enterpriseCAs, candidateTemplates cardinality.Duplex[uint32]) traversal.PatternContinuation {
 	return traversal.NewPattern().
-		Outbound(query.And(
+		OutboundWithDepth(0, 0, query.And(
 			query.Kind(query.Relationship(), ad.MemberOf),
 			query.Kind(query.End(), ad.Group),
 		)).
@@ -733,7 +733,7 @@ func ADCSESC6aPath4Pattern(domainId graph.ID, enterpriseCAs cardinality.Duplex[u
 			query.KindIn(query.End(), ad.Computer),
 		)).
 		Outbound(query.And(
-			query.KindIn(query.Relationship(), ad.DCFor),
+			query.KindIn(query.Relationship(), ad.DCFor, ad.TrustedBy),
 			query.Equals(query.EndID(), domainId),
 		))
 }

--- a/packages/go/analysis/ad/ad.go
+++ b/packages/go/analysis/ad/ad.go
@@ -718,15 +718,15 @@ func ADCSESC6aPath3Pattern(domainId graph.ID, enterpriseCAs, candidateTemplates 
 
 func ADCSESC6aPath4Pattern(domainId graph.ID, enterpriseCAs cardinality.Duplex[uint32]) traversal.PatternContinuation {
 	return traversal.NewPattern().
-		Outbound(query.Or(
+		Outbound(
 			query.And(
 				query.Kind(query.Relationship(), ad.MemberOf),
 				query.Kind(query.End(), ad.Group),
-			),
-			query.And(
-				query.KindIn(query.Relationship(), ad.Enroll),
-				query.KindIn(query.End(), ad.EnterpriseCA),
-				query.InIDs(query.End(), cardinality.DuplexToGraphIDs(enterpriseCAs)...)),
+			)).
+		Outbound(query.And(
+			query.KindIn(query.Relationship(), ad.Enroll),
+			query.KindIn(query.End(), ad.EnterpriseCA),
+			query.InIDs(query.End(), cardinality.DuplexToGraphIDs(enterpriseCAs)...),
 		)).
 		Outbound(query.And(
 			query.KindIn(query.Relationship(), ad.CanAbuseWeakCertBinding),

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/ADCSESC6a/ADCSESC6a.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/ADCSESC6a/ADCSESC6a.tsx
@@ -19,6 +19,7 @@ import WindowsAbuse from './WindowsAbuse';
 import LinuxAbuse from './LinuxAbuse';
 import Opsec from './Opsec';
 import References from './References';
+import Composition from './Composition';
 
 const ADCSESC6a = {
     general: General,
@@ -26,6 +27,7 @@ const ADCSESC6a = {
     linuxAbuse: LinuxAbuse,
     opsec: Opsec,
     references: References,
+    composition: Composition,
 };
 
 export default ADCSESC6a;

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/ADCSESC6a/Composition.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/ADCSESC6a/Composition.tsx
@@ -1,0 +1,54 @@
+// Copyright 2024 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { FC } from 'react';
+import { Alert, Box, Skeleton, Typography } from '@mui/material';
+import { apiClient } from '../../../utils/api';
+import { EdgeInfoProps } from '..';
+import { useQuery } from 'react-query';
+import VirtualizedNodeList, { VirtualizedNodeListItem } from '../../VirtualizedNodeList';
+
+const Composition: FC<EdgeInfoProps> = ({ sourceDBId, targetDBId, edgeName }) => {
+    const { data, isLoading, isError } = useQuery(['edgeComposition', sourceDBId, targetDBId, edgeName], ({ signal }) =>
+        apiClient.getEdgeComposition(sourceDBId!, targetDBId!, edgeName!).then((result) => result.data)
+    );
+
+    const nodesArray: VirtualizedNodeListItem[] = Object.values(data?.data.nodes || {}).map((node) => ({
+        name: node.label,
+        objectId: node.objectId,
+        kind: node.kind,
+    }));
+
+    return (
+        <>
+            <Typography variant='body2'>
+                The relationship represents the effective outcome of the configuration and relationships between several
+                different objects. All objects involved in the creation of this relationship are listed here:
+            </Typography>
+            <Box py={1}>
+                {isLoading ? (
+                    <Skeleton variant='rounded' />
+                ) : isError ? (
+                    <Alert severity='error'>Couldn't load edge composition</Alert>
+                ) : (
+                    <VirtualizedNodeList nodes={nodesArray} />
+                )}
+            </Box>
+        </>
+    );
+};
+
+export default Composition;

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/utils.ts
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/utils.ts
@@ -14,7 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { makeStyles } from "@mui/styles";
+import { makeStyles } from '@mui/styles';
 
 export const groupSpecialFormat = (sourceType: string | undefined, sourceName: string | undefined) => {
     if (!sourceType || !sourceName) return 'This entity has';
@@ -43,7 +43,6 @@ export const typeFormat = (type: string | undefined): string => {
         return type.toLowerCase();
     }
 };
-
 
 export const useHelpTextStyles = makeStyles((theme) => ({
     containsCodeEl: {


### PR DESCRIPTION
## Description
This changeset enables viewing the ESC6a edge composition from the edge information pane.
<!--- Describe your changes in detail -->

## Motivation and Context
The current 6a edge information pane does not have the composition accordion implemented.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Integration tests have been updated to check for composition details.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

<img width="1501" alt="Screenshot 2024-01-29 at 10 57 09 AM" src="https://github.com/SpecterOps/BloodHound/assets/16910931/a8d9c4b3-8bb0-44ad-a2eb-17ff539162d3">


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [x] I have added and/or updated tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] My changes include a database migration.
