### PR TITLE
feat: Add /count endpoint to /asset-group/:assetGroupId/members endpoint

### DIFF
--- a/cmd/api/src/api/agi.go
+++ b/cmd/api/src/api/agi.go
@@ -211,3 +211,8 @@ func (s AssetGroupMembers) GetValidFilterPredicatesAsStrings(column string) ([]s
 type ListAssetGroupMembersResponse struct {
 	Members AssetGroupMembers `json:"members"`
 }
+
+type ListAssetGroupMembersCountsResponse struct {
+	TotalCount int            `json:"total_count"`
+	Counts     map[string]int `json:"counts"`
+}

--- a/cmd/api/src/api/agi.go
+++ b/cmd/api/src/api/agi.go
@@ -212,7 +212,7 @@ type ListAssetGroupMembersResponse struct {
 	Members AssetGroupMembers `json:"members"`
 }
 
-type ListAssetGroupMembersCountsResponse struct {
+type ListAssetGroupMemberCountsResponse struct {
 	TotalCount int            `json:"total_count"`
 	Counts     map[string]int `json:"counts"`
 }

--- a/cmd/api/src/api/registration/v2.go
+++ b/cmd/api/src/api/registration/v2.go
@@ -140,6 +140,7 @@ func NewV2API(cfg config.Configuration, resources v2.Resources, routerInst *rout
 		routerInst.DELETE(fmt.Sprintf("/api/v2/asset-groups/{%s}/selectors/{%s}", api.URIPathVariableAssetGroupID, api.URIPathVariableAssetGroupSelectorID), resources.DeleteAssetGroupSelector).RequirePermissions(permissions.GraphDBWrite),
 		routerInst.GET(fmt.Sprintf("/api/v2/asset-groups/{%s}/collections", api.URIPathVariableAssetGroupID), resources.ListAssetGroupCollections).RequirePermissions(permissions.GraphDBRead),
 		routerInst.GET(fmt.Sprintf("/api/v2/asset-groups/{%s}/members", api.URIPathVariableAssetGroupID), resources.ListAssetGroupMembers).RequirePermissions(permissions.GraphDBRead),
+		routerInst.GET(fmt.Sprintf("/api/v2/asset-groups/{%s}/members/count", api.URIPathVariableAssetGroupID), resources.ListAssetGroupMemberCountsByKind).RequirePermissions(permissions.GraphDBRead),
 		routerInst.PUT(fmt.Sprintf("/api/v2/asset-groups/{%s}/selectors", api.URIPathVariableAssetGroupID), resources.UpdateAssetGroupSelectors).RequirePermissions(permissions.GraphDBWrite),
 		// DEPRECATED: this has been changed to a PUT endpoint above, and must be removed for API V3
 		routerInst.POST(fmt.Sprintf("/api/v2/asset-groups/{%s}/selectors", api.URIPathVariableAssetGroupID), resources.UpdateAssetGroupSelectors).RequirePermissions(permissions.GraphDBWrite),

--- a/cmd/api/src/api/registration/v2.go
+++ b/cmd/api/src/api/registration/v2.go
@@ -140,7 +140,7 @@ func NewV2API(cfg config.Configuration, resources v2.Resources, routerInst *rout
 		routerInst.DELETE(fmt.Sprintf("/api/v2/asset-groups/{%s}/selectors/{%s}", api.URIPathVariableAssetGroupID, api.URIPathVariableAssetGroupSelectorID), resources.DeleteAssetGroupSelector).RequirePermissions(permissions.GraphDBWrite),
 		routerInst.GET(fmt.Sprintf("/api/v2/asset-groups/{%s}/collections", api.URIPathVariableAssetGroupID), resources.ListAssetGroupCollections).RequirePermissions(permissions.GraphDBRead),
 		routerInst.GET(fmt.Sprintf("/api/v2/asset-groups/{%s}/members", api.URIPathVariableAssetGroupID), resources.ListAssetGroupMembers).RequirePermissions(permissions.GraphDBRead),
-		routerInst.GET(fmt.Sprintf("/api/v2/asset-groups/{%s}/members/count", api.URIPathVariableAssetGroupID), resources.ListAssetGroupMemberCountsByKind).RequirePermissions(permissions.GraphDBRead),
+		routerInst.GET(fmt.Sprintf("/api/v2/asset-groups/{%s}/members/counts", api.URIPathVariableAssetGroupID), resources.ListAssetGroupMemberCountsByKind).RequirePermissions(permissions.GraphDBRead),
 		routerInst.PUT(fmt.Sprintf("/api/v2/asset-groups/{%s}/selectors", api.URIPathVariableAssetGroupID), resources.UpdateAssetGroupSelectors).RequirePermissions(permissions.GraphDBWrite),
 		// DEPRECATED: this has been changed to a PUT endpoint above, and must be removed for API V3
 		routerInst.POST(fmt.Sprintf("/api/v2/asset-groups/{%s}/selectors", api.URIPathVariableAssetGroupID), resources.UpdateAssetGroupSelectors).RequirePermissions(permissions.GraphDBWrite),

--- a/cmd/api/src/api/v2/agi.go
+++ b/cmd/api/src/api/v2/agi.go
@@ -376,29 +376,28 @@ func getLatestQueryParameter(query url.Values) (bool, error) {
 	return wantsLatest, nil
 }
 
-func (s Resources) ListAssetGroupMembers(response http.ResponseWriter, request *http.Request) {
+func (s Resources) getAssetGroupMembers(response http.ResponseWriter, request *http.Request) (api.AssetGroupMembers, error) {
 	var (
+		agMembers       = api.AssetGroupMembers{}
 		pathVars        = mux.Vars(request)
 		rawAssetGroupID = pathVars[api.URIPathVariableAssetGroupID]
-		agMembers       api.AssetGroupMembers
-		queryParams     = request.URL.Query()
-		sortByColumns   = queryParams[api.QueryParameterSortBy]
+		sortByColumns   = request.URL.Query()[api.QueryParameterSortBy]
 	)
 
 	queryParameterFilterParser := model.NewQueryParameterFilterParser()
 	if queryFilters, err := queryParameterFilterParser.ParseQueryParameterFilters(request); err != nil {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, api.ErrorResponseDetailsBadQueryParameterFilters, request), response)
-		return
+		return agMembers, err
 	} else {
 		for name, filters := range queryFilters {
 			if validPredicates, err := agMembers.GetValidFilterPredicatesAsStrings(name); err != nil {
 				api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, fmt.Sprintf("%s: %s", api.ErrorResponseDetailsColumnNotFilterable, name), request), response)
-				return
+				return agMembers, err
 			} else {
 				for _, filter := range filters {
 					if !slices.Contains(validPredicates, string(filter.Operator)) {
 						api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, fmt.Sprintf("%s: %s %s", api.ErrorResponseDetailsFilterPredicateNotSupported, filter.Name, filter.Operator), request), response)
-						return
+						return agMembers, err
 					}
 				}
 			}
@@ -406,15 +405,30 @@ func (s Resources) ListAssetGroupMembers(response http.ResponseWriter, request *
 
 		if assetGroupID, err := strconv.Atoi(rawAssetGroupID); err != nil {
 			api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, api.ErrorResponseDetailsIDMalformed, request), response)
+			return agMembers, err
 		} else if assetGroup, err := s.DB.GetAssetGroup(int32(assetGroupID)); err != nil {
 			api.HandleDatabaseError(request, response, err)
+			return agMembers, err
 		} else if assetGroupNodes, err := s.GraphQuery.GetAssetGroupNodes(request.Context(), assetGroup.Tag); err != nil {
 			api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusInternalServerError, fmt.Sprintf("Graph error fetching nodes for asset group ID %v: %v", assetGroup.ID, err), request), response)
