### PR TITLE
fix: incorrect pgadmin dockerfile pw

### DIFF
--- a/tools/docker-compose/pgadmin.Dockerfile
+++ b/tools/docker-compose/pgadmin.Dockerfile
@@ -1,19 +1,28 @@
 # Copyright 2023 Specter Ops, Inc.
-# 
+#
 # Licensed under the Apache License, Version 2.0
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# 
+#
 # SPDX-License-Identifier: Apache-2.0
 
 FROM docker.io/dpage/pgadmin4
+
+# Add bh server config
 COPY configs/pgadmin/servers.json /pgadmin4/servers.json
-COPY configs/pgadmin/pgpass /pgpass
+
+# Need to make directory
+RUN mkdir -p /var/lib/pgadmin/storage/bloodhound_specterops.io/
+COPY configs/pgadmin/pgpass /var/lib/pgadmin/storage/bloodhound_specterops.io/pgpass
+
+# Give pgadmin ownership or it will be owned by root and set u(rw) for password file or pgadmin will not use the file
+USER root
+RUN chown -R pgadmin /var/lib/pgadmin && chmod 600 /var/lib/pgadmin/storage/bloodhound_specterops.io/pgpass


### PR DESCRIPTION
## Description

Currently the pgadmin does not properly insert the provided pw file into the pgadmin docker container so each time you reload the stack, you must manually provide the password.

## Motivation and Context

I don't want to manually put the password in every time because I'm lazy.

## How Has This Been Tested?

Rebuild your docker container for pgadmin
Run `just bh-dev`

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
