### PR TITLE
fix: plumb ctx into ingest db methods 

### DIFF
--- a/cmd/api/src/api/v2/file_uploads.go
+++ b/cmd/api/src/api/v2/file_uploads.go
@@ -138,7 +138,7 @@ func (s Resources) ProcessFileUpload(response http.ResponseWriter, request *http
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, fmt.Sprintf("Error saving ingest file: %v", err), request), response)
 	} else if err != nil {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusInternalServerError, fmt.Sprintf("Error saving ingest file: %v", err), request), response)
-	} else if _, err = ingest.CreateIngestTask(s.DB, fileName, requestId, int64(fileUploadJobID)); err != nil {
+	} else if _, err = ingest.CreateIngestTask(request.Context(), s.DB, fileName, requestId, int64(fileUploadJobID)); err != nil {
 		api.HandleDatabaseError(request, response, err)
 	} else if err = fileupload.TouchFileUploadJobLastIngest(s.DB, fileUploadJob); err != nil {
 		api.HandleDatabaseError(request, response, err)

--- a/cmd/api/src/daemons/datapipe/datapipe.go
+++ b/cmd/api/src/daemons/datapipe/datapipe.go
@@ -133,8 +133,8 @@ func resetCache(cacher cache.Cache, cacheEnabled bool) {
 	}
 }
 
