### PR TITLE
Remove unused agi code

### DIFF
--- a/cmd/api/src/api/v2/apiclient/agi.go
+++ b/cmd/api/src/api/v2/apiclient/agi.go
@@ -1,17 +1,17 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 package apiclient
@@ -174,9 +174,13 @@ func (s Client) UpdateAssetGroup(assetGroupID int32, request v2.UpdateAssetGroup
 }
 
 func (s Client) CreateAssetGroupSelector(assetGroupID int32, spec model.AssetGroupSelectorSpec) (model.AssetGroupSelector, error) {
+	type assetGroupSelectorResponse struct {
+		AddedSelectors model.AssetGroupSelectors `json:"added_selectors"`
+	}
+	var createResponse assetGroupSelectorResponse
 	var assetGroupSelector model.AssetGroupSelector
 
-	if response, err := s.Request(http.MethodPost, fmt.Sprintf("api/v2/asset-groups/%d/selectors", assetGroupID), nil, []model.AssetGroupSelectorSpec{spec}); err != nil {
+	if response, err := s.Request(http.MethodPut, fmt.Sprintf("api/v2/asset-groups/%d/selectors", assetGroupID), nil, []model.AssetGroupSelectorSpec{spec}); err != nil {
 		return assetGroupSelector, err
 	} else {
 		defer response.Body.Close()
@@ -185,6 +189,14 @@ func (s Client) CreateAssetGroupSelector(assetGroupID int32, spec model.AssetGro
 			return assetGroupSelector, ReadAPIError(response)
 		}
 
-		return assetGroupSelector, api.ReadAPIV2ResponsePayload(&assetGroupSelector, response)
+		if err := api.ReadAPIV2ResponsePayload(&createResponse, response); err != nil {
+			return assetGroupSelector, err
+		}
+
+		if len(createResponse.AddedSelectors) >= 1 {
+			return createResponse.AddedSelectors[0], nil
+		} else {
+			return assetGroupSelector, fmt.Errorf("returned response did not contain any asset group selectors %v", createResponse)
+		}
 	}
 }

--- a/cmd/api/src/database/agi.go
+++ b/cmd/api/src/database/agi.go
@@ -137,7 +137,6 @@ func (s *BloodhoundDB) GetAssetGroupCollections(assetGroupID int32, order string
 	return collections, CheckError(result)
 }
 
-// GetLatestAssetGroupCollection has been DEPRECATED as part of V1 and will be deleted. Use GetAllAssetGroupCollections with filters and limits instead
 func (s *BloodhoundDB) GetLatestAssetGroupCollection(assetGroupID int32) (model.AssetGroupCollection, error) {
 	var collection model.AssetGroupCollection
 
@@ -145,7 +144,6 @@ func (s *BloodhoundDB) GetLatestAssetGroupCollection(assetGroupID int32) (model.
 	return collection, CheckError(result)
 }
 
-// GetTimeRangedAssetGroupCollections has been DEPRECATED as part of V1 and will be deleted. Use GetAllAssetGroupCollections with filters instead
 func (s *BloodhoundDB) GetTimeRangedAssetGroupCollections(assetGroupID int32, from int64, to int64, order string) (model.AssetGroupCollections, error) {
 	var (
 		collections model.AssetGroupCollections
@@ -166,29 +164,9 @@ func (s *BloodhoundDB) GetTimeRangedAssetGroupCollections(assetGroupID int32, fr
 	return collections, CheckError(result)
 }
 
-func (s *BloodhoundDB) GetAllAssetGroupCollections() (model.AssetGroupCollections, error) {
-	var collections model.AssetGroupCollections
-
-	result := s.preload(model.AssetGroupCollectionAssociations()).Find(&collections)
-	return collections, CheckError(result)
-}
-
 func (s *BloodhoundDB) GetAssetGroupSelector(id int32) (model.AssetGroupSelector, error) {
 	var assetGroupSelector model.AssetGroupSelector
 	return assetGroupSelector, CheckError(s.db.Find(&assetGroupSelector, id))
-}
-
-func (s *BloodhoundDB) UpdateAssetGroupSelector(ctx context.Context, selector model.AssetGroupSelector) error {
-	var (
-		auditEntry = model.AuditEntry{
-			Action: "UpdateAssetGroupSelector",
-			Model:  &selector, // Pointer is required to ensure success log contains updated fields after transaction
-		}
-	)
-
-	return s.AuditableTransaction(ctx, auditEntry, func(tx *gorm.DB) error {
-		return CheckError(tx.Save(&selector))
-	})
 }
 
 func (s *BloodhoundDB) DeleteAssetGroupSelector(ctx context.Context, selector model.AssetGroupSelector) error {
@@ -202,27 +180,6 @@ func (s *BloodhoundDB) DeleteAssetGroupSelector(ctx context.Context, selector mo
 	return s.AuditableTransaction(ctx, auditEntry, func(tx *gorm.DB) error {
 		return CheckError(tx.Delete(&selector))
 	})
-}
-
-func (s *BloodhoundDB) CreateRawAssetGroupSelector(assetGroup model.AssetGroup, name, selector string) (model.AssetGroupSelector, error) {
-	assetGroupSelector := model.AssetGroupSelector{
-		AssetGroupID: assetGroup.ID,
-		Name:         name,
-		Selector:     selector,
-	}
-
-	return assetGroupSelector, CheckError(s.db.Create(&assetGroupSelector))
-}
-
-func (s *BloodhoundDB) CreateAssetGroupSelector(assetGroup model.AssetGroup, spec model.AssetGroupSelectorSpec, systemSelector bool) (model.AssetGroupSelector, error) {
-	assetGroupSelector := model.AssetGroupSelector{
-		AssetGroupID:   assetGroup.ID,
-		Name:           spec.SelectorName,
-		Selector:       spec.EntityObjectID,
-		SystemSelector: systemSelector,
-	}
-
-	return assetGroupSelector, CheckError(s.db.Create(&assetGroupSelector))
 }
 
 func (s *BloodhoundDB) UpdateAssetGroupSelectors(ctx ctx.Context, assetGroup model.AssetGroup, selectorSpecs []model.AssetGroupSelectorSpec, systemSelector bool) (model.UpdatedAssetGroupSelectors, error) {
@@ -265,12 +222,6 @@ func (s *BloodhoundDB) UpdateAssetGroupSelectors(ctx ctx.Context, assetGroup mod
 	})
 
 	return updatedSelectors, err
-}
-
-func (s *BloodhoundDB) GetAllAssetGroupSelectors() (model.AssetGroupSelectors, error) {
-	var assetGroupSelectors model.AssetGroupSelectors
-
-	return assetGroupSelectors, CheckError(s.db.Find(&assetGroupSelectors))
 }
 
 func (s *BloodhoundDB) CreateAssetGroupCollection(collection model.AssetGroupCollection, entries model.AssetGroupCollectionEntries) error {

--- a/cmd/api/src/database/db.go
+++ b/cmd/api/src/database/db.go
@@ -70,14 +70,9 @@ type Database interface {
 	GetAssetGroupCollections(assetGroupID int32, order string, filter model.SQLFilter) (model.AssetGroupCollections, error)
 	GetLatestAssetGroupCollection(assetGroupID int32) (model.AssetGroupCollection, error)
 	GetTimeRangedAssetGroupCollections(assetGroupID int32, from int64, to int64, order string) (model.AssetGroupCollections, error)
-	GetAllAssetGroupCollections() (model.AssetGroupCollections, error)
 	GetAssetGroupSelector(id int32) (model.AssetGroupSelector, error)
-	UpdateAssetGroupSelector(ctx context.Context, selector model.AssetGroupSelector) error
 	DeleteAssetGroupSelector(ctx context.Context, selector model.AssetGroupSelector) error
-	CreateRawAssetGroupSelector(assetGroup model.AssetGroup, name, selector string) (model.AssetGroupSelector, error)
-	CreateAssetGroupSelector(assetGroup model.AssetGroup, spec model.AssetGroupSelectorSpec, systemSelector bool) (model.AssetGroupSelector, error)
 	UpdateAssetGroupSelectors(ctx ctx.Context, assetGroup model.AssetGroup, selectorSpecs []model.AssetGroupSelectorSpec, systemSelector bool) (model.UpdatedAssetGroupSelectors, error)
-	GetAllAssetGroupSelectors() (model.AssetGroupSelectors, error)
 	CreateAssetGroupCollection(collection model.AssetGroupCollection, entries model.AssetGroupCollectionEntries) error
 	RawFirst(value any) error
 	Wipe() error

--- a/cmd/api/src/database/mocks/db.go
+++ b/cmd/api/src/database/mocks/db.go
@@ -140,21 +140,6 @@ func (mr *MockDatabaseMockRecorder) CreateAssetGroupCollection(arg0, arg1 interf
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAssetGroupCollection", reflect.TypeOf((*MockDatabase)(nil).CreateAssetGroupCollection), arg0, arg1)
 }
 
-// CreateAssetGroupSelector mocks base method.
-func (m *MockDatabase) CreateAssetGroupSelector(arg0 model.AssetGroup, arg1 model.AssetGroupSelectorSpec, arg2 bool) (model.AssetGroupSelector, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateAssetGroupSelector", arg0, arg1, arg2)
-	ret0, _ := ret[0].(model.AssetGroupSelector)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// CreateAssetGroupSelector indicates an expected call of CreateAssetGroupSelector.
-func (mr *MockDatabaseMockRecorder) CreateAssetGroupSelector(arg0, arg1, arg2 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAssetGroupSelector", reflect.TypeOf((*MockDatabase)(nil).CreateAssetGroupSelector), arg0, arg1, arg2)
-}
-
 // CreateAuditLog mocks base method.
 func (m *MockDatabase) CreateAuditLog(arg0 model.AuditLog) error {
 	m.ctrl.T.Helper()
@@ -287,21 +272,6 @@ func (m *MockDatabase) CreatePermission(arg0 model.Permission) (model.Permission
 func (mr *MockDatabaseMockRecorder) CreatePermission(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreatePermission", reflect.TypeOf((*MockDatabase)(nil).CreatePermission), arg0)
-}
-
-// CreateRawAssetGroupSelector mocks base method.
-func (m *MockDatabase) CreateRawAssetGroupSelector(arg0 model.AssetGroup, arg1, arg2 string) (model.AssetGroupSelector, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateRawAssetGroupSelector", arg0, arg1, arg2)
-	ret0, _ := ret[0].(model.AssetGroupSelector)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// CreateRawAssetGroupSelector indicates an expected call of CreateRawAssetGroupSelector.
-func (mr *MockDatabaseMockRecorder) CreateRawAssetGroupSelector(arg0, arg1, arg2 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateRawAssetGroupSelector", reflect.TypeOf((*MockDatabase)(nil).CreateRawAssetGroupSelector), arg0, arg1, arg2)
 }
 
 // CreateRole mocks base method.
@@ -533,36 +503,6 @@ func (m *MockDatabase) GetADDataQualityStats(arg0 string, arg1, arg2 time.Time, 
 func (mr *MockDatabaseMockRecorder) GetADDataQualityStats(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetADDataQualityStats", reflect.TypeOf((*MockDatabase)(nil).GetADDataQualityStats), arg0, arg1, arg2, arg3, arg4, arg5)
-}
-
-// GetAllAssetGroupCollections mocks base method.
-func (m *MockDatabase) GetAllAssetGroupCollections() (model.AssetGroupCollections, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAllAssetGroupCollections")
-	ret0, _ := ret[0].(model.AssetGroupCollections)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetAllAssetGroupCollections indicates an expected call of GetAllAssetGroupCollections.
-func (mr *MockDatabaseMockRecorder) GetAllAssetGroupCollections() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllAssetGroupCollections", reflect.TypeOf((*MockDatabase)(nil).GetAllAssetGroupCollections))
-}
-
-// GetAllAssetGroupSelectors mocks base method.
-func (m *MockDatabase) GetAllAssetGroupSelectors() (model.AssetGroupSelectors, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAllAssetGroupSelectors")
-	ret0, _ := ret[0].(model.AssetGroupSelectors)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetAllAssetGroupSelectors indicates an expected call of GetAllAssetGroupSelectors.
-func (mr *MockDatabaseMockRecorder) GetAllAssetGroupSelectors() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllAssetGroupSelectors", reflect.TypeOf((*MockDatabase)(nil).GetAllAssetGroupSelectors))
 }
 
 // GetAllAssetGroups mocks base method.
@@ -1398,20 +1338,6 @@ func (m *MockDatabase) UpdateAssetGroup(arg0 context.Context, arg1 model.AssetGr
 func (mr *MockDatabaseMockRecorder) UpdateAssetGroup(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAssetGroup", reflect.TypeOf((*MockDatabase)(nil).UpdateAssetGroup), arg0, arg1)
-}
-
-// UpdateAssetGroupSelector mocks base method.
-func (m *MockDatabase) UpdateAssetGroupSelector(arg0 context.Context, arg1 model.AssetGroupSelector) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateAssetGroupSelector", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// UpdateAssetGroupSelector indicates an expected call of UpdateAssetGroupSelector.
-func (mr *MockDatabaseMockRecorder) UpdateAssetGroupSelector(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAssetGroupSelector", reflect.TypeOf((*MockDatabase)(nil).UpdateAssetGroupSelector), arg0, arg1)
 }
 
 // UpdateAssetGroupSelectors mocks base method.


### PR DESCRIPTION
## Description

This PR removes some database function (and the corresponding mock functions) that are no longer used across the code base for tidiness.

I also updated the `CreateAssetGroupSelector` API client function to use a `PUT` instead of a `POST` as the latter has been deprecated. While fixing this I noticed that the response body didn't match the struct we were trying to parse into, so I updated that to match as well.

## Motivation and Context

* Clean code is happy code

## How Has This Been Tested?

* Existing tests still pass

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
