### PR TITLE
Reduce noise when X-Forwarded-For is missing

### DIFF
--- a/cmd/api/src/api/middleware/middleware.go
+++ b/cmd/api/src/api/middleware/middleware.go
@@ -156,14 +156,14 @@ func parseUserIP(r *http.Request) string {
 
 	// The point of this code is to strip the port, so we don't need to save it.
 	if host, _, err := net.SplitHostPort(r.RemoteAddr); err != nil {
-		log.Warnf("Error parsing remoteAddress 's': %s", r.RemoteAddr, err)
+		log.Warnf("Error parsing remoteAddress '%s': %s", r.RemoteAddr, err)
 		remoteIp = r.RemoteAddr
 	} else {
 		remoteIp = host
 	}
 
 	if result := r.Header.Get("X-Forwarded-For"); result == "" {
-		log.Warnf("No data found in X-Forwarded-For header")
+		log.Debugf("No data found in X-Forwarded-For header")
 		return remoteIp
 	} else {
 		result += "," + remoteIp


### PR DESCRIPTION
## Description

This PR changes the logging level for a missing `X-Forwarded-For` to debug as it was proving to be a bit noisy. There was also a typo fix to another log line in the same area.

## Motivation and Context

* Reduce unnecessary noise in the logs

## How Has This Been Tested?

* Verified the log only displays when debug logging is enabled

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
