### PR TITLE
feat: audit log steel thread

### DIFF
--- a/.github/config/integration.config.json
+++ b/.github/config/integration.config.json
@@ -7,6 +7,8 @@
     "collectors_base_path": "/tmp/collectors",
     "log_level": "ERROR",
     "log_path": "bhapi.log",
+    "enable_startup_wait_period": false,
+    "datapipe_interval": 1,
     "features": {
         "enable_auth": true
     },

--- a/cmd/api/src/api/error.go
+++ b/cmd/api/src/api/error.go
@@ -111,8 +111,6 @@ func BuildErrorResponse(httpStatus int, message string, request *http.Request) *
 // HandleDatabaseError writes an error (not found or other) depending on the database error encountered
 // Alternate: FormatDatabaseError()
 func HandleDatabaseError(request *http.Request, response http.ResponseWriter, err error) {
-	ctx.SetErrorContext(request, err)
-
 	if errors.Is(err, database.ErrNotFound) {
 		WriteErrorResponse(request.Context(), BuildErrorResponse(http.StatusNotFound, ErrorResponseDetailsResourceNotFound, request), response)
 	} else {

--- a/cmd/api/src/api/middleware/logging.go
+++ b/cmd/api/src/api/middleware/logging.go
@@ -170,14 +170,6 @@ func LoggingMiddleware(cfg config.Configuration, idResolver auth.IdentityResolve
 			logEvent.Int64("response_bytes", loggedResponse.bytesWritten)
 			logEvent.Int("status", loggedResponse.statusCode)
 			logEvent.Duration("elapsed", time.Since(requestContext.StartTime.UTC()))
-
-			if requestContext.AuditCtx.Action != "" {
-				requestContext.AuditCtx.SetStatus(loggedResponse.statusCode)
-
-				if err := db.AppendAuditLog(*requestContext, "", requestContext.AuditCtx.Model); err != nil {
-					log.Errorf("error writing to audit log: %s", err)
-				}
-			}
 		})
 	}
 }

--- a/cmd/api/src/api/v2/agi.go
+++ b/cmd/api/src/api/v2/agi.go
@@ -200,7 +200,7 @@ func (s Resources) CreateAssetGroup(response http.ResponseWriter, request *http.
 
 	if err := api.ReadJSONRequestPayloadLimited(&createRequest, request); err != nil {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, err.Error(), request), response)
-	} else if newAssetGroup, err := s.DB.CreateAssetGroup(createRequest.Name, createRequest.Tag, false); err != nil {
+	} else if newAssetGroup, err := s.DB.CreateAssetGroup(request.Context(), createRequest.Name, createRequest.Tag, false); err != nil {
 		api.HandleDatabaseError(request, response, err)
 	} else {
 		assetGroupURL := *ctx.Get(request.Context()).Host
@@ -224,7 +224,7 @@ func (s Resources) DeleteAssetGroup(response http.ResponseWriter, request *http.
 		api.HandleDatabaseError(request, response, err)
 	} else if assetGroup.SystemGroup {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusConflict, "Cannot delete a system defined asset group.", request), response)
-	} else if err := s.DB.DeleteAssetGroup(assetGroup); err != nil {
+	} else if err := s.DB.DeleteAssetGroup(request.Context(), assetGroup); err != nil {
 		api.HandleDatabaseError(request, response, err)
 	} else {
 		response.WriteHeader(http.StatusOK)

--- a/cmd/api/src/api/v2/agi.go
+++ b/cmd/api/src/api/v2/agi.go
@@ -178,8 +178,6 @@ func (s Resources) UpdateAssetGroup(response http.ResponseWriter, request *http.
 		assetGroup              model.AssetGroup
 	)
 
-	ctx.SetAuditContext(request, model.AuditContext{Action: "UpdateAssetGroup", Model: &assetGroup})
-
 	if assetGroupID, err := strconv.Atoi(rawAssetGroupID); err != nil {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, api.ErrorResponseDetailsIDMalformed, request), response)
 	} else if err := api.ReadJSONRequestPayloadLimited(&updateAssetGroupRequest, request); err != nil {
@@ -200,8 +198,6 @@ func (s Resources) UpdateAssetGroup(response http.ResponseWriter, request *http.
 func (s Resources) CreateAssetGroup(response http.ResponseWriter, request *http.Request) {
 	var createRequest CreateAssetGroupRequest
 
-	ctx.SetAuditContext(request, model.AuditContext{Action: "CreateAssetGroup", Model: &createRequest})
-
 	if err := api.ReadJSONRequestPayloadLimited(&createRequest, request); err != nil {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, err.Error(), request), response)
 	} else if newAssetGroup, err := s.DB.CreateAssetGroup(createRequest.Name, createRequest.Tag, false); err != nil {
@@ -221,8 +217,6 @@ func (s Resources) DeleteAssetGroup(response http.ResponseWriter, request *http.
 		rawAssetGroupID = pathVars[api.URIPathVariableAssetGroupID]
 		assetGroup      model.AssetGroup
 	)
-
-	ctx.SetAuditContext(request, model.AuditContext{Action: "DeleteAssetGroup", Model: &assetGroup})
 
 	if assetGroupID, err := strconv.Atoi(rawAssetGroupID); err != nil {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, api.ErrorResponseDetailsIDMalformed, request), response)
@@ -281,8 +275,6 @@ func (s Resources) DeleteAssetGroupSelector(response http.ResponseWriter, reques
 		rawAssetGroupID         = pathVars[api.URIPathVariableAssetGroupID]
 		rawAssetGroupSelectorID = pathVars[api.URIPathVariableAssetGroupSelectorID]
 	)
-
-	ctx.SetAuditContext(request, model.AuditContext{Action: "DeleteAssetGroupSelector", Model: &assetGroupSelector})
 
 	if assetGroupID, err := strconv.Atoi(rawAssetGroupID); err != nil {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, api.ErrorResponseDetailsIDMalformed, request), response)

