### PR TITLE
fix: plumb context into config parameter db methods

### DIFF
--- a/cmd/api/src/api/v2/app_config.go
+++ b/cmd/api/src/api/v2/app_config.go
@@ -1,17 +1,17 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 package v2
@@ -52,7 +52,7 @@ func (s Resources) GetApplicationConfigurations(response http.ResponseWriter, re
 		} else {
 			api.WriteBasicResponse(request.Context(), appcfg.Parameters{cfgParameter}, http.StatusOK, response)
 		}
-	} else if cfgParameters, err := s.DB.GetAllConfigurationParameters(); err != nil {
+	} else if cfgParameters, err := s.DB.GetAllConfigurationParameters(request.Context()); err != nil {
 		api.HandleDatabaseError(request, response, err)
 	} else {
 		api.WriteBasicResponse(request.Context(), cfgParameters, http.StatusOK, response)

--- a/cmd/api/src/api/v2/app_config.go
+++ b/cmd/api/src/api/v2/app_config.go
@@ -70,7 +70,7 @@ func (s Resources) SetApplicationConfiguration(response http.ResponseWriter, req
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, fmt.Sprintf("Configuration update request not converted to a parameter: %s", parameter.Key), request), response)
 	} else if !parameter.IsValid(parameter.Key) {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, fmt.Sprintf("Configuration parameter %s is not valid.", parameter.Key), request), response)
-	} else if err = s.DB.SetConfigurationParameter(parameter); err != nil {
+	} else if err = s.DB.SetConfigurationParameter(request.Context(), parameter); err != nil {
 		api.HandleDatabaseError(request, response, err)
 	} else {
 		api.WriteBasicResponse(request.Context(), appConfig, http.StatusOK, response)

--- a/cmd/api/src/api/v2/app_config.go
+++ b/cmd/api/src/api/v2/app_config.go
@@ -47,7 +47,7 @@ func (s Resources) GetApplicationConfigurations(response http.ResponseWriter, re
 			api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, fmt.Sprintf("%s: %s %s", api.ErrorResponseDetailsFilterPredicateNotSupported, parameterFilter.Name, parameterFilter.Operator), request), response)
 		} else if !cfgParameter.IsValid(parameterFilter.Value) {
 			api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, fmt.Sprintf("Configuration parameter %s is not valid.", parameterFilter.Value), request), response)
