### PR TITLE
fix: plumb ctx into user db methods

### DIFF
--- a/cmd/api/src/api/auth.go
+++ b/cmd/api/src/api/auth.go
@@ -111,7 +111,7 @@ func (s authenticator) auditLogin(requestContext context.Context, commitID uuid.
 }
 
 func (s authenticator) validateSecretLogin(ctx context.Context, loginRequest LoginRequest) (model.User, string, error) {
-	if user, err := s.db.LookupUser(loginRequest.Username); err != nil {
+	if user, err := s.db.LookupUser(ctx, loginRequest.Username); err != nil {
 		if errors.Is(err, database.ErrNotFound) {
 			return model.User{}, "", ErrInvalidAuth
 		}

--- a/cmd/api/src/api/saml/saml_internal_test.go
+++ b/cmd/api/src/api/saml/saml_internal_test.go
@@ -114,7 +114,7 @@ func TestProviderResource_createSessionFromAssertion(t *testing.T) {
 	httpRequest, _ := http.NewRequestWithContext(context.WithValue(context.TODO(), ctx.ValueKey, &ctx.Context{Host: &resource.cfg.RootURL.URL}), http.MethodPost, "http://localhost", nil)
 
 	// Test happy path
-	mockDB.EXPECT().LookupUser(goodUsername).Return(goodUser, nil)
+	mockDB.EXPECT().LookupUser(gomock.Any(), goodUsername).Return(goodUser, nil)
 	mockAuthenticator.EXPECT().CreateSession(goodUser, gomock.Any()).Return(goodJWT, nil)
 
 	resource.createSessionFromAssertion(httpRequest, response, expires, testAssertion)
@@ -126,7 +126,7 @@ func TestProviderResource_createSessionFromAssertion(t *testing.T) {
 	// Change the assertion statement attribute to the bad username to assert we get a 403
 	testAssertion.AttributeStatements[0].Attributes[0].Values[0].Value = badUsername
 
-	mockDB.EXPECT().LookupUser(badUsername).Return(model.User{}, database.ErrNotFound)
+	mockDB.EXPECT().LookupUser(gomock.Any(), badUsername).Return(model.User{}, database.ErrNotFound)
 
 	response = httptest.NewRecorder()
 
@@ -134,7 +134,7 @@ func TestProviderResource_createSessionFromAssertion(t *testing.T) {
 	require.Equal(t, http.StatusForbidden, response.Code)
 
 	// Change the db return to a user that isn't associated with a SAML Provider
-	mockDB.EXPECT().LookupUser(badUsername).Return(model.User{}, nil)
+	mockDB.EXPECT().LookupUser(gomock.Any(), badUsername).Return(model.User{}, nil)
 
 	response = httptest.NewRecorder()
 
@@ -142,7 +142,7 @@ func TestProviderResource_createSessionFromAssertion(t *testing.T) {
 	require.Equal(t, http.StatusForbidden, response.Code)
 
 	// Change the db return to a user that isn't associated with this SAML Provider
-	mockDB.EXPECT().LookupUser(badUsername).Return(model.User{
+	mockDB.EXPECT().LookupUser(gomock.Any(), badUsername).Return(model.User{
 		SAMLProviderID: null.Int32From(2),
 		SAMLProvider: &model.SAMLProvider{
 			Serial: model.Serial{

--- a/cmd/api/src/api/v2/auth/auth.go
+++ b/cmd/api/src/api/v2/auth/auth.go
@@ -514,7 +514,7 @@ func (s ManagementResource) UpdateUser(response http.ResponseWriter, request *ht
 
 	if userID, err := uuid.FromString(rawUserID); err != nil {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, api.ErrorResponseDetailsIDMalformed, request), response)
-	} else if user, err := s.db.GetUser(userID); err != nil {
+	} else if user, err := s.db.GetUser(request.Context(), userID); err != nil {
 		api.HandleDatabaseError(request, response, err)
 	} else if err := api.ReadJSONRequestPayloadLimited(&updateUserRequest, request); err != nil {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, err.Error(), request), response)
@@ -578,7 +578,7 @@ func (s ManagementResource) GetUser(response http.ResponseWriter, request *http.
 
 	if userID, err := uuid.FromString(rawUserID); err != nil {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, api.ErrorResponseDetailsIDMalformed, request), response)
-	} else if user, err := s.db.GetUser(userID); err != nil {
+	} else if user, err := s.db.GetUser(request.Context(), userID); err != nil {
 		api.HandleDatabaseError(request, response, err)
 	} else {
 		api.WriteBasicResponse(request.Context(), user, http.StatusOK, response)
@@ -599,7 +599,7 @@ func (s ManagementResource) DeleteUser(response http.ResponseWriter, request *ht
 
 	if userID, err := uuid.FromString(rawUserID); err != nil {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, api.ErrorResponseDetailsIDMalformed, request), response)
-	} else if user, err = s.db.GetUser(userID); err != nil {
+	} else if user, err = s.db.GetUser(request.Context(), userID); err != nil {
 		api.HandleDatabaseError(request, response, err)
 	} else if err := s.db.DeleteUser(request.Context(), user); err != nil {
 		api.HandleDatabaseError(request, response, err)
@@ -643,7 +643,7 @@ func (s ManagementResource) PutUserAuthSecret(response http.ResponseWriter, requ
 	} else if errs := validation.Validate(setUserSecretRequest); errs != nil {
 		msg := strings.Join(utils.Errors(errs).AsStringSlice(), ", ")
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, msg, request), response)
-	} else if targetUser, err := s.db.GetUser(userID); err != nil {
+	} else if targetUser, err := s.db.GetUser(request.Context(), userID); err != nil {
 		api.HandleDatabaseError(request, response, err)
 	} else if targetUser.SAMLProviderID.Valid {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, "Invalid operation, user is SSO", request), response)
@@ -678,7 +678,7 @@ func (s ManagementResource) ExpireUserAuthSecret(response http.ResponseWriter, r
 
 	if userID, err := uuid.FromString(rawUserID); err != nil {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, api.ErrorResponseDetailsIDMalformed, request), response)
-	} else if targetUser, err := s.db.GetUser(userID); err != nil {
+	} else if targetUser, err := s.db.GetUser(request.Context(), userID); err != nil {
 		api.HandleDatabaseError(request, response, err)
 	} else if targetUser.SAMLProviderID.Valid {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusConflict, "user has SAML auth enabled", request), response)
@@ -783,7 +783,7 @@ func (s ManagementResource) CreateAuthToken(response http.ResponseWriter, reques
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusInternalServerError, api.ErrorResponseDetailsInternalServerError, request), response)
 	} else if err := api.ReadJSONRequestPayloadLimited(&createUserTokenRequest, request); err != nil {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, api.ErrorResponsePayloadUnmarshalError, request), response)
-	} else if user, err := s.db.GetUser(user.ID); err != nil {
+	} else if user, err := s.db.GetUser(request.Context(), user.ID); err != nil {
 		api.HandleDatabaseError(request, response, err)
 	} else if err := verifyUserID(&createUserTokenRequest, user, bhCtx, s.authorizer); err != nil {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusForbidden, err.Error(), request), response)
@@ -871,7 +871,7 @@ func (s ManagementResource) EnrollMFA(response http.ResponseWriter, request *htt
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, api.ErrorResponseDetailsIDMalformed, request), response)
 	} else if err := api.ReadJSONRequestPayloadLimited(&payload, request); err != nil {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, api.ErrorContentTypeJson.Error(), request), response)
