### PR TITLE
fix: plumb context into client db methods

### DIFF
--- a/cmd/api/src/api/auth.go
+++ b/cmd/api/src/api/auth.go
@@ -232,7 +232,7 @@ func (s authenticator) ValidateRequestSignature(tokenID uuid.UUID, request *http
 		return auth.Context{}, http.StatusBadRequest, fmt.Errorf("malformed signature header: %w", err)
 	} else if authToken, err := s.db.GetAuthToken(tokenID); err != nil {
 		return handleAuthDBError(err)
-	} else if authContext, err := s.ctxInitializer.InitContextFromToken(authToken); err != nil {
+	} else if authContext, err := s.ctxInitializer.InitContextFromToken(request.Context(), authToken); err != nil {
 		return handleAuthDBError(err)
 	} else if user, isUser := auth.GetUserFromAuthCtx(authContext); isUser && user.IsDisabled {
 		return authContext, http.StatusForbidden, errors.Error("user disabled")

--- a/cmd/api/src/database/auth.go
+++ b/cmd/api/src/database/auth.go
@@ -63,7 +63,7 @@ func NewClientAuthToken(ownerID uuid.UUID, hmacMethod string) (model.AuthToken, 
 }
 
 type AuthContextInitializer interface {
-	InitContextFromToken(authToken model.AuthToken) (auth.Context, error)
+	InitContextFromToken(ctx context.Context, authToken model.AuthToken) (auth.Context, error)
 }
 
 type contextInitializer struct {
@@ -74,7 +74,7 @@ func NewContextInitializer(db Database) AuthContextInitializer {
 	return contextInitializer{db: db}
 }
 
-func (s contextInitializer) InitContextFromToken(authToken model.AuthToken) (auth.Context, error) {
+func (s contextInitializer) InitContextFromToken(_ context.Context, authToken model.AuthToken) (auth.Context, error) {
 	if authToken.UserID.Valid {
 		if user, err := s.db.GetUser(authToken.UserID.UUID); err != nil {
 			return auth.Context{}, err


### PR DESCRIPTION
## Description

Plumb context into gorm client db methods
https://gorm.io/docs/context.html#Context-Timeout

## Motivation and Context

Currently as it stands any endpoints that rely on purely gorm do not respect `request.Context` and as such timeouts are not respected either. While we want to eventually get to the removal of the gorm dependency altogether, that is a long way and a lot of effort away and this I think this approach would give us that much room to maneuver while we get there.

## How Has This Been Tested?

Using a rest client and the prefer header
Add a sleep inside of the handler
Look for the `500 request timed out` after exceeding the timeout. (Note: the request will take as long as the sleep is set, it's not tied to the prefer header)

## Types of changes

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [x] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
