### PR TITLE
refactor: audit log action to constant

### DIFF
--- a/cmd/api/src/api/auth.go
+++ b/cmd/api/src/api/auth.go
@@ -89,7 +89,7 @@ func NewAuthenticator(cfg config.Configuration, db database.Database, ctxInitial
 func (s authenticator) auditLogin(requestContext context.Context, commitID uuid.UUID, user model.User, loginRequest LoginRequest, status string, loginError error) {
 	bhCtx := ctx.Get(requestContext)
 	auditLog := model.AuditLog{
-		Action:          "LoginAttempt",
+		Action:          model.AuditLogActionLoginAttempt,
 		Fields:          types.JSONUntypedObject{"username": loginRequest.Username},
 		RequestID:       bhCtx.RequestID,
 		SourceIpAddress: bhCtx.RequestIP,
@@ -103,7 +103,7 @@ func (s authenticator) auditLogin(requestContext context.Context, commitID uuid.
 		auditLog.ActorEmail = user.EmailAddress.ValueOrZero()
 	}
 
-	if status == string(model.AuditStatusFailure) {
+	if status == string(model.AuditLogStatusFailure) {
 		auditLog.Fields["error"] = loginError
 	}
 
@@ -144,15 +144,15 @@ func (s authenticator) LoginWithSecret(ctx context.Context, loginRequest LoginRe
 		return LoginDetails{}, err
 	}
 
-	s.auditLogin(ctx, commitID, user, loginRequest, string(model.AuditStatusIntent), err)
+	s.auditLogin(ctx, commitID, user, loginRequest, string(model.AuditLogStatusIntent), err)
 
 	user, sessionToken, err = s.validateSecretLogin(ctx, loginRequest)
 
 	if err != nil {
-		s.auditLogin(ctx, commitID, user, loginRequest, string(model.AuditStatusFailure), err)
+		s.auditLogin(ctx, commitID, user, loginRequest, string(model.AuditLogStatusFailure), err)
 		return LoginDetails{}, err
 	} else {
-		s.auditLogin(ctx, commitID, user, loginRequest, string(model.AuditStatusSuccess), err)
+		s.auditLogin(ctx, commitID, user, loginRequest, string(model.AuditLogStatusSuccess), err)
 		return LoginDetails{
 			User:         user,
 			SessionToken: sessionToken,

--- a/cmd/api/src/api/auth_internal_test.go
+++ b/cmd/api/src/api/auth_internal_test.go
@@ -47,7 +47,7 @@ func buildAuditLog(testCtx context.Context, user model.User, loginRequest LoginR
 	bhCtx := ctx.Get(testCtx)
 
 	auditLog := model.AuditLog{
-		Action:          "LoginAttempt",
+		Action:          model.AuditLogActionLoginAttempt,
 		ActorName:       user.PrincipalName,
 		ActorEmail:      user.EmailAddress.ValueOrZero(),
 		Fields:          types.JSONUntypedObject{"username": loginRequest.Username},
@@ -75,10 +75,10 @@ func TestAuditLogin(t *testing.T) {
 		db: mockDB,
 	}
 	testCtx, loginRequest := setupRequest(testyUser)
-	expectedAuditLog := buildAuditLog(testCtx, testyUser, loginRequest, string(model.AuditStatusSuccess), nil)
+	expectedAuditLog := buildAuditLog(testCtx, testyUser, loginRequest, string(model.AuditLogStatusSuccess), nil)
 
 	mockDB.EXPECT().CreateAuditLog(testCtx, expectedAuditLog)
-	a.auditLogin(testCtx, commitId, testyUser, loginRequest, string(model.AuditStatusSuccess), nil)
+	a.auditLogin(testCtx, commitId, testyUser, loginRequest, string(model.AuditLogStatusSuccess), nil)
 }
 
 func TestAuditLogin_UserNotFound(t *testing.T) {
@@ -88,8 +88,8 @@ func TestAuditLogin_UserNotFound(t *testing.T) {
 		db: mockDB,
 	}
 	testCtx, loginRequest := setupRequest(model.User{})
-	expectedAuditLog := buildAuditLog(testCtx, model.User{}, loginRequest, string(model.AuditStatusFailure), ErrInvalidAuth)
+	expectedAuditLog := buildAuditLog(testCtx, model.User{}, loginRequest, string(model.AuditLogStatusFailure), ErrInvalidAuth)
 
 	mockDB.EXPECT().CreateAuditLog(testCtx, expectedAuditLog)
-	a.auditLogin(testCtx, commitId, model.User{}, loginRequest, string(model.AuditStatusFailure), ErrInvalidAuth)
+	a.auditLogin(testCtx, commitId, model.User{}, loginRequest, string(model.AuditLogStatusFailure), ErrInvalidAuth)
 }

--- a/cmd/api/src/api/middleware/auth_test.go
+++ b/cmd/api/src/api/middleware/auth_test.go
@@ -44,7 +44,7 @@ func permissionsCheckAtLeastOneHandler(db *dbmocks.MockDatabase, internalHandler
 	return PermissionsCheckAtLeastOne(auth.NewAuthorizer(db), permissions...)(internalHandler)
 }
 
-func auditEntryAndContext(bhCtx ctx.Context, action string, fields model.AuditData, status model.AuditEntryStatus) (context.Context, model.AuditEntry) {
+func auditEntryAndContext(bhCtx ctx.Context, action model.AuditLogAction, fields model.AuditData, status model.AuditLogEntryStatus) (context.Context, model.AuditEntry) {
 	testCtx := context.Background()
 	testCtx = ctx.Set(testCtx, &bhCtx)
 
@@ -142,9 +142,9 @@ func TestPermissionsCheckAll(t *testing.T) {
 		ResponseStatusCode(http.StatusOK)
 
 	auditContext, noPermsEntry := auditEntryAndContext(
-		noPermsCtx, "UnauthorizedAccessAttempt",
+		noPermsCtx, model.AuditLogActionUnauthorizedAccessAttempt,
 		model.AuditData{"endpoint": "POST /test"},
-		model.AuditStatusFailure,
+		model.AuditLogStatusFailure,
 	)
 	mockDB.EXPECT().AppendAuditLog(auditContext, noPermsEntry).Times(1)
 	test.Request(t).
@@ -268,9 +268,9 @@ func TestPermissionsCheckAtLeastOne(t *testing.T) {
 		ResponseStatusCode(http.StatusOK)
 
 	auditContext, missingPermsEntry := auditEntryAndContext(
-		missingPermsCtx, "UnauthorizedAccessAttempt",
+		missingPermsCtx, model.AuditLogActionUnauthorizedAccessAttempt,
 		model.AuditData{"endpoint": "PUT /test"},
-		model.AuditStatusFailure,
+		model.AuditLogStatusFailure,
 	)
 	mockDB.EXPECT().AppendAuditLog(auditContext, missingPermsEntry).Times(1)
 	test.Request(t).

--- a/cmd/api/src/auth/model.go
+++ b/cmd/api/src/auth/model.go
@@ -159,9 +159,9 @@ func (s authorizer) AuditLogUnauthorizedAccess(request *http.Request) {
 		if err := s.auditLogger.AppendAuditLog(
 			request.Context(),
 			model.AuditEntry{
-				Action:   "UnauthorizedAccessAttempt",
+				Action:   model.AuditLogActionUnauthorizedAccessAttempt,
 				Model:    model.AuditData{"endpoint": request.Method + " " + request.URL.Path},
-				Status:   model.AuditStatusFailure,
+				Status:   model.AuditLogStatusFailure,
 				CommitID: commitId,
 			},
 		); err != nil {

--- a/cmd/api/src/database/agi.go
+++ b/cmd/api/src/database/agi.go
@@ -35,7 +35,7 @@ func (s *BloodhoundDB) CreateAssetGroup(ctx context.Context, name, tag string, s
 		}
 
 		auditEntry = model.AuditEntry{
-			Action: "CreateAssetGroup",
+			Action: model.AuditLogActionCreateAssetGroup,
 			Model:  &assetGroup, // Pointer is required to ensure success log contains updated fields after transaction
 		}
 	)
@@ -48,7 +48,7 @@ func (s *BloodhoundDB) CreateAssetGroup(ctx context.Context, name, tag string, s
 func (s *BloodhoundDB) UpdateAssetGroup(ctx context.Context, assetGroup model.AssetGroup) error {
 	var (
 		auditEntry = model.AuditEntry{
-			Action: "UpdateAssetGroup",
+			Action: model.AuditLogActionUpdateAssetGroup,
 			Model:  &assetGroup, // Pointer is required to ensure success log contains updated fields after transaction
 		}
 	)
@@ -61,7 +61,7 @@ func (s *BloodhoundDB) UpdateAssetGroup(ctx context.Context, assetGroup model.As
 func (s *BloodhoundDB) DeleteAssetGroup(ctx context.Context, assetGroup model.AssetGroup) error {
 	var (
 		auditEntry = model.AuditEntry{
-			Action: "DeleteAssetGroup",
+			Action: model.AuditLogActionDeleteAssetGroup,
 			Model:  &assetGroup, // Pointer is required to ensure success log contains updated fields after transaction
 		}
 	)
@@ -171,7 +171,7 @@ func (s *BloodhoundDB) GetAssetGroupSelector(ctx context.Context, id int32) (mod
 func (s *BloodhoundDB) DeleteAssetGroupSelector(ctx context.Context, selector model.AssetGroupSelector) error {
 	var (
 		auditEntry = model.AuditEntry{
-			Action: "DeleteAssetGroupSelector",
+			Action: model.AuditLogActionDeleteAssetGroupSelector,
 			Model:  &selector, // Pointer is required to ensure success log contains updated fields after transaction
 		}
 	)

--- a/cmd/api/src/database/agi_test.go
+++ b/cmd/api/src/database/agi_test.go
@@ -28,7 +28,7 @@ func TestCreateGetUpdateDeleteAssetGroup(t *testing.T) {
 
 	if newAssetGroup, err = dbInst.CreateAssetGroup(context.Background(), "test asset group", "test", false); err != nil {
 		t.Fatalf("Error creating asset group: %v", err)
-	} else if err = test.VerifyAuditLogs(dbInst, "CreateAssetGroup", "asset_group_name", newAssetGroup.Name); err != nil {
+	} else if err = test.VerifyAuditLogs(dbInst, model.AuditLogActionCreateAssetGroup, "asset_group_name", newAssetGroup.Name); err != nil {
 		t.Fatalf("Error verifying CreateAssetGroup audit logs:\n%v", err)
 	}
 
@@ -51,13 +51,13 @@ func TestCreateGetUpdateDeleteAssetGroup(t *testing.T) {
 	}
 	if err = dbInst.UpdateAssetGroup(context.Background(), updatedAssetGroup); err != nil {
 		t.Fatalf("Error updating asset group: %v", err)
-	} else if err = test.VerifyAuditLogs(dbInst, "UpdateAssetGroup", "asset_group_name", "updated asset group"); err != nil {
+	} else if err = test.VerifyAuditLogs(dbInst, model.AuditLogActionUpdateAssetGroup, "asset_group_name", "updated asset group"); err != nil {
 		t.Fatalf("Error veriying UpdateAssetGroup audit logs:\n%v", err)
 	}
 
 	if err = dbInst.DeleteAssetGroup(context.Background(), updatedAssetGroup); err != nil {
 		t.Fatalf("Error deleting asset group: %v", err)
-	} else if err = test.VerifyAuditLogs(dbInst, "DeleteAssetGroup", "asset_group_name", "updated asset group"); err != nil {
+	} else if err = test.VerifyAuditLogs(dbInst, model.AuditLogActionDeleteAssetGroup, "asset_group_name", "updated asset group"); err != nil {
 		t.Fatalf("Error veriying DeleteAssetGroup audit logs:\n%v", err)
 	}
 }

--- a/cmd/api/src/database/audit.go
+++ b/cmd/api/src/database/audit.go
@@ -129,7 +129,7 @@ func (s *BloodhoundDB) AuditableTransaction(ctx context.Context, auditEntry mode
 	}
 
 	auditEntry.CommitID = commitID
-	auditEntry.Status = model.AuditStatusIntent
+	auditEntry.Status = model.AuditLogStatusIntent
 
 	if err := s.AppendAuditLog(ctx, auditEntry); err != nil {
 		return fmt.Errorf("could not append intent to audit log: %w", err)
@@ -138,10 +138,10 @@ func (s *BloodhoundDB) AuditableTransaction(ctx context.Context, auditEntry mode
 	err = s.db.WithContext(ctx).Transaction(f, opts...)
 
 	if err != nil {
-		auditEntry.Status = model.AuditStatusFailure
+		auditEntry.Status = model.AuditLogStatusFailure
 		auditEntry.ErrorMsg = err.Error()
 	} else {
-		auditEntry.Status = model.AuditStatusSuccess
+		auditEntry.Status = model.AuditLogStatusSuccess
 	}
 
 	if err := s.AppendAuditLog(ctx, auditEntry); err != nil {

--- a/cmd/api/src/database/audit_internal_test.go
+++ b/cmd/api/src/database/audit_internal_test.go
@@ -21,7 +21,7 @@ var (
 		CommitID: commitId,
 		Action:   "TestAction",
 		Model:    auditData,
-		Status:   model.AuditStatusSuccess,
+		Status:   model.AuditLogStatusSuccess,
 	}
 	idResolver  = auth.NewIdentityResolver()
 	requestID   = "12345"
@@ -66,13 +66,13 @@ func TestNewAuditLog(t *testing.T) {
 	require.Equal(t, fmt.Sprintf("%s", auditData), fmt.Sprintf("%s", auditLog.Fields))
 	require.Equal(t, requestID, auditLog.RequestID)
 	require.Equal(t, requestIP, auditLog.SourceIpAddress)
-	require.Equal(t, string(model.AuditStatusSuccess), auditLog.Status)
+	require.Equal(t, string(model.AuditLogStatusSuccess), auditLog.Status)
 }
 
 func TestNewAuditLog_Error(t *testing.T) {
 	testCtx := setupRequest(testyUser)
 	errorEntry := entry
-	errorEntry.Status = model.AuditStatusFailure
+	errorEntry.Status = model.AuditLogStatusFailure
 	errorEntry.ErrorMsg = "this is a test error message"
 
 	auditLog, err := newAuditLog(testCtx, errorEntry, idResolver)
@@ -80,7 +80,7 @@ func TestNewAuditLog_Error(t *testing.T) {
 		t.Errorf("error creating audit log: %s", err.Error())
 	}
 
-	require.Equal(t, string(model.AuditStatusFailure), auditLog.Status)
+	require.Equal(t, string(model.AuditLogStatusFailure), auditLog.Status)
 	require.Equal(t, auditLog.Fields, types.JSONUntypedObject{"error": "this is a test error message", "test": "message"})
 }
 
@@ -97,7 +97,7 @@ func TestNewAuditLog_BadAuthContext(t *testing.T) {
 		CommitID: commitId,
 		Action:   "TestAction",
 		Model:    auditData,
-		Status:   model.AuditStatusFailure,
+		Status:   model.AuditLogStatusFailure,
 		ErrorMsg: "this is a test error message",
 	}
 

--- a/cmd/api/src/database/audit_test.go
+++ b/cmd/api/src/database/audit_test.go
@@ -57,7 +57,7 @@ func TestDatabase_ListAuditLogs(t *testing.T) {
 	}
 
 	for i := 0; i < 7; i++ {
-		if err := dbInst.AppendAuditLog(testCtx, model.AuditEntry{Model: &model.User{}, Action: "CreateUser", Status: model.AuditStatusSuccess}); err != nil {
+		if err := dbInst.AppendAuditLog(testCtx, model.AuditEntry{Model: &model.User{}, Action: model.AuditLogActionCreateUser, Status: model.AuditLogStatusSuccess}); err != nil {
 			t.Fatalf("Error creating audit log: %v", err)
 		}
 	}

--- a/cmd/api/src/database/auth.go
+++ b/cmd/api/src/database/auth.go
@@ -356,7 +356,7 @@ func (s *BloodhoundDB) CreateUser(ctx context.Context, user model.User) (model.U
 	}
 
 	auditEntry := model.AuditEntry{
-		Action: "CreateUser",
+		Action: model.AuditLogActionCreateUser,
 		Model:  &updatedUser,
 	}
 	return updatedUser, s.AuditableTransaction(ctx, auditEntry, func(tx *gorm.DB) error {
@@ -369,7 +369,7 @@ func (s *BloodhoundDB) CreateUser(ctx context.Context, user model.User) (model.U
 func (s *BloodhoundDB) UpdateUser(ctx context.Context, user model.User) error {
 	var (
 		auditEntry = model.AuditEntry{
-			Action: "UpdateUser",
+			Action: model.AuditLogActionUpdateUser,
 			Model:  &user, // Pointer is required to ensure success log contains updated fields after transaction
 		}
 	)
@@ -419,7 +419,7 @@ func (s *BloodhoundDB) GetUser(id uuid.UUID) (model.User, error) {
 // UPDATE users SET roles = nil WHERE user_id = ....
 func (s *BloodhoundDB) DeleteUser(ctx context.Context, user model.User) error {
 	auditEntry := model.AuditEntry{
-		Action: "DeleteUser",
+		Action: model.AuditLogActionDeleteUser,
 		Model:  &user,
 	}
 
@@ -451,7 +451,7 @@ func (s *BloodhoundDB) LookupUser(name string) (model.User, error) {
 // INSERT INTO auth_tokens (...) VALUES (....)
 func (s *BloodhoundDB) CreateAuthToken(ctx context.Context, authToken model.AuthToken) (model.AuthToken, error) {
 	auditEntry := model.AuditEntry{
-		Action: "CreateAuthToken",
+		Action: model.AuditLogActionCreateAuthToken,
 		Model:  &authToken,
 	}
 
@@ -529,7 +529,7 @@ func (s *BloodhoundDB) GetUserToken(userId, tokenId uuid.UUID) (model.AuthToken,
 // DELETE FROM auth_tokens WHERE id = ...
 func (s *BloodhoundDB) DeleteAuthToken(ctx context.Context, authToken model.AuthToken) error {
 	auditEntry := model.AuditEntry{
-		Action: "DeleteAuthToken",
+		Action: model.AuditLogActionDeleteAuthToken,
 		Model:  &authToken,
 	}
 
@@ -542,7 +542,7 @@ func (s *BloodhoundDB) DeleteAuthToken(ctx context.Context, authToken model.Auth
 // INSERT INTO auth_secrets (...) VALUES (....)
 func (s *BloodhoundDB) CreateAuthSecret(ctx context.Context, authSecret model.AuthSecret) (model.AuthSecret, error) {
 	auditEntry := model.AuditEntry{
-		Action: "CreateAuthSecret",
+		Action: model.AuditLogActionCreateAuthSecret,
 		Model:  &authSecret,
 	}
 
@@ -567,7 +567,7 @@ func (s *BloodhoundDB) GetAuthSecret(id int32) (model.AuthSecret, error) {
 // WHERE user_id = ....
 func (s *BloodhoundDB) UpdateAuthSecret(ctx context.Context, authSecret model.AuthSecret) error {
 	auditEntry := model.AuditEntry{
-		Action: "UpdateAuthSecret",
+		Action: model.AuditLogActionUpdateAuthSecret,
 		Model:  &authSecret,
 	}
 
@@ -580,7 +580,7 @@ func (s *BloodhoundDB) UpdateAuthSecret(ctx context.Context, authSecret model.Au
 // DELETE FROM auth_secrets WHERE user_id = ...
 func (s *BloodhoundDB) DeleteAuthSecret(ctx context.Context, authSecret model.AuthSecret) error {
 	auditEntry := model.AuditEntry{
-		Action: "DeleteAuthSecret",
+		Action: model.AuditLogActionDeleteAuthSecret,
 		Model:  &authSecret,
 	}
 
@@ -594,7 +594,7 @@ func (s *BloodhoundDB) DeleteAuthSecret(ctx context.Context, authSecret model.Au
 func (s *BloodhoundDB) CreateSAMLIdentityProvider(ctx context.Context, samlProvider model.SAMLProvider) (model.SAMLProvider, error) {
 	var (
 		auditEntry = model.AuditEntry{
-			Action: "CreateSAMLIdentityProvider",
+			Action: model.AuditLogActionCreateSAMLIdentityProvider,
 			Model:  &samlProvider, // Pointer is required to ensure success log contains updated fields after transaction
 		}
 	)
@@ -611,7 +611,7 @@ func (s *BloodhoundDB) CreateSAMLIdentityProvider(ctx context.Context, samlProvi
 func (s *BloodhoundDB) UpdateSAMLIdentityProvider(ctx context.Context, provider model.SAMLProvider) error {
 	var (
 		auditEntry = model.AuditEntry{
-			Action: "UpdateSAMLIdentityProvider",
+			Action: model.AuditLogActionUpdateSAMLIdentityProvider,
 			Model:  &provider, // Pointer is required to ensure success log contains updated fields after transaction
 		}
 	)
@@ -657,7 +657,7 @@ func (s *BloodhoundDB) GetSAMLProvider(id int32) (model.SAMLProvider, error) {
 func (s *BloodhoundDB) DeleteSAMLProvider(ctx context.Context, provider model.SAMLProvider) error {
 	var (
 		auditEntry = model.AuditEntry{
-			Action: "DeleteSAMLIdentityProvider",
+			Action: model.AuditLogActionDeleteSAMLIdentityProvider,
 			Model:  &provider, // Pointer is required to ensure success log contains updated fields after transaction
 		}
 	)

--- a/cmd/api/src/database/auth_test.go
+++ b/cmd/api/src/database/auth_test.go
@@ -205,7 +205,7 @@ func TestDatabase_CreateGetDeleteUser(t *testing.T) {
 			t.Fatalf("Error creating user: %v", err)
 		} else if newUser, err := dbInst.LookupUser(user.PrincipalName); err != nil {
 			t.Fatalf("Failed looking up user by principal %s: %v", user.PrincipalName, err)
-		} else if err = test.VerifyAuditLogs(dbInst, "CreateUser", "principal_name", newUser.PrincipalName); err != nil {
+		} else if err = test.VerifyAuditLogs(dbInst, model.AuditLogActionCreateUser, "principal_name", newUser.PrincipalName); err != nil {
 			t.Fatalf("Failed to validate CreateUser audit logs:\n%v", err)
 		} else {
 			for _, role := range roles {
@@ -228,7 +228,7 @@ func TestDatabase_CreateGetDeleteUser(t *testing.T) {
 
 			if err := dbInst.UpdateUser(context.Background(), newUser); err != nil {
 				t.Fatalf("Failed to update user: %v", err)
-			} else if err = test.VerifyAuditLogs(dbInst, "UpdateUser", "principal_name", newUser.PrincipalName); err != nil {
+			} else if err = test.VerifyAuditLogs(dbInst, model.AuditLogActionUpdateUser, "principal_name", newUser.PrincipalName); err != nil {
 				t.Fatalf("Failed to validate UpdateUser audit logs:\n%v", err)
 			} else if updatedUser, err := dbInst.LookupUser(user.PrincipalName); err != nil {
 				t.Fatalf("Failed looking up user by principal %s: %v", user.PrincipalName, err)
@@ -240,7 +240,7 @@ func TestDatabase_CreateGetDeleteUser(t *testing.T) {
 
 	if err := dbInst.DeleteUser(context.Background(), createdUsers[1]); err != nil {
 		t.Fatalf("Failed to delete user: %v", err)
-	} else if err = test.VerifyAuditLogs(dbInst, "DeleteUser", "principal_name", users[1].PrincipalName); err != nil {
+	} else if err = test.VerifyAuditLogs(dbInst, model.AuditLogActionDeleteUser, "principal_name", users[1].PrincipalName); err != nil {
 		t.Fatalf("Failed to validate Deleteuser audit logs:\n%v", err)
 	}
 
@@ -268,7 +268,7 @@ func TestDatabase_CreateGetDeleteAuthToken(t *testing.T) {
 
 	if newToken, err := dbInst.CreateAuthToken(ctx, token); err != nil {
 		t.Fatalf("Failed to create auth token: %v", err)
-	} else if err = test.VerifyAuditLogs(dbInst, "CreateAuthToken", "id", newToken.ID.String()); err != nil {
+	} else if err = test.VerifyAuditLogs(dbInst, model.AuditLogActionCreateAuthToken, "id", newToken.ID.String()); err != nil {
 		t.Fatalf("Failed to validate CreateAuthToken audit logs:\n%v", err)
 	} else if updatedUser, err := dbInst.GetUser(user.ID); err != nil {
 		t.Fatalf("Failed to fetch updated user: %v", err)
@@ -280,7 +280,7 @@ func TestDatabase_CreateGetDeleteAuthToken(t *testing.T) {
 		t.Fatalf("Expected auth token to have name %s but saw %v", expectedName, newToken.Name.String)
 	} else if err = dbInst.DeleteAuthToken(ctx, newToken); err != nil {
 		t.Fatalf("Failed to delete auth token: %v", err)
-	} else if err = test.VerifyAuditLogs(dbInst, "DeleteAuthToken", "id", newToken.ID.String()); err != nil {
+	} else if err = test.VerifyAuditLogs(dbInst, model.AuditLogActionDeleteAuthToken, "id", newToken.ID.String()); err != nil {
 		t.Fatalf("Failed to validate DeleteAuthToken audit logs:\n%v", err)
 	}
 
@@ -307,7 +307,7 @@ func TestDatabase_CreateGetDeleteAuthSecret(t *testing.T) {
 
 	if newSecret, err := dbInst.CreateAuthSecret(ctx, secret); err != nil {
 		t.Fatalf("Failed to create auth secret: %v", err)
-	} else if err = test.VerifyAuditLogs(dbInst, "CreateAuthSecret", "secret_user_id", newSecret.UserID.String()); err != nil {
+	} else if err = test.VerifyAuditLogs(dbInst, model.AuditLogActionCreateAuthSecret, "secret_user_id", newSecret.UserID.String()); err != nil {
 		t.Fatalf("Failed to validate CreateAuthSecret audit logs:\n%v", err)
 	} else if updatedUser, err := dbInst.GetUser(user.ID); err != nil {
 		t.Fatalf("Failed to fetch updated user: %v", err)
@@ -318,7 +318,7 @@ func TestDatabase_CreateGetDeleteAuthSecret(t *testing.T) {
 
 		if err := dbInst.UpdateAuthSecret(ctx, newSecret); err != nil {
 			t.Fatalf("Failed to update auth secret %d: %v", newSecret.ID, err)
-		} else if err = test.VerifyAuditLogs(dbInst, "UpdateAuthSecret", "secret_user_id", newSecret.UserID.String()); err != nil {
+		} else if err = test.VerifyAuditLogs(dbInst, model.AuditLogActionUpdateAuthSecret, "secret_user_id", newSecret.UserID.String()); err != nil {
 			t.Fatalf("Failed to validate UpdateAuthSecret audit logs:\n%v", err)
 		} else if updatedSecret, err := dbInst.GetAuthSecret(newSecret.ID); err != nil {
 			t.Fatalf("Failed to fetch updated auth secret: %v", err)
@@ -328,7 +328,7 @@ func TestDatabase_CreateGetDeleteAuthSecret(t *testing.T) {
 
 		if err := dbInst.DeleteAuthSecret(ctx, newSecret); err != nil {
 			t.Fatalf("Failed to delete auth token: %v", err)
-		} else if err = test.VerifyAuditLogs(dbInst, "DeleteAuthSecret", "secret_user_id", newSecret.UserID.String()); err != nil {
+		} else if err = test.VerifyAuditLogs(dbInst, model.AuditLogActionDeleteAuthSecret, "secret_user_id", newSecret.UserID.String()); err != nil {
 			t.Fatalf("Failed to validate DeleteAuthSecret audit logs:\n%v", err)
 		}
 	}
@@ -357,7 +357,7 @@ func TestDatabase_CreateUpdateDeleteSAMLProvider(t *testing.T) {
 
 	if newSAMLProvider, err = dbInst.CreateSAMLIdentityProvider(context.Background(), samlProvider); err != nil {
 		t.Fatalf("Failed to create SAML provider: %v", err)
-	} else if err = test.VerifyAuditLogs(dbInst, "CreateSAMLIdentityProvider", "saml_name", newSAMLProvider.Name); err != nil {
+	} else if err = test.VerifyAuditLogs(dbInst, model.AuditLogActionCreateSAMLIdentityProvider, "saml_name", newSAMLProvider.Name); err != nil {
 		t.Fatalf("Failed to validate CreateSAMLIdentityProvider audit logs:\n%v", err)
 	} else {
 		user.SAMLProviderID = null.Int32From(newSAMLProvider.ID)
@@ -386,7 +386,7 @@ func TestDatabase_CreateUpdateDeleteSAMLProvider(t *testing.T) {
 	}
 	if err := dbInst.UpdateSAMLIdentityProvider(context.Background(), updatedSAMLProvider); err != nil {
 		t.Fatalf("Failed to update SAML provider: %v", err)
-	} else if err = test.VerifyAuditLogs(dbInst, "UpdateSAMLIdentityProvider", "saml_name", "updated provider"); err != nil {
+	} else if err = test.VerifyAuditLogs(dbInst, model.AuditLogActionUpdateSAMLIdentityProvider, "saml_name", "updated provider"); err != nil {
 		t.Fatalf("Failed to validate UpdateSAMLIdentityProvider audit logs:\n%v", err)
 	}
 
@@ -395,7 +395,7 @@ func TestDatabase_CreateUpdateDeleteSAMLProvider(t *testing.T) {
 		t.Fatalf("Failed to update user: %v", err)
 	} else if err := dbInst.DeleteSAMLProvider(context.Background(), newSAMLProvider); err != nil {
 		t.Fatalf("Failed to delete SAML provider: %v", err)
-	} else if err = test.VerifyAuditLogs(dbInst, "DeleteSAMLIdentityProvider", "saml_name", "provider"); err != nil {
+	} else if err = test.VerifyAuditLogs(dbInst, model.AuditLogActionDeleteSAMLIdentityProvider, "saml_name", "provider"); err != nil {
 		t.Fatalf("Failed to validate DeleteSAMLIdentityProvider audit logs:\n%v", err)
 	}
 }

--- a/cmd/api/src/database/mocks/db.go
+++ b/cmd/api/src/database/mocks/db.go
@@ -1094,9 +1094,9 @@ func (mr *MockDatabaseMockRecorder) InitializeSecretAuth(arg0, arg1 interface{})
 }
 
 // ListAuditLogs mocks base method.
-func (m *MockDatabase) ListAuditLogs(arg0, arg1 time.Time, arg2, arg3 int, arg4 string, arg5 model.SQLFilter) (model.AuditLogs, int, error) {
+func (m *MockDatabase) ListAuditLogs(arg0 context.Context, arg1, arg2 time.Time, arg3, arg4 int, arg5 string, arg6 model.SQLFilter) (model.AuditLogs, int, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListAuditLogs", arg0, arg1, arg2, arg3, arg4, arg5)
+	ret := m.ctrl.Call(m, "ListAuditLogs", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 	ret0, _ := ret[0].(model.AuditLogs)
 	ret1, _ := ret[1].(int)
 	ret2, _ := ret[2].(error)
@@ -1104,9 +1104,9 @@ func (m *MockDatabase) ListAuditLogs(arg0, arg1 time.Time, arg2, arg3 int, arg4 
 }
 
 // ListAuditLogs indicates an expected call of ListAuditLogs.
-func (mr *MockDatabaseMockRecorder) ListAuditLogs(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
+func (mr *MockDatabaseMockRecorder) ListAuditLogs(arg0, arg1, arg2, arg3, arg4, arg5, arg6 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAuditLogs", reflect.TypeOf((*MockDatabase)(nil).ListAuditLogs), arg0, arg1, arg2, arg3, arg4, arg5)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAuditLogs", reflect.TypeOf((*MockDatabase)(nil).ListAuditLogs), arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 }
 
 // ListSavedQueries mocks base method.

--- a/cmd/api/src/model/audit.go
+++ b/cmd/api/src/model/audit.go
@@ -25,12 +25,48 @@ import (
 	"github.com/specterops/bloodhound/src/database/types"
 )
 
-type AuditEntryStatus string
+type AuditLogEntryStatus string
 
 const (
-	AuditStatusSuccess AuditEntryStatus = "success"
-	AuditStatusFailure AuditEntryStatus = "failure"
-	AuditStatusIntent  AuditEntryStatus = "intent"
+	AuditLogStatusSuccess AuditLogEntryStatus = "success"
+	AuditLogStatusFailure AuditLogEntryStatus = "failure"
+	AuditLogStatusIntent  AuditLogEntryStatus = "intent"
+)
+
+type AuditLogAction string
+
+const (
+	AuditLogActionAcceptEULA = "AcceptEULA"
+
+	AuditLogActionLoginAttempt              = "LoginAttempt"
+	AuditLogActionUnauthorizedAccessAttempt = "UnauthorizedAccessAttempt"
+
+	AuditLogActionCreateUser = "CreateUser"
+	AuditLogActionUpdateUser = "UpdateUser"
+	AuditLogActionDeleteUser = "DeleteUser"
+
+	AuditLogActionCreateAssetGroup = "CreateAssetGroup"
+	AuditLogActionUpdateAssetGroup = "UpdateAssetGroup"
+	AuditLogActionDeleteAssetGroup = "DeleteAssetGroup"
+
+	AuditLogActionDeleteAssetGroupSelector = "DeleteAssetGroupSelector"
+
+	AuditLogActionCreateAuthToken = "CreateAuthToken"
+	AuditLogActionDeleteAuthToken = "DeleteAuthToken"
+
+	AuditLogActionCreateAuthSecret = "CreateAuthSecret"
+	AuditLogActionUpdateAuthSecret = "UpdateAuthSecret"
+	AuditLogActionDeleteAuthSecret = "DeleteAuthSecret"
+
+	AuditLogActionCreateSAMLIdentityProvider = "CreateSAMLIdentityProvider"
+	AuditLogActionUpdateSAMLIdentityProvider = "UpdateSAMLIdentityProvider"
+	AuditLogActionDeleteSAMLIdentityProvider = "DeleteSAMLIdentityProvider"
+
+	AuditLogActionAcceptRisk   = "AcceptRisk"
+	AuditLogActionUnacceptRisk = "UnacceptRisk"
+
+	AuditLogActionExportRelationshipRisks = "ExportRelationshipRisks"
+	AuditLogActionExportListRisks         = "ExportListRisks"
 )
 
 // TODO embed Basic into this struct instead of declaring the ID and CreatedAt fields. This will require a migration
@@ -40,7 +76,7 @@ type AuditLog struct {
 	ActorID         string                  `json:"actor_id" gorm:"index"`
 	ActorName       string                  `json:"actor_name"`
 	ActorEmail      string                  `json:"actor_email"`
-	Action          string                  `json:"action" gorm:"index"`
+	Action          AuditLogAction          `json:"action" gorm:"index"`
 	Fields          types.JSONUntypedObject `json:"fields"`
 	RequestID       string                  `json:"request_id"`
 	SourceIpAddress string                  `json:"source_ip_address"`
@@ -151,9 +187,9 @@ type Auditable interface {
 
 type AuditEntry struct {
 	CommitID uuid.UUID
-	Action   string
+	Action   AuditLogAction
 	Model    Auditable
-	Status   AuditEntryStatus
+	Status   AuditLogEntryStatus
 	ErrorMsg string
 }
 


### PR DESCRIPTION
## Description

Refactored audit log action from string to AuditLogAction type and added constants for all the hardcoded action strings.

## Motivation and Context

While working on ctx plumbing https://github.com/SpecterOps/BloodHound/pull/467, I noticed that we were hardcoding the audit log action strings in a multitude of places. It felt like a good time to abstract them out to a constant. The added benefit here is there's also 1 place we can look to see all of the audit logs types we have without _auditing_ the entire codebase.

## How Has This Been Tested?

Relied on integration tests

## Screenshots (if appropriate):

## Types of changes

-   [x] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