-	} else if user, err := s.db.GetUser(userId); err != nil {
+	} else if user, err := s.db.GetUser(request.Context(), userId); err != nil {
 		api.HandleDatabaseError(request, response, err)
 	} else if user.SAMLProviderID.Valid {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, "Invalid operation, user is SSO", request), response)
@@ -911,7 +911,7 @@ func (s ManagementResource) DisenrollMFA(response http.ResponseWriter, request *
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, api.ErrorResponseDetailsIDMalformed, request), response)
 	} else if err := api.ReadJSONRequestPayloadLimited(&payload, request); err != nil {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, api.ErrorContentTypeJson.Error(), request), response)
-	} else if user, err := s.db.GetUser(userId); err != nil {
+	} else if user, err := s.db.GetUser(request.Context(), userId); err != nil {
 		api.HandleDatabaseError(request, response, err)
 	} else {
 		// Default the password to check against to the user from the path param
@@ -957,7 +957,7 @@ func (s ManagementResource) GetMFAActivationStatus(response http.ResponseWriter,
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, v2.ErrorParseParams, request), response)
 	} else if userId, err := uuid.FromString(rawUserId); err != nil {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, api.ErrorResponseDetailsIDMalformed, request), response)
-	} else if user, err := s.db.GetUser(userId); err != nil {
+	} else if user, err := s.db.GetUser(request.Context(), userId); err != nil {
 		api.HandleDatabaseError(request, response, err)
 	} else {
 		responseBody := MFAStatusResponse{}
@@ -983,7 +983,7 @@ func (s ManagementResource) ActivateMFA(response http.ResponseWriter, request *h
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, api.ErrorResponseDetailsIDMalformed, request), response)
 	} else if err := api.ReadJSONRequestPayloadLimited(&payload, request); err != nil {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, api.ErrorContentTypeJson.Error(), request), response)
-	} else if user, err := s.db.GetUser(userId); err != nil {
+	} else if user, err := s.db.GetUser(request.Context(), userId); err != nil {
 		api.HandleDatabaseError(request, response, err)
 	} else if user.AuthSecret.TOTPSecret == "" {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, ErrorResponseDetailsMFAEnrollmentRequired, request), response)

--- a/cmd/api/src/api/v2/auth/auth.go
+++ b/cmd/api/src/api/v2/auth/auth.go
@@ -410,7 +410,7 @@ func (s ManagementResource) ListUsers(response http.ResponseWriter, request *htt
 		if sqlFilter, err := queryFilters.BuildSQLFilter(); err != nil {
 			api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, "error building SQL for filter", request), response)
 			return
