### PR TITLE
fix: plumb ctx into asset-groups db methods

### DIFF
--- a/cmd/api/src/api/v2/agi_test.go
+++ b/cmd/api/src/api/v2/agi_test.go
@@ -91,7 +91,7 @@ func TestResources_ListAssetGroups(t *testing.T) {
 				Name: "DatabaseError",
 				Setup: func() {
 					mockDB.EXPECT().
-						GetAllAssetGroups(gomock.Any(), gomock.Any()).
+						GetAllAssetGroups(gomock.Any(), gomock.Any(), gomock.Any()).
 						Return(model.AssetGroups{}, errors.New("database error"))
 				},
 				Test: func(output apitest.Output) {
@@ -103,7 +103,7 @@ func TestResources_ListAssetGroups(t *testing.T) {
 				Name: "SuccessDataTest",
 				Setup: func() {
 					mockDB.EXPECT().
-						GetAllAssetGroups(gomock.Any(), gomock.Any()).
+						GetAllAssetGroups(gomock.Any(), gomock.Any(), gomock.Any()).
 						Return(model.AssetGroups{ag1, ag2}, nil)
 				},
 				Test: func(output apitest.Output) {
@@ -120,7 +120,7 @@ func TestResources_ListAssetGroups(t *testing.T) {
 				},
 				Setup: func() {
 					mockDB.EXPECT().
-						GetAllAssetGroups("name", gomock.Any()).
+						GetAllAssetGroups(gomock.Any(), "name", gomock.Any()).
 						Return(model.AssetGroups{ag1, ag2}, nil)
 				},
 				Test: func(output apitest.Output) {
@@ -134,7 +134,7 @@ func TestResources_ListAssetGroups(t *testing.T) {
 				},
 				Setup: func() {
 					mockDB.EXPECT().
-						GetAllAssetGroups("name desc", gomock.Any()).
+						GetAllAssetGroups(gomock.Any(), "name desc", gomock.Any()).
 						Return(model.AssetGroups{ag2, ag1}, nil)
 				},
 				Test: func(output apitest.Output) {
@@ -148,7 +148,7 @@ func TestResources_ListAssetGroups(t *testing.T) {
 				},
 				Setup: func() {
 					mockDB.EXPECT().
-						GetAllAssetGroups("", model.SQLFilter{SQLString: "name = ?", Params: []any{"ag1"}}).
+						GetAllAssetGroups(gomock.Any(), "", model.SQLFilter{SQLString: "name = ?", Params: []any{"ag1"}}).
 						Return(model.AssetGroups{ag1}, nil)
 				},
 				Test: func(output apitest.Output) {
@@ -180,7 +180,7 @@ func TestResources_GetAssetGroup(t *testing.T) {
 		ResponseStatusCode(http.StatusBadRequest)
 
 	// DB fails
-	mockDB.EXPECT().GetAssetGroup(int32(1234)).Return(model.AssetGroup{}, fmt.Errorf("explosions"))
+	mockDB.EXPECT().GetAssetGroup(gomock.Any(), int32(1234)).Return(model.AssetGroup{}, fmt.Errorf("explosions"))
 
 	requestTemplate.
 		WithURLPathVars(map[string]string{
@@ -191,7 +191,7 @@ func TestResources_GetAssetGroup(t *testing.T) {
 		ResponseStatusCode(http.StatusInternalServerError)
 
 	// Happy path
-	mockDB.EXPECT().GetAssetGroup(int32(1234)).Return(model.AssetGroup{}, nil)
+	mockDB.EXPECT().GetAssetGroup(gomock.Any(), int32(1234)).Return(model.AssetGroup{}, nil)
 
 	requestTemplate.
 		WithURLPathVars(map[string]string{
@@ -230,7 +230,7 @@ func TestResources_GetAssetGroupMemberCount_DBError(t *testing.T) {
 
 	req = mux.SetURLVars(req, map[string]string{api.URIPathVariableAssetGroupID: "1"})
 	mockDB := dbmocks.NewMockDatabase(mockCtrl)
-	mockDB.EXPECT().GetAssetGroup(gomock.Any()).Return(model.AssetGroup{}, fmt.Errorf("test error"))
+	mockDB.EXPECT().GetAssetGroup(req.Context(), gomock.Any()).Return(model.AssetGroup{}, fmt.Errorf("test error"))
 
 	resources := v2.Resources{DB: mockDB}
 
@@ -301,7 +301,7 @@ func TestResources_GetAssetGroupMemberCount_Success(t *testing.T) {
 
 	req = mux.SetURLVars(req, map[string]string{api.URIPathVariableAssetGroupID: "1"})
 	mockDB := dbmocks.NewMockDatabase(mockCtrl)
-	mockDB.EXPECT().GetAssetGroup(gomock.Any()).Return(assetGroup, nil)
+	mockDB.EXPECT().GetAssetGroup(req.Context(), gomock.Any()).Return(assetGroup, nil)
 
 	resources := v2.Resources{DB: mockDB}
 
@@ -350,7 +350,7 @@ func TestResources_UpdateAssetGroup(t *testing.T) {
 		ResponseStatusCode(http.StatusBadRequest)
 
 	// GetAssetGroup DB fails
-	mockDB.EXPECT().GetAssetGroup(int32(1234)).Return(model.AssetGroup{}, fmt.Errorf("exploded"))
+	mockDB.EXPECT().GetAssetGroup(gomock.Any(), int32(1234)).Return(model.AssetGroup{}, fmt.Errorf("exploded"))
 
 	requestTemplate.
 		WithURLPathVars(map[string]string{
@@ -362,7 +362,7 @@ func TestResources_UpdateAssetGroup(t *testing.T) {
 		ResponseStatusCode(http.StatusInternalServerError)
 
 	// UpdateAssetGroup DB fails
-	mockDB.EXPECT().GetAssetGroup(int32(1234)).Return(model.AssetGroup{}, nil)
+	mockDB.EXPECT().GetAssetGroup(gomock.Any(), int32(1234)).Return(model.AssetGroup{}, nil)
 	mockDB.EXPECT().UpdateAssetGroup(gomock.Any(), model.AssetGroup{}).Return(fmt.Errorf("exploded"))
 
 	requestTemplate.
@@ -375,7 +375,7 @@ func TestResources_UpdateAssetGroup(t *testing.T) {
 		ResponseStatusCode(http.StatusInternalServerError)
 
 	// Success
-	mockDB.EXPECT().GetAssetGroup(int32(1234)).Return(model.AssetGroup{}, nil)
+	mockDB.EXPECT().GetAssetGroup(gomock.Any(), int32(1234)).Return(model.AssetGroup{}, nil)
 	mockDB.EXPECT().UpdateAssetGroup(gomock.Any(), model.AssetGroup{}).Return(nil)
 
 	requestTemplate.
@@ -483,7 +483,7 @@ func TestResources_UpdateAssetGroupSelectors_GetAssetGroupError(t *testing.T) {
 	req = mux.SetURLVars(req, map[string]string{api.URIPathVariableAssetGroupID: "1"})
 
 	mockDB := dbmocks.NewMockDatabase(mockCtrl)
-	mockDB.EXPECT().GetAssetGroup(gomock.Any()).Return(model.AssetGroup{}, fmt.Errorf("test error"))
+	mockDB.EXPECT().GetAssetGroup(req.Context(), gomock.Any()).Return(model.AssetGroup{}, fmt.Errorf("test error"))
 	handlers := v2.Resources{DB: mockDB}
 
 	response := httptest.NewRecorder()
@@ -513,7 +513,7 @@ func TestResources_UpdateAssetGroupSelectors_PayloadError(t *testing.T) {
 	}
 
 	mockDB := dbmocks.NewMockDatabase(mockCtrl)
-	mockDB.EXPECT().GetAssetGroup(gomock.Any()).Return(assetGroup, nil)
+	mockDB.EXPECT().GetAssetGroup(req.Context(), gomock.Any()).Return(assetGroup, nil)
 	handlers := v2.Resources{DB: mockDB}
 
 	response := httptest.NewRecorder()
@@ -588,7 +588,7 @@ func TestResources_UpdateAssetGroupSelectors_SuccessT0(t *testing.T) {
 	mockDB := dbmocks.NewMockDatabase(mockCtrl)
 	mockGraph := queriesMocks.NewMockGraph(mockCtrl)
 
-	mockDB.EXPECT().GetAssetGroup(gomock.Any()).Return(assetGroup, nil)
+	mockDB.EXPECT().GetAssetGroup(req.Context(), gomock.Any()).Return(assetGroup, nil)
 	mockDB.EXPECT().UpdateAssetGroupSelectors(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(expectedResult, nil)
 	mockGraph.EXPECT().UpdateSelectorTags(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 
@@ -682,7 +682,7 @@ func TestResources_UpdateAssetGroupSelectors_SuccessOwned(t *testing.T) {
 	mockDB := dbmocks.NewMockDatabase(mockCtrl)
 	mockGraph := queriesMocks.NewMockGraph(mockCtrl)
 
-	mockDB.EXPECT().GetAssetGroup(gomock.Any()).Return(assetGroup, nil)
+	mockDB.EXPECT().GetAssetGroup(req.Context(), gomock.Any()).Return(assetGroup, nil)
 	mockDB.EXPECT().UpdateAssetGroupSelectors(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(expectedResult, nil)
 
 	mockGraph.EXPECT().UpdateSelectorTags(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
@@ -740,7 +740,7 @@ func TestResources_DeleteAssetGroup(t *testing.T) {
 		ResponseStatusCode(http.StatusBadRequest)
 
 	// GetAssetGroup DB fails
-	mockDB.EXPECT().GetAssetGroup(int32(1234)).Return(model.AssetGroup{}, fmt.Errorf("exploded"))
+	mockDB.EXPECT().GetAssetGroup(gomock.Any(), int32(1234)).Return(model.AssetGroup{}, fmt.Errorf("exploded"))
 
 	requestTemplate.
 		WithURLPathVars(map[string]string{
@@ -751,7 +751,7 @@ func TestResources_DeleteAssetGroup(t *testing.T) {
 		ResponseStatusCode(http.StatusInternalServerError)
 
 	// DeleteAssetGroup DB fails
-	mockDB.EXPECT().GetAssetGroup(int32(1234)).Return(model.AssetGroup{}, nil)
+	mockDB.EXPECT().GetAssetGroup(gomock.Any(), int32(1234)).Return(model.AssetGroup{}, nil)
 	mockDB.EXPECT().DeleteAssetGroup(gomock.Any(), model.AssetGroup{}).Return(fmt.Errorf("exploded"))
 
 	requestTemplate.
@@ -763,7 +763,7 @@ func TestResources_DeleteAssetGroup(t *testing.T) {
 		ResponseStatusCode(http.StatusInternalServerError)
 
 	// Success
-	mockDB.EXPECT().GetAssetGroup(int32(1234)).Return(model.AssetGroup{}, nil)
+	mockDB.EXPECT().GetAssetGroup(gomock.Any(), int32(1234)).Return(model.AssetGroup{}, nil)
 	mockDB.EXPECT().DeleteAssetGroup(gomock.Any(), model.AssetGroup{}).Return(nil)
 
 	requestTemplate.
@@ -797,7 +797,7 @@ func TestResources_DeleteAssetGroupSelector(t *testing.T) {
 		ResponseStatusCode(http.StatusBadRequest)
 
 	// GetAssetGroup DB fails
-	mockDB.EXPECT().GetAssetGroup(int32(1234)).Return(model.AssetGroup{}, fmt.Errorf("exploded"))
+	mockDB.EXPECT().GetAssetGroup(gomock.Any(), int32(1234)).Return(model.AssetGroup{}, fmt.Errorf("exploded"))
 
 	requestTemplate.
 		WithURLPathVars(map[string]string{
@@ -808,7 +808,7 @@ func TestResources_DeleteAssetGroupSelector(t *testing.T) {
 		ResponseStatusCode(http.StatusInternalServerError)
 
 	// Error where AG Selector ID is not a valid int
-	mockDB.EXPECT().GetAssetGroup(int32(1234)).Return(model.AssetGroup{}, nil)
+	mockDB.EXPECT().GetAssetGroup(gomock.Any(), int32(1234)).Return(model.AssetGroup{}, nil)
 
 	requestTemplate.
 		WithURLPathVars(map[string]string{
@@ -820,8 +820,8 @@ func TestResources_DeleteAssetGroupSelector(t *testing.T) {
 		ResponseStatusCode(http.StatusBadRequest)
 
 	// GetAssetGroupSelector DB fails
-	mockDB.EXPECT().GetAssetGroup(int32(1234)).Return(model.AssetGroup{}, nil)
-	mockDB.EXPECT().GetAssetGroupSelector(int32(1234)).Return(model.AssetGroupSelector{}, fmt.Errorf("exploded"))
+	mockDB.EXPECT().GetAssetGroup(gomock.Any(), int32(1234)).Return(model.AssetGroup{}, nil)
+	mockDB.EXPECT().GetAssetGroupSelector(gomock.Any(), int32(1234)).Return(model.AssetGroupSelector{}, fmt.Errorf("exploded"))
 
 	requestTemplate.
 		WithURLPathVars(map[string]string{
@@ -833,8 +833,8 @@ func TestResources_DeleteAssetGroupSelector(t *testing.T) {
 		ResponseStatusCode(http.StatusInternalServerError)
 
 	// Is System Selector should fail
-	mockDB.EXPECT().GetAssetGroup(int32(1234)).Return(model.AssetGroup{}, nil)
-	mockDB.EXPECT().GetAssetGroupSelector(int32(1234)).Return(model.AssetGroupSelector{SystemSelector: true}, nil)
+	mockDB.EXPECT().GetAssetGroup(gomock.Any(), int32(1234)).Return(model.AssetGroup{}, nil)
+	mockDB.EXPECT().GetAssetGroupSelector(gomock.Any(), int32(1234)).Return(model.AssetGroupSelector{SystemSelector: true}, nil)
 
 	requestTemplate.
 		WithURLPathVars(map[string]string{
@@ -846,8 +846,8 @@ func TestResources_DeleteAssetGroupSelector(t *testing.T) {
 		ResponseStatusCode(http.StatusConflict)
 
 	// DeleteAssetGroupSelector DB fails
-	mockDB.EXPECT().GetAssetGroup(int32(1234)).Return(model.AssetGroup{}, nil)
-	mockDB.EXPECT().GetAssetGroupSelector(int32(1234)).Return(model.AssetGroupSelector{}, nil)
+	mockDB.EXPECT().GetAssetGroup(gomock.Any(), int32(1234)).Return(model.AssetGroup{}, nil)
+	mockDB.EXPECT().GetAssetGroupSelector(gomock.Any(), int32(1234)).Return(model.AssetGroupSelector{}, nil)
 	mockDB.EXPECT().DeleteAssetGroupSelector(gomock.Any(), model.AssetGroupSelector{}).Return(fmt.Errorf("exploded"))
 
 	requestTemplate.
@@ -860,8 +860,8 @@ func TestResources_DeleteAssetGroupSelector(t *testing.T) {
 		ResponseStatusCode(http.StatusInternalServerError)
 
 	// Success
-	mockDB.EXPECT().GetAssetGroup(int32(1234)).Return(model.AssetGroup{}, nil)
-	mockDB.EXPECT().GetAssetGroupSelector(int32(1234)).Return(model.AssetGroupSelector{}, nil)
+	mockDB.EXPECT().GetAssetGroup(gomock.Any(), int32(1234)).Return(model.AssetGroup{}, nil)
+	mockDB.EXPECT().GetAssetGroupSelector(gomock.Any(), int32(1234)).Return(model.AssetGroupSelector{}, nil)
 	mockDB.EXPECT().DeleteAssetGroupSelector(gomock.Any(), model.AssetGroupSelector{}).Return(nil)
 
 	requestTemplate.
@@ -940,7 +940,7 @@ func TestResources_ListAssetGroupCollections(t *testing.T) {
 				Name: "DatabaseGetAssetGroupError",
 				Setup: func() {
 					mockDB.EXPECT().
-						GetAssetGroup(gomock.Any()).
+						GetAssetGroup(gomock.Any(), gomock.Any()).
 						Return(model.AssetGroup{}, errors.New("GetAssetGroup fail"))
 				},
 				Test: func(output apitest.Output) {
@@ -952,10 +952,10 @@ func TestResources_ListAssetGroupCollections(t *testing.T) {
 				Name: "DatabaseGetAssetGroupCollectionsError",
 				Setup: func() {
 					mockDB.EXPECT().
-						GetAssetGroup(gomock.Any()).
+						GetAssetGroup(gomock.Any(), gomock.Any()).
 						Return(assetGroup, nil)
 					mockDB.EXPECT().
-						GetAssetGroupCollections(gomock.Any(), "", gomock.Any()).
+						GetAssetGroupCollections(gomock.Any(), gomock.Any(), "", gomock.Any()).
 						Return(nil, errors.New("GetAssetGroupCollectionsError"))
 				},
 				Test: func(output apitest.Output) {
@@ -966,10 +966,10 @@ func TestResources_ListAssetGroupCollections(t *testing.T) {
 				Name: "SuccessDataTest",
 				Setup: func() {
 					mockDB.EXPECT().
-						GetAssetGroup(gomock.Any()).
+						GetAssetGroup(gomock.Any(), gomock.Any()).
 						Return(assetGroup, nil)
 					mockDB.EXPECT().
-						GetAssetGroupCollections(gomock.Any(), "", gomock.Any()).
+						GetAssetGroupCollections(gomock.Any(), gomock.Any(), "", gomock.Any()).
 						Return(collections, nil)
 				},
 				Test: func(output apitest.Output) {
@@ -994,10 +994,10 @@ func TestResources_ListAssetGroupCollections(t *testing.T) {
 				},
 				Setup: func() {
 					mockDB.EXPECT().
-						GetAssetGroup(gomock.Any()).
+						GetAssetGroup(gomock.Any(), gomock.Any()).
 						Return(assetGroup, nil)
 					mockDB.EXPECT().
-						GetAssetGroupCollections(gomock.Any(), "created_at", gomock.Any()).
+						GetAssetGroupCollections(gomock.Any(), gomock.Any(), "created_at", gomock.Any()).
 						Return(collections, nil)
 				},
 				Test: func(output apitest.Output) {
@@ -1011,10 +1011,10 @@ func TestResources_ListAssetGroupCollections(t *testing.T) {
 				},
 				Setup: func() {
 					mockDB.EXPECT().
-						GetAssetGroup(gomock.Any()).
+						GetAssetGroup(gomock.Any(), gomock.Any()).
 						Return(assetGroup, nil)
 					mockDB.EXPECT().
-						GetAssetGroupCollections(gomock.Any(), "created_at desc", gomock.Any()).
+						GetAssetGroupCollections(gomock.Any(), gomock.Any(), "created_at desc", gomock.Any()).
 						Return(collections, nil)
 				},
 				Test: func(output apitest.Output) {
@@ -1028,9 +1028,9 @@ func TestResources_ListAssetGroupCollections(t *testing.T) {
 					apitest.SetURLVar(input, api.URIPathVariableAssetGroupID, "1")
 				},
 				Setup: func() {
-					mockDB.EXPECT().GetAssetGroup(gomock.Any()).Return(assetGroup, nil)
+					mockDB.EXPECT().GetAssetGroup(gomock.Any(), gomock.Any()).Return(assetGroup, nil)
 					mockDB.EXPECT().
-						GetAssetGroupCollections(gomock.Any(), "",
+						GetAssetGroupCollections(gomock.Any(), gomock.Any(), "",
 							model.SQLFilter{SQLString: "id = ?", Params: []any{"1"}}).
 						Return(collections, nil)
 				},
@@ -1100,7 +1100,7 @@ func TestResources_ListAssetGroupMembers(t *testing.T) {
 				},
 				Setup: func() {
 					mockDB.EXPECT().
-						GetAssetGroup(gomock.Any()).
+						GetAssetGroup(gomock.Any(), gomock.Any()).
 						Return(model.AssetGroup{}, errors.New("GetAssetGroup fail"))
 				},
 				Test: func(output apitest.Output) {
@@ -1115,7 +1115,7 @@ func TestResources_ListAssetGroupMembers(t *testing.T) {
 				},
 				Setup: func() {
 					mockDB.EXPECT().
-						GetAssetGroup(gomock.Any()).
+						GetAssetGroup(gomock.Any(), gomock.Any()).
 						Return(assetGroup, nil)
 					mockGraph.EXPECT().
 						GetAssetGroupNodes(gomock.Any(), gomock.Any()).
@@ -1132,7 +1132,7 @@ func TestResources_ListAssetGroupMembers(t *testing.T) {
 				},
 				Setup: func() {
 					mockDB.EXPECT().
-						GetAssetGroup(gomock.Any()).
+						GetAssetGroup(gomock.Any(), gomock.Any()).
 						Return(assetGroup, nil)
 					mockGraph.EXPECT().
 						GetAssetGroupNodes(gomock.Any(), gomock.Any()).
@@ -1182,7 +1182,7 @@ func TestResources_ListAssetGroupMembers(t *testing.T) {
 				},
 				Setup: func() {
 					mockDB.EXPECT().
-						GetAssetGroup(gomock.Any()).
+						GetAssetGroup(gomock.Any(), gomock.Any()).
 						Return(assetGroup, nil)
 					mockGraph.EXPECT().
 						GetAssetGroupNodes(gomock.Any(), gomock.Any()).
@@ -1218,7 +1218,7 @@ func TestResources_ListAssetGroupMembers(t *testing.T) {
 				},
 				Setup: func() {
 					mockDB.EXPECT().
-						GetAssetGroup(gomock.Any()).
+						GetAssetGroup(gomock.Any(), gomock.Any()).
 						Return(assetGroup, nil)
 					mockGraph.EXPECT().
 						GetAssetGroupNodes(gomock.Any(), gomock.Any()).
@@ -1259,7 +1259,7 @@ func TestResources_ListAssetGroupMembers(t *testing.T) {
 				},
 				Setup: func() {
 					mockDB.EXPECT().
-						GetAssetGroup(gomock.Any()).
+						GetAssetGroup(gomock.Any(), gomock.Any()).
 						Return(assetGroup, nil)
 					mockGraph.EXPECT().
 						GetAssetGroupNodes(gomock.Any(), gomock.Any()).
@@ -1302,7 +1302,7 @@ func TestResources_ListAssetGroupMembers(t *testing.T) {
 				},
 				Setup: func() {
 					mockDB.EXPECT().
-						GetAssetGroup(gomock.Any()).
+						GetAssetGroup(gomock.Any(), gomock.Any()).
 						Return(assetGroup, nil)
 					mockGraph.EXPECT().
 						GetAssetGroupNodes(gomock.Any(), gomock.Any()).
@@ -1337,7 +1337,7 @@ func TestResources_ListAssetGroupMembers(t *testing.T) {
 				},
 				Setup: func() {
 					mockDB.EXPECT().
-						GetAssetGroup(gomock.Any()).
+						GetAssetGroup(gomock.Any(), gomock.Any()).
 						Return(assetGroup, nil)
 					mockGraph.EXPECT().
 						GetAssetGroupNodes(gomock.Any(), gomock.Any()).
@@ -1429,7 +1429,7 @@ func TestResources_ListAssetGroupMembersCount(t *testing.T) {
 				},
 				Setup: func() {
 					mockDB.EXPECT().
-						GetAssetGroup(gomock.Any()).
+						GetAssetGroup(gomock.Any(), gomock.Any()).
 						Return(model.AssetGroup{}, errors.New("GetAssetGroup fail"))
 				},
 				Test: func(output apitest.Output) {
@@ -1444,7 +1444,7 @@ func TestResources_ListAssetGroupMembersCount(t *testing.T) {
 				},
 				Setup: func() {
 					mockDB.EXPECT().
-						GetAssetGroup(gomock.Any()).
+						GetAssetGroup(gomock.Any(), gomock.Any()).
 						Return(assetGroup, nil)
 					mockGraph.EXPECT().
 						GetAssetGroupNodes(gomock.Any(), gomock.Any()).
@@ -1461,7 +1461,7 @@ func TestResources_ListAssetGroupMembersCount(t *testing.T) {
 				},
 				Setup: func() {
 					mockDB.EXPECT().
-						GetAssetGroup(gomock.Any()).
+						GetAssetGroup(gomock.Any(), gomock.Any()).
 						Return(assetGroup, nil)
 					mockGraph.EXPECT().
 						GetAssetGroupNodes(gomock.Any(), gomock.Any()).
@@ -1497,7 +1497,7 @@ func TestResources_ListAssetGroupMembersCount(t *testing.T) {
 				},
 				Setup: func() {
 					mockDB.EXPECT().
-						GetAssetGroup(gomock.Any()).
+						GetAssetGroup(gomock.Any(), gomock.Any()).
 						Return(assetGroup, nil)
 					mockGraph.EXPECT().
 						GetAssetGroupNodes(gomock.Any(), gomock.Any()).

--- a/cmd/api/src/daemons/datapipe/agi.go
+++ b/cmd/api/src/daemons/datapipe/agi.go
@@ -182,7 +182,7 @@ func TagActiveDirectoryTierZero(ctx context.Context, db graph.Database) error {
 func RunAssetGroupIsolationCollections(ctx context.Context, db database.Database, graphDB graph.Database, kindGetter func(*graph.Node) string) error {
 	defer log.Measure(log.LevelInfo, "Asset Group Isolation Collections")()
 
-	if assetGroups, err := db.GetAllAssetGroups("", model.SQLFilter{}); err != nil {
+	if assetGroups, err := db.GetAllAssetGroups(ctx, "", model.SQLFilter{}); err != nil {
 		return err
 	} else {
 		return graphDB.WriteTransaction(ctx, func(tx graph.Transaction) error {
@@ -221,7 +221,7 @@ func RunAssetGroupIsolationCollections(ctx context.Context, db database.Database
 					}
 
 					// Enter a collection, even if it's empty to signal that we did do a tagging/collection run
-					if err := db.CreateAssetGroupCollection(collection, entries); err != nil {
+					if err := db.CreateAssetGroupCollection(ctx, collection, entries); err != nil {
 						return err
 					}
 				}

--- a/cmd/api/src/database/agi.go
+++ b/cmd/api/src/database/agi.go
@@ -22,7 +22,6 @@ import (
 
 	"gorm.io/gorm"
 
-	"github.com/specterops/bloodhound/src/ctx"
 	"github.com/specterops/bloodhound/src/database/types"
 	"github.com/specterops/bloodhound/src/model"
 )
@@ -72,28 +71,28 @@ func (s *BloodhoundDB) DeleteAssetGroup(ctx context.Context, assetGroup model.As
 	})
 }
 
-func (s *BloodhoundDB) GetAssetGroup(id int32) (model.AssetGroup, error) {
+func (s *BloodhoundDB) GetAssetGroup(ctx context.Context, id int32) (model.AssetGroup, error) {
 	var (
 		assetGroup model.AssetGroup
-		result     = s.preload(model.AssetGroupAssociations()).First(&assetGroup, id)
+		result     = s.preload(model.AssetGroupAssociations()).WithContext(ctx).First(&assetGroup, id)
 	)
 	return assetGroup, CheckError(result)
 }
 
-func (s *BloodhoundDB) GetAllAssetGroups(order string, filter model.SQLFilter) (model.AssetGroups, error) {
+func (s *BloodhoundDB) GetAllAssetGroups(ctx context.Context, order string, filter model.SQLFilter) (model.AssetGroups, error) {
 	var (
 		assetGroups model.AssetGroups
 		result      *gorm.DB
 	)
 
 	if order != "" && filter.SQLString == "" {
-		result = s.preload(model.AssetGroupAssociations()).Order(order).Find(&assetGroups)
+		result = s.preload(model.AssetGroupAssociations()).WithContext(ctx).Order(order).Find(&assetGroups)
 	} else if order != "" && filter.SQLString != "" {
-		result = s.preload(model.AssetGroupAssociations()).Where(filter.SQLString, filter.Params).Order(order).Find(&assetGroups)
+		result = s.preload(model.AssetGroupAssociations()).WithContext(ctx).Where(filter.SQLString, filter.Params).Order(order).Find(&assetGroups)
 	} else if order == "" && filter.SQLString != "" {
-		result = s.preload(model.AssetGroupAssociations()).Where(filter.SQLString, filter.Params).Find(&assetGroups)
+		result = s.preload(model.AssetGroupAssociations()).WithContext(ctx).Where(filter.SQLString, filter.Params).Find(&assetGroups)
 	} else {
-		result = s.preload(model.AssetGroupAssociations()).Find(&assetGroups)
+		result = s.preload(model.AssetGroupAssociations()).WithContext(ctx).Find(&assetGroups)
 	}
 
 	if result.Error != nil {
@@ -101,7 +100,7 @@ func (s *BloodhoundDB) GetAllAssetGroups(order string, filter model.SQLFilter) (
 	}
 
 	for idx, assetGroup := range assetGroups {
-		if latestCollection, err := s.GetLatestAssetGroupCollection(assetGroup.ID); err != nil {
+		if latestCollection, err := s.GetLatestAssetGroupCollection(ctx, assetGroup.ID); err != nil {
 			if err == ErrNotFound {
 				assetGroup.MemberCount = 0
 			} else {
@@ -119,43 +118,43 @@ func (s *BloodhoundDB) SweepAssetGroupCollections() {
 	s.db.Where("created_at < now() - INTERVAL '30 DAYS'").Delete(&model.AssetGroupCollection{})
 }
 
-func (s *BloodhoundDB) GetAssetGroupCollections(assetGroupID int32, order string, filter model.SQLFilter) (model.AssetGroupCollections, error) {
+func (s *BloodhoundDB) GetAssetGroupCollections(ctx context.Context, assetGroupID int32, order string, filter model.SQLFilter) (model.AssetGroupCollections, error) {
 	var (
 		collections model.AssetGroupCollections
 		result      *gorm.DB
 	)
 
 	if order == "" && filter.SQLString == "" {
-		result = s.preload(model.AssetGroupCollectionAssociations()).Where("asset_group_id = ?", assetGroupID).Find(&collections)
+		result = s.preload(model.AssetGroupCollectionAssociations()).WithContext(ctx).Where("asset_group_id = ?", assetGroupID).Find(&collections)
 	} else if order != "" && filter.SQLString == "" {
-		result = s.preload(model.AssetGroupCollectionAssociations()).Order(order).Where("asset_group_id = ?", assetGroupID).Find(&collections)
+		result = s.preload(model.AssetGroupCollectionAssociations()).WithContext(ctx).Order(order).Where("asset_group_id = ?", assetGroupID).Find(&collections)
 	} else if order == "" && filter.SQLString != "" {
-		result = s.preload(model.AssetGroupCollectionAssociations()).Where("asset_group_id = ?", assetGroupID).Where(filter.SQLString, filter.Params).Find(&collections)
+		result = s.preload(model.AssetGroupCollectionAssociations()).WithContext(ctx).Where("asset_group_id = ?", assetGroupID).Where(filter.SQLString, filter.Params).Find(&collections)
 	} else {
-		result = s.preload(model.AssetGroupCollectionAssociations()).Order(order).Where("asset_group_id = ?", assetGroupID).Where(filter.SQLString, filter.Params).Find(&collections)
+		result = s.preload(model.AssetGroupCollectionAssociations()).WithContext(ctx).Order(order).Where("asset_group_id = ?", assetGroupID).Where(filter.SQLString, filter.Params).Find(&collections)
 	}
 	return collections, CheckError(result)
 }
 
-func (s *BloodhoundDB) GetLatestAssetGroupCollection(assetGroupID int32) (model.AssetGroupCollection, error) {
+func (s *BloodhoundDB) GetLatestAssetGroupCollection(ctx context.Context, assetGroupID int32) (model.AssetGroupCollection, error) {
 	var collection model.AssetGroupCollection
 
-	result := s.preload(model.AssetGroupCollectionAssociations()).Where("asset_group_id = ?", assetGroupID).Last(&collection)
+	result := s.preload(model.AssetGroupCollectionAssociations()).WithContext(ctx).Where("asset_group_id = ?", assetGroupID).Last(&collection)
 	return collection, CheckError(result)
 }
 
-func (s *BloodhoundDB) GetTimeRangedAssetGroupCollections(assetGroupID int32, from int64, to int64, order string) (model.AssetGroupCollections, error) {
+func (s *BloodhoundDB) GetTimeRangedAssetGroupCollections(ctx context.Context, assetGroupID int32, from int64, to int64, order string) (model.AssetGroupCollections, error) {
 	var (
 		collections model.AssetGroupCollections
 		result      *gorm.DB
 	)
 
 	if order == "" {
-		result = s.preload(model.AssetGroupCollectionAssociations()).
+		result = s.preload(model.AssetGroupCollectionAssociations()).WithContext(ctx).
 			Where("asset_group_id = ? AND created_at BETWEEN ? AND ?", assetGroupID, from, to).
 			Find(&collections)
 	} else {
-		result = s.preload(model.AssetGroupCollectionAssociations()).
+		result = s.preload(model.AssetGroupCollectionAssociations()).WithContext(ctx).
 			Order(order).
 			Where("asset_group_id = ? AND created_at BETWEEN ? AND ?", assetGroupID, from, to).
 			Find(&collections)
@@ -164,9 +163,9 @@ func (s *BloodhoundDB) GetTimeRangedAssetGroupCollections(assetGroupID int32, fr
 	return collections, CheckError(result)
 }
 
-func (s *BloodhoundDB) GetAssetGroupSelector(id int32) (model.AssetGroupSelector, error) {
+func (s *BloodhoundDB) GetAssetGroupSelector(ctx context.Context, id int32) (model.AssetGroupSelector, error) {
 	var assetGroupSelector model.AssetGroupSelector
-	return assetGroupSelector, CheckError(s.db.Find(&assetGroupSelector, id))
+	return assetGroupSelector, CheckError(s.db.WithContext(ctx).Find(&assetGroupSelector, id))
 }
 
 func (s *BloodhoundDB) DeleteAssetGroupSelector(ctx context.Context, selector model.AssetGroupSelector) error {
@@ -182,10 +181,10 @@ func (s *BloodhoundDB) DeleteAssetGroupSelector(ctx context.Context, selector mo
 	})
 }
 
-func (s *BloodhoundDB) UpdateAssetGroupSelectors(ctx ctx.Context, assetGroup model.AssetGroup, selectorSpecs []model.AssetGroupSelectorSpec, systemSelector bool) (model.UpdatedAssetGroupSelectors, error) {
+func (s *BloodhoundDB) UpdateAssetGroupSelectors(ctx context.Context, assetGroup model.AssetGroup, selectorSpecs []model.AssetGroupSelectorSpec, systemSelector bool) (model.UpdatedAssetGroupSelectors, error) {
 	var updatedSelectors = model.UpdatedAssetGroupSelectors{}
 
-	err := s.db.Transaction(func(tx *gorm.DB) error {
+	err := s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		for _, selectorSpec := range selectorSpecs {
 			switch selectorSpec.Action {
 			case model.SelectorSpecActionAdd:
@@ -224,12 +223,12 @@ func (s *BloodhoundDB) UpdateAssetGroupSelectors(ctx ctx.Context, assetGroup mod
 	return updatedSelectors, err
 }
 
-func (s *BloodhoundDB) CreateAssetGroupCollection(collection model.AssetGroupCollection, entries model.AssetGroupCollectionEntries) error {
+func (s *BloodhoundDB) CreateAssetGroupCollection(ctx context.Context, collection model.AssetGroupCollection, entries model.AssetGroupCollectionEntries) error {
 	const CreateAssetGroupCollectionQuery = `INSERT INTO "asset_group_collection_entries"
     ("asset_group_collection_id","object_id","node_label","properties","created_at","updated_at")
 	(SELECT * FROM unnest($1::bigint[], $2::text[], $3::text[], $4::jsonb[], $5::timestamp[], $5::timestamp[]));`
 
-	return s.db.Transaction(func(tx *gorm.DB) error {
+	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		var newCollection = collection
 
 		if result := tx.Create(&newCollection); result.Error != nil {

--- a/cmd/api/src/database/agi_test.go
+++ b/cmd/api/src/database/agi_test.go
@@ -31,7 +31,7 @@ func TestCreateGetUpdateDeleteAssetGroup(t *testing.T) {
 		t.Fatalf("Error verifying CreateAssetGroup audit logs:\n%v", err)
 	}
 
-	if assetGroups, err := dbInst.GetAllAssetGroups("", model.SQLFilter{}); err != nil {
+	if assetGroups, err := dbInst.GetAllAssetGroups(context.Background(), "", model.SQLFilter{}); err != nil {
 		t.Fatalf("Error retrieving asset groups: %v", err)
 	} else if !slices.ContainsFunc(assetGroups, func(ag model.AssetGroup) bool { return ag.Name == "test asset group" }) {
 		t.Fatalf("Created asset group not returned:\n%#v", assetGroups)

--- a/cmd/api/src/database/audit.go
+++ b/cmd/api/src/database/audit.go
@@ -135,7 +135,7 @@ func (s *BloodhoundDB) AuditableTransaction(ctx context.Context, auditEntry mode
 		return fmt.Errorf("could not append intent to audit log: %w", err)
 	}
 
-	err = s.db.Transaction(f, opts...)
+	err = s.db.WithContext(ctx).Transaction(f, opts...)
 
 	if err != nil {
 		auditEntry.Status = model.AuditStatusFailure

--- a/cmd/api/src/database/db.go
+++ b/cmd/api/src/database/db.go
@@ -75,7 +75,7 @@ type Database interface {
 	DeleteAssetGroupSelector(ctx context.Context, selector model.AssetGroupSelector) error
 	UpdateAssetGroupSelectors(ctx context.Context, assetGroup model.AssetGroup, selectorSpecs []model.AssetGroupSelectorSpec, systemSelector bool) (model.UpdatedAssetGroupSelectors, error)
 	CreateAssetGroupCollection(ctx context.Context, collection model.AssetGroupCollection, entries model.AssetGroupCollectionEntries) error
-	RawFirst(value any) error
+
 	Wipe() error
 	Migrate() error
 	RequiresMigration() (bool, error)
@@ -193,10 +193,6 @@ func OpenDatabase(connection string) (*gorm.DB, error) {
 	} else {
 		return db, nil
 	}
-}
-
-func (s *BloodhoundDB) RawFirst(value any) error {
-	return CheckError(s.db.Model(value).First(value))
 }
 
 func (s *BloodhoundDB) RawDelete(value any) error {

--- a/cmd/api/src/database/db.go
+++ b/cmd/api/src/database/db.go
@@ -27,7 +27,6 @@ import (
 	"github.com/specterops/bloodhound/errors"
 	"github.com/specterops/bloodhound/log"
 	"github.com/specterops/bloodhound/src/auth"
-	"github.com/specterops/bloodhound/src/ctx"
 	"github.com/specterops/bloodhound/src/database/migration"
 	"github.com/specterops/bloodhound/src/model"
 	"github.com/specterops/bloodhound/src/model/appcfg"
@@ -61,19 +60,21 @@ type Database interface {
 	DeleteIngestTask(ingestTask model.IngestTask) error
 	GetIngestTasksForJob(jobID int64) (model.IngestTasks, error)
 	GetUnfinishedIngestIDs() ([]int64, error)
+
+	// Asset Groups
 	CreateAssetGroup(ctx context.Context, name, tag string, systemGroup bool) (model.AssetGroup, error)
 	UpdateAssetGroup(ctx context.Context, assetGroup model.AssetGroup) error
 	DeleteAssetGroup(ctx context.Context, assetGroup model.AssetGroup) error
-	GetAssetGroup(id int32) (model.AssetGroup, error)
-	GetAllAssetGroups(order string, filter model.SQLFilter) (model.AssetGroups, error)
+	GetAssetGroup(ctx context.Context, id int32) (model.AssetGroup, error)
+	GetAllAssetGroups(ctx context.Context, order string, filter model.SQLFilter) (model.AssetGroups, error)
 	SweepAssetGroupCollections()
-	GetAssetGroupCollections(assetGroupID int32, order string, filter model.SQLFilter) (model.AssetGroupCollections, error)
-	GetLatestAssetGroupCollection(assetGroupID int32) (model.AssetGroupCollection, error)
-	GetTimeRangedAssetGroupCollections(assetGroupID int32, from int64, to int64, order string) (model.AssetGroupCollections, error)
-	GetAssetGroupSelector(id int32) (model.AssetGroupSelector, error)
+	GetAssetGroupCollections(ctx context.Context, assetGroupID int32, order string, filter model.SQLFilter) (model.AssetGroupCollections, error)
+	GetLatestAssetGroupCollection(ctx context.Context, assetGroupID int32) (model.AssetGroupCollection, error)
+	GetTimeRangedAssetGroupCollections(ctx context.Context, assetGroupID int32, from int64, to int64, order string) (model.AssetGroupCollections, error)
+	GetAssetGroupSelector(ctx context.Context, id int32) (model.AssetGroupSelector, error)
 	DeleteAssetGroupSelector(ctx context.Context, selector model.AssetGroupSelector) error
-	UpdateAssetGroupSelectors(ctx ctx.Context, assetGroup model.AssetGroup, selectorSpecs []model.AssetGroupSelectorSpec, systemSelector bool) (model.UpdatedAssetGroupSelectors, error)
-	CreateAssetGroupCollection(collection model.AssetGroupCollection, entries model.AssetGroupCollectionEntries) error
+	UpdateAssetGroupSelectors(ctx context.Context, assetGroup model.AssetGroup, selectorSpecs []model.AssetGroupSelectorSpec, systemSelector bool) (model.UpdatedAssetGroupSelectors, error)
+	CreateAssetGroupCollection(ctx context.Context, collection model.AssetGroupCollection, entries model.AssetGroupCollectionEntries) error
 	RawFirst(value any) error
 	Wipe() error
 	Migrate() error

--- a/cmd/api/src/database/migration/agi_integration_test.go
+++ b/cmd/api/src/database/migration/agi_integration_test.go
@@ -20,6 +20,7 @@
 package migration_test
 
 import (
+	"context"
 	"github.com/specterops/bloodhound/src/model"
 	"github.com/specterops/bloodhound/src/test/integration"
 	"github.com/stretchr/testify/require"
@@ -34,7 +35,7 @@ func TestMigration_AssetGroups(t *testing.T) {
 		t.Fatalf("Failed preparing DB: %v", err)
 	}
 
-	assetGroups, err := dbInst.GetAllAssetGroups("", model.SQLFilter{})
+	assetGroups, err := dbInst.GetAllAssetGroups(context.Background(), "", model.SQLFilter{})
 	require.Nil(t, err)
 	require.Equal(t, expectedNumAssetGroups, len(assetGroups))
 }

--- a/cmd/api/src/database/mocks/db.go
+++ b/cmd/api/src/database/mocks/db.go
@@ -26,7 +26,6 @@ import (
 	time "time"
 
 	uuid "github.com/gofrs/uuid"
-	ctx "github.com/specterops/bloodhound/src/ctx"
 	model "github.com/specterops/bloodhound/src/model"
 	appcfg "github.com/specterops/bloodhound/src/model/appcfg"
 	gomock "go.uber.org/mock/gomock"
@@ -127,17 +126,17 @@ func (mr *MockDatabaseMockRecorder) CreateAssetGroup(arg0, arg1, arg2, arg3 inte
 }
 
 // CreateAssetGroupCollection mocks base method.
-func (m *MockDatabase) CreateAssetGroupCollection(arg0 model.AssetGroupCollection, arg1 model.AssetGroupCollectionEntries) error {
+func (m *MockDatabase) CreateAssetGroupCollection(arg0 context.Context, arg1 model.AssetGroupCollection, arg2 model.AssetGroupCollectionEntries) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateAssetGroupCollection", arg0, arg1)
+	ret := m.ctrl.Call(m, "CreateAssetGroupCollection", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CreateAssetGroupCollection indicates an expected call of CreateAssetGroupCollection.
-func (mr *MockDatabaseMockRecorder) CreateAssetGroupCollection(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockDatabaseMockRecorder) CreateAssetGroupCollection(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAssetGroupCollection", reflect.TypeOf((*MockDatabase)(nil).CreateAssetGroupCollection), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAssetGroupCollection", reflect.TypeOf((*MockDatabase)(nil).CreateAssetGroupCollection), arg0, arg1, arg2)
 }
 
 // CreateAuditLog mocks base method.
@@ -506,18 +505,18 @@ func (mr *MockDatabaseMockRecorder) GetADDataQualityStats(arg0, arg1, arg2, arg3
 }
 
 // GetAllAssetGroups mocks base method.
-func (m *MockDatabase) GetAllAssetGroups(arg0 string, arg1 model.SQLFilter) (model.AssetGroups, error) {
+func (m *MockDatabase) GetAllAssetGroups(arg0 context.Context, arg1 string, arg2 model.SQLFilter) (model.AssetGroups, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAllAssetGroups", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetAllAssetGroups", arg0, arg1, arg2)
 	ret0, _ := ret[0].(model.AssetGroups)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetAllAssetGroups indicates an expected call of GetAllAssetGroups.
-func (mr *MockDatabaseMockRecorder) GetAllAssetGroups(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockDatabaseMockRecorder) GetAllAssetGroups(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllAssetGroups", reflect.TypeOf((*MockDatabase)(nil).GetAllAssetGroups), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllAssetGroups", reflect.TypeOf((*MockDatabase)(nil).GetAllAssetGroups), arg0, arg1, arg2)
 }
 
 // GetAllAuthTokens mocks base method.
@@ -657,48 +656,48 @@ func (mr *MockDatabaseMockRecorder) GetAllUsers(arg0, arg1 interface{}) *gomock.
 }
 
 // GetAssetGroup mocks base method.
-func (m *MockDatabase) GetAssetGroup(arg0 int32) (model.AssetGroup, error) {
+func (m *MockDatabase) GetAssetGroup(arg0 context.Context, arg1 int32) (model.AssetGroup, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAssetGroup", arg0)
+	ret := m.ctrl.Call(m, "GetAssetGroup", arg0, arg1)
 	ret0, _ := ret[0].(model.AssetGroup)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetAssetGroup indicates an expected call of GetAssetGroup.
-func (mr *MockDatabaseMockRecorder) GetAssetGroup(arg0 interface{}) *gomock.Call {
+func (mr *MockDatabaseMockRecorder) GetAssetGroup(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAssetGroup", reflect.TypeOf((*MockDatabase)(nil).GetAssetGroup), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAssetGroup", reflect.TypeOf((*MockDatabase)(nil).GetAssetGroup), arg0, arg1)
 }
 
 // GetAssetGroupCollections mocks base method.
-func (m *MockDatabase) GetAssetGroupCollections(arg0 int32, arg1 string, arg2 model.SQLFilter) (model.AssetGroupCollections, error) {
+func (m *MockDatabase) GetAssetGroupCollections(arg0 context.Context, arg1 int32, arg2 string, arg3 model.SQLFilter) (model.AssetGroupCollections, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAssetGroupCollections", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "GetAssetGroupCollections", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(model.AssetGroupCollections)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetAssetGroupCollections indicates an expected call of GetAssetGroupCollections.
-func (mr *MockDatabaseMockRecorder) GetAssetGroupCollections(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockDatabaseMockRecorder) GetAssetGroupCollections(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAssetGroupCollections", reflect.TypeOf((*MockDatabase)(nil).GetAssetGroupCollections), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAssetGroupCollections", reflect.TypeOf((*MockDatabase)(nil).GetAssetGroupCollections), arg0, arg1, arg2, arg3)
 }
 
 // GetAssetGroupSelector mocks base method.
-func (m *MockDatabase) GetAssetGroupSelector(arg0 int32) (model.AssetGroupSelector, error) {
+func (m *MockDatabase) GetAssetGroupSelector(arg0 context.Context, arg1 int32) (model.AssetGroupSelector, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAssetGroupSelector", arg0)
+	ret := m.ctrl.Call(m, "GetAssetGroupSelector", arg0, arg1)
 	ret0, _ := ret[0].(model.AssetGroupSelector)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetAssetGroupSelector indicates an expected call of GetAssetGroupSelector.
-func (mr *MockDatabaseMockRecorder) GetAssetGroupSelector(arg0 interface{}) *gomock.Call {
+func (mr *MockDatabaseMockRecorder) GetAssetGroupSelector(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAssetGroupSelector", reflect.TypeOf((*MockDatabase)(nil).GetAssetGroupSelector), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAssetGroupSelector", reflect.TypeOf((*MockDatabase)(nil).GetAssetGroupSelector), arg0, arg1)
 }
 
 // GetAuthSecret mocks base method.
@@ -884,18 +883,18 @@ func (mr *MockDatabaseMockRecorder) GetInstallation() *gomock.Call {
 }
 
 // GetLatestAssetGroupCollection mocks base method.
-func (m *MockDatabase) GetLatestAssetGroupCollection(arg0 int32) (model.AssetGroupCollection, error) {
+func (m *MockDatabase) GetLatestAssetGroupCollection(arg0 context.Context, arg1 int32) (model.AssetGroupCollection, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetLatestAssetGroupCollection", arg0)
+	ret := m.ctrl.Call(m, "GetLatestAssetGroupCollection", arg0, arg1)
 	ret0, _ := ret[0].(model.AssetGroupCollection)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetLatestAssetGroupCollection indicates an expected call of GetLatestAssetGroupCollection.
-func (mr *MockDatabaseMockRecorder) GetLatestAssetGroupCollection(arg0 interface{}) *gomock.Call {
+func (mr *MockDatabaseMockRecorder) GetLatestAssetGroupCollection(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLatestAssetGroupCollection", reflect.TypeOf((*MockDatabase)(nil).GetLatestAssetGroupCollection), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLatestAssetGroupCollection", reflect.TypeOf((*MockDatabase)(nil).GetLatestAssetGroupCollection), arg0, arg1)
 }
 
 // GetPermission mocks base method.
@@ -989,18 +988,18 @@ func (mr *MockDatabaseMockRecorder) GetSAMLProviderUsers(arg0 interface{}) *gomo
 }
 
 // GetTimeRangedAssetGroupCollections mocks base method.
-func (m *MockDatabase) GetTimeRangedAssetGroupCollections(arg0 int32, arg1, arg2 int64, arg3 string) (model.AssetGroupCollections, error) {
+func (m *MockDatabase) GetTimeRangedAssetGroupCollections(arg0 context.Context, arg1 int32, arg2, arg3 int64, arg4 string) (model.AssetGroupCollections, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetTimeRangedAssetGroupCollections", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "GetTimeRangedAssetGroupCollections", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(model.AssetGroupCollections)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetTimeRangedAssetGroupCollections indicates an expected call of GetTimeRangedAssetGroupCollections.
-func (mr *MockDatabaseMockRecorder) GetTimeRangedAssetGroupCollections(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockDatabaseMockRecorder) GetTimeRangedAssetGroupCollections(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTimeRangedAssetGroupCollections", reflect.TypeOf((*MockDatabase)(nil).GetTimeRangedAssetGroupCollections), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTimeRangedAssetGroupCollections", reflect.TypeOf((*MockDatabase)(nil).GetTimeRangedAssetGroupCollections), arg0, arg1, arg2, arg3, arg4)
 }
 
 // GetUnfinishedIngestIDs mocks base method.
@@ -1341,7 +1340,7 @@ func (mr *MockDatabaseMockRecorder) UpdateAssetGroup(arg0, arg1 interface{}) *go
 }
 
 // UpdateAssetGroupSelectors mocks base method.
-func (m *MockDatabase) UpdateAssetGroupSelectors(arg0 ctx.Context, arg1 model.AssetGroup, arg2 []model.AssetGroupSelectorSpec, arg3 bool) (model.UpdatedAssetGroupSelectors, error) {
+func (m *MockDatabase) UpdateAssetGroupSelectors(arg0 context.Context, arg1 model.AssetGroup, arg2 []model.AssetGroupSelectorSpec, arg3 bool) (model.UpdatedAssetGroupSelectors, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateAssetGroupSelectors", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(model.UpdatedAssetGroupSelectors)

--- a/cmd/api/src/database/mocks/db.go
+++ b/cmd/api/src/database/mocks/db.go
@@ -1229,20 +1229,6 @@ func (mr *MockDatabaseMockRecorder) Migrate() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Migrate", reflect.TypeOf((*MockDatabase)(nil).Migrate))
 }
 
-// RawFirst mocks base method.
-func (m *MockDatabase) RawFirst(arg0 interface{}) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RawFirst", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// RawFirst indicates an expected call of RawFirst.
-func (mr *MockDatabaseMockRecorder) RawFirst(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RawFirst", reflect.TypeOf((*MockDatabase)(nil).RawFirst), arg0)
-}
-
 // RequiresMigration mocks base method.
 func (m *MockDatabase) RequiresMigration() (bool, error) {
 	m.ctrl.T.Helper()

--- a/cmd/api/src/queries/graph.go
+++ b/cmd/api/src/queries/graph.go
@@ -911,7 +911,7 @@ func (s *GraphQuery) UpdateSelectorTags(ctx context.Context, db agi.AgiData, sel
 }
 
 func addTagsToSelector(ctx context.Context, graphQuery *GraphQuery, db agi.AgiData, selector model.AssetGroupSelector) error {
-	if assetGroup, err := db.GetAssetGroup(selector.AssetGroupID); err != nil {
+	if assetGroup, err := db.GetAssetGroup(ctx, selector.AssetGroupID); err != nil {
 		return err
 	} else {
 		return graphQuery.Graph.WriteTransaction(ctx, func(tx graph.Transaction) error {
@@ -949,7 +949,7 @@ func addTagsToSelector(ctx context.Context, graphQuery *GraphQuery, db agi.AgiDa
 }
 
 func removeTagsFromSelector(ctx context.Context, graphQuery *GraphQuery, db agi.AgiData, selector model.AssetGroupSelector) error {
-	if assetGroup, err := db.GetAssetGroup(selector.AssetGroupID); err != nil {
+	if assetGroup, err := db.GetAssetGroup(ctx, selector.AssetGroupID); err != nil {
 		return err
 	} else {
 		return graphQuery.Graph.WriteTransaction(ctx, func(tx graph.Transaction) error {

--- a/cmd/api/src/services/agi/agi.go
+++ b/cmd/api/src/services/agi/agi.go
@@ -31,15 +31,15 @@ import (
 )
 
 type AgiData interface {
-	GetAllAssetGroups(order string, filter model.SQLFilter) (model.AssetGroups, error)
-	GetAssetGroup(id int32) (model.AssetGroup, error)
-	CreateAssetGroupCollection(collection model.AssetGroupCollection, entries model.AssetGroupCollectionEntries) error
+	GetAllAssetGroups(ctx context.Context, order string, filter model.SQLFilter) (model.AssetGroups, error)
+	GetAssetGroup(ctx context.Context, id int32) (model.AssetGroup, error)
+	CreateAssetGroupCollection(ctx context.Context, collection model.AssetGroupCollection, entries model.AssetGroupCollectionEntries) error
 }
 
 func RunAssetGroupIsolationCollections(ctx context.Context, db AgiData, graphDB graph.Database, kindGetter func(*graph.Node) string) error {
 	defer log.Measure(log.LevelInfo, "Asset Group Isolation Collections")()
 
-	if assetGroups, err := db.GetAllAssetGroups("", model.SQLFilter{}); err != nil {
+	if assetGroups, err := db.GetAllAssetGroups(ctx, "", model.SQLFilter{}); err != nil {
 		return err
 	} else {
 		return graphDB.WriteTransaction(ctx, func(tx graph.Transaction) error {
@@ -78,7 +78,7 @@ func RunAssetGroupIsolationCollections(ctx context.Context, db AgiData, graphDB 
 					}
 
 					// Enter a collection, even if it's empty to signal that we did do a tagging/collection run
-					if err := db.CreateAssetGroupCollection(collection, entries); err != nil {
+					if err := db.CreateAssetGroupCollection(ctx, collection, entries); err != nil {
 						return err
 					}
 				}
@@ -90,7 +90,7 @@ func RunAssetGroupIsolationCollections(ctx context.Context, db AgiData, graphDB 
 }
 
 func UpdateAssetGroupIsolationTags(ctx context.Context, db AgiData, graphDb graph.Database) error {
-	if assetGroups, err := db.GetAllAssetGroups("", model.SQLFilter{}); err != nil {
+	if assetGroups, err := db.GetAllAssetGroups(ctx, "", model.SQLFilter{}); err != nil {
 		return err
 	} else {
 		return graphDb.WriteTransaction(ctx, func(tx graph.Transaction) error {

--- a/cmd/api/src/services/agi/mocks/mock.go
+++ b/cmd/api/src/services/agi/mocks/mock.go
@@ -21,6 +21,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	model "github.com/specterops/bloodhound/src/model"
@@ -51,45 +52,45 @@ func (m *MockAgiData) EXPECT() *MockAgiDataMockRecorder {
 }
 
 // CreateAssetGroupCollection mocks base method.
-func (m *MockAgiData) CreateAssetGroupCollection(arg0 model.AssetGroupCollection, arg1 model.AssetGroupCollectionEntries) error {
+func (m *MockAgiData) CreateAssetGroupCollection(arg0 context.Context, arg1 model.AssetGroupCollection, arg2 model.AssetGroupCollectionEntries) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateAssetGroupCollection", arg0, arg1)
+	ret := m.ctrl.Call(m, "CreateAssetGroupCollection", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CreateAssetGroupCollection indicates an expected call of CreateAssetGroupCollection.
-func (mr *MockAgiDataMockRecorder) CreateAssetGroupCollection(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockAgiDataMockRecorder) CreateAssetGroupCollection(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAssetGroupCollection", reflect.TypeOf((*MockAgiData)(nil).CreateAssetGroupCollection), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAssetGroupCollection", reflect.TypeOf((*MockAgiData)(nil).CreateAssetGroupCollection), arg0, arg1, arg2)
 }
 
 // GetAllAssetGroups mocks base method.
-func (m *MockAgiData) GetAllAssetGroups(arg0 string, arg1 model.SQLFilter) (model.AssetGroups, error) {
+func (m *MockAgiData) GetAllAssetGroups(arg0 context.Context, arg1 string, arg2 model.SQLFilter) (model.AssetGroups, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAllAssetGroups", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetAllAssetGroups", arg0, arg1, arg2)
 	ret0, _ := ret[0].(model.AssetGroups)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetAllAssetGroups indicates an expected call of GetAllAssetGroups.
-func (mr *MockAgiDataMockRecorder) GetAllAssetGroups(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockAgiDataMockRecorder) GetAllAssetGroups(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllAssetGroups", reflect.TypeOf((*MockAgiData)(nil).GetAllAssetGroups), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllAssetGroups", reflect.TypeOf((*MockAgiData)(nil).GetAllAssetGroups), arg0, arg1, arg2)
 }
 
 // GetAssetGroup mocks base method.
-func (m *MockAgiData) GetAssetGroup(arg0 int32) (model.AssetGroup, error) {
+func (m *MockAgiData) GetAssetGroup(arg0 context.Context, arg1 int32) (model.AssetGroup, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAssetGroup", arg0)
+	ret := m.ctrl.Call(m, "GetAssetGroup", arg0, arg1)
 	ret0, _ := ret[0].(model.AssetGroup)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetAssetGroup indicates an expected call of GetAssetGroup.
-func (mr *MockAgiDataMockRecorder) GetAssetGroup(arg0 interface{}) *gomock.Call {
+func (mr *MockAgiDataMockRecorder) GetAssetGroup(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAssetGroup", reflect.TypeOf((*MockAgiData)(nil).GetAssetGroup), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAssetGroup", reflect.TypeOf((*MockAgiData)(nil).GetAssetGroup), arg0, arg1)
 }


### PR DESCRIPTION
## Description

Plumb context into gorm asset-group db methods
https://gorm.io/docs/context.html#Context-Timeout

I also noticed there was a number of unused db methods related to the asset-groups so I removed those to keep things nice and clean. (I didn't check the rest of the methods, but I do think it would be beneficial to give them all a quick audit)

## Motivation and Context

Currently as it stands any endpoints that rely on purely gorm do not respect `request.Context` and as such timeouts are not respected either. While we want to eventually get to the removal of the gorm dependency altogether, that is a long way and a lot of effort away and this I think this approach would give us that much room to maneuver while we get there.

## How Has This Been Tested?

Using a rest client and the prefer header
Add a sleep inside of the handler
Look for the `500 request timed out` after exceeding the timeout. (Note: the request will take as long as the sleep is set, it's not tied to the prefer header)

## Types of changes

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [x] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