+			return agMembers, err
 		} else if agMembers, err = parseAGMembersFromNodes(assetGroupNodes, assetGroup.Selectors, int(assetGroup.ID)).SortBy(sortByColumns); err != nil {
 			api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, err.Error(), request), response)
+			return agMembers, err
 		} else if agMembers, err = agMembers.Filter(queryFilters); err != nil {
 			api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusInternalServerError, fmt.Sprintf("error filtering asset group members: %v", err), request), response)
-		} else if skip, err := ParseSkipQueryParameter(queryParams, 0); err != nil {
+			return agMembers, err
+		} else {
+			return agMembers, err
+		}
+	}
+}
+
+func (s Resources) ListAssetGroupMembers(response http.ResponseWriter, request *http.Request) {
+	if agMembers, err := s.getAssetGroupMembers(response, request); err == nil {
+		var queryParams = request.URL.Query()
+
+		if skip, err := ParseSkipQueryParameter(queryParams, 0); err != nil {
 			api.WriteErrorResponse(request.Context(), ErrBadQueryParameter(request, model.PaginationQueryParameterSkip, err), response)
 		} else if skip > len(agMembers) {
 			api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, fmt.Sprintf(utils.ErrorInvalidSkip, "value must be less than total count"), request), response)
@@ -431,45 +445,13 @@ func (s Resources) ListAssetGroupMembers(response http.ResponseWriter, request *
 }
 
 func (s Resources) ListAssetGroupMemberCountsByKind(response http.ResponseWriter, request *http.Request) {
-	var agMembers api.AssetGroupMembers
-
-	queryParameterFilterParser := model.NewQueryParameterFilterParser()
-	if queryFilters, err := queryParameterFilterParser.ParseQueryParameterFilters(request); err != nil {
-		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, api.ErrorResponseDetailsBadQueryParameterFilters, request), response)
-		return
-	} else {
-		for name, filters := range queryFilters {
-			if validPredicates, err := agMembers.GetValidFilterPredicatesAsStrings(name); err != nil || name == "primary_kind" {
-				api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, fmt.Sprintf("%s: %s", api.ErrorResponseDetailsColumnNotFilterable, name), request), response)
-				return
-			} else {
-				for _, filter := range filters {
-					if !slices.Contains(validPredicates, string(filter.Operator)) {
-						api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, fmt.Sprintf("%s: %s %s", api.ErrorResponseDetailsFilterPredicateNotSupported, filter.Name, filter.Operator), request), response)
-						return
-					}
-				}
-			}
+	if agMembers, err := s.getAssetGroupMembers(response, request); err == nil {
+		data := api.ListAssetGroupMemberCountsResponse{Counts: map[string]int{}}
+		for _, member := range agMembers {
+			data.Counts[member.PrimaryKind]++
+			data.TotalCount++
 		}
-
-		if assetGroupID, err := strconv.Atoi(mux.Vars(request)[api.URIPathVariableAssetGroupID]); err != nil {
-			api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, api.ErrorResponseDetailsIDMalformed, request), response)
-		} else if assetGroup, err := s.DB.GetAssetGroup(int32(assetGroupID)); err != nil {
-			api.HandleDatabaseError(request, response, err)
-		} else if assetGroupNodes, err := s.GraphQuery.GetAssetGroupNodes(request.Context(), assetGroup.Tag); err != nil {
-			api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusInternalServerError, fmt.Sprintf("Graph error fetching nodes for asset group ID %v: %v", assetGroup.ID, err), request), response)
-		} else if agMembers = parseAGMembersFromNodes(assetGroupNodes, assetGroup.Selectors, int(assetGroup.ID)); err != nil {
-			api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, err.Error(), request), response)
-		} else if agMembers, err = agMembers.Filter(queryFilters); err != nil {
-			api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusInternalServerError, fmt.Sprintf("error filtering asset group members: %v", err), request), response)
-		} else {
-			data := api.ListAssetGroupMembersCountsResponse{Counts: map[string]int{}}
-			for _, member := range agMembers {
-				data.Counts[member.PrimaryKind]++
-				data.TotalCount++
-			}
-			api.WriteBasicResponse(request.Context(), data, http.StatusOK, response)
-		}
+		api.WriteBasicResponse(request.Context(), data, http.StatusOK, response)
 	}
 }
 

