### PR TITLE
[BED-4105] Add new risk exposure calculation flag

### DIFF
--- a/cmd/api/src/model/appcfg/flag.go
+++ b/cmd/api/src/model/appcfg/flag.go
@@ -140,5 +140,5 @@ type FeatureFlagService interface {
 
 type GetFlagByKeyer interface {
 	// GetFlagByKey attempts to fetch a FeatureFlag by its key.
-	GetFlagByKey(key string) (FeatureFlag, error)
+	GetFlagByKey(context.Context, string) (FeatureFlag, error)
 }

--- a/cmd/api/src/model/appcfg/flag.go
+++ b/cmd/api/src/model/appcfg/flag.go
@@ -18,17 +18,19 @@ package appcfg
 
 import (
 	"context"
+
 	"github.com/specterops/bloodhound/src/model"
 )
 
 const (
-	FeatureButterflyAnalysis   = "butterfly_analysis"
-	FeatureEnableSAMLSSO       = "enable_saml_sso"
-	FeatureScopeCollectionByOU = "scope_collection_by_ou"
-	FeatureAzureSupport        = "azure_support"
-	FeatureReconciliation      = "reconciliation"
-	FeatureEntityPanelCaching  = "entity_panel_cache"
-	FeatureAdcs                = "adcs"
+	FeatureButterflyAnalysis          = "butterfly_analysis"
+	FeatureEnableSAMLSSO              = "enable_saml_sso"
+	FeatureScopeCollectionByOU        = "scope_collection_by_ou"
+	FeatureAzureSupport               = "azure_support"
+	FeatureReconciliation             = "reconciliation"
+	FeatureEntityPanelCaching         = "entity_panel_cache"
+	FeatureAdcs                       = "adcs"
+	FeatureRiskExposureNewCalculation = "risk_exposure_new_calculation"
 )
 
 // AvailableFlags returns a FeatureFlagSet of expected feature flags. Feature flag defaults introduced here will become the initial
@@ -84,6 +86,13 @@ func AvailableFlags() FeatureFlagSet {
 			Enabled:       false,
 			UserUpdatable: false,
 		},
+		FeatureRiskExposureNewCalculation: {
+			Key:           FeatureRiskExposureNewCalculation,
+			Name:          "Use new tier zero risk exposure calculation",
+			Description:   "Enables the use of new tier zero risk exposure metatree metrics.",
+			Enabled:       false,
+			UserUpdatable: false,
+		},
 	}
 }
 
@@ -117,15 +126,19 @@ type FeatureFlagSet map[string]FeatureFlag
 
 // FeatureFlagService defines a contract for fetching and setting feature flags.
 type FeatureFlagService interface {
+	GetFlagByKeyer
+
 	// GetAllFlags gets all available runtime feature flags as a FeatureFlagSet for the application.
 	GetAllFlags(ctx context.Context) ([]FeatureFlag, error)
 
 	// GetFlag attempts to fetch a FeatureFlag by its ID.
 	GetFlag(ctx context.Context, id int32) (FeatureFlag, error)
 
-	// GetFlagByKey attempts to fetch a FeatureFlag by its key.
-	GetFlagByKey(ctx context.Context, key string) (FeatureFlag, error)
-
 	// SetFlag attempts to store or update the given FeatureFlag by its feature Key.
 	SetFlag(ctx context.Context, value FeatureFlag) error
+}
+
+type GetFlagByKeyer interface {
+	// GetFlagByKey attempts to fetch a FeatureFlag by its key.
+	GetFlagByKey(key string) (FeatureFlag, error)
 }


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Add feature flag for new tier zero risk exposure calculation.  Default disabled, not user definable.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://specterops.atlassian.net/browse/BED-4105

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Verified flag use on local.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
