### PR TITLE
feat: BED-4099 - Provide Configurable Auth Session TTL

### DIFF
--- a/cmd/api/src/api/auth.go
+++ b/cmd/api/src/api/auth.go
@@ -274,7 +274,7 @@ func (s authenticator) CreateSession(user model.User, authProvider any) (string,
 	userSession := model.UserSession{
 		User:      user,
 		UserID:    user.ID,
-		ExpiresAt: time.Now().UTC().Add(auth.SessionTTL),
+		ExpiresAt: time.Now().UTC().Add(s.cfg.AuthSessionTTL()),
 	}
 
 	switch typedAuthProvider := authProvider.(type) {

--- a/cmd/api/src/api/saml/saml.go
+++ b/cmd/api/src/api/saml/saml.go
@@ -1,17 +1,17 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 package saml
@@ -26,13 +26,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/specterops/bloodhound/src/api"
-	"github.com/specterops/bloodhound/src/auth"
-	"github.com/specterops/bloodhound/src/auth/bhsaml"
-	"github.com/specterops/bloodhound/src/config"
-	"github.com/specterops/bloodhound/src/ctx"
-	"github.com/specterops/bloodhound/src/database"
-	"github.com/specterops/bloodhound/src/model"
 	"github.com/crewjam/saml"
 	"github.com/crewjam/saml/samlsp"
 	"github.com/gorilla/mux"
@@ -40,6 +33,12 @@ import (
 	"github.com/specterops/bloodhound/headers"
 	"github.com/specterops/bloodhound/log"
 	"github.com/specterops/bloodhound/mediatypes"
+	"github.com/specterops/bloodhound/src/api"
+	"github.com/specterops/bloodhound/src/auth/bhsaml"
+	"github.com/specterops/bloodhound/src/config"
+	"github.com/specterops/bloodhound/src/ctx"
+	"github.com/specterops/bloodhound/src/database"
+	"github.com/specterops/bloodhound/src/model"
 )
 
 const (
@@ -430,7 +429,7 @@ func (s ProviderResource) serveAssertionConsumerService(response http.ResponseWr
 
 			s.writeAPIErrorResponse(request, response, http.StatusUnauthorized, api.ErrorResponseDetailsAuthenticationInvalid)
 		} else {
-			s.createSessionFromAssertion(request, response, time.Now().UTC().Add(auth.SessionTTL), assertion)
+			s.createSessionFromAssertion(request, response, time.Now().UTC().Add(s.cfg.AuthSessionTTL()), assertion)
 		}
 	}
 }

--- a/cmd/api/src/api/saml/saml_internal_test.go
+++ b/cmd/api/src/api/saml/saml_internal_test.go
@@ -1,17 +1,17 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 package saml
@@ -28,7 +28,6 @@ import (
 
 	"github.com/specterops/bloodhound/src/api"
 	apimocks "github.com/specterops/bloodhound/src/api/mocks"
-	"github.com/specterops/bloodhound/src/auth"
 	"github.com/specterops/bloodhound/src/auth/bhsaml"
 	"github.com/specterops/bloodhound/src/config"
 	"github.com/specterops/bloodhound/src/ctx"
@@ -87,7 +86,7 @@ func TestProviderResource_createSessionFromAssertion(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	var (
-		expires               = time.Now().UTC().Add(auth.SessionTTL)
+		expires               = time.Now().UTC().Add(time.Hour)
 		response              = httptest.NewRecorder()
 		expectedCookieContent = fmt.Sprintf("token=fake; Path=/; Expires=%s; Secure; SameSite=Strict", expires.Format(http.TimeFormat))
 

--- a/cmd/api/src/auth/model.go
+++ b/cmd/api/src/auth/model.go
@@ -37,8 +37,6 @@ const (
 	ProviderTypeSecret = "secret"
 
 	HMAC_SHA2_256 = "hmac-sha2-256"
-
-	SessionTTL = time.Hour * 8
 )
 
 type SessionData struct {

--- a/cmd/api/src/config/config.go
+++ b/cmd/api/src/config/config.go
@@ -25,6 +25,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/specterops/bloodhound/crypto"
 	"github.com/specterops/bloodhound/log"
@@ -166,6 +167,11 @@ type Configuration struct {
 	DisableCypherQC         bool                      `json:"disable_cypher_qc"`
 	DisableMigrations       bool                      `json:"disable_migrations"`
 	TraversalMemoryLimit    uint16                    `json:"traversal_memory_limit"`
+	AuthSessionTTLHours     int                       `json:"auth_session_ttl_hours"`
+}
+
+func (s Configuration) AuthSessionTTL() time.Duration {
+	return time.Hour * time.Duration(s.AuthSessionTTLHours)
 }
 
 func (s Configuration) TempDirectory() string {

--- a/cmd/api/src/config/default.go
+++ b/cmd/api/src/config/default.go
@@ -52,6 +52,7 @@ func NewDefaultConfiguration() (Configuration, error) {
 			DisableAnalysis:         false,
 			DisableCypherQC:         false,
 			DisableMigrations:       false,
+			AuthSessionTTLHours:     8, // Default to a logged in auth session time to live of 8 hours
 			TraversalMemoryLimit:    2, // 2 GiB by default
 			TLS:                     TLSConfiguration{},
 			SAML:                    SAMLConfiguration{},


### PR DESCRIPTION
## Description

Support a new configuration parameter auth_session_ttl_hours and the corresponding environment variable BHE_AUTH_SESSION_TTL_HOURS for setting authenticated login session time to live values.

## Motivation and Context

Allow the auth session TTL to be configurable.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