-func (s *Daemon) ingestAvailableTasks() {
-	if ingestTasks, err := s.db.GetAllIngestTasks(); err != nil {
+func (s *Daemon) ingestAvailableTasks(ctx context.Context) {
+	if ingestTasks, err := s.db.GetAllIngestTasks(ctx); err != nil {
 		log.Errorf("Failed fetching available ingest tasks: %v", err)
 	} else {
 		s.processIngestTasks(s.ctx, ingestTasks)
@@ -150,16 +150,16 @@ func (s *Daemon) Start() {
 	defer datapipeLoopTimer.Stop()
 	defer pruningTicker.Stop()
 
-	s.clearOrphanedData()
+	s.clearOrphanedData(s.ctx)
 
 	for {
 		select {
 		case <-pruningTicker.C:
-			s.clearOrphanedData()
+			s.clearOrphanedData(s.ctx)
 
 		case <-datapipeLoopTimer.C:
 			// Ingest all available ingest tasks
-			s.ingestAvailableTasks()
+			s.ingestAvailableTasks(s.ctx)
 
 			// Manage time-out state progression for file upload jobs
 			fileupload.ProcessStaleFileUploadJobs(s.ctx, s.db)
@@ -186,8 +186,8 @@ func (s *Daemon) Stop(ctx context.Context) error {
 	return nil
 }
 
-func (s *Daemon) clearOrphanedData() {
-	if ingestTasks, err := s.db.GetAllIngestTasks(); err != nil {
+func (s *Daemon) clearOrphanedData(ctx context.Context) {
+	if ingestTasks, err := s.db.GetAllIngestTasks(ctx); err != nil {
 		log.Errorf("Failed fetching available file upload ingest tasks: %v", err)
 	} else {
 		expectedFiles := make([]string, len(ingestTasks))

--- a/cmd/api/src/daemons/datapipe/jobs.go
+++ b/cmd/api/src/daemons/datapipe/jobs.go
@@ -113,8 +113,8 @@ func ProcessIngestedFileUploadJobs(ctx context.Context, db database.Database) {
 }
 
 // clearFileTask removes a generic file upload task for ingested data.
-func (s *Daemon) clearFileTask(ingestTask model.IngestTask) {
-	if err := s.db.DeleteIngestTask(ingestTask); err != nil {
+func (s *Daemon) clearFileTask(ctx context.Context, ingestTask model.IngestTask) {
+	if err := s.db.DeleteIngestTask(ctx, ingestTask); err != nil {
 		log.Errorf("Error removing file upload task from db: %v", err)
 	}
 }
@@ -160,6 +160,6 @@ func (s *Daemon) processIngestTasks(ctx context.Context, ingestTasks model.Inges
 			log.Errorf("Failed processing ingest task %d with file %s: %v", ingestTask.ID, ingestTask.FileName, err)
 		}
 
-		s.clearFileTask(ingestTask)
+		s.clearFileTask(ctx, ingestTask)
 	}
 }

--- a/cmd/api/src/daemons/datapipe/jobs.go
+++ b/cmd/api/src/daemons/datapipe/jobs.go
@@ -101,7 +101,7 @@ func ProcessIngestedFileUploadJobs(ctx context.Context, db database.Database) {
 		log.Errorf("Failed to look up finished file upload jobs: %v", err)
 	} else {
 		for _, ingestingFileUploadJob := range ingestingFileUploadJobs {
-			if remainingIngestTasks, err := db.GetIngestTasksForJob(ingestingFileUploadJob.ID); err != nil {
+			if remainingIngestTasks, err := db.GetIngestTasksForJob(ctx, ingestingFileUploadJob.ID); err != nil {
 				log.Errorf("Failed looking up remaining ingest tasks for file upload job %d: %v", ingestingFileUploadJob.ID, err)
 			} else if len(remainingIngestTasks) == 0 {
 				if err := fileupload.UpdateFileUploadJobStatus(db, ingestingFileUploadJob, model.JobStatusAnalyzing, "Analyzing"); err != nil {

--- a/cmd/api/src/daemons/datapipe/jobs.go
+++ b/cmd/api/src/daemons/datapipe/jobs.go
@@ -113,8 +113,8 @@ func ProcessIngestedFileUploadJobs(ctx context.Context, db database.Database) {
 }
 
 // clearFileTask removes a generic file upload task for ingested data.
-func (s *Daemon) clearFileTask(ctx context.Context, ingestTask model.IngestTask) {
-	if err := s.db.DeleteIngestTask(ctx, ingestTask); err != nil {
+func (s *Daemon) clearFileTask(ingestTask model.IngestTask) {
+	if err := s.db.DeleteIngestTask(s.ctx, ingestTask); err != nil {
 		log.Errorf("Error removing file upload task from db: %v", err)
 	}
 }
@@ -160,6 +160,6 @@ func (s *Daemon) processIngestTasks(ctx context.Context, ingestTasks model.Inges
 			log.Errorf("Failed processing ingest task %d with file %s: %v", ingestTask.ID, ingestTask.FileName, err)
 		}
 
-		s.clearFileTask(ctx, ingestTask)
+		s.clearFileTask(ingestTask)
 	}
 }

--- a/cmd/api/src/daemons/datapipe/jobs_test.go
+++ b/cmd/api/src/daemons/datapipe/jobs_test.go
@@ -125,7 +125,7 @@ func TestProcessIngestedFileUploadJobs(t *testing.T) {
 			Status: model.JobStatusIngesting,
 		}}, nil)
 
-		dbMock.EXPECT().GetIngestTasksForJob(jobID).Return([]model.IngestTask{}, nil)
+		dbMock.EXPECT().GetIngestTasksForJob(gomock.Any(), jobID).Return([]model.IngestTask{}, nil)
 		dbMock.EXPECT().UpdateFileUploadJob(gomock.Any()).DoAndReturn(func(fileUploadJob model.FileUploadJob) error {
 			require.Equal(t, model.JobStatusAnalyzing, fileUploadJob.Status)
 			return nil
@@ -142,7 +142,7 @@ func TestProcessIngestedFileUploadJobs(t *testing.T) {
 			Status: model.JobStatusIngesting,
 		}}, nil)
 
-		dbMock.EXPECT().GetIngestTasksForJob(jobID).Return([]model.IngestTask{{}}, nil)
+		dbMock.EXPECT().GetIngestTasksForJob(gomock.Any(), jobID).Return([]model.IngestTask{{}}, nil)
 
 		datapipe.ProcessIngestedFileUploadJobs(context.Background(), dbMock)
 	})

--- a/cmd/api/src/database/db.go
+++ b/cmd/api/src/database/db.go
@@ -60,7 +60,6 @@ type Database interface {
 	GetAllIngestTasks(ctx context.Context) (model.IngestTasks, error)
 	DeleteIngestTask(ctx context.Context, ingestTask model.IngestTask) error
 	GetIngestTasksForJob(ctx context.Context, jobID int64) (model.IngestTasks, error)
-	GetUnfinishedIngestIDs() ([]int64, error)
 
 	// Asset Groups
 	agi.AgiData

--- a/cmd/api/src/database/db.go
+++ b/cmd/api/src/database/db.go
@@ -58,7 +58,7 @@ type Database interface {
 	// Ingest
 	ingest.IngestData
 	GetAllIngestTasks(ctx context.Context) (model.IngestTasks, error)
-	DeleteIngestTask(ingestTask model.IngestTask) error
+	DeleteIngestTask(ctx context.Context, ingestTask model.IngestTask) error
 	GetIngestTasksForJob(jobID int64) (model.IngestTasks, error)
 	GetUnfinishedIngestIDs() ([]int64, error)
 

--- a/cmd/api/src/database/db.go
+++ b/cmd/api/src/database/db.go
@@ -57,7 +57,7 @@ type Database interface {
 
 	// Ingest
 	ingest.IngestData
-	GetAllIngestTasks() (model.IngestTasks, error)
+	GetAllIngestTasks(ctx context.Context) (model.IngestTasks, error)
 	DeleteIngestTask(ingestTask model.IngestTask) error
 	GetIngestTasksForJob(jobID int64) (model.IngestTasks, error)
 	GetUnfinishedIngestIDs() ([]int64, error)

--- a/cmd/api/src/database/db.go
+++ b/cmd/api/src/database/db.go
@@ -59,7 +59,7 @@ type Database interface {
 	ingest.IngestData
 	GetAllIngestTasks(ctx context.Context) (model.IngestTasks, error)
 	DeleteIngestTask(ctx context.Context, ingestTask model.IngestTask) error
-	GetIngestTasksForJob(jobID int64) (model.IngestTasks, error)
+	GetIngestTasksForJob(ctx context.Context, jobID int64) (model.IngestTasks, error)
 	GetUnfinishedIngestIDs() ([]int64, error)
 
 	// Asset Groups

--- a/cmd/api/src/database/db.go
+++ b/cmd/api/src/database/db.go
@@ -21,6 +21,8 @@ package database
 import (
 	"context"
 	"fmt"
+	"github.com/specterops/bloodhound/src/services/agi"
+	"github.com/specterops/bloodhound/src/services/ingest"
 	"time"
 
 	"github.com/gofrs/uuid"
@@ -52,18 +54,19 @@ type Database interface {
 	appcfg.FeatureFlagService
 
 	Close()
-	CreateIngestTask(ingestTask model.IngestTask) (model.IngestTask, error)
+
+	// Ingest
+	ingest.IngestData
 	GetAllIngestTasks() (model.IngestTasks, error)
 	DeleteIngestTask(ingestTask model.IngestTask) error
 	GetIngestTasksForJob(jobID int64) (model.IngestTasks, error)
 	GetUnfinishedIngestIDs() ([]int64, error)
 
 	// Asset Groups
+	agi.AgiData
 	CreateAssetGroup(ctx context.Context, name, tag string, systemGroup bool) (model.AssetGroup, error)
 	UpdateAssetGroup(ctx context.Context, assetGroup model.AssetGroup) error
 	DeleteAssetGroup(ctx context.Context, assetGroup model.AssetGroup) error
-	GetAssetGroup(ctx context.Context, id int32) (model.AssetGroup, error)
-	GetAllAssetGroups(ctx context.Context, order string, filter model.SQLFilter) (model.AssetGroups, error)
 	SweepAssetGroupCollections()
 	GetAssetGroupCollections(ctx context.Context, assetGroupID int32, order string, filter model.SQLFilter) (model.AssetGroupCollections, error)
 	GetLatestAssetGroupCollection(ctx context.Context, assetGroupID int32) (model.AssetGroupCollection, error)
@@ -71,7 +74,6 @@ type Database interface {
 	GetAssetGroupSelector(ctx context.Context, id int32) (model.AssetGroupSelector, error)
 	DeleteAssetGroupSelector(ctx context.Context, selector model.AssetGroupSelector) error
 	UpdateAssetGroupSelectors(ctx context.Context, assetGroup model.AssetGroup, selectorSpecs []model.AssetGroupSelectorSpec, systemSelector bool) (model.UpdatedAssetGroupSelectors, error)
-	CreateAssetGroupCollection(ctx context.Context, collection model.AssetGroupCollection, entries model.AssetGroupCollectionEntries) error
 
 	Wipe() error
 	Migrate() error

--- a/cmd/api/src/database/ingest.go
+++ b/cmd/api/src/database/ingest.go
@@ -27,9 +27,9 @@ func (s *BloodhoundDB) CreateIngestTask(ctx context.Context, ingestTask model.In
 	return ingestTask, CheckError(result)
 }
 
-func (s *BloodhoundDB) GetAllIngestTasks() (model.IngestTasks, error) {
+func (s *BloodhoundDB) GetAllIngestTasks(ctx context.Context) (model.IngestTasks, error) {
 	var ingestTasks model.IngestTasks
-	result := s.db.Find(&ingestTasks)
+	result := s.db.WithContext(ctx).Find(&ingestTasks)
 
 	return ingestTasks, CheckError(result)
 }

--- a/cmd/api/src/database/ingest.go
+++ b/cmd/api/src/database/ingest.go
@@ -39,9 +39,9 @@ func (s *BloodhoundDB) DeleteIngestTask(ctx context.Context, ingestTask model.In
 	return CheckError(result)
 }
 
-func (s *BloodhoundDB) GetIngestTasksForJob(jobID int64) (model.IngestTasks, error) {
+func (s *BloodhoundDB) GetIngestTasksForJob(ctx context.Context, jobID int64) (model.IngestTasks, error) {
 	var ingestTasks model.IngestTasks
-	result := s.db.Where("task_id=?", jobID).Find(&ingestTasks)
+	result := s.db.WithContext(ctx).Where("task_id=?", jobID).Find(&ingestTasks)
 
 	return ingestTasks, CheckError(result)
 }

--- a/cmd/api/src/database/ingest.go
+++ b/cmd/api/src/database/ingest.go
@@ -34,8 +34,8 @@ func (s *BloodhoundDB) GetAllIngestTasks(ctx context.Context) (model.IngestTasks
 	return ingestTasks, CheckError(result)
 }
 
-func (s *BloodhoundDB) DeleteIngestTask(ingestTask model.IngestTask) error {
-	result := s.db.Delete(&ingestTask)
+func (s *BloodhoundDB) DeleteIngestTask(ctx context.Context, ingestTask model.IngestTask) error {
+	result := s.db.WithContext(ctx).Delete(&ingestTask)
 	return CheckError(result)
 }
 

--- a/cmd/api/src/database/ingest.go
+++ b/cmd/api/src/database/ingest.go
@@ -1,25 +1,28 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 package database
 
-import "github.com/specterops/bloodhound/src/model"
+import (
+	"context"
+	"github.com/specterops/bloodhound/src/model"
+)
 
-func (s *BloodhoundDB) CreateIngestTask(ingestTask model.IngestTask) (model.IngestTask, error) {
-	result := s.db.Create(&ingestTask)
+func (s *BloodhoundDB) CreateIngestTask(ctx context.Context, ingestTask model.IngestTask) (model.IngestTask, error) {
+	result := s.db.WithContext(ctx).Create(&ingestTask)
 
 	return ingestTask, CheckError(result)
 }

--- a/cmd/api/src/database/ingest.go
+++ b/cmd/api/src/database/ingest.go
@@ -45,10 +45,3 @@ func (s *BloodhoundDB) GetIngestTasksForJob(ctx context.Context, jobID int64) (m
 
 	return ingestTasks, CheckError(result)
 }
-
-func (s *BloodhoundDB) GetUnfinishedIngestIDs() ([]int64, error) {
-	var ids []int64
-	result := s.db.Model(&model.IngestTask{}).Distinct("task_id").Pluck("task_id", &ids)
-
-	return ids, CheckError(result)
-}

--- a/cmd/api/src/database/mocks/db.go
+++ b/cmd/api/src/database/mocks/db.go
@@ -880,18 +880,18 @@ func (mr *MockDatabaseMockRecorder) GetFlagByKey(arg0 interface{}) *gomock.Call 
 }
 
 // GetIngestTasksForJob mocks base method.
-func (m *MockDatabase) GetIngestTasksForJob(arg0 int64) (model.IngestTasks, error) {
+func (m *MockDatabase) GetIngestTasksForJob(arg0 context.Context, arg1 int64) (model.IngestTasks, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetIngestTasksForJob", arg0)
+	ret := m.ctrl.Call(m, "GetIngestTasksForJob", arg0, arg1)
 	ret0, _ := ret[0].(model.IngestTasks)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetIngestTasksForJob indicates an expected call of GetIngestTasksForJob.
-func (mr *MockDatabaseMockRecorder) GetIngestTasksForJob(arg0 interface{}) *gomock.Call {
+func (mr *MockDatabaseMockRecorder) GetIngestTasksForJob(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIngestTasksForJob", reflect.TypeOf((*MockDatabase)(nil).GetIngestTasksForJob), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIngestTasksForJob", reflect.TypeOf((*MockDatabase)(nil).GetIngestTasksForJob), arg0, arg1)
 }
 
 // GetInstallation mocks base method.

--- a/cmd/api/src/database/mocks/db.go
+++ b/cmd/api/src/database/mocks/db.go
@@ -229,18 +229,18 @@ func (mr *MockDatabaseMockRecorder) CreateFileUploadJob(arg0 interface{}) *gomoc
 }
 
 // CreateIngestTask mocks base method.
-func (m *MockDatabase) CreateIngestTask(arg0 model.IngestTask) (model.IngestTask, error) {
+func (m *MockDatabase) CreateIngestTask(arg0 context.Context, arg1 model.IngestTask) (model.IngestTask, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateIngestTask", arg0)
+	ret := m.ctrl.Call(m, "CreateIngestTask", arg0, arg1)
 	ret0, _ := ret[0].(model.IngestTask)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateIngestTask indicates an expected call of CreateIngestTask.
-func (mr *MockDatabaseMockRecorder) CreateIngestTask(arg0 interface{}) *gomock.Call {
+func (mr *MockDatabaseMockRecorder) CreateIngestTask(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateIngestTask", reflect.TypeOf((*MockDatabase)(nil).CreateIngestTask), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateIngestTask", reflect.TypeOf((*MockDatabase)(nil).CreateIngestTask), arg0, arg1)
 }
 
 // CreateInstallation mocks base method.
@@ -623,18 +623,18 @@ func (mr *MockDatabaseMockRecorder) GetAllFlags() *gomock.Call {
 }
 
 // GetAllIngestTasks mocks base method.
-func (m *MockDatabase) GetAllIngestTasks() (model.IngestTasks, error) {
+func (m *MockDatabase) GetAllIngestTasks(arg0 context.Context) (model.IngestTasks, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAllIngestTasks")
+	ret := m.ctrl.Call(m, "GetAllIngestTasks", arg0)
 	ret0, _ := ret[0].(model.IngestTasks)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetAllIngestTasks indicates an expected call of GetAllIngestTasks.
-func (mr *MockDatabaseMockRecorder) GetAllIngestTasks() *gomock.Call {
+func (mr *MockDatabaseMockRecorder) GetAllIngestTasks(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllIngestTasks", reflect.TypeOf((*MockDatabase)(nil).GetAllIngestTasks))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllIngestTasks", reflect.TypeOf((*MockDatabase)(nil).GetAllIngestTasks), arg0)
 }
 
 // GetAllPermissions mocks base method.

--- a/cmd/api/src/database/mocks/db.go
+++ b/cmd/api/src/database/mocks/db.go
@@ -447,17 +447,17 @@ func (mr *MockDatabaseMockRecorder) DeleteAuthToken(arg0, arg1 interface{}) *gom
 }
 
 // DeleteIngestTask mocks base method.
-func (m *MockDatabase) DeleteIngestTask(arg0 model.IngestTask) error {
+func (m *MockDatabase) DeleteIngestTask(arg0 context.Context, arg1 model.IngestTask) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteIngestTask", arg0)
+	ret := m.ctrl.Call(m, "DeleteIngestTask", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteIngestTask indicates an expected call of DeleteIngestTask.
-func (mr *MockDatabaseMockRecorder) DeleteIngestTask(arg0 interface{}) *gomock.Call {
+func (mr *MockDatabaseMockRecorder) DeleteIngestTask(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteIngestTask", reflect.TypeOf((*MockDatabase)(nil).DeleteIngestTask), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteIngestTask", reflect.TypeOf((*MockDatabase)(nil).DeleteIngestTask), arg0, arg1)
 }
 
 // DeleteSAMLProvider mocks base method.

--- a/cmd/api/src/database/mocks/db.go
+++ b/cmd/api/src/database/mocks/db.go
@@ -1029,21 +1029,6 @@ func (mr *MockDatabaseMockRecorder) GetTimeRangedAssetGroupCollections(arg0, arg
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTimeRangedAssetGroupCollections", reflect.TypeOf((*MockDatabase)(nil).GetTimeRangedAssetGroupCollections), arg0, arg1, arg2, arg3, arg4)
 }
 
-// GetUnfinishedIngestIDs mocks base method.
-func (m *MockDatabase) GetUnfinishedIngestIDs() ([]int64, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetUnfinishedIngestIDs")
-	ret0, _ := ret[0].([]int64)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetUnfinishedIngestIDs indicates an expected call of GetUnfinishedIngestIDs.
-func (mr *MockDatabaseMockRecorder) GetUnfinishedIngestIDs() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUnfinishedIngestIDs", reflect.TypeOf((*MockDatabase)(nil).GetUnfinishedIngestIDs))
-}
-
 // GetUser mocks base method.
 func (m *MockDatabase) GetUser(arg0 uuid.UUID) (model.User, error) {
 	m.ctrl.T.Helper()

--- a/cmd/api/src/services/ingest/ingest.go
+++ b/cmd/api/src/services/ingest/ingest.go
@@ -1,36 +1,37 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 package ingest
 
 import (
+	"context"
 	"github.com/specterops/bloodhound/src/database/types/null"
 	"github.com/specterops/bloodhound/src/model"
 )
 
 type IngestData interface {
-	CreateIngestTask(task model.IngestTask) (model.IngestTask, error)
+	CreateIngestTask(ctx context.Context, task model.IngestTask) (model.IngestTask, error)
 }
 
-func CreateIngestTask(db IngestData, filename string, requestID string, jobID int64) (model.IngestTask, error) {
+func CreateIngestTask(ctx context.Context, db IngestData, filename string, requestID string, jobID int64) (model.IngestTask, error) {
 	newIngestTask := model.IngestTask{
 		FileName:    filename,
 		RequestGUID: requestID,
 		TaskID:      null.Int64From(jobID),
 	}
 
-	return db.CreateIngestTask(newIngestTask)
+	return db.CreateIngestTask(ctx, newIngestTask)
 }


### PR DESCRIPTION
## Description

Plumb context into gorm ingest db methods
https://gorm.io/docs/context.html#Context-Timeout

I also noticed that `GetUnfinishedIngestIDs` was an unused db methods related to the ingest so I removed it to keep things nice and clean.

## Motivation and Context

Currently as it stands any endpoints that rely on purely gorm do not respect `request.Context` and as such timeouts are not respected either. While we want to eventually get to the removal of the gorm dependency altogether, that is a long way and a lot of effort away and this I think this approach would give us that much room to maneuver while we get there.

## How Has This Been Tested?

Using a rest client and the prefer header
Add a sleep inside of the handler
Look for the `500 request timed out` after exceeding the timeout. (Note: the request will take as long as the sleep is set, it's not tied to the prefer header)

## Types of changes

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [x] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
