### PR TITLE
Datapipe State Transition Hardening and ADCS Post Processing Fixes

### DIFF
--- a/cmd/api/src/daemons/datapipe/jobs.go
+++ b/cmd/api/src/daemons/datapipe/jobs.go
@@ -18,6 +18,7 @@ package datapipe
 
 import (
 	"context"
+	"github.com/specterops/bloodhound/src/database"
 	"os"
 
 	"github.com/specterops/bloodhound/dawgs/graph"
@@ -26,39 +27,65 @@ import (
 	"github.com/specterops/bloodhound/src/services/fileupload"
 )
 
-func (s *Daemon) failJobsUnderAnalysis() {
-	if fileUploadJobsUnderAnalysis, err := s.db.GetFileUploadJobsWithStatus(model.JobStatusAnalyzing); err != nil {
+func HasFileUploadJobsWaitingForAnalysis(db database.Database) (bool, error) {
+	if fileUploadJobsUnderAnalysis, err := db.GetFileUploadJobsWithStatus(model.JobStatusAnalyzing); err != nil {
+		return false, err
+	} else {
+		return len(fileUploadJobsUnderAnalysis) > 0, nil
+	}
+}
+
+func FailAnalyzedFileUploadJobs(ctx context.Context, db database.Database) {
+	// Because our database interfaces do not yet accept contexts this is a best-effort check to ensure that we do not
+	// commit state transitions when we are shutting down.
+	if ctx.Err() != nil {
+		return
+	}
+
+	if fileUploadJobsUnderAnalysis, err := db.GetFileUploadJobsWithStatus(model.JobStatusAnalyzing); err != nil {
 		log.Errorf("Failed to load file upload jobs under analysis: %v", err)
 	} else {
 		for _, job := range fileUploadJobsUnderAnalysis {
-			if err := fileupload.FailFileUploadJob(s.db, job.ID, "Analysis failed"); err != nil {
+			if err := fileupload.UpdateFileUploadJobStatus(db, job, model.JobStatusFailed, "Analysis failed"); err != nil {
 				log.Errorf("Failed updating file upload job %d to failed status: %v", job.ID, err)
 			}
 		}
 	}
 }
 
-func (s *Daemon) completeJobsUnderAnalysis() {
-	if fileUploadJobsUnderAnalysis, err := s.db.GetFileUploadJobsWithStatus(model.JobStatusAnalyzing); err != nil {
+func CompleteAnalyzedFileUploadJobs(ctx context.Context, db database.Database) {
+	// Because our database interfaces do not yet accept contexts this is a best-effort check to ensure that we do not
+	// commit state transitions when we are shutting down.
+	if ctx.Err() != nil {
+		return
+	}
+
+	if fileUploadJobsUnderAnalysis, err := db.GetFileUploadJobsWithStatus(model.JobStatusAnalyzing); err != nil {
 		log.Errorf("Failed to load file upload jobs under analysis: %v", err)
 	} else {
 		for _, job := range fileUploadJobsUnderAnalysis {
-			if err := fileupload.UpdateFileUploadJobStatus(s.db, job, model.JobStatusComplete, "Complete"); err != nil {
+			if err := fileupload.UpdateFileUploadJobStatus(db, job, model.JobStatusComplete, "Complete"); err != nil {
 				log.Errorf("Error updating fileupload job %d: %v", job.ID, err)
 			}
 		}
 	}
 }
 
-func (s *Daemon) processIngestedFileUploadJobs() {
-	if ingestingFileUploadJobs, err := s.db.GetFileUploadJobsWithStatus(model.JobStatusIngesting); err != nil {
+func ProcessIngestedFileUploadJobs(ctx context.Context, db database.Database) {
+	// Because our database interfaces do not yet accept contexts this is a best-effort check to ensure that we do not
+	// commit state transitions when shutting down.
+	if ctx.Err() != nil {
+		return
+	}
+
+	if ingestingFileUploadJobs, err := db.GetFileUploadJobsWithStatus(model.JobStatusIngesting); err != nil {
 		log.Errorf("Failed to look up finished file upload jobs: %v", err)
 	} else {
 		for _, ingestingFileUploadJob := range ingestingFileUploadJobs {
-			if remainingIngestTasks, err := s.db.GetIngestTasksForJob(ingestingFileUploadJob.ID); err != nil {
+			if remainingIngestTasks, err := db.GetIngestTasksForJob(ingestingFileUploadJob.ID); err != nil {
 				log.Errorf("Failed looking up remaining ingest tasks for file upload job %d: %v", ingestingFileUploadJob.ID, err)
 			} else if len(remainingIngestTasks) == 0 {
-				if err := fileupload.UpdateFileUploadJobStatus(s.db, ingestingFileUploadJob, model.JobStatusAnalyzing, "Analyzing"); err != nil {
+				if err := fileupload.UpdateFileUploadJobStatus(db, ingestingFileUploadJob, model.JobStatusAnalyzing, "Analyzing"); err != nil {
 					log.Errorf("Error updating fileupload job %d: %v", ingestingFileUploadJob.ID, err)
 				}
 			}
@@ -101,10 +128,8 @@ func (s *Daemon) processIngestTasks(ctx context.Context, ingestTasks model.Inges
 	for _, ingestTask := range ingestTasks {
 		// Check the context to see if we should continue processing ingest tasks. This has to be explicit since error
 		// handling assumes that all failures should be logged and not returned.
-		select {
-		case <-ctx.Done():
+		if ctx.Err() != nil {
 			return
-		default:
 		}
 
 		if err := s.processIngestFile(ctx, ingestTask.FileName); err != nil {

--- a/cmd/api/src/daemons/datapipe/jobs_test.go
+++ b/cmd/api/src/daemons/datapipe/jobs_test.go
@@ -1,0 +1,133 @@
+package datapipe_test
+
+import (
+	"context"
+	"github.com/specterops/bloodhound/src/daemons/datapipe"
+	"github.com/specterops/bloodhound/src/database/mocks"
+	"github.com/specterops/bloodhound/src/model"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+	"testing"
+)
+
+func TestHasJobsWaitingForAnalysis(t *testing.T) {
+	var (
+		mockCtrl = gomock.NewController(t)
+		dbMock   = mocks.NewMockDatabase(mockCtrl)
+	)
+
+	defer mockCtrl.Finish()
+
+	t.Run("Has Jobs Waiting for Analysis", func(t *testing.T) {
+		dbMock.EXPECT().GetFileUploadJobsWithStatus(model.JobStatusAnalyzing).Return([]model.FileUploadJob{{}}, nil)
+
+		hasJobs, err := datapipe.HasFileUploadJobsWaitingForAnalysis(dbMock)
+
+		require.True(t, hasJobs)
+		require.Nil(t, err)
+	})
+
+	t.Run("Has No Jobs Waiting for Analysis", func(t *testing.T) {
+		dbMock.EXPECT().GetFileUploadJobsWithStatus(model.JobStatusAnalyzing).Return([]model.FileUploadJob{}, nil)
+
+		hasJobs, err := datapipe.HasFileUploadJobsWaitingForAnalysis(dbMock)
+
+		require.False(t, hasJobs)
+		require.Nil(t, err)
+	})
+}
+
+func TestFailAnalyzedFileUploadJobs(t *testing.T) {
+	const jobID int64 = 1
+
+	var (
+		mockCtrl = gomock.NewController(t)
+		dbMock   = mocks.NewMockDatabase(mockCtrl)
+	)
+
+	defer mockCtrl.Finish()
+
+	t.Run("Fail Analyzed File Upload Jobs", func(t *testing.T) {
+		dbMock.EXPECT().GetFileUploadJobsWithStatus(model.JobStatusAnalyzing).Return([]model.FileUploadJob{{
+			BigSerial: model.BigSerial{
+				ID: jobID,
+			},
+			Status: model.JobStatusAnalyzing,
+		}}, nil)
+
+		dbMock.EXPECT().UpdateFileUploadJob(gomock.Any()).DoAndReturn(func(fileUploadJob model.FileUploadJob) error {
+			require.Equal(t, model.JobStatusFailed, fileUploadJob.Status)
+			return nil
+		})
+
+		datapipe.FailAnalyzedFileUploadJobs(context.Background(), dbMock)
+	})
+}
+
+func TestCompleteAnalyzedFileUploadJobs(t *testing.T) {
+	const jobID int64 = 1
+
+	var (
+		mockCtrl = gomock.NewController(t)
+		dbMock   = mocks.NewMockDatabase(mockCtrl)
+	)
+
+	defer mockCtrl.Finish()
+
+	t.Run("Complete Analyzed File Upload Jobs", func(t *testing.T) {
+		dbMock.EXPECT().GetFileUploadJobsWithStatus(model.JobStatusAnalyzing).Return([]model.FileUploadJob{{
+			BigSerial: model.BigSerial{
+				ID: jobID,
+			},
+			Status: model.JobStatusAnalyzing,
+		}}, nil)
+
+		dbMock.EXPECT().UpdateFileUploadJob(gomock.Any()).DoAndReturn(func(fileUploadJob model.FileUploadJob) error {
+			require.Equal(t, model.JobStatusComplete, fileUploadJob.Status)
+			return nil
+		})
+
+		datapipe.CompleteAnalyzedFileUploadJobs(context.Background(), dbMock)
+	})
+}
+
+func TestProcessIngestedFileUploadJobs(t *testing.T) {
+	const jobID int64 = 1
+
+	var (
+		mockCtrl = gomock.NewController(t)
+		dbMock   = mocks.NewMockDatabase(mockCtrl)
+	)
+
+	defer mockCtrl.Finish()
+
+	t.Run("Transition Jobs with No Remaining Ingest Tasks", func(t *testing.T) {
+		dbMock.EXPECT().GetFileUploadJobsWithStatus(model.JobStatusIngesting).Return([]model.FileUploadJob{{
+			BigSerial: model.BigSerial{
+				ID: jobID,
+			},
+			Status: model.JobStatusIngesting,
+		}}, nil)
+
+		dbMock.EXPECT().GetIngestTasksForJob(jobID).Return([]model.IngestTask{}, nil)
+		dbMock.EXPECT().UpdateFileUploadJob(gomock.Any()).DoAndReturn(func(fileUploadJob model.FileUploadJob) error {
+			require.Equal(t, model.JobStatusAnalyzing, fileUploadJob.Status)
+			return nil
+		})
+
+		datapipe.ProcessIngestedFileUploadJobs(context.Background(), dbMock)
+	})
+
+	t.Run("Don't Transition Jobs with Remaining Ingest Tasks", func(t *testing.T) {
+		dbMock.EXPECT().GetFileUploadJobsWithStatus(model.JobStatusIngesting).Return([]model.FileUploadJob{{
+			BigSerial: model.BigSerial{
+				ID: jobID,
+			},
+			Status: model.JobStatusIngesting,
+		}}, nil)
+
+		dbMock.EXPECT().GetIngestTasksForJob(jobID).Return([]model.IngestTask{{}}, nil)
+
+		datapipe.ProcessIngestedFileUploadJobs(context.Background(), dbMock)
+	})
+}

--- a/packages/go/analysis/ad/adcs.go
+++ b/packages/go/analysis/ad/adcs.go
@@ -449,29 +449,25 @@ func PostADCS(ctx context.Context, db graph.Database, groupExpansions impact.Pat
 	if !adcsEnabled {
 		return &analysis.AtomicPostProcessingStats{}, nil
 	}
-	operation := analysis.NewPostRelationshipOperation(ctx, db, "ADCS Post Processing")
 
 	if enterpriseCertAuthorities, err := FetchNodesByKind(ctx, db, ad.EnterpriseCA); err != nil {
-		operation.Done()
 		return &analysis.AtomicPostProcessingStats{}, fmt.Errorf("failed fetching enterpriseCA nodes: %w", err)
 	} else if rootCertAuthorities, err := FetchNodesByKind(ctx, db, ad.RootCA); err != nil {
-		operation.Done()
 		return &analysis.AtomicPostProcessingStats{}, fmt.Errorf("failed fetching rootCA nodes: %w", err)
 	} else if certTemplates, err := FetchNodesByKind(ctx, db, ad.CertTemplate); err != nil {
-		operation.Done()
 		return &analysis.AtomicPostProcessingStats{}, fmt.Errorf("failed fetching cert template nodes: %w", err)
 	} else if domains, err := FetchNodesByKind(ctx, db, ad.Domain); err != nil {
-		operation.Done()
 		return &analysis.AtomicPostProcessingStats{}, fmt.Errorf("failed fetching domain nodes: %w", err)
 	} else if step1Stats, err := postADCSPreProcessStep1(ctx, db, enterpriseCertAuthorities, rootCertAuthorities); err != nil {
-		operation.Done()
 		return &analysis.AtomicPostProcessingStats{}, fmt.Errorf("failed adcs pre-processing step 1: %w", err)
 	} else if step2Stats, err := postADCSPreProcessStep2(ctx, db, certTemplates); err != nil {
-		operation.Done()
 		return &analysis.AtomicPostProcessingStats{}, fmt.Errorf("failed adcs pre-processing step 2: %w", err)
 	} else {
+		operation := analysis.NewPostRelationshipOperation(ctx, db, "ADCS Post Processing")
+
 		operation.Stats.Merge(step1Stats)
 		operation.Stats.Merge(step2Stats)
+
 		var cache = NewADCSCache()
 		cache.BuildCache(ctx, db, enterpriseCertAuthorities, certTemplates)
 


### PR DESCRIPTION
## Description

This adds an ingest task lookup before transitioning file upload jobs from the `INGESTING` state to the `ANALYZING` state. There is a potential race where a job may transition into `INGESTING` after `ingestAvailableTasks(...)` is called. In this rare case, ingest tasks would remain until the next datapipe loop tick. Upon ingestion of the remaining tasks analysis would not be triggered, leaving the system in a inconsistent state until the next analysis run.

Additionally, this changeset contains a change in the ADCS post-processing logic that defers creation of a parallel operation context. The functions that previously ran between creation of the parallel operation context would spin up their own parallel operation contexts resulting in creation of 12+ concurrent connections to the database. The system is designed to limit concurrent connections to 10 leaving some of the parallel operations hung until their association context is canceled.

## Motivation and Context

State transition hardening will ensure there are no graph inconsistency gaps. The ADCS post-processing change will increase resiliency of the associated parallel operation code paths. 

## How Has This Been Tested?

Minor changes are covered by existing integration tests.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] My changes include a database migration.
