### PR TITLE
fix: cypher pattern range parsing

### DIFF
--- a/packages/go/cypher/frontend/query.go
+++ b/packages/go/cypher/frontend/query.go
@@ -186,6 +186,12 @@ type RangeLiteralVisitor struct {
 	PatternRange *model.PatternRange
 }
 
+func NewRangeLiteralVisitor() *RangeLiteralVisitor {
+	return &RangeLiteralVisitor{
+		PatternRange: &model.PatternRange{},
+	}
+}
+
 func (s *RangeLiteralVisitor) EnterOC_IntegerLiteral(ctx *parser.OC_IntegerLiteralContext) {
 	if value, err := strconv.ParseInt(ctx.GetText(), 10, 64); err != nil {
 		s.ctx.AddErrors(fmt.Errorf("failed parsing range literal: %w", err))

--- a/packages/go/cypher/frontend/util.go
+++ b/packages/go/cypher/frontend/util.go
@@ -1,17 +1,17 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 package frontend
@@ -80,6 +80,7 @@ var (
 	TokenTypeSlash              = findTokenRuleIndex("/")
 	TokenTypePercentSign        = findTokenRuleIndex("%")
 	TokenTypeAsterisk           = findTokenRuleIndex("*")
+	TokenTypeRange              = findTokenRuleIndex("..")
 	TokenTypeComma              = findTokenRuleIndex(",")
 	TokenTypeCaret              = findTokenRuleIndex("^")
 

--- a/packages/go/cypher/test/cases/positive_tests.json
+++ b/packages/go/cypher/test/cases/positive_tests.json
@@ -1035,6 +1035,14 @@
             }
         },
         {
+            "name": "Find Shortest Paths to Domain Admins with Traversal Limit",
+            "type": "string_match",
+            "details": {
+                "query": "match p = shortestPath((n)-[:HasSession|AdminTo|Contains|AZLogicAppContributor*5..1]->(m:Group {name: 'DOMAIN ADMINS@DOMAIN.PAIN'})) where not (n = m) return p",
+                "complexity": 7.0
+            }
+        },
+        {
             "name": "Find Computers with Unsupported Operating Systems",
             "type": "string_match",
             "details": {


### PR DESCRIPTION
## Description
This change works around some minor deficiencies in the ANTLR generated parser for openCypher to correctly parse pattern ranges.

## Motivation and Context
As written, the openCypher parser would incorrectly set the starting range index of a pattern when only an ending range index is specified.

This was discovered while attempting to perform ranged pattern matching: `match p = (:User)<-[*1..3]-(t:Base) where t.name = 'example' return p`.

The above query was being parsed and emitted as: `match p = (:User)<-[*3..]-(t:Base) where t.name = 'example' return p` which would then result in an unbounded traversal and crash Neo4j.

## How Has This Been Tested?
An additional test case was added to cover this.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
