### PR TITLE
feat: add /accepted-types endpoint to file-uploads

### DIFF
--- a/cmd/api/src/api/registration/v2.go
+++ b/cmd/api/src/api/registration/v2.go
@@ -104,6 +104,7 @@ func NewV2API(cfg config.Configuration, resources v2.Resources, routerInst *rout
 	// Ingest APIs
 	//TODO: What permission should we use here? GraphDB Write
 	routerInst.GET("/api/v2/file-upload", resources.ListFileUploadJobs).RequireAuth()
+	routerInst.GET("/api/v2/file-upload/accepted-types", resources.ListAcceptedFileUploadTypes).RequireAuth()
 	routerInst.POST("/api/v2/file-upload/start", resources.StartFileUploadJob).RequirePermissions(permissions.GraphDBWrite)
 	routerInst.POST(fmt.Sprintf("/api/v2/file-upload/{%s}", v2.FileUploadJobIdPathParameterName), resources.ProcessFileUpload).RequirePermissions(permissions.GraphDBWrite)
 	routerInst.POST(fmt.Sprintf("/api/v2/file-upload/{%s}/end", v2.FileUploadJobIdPathParameterName), resources.EndFileUploadJob).RequirePermissions(permissions.GraphDBWrite)

--- a/cmd/api/src/api/v2/file_uploads.go
+++ b/cmd/api/src/api/v2/file_uploads.go
@@ -19,6 +19,7 @@ package v2
 import (
 	"errors"
 	"fmt"
+	"github.com/specterops/bloodhound/mediatypes"
 	"net/http"
 	"slices"
 	"strconv"
@@ -35,6 +36,12 @@ import (
 )
 
 const FileUploadJobIdPathParameterName = "file_upload_job_id"
+
+var AllowedFileUploadTypes = []string{
+	mediatypes.ApplicationJson.WithCharset("utf-8"),
+	// todo - Add applicationZip once zip support is complete
+	//mediatypes.ApplicationZip.String(),
+}
 
 func (s Resources) ListFileUploadJobs(response http.ResponseWriter, request *http.Request) {
 	var (
@@ -156,4 +163,8 @@ func (s Resources) EndFileUploadJob(response http.ResponseWriter, request *http.
 	} else {
 		response.WriteHeader(http.StatusOK)
 	}
+}
+
+func (s Resources) ListAcceptedFileUploadTypes(response http.ResponseWriter, request *http.Request) {
+	api.WriteBasicResponse(request.Context(), AllowedFileUploadTypes, http.StatusOK, response)
 }

--- a/cmd/api/src/api/v2/file_uploads_test.go
+++ b/cmd/api/src/api/v2/file_uploads_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"database/sql"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/specterops/bloodhound/errors"
@@ -219,6 +220,20 @@ func TestResources_EndFileUploadJob(t *testing.T) {
 				},
 				Test: func(output apitest.Output) {
 					apitest.StatusCode(output, http.StatusOK)
+				},
+			},
+		})
+}
+
+func TestResources_ListAcceptedFileUploadTypes(t *testing.T) {
+	apitest.
+		NewHarness(t, v2.Resources{}.ListAcceptedFileUploadTypes).
+		Run([]apitest.Case{
+			{
+				Name: "Success",
+				Test: func(output apitest.Output) {
+					apitest.StatusCode(output, http.StatusOK)
+					apitest.BodyContains(output, strings.Join(v2.AllowedFileUploadTypes, ","))
 				},
 			},
 		})

--- a/cmd/api/src/docs/json/paths/v2/file_upload.json
+++ b/cmd/api/src/docs/json/paths/v2/file_upload.json
@@ -132,6 +132,36 @@
             }
         }
     },
+    "/api/v2/file-upload/accepted-types": {
+        "get": {
+            "description": "Get accepted file types for file uploads",
+            "tags": [
+                "Uploads",
+                "Community",
+                "Enterprise"
+            ],
+            "summary": "Get accepted file types for file uploads",
+            "responses": {
+                "200": {
+                    "content": {
+                        "application/json": {
+                            "schema":{
+                                "type":"object",
+                                "properties": {
+                                    "data": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
     "/api/v2/file-upload/start": {
         "post": {
             "description": "Creates a file upload job for sending collection files",


### PR DESCRIPTION
## Description

This adds GET endpoint `/accepted-types` to /file-uploads for consumption by the UI to support MIME type validation.

## Motivation and Context
In order to allow for UI side validation but not need to maintain multiple areas, we want to add an endpoint that returns supported types. 


## How Has This Been Tested?

Locally hit endpoint GET `api/v2/file-upload/accepted-types`
Added integration test as well

## Screenshots (if appropriate):
<img width="444" alt="image" src="https://github.com/SpecterOps/BloodHound/assets/26472282/96a00604-553b-43ee-a225-339e2d8c1bca">

## Types of changes

-   [ ] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [x] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
