### PR TITLE
refactor: remove context timeout check from response marshalling

### DIFF
--- a/cmd/api/src/api/marshalling_test.go
+++ b/cmd/api/src/api/marshalling_test.go
@@ -1,17 +1,17 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 package api_test
@@ -25,21 +25,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
 	"github.com/specterops/bloodhound/headers"
 	"github.com/specterops/bloodhound/mediatypes"
+	"github.com/stretchr/testify/require"
 
 	"github.com/specterops/bloodhound/src/api"
 )
-
-func TestWriteErrorResponse_Timeout(t *testing.T) {
-	response := httptest.NewRecorder()
-	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-1*time.Second))
-	defer cancel()
-
-	api.WriteErrorResponse(ctx, fmt.Errorf("foo"), response)
-	require.Empty(t, response.Body.String())
-}
 
 func TestWriteErrorResponse_InvalidFormat(t *testing.T) {
 	response := httptest.NewRecorder()
@@ -71,29 +62,11 @@ func TestWriteErrorResponse_V2(t *testing.T) {
 	require.Contains(t, response.Body.String(), "baz")
 }
 
-func TestWriteBasicResponse_Timeout(t *testing.T) {
-	response := httptest.NewRecorder()
-	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-1*time.Second))
-	defer cancel()
-
-	api.WriteBasicResponse(ctx, json.RawMessage(`{"foo":"bar"}`), http.StatusOK, response)
-	require.Empty(t, response.Body.String())
-}
-
 func TestWriteBasicResponse(t *testing.T) {
 	response := httptest.NewRecorder()
 	api.WriteBasicResponse(context.Background(), json.RawMessage(`{"foo":"bar"}`), http.StatusOK, response)
 	require.Equal(t, http.StatusOK, response.Code)
 	require.Contains(t, response.Body.String(), "foo")
-}
-
-func TestWriteResponseWrapperWithPagination_Timeout(t *testing.T) {
-	response := httptest.NewRecorder()
-	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-1*time.Second))
-	defer cancel()
-
-	api.WriteResponseWrapperWithPagination(ctx, json.RawMessage(`{"foo":"bar"}`), 5, 10, 100, http.StatusOK, response)
-	require.Empty(t, response.Body.String())
 }
 
 func TestWriteResponseWrapperWithPagination(t *testing.T) {
@@ -103,29 +76,11 @@ func TestWriteResponseWrapperWithPagination(t *testing.T) {
 	require.Contains(t, response.Body.String(), "foo")
 }
 
-func TestWriteTimeWindowedResponse_Timeout(t *testing.T) {
-	response := httptest.NewRecorder()
-	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-1*time.Second))
-	defer cancel()
-
-	api.WriteTimeWindowedResponse(ctx, json.RawMessage(`{"foo":"bar"}`), time.Now().Add(-1*time.Second), time.Now(), http.StatusOK, response)
-	require.Empty(t, response.Body.String())
-}
-
 func TestWriteTimeWindowedResponse(t *testing.T) {
 	response := httptest.NewRecorder()
 	api.WriteTimeWindowedResponse(context.Background(), json.RawMessage(`{"foo":"bar"}`), time.Now().Add(-1*time.Second), time.Now(), http.StatusOK, response)
 	require.Equal(t, http.StatusOK, response.Code)
 	require.Contains(t, response.Body.String(), "foo")
-}
-
-func TestWriteResponseWrapperWithTimeWindowAndPagination_Timeout(t *testing.T) {
-	response := httptest.NewRecorder()
-	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-1*time.Second))
-	defer cancel()
-
-	api.WriteResponseWrapperWithTimeWindowAndPagination(ctx, json.RawMessage(`{"foo":"bar"}`), time.Now().Add(-5*time.Second), time.Now(), 5, 10, 100, http.StatusOK, response)
-	require.Empty(t, response.Body.String())
 }
 
 func TestWriteResponseWrapperWithTimeWindowAndPagination(t *testing.T) {
@@ -146,15 +101,6 @@ func TestWriteResponseWrapperWithTimeWindowAndPagination(t *testing.T) {
 	require.Contains(t, response.Body.String(), "limit")
 	require.NotContains(t, response.Body.String(), "start")
 	require.NotContains(t, response.Body.String(), "end")
-}
-
-func TestWriteBinaryResponse_Timeout(t *testing.T) {
-	response := httptest.NewRecorder()
-	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-1*time.Second))
-	defer cancel()
-
-	api.WriteBinaryResponse(ctx, []byte(`{"foo":"bar"}`), "filename", http.StatusOK, response)
-	require.Empty(t, response.Body.String())
 }
 
 func TestWriteBinaryResponse(t *testing.T) {

--- a/cmd/api/src/api/middleware/rate_limit.go
+++ b/cmd/api/src/api/middleware/rate_limit.go
@@ -1,17 +1,17 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 package middleware
@@ -22,10 +22,10 @@ import (
 
 	"github.com/specterops/bloodhound/headers"
 
-	"github.com/specterops/bloodhound/src/api"
 	"github.com/didip/tollbooth/v6"
 	"github.com/didip/tollbooth/v6/limiter"
 	"github.com/gorilla/mux"
+	"github.com/specterops/bloodhound/src/api"
 )
 
 // DefaultRateLimit is the default number of allowed requests per second
@@ -43,34 +43,23 @@ const DefaultRateLimit = 55
 //	router.Handle("/teapot", RateLimitHandler(limiter, handler))
 func RateLimitHandler(limiter *limiter.Limiter, handler http.Handler) http.Handler {
 	return http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		if err := tollbooth.LimitByRequest(limiter, response, request); err != nil {
+			// In case SetOnLimitReached was called
+			limiter.ExecOnLimitReached(response, request)
 
-		ctx := request.Context()
-		select {
-		case <-ctx.Done():
-			api.WriteErrorResponse(request.Context(), &api.ErrorResponse{
-				HTTPStatus: http.StatusBadRequest,
-				Error:      "client closed the connection before the request could be completed",
-			}, response)
-		default:
-			if err := tollbooth.LimitByRequest(limiter, response, request); err != nil {
-				// In case SetOnLimitReached was called
-				limiter.ExecOnLimitReached(response, request)
-
-				api.WriteErrorResponse(request.Context(), &api.ErrorWrapper{
-					HTTPStatus: err.StatusCode,
-					Timestamp:  time.Now(),
-					RequestID:  request.Header.Get(headers.RequestID.String()),
-					Errors: []api.ErrorDetails{
-						{
-							Context: "middleware",
-							Message: err.Error(),
-						},
+			api.WriteErrorResponse(request.Context(), &api.ErrorWrapper{
+				HTTPStatus: err.StatusCode,
+				Timestamp:  time.Now(),
+				RequestID:  request.Header.Get(headers.RequestID.String()),
+				Errors: []api.ErrorDetails{
+					{
+						Context: "middleware",
+						Message: err.Error(),
 					},
-				}, response)
-			} else {
-				handler.ServeHTTP(response, request)
-			}
-
+				},
+			}, response)
+		} else {
+			handler.ServeHTTP(response, request)
 		}
 	})
 }

--- a/cmd/api/src/api/middleware/rate_limit_test.go
+++ b/cmd/api/src/api/middleware/rate_limit_test.go
@@ -1,30 +1,29 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 package middleware_test
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
-	"github.com/specterops/bloodhound/src/api/middleware"
 	"github.com/didip/tollbooth/v6"
 	"github.com/gorilla/mux"
+	"github.com/specterops/bloodhound/src/api/middleware"
 )
 
 func TestRateLimitHandler(t *testing.T) {
@@ -131,30 +130,6 @@ func TestDefaultRateLimitMiddleware(t *testing.T) {
 
 	if testHandler.Count != middleware.DefaultRateLimit {
 		t.Errorf("invalid HTTP 200 count: got %v want %v", testHandler.Count, middleware.DefaultRateLimit)
-	}
-}
-
-func TestDefaultRateLimitMiddlewareCanceledRequest(t *testing.T) {
-	testHandler := &CountingHandler{}
-
-	router := mux.NewRouter()
-	router.Use(middleware.DefaultRateLimitMiddleware())
-	router.Handle("/teapot", testHandler)
-
-	ctx, cancel := context.WithCancel(context.Background())
-	if req, err := http.NewRequestWithContext(ctx, "GET", "/teapot", nil); err != nil {
-		cancel()
-		t.Fatal(err)
-	} else {
-		req.Header.Set("X-Real-IP", "8.8.8.8")
-		cancel()
-
-		rr := httptest.NewRecorder()
-		router.ServeHTTP(rr, req)
-
-		if rr.Code != http.StatusBadRequest {
-			t.Errorf("invalid HTTPStatus: got %v want %v", rr.Code, http.StatusBadRequest)
-		}
 	}
 }
 


### PR DESCRIPTION
## Description

- Removed the context timeout check from inside the response marshalling utility functions
- Removed an incorrect error that occurred during rate limits

## Motivation and Context

Response marshalling was dependent on the request context checking for deadline timeout which was causing race conditions between writing the JSON and the request context timing out. This sometimes resulted in an errant empty 200 response. 

While cleaning these up, the rate limit error middleware was returning an incorrect response that was both confusing and used the wrong status code.

## How Has This Been Tested?

Integration tests hopefully all passed but definitely want to soak this puppy to make sure I didn't miss any.

## Types of changes

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