--- a/cmd/api/src/api/v2/agi_test.go
+++ b/cmd/api/src/api/v2/agi_test.go
@@ -1446,7 +1446,7 @@ func TestResources_ListAssetGroupMembersCount(t *testing.T) {
 				},
 				Test: func(output apitest.Output) {
 					apitest.StatusCode(output, http.StatusOK)
-					result := api.ListAssetGroupMembersCountsResponse{}
+					result := api.ListAssetGroupMemberCountsResponse{}
 					apitest.UnmarshalData(output, &result)
 					require.Equal(t, 2, result.TotalCount)
 					require.Equal(t, 2, result.Counts[ad.Domain.String()])
@@ -1482,7 +1482,7 @@ func TestResources_ListAssetGroupMembersCount(t *testing.T) {
 				},
 				Test: func(output apitest.Output) {
 					apitest.StatusCode(output, http.StatusOK)
-					result := api.ListAssetGroupMembersCountsResponse{}
+					result := api.ListAssetGroupMemberCountsResponse{}
 					apitest.UnmarshalData(output, &result)
 					require.Equal(t, 1, result.TotalCount)
 					require.Equal(t, 1, result.Counts[azure.Tenant.String()])

--- a/cmd/api/src/docs/json/definitions/v2.json
+++ b/cmd/api/src/docs/json/definitions/v2.json
@@ -76,6 +76,24 @@
       }
     }
   },
+  "v2.ListAssetGroupMembersCountResponse": {
+        "properties": {
+            "data": {
+                "type": "object",
+                "properties": {
+                    "total_count": {
+                        "type": "integer"
+                    },
+                    "counts": {
+                        "type": "object",
+                        "items": {
+                            "type": "integer"
+                        }
+                    }
+                }
+            }
+        }
+    },
   "v2.CreateAssetGroupSelectorResponse": {
     "properties": {
       "data": {

--- a/cmd/api/src/docs/json/definitions/v2.json
+++ b/cmd/api/src/docs/json/definitions/v2.json
@@ -76,7 +76,7 @@
       }
     }
   },
