### PR TITLE
chore: remove tabnine from extension recommendations

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -24,7 +24,6 @@
         "buenon.scratchpads",
         "richie5um2.vscode-sort-json",
         "luisfontes19.vscode-swissknife",
-        "tabnine.tabnine-vscode",
         "gruntfuggly.todo-tree",
         "tomsaunders.vscode-workspace-explorer",
         "tonybaloney.vscode-pets",


### PR DESCRIPTION
## Description

Remove the TabNine extension from our recommended extensions list

## Motivation and Context

TabNine has been underperforming, and the ability to engage local only processing has become hampered. It is no longer recommended to use TabNine for development.

## How Has This Been Tested?

No longer listed in extension suggestions

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
