### PR TITLE
Fix: Missing Group Management Page (stage/v5.7.0)

### DIFF
--- a/cmd/ui/src/views/GroupManagement/GroupManagement.test.tsx
+++ b/cmd/ui/src/views/GroupManagement/GroupManagement.test.tsx
@@ -82,7 +82,7 @@ describe('GroupManagement', () => {
     it('displays default text for domain selector when globalDomain is null', async () => {
         const { screen } = await setup();
 
-        expect(screen.getByText('Unknown Domain or Tenant')).toBeInTheDocument();
+        expect(screen.getByTestId('data-selector')).toBeInTheDocument();
     });
 
     it('renders an edit form for the selected asset group', async () => {

--- a/cmd/ui/src/views/GroupManagement/GroupManagement.test.tsx
+++ b/cmd/ui/src/views/GroupManagement/GroupManagement.test.tsx
@@ -61,7 +61,7 @@ describe('GroupManagement', () => {
             const screen = render(<GroupManagement />, {
                 initialState: {
                     global: {
-                        options: { domain: {} },
+                        options: { domain: null },
                     },
                 },
             });
@@ -77,6 +77,12 @@ describe('GroupManagement', () => {
         expect(screen.getByText('Environment:')).toBeInTheDocument();
         expect(groupSelector).toBeInTheDocument();
         expect(tenantSelector).toBeInTheDocument();
+    });
+
+    it('displays default text for domain selector when globalDomain is null', async () => {
+        const { screen } = await setup();
+
+        expect(screen.getByText('Unknown Domain or Tenant')).toBeInTheDocument();
     });
 
     it('renders an edit form for the selected asset group', async () => {

--- a/cmd/ui/src/views/GroupManagement/GroupManagement.tsx
+++ b/cmd/ui/src/views/GroupManagement/GroupManagement.tsx
@@ -71,7 +71,6 @@ const GroupManagement = () => {
         });
     };
 
-    if (!globalDomain) return null;
     return (
         <GroupManagementContent
             globalDomain={globalDomain}

--- a/packages/javascript/bh-shared-ui/src/components/GroupManagementContent/GroupManagementContent.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/GroupManagementContent/GroupManagementContent.tsx
@@ -31,7 +31,7 @@ import { FILTERABLE_PARAMS } from '../AssetGroupFilters/AssetGroupFilters';
 
 // Top level layout and shared logic for the Group Management page
 const GroupManagementContent: FC<{
-    globalDomain: SelectedDomain;
+    globalDomain: SelectedDomain | null;
     showExplorePageLink: boolean;
     tierZeroLabel: string;
     tierZeroTag: string;


### PR DESCRIPTION
## Description
Fixes blank group management page when globalDomain is null. 

## Motivation and Context
We should display something if globalDomain is null to give the appearance that things are not broken.

## How Has This Been Tested?
Manual test and added unit test

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [x] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