-		} else if cfgParameter, err = s.DB.GetConfigurationParameter(parameterFilter.Value); err != nil {
+		} else if cfgParameter, err = s.DB.GetConfigurationParameter(request.Context(), parameterFilter.Value); err != nil {
 			api.HandleDatabaseError(request, response, err)
 		} else {
 			api.WriteBasicResponse(request.Context(), appcfg.Parameters{cfgParameter}, http.StatusOK, response)

--- a/cmd/api/src/api/v2/app_config_test.go
+++ b/cmd/api/src/api/v2/app_config_test.go
@@ -95,7 +95,7 @@ func Test_GetApplicationConfigurations(t *testing.T) {
 		ResponseStatusCode(http.StatusBadRequest)
 
 	mockDB.EXPECT().
-		GetConfigurationParameter(appcfg.PasswordExpirationWindow).
+		GetConfigurationParameter(gomock.Any(), appcfg.PasswordExpirationWindow).
 		Return(appcfg.Parameter{}, errors.Error("db error"))
 
 	test.Request(t).
@@ -113,7 +113,7 @@ func Test_GetApplicationConfigurations(t *testing.T) {
 		ResponseStatusCode(http.StatusBadRequest)
 
 	mockDB.EXPECT().
-		GetConfigurationParameter(appcfg.PasswordExpirationWindow).
+		GetConfigurationParameter(gomock.Any(), appcfg.PasswordExpirationWindow).
 		Return(expectedAppConfig, nil)
 
 	test.Request(t).

--- a/cmd/api/src/api/v2/app_config_test.go
+++ b/cmd/api/src/api/v2/app_config_test.go
@@ -1,17 +1,17 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 package v2_test
@@ -22,13 +22,13 @@ import (
 
 	"go.uber.org/mock/gomock"
 
+	"github.com/specterops/bloodhound/errors"
 	v2 "github.com/specterops/bloodhound/src/api/v2"
 	"github.com/specterops/bloodhound/src/database/mocks"
 	"github.com/specterops/bloodhound/src/model"
 	"github.com/specterops/bloodhound/src/model/appcfg"
 	"github.com/specterops/bloodhound/src/test/must"
 	"github.com/specterops/bloodhound/src/utils/test"
-	"github.com/specterops/bloodhound/errors"
 )
 
 func Test_GetApplicationConfigurations(t *testing.T) {
@@ -55,7 +55,7 @@ func Test_GetApplicationConfigurations(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	mockDB.EXPECT().
-		GetAllConfigurationParameters().
+		GetAllConfigurationParameters(gomock.Any()).
 		Return(expectedAppConfigs, nil)
 
 	test.Request(t).
@@ -70,7 +70,7 @@ func Test_GetApplicationConfigurations(t *testing.T) {
 
 	// Second call to GetAll should fail
 	mockDB.EXPECT().
-		GetAllConfigurationParameters().
+		GetAllConfigurationParameters(gomock.Any()).
 		Return(nil, errors.Error("db error"))
 
 	test.Request(t).

--- a/cmd/api/src/api/v2/auth/auth.go
+++ b/cmd/api/src/api/v2/auth/auth.go
@@ -448,7 +448,7 @@ func (s ManagementResource) CreateUser(response http.ResponseWriter, request *ht
 				log.Errorf("Error while attempting to digest secret for user: %v", err)
 				api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusInternalServerError, api.ErrorResponseDetailsInternalServerError, request), response)
 				return
-			} else if passwordExpiration, err := appcfg.GetPasswordExpiration(s.db); err != nil {
+			} else if passwordExpiration, err := appcfg.GetPasswordExpiration(request.Context(), s.db); err != nil {
 				log.Errorf("Error while attempting to fetch password expiration window: %v", err)
 				api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusInternalServerError, api.ErrorResponseDetailsInternalServerError, request), response)
 			} else {
@@ -647,7 +647,7 @@ func (s ManagementResource) PutUserAuthSecret(response http.ResponseWriter, requ
 		api.HandleDatabaseError(request, response, err)
 	} else if targetUser.SAMLProviderID.Valid {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, "Invalid operation, user is SSO", request), response)
-	} else if passwordExpiration, err := appcfg.GetPasswordExpiration(s.db); err != nil {
+	} else if passwordExpiration, err := appcfg.GetPasswordExpiration(request.Context(), s.db); err != nil {
 		log.Errorf("Error while attempting to fetch password expiration window: %v", err)
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusInternalServerError, api.ErrorResponseCodeInternalServerError, request), response)
 	} else if secretDigest, err := s.secretDigester.Digest(setUserSecretRequest.Secret); err != nil {

--- a/cmd/api/src/api/v2/auth/auth_test.go
+++ b/cmd/api/src/api/v2/auth/auth_test.go
@@ -75,7 +75,7 @@ func TestManagementResource_PutUserAuthSecret(t *testing.T) {
 
 	mockDB.EXPECT().GetUser(badUserID).Return(model.User{SAMLProviderID: null.Int32From(1)}, nil)
 	mockDB.EXPECT().GetUser(goodUserID).Return(model.User{}, nil)
-	mockDB.EXPECT().GetConfigurationParameter(appcfg.PasswordExpirationWindow).Return(appcfg.Parameter{
+	mockDB.EXPECT().GetConfigurationParameter(gomock.Any(), appcfg.PasswordExpirationWindow).Return(appcfg.Parameter{
 		Key: appcfg.PasswordExpirationWindow,
 		Value: must.NewJSONBObject(appcfg.PasswordExpiration{
 			Duration: appcfg.DefaultPasswordExpirationWindow,
@@ -1048,7 +1048,7 @@ func TestCreateUser_Failure(t *testing.T) {
 	}
 
 	resources, mockDB := apitest.NewAuthManagementResource(mockCtrl)
-	mockDB.EXPECT().GetConfigurationParameter(appcfg.PasswordExpirationWindow).Return(appcfg.Parameter{
+	mockDB.EXPECT().GetConfigurationParameter(gomock.Any(), appcfg.PasswordExpirationWindow).Return(appcfg.Parameter{
 		Key: appcfg.PasswordExpirationWindow,
 		Value: must.NewJSONBObject(appcfg.PasswordExpiration{
 			Duration: appcfg.DefaultPasswordExpirationWindow,
@@ -1164,7 +1164,7 @@ func TestCreateUser_Success(t *testing.T) {
 	goodUser := model.User{PrincipalName: "good user"}
 
 	resources, mockDB := apitest.NewAuthManagementResource(mockCtrl)
-	mockDB.EXPECT().GetConfigurationParameter(appcfg.PasswordExpirationWindow).Return(appcfg.Parameter{
+	mockDB.EXPECT().GetConfigurationParameter(gomock.Any(), appcfg.PasswordExpirationWindow).Return(appcfg.Parameter{
 		Key: appcfg.PasswordExpirationWindow,
 		Value: must.NewJSONBObject(appcfg.PasswordExpiration{
 			Duration: appcfg.DefaultPasswordExpirationWindow,
@@ -1217,7 +1217,7 @@ func TestCreateUser_ResetPassword(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	resources, mockDB := apitest.NewAuthManagementResource(mockCtrl)
-	mockDB.EXPECT().GetConfigurationParameter(appcfg.PasswordExpirationWindow).Return(appcfg.Parameter{
+	mockDB.EXPECT().GetConfigurationParameter(gomock.Any(), appcfg.PasswordExpirationWindow).Return(appcfg.Parameter{
 		Key: appcfg.PasswordExpirationWindow,
 		Value: must.NewJSONBObject(appcfg.PasswordExpiration{
 			Duration: appcfg.DefaultPasswordExpirationWindow,
@@ -1290,7 +1290,7 @@ func TestManagementResource_UpdateUser_IDMalformed(t *testing.T) {
 	}
 
 	resources, mockDB := apitest.NewAuthManagementResource(mockCtrl)
-	mockDB.EXPECT().GetConfigurationParameter(appcfg.PasswordExpirationWindow).Return(appcfg.Parameter{
+	mockDB.EXPECT().GetConfigurationParameter(gomock.Any(), appcfg.PasswordExpirationWindow).Return(appcfg.Parameter{
 		Key: appcfg.PasswordExpirationWindow,
 		Value: must.NewJSONBObject(appcfg.PasswordExpiration{
 			Duration: appcfg.DefaultPasswordExpirationWindow,
@@ -1353,7 +1353,7 @@ func TestManagementResource_UpdateUser_GetUserError(t *testing.T) {
 	}
 
 	resources, mockDB := apitest.NewAuthManagementResource(mockCtrl)
-	mockDB.EXPECT().GetConfigurationParameter(appcfg.PasswordExpirationWindow).Return(appcfg.Parameter{
+	mockDB.EXPECT().GetConfigurationParameter(gomock.Any(), appcfg.PasswordExpirationWindow).Return(appcfg.Parameter{
 		Key: appcfg.PasswordExpirationWindow,
 		Value: must.NewJSONBObject(appcfg.PasswordExpiration{
 			Duration: appcfg.DefaultPasswordExpirationWindow,
@@ -1417,7 +1417,7 @@ func TestManagementResource_UpdateUser_GetRolesError(t *testing.T) {
 	}
 
 	resources, mockDB := apitest.NewAuthManagementResource(mockCtrl)
-	mockDB.EXPECT().GetConfigurationParameter(appcfg.PasswordExpirationWindow).Return(appcfg.Parameter{
+	mockDB.EXPECT().GetConfigurationParameter(gomock.Any(), appcfg.PasswordExpirationWindow).Return(appcfg.Parameter{
 		Key: appcfg.PasswordExpirationWindow,
 		Value: must.NewJSONBObject(appcfg.PasswordExpiration{
 			Duration: appcfg.DefaultPasswordExpirationWindow,
@@ -1475,7 +1475,7 @@ func TestManagementResource_UpdateUser_SelfDisable(t *testing.T) {
 	goodUser := model.User{PrincipalName: "good user"}
 
 	resources, mockDB := apitest.NewAuthManagementResource(mockCtrl)
-	mockDB.EXPECT().GetConfigurationParameter(appcfg.PasswordExpirationWindow).Return(appcfg.Parameter{
+	mockDB.EXPECT().GetConfigurationParameter(gomock.Any(), appcfg.PasswordExpirationWindow).Return(appcfg.Parameter{
 		Key: appcfg.PasswordExpirationWindow,
 		Value: must.NewJSONBObject(appcfg.PasswordExpiration{
 			Duration: appcfg.DefaultPasswordExpirationWindow,
@@ -1556,7 +1556,7 @@ func TestManagementResource_UpdateUser_LookupActiveSessionsError(t *testing.T) {
 	}
 
 	resources, mockDB := apitest.NewAuthManagementResource(mockCtrl)
-	mockDB.EXPECT().GetConfigurationParameter(appcfg.PasswordExpirationWindow).Return(appcfg.Parameter{
+	mockDB.EXPECT().GetConfigurationParameter(gomock.Any(), appcfg.PasswordExpirationWindow).Return(appcfg.Parameter{
 		Key: appcfg.PasswordExpirationWindow,
 		Value: must.NewJSONBObject(appcfg.PasswordExpiration{
 			Duration: appcfg.DefaultPasswordExpirationWindow,
@@ -1637,7 +1637,7 @@ func TestManagementResource_UpdateUser_DBError(t *testing.T) {
 	}
 
 	resources, mockDB := apitest.NewAuthManagementResource(mockCtrl)
-	mockDB.EXPECT().GetConfigurationParameter(appcfg.PasswordExpirationWindow).Return(appcfg.Parameter{
+	mockDB.EXPECT().GetConfigurationParameter(gomock.Any(), appcfg.PasswordExpirationWindow).Return(appcfg.Parameter{
 		Key: appcfg.PasswordExpirationWindow,
 		Value: must.NewJSONBObject(appcfg.PasswordExpiration{
 			Duration: appcfg.DefaultPasswordExpirationWindow,
@@ -1862,7 +1862,7 @@ func TestManagementResource_UpdateUser_Success(t *testing.T) {
 	}
 
 	resources, mockDB := apitest.NewAuthManagementResource(mockCtrl)
-	mockDB.EXPECT().GetConfigurationParameter(appcfg.PasswordExpirationWindow).Return(appcfg.Parameter{
+	mockDB.EXPECT().GetConfigurationParameter(gomock.Any(), appcfg.PasswordExpirationWindow).Return(appcfg.Parameter{
 		Key: appcfg.PasswordExpirationWindow,
 		Value: must.NewJSONBObject(appcfg.PasswordExpiration{
 			Duration: appcfg.DefaultPasswordExpirationWindow,

--- a/cmd/api/src/database/app_config.go
+++ b/cmd/api/src/database/app_config.go
@@ -18,8 +18,6 @@ package database
 
 import (
 	"context"
-	"strings"
-
 	"github.com/specterops/bloodhound/src/model/appcfg"
 	"gorm.io/gorm/clause"
 )
@@ -51,17 +49,6 @@ func (s *BloodhoundDB) GetAllConfigurationParameters(ctx context.Context) (appcf
 func (s *BloodhoundDB) GetConfigurationParameter(parameterKey string) (appcfg.Parameter, error) {
 	var parameter appcfg.Parameter
 	return parameter, CheckError(s.db.First(&parameter, "key = ?", parameterKey))
-}
-
-func (s *BloodhoundDB) GetConfigurationParametersByPrefix(parameterKeyPrefix string) (appcfg.Parameters, error) {
-	const matchAllWildcard = "%"
-
-	if !strings.HasSuffix(parameterKeyPrefix, matchAllWildcard) {
-		parameterKeyPrefix += matchAllWildcard
-	}
-
-	var parameters appcfg.Parameters
-	return parameters, CheckError(s.db.First(&parameters, "key like ?", parameterKeyPrefix))
 }
 
 func (s *BloodhoundDB) SetConfigurationParameter(ctx context.Context, parameter appcfg.Parameter) error {

--- a/cmd/api/src/database/app_config.go
+++ b/cmd/api/src/database/app_config.go
@@ -46,9 +46,9 @@ func (s *BloodhoundDB) GetAllConfigurationParameters(ctx context.Context) (appcf
 	return appConfig, CheckError(s.db.WithContext(ctx).Find(&appConfig))
 }
 
-func (s *BloodhoundDB) GetConfigurationParameter(parameterKey string) (appcfg.Parameter, error) {
+func (s *BloodhoundDB) GetConfigurationParameter(ctx context.Context, parameterKey string) (appcfg.Parameter, error) {
 	var parameter appcfg.Parameter
-	return parameter, CheckError(s.db.First(&parameter, "key = ?", parameterKey))
+	return parameter, CheckError(s.db.WithContext(ctx).First(&parameter, "key = ?", parameterKey))
 }
 
 func (s *BloodhoundDB) SetConfigurationParameter(ctx context.Context, parameter appcfg.Parameter) error {

--- a/cmd/api/src/database/app_config.go
+++ b/cmd/api/src/database/app_config.go
@@ -64,8 +64,8 @@ func (s *BloodhoundDB) GetConfigurationParametersByPrefix(parameterKeyPrefix str
 	return parameters, CheckError(s.db.First(&parameters, "key like ?", parameterKeyPrefix))
 }
 
-func (s *BloodhoundDB) SetConfigurationParameter(parameter appcfg.Parameter) error {
-	return CheckError(s.db.Clauses(clause.OnConflict{
+func (s *BloodhoundDB) SetConfigurationParameter(ctx context.Context, parameter appcfg.Parameter) error {
+	return CheckError(s.db.WithContext(ctx).Clauses(clause.OnConflict{
 		Columns:   []clause.Column{{Name: "key"}},
 		DoUpdates: clause.AssignmentColumns([]string{"value"}),
 	}).Create(&parameter))

--- a/cmd/api/src/database/app_config.go
+++ b/cmd/api/src/database/app_config.go
@@ -1,22 +1,23 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 package database
 
 import (
+	"context"
 	"strings"
 
 	"github.com/specterops/bloodhound/src/model/appcfg"
@@ -42,9 +43,9 @@ func (s *BloodhoundDB) SetFlag(flag appcfg.FeatureFlag) error {
 	return CheckError(s.db.Save(&flag))
 }
 
-func (s *BloodhoundDB) GetAllConfigurationParameters() (appcfg.Parameters, error) {
+func (s *BloodhoundDB) GetAllConfigurationParameters(ctx context.Context) (appcfg.Parameters, error) {
 	var appConfig appcfg.Parameters
-	return appConfig, CheckError(s.db.Find(&appConfig))
+	return appConfig, CheckError(s.db.WithContext(ctx).Find(&appConfig))
 }
 
 func (s *BloodhoundDB) GetConfigurationParameter(parameterKey string) (appcfg.Parameter, error) {

--- a/cmd/api/src/database/db.go
+++ b/cmd/api/src/database/db.go
@@ -54,7 +54,7 @@ type Database interface {
 	Close()
 	GetConfigurationParameter(parameter string) (appcfg.Parameter, error)
 	SetConfigurationParameter(appConfig appcfg.Parameter) error
-	GetAllConfigurationParameters() (appcfg.Parameters, error)
+	GetAllConfigurationParameters(ctx context.Context) (appcfg.Parameters, error)
 	CreateIngestTask(ingestTask model.IngestTask) (model.IngestTask, error)
 	GetAllIngestTasks() (model.IngestTasks, error)
 	DeleteIngestTask(ingestTask model.IngestTask) error

--- a/cmd/api/src/database/db.go
+++ b/cmd/api/src/database/db.go
@@ -53,7 +53,7 @@ type Database interface {
 
 	Close()
 	GetConfigurationParameter(parameter string) (appcfg.Parameter, error)
-	SetConfigurationParameter(appConfig appcfg.Parameter) error
+	SetConfigurationParameter(ctx context.Context, appConfig appcfg.Parameter) error
 	GetAllConfigurationParameters(ctx context.Context) (appcfg.Parameters, error)
 	CreateIngestTask(ingestTask model.IngestTask) (model.IngestTask, error)
 	GetAllIngestTasks() (model.IngestTasks, error)

--- a/cmd/api/src/database/db.go
+++ b/cmd/api/src/database/db.go
@@ -52,9 +52,6 @@ type Database interface {
 	appcfg.FeatureFlagService
 
 	Close()
-	GetConfigurationParameter(parameter string) (appcfg.Parameter, error)
-	SetConfigurationParameter(ctx context.Context, appConfig appcfg.Parameter) error
-	GetAllConfigurationParameters(ctx context.Context) (appcfg.Parameters, error)
 	CreateIngestTask(ingestTask model.IngestTask) (model.IngestTask, error)
 	GetAllIngestTasks() (model.IngestTasks, error)
 	DeleteIngestTask(ingestTask model.IngestTask) error

--- a/cmd/api/src/database/mocks/db.go
+++ b/cmd/api/src/database/mocks/db.go
@@ -777,21 +777,6 @@ func (mr *MockDatabaseMockRecorder) GetConfigurationParameter(arg0 interface{}) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConfigurationParameter", reflect.TypeOf((*MockDatabase)(nil).GetConfigurationParameter), arg0)
 }
 
-// GetConfigurationParametersByPrefix mocks base method.
-func (m *MockDatabase) GetConfigurationParametersByPrefix(arg0 string) (appcfg.Parameters, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetConfigurationParametersByPrefix", arg0)
-	ret0, _ := ret[0].(appcfg.Parameters)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetConfigurationParametersByPrefix indicates an expected call of GetConfigurationParametersByPrefix.
-func (mr *MockDatabaseMockRecorder) GetConfigurationParametersByPrefix(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConfigurationParametersByPrefix", reflect.TypeOf((*MockDatabase)(nil).GetConfigurationParametersByPrefix), arg0)
-}
-
 // GetFileUploadJob mocks base method.
 func (m *MockDatabase) GetFileUploadJob(arg0 int64) (model.FileUploadJob, error) {
 	m.ctrl.T.Helper()

--- a/cmd/api/src/database/mocks/db.go
+++ b/cmd/api/src/database/mocks/db.go
@@ -535,18 +535,18 @@ func (mr *MockDatabaseMockRecorder) GetAllAuthTokens(arg0, arg1 interface{}) *go
 }
 
 // GetAllConfigurationParameters mocks base method.
-func (m *MockDatabase) GetAllConfigurationParameters() (appcfg.Parameters, error) {
+func (m *MockDatabase) GetAllConfigurationParameters(arg0 context.Context) (appcfg.Parameters, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAllConfigurationParameters")
+	ret := m.ctrl.Call(m, "GetAllConfigurationParameters", arg0)
 	ret0, _ := ret[0].(appcfg.Parameters)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetAllConfigurationParameters indicates an expected call of GetAllConfigurationParameters.
-func (mr *MockDatabaseMockRecorder) GetAllConfigurationParameters() *gomock.Call {
+func (mr *MockDatabaseMockRecorder) GetAllConfigurationParameters(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllConfigurationParameters", reflect.TypeOf((*MockDatabase)(nil).GetAllConfigurationParameters))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllConfigurationParameters", reflect.TypeOf((*MockDatabase)(nil).GetAllConfigurationParameters), arg0)
 }
 
 // GetAllFileUploadJobs mocks base method.

--- a/cmd/api/src/database/mocks/db.go
+++ b/cmd/api/src/database/mocks/db.go
@@ -763,18 +763,18 @@ func (mr *MockDatabaseMockRecorder) GetAzureDataQualityStats(arg0, arg1, arg2, a
 }
 
 // GetConfigurationParameter mocks base method.
-func (m *MockDatabase) GetConfigurationParameter(arg0 string) (appcfg.Parameter, error) {
+func (m *MockDatabase) GetConfigurationParameter(arg0 context.Context, arg1 string) (appcfg.Parameter, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetConfigurationParameter", arg0)
+	ret := m.ctrl.Call(m, "GetConfigurationParameter", arg0, arg1)
 	ret0, _ := ret[0].(appcfg.Parameter)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetConfigurationParameter indicates an expected call of GetConfigurationParameter.
-func (mr *MockDatabaseMockRecorder) GetConfigurationParameter(arg0 interface{}) *gomock.Call {
+func (mr *MockDatabaseMockRecorder) GetConfigurationParameter(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConfigurationParameter", reflect.TypeOf((*MockDatabase)(nil).GetConfigurationParameter), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConfigurationParameter", reflect.TypeOf((*MockDatabase)(nil).GetConfigurationParameter), arg0, arg1)
 }
 
 // GetFileUploadJob mocks base method.

--- a/cmd/api/src/database/mocks/db.go
+++ b/cmd/api/src/database/mocks/db.go
@@ -1260,17 +1260,17 @@ func (mr *MockDatabaseMockRecorder) SavedQueryBelongsToUser(arg0, arg1 interface
 }
 
 // SetConfigurationParameter mocks base method.
-func (m *MockDatabase) SetConfigurationParameter(arg0 appcfg.Parameter) error {
+func (m *MockDatabase) SetConfigurationParameter(arg0 context.Context, arg1 appcfg.Parameter) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetConfigurationParameter", arg0)
+	ret := m.ctrl.Call(m, "SetConfigurationParameter", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetConfigurationParameter indicates an expected call of SetConfigurationParameter.
-func (mr *MockDatabaseMockRecorder) SetConfigurationParameter(arg0 interface{}) *gomock.Call {
+func (mr *MockDatabaseMockRecorder) SetConfigurationParameter(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetConfigurationParameter", reflect.TypeOf((*MockDatabase)(nil).SetConfigurationParameter), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetConfigurationParameter", reflect.TypeOf((*MockDatabase)(nil).SetConfigurationParameter), arg0, arg1)
 }
 
 // SetFlag mocks base method.

--- a/cmd/api/src/model/appcfg/parameter.go
+++ b/cmd/api/src/model/appcfg/parameter.go
@@ -86,7 +86,7 @@ type ParameterService interface {
 	GetConfigurationParametersByPrefix(prefix string) (Parameters, error)
 
 	// SetConfigurationParameter attempts to store or update the given Parameter.
-	SetConfigurationParameter(configurationParameter Parameter) error
+	SetConfigurationParameter(ctx context.Context, configurationParameter Parameter) error
 }
 
 func AvailableParameters() (ParameterSet, error) {

--- a/cmd/api/src/model/appcfg/parameter.go
+++ b/cmd/api/src/model/appcfg/parameter.go
@@ -79,7 +79,7 @@ type ParameterService interface {
 	GetAllConfigurationParameters(ctx context.Context) (Parameters, error)
 
 	// GetConfigurationParameter attempts to fetch a Parameter struct by its parameter name.
-	GetConfigurationParameter(parameter string) (Parameter, error)
+	GetConfigurationParameter(ctx context.Context, parameter string) (Parameter, error)
 
 	// SetConfigurationParameter attempts to store or update the given Parameter.
 	SetConfigurationParameter(ctx context.Context, configurationParameter Parameter) error
@@ -126,10 +126,10 @@ func (s PasswordExpiration) ParseDuration() (time.Duration, error) {
 	}
 }
 
-func GetPasswordExpiration(service ParameterService) (time.Duration, error) {
+func GetPasswordExpiration(ctx context.Context, service ParameterService) (time.Duration, error) {
 	var expiration PasswordExpiration
 
-	if cfg, err := service.GetConfigurationParameter(PasswordExpirationWindow); err != nil {
+	if cfg, err := service.GetConfigurationParameter(ctx, PasswordExpirationWindow); err != nil {
 		return 0, err
 	} else if err := cfg.Map(&expiration); err != nil {
 		return 0, err
@@ -143,10 +143,10 @@ type Neo4jParameters struct {
 	BatchWriteSize int `json:"batch_write_size,omitempty"`
 }
 
-func GetNeo4jParameters(service ParameterService) Neo4jParameters {
+func GetNeo4jParameters(ctx context.Context, service ParameterService) Neo4jParameters {
 	var result Neo4jParameters
 
-	if neo4jParametersCfg, err := service.GetConfigurationParameter(Neo4jConfigs); err != nil {
+	if neo4jParametersCfg, err := service.GetConfigurationParameter(ctx, Neo4jConfigs); err != nil {
 		log.Errorf("failed to fetch neo4j configuration; returning default values")
 		result = Neo4jParameters{
 			WriteFlushSize: neo4j.DefaultWriteFlushSize,

--- a/cmd/api/src/model/appcfg/parameter.go
+++ b/cmd/api/src/model/appcfg/parameter.go
@@ -1,30 +1,31 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 package appcfg
 
 import (
+	"context"
 	"fmt"
 	"time"
 
-	"github.com/specterops/bloodhound/src/database/types"
-	"github.com/specterops/bloodhound/src/model"
 	iso8601 "github.com/channelmeter/iso8601duration"
 	"github.com/specterops/bloodhound/dawgs/drivers/neo4j"
 	"github.com/specterops/bloodhound/log"
+	"github.com/specterops/bloodhound/src/database/types"
+	"github.com/specterops/bloodhound/src/model"
 )
 
 const (
@@ -75,7 +76,7 @@ type ParameterSet map[string]Parameter
 // abstract backend storage.
 type ParameterService interface {
 	// GetAllConfigurationParameters gets all available runtime Parameters for the application.
-	GetAllConfigurationParameters() (Parameters, error)
+	GetAllConfigurationParameters(ctx context.Context) (Parameters, error)
 
 	// GetConfigurationParameter attempts to fetch a Parameter struct by its parameter name.
 	GetConfigurationParameter(parameter string) (Parameter, error)

--- a/cmd/api/src/model/appcfg/parameter.go
+++ b/cmd/api/src/model/appcfg/parameter.go
@@ -81,10 +81,6 @@ type ParameterService interface {
 	// GetConfigurationParameter attempts to fetch a Parameter struct by its parameter name.
 	GetConfigurationParameter(parameter string) (Parameter, error)
 
-	// GetConfigurationParametersByPrefix attempts to fetch all Parameters that have a parameter name that
-	// starts with the given prefix.
-	GetConfigurationParametersByPrefix(prefix string) (Parameters, error)
-
 	// SetConfigurationParameter attempts to store or update the given Parameter.
 	SetConfigurationParameter(ctx context.Context, configurationParameter Parameter) error
 }

--- a/cmd/api/src/services/entrypoint.go
+++ b/cmd/api/src/services/entrypoint.go
@@ -99,7 +99,7 @@ func Entrypoint(ctx context.Context, cfg config.Configuration, connections boots
 		registration.RegisterFossRoutes(&routerInst, cfg, connections.RDMS, connections.Graph, graphQuery, apiCache, collectorManifests, authenticator, datapipeDaemon)
 
 		// Set neo4j batch and flush sizes
-		neo4jParameters := appcfg.GetNeo4jParameters(connections.RDMS)
+		neo4jParameters := appcfg.GetNeo4jParameters(ctx, connections.RDMS)
 		connections.Graph.SetBatchWriteSize(neo4jParameters.BatchWriteSize)
 		connections.Graph.SetWriteFlushSize(neo4jParameters.WriteFlushSize)
 


### PR DESCRIPTION
## Description

Plumb context into gorm config parameters db methods
https://gorm.io/docs/context.html#Context-Timeout

## Motivation and Context

Currently as it stands any endpoints that rely on purely gorm do not respect `request.Context` and as such timeouts are not respected either. While we want to eventually get to the removal of the gorm dependency altogether, that is a long way and a lot of effort away and this I think this approach would give us that much room to maneuver while we get there.

## How Has This Been Tested?

Using a rest client and the prefer header
Add a sleep inside of the handler
Look for the `500 request timed out` after exceeding the timeout. (Note: the request will take as long as the sleep is set, it's not tied to the prefer header)

## Types of changes

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [x] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
