### PR TITLE
Fix ingest decoder bug

### DIFF
--- a/cmd/api/src/api/v2/file_uploads_integration_test.go
+++ b/cmd/api/src/api/v2/file_uploads_integration_test.go
@@ -179,6 +179,7 @@ func Test_FileUploadWorkFlowVersion6(t *testing.T) {
 	//Assert that we created stuff we expected
 	testCtx.AssertIngest(fixtures.IngestAssertions)
 	testCtx.AssertIngest(fixtures.IngestAssertionsv6)
+	testCtx.AssertIngest(fixtures.PropertyAssertions)
 }
 
 func Test_FileUploadVersion6AllOptionADCS(t *testing.T) {
@@ -219,6 +220,7 @@ func Test_CompressedFileUploadWorkFlowVersion5(t *testing.T) {
 
 	//Assert that we created stuff we expected
 	testCtx.AssertIngest(fixtures.IngestAssertions)
+	testCtx.AssertIngest(fixtures.PropertyAssertions)
 }
 
 func Test_CompressedFileUploadWorkFlowVersion6(t *testing.T) {
@@ -239,4 +241,5 @@ func Test_CompressedFileUploadWorkFlowVersion6(t *testing.T) {
 	//Assert that we created stuff we expected
 	testCtx.AssertIngest(fixtures.IngestAssertions)
 	testCtx.AssertIngest(fixtures.IngestAssertionsv6)
+	testCtx.AssertIngest(fixtures.PropertyAssertions)
 }

--- a/cmd/api/src/api/v2/integration/ingest.go
+++ b/cmd/api/src/api/v2/integration/ingest.go
@@ -148,3 +148,13 @@ func (s *Context) AssertIngest(assertion IngestAssertion) {
 		return nil
 	}), "Unexpected database error during reconciliation assertion")
 }
+
+func (s *Context) AssertIngestProperties(assertion IngestAssertion) {
+	graphDB := integration.OpenGraphDB(s.TestCtrl)
+	defer graphDB.Close(s.ctx)
+
+	require.Nil(s.TestCtrl, graphDB.ReadTransaction(s.ctx, func(tx graph.Transaction) error {
+		assertion(s.TestCtrl, tx)
+		return nil
+	}), "Unexpected database error during reconciliation assertion")
+}

--- a/cmd/api/src/daemons/datapipe/decoders.go
+++ b/cmd/api/src/daemons/datapipe/decoders.go
@@ -73,11 +73,11 @@ func decodeGroupData(batch graph.Batch, reader io.ReadSeeker) error {
 
 	var (
 		convertedData = ConvertedGroupData{}
-		group         ein.Group
 		count         = 0
 	)
 
 	for decoder.More() {
+		var group ein.Group
 		if err := decoder.Decode(&group); err != nil {
 			log.Errorf("Error decoding group object: %v", err)
 		} else {
@@ -106,10 +106,10 @@ func decodeSessionData(batch graph.Batch, reader io.ReadSeeker) error {
 
 	var (
 		convertedData = ConvertedSessionData{}
-		session       ein.Session
 		count         = 0
 	)
 	for decoder.More() {
+		var session ein.Session
 		if err := decoder.Decode(&session); err != nil {
 			log.Errorf("Error decoding session object: %v", err)
 		} else {
@@ -138,11 +138,11 @@ func decodeAzureData(batch graph.Batch, reader io.ReadSeeker) error {
 
 	var (
 		convertedData = ConvertedAzureData{}
-		data          AzureBase
 		count         = 0
 	)
 
 	for decoder.More() {
+		var data AzureBase
 		if err := decoder.Decode(&data); err != nil {
 			log.Errorf("Error decoding azure object: %v", err)
 		} else {


### PR DESCRIPTION
## Description
Allocating a struct before the decoder loop leads to properties stacking on top of each other due to re-use of the struct

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Tested locally
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![image](https://github.com/SpecterOps/BloodHound/assets/5720446/febfda48-d68c-48ea-a490-d8c18fb6e76a)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