--- a/cmd/api/src/api/v2/agi_test.go
+++ b/cmd/api/src/api/v2/agi_test.go
@@ -407,7 +407,7 @@ func TestResources_CreateAssetGroup(t *testing.T) {
 		ResponseStatusCode(http.StatusBadRequest)
 
 	// Create DB Query fails
-	mockDB.EXPECT().CreateAssetGroup(gomock.Any(), gomock.Any(), gomock.Any()).Return(model.AssetGroup{}, fmt.Errorf("exploded"))
+	mockDB.EXPECT().CreateAssetGroup(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(model.AssetGroup{}, fmt.Errorf("exploded"))
 
 	requestTemplate.
 		WithBody(v2.CreateAssetGroupRequest{}).
@@ -416,7 +416,7 @@ func TestResources_CreateAssetGroup(t *testing.T) {
 		ResponseStatusCode(http.StatusInternalServerError)
 
 	// Success
-	mockDB.EXPECT().CreateAssetGroup(gomock.Any(), gomock.Any(), gomock.Any()).Return(model.AssetGroup{}, nil)
+	mockDB.EXPECT().CreateAssetGroup(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(model.AssetGroup{}, nil)
 
 	requestTemplate.
 		WithContext(&ctx.Context{
@@ -715,7 +715,7 @@ func TestResources_DeleteAssetGroup(t *testing.T) {
 
 	// DeleteAssetGroup DB fails
 	mockDB.EXPECT().GetAssetGroup(int32(1234)).Return(model.AssetGroup{}, nil)
-	mockDB.EXPECT().DeleteAssetGroup(model.AssetGroup{}).Return(fmt.Errorf("exploded"))
+	mockDB.EXPECT().DeleteAssetGroup(gomock.Any(), model.AssetGroup{}).Return(fmt.Errorf("exploded"))
 
 	requestTemplate.
 		WithURLPathVars(map[string]string{
@@ -727,7 +727,7 @@ func TestResources_DeleteAssetGroup(t *testing.T) {
 
 	// Success
 	mockDB.EXPECT().GetAssetGroup(int32(1234)).Return(model.AssetGroup{}, nil)
-	mockDB.EXPECT().DeleteAssetGroup(model.AssetGroup{}).Return(nil)
+	mockDB.EXPECT().DeleteAssetGroup(gomock.Any(), model.AssetGroup{}).Return(nil)
 
 	requestTemplate.
 		WithURLPathVars(map[string]string{

--- a/cmd/api/src/api/v2/agi_test.go
+++ b/cmd/api/src/api/v2/agi_test.go
@@ -349,20 +349,7 @@ func TestResources_UpdateAssetGroup(t *testing.T) {
 		Require().
 		ResponseStatusCode(http.StatusBadRequest)
 
-	// Audit Log fails
-	mockDB.EXPECT().AppendAuditLog(gomock.Any(), gomock.Any()).Return(fmt.Errorf("exploded"))
-
-	requestTemplate.
-		WithURLPathVars(map[string]string{
-			"asset_group_id": "1234",
-		}).
-		WithBody(v2.UpdateAssetGroupRequest{}).
-		OnHandlerFunc(resources.UpdateAssetGroup).
-		Require().
-		ResponseStatusCode(http.StatusInternalServerError)
-
 	// GetAssetGroup DB fails
-	mockDB.EXPECT().AppendAuditLog(gomock.Any(), gomock.Any()).Return(nil)
 	mockDB.EXPECT().GetAssetGroup(int32(1234)).Return(model.AssetGroup{}, fmt.Errorf("exploded"))
 
 	requestTemplate.
@@ -375,7 +362,6 @@ func TestResources_UpdateAssetGroup(t *testing.T) {
 		ResponseStatusCode(http.StatusInternalServerError)
 
 	// UpdateAssetGroup DB fails
-	mockDB.EXPECT().AppendAuditLog(gomock.Any(), gomock.Any()).Return(nil)
 	mockDB.EXPECT().GetAssetGroup(int32(1234)).Return(model.AssetGroup{}, nil)
 	mockDB.EXPECT().UpdateAssetGroup(model.AssetGroup{}).Return(fmt.Errorf("exploded"))
 
@@ -389,7 +375,6 @@ func TestResources_UpdateAssetGroup(t *testing.T) {
 		ResponseStatusCode(http.StatusInternalServerError)
 
 	// Success
-	mockDB.EXPECT().AppendAuditLog(gomock.Any(), gomock.Any()).Return(nil)
 	mockDB.EXPECT().GetAssetGroup(int32(1234)).Return(model.AssetGroup{}, nil)
 	mockDB.EXPECT().UpdateAssetGroup(model.AssetGroup{}).Return(nil)
 
@@ -421,17 +406,7 @@ func TestResources_CreateAssetGroup(t *testing.T) {
 		Require().
 		ResponseStatusCode(http.StatusBadRequest)
 
-	// Audit Log fails
-	mockDB.EXPECT().AppendAuditLog(gomock.Any(), gomock.Any()).Return(fmt.Errorf("exploded"))
-
-	requestTemplate.
-		WithBody(v2.CreateAssetGroupRequest{}).
-		OnHandlerFunc(resources.CreateAssetGroup).
-		Require().
-		ResponseStatusCode(http.StatusInternalServerError)
-
 	// Create DB Query fails
-	mockDB.EXPECT().AppendAuditLog(gomock.Any(), gomock.Any()).Return(nil)
 	mockDB.EXPECT().CreateAssetGroup(gomock.Any(), gomock.Any(), gomock.Any()).Return(model.AssetGroup{}, fmt.Errorf("exploded"))
 
 	requestTemplate.
@@ -441,7 +416,6 @@ func TestResources_CreateAssetGroup(t *testing.T) {
 		ResponseStatusCode(http.StatusInternalServerError)
 
 	// Success
-	mockDB.EXPECT().AppendAuditLog(gomock.Any(), gomock.Any()).Return(nil)
 	mockDB.EXPECT().CreateAssetGroup(gomock.Any(), gomock.Any(), gomock.Any()).Return(model.AssetGroup{}, nil)
 
 	requestTemplate.
@@ -739,21 +713,8 @@ func TestResources_DeleteAssetGroup(t *testing.T) {
 		Require().
 		ResponseStatusCode(http.StatusInternalServerError)
 
-	// Audit Log DB fails
-	mockDB.EXPECT().GetAssetGroup(int32(1234)).Return(model.AssetGroup{}, nil)
-	mockDB.EXPECT().AppendAuditLog(gomock.Any(), gomock.Any()).Return(fmt.Errorf("exploded"))
-
-	requestTemplate.
-		WithURLPathVars(map[string]string{
-			"asset_group_id": "1234",
-		}).
-		OnHandlerFunc(resources.DeleteAssetGroup).
-		Require().
-		ResponseStatusCode(http.StatusInternalServerError)
-
 	// DeleteAssetGroup DB fails
 	mockDB.EXPECT().GetAssetGroup(int32(1234)).Return(model.AssetGroup{}, nil)
-	mockDB.EXPECT().AppendAuditLog(gomock.Any(), gomock.Any()).Return(nil)
 	mockDB.EXPECT().DeleteAssetGroup(model.AssetGroup{}).Return(fmt.Errorf("exploded"))
 
 	requestTemplate.
@@ -766,7 +727,6 @@ func TestResources_DeleteAssetGroup(t *testing.T) {
 
 	// Success
 	mockDB.EXPECT().GetAssetGroup(int32(1234)).Return(model.AssetGroup{}, nil)
-	mockDB.EXPECT().AppendAuditLog(gomock.Any(), gomock.Any()).Return(nil)
 	mockDB.EXPECT().DeleteAssetGroup(model.AssetGroup{}).Return(nil)
 
 	requestTemplate.
@@ -848,24 +808,9 @@ func TestResources_DeleteAssetGroupSelector(t *testing.T) {
 		Require().
 		ResponseStatusCode(http.StatusConflict)
 
-	// Audit Log DB fails
-	mockDB.EXPECT().GetAssetGroup(int32(1234)).Return(model.AssetGroup{}, nil)
-	mockDB.EXPECT().GetAssetGroupSelector(int32(1234)).Return(model.AssetGroupSelector{}, nil)
-	mockDB.EXPECT().AppendAuditLog(gomock.Any(), gomock.Any()).Return(fmt.Errorf("exploded"))
-
-	requestTemplate.
-		WithURLPathVars(map[string]string{
-			"asset_group_id":          "1234",
-			"asset_group_selector_id": "1234",
-		}).
-		OnHandlerFunc(resources.DeleteAssetGroupSelector).
-		Require().
-		ResponseStatusCode(http.StatusInternalServerError)
-
 	// DeleteAssetGroupSelector DB fails
 	mockDB.EXPECT().GetAssetGroup(int32(1234)).Return(model.AssetGroup{}, nil)
 	mockDB.EXPECT().GetAssetGroupSelector(int32(1234)).Return(model.AssetGroupSelector{}, nil)
-	mockDB.EXPECT().AppendAuditLog(gomock.Any(), gomock.Any()).Return(nil)
 	mockDB.EXPECT().DeleteAssetGroupSelector(model.AssetGroupSelector{}).Return(fmt.Errorf("exploded"))
 
 	requestTemplate.
@@ -880,7 +825,6 @@ func TestResources_DeleteAssetGroupSelector(t *testing.T) {
 	// Success
 	mockDB.EXPECT().GetAssetGroup(int32(1234)).Return(model.AssetGroup{}, nil)
 	mockDB.EXPECT().GetAssetGroupSelector(int32(1234)).Return(model.AssetGroupSelector{}, nil)
-	mockDB.EXPECT().AppendAuditLog(gomock.Any(), gomock.Any()).Return(nil)
 	mockDB.EXPECT().DeleteAssetGroupSelector(model.AssetGroupSelector{}).Return(nil)
 
 	requestTemplate.

--- a/cmd/api/src/api/v2/agi_test.go
+++ b/cmd/api/src/api/v2/agi_test.go
@@ -20,14 +20,15 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/specterops/bloodhound/headers"
-	"github.com/specterops/bloodhound/mediatypes"
-	"github.com/specterops/bloodhound/src/auth"
-	"github.com/specterops/bloodhound/src/test/must"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"testing"
+
+	"github.com/specterops/bloodhound/headers"
+	"github.com/specterops/bloodhound/mediatypes"
+	"github.com/specterops/bloodhound/src/auth"
+	"github.com/specterops/bloodhound/src/test/must"
 
 	"github.com/gorilla/mux"
 	"github.com/specterops/bloodhound/dawgs/graph"
@@ -349,7 +350,7 @@ func TestResources_UpdateAssetGroup(t *testing.T) {
 		ResponseStatusCode(http.StatusBadRequest)
 
 	// Audit Log fails
-	mockDB.EXPECT().AppendAuditLog(gomock.Any(), gomock.Any(), gomock.Any()).Return(fmt.Errorf("exploded"))
+	mockDB.EXPECT().AppendAuditLog(gomock.Any(), gomock.Any()).Return(fmt.Errorf("exploded"))
 
 	requestTemplate.
 		WithURLPathVars(map[string]string{
@@ -361,7 +362,7 @@ func TestResources_UpdateAssetGroup(t *testing.T) {
 		ResponseStatusCode(http.StatusInternalServerError)
 
 	// GetAssetGroup DB fails
-	mockDB.EXPECT().AppendAuditLog(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+	mockDB.EXPECT().AppendAuditLog(gomock.Any(), gomock.Any()).Return(nil)
 	mockDB.EXPECT().GetAssetGroup(int32(1234)).Return(model.AssetGroup{}, fmt.Errorf("exploded"))
 
 	requestTemplate.
@@ -374,7 +375,7 @@ func TestResources_UpdateAssetGroup(t *testing.T) {
 		ResponseStatusCode(http.StatusInternalServerError)
 
 	// UpdateAssetGroup DB fails
-	mockDB.EXPECT().AppendAuditLog(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+	mockDB.EXPECT().AppendAuditLog(gomock.Any(), gomock.Any()).Return(nil)
 	mockDB.EXPECT().GetAssetGroup(int32(1234)).Return(model.AssetGroup{}, nil)
 	mockDB.EXPECT().UpdateAssetGroup(model.AssetGroup{}).Return(fmt.Errorf("exploded"))
 
@@ -388,7 +389,7 @@ func TestResources_UpdateAssetGroup(t *testing.T) {
 		ResponseStatusCode(http.StatusInternalServerError)
 
 	// Success
-	mockDB.EXPECT().AppendAuditLog(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+	mockDB.EXPECT().AppendAuditLog(gomock.Any(), gomock.Any()).Return(nil)
 	mockDB.EXPECT().GetAssetGroup(int32(1234)).Return(model.AssetGroup{}, nil)
 	mockDB.EXPECT().UpdateAssetGroup(model.AssetGroup{}).Return(nil)
 
@@ -421,7 +422,7 @@ func TestResources_CreateAssetGroup(t *testing.T) {
 		ResponseStatusCode(http.StatusBadRequest)
 
 	// Audit Log fails
-	mockDB.EXPECT().AppendAuditLog(gomock.Any(), gomock.Any(), gomock.Any()).Return(fmt.Errorf("exploded"))
+	mockDB.EXPECT().AppendAuditLog(gomock.Any(), gomock.Any()).Return(fmt.Errorf("exploded"))
 
 	requestTemplate.
 		WithBody(v2.CreateAssetGroupRequest{}).
@@ -430,7 +431,7 @@ func TestResources_CreateAssetGroup(t *testing.T) {
 		ResponseStatusCode(http.StatusInternalServerError)
 
 	// Create DB Query fails
-	mockDB.EXPECT().AppendAuditLog(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+	mockDB.EXPECT().AppendAuditLog(gomock.Any(), gomock.Any()).Return(nil)
 	mockDB.EXPECT().CreateAssetGroup(gomock.Any(), gomock.Any(), gomock.Any()).Return(model.AssetGroup{}, fmt.Errorf("exploded"))
 
 	requestTemplate.
@@ -440,7 +441,7 @@ func TestResources_CreateAssetGroup(t *testing.T) {
 		ResponseStatusCode(http.StatusInternalServerError)
 
 	// Success
-	mockDB.EXPECT().AppendAuditLog(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+	mockDB.EXPECT().AppendAuditLog(gomock.Any(), gomock.Any()).Return(nil)
 	mockDB.EXPECT().CreateAssetGroup(gomock.Any(), gomock.Any(), gomock.Any()).Return(model.AssetGroup{}, nil)
 
 	requestTemplate.
@@ -740,7 +741,7 @@ func TestResources_DeleteAssetGroup(t *testing.T) {
 
 	// Audit Log DB fails
 	mockDB.EXPECT().GetAssetGroup(int32(1234)).Return(model.AssetGroup{}, nil)
-	mockDB.EXPECT().AppendAuditLog(gomock.Any(), gomock.Any(), gomock.Any()).Return(fmt.Errorf("exploded"))
+	mockDB.EXPECT().AppendAuditLog(gomock.Any(), gomock.Any()).Return(fmt.Errorf("exploded"))
 
 	requestTemplate.
 		WithURLPathVars(map[string]string{
@@ -752,7 +753,7 @@ func TestResources_DeleteAssetGroup(t *testing.T) {
 
 	// DeleteAssetGroup DB fails
 	mockDB.EXPECT().GetAssetGroup(int32(1234)).Return(model.AssetGroup{}, nil)
-	mockDB.EXPECT().AppendAuditLog(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+	mockDB.EXPECT().AppendAuditLog(gomock.Any(), gomock.Any()).Return(nil)
 	mockDB.EXPECT().DeleteAssetGroup(model.AssetGroup{}).Return(fmt.Errorf("exploded"))
 
 	requestTemplate.
@@ -765,7 +766,7 @@ func TestResources_DeleteAssetGroup(t *testing.T) {
 
 	// Success
 	mockDB.EXPECT().GetAssetGroup(int32(1234)).Return(model.AssetGroup{}, nil)
-	mockDB.EXPECT().AppendAuditLog(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+	mockDB.EXPECT().AppendAuditLog(gomock.Any(), gomock.Any()).Return(nil)
 	mockDB.EXPECT().DeleteAssetGroup(model.AssetGroup{}).Return(nil)
 
 	requestTemplate.
@@ -850,7 +851,7 @@ func TestResources_DeleteAssetGroupSelector(t *testing.T) {
 	// Audit Log DB fails
 	mockDB.EXPECT().GetAssetGroup(int32(1234)).Return(model.AssetGroup{}, nil)
 	mockDB.EXPECT().GetAssetGroupSelector(int32(1234)).Return(model.AssetGroupSelector{}, nil)
-	mockDB.EXPECT().AppendAuditLog(gomock.Any(), gomock.Any(), gomock.Any()).Return(fmt.Errorf("exploded"))
+	mockDB.EXPECT().AppendAuditLog(gomock.Any(), gomock.Any()).Return(fmt.Errorf("exploded"))
 
 	requestTemplate.
 		WithURLPathVars(map[string]string{
@@ -864,7 +865,7 @@ func TestResources_DeleteAssetGroupSelector(t *testing.T) {
 	// DeleteAssetGroupSelector DB fails
 	mockDB.EXPECT().GetAssetGroup(int32(1234)).Return(model.AssetGroup{}, nil)
 	mockDB.EXPECT().GetAssetGroupSelector(int32(1234)).Return(model.AssetGroupSelector{}, nil)
-	mockDB.EXPECT().AppendAuditLog(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+	mockDB.EXPECT().AppendAuditLog(gomock.Any(), gomock.Any()).Return(nil)
 	mockDB.EXPECT().DeleteAssetGroupSelector(model.AssetGroupSelector{}).Return(fmt.Errorf("exploded"))
 
 	requestTemplate.
@@ -879,7 +880,7 @@ func TestResources_DeleteAssetGroupSelector(t *testing.T) {
 	// Success
 	mockDB.EXPECT().GetAssetGroup(int32(1234)).Return(model.AssetGroup{}, nil)
 	mockDB.EXPECT().GetAssetGroupSelector(int32(1234)).Return(model.AssetGroupSelector{}, nil)
-	mockDB.EXPECT().AppendAuditLog(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+	mockDB.EXPECT().AppendAuditLog(gomock.Any(), gomock.Any()).Return(nil)
 	mockDB.EXPECT().DeleteAssetGroupSelector(model.AssetGroupSelector{}).Return(nil)
 
 	requestTemplate.

--- a/cmd/api/src/api/v2/audit_integration_test.go
+++ b/cmd/api/src/api/v2/audit_integration_test.go
@@ -57,9 +57,24 @@ func Test_ListAuditLogs(t *testing.T) {
 
 		// Expect one audit log entry from the deletion
 		auditLogs := testCtx.ListAuditLogs(deletionTimestamp, time.Now(), 0, 1000)
-		require.Equal(t, 1, len(auditLogs), "Expected only 1 audit log entry but saw %d", len(auditLogs))
+		require.Equal(t, 2, len(auditLogs), "Expected only 2 audit log entries but saw %d", len(auditLogs))
+
+		// Make sure these two actions are from the same request
+		require.Equal(t, auditLogs[0].RequestID, auditLogs[1].RequestID)
+
+		// Makes sure these two actions are from the same two phase commit
+		require.Equal(t, auditLogs[0].CommitID, auditLogs[1].CommitID)
+
+		// Audit logs are in LIFO order
+		require.Equal(t, auditLogs[0].Status, "success")
+		require.Equal(t, auditLogs[1].Status, "intent")
 
 		testCtx.AssetAuditLog(auditLogs[0], "DeleteAssetGroup", map[string]any{
+			"asset_group_name": newAssetGroup.Name,
+			"asset_group_tag":  newAssetGroup.Tag,
+		})
+
+		testCtx.AssetAuditLog(auditLogs[1], "DeleteAssetGroup", map[string]any{
 			"asset_group_name": newAssetGroup.Name,
 			"asset_group_tag":  newAssetGroup.Tag,
 		})

--- a/cmd/api/src/api/v2/audit_integration_test.go
+++ b/cmd/api/src/api/v2/audit_integration_test.go
@@ -57,7 +57,7 @@ func Test_ListAuditLogs(t *testing.T) {
 
 		// Expect one audit log entry from the deletion
 		auditLogs := testCtx.ListAuditLogs(deletionTimestamp, time.Now(), 0, 1000)
-		require.Equal(t, 2, len(auditLogs), "Expected only 2 audit log entries but saw %d", len(auditLogs))
+		require.Equal(t, 2, len(auditLogs), "Expected exactly 2 audit log entries but saw %d", len(auditLogs))
 
 		// Make sure these two actions are from the same request
 		require.Equal(t, auditLogs[0].RequestID, auditLogs[1].RequestID)

--- a/cmd/api/src/api/v2/auth/auth.go
+++ b/cmd/api/src/api/v2/auth/auth.go
@@ -165,7 +165,7 @@ func (s ManagementResource) disassociateUsersFromSAMLProvider(request *http.Requ
 		user.SAMLProvider = nil
 		user.SAMLProviderID = null.NewInt32(0, false)
 
-		if err := s.db.UpdateUser(user); err != nil {
+		if err := s.db.UpdateUser(request.Context(), user); err != nil {
 			return api.FormatDatabaseError(err)
 		}
 	}
@@ -485,7 +485,7 @@ func (s ManagementResource) CreateUser(response http.ResponseWriter, request *ht
 }
 
 func (s ManagementResource) updateUser(response http.ResponseWriter, request *http.Request, user model.User) {
-	if err := s.db.UpdateUser(user); err != nil {
+	if err := s.db.UpdateUser(request.Context(), user); err != nil {
 		api.HandleDatabaseError(request, response, err)
 	} else {
 		response.WriteHeader(http.StatusOK)

--- a/cmd/api/src/api/v2/auth/auth_test.go
+++ b/cmd/api/src/api/v2/auth/auth_test.go
@@ -82,7 +82,7 @@ func TestManagementResource_PutUserAuthSecret(t *testing.T) {
 		}),
 	}, nil).Times(1)
 	mockDB.EXPECT().CreateAuthSecret(gomock.Any()).Return(model.AuthSecret{}, nil).Times(1)
-	mockDB.EXPECT().AppendAuditLog(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+	mockDB.EXPECT().AppendAuditLog(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 
 	// Happy path
 	test.Request(t).
@@ -141,7 +141,7 @@ func TestManagementResource_EnableUserSAML(t *testing.T) {
 	mockDB.EXPECT().GetUser(badUserID).Return(model.User{AuthSecret: &model.AuthSecret{}}, nil)
 	mockDB.EXPECT().GetUser(goodUserID).Return(model.User{}, nil)
 	mockDB.EXPECT().GetSAMLProvider(samlProviderID).Return(model.SAMLProvider{}, nil).Times(2)
-	mockDB.EXPECT().AppendAuditLog(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(5)
+	mockDB.EXPECT().AppendAuditLog(gomock.Any(), gomock.Any()).Return(nil).Times(5)
 	mockDB.EXPECT().UpdateUser(gomock.Any()).Return(nil).Times(2)
 	mockDB.EXPECT().DeleteAuthSecret(gomock.Any()).Return(nil)
 
@@ -206,12 +206,12 @@ func TestManagementResource_DeleteSAMLProvider(t *testing.T) {
 
 	mockDB.EXPECT().GetSAMLProvider(goodSAMLProvider.ID).Return(goodSAMLProvider, nil)
 	mockDB.EXPECT().GetSAMLProvider(samlProviderWithUsers.ID).Return(samlProviderWithUsers, nil)
-	mockDB.EXPECT().DeleteSAMLProvider(gomock.Eq(goodSAMLProvider)).Return(nil)
-	mockDB.EXPECT().DeleteSAMLProvider(gomock.Eq(samlProviderWithUsers)).Return(nil)
+	mockDB.EXPECT().DeleteSAMLProvider(gomock.Any(), gomock.Eq(goodSAMLProvider)).Return(nil)
+	mockDB.EXPECT().DeleteSAMLProvider(gomock.Any(), gomock.Eq(samlProviderWithUsers)).Return(nil)
 	mockDB.EXPECT().GetSAMLProviderUsers(goodSAMLProvider.ID).Return(nil, nil)
 	mockDB.EXPECT().GetSAMLProviderUsers(samlProviderWithUsers.ID).Return(model.Users{samlEnabledUser}, nil)
 	mockDB.EXPECT().UpdateUser(gomock.Eq(samlEnabledUser)).Return(nil)
-	mockDB.EXPECT().AppendAuditLog(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(3)
+	mockDB.EXPECT().AppendAuditLog(gomock.Any(), gomock.Any()).Return(nil).Times(3)
 
 	// Happy path
 	test.Request(t).
@@ -761,7 +761,7 @@ func TestExpireUserAuthSecret_Success(t *testing.T) {
 	resources, mockDB := apitest.NewAuthManagementResource(mockCtrl)
 
 	mockDB.EXPECT().GetUser(userId).Return(model.User{AuthSecret: &model.AuthSecret{}}, nil)
-	mockDB.EXPECT().AppendAuditLog(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+	mockDB.EXPECT().AppendAuditLog(gomock.Any(), gomock.Any()).Return(nil)
 	mockDB.EXPECT().UpdateAuthSecret(gomock.Any()).Return(nil)
 
 	ctx := context.WithValue(context.Background(), ctx.ValueKey, &ctx.Context{})
@@ -1060,7 +1060,7 @@ func TestCreateUser_Failure(t *testing.T) {
 	}, nil).AnyTimes()
 	mockDB.EXPECT().GetRoles(badRole).Return(model.Roles{}, fmt.Errorf("db error"))
 	mockDB.EXPECT().GetRoles(gomock.Not(badRole)).Return(model.Roles{}, nil).AnyTimes()
-	mockDB.EXPECT().AppendAuditLog(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	mockDB.EXPECT().AppendAuditLog(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	mockDB.EXPECT().CreateUser(badUser).Return(model.User{}, fmt.Errorf("db error"))
 
 	type Input struct {
@@ -1175,7 +1175,7 @@ func TestCreateUser_Success(t *testing.T) {
 		}),
 	}, nil)
 	mockDB.EXPECT().GetRoles(gomock.Any()).Return(model.Roles{}, nil)
-	mockDB.EXPECT().AppendAuditLog(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+	mockDB.EXPECT().AppendAuditLog(gomock.Any(), gomock.Any()).Return(nil)
 	mockDB.EXPECT().CreateUser(gomock.Any()).Return(goodUser, nil).AnyTimes()
 
 	ctx := context.WithValue(context.Background(), ctx.ValueKey, &ctx.Context{})
@@ -1229,7 +1229,7 @@ func TestCreateUser_ResetPassword(t *testing.T) {
 		}),
 	}, nil)
 	mockDB.EXPECT().GetRoles(gomock.Any()).Return(model.Roles{}, nil)
-	mockDB.EXPECT().AppendAuditLog(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+	mockDB.EXPECT().AppendAuditLog(gomock.Any(), gomock.Any()).Return(nil)
 	mockDB.EXPECT().CreateUser(gomock.Any()).Return(goodUser, nil)
 
 	input := struct {
@@ -1303,7 +1303,7 @@ func TestManagementResource_UpdateUser_IDMalformed(t *testing.T) {
 		}),
 	}, nil)
 	mockDB.EXPECT().GetRoles(gomock.Any()).Return(model.Roles{}, nil)
-	mockDB.EXPECT().AppendAuditLog(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+	mockDB.EXPECT().AppendAuditLog(gomock.Any(), gomock.Any()).Return(nil)
 	mockDB.EXPECT().CreateUser(gomock.Any()).Return(goodUser, nil).AnyTimes()
 
 	ctx := context.WithValue(context.Background(), ctx.ValueKey, &ctx.Context{})
@@ -1367,7 +1367,7 @@ func TestManagementResource_UpdateUser_GetUserError(t *testing.T) {
 		}),
 	}, nil)
 	mockDB.EXPECT().GetRoles(gomock.Any()).Return(model.Roles{}, nil)
-	mockDB.EXPECT().AppendAuditLog(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+	mockDB.EXPECT().AppendAuditLog(gomock.Any(), gomock.Any()).Return(nil)
 	mockDB.EXPECT().CreateUser(gomock.Any()).Return(goodUser, nil).AnyTimes()
 	mockDB.EXPECT().GetUser(gomock.Any()).Return(model.User{}, fmt.Errorf("foo"))
 
@@ -1432,7 +1432,7 @@ func TestManagementResource_UpdateUser_GetRolesError(t *testing.T) {
 		}),
 	}, nil)
 	mockDB.EXPECT().GetRoles(gomock.Any()).Return(model.Roles{}, nil)
-	mockDB.EXPECT().AppendAuditLog(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+	mockDB.EXPECT().AppendAuditLog(gomock.Any(), gomock.Any()).Return(nil)
 	mockDB.EXPECT().CreateUser(gomock.Any()).Return(goodUser, nil).AnyTimes()
 	mockDB.EXPECT().GetUser(gomock.Any()).Return(goodUser, nil)
 	mockDB.EXPECT().GetRoles(gomock.Any()).Return(model.Roles{}, fmt.Errorf("foo"))
@@ -1491,7 +1491,7 @@ func TestManagementResource_UpdateUser_SelfDisable(t *testing.T) {
 		}),
 	}, nil)
 	mockDB.EXPECT().GetRoles(gomock.Any()).Return(model.Roles{}, nil)
-	mockDB.EXPECT().AppendAuditLog(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+	mockDB.EXPECT().AppendAuditLog(gomock.Any(), gomock.Any()).Return(nil)
 	mockDB.EXPECT().CreateUser(gomock.Any()).Return(goodUser, nil).AnyTimes()
 	mockDB.EXPECT().GetUser(gomock.Any()).Return(goodUser, nil)
 	mockDB.EXPECT().GetRoles(gomock.Any()).Return(model.Roles{model.Role{
@@ -1573,7 +1573,7 @@ func TestManagementResource_UpdateUser_LookupActiveSessionsError(t *testing.T) {
 		}),
 	}, nil)
 	mockDB.EXPECT().GetRoles(gomock.Any()).Return(model.Roles{}, nil)
-	mockDB.EXPECT().AppendAuditLog(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+	mockDB.EXPECT().AppendAuditLog(gomock.Any(), gomock.Any()).Return(nil)
 	mockDB.EXPECT().CreateUser(gomock.Any()).Return(goodUser, nil).AnyTimes()
 	mockDB.EXPECT().GetUser(gomock.Any()).Return(goodUser, nil)
 	mockDB.EXPECT().GetRoles(gomock.Any()).Return(model.Roles{model.Role{
@@ -1655,7 +1655,7 @@ func TestManagementResource_UpdateUser_AppendAuditLogError(t *testing.T) {
 		}),
 	}, nil)
 	mockDB.EXPECT().GetRoles(gomock.Any()).Return(model.Roles{}, nil)
-	mockDB.EXPECT().AppendAuditLog(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+	mockDB.EXPECT().AppendAuditLog(gomock.Any(), gomock.Any()).Return(nil)
 	mockDB.EXPECT().CreateUser(gomock.Any()).Return(goodUser, nil).AnyTimes()
 	mockDB.EXPECT().GetUser(gomock.Any()).Return(goodUser, nil)
 	mockDB.EXPECT().GetRoles(gomock.Any()).Return(model.Roles{model.Role{
@@ -1668,7 +1668,7 @@ func TestManagementResource_UpdateUser_AppendAuditLogError(t *testing.T) {
 		}},
 		Serial: model.Serial{},
 	}}, nil)
-	mockDB.EXPECT().AppendAuditLog(gomock.Any(), gomock.Any(), gomock.Any()).Return(fmt.Errorf("foo"))
+	mockDB.EXPECT().AppendAuditLog(gomock.Any(), gomock.Any()).Return(fmt.Errorf("foo"))
 
 	ctx := context.WithValue(context.Background(), ctx.ValueKey, &ctx.Context{})
 	input := v2.CreateUserRequest{
@@ -1736,7 +1736,7 @@ func TestManagementResource_UpdateUser_DBError(t *testing.T) {
 		}),
 	}, nil)
 	mockDB.EXPECT().GetRoles(gomock.Any()).Return(model.Roles{}, nil)
-	mockDB.EXPECT().AppendAuditLog(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+	mockDB.EXPECT().AppendAuditLog(gomock.Any(), gomock.Any()).Return(nil)
 	mockDB.EXPECT().CreateUser(gomock.Any()).Return(goodUser, nil).AnyTimes()
 	mockDB.EXPECT().GetUser(gomock.Any()).Return(goodUser, nil)
 	mockDB.EXPECT().GetRoles(gomock.Any()).Return(model.Roles{model.Role{
@@ -1749,7 +1749,7 @@ func TestManagementResource_UpdateUser_DBError(t *testing.T) {
 		}},
 		Serial: model.Serial{},
 	}}, nil)
-	mockDB.EXPECT().AppendAuditLog(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+	mockDB.EXPECT().AppendAuditLog(gomock.Any(), gomock.Any()).Return(nil)
 	mockDB.EXPECT().UpdateUser(gomock.Any()).Return(fmt.Errorf("foo"))
 
 	ctx := context.WithValue(context.Background(), ctx.ValueKey, &ctx.Context{})
@@ -1820,7 +1820,7 @@ func TestManagementResource_UpdateUser_Success(t *testing.T) {
 		}),
 	}, nil)
 	mockDB.EXPECT().GetRoles(gomock.Any()).Return(model.Roles{}, nil)
-	mockDB.EXPECT().AppendAuditLog(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+	mockDB.EXPECT().AppendAuditLog(gomock.Any(), gomock.Any()).Return(nil)
 	mockDB.EXPECT().CreateUser(gomock.Any()).Return(goodUser, nil).AnyTimes()
 	mockDB.EXPECT().GetUser(gomock.Any()).Return(goodUser, nil)
 	mockDB.EXPECT().GetRoles(gomock.Any()).Return(model.Roles{model.Role{
@@ -1834,7 +1834,7 @@ func TestManagementResource_UpdateUser_Success(t *testing.T) {
 		Serial: model.Serial{},
 	}}, nil)
 	mockDB.EXPECT().LookupActiveSessionsByUser(gomock.Any()).Return([]model.UserSession{}, nil)
-	mockDB.EXPECT().AppendAuditLog(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+	mockDB.EXPECT().AppendAuditLog(gomock.Any(), gomock.Any()).Return(nil)
 	mockDB.EXPECT().UpdateUser(gomock.Any()).Return(nil)
 
 	ctx := context.WithValue(context.Background(), ctx.ValueKey, &ctx.Context{})

--- a/cmd/api/src/api/v2/auth/auth_test.go
+++ b/cmd/api/src/api/v2/auth/auth_test.go
@@ -140,7 +140,7 @@ func TestManagementResource_EnableUserSAML(t *testing.T) {
 	mockDB.EXPECT().GetUser(badUserID).Return(model.User{AuthSecret: &model.AuthSecret{}}, nil)
 	mockDB.EXPECT().GetUser(goodUserID).Return(model.User{}, nil)
 	mockDB.EXPECT().GetSAMLProvider(samlProviderID).Return(model.SAMLProvider{}, nil).Times(2)
-	mockDB.EXPECT().UpdateUser(gomock.Any()).Return(nil).Times(2)
+	mockDB.EXPECT().UpdateUser(gomock.Any(), gomock.Any()).Return(nil).Times(2)
 	mockDB.EXPECT().DeleteAuthSecret(gomock.Any()).Return(nil)
 
 	// Happy path
@@ -208,7 +208,7 @@ func TestManagementResource_DeleteSAMLProvider(t *testing.T) {
 	mockDB.EXPECT().DeleteSAMLProvider(gomock.Any(), gomock.Eq(samlProviderWithUsers)).Return(nil)
 	mockDB.EXPECT().GetSAMLProviderUsers(goodSAMLProvider.ID).Return(nil, nil)
 	mockDB.EXPECT().GetSAMLProviderUsers(samlProviderWithUsers.ID).Return(model.Users{samlEnabledUser}, nil)
-	mockDB.EXPECT().UpdateUser(gomock.Eq(samlEnabledUser)).Return(nil)
+	mockDB.EXPECT().UpdateUser(gomock.Any(), gomock.Eq(samlEnabledUser)).Return(nil)
 
 	// Happy path
 	test.Request(t).
@@ -1656,7 +1656,7 @@ func TestManagementResource_UpdateUser_DBError(t *testing.T) {
 		}},
 		Serial: model.Serial{},
 	}}, nil)
-	mockDB.EXPECT().UpdateUser(gomock.Any()).Return(fmt.Errorf("foo"))
+	mockDB.EXPECT().UpdateUser(gomock.Any(), gomock.Any()).Return(fmt.Errorf("foo"))
 
 	ctx := context.WithValue(context.Background(), ctx.ValueKey, &ctx.Context{})
 	input := v2.CreateUserRequest{
@@ -1739,7 +1739,7 @@ func TestManagementResource_UpdateUser_Success(t *testing.T) {
 		Serial: model.Serial{},
 	}}, nil)
 	mockDB.EXPECT().LookupActiveSessionsByUser(gomock.Any()).Return([]model.UserSession{}, nil)
-	mockDB.EXPECT().UpdateUser(gomock.Any()).Return(nil)
+	mockDB.EXPECT().UpdateUser(gomock.Any(), gomock.Any()).Return(nil)
 
 	ctx := context.WithValue(context.Background(), ctx.ValueKey, &ctx.Context{})
 	input := v2.CreateUserRequest{

--- a/cmd/api/src/api/v2/auth/login.go
+++ b/cmd/api/src/api/v2/auth/login.go
@@ -1,22 +1,23 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 package auth
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"strings"
@@ -73,7 +74,7 @@ func (s LoginResource) Login(response http.ResponseWriter, request *http.Request
 
 	if err := api.ReadJSONRequestPayloadLimited(&loginRequest, request); err != nil {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, err.Error(), request), response)
-	} else if err = s.patchEULAAcceptance(loginRequest.Username); err != nil {
+	} else if err = s.patchEULAAcceptance(request.Context(), loginRequest.Username); err != nil {
 		api.HandleDatabaseError(request, response, err)
 	} else {
 		switch strings.ToLower(loginRequest.LoginMethod) {
@@ -87,12 +88,12 @@ func (s LoginResource) Login(response http.ResponseWriter, request *http.Request
 }
 
 // EULA Acceptance does not pertain to Bloodhound Community Edition; this flag is used for Bloodhound Enterprise users.
-func (s LoginResource) patchEULAAcceptance(username string) error {
+func (s LoginResource) patchEULAAcceptance(ctx context.Context, username string) error {
 	if user, err := s.db.LookupUser(username); err != nil {
 		return err
 	} else {
 		user.EULAAccepted = true
-		if err = s.db.UpdateUser(user); err != nil {
+		if err = s.db.UpdateUser(ctx, user); err != nil {
 			return err
 		}
 	}

--- a/cmd/api/src/api/v2/auth/login_internal_test.go
+++ b/cmd/api/src/api/v2/auth/login_internal_test.go
@@ -1,17 +1,17 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 package auth
@@ -89,7 +89,7 @@ func TestLoginFailure(t *testing.T) {
 	mockAuthenticator.EXPECT().LoginWithSecret(gomock.Any(), req3).Return(api.LoginDetails{User: model.User{EULAAccepted: true}}, fmt.Errorf("db error"))
 	mockAuthenticator.EXPECT().LoginWithSecret(gomock.Any(), req4).Return(api.LoginDetails{User: model.User{EULAAccepted: true}}, api.ErrUserDisabled)
 	mockDB.EXPECT().LookupUser(gomock.Any()).Return(model.User{EULAAccepted: false}, nil).Times(5)
-	mockDB.EXPECT().UpdateUser(gomock.Any()).Return(nil).Times(5)
+	mockDB.EXPECT().UpdateUser(gomock.Any(), gomock.Any()).Return(nil).Times(5)
 
 	resources := NewLoginResource(config.Configuration{}, mockAuthenticator, mockDB)
 
@@ -211,7 +211,7 @@ func TestLoginSuccess(t *testing.T) {
 	mockAuthenticator := api_mocks.NewMockAuthenticator(mockCtrl)
 	mockAuthenticator.EXPECT().LoginWithSecret(gomock.Any(), input).Return(api.LoginDetails{User: model.User{AuthSecret: &model.AuthSecret{}, EULAAccepted: true}, SessionToken: "imasessiontoken"}, nil)
 	mockDB.EXPECT().LookupUser(gomock.Any()).Return(model.User{EULAAccepted: false}, nil)
-	mockDB.EXPECT().UpdateUser(gomock.Any()).Return(nil)
+	mockDB.EXPECT().UpdateUser(gomock.Any(), gomock.Any()).Return(nil)
 
 	resources := NewLoginResource(config.Configuration{}, mockAuthenticator, mockDB)
 

--- a/cmd/api/src/api/v2/auth/login_test.go
+++ b/cmd/api/src/api/v2/auth/login_test.go
@@ -1,17 +1,17 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 package auth
@@ -63,7 +63,7 @@ func TestLoginExpiry(t *testing.T) {
 	mockAuthenticator.EXPECT().LoginWithSecret(gomock.Any(), req1).Return(api.LoginDetails{User: model.User{AuthSecret: &model.AuthSecret{ExpiresAt: time.Now().UTC().Add(time.Hour * 24)}, EULAAccepted: true}, SessionToken: "imasession"}, nil)
 	mockAuthenticator.EXPECT().LoginWithSecret(gomock.Any(), req2).Return(api.LoginDetails{User: model.User{AuthSecret: &model.AuthSecret{ExpiresAt: time.Now().UTC().Add(time.Hour * 24 * -1)}, EULAAccepted: true}, SessionToken: "imasession"}, nil)
 	mockDB.EXPECT().LookupUser(gomock.Any()).Return(model.User{EULAAccepted: false}, nil).Times(2)
-	mockDB.EXPECT().UpdateUser(gomock.Any()).Return(nil).Times(2)
+	mockDB.EXPECT().UpdateUser(gomock.Any(), gomock.Any()).Return(nil).Times(2)
 
 	resources := NewLoginResource(config.Configuration{}, mockAuthenticator, mockDB)
 

--- a/cmd/api/src/api/v2/integration/audit.go
+++ b/cmd/api/src/api/v2/integration/audit.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/specterops/bloodhound/src/model"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -37,13 +38,13 @@ func (s *Context) ListAuditLogs(after, before time.Time, offset, limit int) mode
 }
 
 func (s *Context) AssetAuditLog(auditLog model.AuditLog, expectedAction string, expectedFields map[string]any) {
-	require.Equal(s.TestCtrl, auditLog.Action, expectedAction)
+	assert.Equal(s.TestCtrl, auditLog.Action, expectedAction)
 
 	for expectedFieldName, expectedFieldValue := range expectedFields {
 		actualFieldValue, hasField := auditLog.Fields[expectedFieldName]
 
-		require.True(s.TestCtrl, hasField)
-		require.Equal(s.TestCtrl, expectedFieldValue, actualFieldValue)
+		assert.True(s.TestCtrl, hasField)
+		assert.Equal(s.TestCtrl, expectedFieldValue, actualFieldValue)
 	}
 }
 

--- a/cmd/api/src/database/agi.go
+++ b/cmd/api/src/database/agi.go
@@ -17,6 +17,7 @@
 package database
 
 import (
+	"context"
 	"time"
 
 	"gorm.io/gorm"
@@ -26,22 +27,40 @@ import (
 	"github.com/specterops/bloodhound/src/model"
 )
 
-func (s *BloodhoundDB) CreateAssetGroup(name, tag string, systemGroup bool) (model.AssetGroup, error) {
-	assetGroup := model.AssetGroup{
-		Name:        name,
-		Tag:         tag,
-		SystemGroup: systemGroup,
-	}
+func (s *BloodhoundDB) CreateAssetGroup(ctx context.Context, name, tag string, systemGroup bool) (model.AssetGroup, error) {
+	var (
+		assetGroup = model.AssetGroup{
+			Name:        name,
+			Tag:         tag,
+			SystemGroup: systemGroup,
+		}
 
-	return assetGroup, CheckError(s.db.Create(&assetGroup))
+		auditEntry = model.AuditEntry{
+			Action: "Create Asset Group",
+			Model:  assetGroup.AuditData(),
+		}
+	)
+
+	return assetGroup, s.AuditableTransaction(ctx, auditEntry, func(tx *gorm.DB) error {
+		return CheckError(tx.Create(&assetGroup))
+	})
 }
 
 func (s *BloodhoundDB) UpdateAssetGroup(assetGroup model.AssetGroup) error {
 	return CheckError(s.db.Save(&assetGroup))
 }
 
-func (s *BloodhoundDB) DeleteAssetGroup(assetGroup model.AssetGroup) error {
-	return CheckError(s.db.Delete(&assetGroup))
+func (s *BloodhoundDB) DeleteAssetGroup(ctx context.Context, assetGroup model.AssetGroup) error {
+	var (
+		auditEntry = model.AuditEntry{
+			Action: "Delete Asset Group",
+			Model:  assetGroup.AuditData(),
+		}
+	)
+
+	return s.AuditableTransaction(ctx, auditEntry, func(tx *gorm.DB) error {
+		return CheckError(tx.Delete(&assetGroup))
+	})
 }
 
 func (s *BloodhoundDB) GetAssetGroup(id int32) (model.AssetGroup, error) {

--- a/cmd/api/src/database/agi.go
+++ b/cmd/api/src/database/agi.go
@@ -36,7 +36,7 @@ func (s *BloodhoundDB) CreateAssetGroup(ctx context.Context, name, tag string, s
 		}
 
 		auditEntry = model.AuditEntry{
-			Action: "Create Asset Group",
+			Action: "CreateAssetGroup",
 			Model:  assetGroup.AuditData(),
 		}
 	)
@@ -53,7 +53,7 @@ func (s *BloodhoundDB) UpdateAssetGroup(assetGroup model.AssetGroup) error {
 func (s *BloodhoundDB) DeleteAssetGroup(ctx context.Context, assetGroup model.AssetGroup) error {
 	var (
 		auditEntry = model.AuditEntry{
-			Action: "Delete Asset Group",
+			Action: "DeleteAssetGroup",
 			Model:  assetGroup.AuditData(),
 		}
 	)
@@ -236,12 +236,6 @@ func (s *BloodhoundDB) UpdateAssetGroupSelectors(ctx ctx.Context, assetGroup mod
 					})
 				}
 			}
-
-			// TODO: complex audit log transform
-			// ctx.AuditCtx = model.AuditContext{Action: "UpdateAssetGroupSelectors", Model: selectorSpec}
-			// if err := s.AppendAuditLog(ctx, "", selectorSpec); err != nil {
-			// 	return err
-			// }
 		}
 
 		return nil

--- a/cmd/api/src/database/audit.go
+++ b/cmd/api/src/database/audit.go
@@ -61,7 +61,7 @@ func newAuditLog(context context.Context, entry model.AuditEntry, idResolver aut
 }
 
 func (s *BloodhoundDB) AppendAuditLog(ctx context.Context, entry model.AuditEntry) error {
-	if auditLog, err := newAuditLog(ctx, entry, s.idResolver); err != nil {
+	if auditLog, err := newAuditLog(ctx, entry, s.idResolver); err != nil && err != ErrAuthContextInvalid {
 		return fmt.Errorf("audit log append: %w", err)
 	} else {
 		return CheckError(s.db.Create(&auditLog))

--- a/cmd/api/src/database/audit.go
+++ b/cmd/api/src/database/audit.go
@@ -44,6 +44,7 @@ func newAuditLog(context context.Context, entry model.AuditEntry, idResolver aut
 		RequestID: bheCtx.RequestID,
 		Source:    bheCtx.RequestIP,
 		Status:    string(entry.Status),
+		CommitID:  entry.CommitID,
 	}
 
 	authContext := bheCtx.AuthCtx

--- a/cmd/api/src/database/audit_test.go
+++ b/cmd/api/src/database/audit_test.go
@@ -55,7 +55,7 @@ func TestDatabase_ListAuditLogs(t *testing.T) {
 		},
 	}
 	for i := 0; i < 7; i++ {
-		if err := dbInst.AppendAuditLog(ctx.Set(context.Background(), &mockCtx), model.AuditEntry{Model: model.User{}, Action: "Create User", Status: model.AuditStatusSuccess}); err != nil {
+		if err := dbInst.AppendAuditLog(ctx.Set(context.Background(), &mockCtx), model.AuditEntry{Model: &model.User{}, Action: "Create User", Status: model.AuditStatusSuccess}); err != nil {
 			t.Fatalf("Error creating audit log: %v", err)
 		}
 	}

--- a/cmd/api/src/database/audit_test.go
+++ b/cmd/api/src/database/audit_test.go
@@ -20,6 +20,7 @@
 package database_test
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -54,7 +55,7 @@ func TestDatabase_ListAuditLogs(t *testing.T) {
 		},
 	}
 	for i := 0; i < 7; i++ {
-		if err := dbInst.AppendAuditLog(mockCtx, model.AuditEntry{Model: model.User{}, Action: "Create User", Status: model.AuditStatusSuccess}); err != nil {
+		if err := dbInst.AppendAuditLog(ctx.Set(context.Background(), &mockCtx), model.AuditEntry{Model: model.User{}, Action: "Create User", Status: model.AuditStatusSuccess}); err != nil {
 			t.Fatalf("Error creating audit log: %v", err)
 		}
 	}

--- a/cmd/api/src/database/audit_test.go
+++ b/cmd/api/src/database/audit_test.go
@@ -20,12 +20,13 @@
 package database_test
 
 import (
+	"testing"
+	"time"
+
 	"github.com/specterops/bloodhound/src/auth"
 	"github.com/specterops/bloodhound/src/ctx"
 	"github.com/specterops/bloodhound/src/model"
 	"github.com/specterops/bloodhound/src/test/integration"
-	"testing"
-	"time"
 )
 
 func TestDatabase_ListAuditLogs(t *testing.T) {
@@ -53,7 +54,7 @@ func TestDatabase_ListAuditLogs(t *testing.T) {
 		},
 	}
 	for i := 0; i < 7; i++ {
-		if err := dbInst.AppendAuditLog(mockCtx, "CreateUser", model.User{}); err != nil {
+		if err := dbInst.AppendAuditLog(mockCtx, model.AuditEntry{Model: model.User{}, Action: "Create User", Status: model.AuditStatusSuccess}); err != nil {
 			t.Fatalf("Error creating audit log: %v", err)
 		}
 	}

--- a/cmd/api/src/database/audit_test.go
+++ b/cmd/api/src/database/audit_test.go
@@ -55,7 +55,7 @@ func TestDatabase_ListAuditLogs(t *testing.T) {
 		},
 	}
 	for i := 0; i < 7; i++ {
-		if err := dbInst.AppendAuditLog(ctx.Set(context.Background(), &mockCtx), model.AuditEntry{Model: &model.User{}, Action: "Create User", Status: model.AuditStatusSuccess}); err != nil {
+		if err := dbInst.AppendAuditLog(ctx.Set(context.Background(), &mockCtx), model.AuditEntry{Model: &model.User{}, Action: "CreateUser", Status: model.AuditStatusSuccess}); err != nil {
 			t.Fatalf("Error creating audit log: %v", err)
 		}
 	}

--- a/cmd/api/src/database/auth.go
+++ b/cmd/api/src/database/auth.go
@@ -1,32 +1,33 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 package database
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/base64"
 	"fmt"
 	"strings"
 	"time"
 
+	"github.com/gofrs/uuid"
 	"github.com/specterops/bloodhound/src/auth"
 	"github.com/specterops/bloodhound/src/database/types/null"
 	"github.com/specterops/bloodhound/src/model"
-	"github.com/gofrs/uuid"
 	"gorm.io/gorm"
 )
 
@@ -597,7 +598,7 @@ func (s *BloodhoundDB) GetSAMLProvider(id int32) (model.SAMLProvider, error) {
 	return samlProvider, CheckError(result)
 }
 
-func (s *BloodhoundDB) DeleteSAMLProvider(provider model.SAMLProvider) error {
+func (s *BloodhoundDB) DeleteSAMLProvider(ctx context.Context, provider model.SAMLProvider) error {
 	return CheckError(s.db.Delete(&provider))
 }
 

--- a/cmd/api/src/database/auth.go
+++ b/cmd/api/src/database/auth.go
@@ -364,7 +364,7 @@ func (s *BloodhoundDB) CreateUser(user model.User) (model.User, error) {
 func (s *BloodhoundDB) UpdateUser(ctx context.Context, user model.User) error {
 	var (
 		auditEntry = model.AuditEntry{
-			Action: "Update User",
+			Action: "UpdateUser",
 			Model:  user.AuditData(),
 		}
 	)
@@ -610,7 +610,7 @@ func (s *BloodhoundDB) GetSAMLProvider(id int32) (model.SAMLProvider, error) {
 func (s *BloodhoundDB) DeleteSAMLProvider(ctx context.Context, provider model.SAMLProvider) error {
 	var (
 		auditEntry = model.AuditEntry{
-			Action: "Delete SAML Provider",
+			Action: "DeleteSAMLProvider",
 			Model:  provider.AuditData(),
 		}
 	)

--- a/cmd/api/src/database/auth.go
+++ b/cmd/api/src/database/auth.go
@@ -616,7 +616,7 @@ func (s *BloodhoundDB) DeleteSAMLProvider(ctx context.Context, provider model.SA
 	)
 
 	return s.AuditableTransaction(ctx, auditEntry, func(tx *gorm.DB) error {
-		return CheckError(s.db.Delete(&provider))
+		return CheckError(tx.Delete(&provider))
 	})
 }
 

--- a/cmd/api/src/database/auth_test.go
+++ b/cmd/api/src/database/auth_test.go
@@ -20,6 +20,7 @@
 package database_test
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -219,7 +220,7 @@ func TestDatabase_CreateGetUser(t *testing.T) {
 
 			newUser.Roles = newUser.Roles.RemoveByName(roleToDelete)
 
-			if err := dbInst.UpdateUser(newUser); err != nil {
+			if err := dbInst.UpdateUser(context.TODO(), newUser); err != nil {
 				t.Fatalf("Failed to update user: %v", err)
 			}
 
@@ -328,7 +329,7 @@ func TestDatabase_CreateSAMLProvider(t *testing.T) {
 	} else {
 		user.SAMLProviderID = null.Int32From(newSAMLProvider.ID)
 
-		if err := dbInst.UpdateUser(user); err != nil {
+		if err := dbInst.UpdateUser(context.TODO(), user); err != nil {
 			t.Fatalf("Failed to update user: %v", err)
 		} else if updatedUser, err := dbInst.GetUser(user.ID); err != nil {
 			t.Fatalf("Failed to fetch updated user: %v", err)

--- a/cmd/api/src/database/db.go
+++ b/cmd/api/src/database/db.go
@@ -19,6 +19,7 @@ package database
 //go:generate go run go.uber.org/mock/mockgen -copyright_file=../../../../LICENSE.header -destination=./mocks/db.go -package=mocks . Database
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -82,7 +83,7 @@ type Database interface {
 	RawFirst(value any) error
 	Wipe() error
 	Migrate() error
-	AppendAuditLog(ctx ctx.Context, action string, data model.Auditable) error
+	AppendAuditLog(ctx ctx.Context, entry model.AuditEntry) error
 	ListAuditLogs(before, after time.Time, offset, limit int, order string, filter model.SQLFilter) (model.AuditLogs, int, error)
 	CreateRole(role model.Role) (model.Role, error)
 	UpdateRole(role model.Role) error
@@ -122,7 +123,7 @@ type Database interface {
 	GetAllSAMLProviders() (model.SAMLProviders, error)
 	GetSAMLProvider(id int32) (model.SAMLProvider, error)
 	GetSAMLProviderUsers(id int32) (model.Users, error)
-	DeleteSAMLProvider(samlProvider model.SAMLProvider) error
+	DeleteSAMLProvider(ctx context.Context, samlProvider model.SAMLProvider) error
 	CreateUserSession(userSession model.UserSession) (model.UserSession, error)
 	LookupActiveSessionsByUser(user model.User) ([]model.UserSession, error)
 	EndUserSession(userSession model.UserSession)

--- a/cmd/api/src/database/db.go
+++ b/cmd/api/src/database/db.go
@@ -83,7 +83,7 @@ type Database interface {
 	RawFirst(value any) error
 	Wipe() error
 	Migrate() error
-	AppendAuditLog(ctx ctx.Context, entry model.AuditEntry) error
+	AppendAuditLog(ctx context.Context, entry model.AuditEntry) error
 	ListAuditLogs(before, after time.Time, offset, limit int, order string, filter model.SQLFilter) (model.AuditLogs, int, error)
 	CreateRole(role model.Role) (model.Role, error)
 	UpdateRole(role model.Role) error
@@ -101,7 +101,7 @@ type Database interface {
 	GetInstallation() (model.Installation, error)
 	HasInstallation() (bool, error)
 	CreateUser(user model.User) (model.User, error)
-	UpdateUser(user model.User) error
+	UpdateUser(ctx context.Context, user model.User) error
 	GetAllUsers(order string, filter model.SQLFilter) (model.Users, error)
 	GetUser(id uuid.UUID) (model.User, error)
 	DeleteUser(user model.User) error

--- a/cmd/api/src/database/db.go
+++ b/cmd/api/src/database/db.go
@@ -61,9 +61,9 @@ type Database interface {
 	DeleteIngestTask(ingestTask model.IngestTask) error
 	GetIngestTasksForJob(jobID int64) (model.IngestTasks, error)
 	GetUnfinishedIngestIDs() ([]int64, error)
-	CreateAssetGroup(name, tag string, systemGroup bool) (model.AssetGroup, error)
+	CreateAssetGroup(ctx context.Context, name, tag string, systemGroup bool) (model.AssetGroup, error)
 	UpdateAssetGroup(assetGroup model.AssetGroup) error
-	DeleteAssetGroup(assetGroup model.AssetGroup) error
+	DeleteAssetGroup(ctx context.Context, assetGroup model.AssetGroup) error
 	GetAssetGroup(id int32) (model.AssetGroup, error)
 	GetAllAssetGroups(order string, filter model.SQLFilter) (model.AssetGroups, error)
 	SweepAssetGroupCollections()

--- a/cmd/api/src/database/migration/migrations/v5.6.0.sql
+++ b/cmd/api/src/database/migration/migrations/v5.6.0.sql
@@ -1,0 +1,9 @@
+ALTER TABLE IF EXISTS audit_logs
+DROP CONSTRAINT IF EXISTS audit_logs_status_check;
+
+ALTER TABLE IF EXISTS audit_logs
+ADD CONSTRAINT status_check
+CHECK (status IN ('intent', 'success', 'failure'));
+
+ALTER TABLE IF EXISTS audit_logs
+ALTER COLUMN status SET DEFAULT 'intent';

--- a/cmd/api/src/database/migration/migrations/v5.6.0.sql
+++ b/cmd/api/src/database/migration/migrations/v5.6.0.sql
@@ -1,9 +1,6 @@
 ALTER TABLE IF EXISTS audit_logs
-DROP CONSTRAINT IF EXISTS audit_logs_status_check;
-
-ALTER TABLE IF EXISTS audit_logs
+DROP CONSTRAINT IF EXISTS audit_logs_status_check,
 ADD CONSTRAINT status_check
-CHECK (status IN ('intent', 'success', 'failure'));
-
-ALTER TABLE IF EXISTS audit_logs
-ALTER COLUMN status SET DEFAULT 'intent';
+CHECK (status IN ('intent', 'success', 'failure')),
+ALTER COLUMN status SET DEFAULT 'intent',
+ADD COLUMN IF NOT EXISTS commit_id TEXT;

--- a/cmd/api/src/database/mocks/db.go
+++ b/cmd/api/src/database/mocks/db.go
@@ -21,6 +21,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 	time "time"
 
@@ -55,17 +56,17 @@ func (m *MockDatabase) EXPECT() *MockDatabaseMockRecorder {
 }
 
 // AppendAuditLog mocks base method.
-func (m *MockDatabase) AppendAuditLog(arg0 ctx.Context, arg1 string, arg2 model.Auditable) error {
+func (m *MockDatabase) AppendAuditLog(arg0 ctx.Context, arg1 model.AuditEntry) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AppendAuditLog", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "AppendAuditLog", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // AppendAuditLog indicates an expected call of AppendAuditLog.
-func (mr *MockDatabaseMockRecorder) AppendAuditLog(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockDatabaseMockRecorder) AppendAuditLog(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppendAuditLog", reflect.TypeOf((*MockDatabase)(nil).AppendAuditLog), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppendAuditLog", reflect.TypeOf((*MockDatabase)(nil).AppendAuditLog), arg0, arg1)
 }
 
 // Close mocks base method.
@@ -435,17 +436,17 @@ func (mr *MockDatabaseMockRecorder) DeleteIngestTask(arg0 interface{}) *gomock.C
 }
 
 // DeleteSAMLProvider mocks base method.
-func (m *MockDatabase) DeleteSAMLProvider(arg0 model.SAMLProvider) error {
+func (m *MockDatabase) DeleteSAMLProvider(arg0 context.Context, arg1 model.SAMLProvider) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteSAMLProvider", arg0)
+	ret := m.ctrl.Call(m, "DeleteSAMLProvider", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteSAMLProvider indicates an expected call of DeleteSAMLProvider.
-func (mr *MockDatabaseMockRecorder) DeleteSAMLProvider(arg0 interface{}) *gomock.Call {
+func (mr *MockDatabaseMockRecorder) DeleteSAMLProvider(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSAMLProvider", reflect.TypeOf((*MockDatabase)(nil).DeleteSAMLProvider), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSAMLProvider", reflect.TypeOf((*MockDatabase)(nil).DeleteSAMLProvider), arg0, arg1)
 }
 
 // DeleteSavedQuery mocks base method.

--- a/cmd/api/src/database/mocks/db.go
+++ b/cmd/api/src/database/mocks/db.go
@@ -112,18 +112,18 @@ func (mr *MockDatabaseMockRecorder) CreateADDataQualityStats(arg0 interface{}) *
 }
 
 // CreateAssetGroup mocks base method.
-func (m *MockDatabase) CreateAssetGroup(arg0, arg1 string, arg2 bool) (model.AssetGroup, error) {
+func (m *MockDatabase) CreateAssetGroup(arg0 context.Context, arg1, arg2 string, arg3 bool) (model.AssetGroup, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateAssetGroup", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "CreateAssetGroup", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(model.AssetGroup)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateAssetGroup indicates an expected call of CreateAssetGroup.
-func (mr *MockDatabaseMockRecorder) CreateAssetGroup(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockDatabaseMockRecorder) CreateAssetGroup(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAssetGroup", reflect.TypeOf((*MockDatabase)(nil).CreateAssetGroup), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAssetGroup", reflect.TypeOf((*MockDatabase)(nil).CreateAssetGroup), arg0, arg1, arg2, arg3)
 }
 
 // CreateAssetGroupCollection mocks base method.
@@ -366,17 +366,17 @@ func (mr *MockDatabaseMockRecorder) CreateUserSession(arg0 interface{}) *gomock.
 }
 
 // DeleteAssetGroup mocks base method.
-func (m *MockDatabase) DeleteAssetGroup(arg0 model.AssetGroup) error {
+func (m *MockDatabase) DeleteAssetGroup(arg0 context.Context, arg1 model.AssetGroup) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteAssetGroup", arg0)
+	ret := m.ctrl.Call(m, "DeleteAssetGroup", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteAssetGroup indicates an expected call of DeleteAssetGroup.
-func (mr *MockDatabaseMockRecorder) DeleteAssetGroup(arg0 interface{}) *gomock.Call {
+func (mr *MockDatabaseMockRecorder) DeleteAssetGroup(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAssetGroup", reflect.TypeOf((*MockDatabase)(nil).DeleteAssetGroup), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAssetGroup", reflect.TypeOf((*MockDatabase)(nil).DeleteAssetGroup), arg0, arg1)
 }
 
 // DeleteAssetGroupSelector mocks base method.

--- a/cmd/api/src/database/mocks/db.go
+++ b/cmd/api/src/database/mocks/db.go
@@ -56,7 +56,7 @@ func (m *MockDatabase) EXPECT() *MockDatabaseMockRecorder {
 }
 
 // AppendAuditLog mocks base method.
-func (m *MockDatabase) AppendAuditLog(arg0 ctx.Context, arg1 model.AuditEntry) error {
+func (m *MockDatabase) AppendAuditLog(arg0 context.Context, arg1 model.AuditEntry) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AppendAuditLog", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -1485,17 +1485,17 @@ func (mr *MockDatabaseMockRecorder) UpdateSAMLIdentityProvider(arg0 interface{})
 }
 
 // UpdateUser mocks base method.
-func (m *MockDatabase) UpdateUser(arg0 model.User) error {
+func (m *MockDatabase) UpdateUser(arg0 context.Context, arg1 model.User) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateUser", arg0)
+	ret := m.ctrl.Call(m, "UpdateUser", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpdateUser indicates an expected call of UpdateUser.
-func (mr *MockDatabaseMockRecorder) UpdateUser(arg0 interface{}) *gomock.Call {
+func (mr *MockDatabaseMockRecorder) UpdateUser(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateUser", reflect.TypeOf((*MockDatabase)(nil).UpdateUser), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateUser", reflect.TypeOf((*MockDatabase)(nil).UpdateUser), arg0, arg1)
 }
 
 // Wipe mocks base method.

--- a/cmd/api/src/model/audit.go
+++ b/cmd/api/src/model/audit.go
@@ -23,10 +23,12 @@ import (
 	"github.com/specterops/bloodhound/src/database/types"
 )
 
+type AuditEntryStatus string
+
 const (
-	AuditStatusSuccess = "success"
-	AuditStatusFailure = "failure"
-	AuditStatusIntent  = "intent"
+	AuditStatusSuccess AuditEntryStatus = "success"
+	AuditStatusFailure AuditEntryStatus = "failure"
+	AuditStatusIntent  AuditEntryStatus = "intent"
 )
 
 type AuditLog struct {
@@ -146,6 +148,6 @@ type Auditable interface {
 type AuditEntry struct {
 	Action   string
 	Model    Auditable
-	Status   string
+	Status   AuditEntryStatus
 	ErrorMsg string
 }

--- a/cmd/api/src/model/audit.go
+++ b/cmd/api/src/model/audit.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/gofrs/uuid"
 	"github.com/specterops/bloodhound/src/database/types"
 )
 
@@ -146,6 +147,7 @@ type Auditable interface {
 }
 
 type AuditEntry struct {
+	CommitID uuid.UUID
 	Action   string
 	Model    Auditable
 	Status   AuditEntryStatus

--- a/cmd/api/src/model/audit.go
+++ b/cmd/api/src/model/audit.go
@@ -26,6 +26,7 @@ import (
 const (
 	AuditStatusSuccess = "success"
 	AuditStatusFailure = "failure"
+	AuditStatusIntent  = "intent"
 )
 
 type AuditLog struct {
@@ -142,17 +143,9 @@ type Auditable interface {
 	AuditData() AuditData
 }
 
-type AuditContext struct {
+type AuditEntry struct {
 	Action   string
 	Model    Auditable
 	Status   string
 	ErrorMsg string
-}
-
-func (s *AuditContext) SetStatus(statusCode int) {
-	if statusCode >= 200 && statusCode < 300 {
-		s.Status = AuditStatusSuccess
-	} else {
-		s.Status = AuditStatusFailure
-	}
 }

--- a/cmd/api/src/model/audit.go
+++ b/cmd/api/src/model/audit.go
@@ -43,6 +43,7 @@ type AuditLog struct {
 	RequestID  string                  `json:"request_id"`
 	Source     string                  `json:"source"`
 	Status     string                  `json:"status"`
+	CommitID   uuid.UUID               `json:"commit_id" gorm:"type:text"`
 }
 
 func (s AuditLog) String() string {

--- a/cmd/api/src/model/auth.go
+++ b/cmd/api/src/model/auth.go
@@ -1,17 +1,17 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 package model
@@ -21,9 +21,9 @@ import (
 	"net/url"
 	"time"
 
+	"github.com/gofrs/uuid"
 	"github.com/specterops/bloodhound/src/database/types/null"
 	"github.com/specterops/bloodhound/src/serde"
-	"github.com/gofrs/uuid"
 )
 
 const PermissionURIScheme = "permission"
@@ -460,18 +460,13 @@ type User struct {
 	Unique
 }
 
-func (s User) AuditData() AuditData {
-	data := AuditData{
-		"id":             s.ID,
-		"principal_name": s.PrincipalName,
-		"roles":          s.Roles.IDs(),
+func (s *User) AuditData() AuditData {
+	return AuditData{
+		"id":               s.ID,
+		"principal_name":   s.PrincipalName,
+		"roles":            s.Roles.IDs(),
+		"saml_provider_id": s.SAMLProviderID.ValueOrZero(),
 	}
-
-	if s.SAMLProviderID.Valid {
-		data["saml_provider_id"] = s.SAMLProviderID
-	}
-
-	return data
 }
 
 func (s *User) RemoveRole(role Role) {

--- a/local-harnesses/build.config.json.template
+++ b/local-harnesses/build.config.json.template
@@ -7,6 +7,8 @@
     "collectors_base_path": "/bhapi/collectors",
     "log_level": "INFO",
     "log_path": "bhapi.log",
+    "enable_startup_wait_period": false,
+    "datapipe_interval": 1,
     "features": {
         "enable_auth": true
     },

--- a/local-harnesses/integration.config.json.template
+++ b/local-harnesses/integration.config.json.template
@@ -7,6 +7,8 @@
     "collectors_base_path": "/tmp/collectors",
     "log_level": "ERROR",
     "log_path": "bhapi.log",
+    "enable_startup_wait_period": false,
+    "datapipe_interval": 1,
     "features": {
         "enable_auth": true
     },


### PR DESCRIPTION
## Description

Steel Thread for Audit Logging

## Motivation and Context

We needed to change our approach to audit logging. This contains the first 4 DB methods to get audit logging to use as reference for our other priority 1 audit enabled methods.

## How Has This Been Tested?

Existing tests were modified as necessary, but generally kept as close to the originals as possible. Passing tests means there's good confidence that these changes are correct, but additional testing should be completed before the main `populate-audit-log-fields` gets merged.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [x] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] My changes include a database migration.