-		} else if users, err = s.db.GetAllUsers(strings.Join(order, ", "), sqlFilter); err != nil {
+		} else if users, err = s.db.GetAllUsers(request.Context(), strings.Join(order, ", "), sqlFilter); err != nil {
 			api.HandleDatabaseError(request, response, err)
 		} else {
 			api.WriteBasicResponse(request.Context(), v2.ListUsersResponse{Users: users}, http.StatusOK, response)

--- a/cmd/api/src/api/v2/auth/auth_test.go
+++ b/cmd/api/src/api/v2/auth/auth_test.go
@@ -911,7 +911,7 @@ func TestManagementResource_ListUsers_DBError(t *testing.T) {
 
 	endpoint := "/api/v2/auth/users"
 	mockDB := dbmocks.NewMockDatabase(mockCtrl)
-	mockDB.EXPECT().GetAllUsers("first_name desc, last_name", model.SQLFilter{}).Return(model.Users{}, fmt.Errorf("foo"))
+	mockDB.EXPECT().GetAllUsers(gomock.Any(), "first_name desc, last_name", model.SQLFilter{}).Return(model.Users{}, fmt.Errorf("foo"))
 
 	config, err := config.NewDefaultConfiguration()
 	require.Nilf(t, err, "Failed to create default configuration: %v", err)
@@ -960,7 +960,7 @@ func TestManagementResource_ListUsers(t *testing.T) {
 	}
 
 	resources, mockDB := apitest.NewAuthManagementResource(mockCtrl)
-	mockDB.EXPECT().GetAllUsers("first_name desc, last_name", model.SQLFilter{}).Return(model.Users{user1, user2}, nil)
+	mockDB.EXPECT().GetAllUsers(gomock.Any(), "first_name desc, last_name", model.SQLFilter{}).Return(model.Users{user1, user2}, nil)
 
 	ctx := context.WithValue(context.Background(), ctx.ValueKey, &ctx.Context{})
 	if req, err := http.NewRequestWithContext(ctx, "GET", endpoint, nil); err != nil {
@@ -1005,7 +1005,7 @@ func TestManagementResource_ListUsers_Filtered(t *testing.T) {
 	}
 
 	resources, mockDB := apitest.NewAuthManagementResource(mockCtrl)
-	mockDB.EXPECT().GetAllUsers("", model.SQLFilter{SQLString: "first_name = ?", Params: []any{"a"}}).Return(model.Users{user1}, nil)
+	mockDB.EXPECT().GetAllUsers(gomock.Any(), "", model.SQLFilter{SQLString: "first_name = ?", Params: []any{"a"}}).Return(model.Users{user1}, nil)
 
 	ctx := context.WithValue(context.Background(), ctx.ValueKey, &ctx.Context{})
 	if req, err := http.NewRequestWithContext(ctx, "GET", endpoint, nil); err != nil {

--- a/cmd/api/src/api/v2/auth/auth_test.go
+++ b/cmd/api/src/api/v2/auth/auth_test.go
@@ -73,8 +73,8 @@ func TestManagementResource_PutUserAuthSecret(t *testing.T) {
 
 	defer mockCtrl.Finish()
 
-	mockDB.EXPECT().GetUser(badUserID).Return(model.User{SAMLProviderID: null.Int32From(1)}, nil)
-	mockDB.EXPECT().GetUser(goodUserID).Return(model.User{}, nil)
+	mockDB.EXPECT().GetUser(gomock.Any(), badUserID).Return(model.User{SAMLProviderID: null.Int32From(1)}, nil)
+	mockDB.EXPECT().GetUser(gomock.Any(), goodUserID).Return(model.User{}, nil)
 	mockDB.EXPECT().GetConfigurationParameter(gomock.Any(), appcfg.PasswordExpirationWindow).Return(appcfg.Parameter{
 		Key: appcfg.PasswordExpirationWindow,
 		Value: must.NewJSONBObject(appcfg.PasswordExpiration{
@@ -137,8 +137,8 @@ func TestManagementResource_EnableUserSAML(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	mockDB.EXPECT().GetRoles(gomock.Eq(goodRoles)).Return(model.Roles{}, nil).AnyTimes()
-	mockDB.EXPECT().GetUser(badUserID).Return(model.User{AuthSecret: &model.AuthSecret{}}, nil)
-	mockDB.EXPECT().GetUser(goodUserID).Return(model.User{}, nil)
+	mockDB.EXPECT().GetUser(gomock.Any(), badUserID).Return(model.User{AuthSecret: &model.AuthSecret{}}, nil)
+	mockDB.EXPECT().GetUser(gomock.Any(), goodUserID).Return(model.User{}, nil)
 	mockDB.EXPECT().GetSAMLProvider(samlProviderID).Return(model.SAMLProvider{}, nil).Times(2)
 	mockDB.EXPECT().UpdateUser(gomock.Any(), gomock.Any()).Return(nil).Times(2)
 	mockDB.EXPECT().DeleteAuthSecret(gomock.Any(), gomock.Any()).Return(nil)
@@ -691,7 +691,7 @@ func TestExpireUserAuthSecret_Failure(t *testing.T) {
 	badUserId := uuid.NullUUID{}
 	resources, mockDB := apitest.NewAuthManagementResource(mockCtrl)
 
-	mockDB.EXPECT().GetUser(badUserId.UUID).Return(model.User{}, fmt.Errorf("db failure"))
+	mockDB.EXPECT().GetUser(gomock.Any(), badUserId.UUID).Return(model.User{}, fmt.Errorf("db failure"))
 
 	type Input struct {
 		UserId string
@@ -757,7 +757,7 @@ func TestExpireUserAuthSecret_Success(t *testing.T) {
 
 	resources, mockDB := apitest.NewAuthManagementResource(mockCtrl)
 
-	mockDB.EXPECT().GetUser(userId).Return(model.User{AuthSecret: &model.AuthSecret{}}, nil)
+	mockDB.EXPECT().GetUser(gomock.Any(), userId).Return(model.User{AuthSecret: &model.AuthSecret{}}, nil)
 	mockDB.EXPECT().UpdateAuthSecret(gomock.Any(), gomock.Any()).Return(nil)
 
 	ctx := context.WithValue(context.Background(), ctx.ValueKey, &ctx.Context{})
@@ -1361,7 +1361,7 @@ func TestManagementResource_UpdateUser_GetUserError(t *testing.T) {
 	}, nil)
 	mockDB.EXPECT().GetRoles(gomock.Any()).Return(model.Roles{}, nil)
 	mockDB.EXPECT().CreateUser(gomock.Any(), gomock.Any()).Return(goodUser, nil).AnyTimes()
-	mockDB.EXPECT().GetUser(gomock.Any()).Return(model.User{}, fmt.Errorf("foo"))
+	mockDB.EXPECT().GetUser(gomock.Any(), gomock.Any()).Return(model.User{}, fmt.Errorf("foo"))
 
 	ctx := context.WithValue(context.Background(), ctx.ValueKey, &ctx.Context{})
 	input := v2.CreateUserRequest{
@@ -1425,7 +1425,7 @@ func TestManagementResource_UpdateUser_GetRolesError(t *testing.T) {
 	}, nil)
 	mockDB.EXPECT().GetRoles(gomock.Any()).Return(model.Roles{}, nil)
 	mockDB.EXPECT().CreateUser(gomock.Any(), gomock.Any()).Return(goodUser, nil).AnyTimes()
-	mockDB.EXPECT().GetUser(gomock.Any()).Return(goodUser, nil)
+	mockDB.EXPECT().GetUser(gomock.Any(), gomock.Any()).Return(goodUser, nil)
 	mockDB.EXPECT().GetRoles(gomock.Any()).Return(model.Roles{}, fmt.Errorf("foo"))
 
 	ctx := context.WithValue(context.Background(), ctx.ValueKey, &ctx.Context{})
@@ -1483,7 +1483,7 @@ func TestManagementResource_UpdateUser_SelfDisable(t *testing.T) {
 	}, nil)
 	mockDB.EXPECT().GetRoles(gomock.Any()).Return(model.Roles{}, nil)
 	mockDB.EXPECT().CreateUser(gomock.Any(), gomock.Any()).Return(goodUser, nil).AnyTimes()
-	mockDB.EXPECT().GetUser(gomock.Any()).Return(goodUser, nil)
+	mockDB.EXPECT().GetUser(gomock.Any(), gomock.Any()).Return(goodUser, nil)
 	mockDB.EXPECT().GetRoles(gomock.Any()).Return(model.Roles{model.Role{
 		Name:        "admin",
 		Description: "admin",
@@ -1564,7 +1564,7 @@ func TestManagementResource_UpdateUser_LookupActiveSessionsError(t *testing.T) {
 	}, nil)
 	mockDB.EXPECT().GetRoles(gomock.Any()).Return(model.Roles{}, nil)
 	mockDB.EXPECT().CreateUser(gomock.Any(), gomock.Any()).Return(goodUser, nil).AnyTimes()
-	mockDB.EXPECT().GetUser(gomock.Any()).Return(goodUser, nil)
+	mockDB.EXPECT().GetUser(gomock.Any(), gomock.Any()).Return(goodUser, nil)
 	mockDB.EXPECT().GetRoles(gomock.Any()).Return(model.Roles{model.Role{
 		Name:        "admin",
 		Description: "admin",
@@ -1645,7 +1645,7 @@ func TestManagementResource_UpdateUser_DBError(t *testing.T) {
 	}, nil)
 	mockDB.EXPECT().GetRoles(gomock.Any()).Return(model.Roles{}, nil)
 	mockDB.EXPECT().CreateUser(gomock.Any(), gomock.Any()).Return(goodUser, nil).AnyTimes()
-	mockDB.EXPECT().GetUser(gomock.Any()).Return(goodUser, nil)
+	mockDB.EXPECT().GetUser(gomock.Any(), gomock.Any()).Return(goodUser, nil)
 	mockDB.EXPECT().GetRoles(gomock.Any()).Return(model.Roles{model.Role{
 		Name:        "admin",
 		Description: "admin",
@@ -1735,7 +1735,7 @@ func TestManagementResource_DeleteUser_UserNotFound(t *testing.T) {
 	require.Nil(t, err)
 
 	resources, mockDB := apitest.NewAuthManagementResource(mockCtrl)
-	mockDB.EXPECT().GetUser(userID).Return(model.User{}, database.ErrNotFound)
+	mockDB.EXPECT().GetUser(gomock.Any(), userID).Return(model.User{}, database.ErrNotFound)
 
 	ctx := context.WithValue(context.Background(), ctx.ValueKey, &ctx.Context{})
 	req, err := http.NewRequestWithContext(ctx, "DELETE", endpoint, nil)
@@ -1761,7 +1761,7 @@ func TestManagementResource_DeleteUser_GetUserError(t *testing.T) {
 	require.Nil(t, err)
 
 	resources, mockDB := apitest.NewAuthManagementResource(mockCtrl)
-	mockDB.EXPECT().GetUser(userID).Return(model.User{}, fmt.Errorf("foo"))
+	mockDB.EXPECT().GetUser(gomock.Any(), userID).Return(model.User{}, fmt.Errorf("foo"))
 
 	ctx := context.WithValue(context.Background(), ctx.ValueKey, &ctx.Context{})
 	req, err := http.NewRequestWithContext(ctx, "DELETE", endpoint, nil)
@@ -1794,7 +1794,7 @@ func TestManagementResource_DeleteUser_DeleteUserError(t *testing.T) {
 	}
 
 	resources, mockDB := apitest.NewAuthManagementResource(mockCtrl)
-	mockDB.EXPECT().GetUser(userID).Return(user, nil)
+	mockDB.EXPECT().GetUser(gomock.Any(), userID).Return(user, nil)
 	mockDB.EXPECT().DeleteUser(gomock.Any(), user).Return(fmt.Errorf("foo"))
 
 	ctx := context.WithValue(context.Background(), ctx.ValueKey, &ctx.Context{})
@@ -1828,7 +1828,7 @@ func TestManagementResource_DeleteUser_Success(t *testing.T) {
 	}
 
 	resources, mockDB := apitest.NewAuthManagementResource(mockCtrl)
-	mockDB.EXPECT().GetUser(userID).Return(user, nil)
+	mockDB.EXPECT().GetUser(gomock.Any(), userID).Return(user, nil)
 	mockDB.EXPECT().DeleteUser(gomock.Any(), user).Return(nil)
 
 	ctx := context.WithValue(context.Background(), ctx.ValueKey, &ctx.Context{})
@@ -1870,7 +1870,7 @@ func TestManagementResource_UpdateUser_Success(t *testing.T) {
 	}, nil)
 	mockDB.EXPECT().GetRoles(gomock.Any()).Return(model.Roles{}, nil)
 	mockDB.EXPECT().CreateUser(gomock.Any(), gomock.Any()).Return(goodUser, nil).AnyTimes()
-	mockDB.EXPECT().GetUser(gomock.Any()).Return(goodUser, nil)
+	mockDB.EXPECT().GetUser(gomock.Any(), gomock.Any()).Return(goodUser, nil)
 	mockDB.EXPECT().GetRoles(gomock.Any()).Return(model.Roles{model.Role{
 		Name:        "admin",
 		Description: "admin",
@@ -2531,11 +2531,11 @@ func TestEnrollMFA(t *testing.T) {
 
 	resources, mockDB := apitest.NewAuthManagementResource(mockCtrl)
 
-	mockDB.EXPECT().GetUser(missingUserId).Return(model.User{}, database.ErrNotFound)
-	mockDB.EXPECT().GetUser(activatedId).Return(model.User{AuthSecret: &model.AuthSecret{TOTPActivated: true}}, nil)
-	mockDB.EXPECT().GetUser(badPassId).Return(model.User{AuthSecret: &model.AuthSecret{}}, nil)
-	mockDB.EXPECT().GetUser(ssoId).Return(model.User{SAMLProviderID: null.Int32From(1)}, nil)
-	mockDB.EXPECT().GetUser(genTOTPFailId).Return(model.User{AuthSecret: defaultDigestAuthSecret(t, "password")}, nil)
+	mockDB.EXPECT().GetUser(gomock.Any(), missingUserId).Return(model.User{}, database.ErrNotFound)
+	mockDB.EXPECT().GetUser(gomock.Any(), activatedId).Return(model.User{AuthSecret: &model.AuthSecret{TOTPActivated: true}}, nil)
+	mockDB.EXPECT().GetUser(gomock.Any(), badPassId).Return(model.User{AuthSecret: &model.AuthSecret{}}, nil)
+	mockDB.EXPECT().GetUser(gomock.Any(), ssoId).Return(model.User{SAMLProviderID: null.Int32From(1)}, nil)
+	mockDB.EXPECT().GetUser(gomock.Any(), genTOTPFailId).Return(model.User{AuthSecret: defaultDigestAuthSecret(t, "password")}, nil)
 
 	type Input struct {
 		UserId string
@@ -2620,7 +2620,7 @@ func TestDisenrollMFA_Failure(t *testing.T) {
 	userId := test.NewUUIDv4(t)
 
 	resources, mockDB := apitest.NewAuthManagementResource(mockCtrl)
-	mockDB.EXPECT().GetUser(missingUserId).Return(model.User{}, database.ErrNotFound)
+	mockDB.EXPECT().GetUser(gomock.Any(), missingUserId).Return(model.User{}, database.ErrNotFound)
 
 	type Input struct {
 		UserId string
@@ -2675,7 +2675,7 @@ func TestDisenrollMFA_Success(t *testing.T) {
 	endpoint := "/api/v2/auth/users/%s/mfa"
 	userId := test.NewUUIDv4(t)
 
-	mockDB.EXPECT().GetUser(userId).Return(model.User{AuthSecret: defaultDigestAuthSecret(t, "password")}, nil)
+	mockDB.EXPECT().GetUser(gomock.Any(), userId).Return(model.User{AuthSecret: defaultDigestAuthSecret(t, "password")}, nil)
 	mockDB.EXPECT().UpdateAuthSecret(gomock.Any(), gomock.Any()).Return(nil)
 
 	input := auth.MFAEnrollmentRequest{"password"}
@@ -2715,7 +2715,7 @@ func TestDisenrollMFA_Admin_Success(t *testing.T) {
 	endpoint := "/api/v2/auth/users/%s/mfa"
 	nonAdminId := test.NewUUIDv4(t)
 
-	mockDB.EXPECT().GetUser(nonAdminId).Return(model.User{AuthSecret: defaultDigestAuthSecret(t, "password")}, nil)
+	mockDB.EXPECT().GetUser(gomock.Any(), nonAdminId).Return(model.User{AuthSecret: defaultDigestAuthSecret(t, "password")}, nil)
 	mockDB.EXPECT().UpdateAuthSecret(gomock.Any(), gomock.Any()).Return(nil)
 
 	adminContext := context.WithValue(context.Background(), ctx.ValueKey, &ctx.Context{})
@@ -2757,7 +2757,7 @@ func TestDisenrollMFA_Admin_FailureIncorrectPassword(t *testing.T) {
 	endpoint := "/api/v2/auth/users/%s/mfa"
 	nonAdminId := test.NewUUIDv4(t)
 
-	mockDB.EXPECT().GetUser(nonAdminId).Return(model.User{AuthSecret: defaultDigestAuthSecret(t, "password"), Unique: model.Unique{ID: nonAdminId}}, nil).AnyTimes()
+	mockDB.EXPECT().GetUser(gomock.Any(), nonAdminId).Return(model.User{AuthSecret: defaultDigestAuthSecret(t, "password"), Unique: model.Unique{ID: nonAdminId}}, nil).AnyTimes()
 
 	admin := model.User{
 		FirstName:     null.String{NullString: sql.NullString{String: "Admin", Valid: true}},
@@ -2809,7 +2809,7 @@ func TestGetMFAActivationStatus_Failure(t *testing.T) {
 	missingId := test.NewUUIDv4(t)
 
 	resources, mockDB := apitest.NewAuthManagementResource(mockCtrl)
-	mockDB.EXPECT().GetUser(missingId).Return(model.User{}, database.ErrNotFound)
+	mockDB.EXPECT().GetUser(gomock.Any(), missingId).Return(model.User{}, database.ErrNotFound)
 
 	type Input struct {
 		UserId string
@@ -2860,9 +2860,9 @@ func TestGetMFAActivationStatus_Success(t *testing.T) {
 
 	resources, mockDB := apitest.NewAuthManagementResource(mockCtrl)
 
-	mockDB.EXPECT().GetUser(activatedId).Return(model.User{AuthSecret: &model.AuthSecret{TOTPActivated: true, TOTPSecret: "imasharedsecret"}}, nil)
-	mockDB.EXPECT().GetUser(pendingId).Return(model.User{AuthSecret: &model.AuthSecret{TOTPActivated: false, TOTPSecret: "imasharedsecret"}}, nil)
-	mockDB.EXPECT().GetUser(deactivatedId).Return(model.User{AuthSecret: &model.AuthSecret{TOTPActivated: false}}, nil)
+	mockDB.EXPECT().GetUser(gomock.Any(), activatedId).Return(model.User{AuthSecret: &model.AuthSecret{TOTPActivated: true, TOTPSecret: "imasharedsecret"}}, nil)
+	mockDB.EXPECT().GetUser(gomock.Any(), pendingId).Return(model.User{AuthSecret: &model.AuthSecret{TOTPActivated: false, TOTPSecret: "imasharedsecret"}}, nil)
+	mockDB.EXPECT().GetUser(gomock.Any(), deactivatedId).Return(model.User{AuthSecret: &model.AuthSecret{TOTPActivated: false}}, nil)
 
 	type Input struct {
 		UserId string
@@ -2925,8 +2925,8 @@ func TestActivateMFA_Failure(t *testing.T) {
 
 	resources, mockDB := apitest.NewAuthManagementResource(mockCtrl)
 
-	mockDB.EXPECT().GetUser(missingUserId).Return(model.User{}, database.ErrNotFound)
-	mockDB.EXPECT().GetUser(unenrolledId).Return(model.User{AuthSecret: defaultDigestAuthSecret(t, "password")}, nil)
+	mockDB.EXPECT().GetUser(gomock.Any(), missingUserId).Return(model.User{}, database.ErrNotFound)
+	mockDB.EXPECT().GetUser(gomock.Any(), unenrolledId).Return(model.User{AuthSecret: defaultDigestAuthSecret(t, "password")}, nil)
 
 	type Input struct {
 		UserId string
@@ -2996,7 +2996,7 @@ func TestActivateMFA_Success(t *testing.T) {
 
 	endpoint := "/api/v2/auth/users/%s/mfa-activation"
 	userId := test.NewUUIDv4(t)
-	mockDB.EXPECT().GetUser(userId).Return(model.User{AuthSecret: defaultDigestAuthSecretWithTOTP(t, "password", totpSecret.Secret())}, nil)
+	mockDB.EXPECT().GetUser(gomock.Any(), userId).Return(model.User{AuthSecret: defaultDigestAuthSecretWithTOTP(t, "password", totpSecret.Secret())}, nil)
 	mockDB.EXPECT().UpdateAuthSecret(gomock.Any(), gomock.Any()).Return(nil)
 
 	ctx := context.WithValue(context.Background(), ctx.ValueKey, &ctx.Context{})

--- a/cmd/api/src/api/v2/auth/login.go
+++ b/cmd/api/src/api/v2/auth/login.go
@@ -89,7 +89,7 @@ func (s LoginResource) Login(response http.ResponseWriter, request *http.Request
 
 // EULA Acceptance does not pertain to Bloodhound Community Edition; this flag is used for Bloodhound Enterprise users.
 func (s LoginResource) patchEULAAcceptance(ctx context.Context, username string) error {
-	if user, err := s.db.LookupUser(username); err != nil {
+	if user, err := s.db.LookupUser(ctx, username); err != nil {
 		return err
 	} else if !user.EULAAccepted {
 		user.EULAAccepted = true

--- a/cmd/api/src/api/v2/auth/login_internal_test.go
+++ b/cmd/api/src/api/v2/auth/login_internal_test.go
@@ -88,7 +88,7 @@ func TestLoginFailure(t *testing.T) {
 	mockAuthenticator.EXPECT().LoginWithSecret(gomock.Any(), req2).Return(api.LoginDetails{User: model.User{EULAAccepted: true}}, api.ErrInvalidAuth)
 	mockAuthenticator.EXPECT().LoginWithSecret(gomock.Any(), req3).Return(api.LoginDetails{User: model.User{EULAAccepted: true}}, fmt.Errorf("db error"))
 	mockAuthenticator.EXPECT().LoginWithSecret(gomock.Any(), req4).Return(api.LoginDetails{User: model.User{EULAAccepted: true}}, api.ErrUserDisabled)
-	mockDB.EXPECT().LookupUser(gomock.Any()).Return(model.User{EULAAccepted: false}, nil).Times(5)
+	mockDB.EXPECT().LookupUser(gomock.Any(), gomock.Any()).Return(model.User{EULAAccepted: false}, nil).Times(5)
 	mockDB.EXPECT().UpdateUser(gomock.Any(), gomock.Any()).Return(nil).Times(5)
 
 	resources := NewLoginResource(config.Configuration{}, mockAuthenticator, mockDB)
@@ -210,7 +210,7 @@ func TestLoginSuccess(t *testing.T) {
 
 	mockAuthenticator := api_mocks.NewMockAuthenticator(mockCtrl)
 	mockAuthenticator.EXPECT().LoginWithSecret(gomock.Any(), input).Return(api.LoginDetails{User: model.User{AuthSecret: &model.AuthSecret{}, EULAAccepted: true}, SessionToken: "imasessiontoken"}, nil)
-	mockDB.EXPECT().LookupUser(gomock.Any()).Return(model.User{EULAAccepted: false}, nil)
+	mockDB.EXPECT().LookupUser(gomock.Any(), gomock.Any()).Return(model.User{EULAAccepted: false}, nil)
 	mockDB.EXPECT().UpdateUser(gomock.Any(), gomock.Any()).Return(nil)
 
 	resources := NewLoginResource(config.Configuration{}, mockAuthenticator, mockDB)

--- a/cmd/api/src/api/v2/auth/login_test.go
+++ b/cmd/api/src/api/v2/auth/login_test.go
@@ -62,7 +62,7 @@ func TestLoginExpiry(t *testing.T) {
 	mockAuthenticator := api_mocks.NewMockAuthenticator(mockCtrl)
 	mockAuthenticator.EXPECT().LoginWithSecret(gomock.Any(), req1).Return(api.LoginDetails{User: model.User{AuthSecret: &model.AuthSecret{ExpiresAt: time.Now().UTC().Add(time.Hour * 24)}, EULAAccepted: true}, SessionToken: "imasession"}, nil)
 	mockAuthenticator.EXPECT().LoginWithSecret(gomock.Any(), req2).Return(api.LoginDetails{User: model.User{AuthSecret: &model.AuthSecret{ExpiresAt: time.Now().UTC().Add(time.Hour * 24 * -1)}, EULAAccepted: true}, SessionToken: "imasession"}, nil)
-	mockDB.EXPECT().LookupUser(gomock.Any()).Return(model.User{EULAAccepted: false}, nil).Times(2)
+	mockDB.EXPECT().LookupUser(gomock.Any(), gomock.Any()).Return(model.User{EULAAccepted: false}, nil).Times(2)
 	mockDB.EXPECT().UpdateUser(gomock.Any(), gomock.Any()).Return(nil).Times(2)
 
 	resources := NewLoginResource(config.Configuration{}, mockAuthenticator, mockDB)

--- a/cmd/api/src/database/auth.go
+++ b/cmd/api/src/database/auth.go
@@ -426,11 +426,11 @@ func (s *BloodhoundDB) DeleteUser(ctx context.Context, user model.User) error {
 
 	return s.AuditableTransaction(ctx, auditEntry, func(tx *gorm.DB) error {
 		// Clear associations first
-		if err := tx.Model(&user).Association("Roles").Clear(); err != nil {
+		if err := tx.Model(&user).WithContext(ctx).Association("Roles").Clear(); err != nil {
 			return err
 		}
 
-		return CheckError(tx.Delete(&user))
+		return CheckError(tx.WithContext(ctx).Delete(&user))
 	})
 }
 

--- a/cmd/api/src/database/auth.go
+++ b/cmd/api/src/database/auth.go
@@ -74,9 +74,9 @@ func NewContextInitializer(db Database) AuthContextInitializer {
 	return contextInitializer{db: db}
 }
 
-func (s contextInitializer) InitContextFromToken(_ context.Context, authToken model.AuthToken) (auth.Context, error) {
+func (s contextInitializer) InitContextFromToken(ctx context.Context, authToken model.AuthToken) (auth.Context, error) {
 	if authToken.UserID.Valid {
-		if user, err := s.db.GetUser(authToken.UserID.UUID); err != nil {
+		if user, err := s.db.GetUser(ctx, authToken.UserID.UUID); err != nil {
 			return auth.Context{}, err
 		} else {
 			return auth.Context{
@@ -407,10 +407,10 @@ func (s *BloodhoundDB) GetAllUsers(ctx context.Context, order string, filter mod
 
 // GetUser returns the user associated with the provided ID
 // SELECT * FROM users WHERE id = ...
-func (s *BloodhoundDB) GetUser(id uuid.UUID) (model.User, error) {
+func (s *BloodhoundDB) GetUser(ctx context.Context, id uuid.UUID) (model.User, error) {
 	var (
 		user   model.User
-		result = s.preload(model.UserAssociations()).First(&user, id)
+		result = s.preload(model.UserAssociations()).WithContext(ctx).First(&user, id)
 	)
 
 	return user, CheckError(result)

--- a/cmd/api/src/database/auth.go
+++ b/cmd/api/src/database/auth.go
@@ -360,7 +360,7 @@ func (s *BloodhoundDB) CreateUser(ctx context.Context, user model.User) (model.U
 		Model:  &updatedUser,
 	}
 	return updatedUser, s.AuditableTransaction(ctx, auditEntry, func(tx *gorm.DB) error {
-		return CheckError(tx.Create(&updatedUser))
+		return CheckError(tx.WithContext(ctx).Create(&updatedUser))
 	})
 }
 
@@ -376,11 +376,11 @@ func (s *BloodhoundDB) UpdateUser(ctx context.Context, user model.User) error {
 
 	return s.AuditableTransaction(ctx, auditEntry, func(tx *gorm.DB) error {
 		// Update roles first
-		if err := tx.Model(&user).Association("Roles").Replace(&user.Roles); err != nil {
+		if err := tx.Model(&user).WithContext(ctx).Association("Roles").Replace(&user.Roles); err != nil {
 			return err
 		}
 
-		result := tx.Save(&user)
+		result := tx.WithContext(ctx).Save(&user)
 		return CheckError(result)
 	})
 }

--- a/cmd/api/src/database/auth.go
+++ b/cmd/api/src/database/auth.go
@@ -438,11 +438,11 @@ func (s *BloodhoundDB) DeleteUser(ctx context.Context, user model.User) error {
 // principal_name and email address fields of a user.
 //
 // SELECT * FROM users WHERE lower(principal_name) = ... or lower(email_address) = ...
-func (s *BloodhoundDB) LookupUser(name string) (model.User, error) {
+func (s *BloodhoundDB) LookupUser(ctx context.Context, name string) (model.User, error) {
 	var (
 		user          model.User
 		formattedName = strings.ToLower(name)
-		result        = s.preload(model.UserAssociations()).Where("principal_name = ? or lower(email_address) = ?", name, formattedName).First(&user)
+		result        = s.preload(model.UserAssociations()).WithContext(ctx).Where("principal_name = ? or lower(email_address) = ?", name, formattedName).First(&user)
 	)
 
 	return user, CheckError(result)

--- a/cmd/api/src/database/auth_test.go
+++ b/cmd/api/src/database/auth_test.go
@@ -244,7 +244,7 @@ func TestDatabase_CreateGetDeleteUser(t *testing.T) {
 		t.Fatalf("Failed to validate Deleteuser audit logs:\n%v", err)
 	}
 
-	if usersResponse, err := dbInst.GetAllUsers("first_name", model.SQLFilter{}); err != nil {
+	if usersResponse, err := dbInst.GetAllUsers(context.Background(), "first_name", model.SQLFilter{}); err != nil {
 		t.Fatalf("Error getting users: %v", err)
 	} else if usersResponse[0].FirstName.String != "First" {
 		t.Fatalf("ListUsers returned incorrectly sorted data")

--- a/cmd/api/src/database/db.go
+++ b/cmd/api/src/database/db.go
@@ -109,7 +109,7 @@ type Database interface {
 	GetAllUsers(ctx context.Context, order string, filter model.SQLFilter) (model.Users, error)
 	GetUser(ctx context.Context, id uuid.UUID) (model.User, error)
 	DeleteUser(ctx context.Context, user model.User) error
-	LookupUser(principalName string) (model.User, error)
+	LookupUser(ctx context.Context, principalName string) (model.User, error)
 
 	CreateAuthToken(ctx context.Context, authToken model.AuthToken) (model.AuthToken, error)
 	UpdateAuthToken(authToken model.AuthToken) error

--- a/cmd/api/src/database/db.go
+++ b/cmd/api/src/database/db.go
@@ -107,7 +107,7 @@ type Database interface {
 	CreateUser(ctx context.Context, user model.User) (model.User, error)
 	UpdateUser(ctx context.Context, user model.User) error
 	GetAllUsers(ctx context.Context, order string, filter model.SQLFilter) (model.Users, error)
-	GetUser(id uuid.UUID) (model.User, error)
+	GetUser(ctx context.Context, id uuid.UUID) (model.User, error)
 	DeleteUser(ctx context.Context, user model.User) error
 	LookupUser(principalName string) (model.User, error)
 

--- a/cmd/api/src/database/db.go
+++ b/cmd/api/src/database/db.go
@@ -83,6 +83,7 @@ type Database interface {
 	AppendAuditLog(ctx context.Context, entry model.AuditEntry) error
 	ListAuditLogs(ctx context.Context, before, after time.Time, offset, limit int, order string, filter model.SQLFilter) (model.AuditLogs, int, error)
 
+	// Roles
 	CreateRole(role model.Role) (model.Role, error)
 	UpdateRole(role model.Role) error
 	GetAllRoles(order string, filter model.SQLFilter) (model.Roles, error)
@@ -90,20 +91,26 @@ type Database interface {
 	GetRolesByName(names []string) (model.Roles, error)
 	GetRole(id int32) (model.Role, error)
 	LookupRoleByName(name string) (model.Role, error)
+
+	// Permissions
 	GetAllPermissions(order string, filter model.SQLFilter) (model.Permissions, error)
 	GetPermission(id int) (model.Permission, error)
 	CreatePermission(permission model.Permission) (model.Permission, error)
+
 	InitializeSAMLAuth(adminUser model.User, samlProvider model.SAMLProvider) (model.SAMLProvider, model.Installation, error)
 	InitializeSecretAuth(adminUser model.User, authSecret model.AuthSecret) (model.Installation, error)
 	CreateInstallation() (model.Installation, error)
 	GetInstallation() (model.Installation, error)
 	HasInstallation() (bool, error)
+
+	// Users
 	CreateUser(ctx context.Context, user model.User) (model.User, error)
 	UpdateUser(ctx context.Context, user model.User) error
 	GetAllUsers(order string, filter model.SQLFilter) (model.Users, error)
 	GetUser(id uuid.UUID) (model.User, error)
 	DeleteUser(ctx context.Context, user model.User) error
 	LookupUser(principalName string) (model.User, error)
+
 	CreateAuthToken(ctx context.Context, authToken model.AuthToken) (model.AuthToken, error)
 	UpdateAuthToken(authToken model.AuthToken) error
 	GetAllAuthTokens(order string, filter model.SQLFilter) (model.AuthTokens, error)

--- a/cmd/api/src/database/db.go
+++ b/cmd/api/src/database/db.go
@@ -106,7 +106,7 @@ type Database interface {
 	// Users
 	CreateUser(ctx context.Context, user model.User) (model.User, error)
 	UpdateUser(ctx context.Context, user model.User) error
-	GetAllUsers(order string, filter model.SQLFilter) (model.Users, error)
+	GetAllUsers(ctx context.Context, order string, filter model.SQLFilter) (model.Users, error)
 	GetUser(id uuid.UUID) (model.User, error)
 	DeleteUser(ctx context.Context, user model.User) error
 	LookupUser(principalName string) (model.User, error)

--- a/cmd/api/src/database/mocks/db.go
+++ b/cmd/api/src/database/mocks/db.go
@@ -1213,18 +1213,18 @@ func (mr *MockDatabaseMockRecorder) LookupSAMLProviderByName(arg0 interface{}) *
 }
 
 // LookupUser mocks base method.
-func (m *MockDatabase) LookupUser(arg0 string) (model.User, error) {
+func (m *MockDatabase) LookupUser(arg0 context.Context, arg1 string) (model.User, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "LookupUser", arg0)
+	ret := m.ctrl.Call(m, "LookupUser", arg0, arg1)
 	ret0, _ := ret[0].(model.User)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // LookupUser indicates an expected call of LookupUser.
-func (mr *MockDatabaseMockRecorder) LookupUser(arg0 interface{}) *gomock.Call {
+func (mr *MockDatabaseMockRecorder) LookupUser(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LookupUser", reflect.TypeOf((*MockDatabase)(nil).LookupUser), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LookupUser", reflect.TypeOf((*MockDatabase)(nil).LookupUser), arg0, arg1)
 }
 
 // Migrate mocks base method.

--- a/cmd/api/src/database/mocks/db.go
+++ b/cmd/api/src/database/mocks/db.go
@@ -1030,18 +1030,18 @@ func (mr *MockDatabaseMockRecorder) GetTimeRangedAssetGroupCollections(arg0, arg
 }
 
 // GetUser mocks base method.
-func (m *MockDatabase) GetUser(arg0 uuid.UUID) (model.User, error) {
+func (m *MockDatabase) GetUser(arg0 context.Context, arg1 uuid.UUID) (model.User, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetUser", arg0)
+	ret := m.ctrl.Call(m, "GetUser", arg0, arg1)
 	ret0, _ := ret[0].(model.User)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetUser indicates an expected call of GetUser.
-func (mr *MockDatabaseMockRecorder) GetUser(arg0 interface{}) *gomock.Call {
+func (mr *MockDatabaseMockRecorder) GetUser(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUser", reflect.TypeOf((*MockDatabase)(nil).GetUser), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUser", reflect.TypeOf((*MockDatabase)(nil).GetUser), arg0, arg1)
 }
 
 // GetUserSession mocks base method.

--- a/cmd/api/src/database/mocks/db.go
+++ b/cmd/api/src/database/mocks/db.go
@@ -683,18 +683,18 @@ func (mr *MockDatabaseMockRecorder) GetAllSAMLProviders() *gomock.Call {
 }
 
 // GetAllUsers mocks base method.
-func (m *MockDatabase) GetAllUsers(arg0 string, arg1 model.SQLFilter) (model.Users, error) {
+func (m *MockDatabase) GetAllUsers(arg0 context.Context, arg1 string, arg2 model.SQLFilter) (model.Users, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAllUsers", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetAllUsers", arg0, arg1, arg2)
 	ret0, _ := ret[0].(model.Users)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetAllUsers indicates an expected call of GetAllUsers.
-func (mr *MockDatabaseMockRecorder) GetAllUsers(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockDatabaseMockRecorder) GetAllUsers(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllUsers", reflect.TypeOf((*MockDatabase)(nil).GetAllUsers), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllUsers", reflect.TypeOf((*MockDatabase)(nil).GetAllUsers), arg0, arg1, arg2)
 }
 
 // GetAssetGroup mocks base method.


### PR DESCRIPTION
## Description

Plumb context into gorm user db methods
https://gorm.io/docs/context.html#Context-Timeout

## Motivation and Context

Currently as it stands any endpoints that rely on purely gorm do not respect `request.Context` and as such timeouts are not respected either. While we want to eventually get to the removal of the gorm dependency altogether, that is a long way and a lot of effort away and this I think this approach would give us that much room to maneuver while we get there.

## How Has This Been Tested?

Using a rest client and the prefer header
Add a sleep inside of the handler
Look for the `500 request timed out` after exceeding the timeout. (Note: the request will take as long as the sleep is set, it's not tied to the prefer header)

## Types of changes

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [x] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
