### PR TITLE
fix: read only missing AuthCreateToken

### DIFF
--- a/cmd/api/src/auth/role.go
+++ b/cmd/api/src/auth/role.go
@@ -73,6 +73,7 @@ func Roles() map[string]RoleTemplate {
 			Permissions: model.Permissions{
 				permissions.AppReadApplicationConfiguration,
 				permissions.APsGenerateReport,
+				permissions.AuthCreateToken,
 				permissions.AuthManageSelf,
 				permissions.GraphDBRead,
 			},


### PR DESCRIPTION
## Description
It was determined after https://github.com/SpecterOps/BloodHound/pull/343 was merged that the ReadOnly role lacks the ability to manage their own auth tokens.

## Motivation and Context

The ReadOnly role should have access to manage own auth tokens.

## How Has This Been Tested?

A new integration test was added

## Types of changes

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [x] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