-  "v2.ListAssetGroupMembersCountResponse": {
+  "v2.ListAssetGroupMemberCountsResponse": {
         "properties": {
             "data": {
                 "type": "object",

--- a/cmd/api/src/docs/json/paths/v2/asset-isolation.json
+++ b/cmd/api/src/docs/json/paths/v2/asset-isolation.json
@@ -603,5 +603,90 @@
                 }
             }
         }
+    },
+    "/api/v2/asset-groups/{asset_group_id}/members/count": {
+        "parameters": [
+            {
+                "type": "integer",
+                "description": "Asset group ID",
+                "name": "asset_group_id",
+                "in": "path",
+                "required": true
+            }
+        ],
+        "get": {
+            "description": "List counts of members of an asset isolation group by primary kind",
+            "consumes": [
+                "application/json"
+            ],
+            "tags": [
+                "Asset Isolation",
+                "Community",
+                "Enterprise"
+            ],
+            "summary": "List counts of members of an asset isolation group by primary kind",
+            "parameters": [
+                {
+                    "$ref": "#/definitions/parameters.PreferHeader"
+                },
+                {
+                    "type": "string",
+                    "description": "Filter results by column value. Valid filter predicates are eq, neq",
+                    "name": "object_id",
+                    "in": "query",
+                    "required": false
+                },
+                {
+                    "type": "string",
+                    "description": "Filter results by column value. Valid filter predicates are eq, neq",
+                    "name": "environment_id",
+                    "in": "query",
+                    "required": false
+                },
+                {
+                    "type": "string",
+                    "description": "Filter results by column value. Valid filter predicates are eq, neq",
+                    "name": "domainsid",
+                    "in": "query",
+                    "required": false
+                },
+                {
+                    "type": "string",
+                    "description": "Filter results by column value. Valid filter predicates are eq, neq",
+                    "name": "environment_kind",
+                    "in": "query",
+                    "required": false
+                },
+                {
+                    "type": "string",
+                    "description": "Filter results by column value. Valid filter predicates are eq, neq",
+                    "name": "name",
+                    "in": "query",
+                    "required": false
+                },
+                {
+                    "type": "string",
+                    "description": "Filter results by column value. Valid filter predicates are eq, neq",
+                    "name": "custom_member",
+                    "in": "query",
+                    "required": false
+                }
+            ],
+            "responses": {
+                "200": {
+                    "description": "OK",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/definitions/v2.ListAssetGroupMembersCountResponse"
+                            }
+                        }
+                    }
+                },
+                "Error": {
+                    "$ref": "#/components/responses/defaultError"
+                }
+            }
+        }
     }
     }

--- a/cmd/api/src/docs/json/paths/v2/asset-isolation.json
+++ b/cmd/api/src/docs/json/paths/v2/asset-isolation.json
@@ -604,7 +604,7 @@
             }
         }
     },
-    "/api/v2/asset-groups/{asset_group_id}/members/count": {
+    "/api/v2/asset-groups/{asset_group_id}/members/counts": {
         "parameters": [
             {
                 "type": "integer",
@@ -652,7 +652,7 @@
                 },
                 {
                     "type": "string",
-                    "description": "Filter results by only this primary_kind. Valid filter predicates are eq, neq",
+                    "description": "Return counts only for the specified node kind. Valid filter predicates are eq, neq",
                     "name": "primary_kind",
                     "in": "query",
                     "required": false

--- a/cmd/api/src/docs/json/paths/v2/asset-isolation.json
+++ b/cmd/api/src/docs/json/paths/v2/asset-isolation.json
@@ -652,6 +652,13 @@
                 },
                 {
                     "type": "string",
+                    "description": "Filter results by only this primary_kind. Valid filter predicates are eq, neq",
+                    "name": "primary_kind",
+                    "in": "query",
+                    "required": false
+                },
+                {
+                    "type": "string",
                     "description": "Filter results by column value. Valid filter predicates are eq, neq",
                     "name": "environment_kind",
                     "in": "query",
@@ -678,7 +685,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "#/definitions/v2.ListAssetGroupMembersCountResponse"
+                                "$ref": "#/definitions/v2.ListAssetGroupMemberCountsResponse"
                             }
                         }
                     }


### PR DESCRIPTION
## Description

The group management page makes duplicate /members requests in order to get the total counts across primary kinds. This is resource intensive and redundant db hits for the same resources.

## Motivation and Context

Decrease the DB load on neo4j as only 1 request needs to be made to obtain the group member counts

## How Has This Been Tested?

Tested against test db
Integration test added

## Screenshots (if appropriate):
<img width="1023" alt="image" src="https://github.com/SpecterOps/BloodHound/assets/26472282/62b239c7-e64b-4da2-86de-c3a5e855550b">

## Types of changes

-   [ ] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

-   [x] Documentation updates are needed, and have been made accordingly.
-   [x] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
