### PR TITLE
fix: not including AZContains in inbound / outbound control traversal

### DIFF
--- a/cmd/api/src/analysis/azure/azure_integration_test.go
+++ b/cmd/api/src/analysis/azure/azure_integration_test.go
@@ -21,7 +21,6 @@ package azure_test
 import (
 	"context"
 	schema "github.com/specterops/bloodhound/graphschema"
-	"sort"
 	"testing"
 
 	"github.com/specterops/bloodhound/graphschema/azure"
@@ -36,14 +35,6 @@ import (
 	"github.com/specterops/bloodhound/dawgs/query"
 	"github.com/specterops/bloodhound/src/test/integration"
 )
-
-func SortIDs(ids []graph.ID) []graph.ID {
-	sort.Slice(ids, func(i, j int) bool {
-		return ids[i].Int64() > ids[j].Int64()
-	})
-
-	return ids
-}
 
 func TestFetchEntityByObjectID(t *testing.T) {
 	testContext := integration.NewGraphTestContext(t, schema.DefaultGraphSchema())
@@ -787,7 +778,7 @@ func TestFetchInboundEntityObjectControlPaths(t *testing.T) {
 		paths, err := azureanalysis.FetchInboundEntityObjectControlPaths(tx, harness.AZInboundControlHarness.ControlledAZUser)
 		require.Nil(t, err)
 		nodes := paths.AllNodes().IDs()
-		require.Equal(t, 7, len(nodes))
+		require.Equal(t, 8, len(nodes))
 		require.NotContains(t, nodes, harness.AZInboundControlHarness.AZAppA.ID)
 		require.Contains(t, nodes, harness.AZInboundControlHarness.ControlledAZUser.ID)
 		require.Contains(t, nodes, harness.AZInboundControlHarness.AZGroupA.ID)
@@ -796,6 +787,7 @@ func TestFetchInboundEntityObjectControlPaths(t *testing.T) {
 		require.Contains(t, nodes, harness.AZInboundControlHarness.AZServicePrincipalB.ID)
 		require.Contains(t, nodes, harness.AZInboundControlHarness.AZUserA.ID)
 		require.Contains(t, nodes, harness.AZInboundControlHarness.AZUserB.ID)
+		require.Contains(t, nodes, harness.AZInboundControlHarness.AZTenant.ID)
 	})
 }
 
@@ -809,7 +801,7 @@ func TestFetchInboundEntityObjectControllers(t *testing.T) {
 		control, err := azureanalysis.FetchInboundEntityObjectControllers(tx, harness.AZInboundControlHarness.ControlledAZUser, 0, 0)
 		require.Nil(t, err)
 		nodes := control.IDs()
-		require.Equal(t, 6, len(nodes))
+		require.Equal(t, 7, len(nodes))
 		require.NotContains(t, nodes, harness.AZInboundControlHarness.ControlledAZUser.ID)
 		require.NotContains(t, nodes, harness.AZInboundControlHarness.AZAppA.ID)
 		require.Contains(t, nodes, harness.AZInboundControlHarness.AZGroupA.ID)
@@ -818,6 +810,7 @@ func TestFetchInboundEntityObjectControllers(t *testing.T) {
 		require.Contains(t, nodes, harness.AZInboundControlHarness.AZServicePrincipalB.ID)
 		require.Contains(t, nodes, harness.AZInboundControlHarness.AZUserA.ID)
 		require.Contains(t, nodes, harness.AZInboundControlHarness.AZUserB.ID)
+		require.Contains(t, nodes, harness.AZInboundControlHarness.AZTenant.ID)
 		control, err = azureanalysis.FetchInboundEntityObjectControllers(tx, harness.AZInboundControlHarness.ControlledAZUser, 0, 1)
 		require.Nil(t, err)
 		require.Equal(t, 1, control.Len())

--- a/cmd/api/src/analysis/azure/azure_integration_test.go
+++ b/cmd/api/src/analysis/azure/azure_integration_test.go
@@ -784,7 +784,7 @@ func TestFetchInboundEntityObjectControlPaths(t *testing.T) {
 		harness.AZInboundControlHarness.Setup(testContext)
 		return nil
 	}, func(harness integration.HarnessDetails, tx graph.Transaction) {
-		paths, err := azureanalysis.FetchInboundEntityObjectControlPaths(tx, harness.AZInboundControlHarness.ControlledAZUser, graph.DirectionInbound)
+		paths, err := azureanalysis.FetchInboundEntityObjectControlPaths(tx, harness.AZInboundControlHarness.ControlledAZUser)
 		require.Nil(t, err)
 		nodes := paths.AllNodes().IDs()
 		require.Equal(t, 7, len(nodes))
@@ -806,7 +806,7 @@ func TestFetchInboundEntityObjectControllers(t *testing.T) {
 		harness.AZInboundControlHarness.Setup(testContext)
 		return nil
 	}, func(harness integration.HarnessDetails, tx graph.Transaction) {
-		control, err := azureanalysis.FetchInboundEntityObjectControllers(tx, harness.AZInboundControlHarness.ControlledAZUser, graph.DirectionInbound, 0, 0)
+		control, err := azureanalysis.FetchInboundEntityObjectControllers(tx, harness.AZInboundControlHarness.ControlledAZUser, 0, 0)
 		require.Nil(t, err)
 		nodes := control.IDs()
 		require.Equal(t, 6, len(nodes))
@@ -818,7 +818,7 @@ func TestFetchInboundEntityObjectControllers(t *testing.T) {
 		require.Contains(t, nodes, harness.AZInboundControlHarness.AZServicePrincipalB.ID)
 		require.Contains(t, nodes, harness.AZInboundControlHarness.AZUserA.ID)
 		require.Contains(t, nodes, harness.AZInboundControlHarness.AZUserB.ID)
-		control, err = azureanalysis.FetchInboundEntityObjectControllers(tx, harness.AZInboundControlHarness.ControlledAZUser, graph.DirectionInbound, 0, 1)
+		control, err = azureanalysis.FetchInboundEntityObjectControllers(tx, harness.AZInboundControlHarness.ControlledAZUser, 0, 1)
 		require.Nil(t, err)
 		require.Equal(t, 1, control.Len())
 	})

--- a/cmd/api/src/analysis/azure/base.go
+++ b/cmd/api/src/analysis/azure/base.go
@@ -1,17 +1,17 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 package azure
@@ -47,7 +47,7 @@ func BaseEntityDetails(db graph.Database, objectID string, hydrateCounts bool) (
 
 func PopulateBaseEntityDetailsCounts(tx graph.Transaction, node *graph.Node, details azure.BaseDetails) (azure.BaseDetails, error) {
 
-	if outboundObjectControl, err := azure.FetchOutboundEntityObjectControl(tx, node, graph.DirectionOutbound, 0, 0); err != nil {
+	if outboundObjectControl, err := azure.FetchOutboundEntityObjectControl(tx, node, 0, 0); err != nil {
 		return details, err
 	} else {
 		details.OutboundObjectControl = outboundObjectControl.Len()

--- a/packages/go/analysis/azure/application.go
+++ b/packages/go/analysis/azure/application.go
@@ -1,17 +1,17 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 package azure
@@ -73,7 +73,7 @@ func getAppServicePrincipalID(tx graph.Transaction, node *graph.Node) (string, e
 
 func PopulateApplicationEntityDetailsCounts(tx graph.Transaction, node *graph.Node, details ApplicationDetails) (ApplicationDetails, error) {
 
-	if inboundObjectControl, err := FetchInboundEntityObjectControllers(tx, node, graph.DirectionInbound, 0, 0); err != nil {
+	if inboundObjectControl, err := FetchInboundEntityObjectControllers(tx, node, 0, 0); err != nil {
 		return details, err
 	} else {
 		details.InboundObjectControl = inboundObjectControl.Len()

--- a/packages/go/analysis/azure/automation_account.go
+++ b/packages/go/analysis/azure/automation_account.go
@@ -1,17 +1,17 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 package azure
@@ -46,7 +46,7 @@ func AutomationAccountEntityDetails(ctx context.Context, db graph.Database, obje
 
 func PopulateAutomationAccountEntityDetailsCounts(tx graph.Transaction, node *graph.Node, details AutomationAccountDetails) (AutomationAccountDetails, error) {
 
-	if inboundObjectControl, err := FetchInboundEntityObjectControllers(tx, node, graph.DirectionInbound, 0, 0); err != nil {
+	if inboundObjectControl, err := FetchInboundEntityObjectControllers(tx, node, 0, 0); err != nil {
 		return details, err
 	} else {
 		details.InboundObjectControl = inboundObjectControl.Len()

--- a/packages/go/analysis/azure/container_registry.go
+++ b/packages/go/analysis/azure/container_registry.go
@@ -1,17 +1,17 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 package azure
@@ -46,7 +46,7 @@ func ContainerRegistryEntityDetails(ctx context.Context, db graph.Database, obje
 
 func PopulateContainerRegistryEntityDetailsCounts(tx graph.Transaction, node *graph.Node, details ContainerRegistryDetails) (ContainerRegistryDetails, error) {
 
-	if inboundObjectControl, err := FetchInboundEntityObjectControllers(tx, node, graph.DirectionInbound, 0, 0); err != nil {
+	if inboundObjectControl, err := FetchInboundEntityObjectControllers(tx, node, 0, 0); err != nil {
 		return details, err
 	} else {
 		details.InboundObjectControl = inboundObjectControl.Len()

--- a/packages/go/analysis/azure/db_ops.go
+++ b/packages/go/analysis/azure/db_ops.go
@@ -1,17 +1,17 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 package azure
@@ -312,10 +312,10 @@ func ListEntityObjectControlPaths(ctx context.Context, db graph.Database, object
 		if node, err := FetchEntityByObjectID(tx, objectID); err != nil {
 			return err
 		} else if direction == graph.DirectionOutbound {
-			paths, err = FetchOutboundEntityObjectControlPaths(tx, node, direction)
+			paths, err = FetchOutboundEntityObjectControlPaths(tx, node)
 			return err
 		} else {
-			paths, err = FetchInboundEntityObjectControlPaths(tx, node, direction)
+			paths, err = FetchInboundEntityObjectControlPaths(tx, node)
 			return err
 		}
 	})
@@ -328,10 +328,10 @@ func ListEntityObjectControl(ctx context.Context, db graph.Database, objectID st
 		if node, err := FetchEntityByObjectID(tx, objectID); err != nil {
 			return err
 		} else if direction == graph.DirectionOutbound {
-			nodes, err = FetchOutboundEntityObjectControl(tx, node, direction, skip, limit)
+			nodes, err = FetchOutboundEntityObjectControl(tx, node, skip, limit)
 			return err
 		} else {
-			nodes, err = FetchInboundEntityObjectControllers(tx, node, direction, skip, limit)
+			nodes, err = FetchInboundEntityObjectControllers(tx, node, skip, limit)
 			return err
 		}
 	})

--- a/packages/go/analysis/azure/device.go
+++ b/packages/go/analysis/azure/device.go
@@ -1,17 +1,17 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 package azure
@@ -54,7 +54,7 @@ func populateDeviceEntityDetailsCounts(tx graph.Transaction, node *graph.Node, d
 		details.InboundExecutionPrivileges = inboundExecutionPrivileges.Len()
 	}
 
-	if inboundObjectControl, err := FetchInboundEntityObjectControllers(tx, node, graph.DirectionInbound, 0, 0); err != nil {
+	if inboundObjectControl, err := FetchInboundEntityObjectControllers(tx, node, 0, 0); err != nil {
 		return details, err
 	} else {
 		details.InboundObjectControl = inboundObjectControl.Len()

--- a/packages/go/analysis/azure/filters.go
+++ b/packages/go/analysis/azure/filters.go
@@ -60,15 +60,6 @@ func FilterAbusableAppRoleAssignmentRelationships() graph.Criteria {
 	return query.KindIn(query.Relationship(), azure.AbusableAppRoleRelationshipKinds()...)
 }
 
-func FilterDescendents(kinds ...graph.Kind) graph.CriteriaProvider {
-	return func() graph.Criteria {
-		return query.And(
-			query.Kind(query.Relationship(), azure.Contains),
-			query.KindIn(query.End(), kinds...),
-		)
-	}
-}
-
 func FilterGroupMembership() graph.Criteria {
 	return query.Kind(query.Relationship(), azure.MemberOf)
 }

--- a/packages/go/analysis/azure/filters.go
+++ b/packages/go/analysis/azure/filters.go
@@ -1,17 +1,17 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 package azure
@@ -49,7 +49,7 @@ func FilterSecretReaders() graph.Criteria {
 }
 
 func FilterControlsRelationships() graph.Criteria {
-	return query.KindIn(query.Relationship(), append(azure.ControlRelationships(), azure.MemberOf)...)
+	return query.KindIn(query.Relationship(), append(azure.ControlRelationships(), azure.MemberOf, azure.Contains)...)
 }
 
 func FilterAppRoleAssignmentTransitRelationships() graph.Criteria {

--- a/packages/go/analysis/azure/function_app.go
+++ b/packages/go/analysis/azure/function_app.go
@@ -1,17 +1,17 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 package azure
@@ -46,7 +46,7 @@ func FunctionAppEntityDetails(ctx context.Context, db graph.Database, objectID s
 
 func PopulateFunctionAppEntityDetailsCounts(tx graph.Transaction, node *graph.Node, details FunctionAppDetails) (FunctionAppDetails, error) {
 
-	if inboundObjectControl, err := FetchInboundEntityObjectControllers(tx, node, graph.DirectionInbound, 0, 0); err != nil {
+	if inboundObjectControl, err := FetchInboundEntityObjectControllers(tx, node, 0, 0); err != nil {
 		return details, err
 	} else {
 		details.InboundObjectControl = inboundObjectControl.Len()

--- a/packages/go/analysis/azure/group.go
+++ b/packages/go/analysis/azure/group.go
@@ -1,17 +1,17 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 package azure
@@ -64,13 +64,13 @@ func PopulateGroupEntityDetailsCounts(tx graph.Transaction, node *graph.Node, de
 		details.GroupMembership = groupMembership.Len()
 	}
 
-	if inboundObjectControl, err := FetchInboundEntityObjectControllers(tx, node, graph.DirectionInbound, 0, 0); err != nil {
+	if inboundObjectControl, err := FetchInboundEntityObjectControllers(tx, node, 0, 0); err != nil {
 		return details, err
 	} else {
 		details.InboundObjectControl = inboundObjectControl.Len()
 	}
 
-	if outboundObjectControl, err := FetchOutboundEntityObjectControl(tx, node, graph.DirectionOutbound, 0, 0); err != nil {
+	if outboundObjectControl, err := FetchOutboundEntityObjectControl(tx, node, 0, 0); err != nil {
 		return details, err
 	} else {
 		details.OutboundObjectControl = outboundObjectControl.Len()

--- a/packages/go/analysis/azure/key_vault.go
+++ b/packages/go/analysis/azure/key_vault.go
@@ -1,17 +1,17 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 package azure
@@ -52,7 +52,7 @@ func PopulateKeyVaultEntityDetailsCounts(tx graph.Transaction, node *graph.Node,
 		details.Readers = keyVaultReaders
 	}
 
-	if inboundObjectControl, err := FetchInboundEntityObjectControllers(tx, node, graph.DirectionInbound, 0, 0); err != nil {
+	if inboundObjectControl, err := FetchInboundEntityObjectControllers(tx, node, 0, 0); err != nil {
 		return details, err
 	} else {
 		details.InboundObjectControl = inboundObjectControl.Len()

--- a/packages/go/analysis/azure/logic_app.go
+++ b/packages/go/analysis/azure/logic_app.go
@@ -1,17 +1,17 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 package azure
@@ -46,7 +46,7 @@ func LogicAppEntityDetails(ctx context.Context, db graph.Database, objectID stri
 
 func PopulateLogicAppEntityDetailsCounts(tx graph.Transaction, node *graph.Node, details LogicAppDetails) (LogicAppDetails, error) {
 
-	if inboundObjectControl, err := FetchInboundEntityObjectControllers(tx, node, graph.DirectionInbound, 0, 0); err != nil {
+	if inboundObjectControl, err := FetchInboundEntityObjectControllers(tx, node, 0, 0); err != nil {
 		return details, err
 	} else {
 		details.InboundObjectControl = inboundObjectControl.Len()

--- a/packages/go/analysis/azure/managed_cluster.go
+++ b/packages/go/analysis/azure/managed_cluster.go
@@ -1,17 +1,17 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 package azure
@@ -46,7 +46,7 @@ func ManagedClusterEntityDetails(ctx context.Context, db graph.Database, objectI
 
 func managedClusterEntityDetails(tx graph.Transaction, node *graph.Node, details ManagedClusterDetails) (ManagedClusterDetails, error) {
 
-	if inboundObjectControl, err := FetchInboundEntityObjectControllers(tx, node, graph.DirectionInbound, 0, 0); err != nil {
+	if inboundObjectControl, err := FetchInboundEntityObjectControllers(tx, node, 0, 0); err != nil {
 		return details, err
 	} else {
 		details.InboundObjectControl = inboundObjectControl.Len()

--- a/packages/go/analysis/azure/management_group.go
+++ b/packages/go/analysis/azure/management_group.go
@@ -1,17 +1,17 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 package azure
@@ -54,7 +54,7 @@ func PopulateManagementGroupEntityDetailsCounts(tx graph.Transaction, node *grap
 		details.Descendents = descendents
 	}
 
-	if inboundObjectControl, err := FetchInboundEntityObjectControllers(tx, node, graph.DirectionInbound, 0, 0); err != nil {
+	if inboundObjectControl, err := FetchInboundEntityObjectControllers(tx, node, 0, 0); err != nil {
 		return details, err
 	} else {
 		details.InboundObjectControl = inboundObjectControl.Len()

--- a/packages/go/analysis/azure/queries.go
+++ b/packages/go/analysis/azure/queries.go
@@ -281,18 +281,16 @@ func FetchAppRoleAssignmentsTransitPaths(tx graph.Transaction, root *graph.Node,
 	})
 }
 
-func InboundControlDescentFilter(ctx *ops.TraversalContext, segment *graph.PathSegment) bool {
-	// The first traversal must be a control relationship for expansion
+func InboundControlDescentFilter(_ *ops.TraversalContext, segment *graph.PathSegment) bool {
+	// The first traversal must be a control relationship for expansion or memberOf / contains due to FilterControlsRelationships
 	if segment.Depth() == 1 {
-		return !segment.Edge.Kind.Is(azure.MemberOf)
-	} else if segment.Depth() > 1 {
-		return segment.Edge.Kind.Is(azure.MemberOf)
+		return true
+	} else {
+		return segment.Edge.Kind.Is(azure.MemberOf) || segment.Edge.Kind.Is(azure.Contains)
 	}
-
-	return true
 }
 
-func OutboundControlDescentFilter(ctx *ops.TraversalContext, segment *graph.PathSegment) bool {
+func OutboundControlDescentFilter(_ *ops.TraversalContext, segment *graph.PathSegment) bool {
 	var (
 		shouldDescend = true
 		sawControlRel = false
@@ -320,7 +318,7 @@ func OutboundControlDescentFilter(ctx *ops.TraversalContext, segment *graph.Path
 }
 
 func OutboundControlPathFilter(_ *ops.TraversalContext, segment *graph.PathSegment) bool {
-	return !segment.Edge.Kind.Is(azure.MemberOf)
+	return !(segment.Edge.Kind.Is(azure.MemberOf) || segment.Edge.Kind.Is(azure.Contains))
 }
 
 func FetchOutboundEntityObjectControlPaths(tx graph.Transaction, root *graph.Node) (graph.PathSet, error) {

--- a/packages/go/analysis/azure/queries.go
+++ b/packages/go/analysis/azure/queries.go
@@ -286,7 +286,7 @@ func InboundControlDescentFilter(_ *ops.TraversalContext, segment *graph.PathSeg
 	if segment.Depth() == 1 {
 		return true
 	} else {
-		return segment.Edge.Kind.Is(azure.MemberOf) || segment.Edge.Kind.Is(azure.Contains)
+		return segment.Edge.Kind.Is(azure.MemberOf, azure.Contains)
 	}
 }
 
@@ -318,7 +318,7 @@ func OutboundControlDescentFilter(_ *ops.TraversalContext, segment *graph.PathSe
 }
 
 func OutboundControlPathFilter(_ *ops.TraversalContext, segment *graph.PathSegment) bool {
-	return !(segment.Edge.Kind.Is(azure.MemberOf) || segment.Edge.Kind.Is(azure.Contains))
+	return !segment.Edge.Kind.Is(azure.MemberOf, azure.Contains)
 }
 
 func FetchOutboundEntityObjectControlPaths(tx graph.Transaction, root *graph.Node) (graph.PathSet, error) {

--- a/packages/go/analysis/azure/queries.go
+++ b/packages/go/analysis/azure/queries.go
@@ -319,33 +319,33 @@ func OutboundControlDescentFilter(ctx *ops.TraversalContext, segment *graph.Path
 	return shouldDescend
 }
 
-func OutboundControlPathFilter(ctx *ops.TraversalContext, segment *graph.PathSegment) bool {
+func OutboundControlPathFilter(_ *ops.TraversalContext, segment *graph.PathSegment) bool {
 	return !segment.Edge.Kind.Is(azure.MemberOf)
 }
 
-func FetchOutboundEntityObjectControlPaths(tx graph.Transaction, root *graph.Node, direction graph.Direction) (graph.PathSet, error) {
+func FetchOutboundEntityObjectControlPaths(tx graph.Transaction, root *graph.Node) (graph.PathSet, error) {
 	return ops.TraversePaths(tx, ops.TraversalPlan{
 		Root:          root,
-		Direction:     direction,
+		Direction:     graph.DirectionOutbound,
 		BranchQuery:   FilterControlsRelationships,
 		DescentFilter: OutboundControlDescentFilter,
 		PathFilter:    OutboundControlPathFilter,
 	})
 }
 
-func FetchInboundEntityObjectControlPaths(tx graph.Transaction, root *graph.Node, direction graph.Direction) (graph.PathSet, error) {
+func FetchInboundEntityObjectControlPaths(tx graph.Transaction, root *graph.Node) (graph.PathSet, error) {
 	return ops.TraversePaths(tx, ops.TraversalPlan{
 		Root:          root,
-		Direction:     direction,
+		Direction:     graph.DirectionInbound,
 		BranchQuery:   FilterControlsRelationships,
 		DescentFilter: InboundControlDescentFilter,
 	})
 }
 
-func FetchOutboundEntityObjectControl(tx graph.Transaction, root *graph.Node, direction graph.Direction, skip, limit int) (graph.NodeSet, error) {
+func FetchOutboundEntityObjectControl(tx graph.Transaction, root *graph.Node, skip, limit int) (graph.NodeSet, error) {
 	return ops.AcyclicTraverseTerminals(tx, ops.TraversalPlan{
 		Root:          root,
-		Direction:     direction,
+		Direction:     graph.DirectionOutbound,
 		Skip:          skip,
 		Limit:         limit,
 		BranchQuery:   FilterControlsRelationships,
@@ -354,10 +354,10 @@ func FetchOutboundEntityObjectControl(tx graph.Transaction, root *graph.Node, di
 	})
 }
 
-func FetchInboundEntityObjectControllers(tx graph.Transaction, root *graph.Node, direction graph.Direction, skip, limit int) (graph.NodeSet, error) {
+func FetchInboundEntityObjectControllers(tx graph.Transaction, root *graph.Node, skip, limit int) (graph.NodeSet, error) {
 	return ops.AcyclicTraverseNodes(tx, ops.TraversalPlan{
 		Root:          root,
-		Direction:     direction,
+		Direction:     graph.DirectionInbound,
 		Skip:          skip,
 		Limit:         limit,
 		BranchQuery:   FilterControlsRelationships,

--- a/packages/go/analysis/azure/resource_group.go
+++ b/packages/go/analysis/azure/resource_group.go
@@ -1,17 +1,17 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 package azure
@@ -54,7 +54,7 @@ func PopulateResourceGroupEntityDetailsCounts(tx graph.Transaction, node *graph.
 		details.Descendents = descendents
 	}
 
-	if inboundObjectControl, err := FetchInboundEntityObjectControllers(tx, node, graph.DirectionInbound, 0, 0); err != nil {
+	if inboundObjectControl, err := FetchInboundEntityObjectControllers(tx, node, 0, 0); err != nil {
 		return details, err
 	} else {
 		details.InboundObjectControl = inboundObjectControl.Len()

--- a/packages/go/analysis/azure/service_principal.go
+++ b/packages/go/analysis/azure/service_principal.go
@@ -1,17 +1,17 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 package azure
@@ -77,13 +77,13 @@ func servicePrincipalEntityDetails(tx graph.Transaction, node *graph.Node, detai
 		details.Roles = roles.Len()
 	}
 
-	if inboundObjectControl, err := FetchInboundEntityObjectControllers(tx, node, graph.DirectionInbound, 0, 0); err != nil {
+	if inboundObjectControl, err := FetchInboundEntityObjectControllers(tx, node, 0, 0); err != nil {
 		return details, err
 	} else {
 		details.InboundObjectControl = inboundObjectControl.Len()
 	}
 
-	if outboundObjectControl, err := FetchOutboundEntityObjectControl(tx, node, graph.DirectionOutbound, 0, 0); err != nil {
+	if outboundObjectControl, err := FetchOutboundEntityObjectControl(tx, node, 0, 0); err != nil {
 		return details, err
 	} else {
 		details.OutboundObjectControl = outboundObjectControl.Len()

--- a/packages/go/analysis/azure/subscription.go
+++ b/packages/go/analysis/azure/subscription.go
@@ -1,17 +1,17 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 package azure
@@ -54,7 +54,7 @@ func PopulateSubscriptionEntityDetailsCounts(tx graph.Transaction, node *graph.N
 		details.Descendents = descendents
 	}
 
-	if inboundObjectControl, err := FetchInboundEntityObjectControllers(tx, node, graph.DirectionInbound, 0, 0); err != nil {
+	if inboundObjectControl, err := FetchInboundEntityObjectControllers(tx, node, 0, 0); err != nil {
 		return details, err
 	} else {
 		details.InboundObjectControl = inboundObjectControl.Len()

--- a/packages/go/analysis/azure/tenant.go
+++ b/packages/go/analysis/azure/tenant.go
@@ -57,7 +57,7 @@ func PopulateTenantEntityDetailsCounts(tx graph.Transaction, node *graph.Node, d
 		details.Descendents = descendents
 	}
 
-	if inboundObjectControl, err := FetchInboundEntityObjectControllers(tx, node, graph.DirectionInbound, 0, 0); err != nil {
+	if inboundObjectControl, err := FetchInboundEntityObjectControllers(tx, node, 0, 0); err != nil {
 		return details, err
 	} else {
 		details.InboundObjectControl = inboundObjectControl.Len()

--- a/packages/go/analysis/azure/user.go
+++ b/packages/go/analysis/azure/user.go
@@ -1,17 +1,17 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 package azure
@@ -64,13 +64,13 @@ func PopulateUserEntityDetailsCounts(tx graph.Transaction, node *graph.Node, det
 		details.ExecutionPrivileges = entityExecutionPrivileges.Len()
 	}
 
-	if inboundObjectControl, err := FetchInboundEntityObjectControllers(tx, node, graph.DirectionInbound, 0, 0); err != nil {
+	if inboundObjectControl, err := FetchInboundEntityObjectControllers(tx, node, 0, 0); err != nil {
 		return details, err
 	} else {
 		details.InboundObjectControl = inboundObjectControl.Len()
 	}
 
-	if outboundObjectControl, err := FetchOutboundEntityObjectControl(tx, node, graph.DirectionOutbound, 0, 0); err != nil {
+	if outboundObjectControl, err := FetchOutboundEntityObjectControl(tx, node, 0, 0); err != nil {
 		return details, err
 	} else {
 		details.OutboundObjectControl = outboundObjectControl.Len()

--- a/packages/go/analysis/azure/vm.go
+++ b/packages/go/analysis/azure/vm.go
@@ -1,17 +1,17 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 package azure
@@ -52,7 +52,7 @@ func vmEntityDetails(tx graph.Transaction, node *graph.Node, details VMDetails) 
 		details.InboundExecutionPrivileges = inboundExecutionPrivileges.Len()
 	}
 
-	if inboundObjectControl, err := FetchInboundEntityObjectControllers(tx, node, graph.DirectionInbound, 0, 0); err != nil {
+	if inboundObjectControl, err := FetchInboundEntityObjectControllers(tx, node, 0, 0); err != nil {
 		return details, err
 	} else {
 		details.InboundObjectControl = inboundObjectControl.Len()

--- a/packages/go/analysis/azure/vm_scale_set.go
+++ b/packages/go/analysis/azure/vm_scale_set.go
@@ -1,17 +1,17 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 package azure
@@ -46,7 +46,7 @@ func VMScaleSetEntityDetails(ctx context.Context, db graph.Database, objectID st
 
 func vmssEntityDetails(tx graph.Transaction, node *graph.Node, details VMScaleSetDetails) (VMScaleSetDetails, error) {
 
-	if inboundObjectControl, err := FetchInboundEntityObjectControllers(tx, node, graph.DirectionInbound, 0, 0); err != nil {
+	if inboundObjectControl, err := FetchInboundEntityObjectControllers(tx, node, 0, 0); err != nil {
 		return details, err
 	} else {
 		details.InboundObjectControl = inboundObjectControl.Len()

--- a/packages/go/analysis/azure/web_app.go
+++ b/packages/go/analysis/azure/web_app.go
@@ -1,17 +1,17 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 package azure
@@ -46,7 +46,7 @@ func WebAppEntityDetails(ctx context.Context, db graph.Database, objectID string
 
 func webappEntityDetails(tx graph.Transaction, node *graph.Node, details WebAppDetails) (WebAppDetails, error) {
 
-	if inboundObjectControl, err := FetchInboundEntityObjectControllers(tx, node, graph.DirectionInbound, 0, 0); err != nil {
+	if inboundObjectControl, err := FetchInboundEntityObjectControllers(tx, node, 0, 0); err != nil {
 		return details, err
 	} else {
 		details.InboundObjectControl = inboundObjectControl.Len()


### PR DESCRIPTION
## Description

Added AZContains to the traversal strategy for both inbound and outbound control entities
Removed redundant `direction` argument from `FetchXEntityObjectControllers`
Removed unused `sortBy`  function in testing file

## Motivation and Context

Currently AZContains is ignored by the inbound / outbound controllers making it appear as though some Azure entities have 0 inbound control entities when that is not the case. This fixes that bug.

Removal of the direction from the FetchXEntityObjectControllers functions IMO helps prevent an issue where a developer may call an OutboundController with a direction.Inbound resulting in a bugged response. I didn't see any of those instances but felt it best to prevent that going forward.

## How Has This Been Tested?

Tested locally as well as added to integration tests.

## Screenshots (if appropriate):
<img width="1262" alt="image" src="https://github.com/SpecterOps/BloodHound/assets/26472282/aaee79e0-c802-48c8-8246-e372dc691aa1">

## Types of changes

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [x] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
