### PR TITLE
fix: feature flag default

### DIFF
--- a/cmd/api/src/database/migration/migrations/v5.6.0.sql
+++ b/cmd/api/src/database/migration/migrations/v5.6.0.sql
@@ -29,4 +29,4 @@ ALTER TABLE IF EXISTS audit_logs
 CREATE INDEX IF NOT EXISTS idx_audit_logs_actor_email ON audit_logs USING btree (actor_email);
 CREATE INDEX IF NOT EXISTS idx_audit_logs_source_ip_address ON audit_logs USING btree (source_ip_address);
 CREATE INDEX IF NOT EXISTS idx_audit_logs_status ON audit_logs USING btree (status);
-UPDATE feature_flags SET enabled = true, user_updatable = false WHERE key = 'adcs';
+UPDATE feature_flags SET enabled = false, user_updatable = false WHERE key = 'adcs';


### PR DESCRIPTION
## Description

The ADCS feature flag is defaulted to true in the migration, but needs to be defaulted to false

## Motivation and Context

False is not true and we want it to be false.

## How Has This Been Tested?

Migration ran and it set the FF to false

## Screenshots (if appropriate):

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [x] My changes include a database migration.
