### PR TITLE
fix: ID Traversal Critical Section in Wrong Order

### DIFF
--- a/packages/go/dawgs/traversal/id.go
+++ b/packages/go/dawgs/traversal/id.go
@@ -101,12 +101,12 @@ func (s IDTraversal) BreadthFirst(ctx context.Context, plan IDPlan) error {
 						errors.Add(fmt.Errorf("%w - Limit: %.2f MB - Memory In-Use: %.2f MB", ops.ErrTraversalMemoryLimit, tx.TraversalMemoryLimit().Mebibytes(), pathTree.SizeOf().Mebibytes()))
 					}
 
+					// Mark descent for this segment as complete
+					descentCount.Add(-1)
+					
 					if !channels.Submit(traversalCtx, completionC, struct{}{}) {
 						return nil
 					}
-
-					// Mark descent for this segment as complete
-					descentCount.Add(-1)
 				}
 			}); err != nil && err != graph.ErrContextTimedOut {
 				// A worker encountered a fatal error, kill the traversal context


### PR DESCRIPTION
## Description

The count that coordinates exit of traversal workers must be decremented before a notification event is sent via the completion channel.

## Motivation and Context

If this is done out of order it's possible for channel starvation to occur.

## How Has This Been Tested?

Local test with dataset.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] My changes include a database migration.
