### PR TITLE
fix: plumb ctx into auth token / secrets db methods 

### DIFF
--- a/cmd/api/src/api/auth.go
+++ b/cmd/api/src/api/auth.go
@@ -255,7 +255,7 @@ func (s authenticator) ValidateRequestSignature(tokenID uuid.UUID, request *http
 
 			authToken.LastAccess = time.Now().UTC()
 
-			if err := s.db.UpdateAuthToken(authToken); err != nil {
+			if err := s.db.UpdateAuthToken(request.Context(), authToken); err != nil {
 				log.Errorf("Error updating last access on AuthToken: %v", err)
 			}
 

--- a/cmd/api/src/api/auth.go
+++ b/cmd/api/src/api/auth.go
@@ -230,7 +230,7 @@ func (s authenticator) ValidateRequestSignature(tokenID uuid.UUID, request *http
 		return auth.Context{}, http.StatusBadRequest, fmt.Errorf("no signature header")
 	} else if signatureBytes, err := base64.StdEncoding.DecodeString(signatureHeader); err != nil {
 		return auth.Context{}, http.StatusBadRequest, fmt.Errorf("malformed signature header: %w", err)
-	} else if authToken, err := s.db.GetAuthToken(tokenID); err != nil {
+	} else if authToken, err := s.db.GetAuthToken(request.Context(), tokenID); err != nil {
 		return handleAuthDBError(err)
 	} else if authContext, err := s.ctxInitializer.InitContextFromToken(request.Context(), authToken); err != nil {
 		return handleAuthDBError(err)

--- a/cmd/api/src/api/v2/auth/auth.go
+++ b/cmd/api/src/api/v2/auth/auth.go
@@ -765,7 +765,7 @@ func (s ManagementResource) ListAuthTokens(response http.ResponseWriter, request
 		if sqlFilter, err := queryFilters.BuildSQLFilter(); err != nil {
 			api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, "error building SQL for filter", request), response)
 			return
-		} else if authTokens, err := s.db.GetAllAuthTokens(strings.Join(order, ", "), sqlFilter); err != nil {
+		} else if authTokens, err := s.db.GetAllAuthTokens(request.Context(), strings.Join(order, ", "), sqlFilter); err != nil {
 			api.HandleDatabaseError(request, response, err)
 		} else {
 			api.WriteBasicResponse(request.Context(), v2.ListTokensResponse{Tokens: authTokens.StripKeys()}, http.StatusOK, response)

--- a/cmd/api/src/api/v2/auth/auth.go
+++ b/cmd/api/src/api/v2/auth/auth.go
@@ -822,7 +822,7 @@ func (s ManagementResource) DeleteAuthToken(response http.ResponseWriter, reques
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusInternalServerError, api.ErrorResponseDetailsInternalServerError, request), response)
 	} else if tokenID, err := uuid.FromString(rawTokenID); err != nil {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, api.ErrorResponseDetailsIDMalformed, request), response)
-	} else if token, err := s.db.GetAuthToken(tokenID); err != nil {
+	} else if token, err := s.db.GetAuthToken(request.Context(), tokenID); err != nil {
 		api.HandleDatabaseError(request, response, err)
 	} else if token.UserID.Valid && token.UserID.UUID != user.ID && !s.authorizer.AllowsPermission(bhCtx.AuthCtx, auth.Permissions().AuthManageUsers) {
 		log.Errorf("Bad user ID: %s != %s", token.UserID.UUID.String(), user.ID.String())

--- a/cmd/api/src/api/v2/auth/auth_test.go
+++ b/cmd/api/src/api/v2/auth/auth_test.go
@@ -2135,7 +2135,7 @@ func TestManagementResource_ListAuthTokens_DBError(t *testing.T) {
 	require.True(t, isUser)
 
 	mockDB := dbmocks.NewMockDatabase(mockCtrl)
-	mockDB.EXPECT().GetAllAuthTokens("name, last_access desc", model.SQLFilter{SQLString: "user_id = ?", Params: []any{user.ID.String()}}).Return(model.AuthTokens{}, fmt.Errorf("foo"))
+	mockDB.EXPECT().GetAllAuthTokens(gomock.Any(), "name, last_access desc", model.SQLFilter{SQLString: "user_id = ?", Params: []any{user.ID.String()}}).Return(model.AuthTokens{}, fmt.Errorf("foo"))
 
 	config, err := config.NewDefaultConfiguration()
 	require.Nilf(t, err, "Failed to create default configuration: %v", err)
@@ -2257,7 +2257,7 @@ func TestManagementResource_ListAuthTokens_Admin(t *testing.T) {
 	require.True(t, isUser)
 
 	resources, mockDB := apitest.NewAuthManagementResource(mockCtrl)
-	mockDB.EXPECT().GetAllAuthTokens("name, last_access desc", model.SQLFilter{}).Return(allAuthTokens, nil)
+	mockDB.EXPECT().GetAllAuthTokens(gomock.Any(), "name, last_access desc", model.SQLFilter{}).Return(allAuthTokens, nil)
 
 	config, err := config.NewDefaultConfiguration()
 	require.Nilf(t, err, "Failed to create default configuration: %v", err)
@@ -2378,7 +2378,7 @@ func TestManagementResource_ListAuthTokens_NonAdmin(t *testing.T) {
 	require.True(t, isUser)
 
 	resources, mockDB := apitest.NewAuthManagementResource(mockCtrl)
-	mockDB.EXPECT().GetAllAuthTokens("name, last_access desc", model.SQLFilter{SQLString: "user_id = ?", Params: []any{user.ID.String()}}).Return(user.AuthTokens, nil)
+	mockDB.EXPECT().GetAllAuthTokens(gomock.Any(), "name, last_access desc", model.SQLFilter{SQLString: "user_id = ?", Params: []any{user.ID.String()}}).Return(user.AuthTokens, nil)
 
 	config, err := config.NewDefaultConfiguration()
 	require.Nilf(t, err, "Failed to create default configuration: %v", err)
@@ -2454,8 +2454,8 @@ func TestManagementResource_ListAuthTokens_Filtered(t *testing.T) {
 	resources, mockDB := apitest.NewAuthManagementResource(mockCtrl)
 	// The filters are stored in a map before parsing, which means we don't know what order the resulted SQLFilter will be in.
 	// Mock out both possibilities to catch both cases.
-	mockDB.EXPECT().GetAllAuthTokens("", model.SQLFilter{SQLString: "name = ? AND user_id = ?", Params: []any{"a", user.ID.String()}}).AnyTimes().Return(model.AuthTokens{authToken1}, nil)
-	mockDB.EXPECT().GetAllAuthTokens("", model.SQLFilter{SQLString: "user_id = ? AND name = ?", Params: []any{user.ID.String(), "a"}}).AnyTimes().Return(model.AuthTokens{authToken1}, nil)
+	mockDB.EXPECT().GetAllAuthTokens(gomock.Any(), "", model.SQLFilter{SQLString: "name = ? AND user_id = ?", Params: []any{"a", user.ID.String()}}).AnyTimes().Return(model.AuthTokens{authToken1}, nil)
+	mockDB.EXPECT().GetAllAuthTokens(gomock.Any(), "", model.SQLFilter{SQLString: "user_id = ? AND name = ?", Params: []any{user.ID.String(), "a"}}).AnyTimes().Return(model.AuthTokens{authToken1}, nil)
 
 	config, err := config.NewDefaultConfiguration()
 	require.Nilf(t, err, "Failed to create default configuration: %v", err)

--- a/cmd/api/src/bootstrap/server.go
+++ b/cmd/api/src/bootstrap/server.go
@@ -111,7 +111,7 @@ func MigrateDB(ctx context.Context, cfg config.Configuration, db database.Databa
 			authSecret.ExpiresAt = time.Now().Add(defaultWindow.ToDuration())
 		}
 
-		if _, err := db.InitializeSecretAuth(adminUser, authSecret); err != nil {
+		if _, err := db.InitializeSecretAuth(ctx, adminUser, authSecret); err != nil {
 			return fmt.Errorf("error in database while initalizing auth: %w", err)
 		} else {
 			passwordMsg := fmt.Sprintf("# Initial Password Set To:    %s    #", cfg.DefaultAdmin.Password)

--- a/cmd/api/src/database/auth.go
+++ b/cmd/api/src/database/auth.go
@@ -398,7 +398,7 @@ func (s *BloodhoundDB) CreateAuthToken(ctx context.Context, authToken model.Auth
 	}
 
 	return authToken, s.AuditableTransaction(ctx, auditEntry, func(tx *gorm.DB) error {
-		return CheckError(tx.Create(&authToken))
+		return CheckError(tx.WithContext(ctx).Create(&authToken))
 	})
 }
 

--- a/cmd/api/src/database/auth.go
+++ b/cmd/api/src/database/auth.go
@@ -493,7 +493,7 @@ func (s *BloodhoundDB) UpdateAuthSecret(ctx context.Context, authSecret model.Au
 	}
 
 	return s.AuditableTransaction(ctx, auditEntry, func(tx *gorm.DB) error {
-		return CheckError(tx.Save(&authSecret))
+		return CheckError(tx.WithContext(ctx).Save(&authSecret))
 	})
 }
 

--- a/cmd/api/src/database/auth.go
+++ b/cmd/api/src/database/auth.go
@@ -438,25 +438,6 @@ func (s *BloodhoundDB) GetAllAuthTokens(ctx context.Context, order string, filte
 	return tokens, CheckError(cursor.Find(&tokens))
 }
 
-func (s *BloodhoundDB) ListUserTokens(userID uuid.UUID, order string, filter model.SQLFilter) (model.AuthTokens, error) {
-	var (
-		authTokens model.AuthTokens
-		result     *gorm.DB
-	)
-
-	if order != "" && filter.SQLString == "" {
-		result = s.db.Where("user_id = ?", userID).Order(order).Find(&authTokens)
-	} else if order == "" && filter.SQLString == "" {
-		result = s.db.Where("user_id = ?", userID).Find(&authTokens)
-	} else if order == "" && filter.SQLString != "" {
-		result = s.db.Where("user_id = ?", userID).Where(filter.SQLString, filter.Params).Find(&authTokens)
-	} else {
-		result = s.db.Where("user_id = ?", userID).Where(filter.SQLString, filter.Params).Order(order).Find(&authTokens)
-	}
-
-	return authTokens, CheckError(result)
-}
-
 func (s *BloodhoundDB) GetUserToken(userId, tokenId uuid.UUID) (model.AuthToken, error) {
 	var (
 		authToken model.AuthToken

--- a/cmd/api/src/database/auth.go
+++ b/cmd/api/src/database/auth.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/gofrs/uuid"
 	"github.com/specterops/bloodhound/src/auth"
-	"github.com/specterops/bloodhound/src/database/types/null"
 	"github.com/specterops/bloodhound/src/model"
 	"gorm.io/gorm"
 )
@@ -156,47 +155,6 @@ func (s *BloodhoundDB) GetPermission(ctx context.Context, id int) (model.Permiss
 	)
 
 	return permission, CheckError(result)
-}
-
-// InitializeSAMLAuth creates new SAMLProvider, User and Installation entries based on the input provided
-func (s *BloodhoundDB) InitializeSAMLAuth(adminUser model.User, samlProvider model.SAMLProvider) (model.SAMLProvider, model.Installation, error) {
-	var (
-		updatedAdminUser    = adminUser
-		updatedSAMLProvider = samlProvider
-		newInstallation     model.Installation
-	)
-
-	err := s.db.Transaction(func(tx *gorm.DB) error {
-		if newInstallationID, err := uuid.NewV4(); err != nil {
-			return err
-		} else {
-			newInstallation.ID = newInstallationID
-
-			if result := tx.Create(&newInstallation); result.Error != nil {
-				return CheckError(result)
-			}
-		}
-
-		if result := tx.Create(&updatedSAMLProvider); result.Error != nil {
-			return CheckError(result)
-		}
-
-		if newUserID, err := uuid.NewV4(); err != nil {
-			return err
-		} else {
-			updatedAdminUser.ID = newUserID
-			updatedAdminUser.SAMLProvider = &updatedSAMLProvider
-			updatedAdminUser.SAMLProviderID = null.Int32From(updatedSAMLProvider.ID)
-
-			if result := tx.Create(&updatedAdminUser); result.Error != nil {
-				return CheckError(result)
-			}
-		}
-
-		return nil
-	})
-
-	return updatedSAMLProvider, newInstallation, err
 }
 
 // InitializeSecretAuth creates new AuthSecret, User and Installation entries based on the input provided

--- a/cmd/api/src/database/auth.go
+++ b/cmd/api/src/database/auth.go
@@ -506,7 +506,7 @@ func (s *BloodhoundDB) DeleteAuthSecret(ctx context.Context, authSecret model.Au
 	}
 
 	return s.AuditableTransaction(ctx, auditEntry, func(tx *gorm.DB) error {
-		return CheckError(tx.Delete(&authSecret))
+		return CheckError(tx.WithContext(ctx).Delete(&authSecret))
 	})
 }
 

--- a/cmd/api/src/database/auth.go
+++ b/cmd/api/src/database/auth.go
@@ -412,10 +412,10 @@ func (s *BloodhoundDB) UpdateAuthToken(ctx context.Context, authToken model.Auth
 
 // GetAuthToken retrieves the AuthToken row associated with the provided ID
 // SELECT * FROM auth_tokens WHERE id = ....
-func (s *BloodhoundDB) GetAuthToken(id uuid.UUID) (model.AuthToken, error) {
+func (s *BloodhoundDB) GetAuthToken(ctx context.Context, id uuid.UUID) (model.AuthToken, error) {
 	var (
 		authToken model.AuthToken
-		result    = s.db.First(&authToken, id)
+		result    = s.db.WithContext(ctx).First(&authToken, id)
 	)
 
 	return authToken, CheckError(result)

--- a/cmd/api/src/database/auth.go
+++ b/cmd/api/src/database/auth.go
@@ -158,14 +158,14 @@ func (s *BloodhoundDB) GetPermission(ctx context.Context, id int) (model.Permiss
 }
 
 // InitializeSecretAuth creates new AuthSecret, User and Installation entries based on the input provided
-func (s *BloodhoundDB) InitializeSecretAuth(adminUser model.User, authSecret model.AuthSecret) (model.Installation, error) {
+func (s *BloodhoundDB) InitializeSecretAuth(ctx context.Context, adminUser model.User, authSecret model.AuthSecret) (model.Installation, error) {
 	var (
 		updatedAdminUser  = adminUser
 		updatedAuthSecret = authSecret
 		newInstallation   model.Installation
 	)
 
-	err := s.db.Transaction(func(tx *gorm.DB) error {
+	err := s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		if newInstallationID, err := uuid.NewV4(); err != nil {
 			return err
 		} else {

--- a/cmd/api/src/database/auth.go
+++ b/cmd/api/src/database/auth.go
@@ -438,10 +438,10 @@ func (s *BloodhoundDB) GetAllAuthTokens(ctx context.Context, order string, filte
 	return tokens, CheckError(cursor.Find(&tokens))
 }
 
-func (s *BloodhoundDB) GetUserToken(userId, tokenId uuid.UUID) (model.AuthToken, error) {
+func (s *BloodhoundDB) GetUserToken(ctx context.Context, userId, tokenId uuid.UUID) (model.AuthToken, error) {
 	var (
 		authToken model.AuthToken
-		result    = s.db.First(&authToken, "id = ? AND user_id = ?", tokenId, userId)
+		result    = s.db.WithContext(ctx).First(&authToken, "id = ? AND user_id = ?", tokenId, userId)
 	)
 	return authToken, CheckError(result)
 }

--- a/cmd/api/src/database/auth.go
+++ b/cmd/api/src/database/auth.go
@@ -468,7 +468,7 @@ func (s *BloodhoundDB) CreateAuthSecret(ctx context.Context, authSecret model.Au
 	}
 
 	return authSecret, s.AuditableTransaction(ctx, auditEntry, func(tx *gorm.DB) error {
-		return CheckError(tx.Create(&authSecret))
+		return CheckError(tx.WithContext(ctx).Create(&authSecret))
 	})
 }
 

--- a/cmd/api/src/database/auth.go
+++ b/cmd/api/src/database/auth.go
@@ -455,7 +455,7 @@ func (s *BloodhoundDB) DeleteAuthToken(ctx context.Context, authToken model.Auth
 	}
 
 	return s.AuditableTransaction(ctx, auditEntry, func(tx *gorm.DB) error {
-		return CheckError(tx.Where("id = ?", authToken.ID).Delete(&authToken))
+		return CheckError(tx.WithContext(ctx).Where("id = ?", authToken.ID).Delete(&authToken))
 	})
 }
 

--- a/cmd/api/src/database/auth.go
+++ b/cmd/api/src/database/auth.go
@@ -474,10 +474,10 @@ func (s *BloodhoundDB) CreateAuthSecret(ctx context.Context, authSecret model.Au
 
 // GetAuthSecret retrieves the AuthSecret row associated with the provided ID
 // SELECT * FROM auth_secrets WHERE id = ....
-func (s *BloodhoundDB) GetAuthSecret(id int32) (model.AuthSecret, error) {
+func (s *BloodhoundDB) GetAuthSecret(ctx context.Context, id int32) (model.AuthSecret, error) {
 	var (
 		authSecret model.AuthSecret
-		result     = s.db.Find(&authSecret, id)
+		result     = s.db.WithContext(ctx).Find(&authSecret, id)
 	)
 
 	return authSecret, CheckError(result)

--- a/cmd/api/src/database/auth.go
+++ b/cmd/api/src/database/auth.go
@@ -405,8 +405,8 @@ func (s *BloodhoundDB) CreateAuthToken(ctx context.Context, authToken model.Auth
 // UpdateAuthToken updates all fields in the AuthToken row as specified in the provided struct
 // UPDATE auth_tokens SET key = ..., hmac_method = ..., last_access = ...
 // WHERE user_id = ... AND client_id = ...
-func (s *BloodhoundDB) UpdateAuthToken(authToken model.AuthToken) error {
-	result := s.db.Save(&authToken)
+func (s *BloodhoundDB) UpdateAuthToken(ctx context.Context, authToken model.AuthToken) error {
+	result := s.db.WithContext(ctx).Save(&authToken)
 	return CheckError(result)
 }
 

--- a/cmd/api/src/database/auth_test.go
+++ b/cmd/api/src/database/auth_test.go
@@ -286,7 +286,7 @@ func TestDatabase_CreateGetDeleteAuthSecret(t *testing.T) {
 			t.Fatalf("Failed to update auth secret %d: %v", newSecret.ID, err)
 		} else if err = test.VerifyAuditLogs(dbInst, "UpdateAuthSecret", "secret_user_id", newSecret.UserID.String()); err != nil {
 			t.Fatalf("Failed to validate UpdateAuthSecret audit logs:\n%v", err)
-		} else if updatedSecret, err := dbInst.GetAuthSecret(newSecret.ID); err != nil {
+		} else if updatedSecret, err := dbInst.GetAuthSecret(ctx, newSecret.ID); err != nil {
 			t.Fatalf("Failed to fetch updated auth secret: %v", err)
 		} else if updatedSecret.Digest != updatedDigest {
 			t.Fatalf("Expected updated auth secret digest to be %s but saw %s", updatedDigest, updatedSecret.Digest)

--- a/cmd/api/src/database/db.go
+++ b/cmd/api/src/database/db.go
@@ -106,7 +106,7 @@ type Database interface {
 
 	// Auth
 	CreateAuthToken(ctx context.Context, authToken model.AuthToken) (model.AuthToken, error)
-	UpdateAuthToken(authToken model.AuthToken) error
+	UpdateAuthToken(ctx context.Context, authToken model.AuthToken) error
 	GetAllAuthTokens(order string, filter model.SQLFilter) (model.AuthTokens, error)
 	GetAuthToken(id uuid.UUID) (model.AuthToken, error)
 	ListUserTokens(userID uuid.UUID, order string, filter model.SQLFilter) (model.AuthTokens, error)

--- a/cmd/api/src/database/db.go
+++ b/cmd/api/src/database/db.go
@@ -109,7 +109,6 @@ type Database interface {
 	UpdateAuthToken(ctx context.Context, authToken model.AuthToken) error
 	GetAllAuthTokens(ctx context.Context, order string, filter model.SQLFilter) (model.AuthTokens, error)
 	GetAuthToken(ctx context.Context, id uuid.UUID) (model.AuthToken, error)
-	ListUserTokens(userID uuid.UUID, order string, filter model.SQLFilter) (model.AuthTokens, error)
 	GetUserToken(userId, tokenId uuid.UUID) (model.AuthToken, error)
 	DeleteAuthToken(ctx context.Context, authToken model.AuthToken) error
 	CreateAuthSecret(ctx context.Context, authSecret model.AuthSecret) (model.AuthSecret, error)

--- a/cmd/api/src/database/db.go
+++ b/cmd/api/src/database/db.go
@@ -107,7 +107,7 @@ type Database interface {
 	// Auth
 	CreateAuthToken(ctx context.Context, authToken model.AuthToken) (model.AuthToken, error)
 	UpdateAuthToken(ctx context.Context, authToken model.AuthToken) error
-	GetAllAuthTokens(order string, filter model.SQLFilter) (model.AuthTokens, error)
+	GetAllAuthTokens(ctx context.Context, order string, filter model.SQLFilter) (model.AuthTokens, error)
 	GetAuthToken(id uuid.UUID) (model.AuthToken, error)
 	ListUserTokens(userID uuid.UUID, order string, filter model.SQLFilter) (model.AuthTokens, error)
 	GetUserToken(userId, tokenId uuid.UUID) (model.AuthToken, error)

--- a/cmd/api/src/database/db.go
+++ b/cmd/api/src/database/db.go
@@ -115,7 +115,7 @@ type Database interface {
 	GetAuthSecret(ctx context.Context, id int32) (model.AuthSecret, error)
 	UpdateAuthSecret(ctx context.Context, authSecret model.AuthSecret) error
 	DeleteAuthSecret(ctx context.Context, authSecret model.AuthSecret) error
-	InitializeSecretAuth(adminUser model.User, authSecret model.AuthSecret) (model.Installation, error)
+	InitializeSecretAuth(ctx context.Context, adminUser model.User, authSecret model.AuthSecret) (model.Installation, error)
 
 	CreateSAMLIdentityProvider(ctx context.Context, samlProvider model.SAMLProvider) (model.SAMLProvider, error)
 	UpdateSAMLIdentityProvider(ctx context.Context, samlProvider model.SAMLProvider) error

--- a/cmd/api/src/database/db.go
+++ b/cmd/api/src/database/db.go
@@ -112,7 +112,7 @@ type Database interface {
 	GetUserToken(ctx context.Context, userId, tokenId uuid.UUID) (model.AuthToken, error)
 	DeleteAuthToken(ctx context.Context, authToken model.AuthToken) error
 	CreateAuthSecret(ctx context.Context, authSecret model.AuthSecret) (model.AuthSecret, error)
-	GetAuthSecret(id int32) (model.AuthSecret, error)
+	GetAuthSecret(ctx context.Context, id int32) (model.AuthSecret, error)
 	UpdateAuthSecret(ctx context.Context, authSecret model.AuthSecret) error
 	DeleteAuthSecret(ctx context.Context, authSecret model.AuthSecret) error
 	InitializeSAMLAuth(adminUser model.User, samlProvider model.SAMLProvider) (model.SAMLProvider, model.Installation, error)

--- a/cmd/api/src/database/db.go
+++ b/cmd/api/src/database/db.go
@@ -92,8 +92,6 @@ type Database interface {
 	GetAllPermissions(ctx context.Context, order string, filter model.SQLFilter) (model.Permissions, error)
 	GetPermission(ctx context.Context, id int) (model.Permission, error)
 
-	InitializeSAMLAuth(adminUser model.User, samlProvider model.SAMLProvider) (model.SAMLProvider, model.Installation, error)
-	InitializeSecretAuth(adminUser model.User, authSecret model.AuthSecret) (model.Installation, error)
 	CreateInstallation() (model.Installation, error)
 	GetInstallation() (model.Installation, error)
 	HasInstallation() (bool, error)
@@ -106,6 +104,7 @@ type Database interface {
 	DeleteUser(ctx context.Context, user model.User) error
 	LookupUser(ctx context.Context, principalName string) (model.User, error)
 
+	// Auth
 	CreateAuthToken(ctx context.Context, authToken model.AuthToken) (model.AuthToken, error)
 	UpdateAuthToken(authToken model.AuthToken) error
 	GetAllAuthTokens(order string, filter model.SQLFilter) (model.AuthTokens, error)
@@ -117,6 +116,9 @@ type Database interface {
 	GetAuthSecret(id int32) (model.AuthSecret, error)
 	UpdateAuthSecret(ctx context.Context, authSecret model.AuthSecret) error
 	DeleteAuthSecret(ctx context.Context, authSecret model.AuthSecret) error
+	InitializeSAMLAuth(adminUser model.User, samlProvider model.SAMLProvider) (model.SAMLProvider, model.Installation, error)
+	InitializeSecretAuth(adminUser model.User, authSecret model.AuthSecret) (model.Installation, error)
+
 	CreateSAMLIdentityProvider(ctx context.Context, samlProvider model.SAMLProvider) (model.SAMLProvider, error)
 	UpdateSAMLIdentityProvider(ctx context.Context, samlProvider model.SAMLProvider) error
 	LookupSAMLProviderByName(name string) (model.SAMLProvider, error)

--- a/cmd/api/src/database/db.go
+++ b/cmd/api/src/database/db.go
@@ -115,7 +115,6 @@ type Database interface {
 	GetAuthSecret(ctx context.Context, id int32) (model.AuthSecret, error)
 	UpdateAuthSecret(ctx context.Context, authSecret model.AuthSecret) error
 	DeleteAuthSecret(ctx context.Context, authSecret model.AuthSecret) error
-	InitializeSAMLAuth(adminUser model.User, samlProvider model.SAMLProvider) (model.SAMLProvider, model.Installation, error)
 	InitializeSecretAuth(adminUser model.User, authSecret model.AuthSecret) (model.Installation, error)
 
 	CreateSAMLIdentityProvider(ctx context.Context, samlProvider model.SAMLProvider) (model.SAMLProvider, error)

--- a/cmd/api/src/database/db.go
+++ b/cmd/api/src/database/db.go
@@ -109,7 +109,7 @@ type Database interface {
 	UpdateAuthToken(ctx context.Context, authToken model.AuthToken) error
 	GetAllAuthTokens(ctx context.Context, order string, filter model.SQLFilter) (model.AuthTokens, error)
 	GetAuthToken(ctx context.Context, id uuid.UUID) (model.AuthToken, error)
-	GetUserToken(userId, tokenId uuid.UUID) (model.AuthToken, error)
+	GetUserToken(ctx context.Context, userId, tokenId uuid.UUID) (model.AuthToken, error)
 	DeleteAuthToken(ctx context.Context, authToken model.AuthToken) error
 	CreateAuthSecret(ctx context.Context, authSecret model.AuthSecret) (model.AuthSecret, error)
 	GetAuthSecret(id int32) (model.AuthSecret, error)

--- a/cmd/api/src/database/db.go
+++ b/cmd/api/src/database/db.go
@@ -108,7 +108,7 @@ type Database interface {
 	CreateAuthToken(ctx context.Context, authToken model.AuthToken) (model.AuthToken, error)
 	UpdateAuthToken(ctx context.Context, authToken model.AuthToken) error
 	GetAllAuthTokens(ctx context.Context, order string, filter model.SQLFilter) (model.AuthTokens, error)
-	GetAuthToken(id uuid.UUID) (model.AuthToken, error)
+	GetAuthToken(ctx context.Context, id uuid.UUID) (model.AuthToken, error)
 	ListUserTokens(userID uuid.UUID, order string, filter model.SQLFilter) (model.AuthTokens, error)
 	GetUserToken(userId, tokenId uuid.UUID) (model.AuthToken, error)
 	DeleteAuthToken(ctx context.Context, authToken model.AuthToken) error

--- a/cmd/api/src/database/mocks/db.go
+++ b/cmd/api/src/database/mocks/db.go
@@ -1107,21 +1107,6 @@ func (mr *MockDatabaseMockRecorder) ListSavedQueries(arg0, arg1, arg2, arg3, arg
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSavedQueries", reflect.TypeOf((*MockDatabase)(nil).ListSavedQueries), arg0, arg1, arg2, arg3, arg4)
 }
 
-// ListUserTokens mocks base method.
-func (m *MockDatabase) ListUserTokens(arg0 uuid.UUID, arg1 string, arg2 model.SQLFilter) (model.AuthTokens, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListUserTokens", arg0, arg1, arg2)
-	ret0, _ := ret[0].(model.AuthTokens)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListUserTokens indicates an expected call of ListUserTokens.
-func (mr *MockDatabaseMockRecorder) ListUserTokens(arg0, arg1, arg2 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListUserTokens", reflect.TypeOf((*MockDatabase)(nil).ListUserTokens), arg0, arg1, arg2)
-}
-
 // LookupActiveSessionsByUser mocks base method.
 func (m *MockDatabase) LookupActiveSessionsByUser(arg0 model.User) ([]model.UserSession, error) {
 	m.ctrl.T.Helper()

--- a/cmd/api/src/database/mocks/db.go
+++ b/cmd/api/src/database/mocks/db.go
@@ -728,18 +728,18 @@ func (mr *MockDatabaseMockRecorder) GetAuthSecret(arg0 interface{}) *gomock.Call
 }
 
 // GetAuthToken mocks base method.
-func (m *MockDatabase) GetAuthToken(arg0 uuid.UUID) (model.AuthToken, error) {
+func (m *MockDatabase) GetAuthToken(arg0 context.Context, arg1 uuid.UUID) (model.AuthToken, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAuthToken", arg0)
+	ret := m.ctrl.Call(m, "GetAuthToken", arg0, arg1)
 	ret0, _ := ret[0].(model.AuthToken)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetAuthToken indicates an expected call of GetAuthToken.
-func (mr *MockDatabaseMockRecorder) GetAuthToken(arg0 interface{}) *gomock.Call {
+func (mr *MockDatabaseMockRecorder) GetAuthToken(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAuthToken", reflect.TypeOf((*MockDatabase)(nil).GetAuthToken), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAuthToken", reflect.TypeOf((*MockDatabase)(nil).GetAuthToken), arg0, arg1)
 }
 
 // GetAzureDataQualityAggregations mocks base method.

--- a/cmd/api/src/database/mocks/db.go
+++ b/cmd/api/src/database/mocks/db.go
@@ -1045,18 +1045,18 @@ func (mr *MockDatabaseMockRecorder) HasInstallation() *gomock.Call {
 }
 
 // InitializeSecretAuth mocks base method.
-func (m *MockDatabase) InitializeSecretAuth(arg0 model.User, arg1 model.AuthSecret) (model.Installation, error) {
+func (m *MockDatabase) InitializeSecretAuth(arg0 context.Context, arg1 model.User, arg2 model.AuthSecret) (model.Installation, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InitializeSecretAuth", arg0, arg1)
+	ret := m.ctrl.Call(m, "InitializeSecretAuth", arg0, arg1, arg2)
 	ret0, _ := ret[0].(model.Installation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // InitializeSecretAuth indicates an expected call of InitializeSecretAuth.
-func (mr *MockDatabaseMockRecorder) InitializeSecretAuth(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockDatabaseMockRecorder) InitializeSecretAuth(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InitializeSecretAuth", reflect.TypeOf((*MockDatabase)(nil).InitializeSecretAuth), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InitializeSecretAuth", reflect.TypeOf((*MockDatabase)(nil).InitializeSecretAuth), arg0, arg1, arg2)
 }
 
 // ListAuditLogs mocks base method.

--- a/cmd/api/src/database/mocks/db.go
+++ b/cmd/api/src/database/mocks/db.go
@@ -713,18 +713,18 @@ func (mr *MockDatabaseMockRecorder) GetAssetGroupSelector(arg0, arg1 interface{}
 }
 
 // GetAuthSecret mocks base method.
-func (m *MockDatabase) GetAuthSecret(arg0 int32) (model.AuthSecret, error) {
+func (m *MockDatabase) GetAuthSecret(arg0 context.Context, arg1 int32) (model.AuthSecret, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAuthSecret", arg0)
+	ret := m.ctrl.Call(m, "GetAuthSecret", arg0, arg1)
 	ret0, _ := ret[0].(model.AuthSecret)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetAuthSecret indicates an expected call of GetAuthSecret.
-func (mr *MockDatabaseMockRecorder) GetAuthSecret(arg0 interface{}) *gomock.Call {
+func (mr *MockDatabaseMockRecorder) GetAuthSecret(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAuthSecret", reflect.TypeOf((*MockDatabase)(nil).GetAuthSecret), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAuthSecret", reflect.TypeOf((*MockDatabase)(nil).GetAuthSecret), arg0, arg1)
 }
 
 // GetAuthToken mocks base method.

--- a/cmd/api/src/database/mocks/db.go
+++ b/cmd/api/src/database/mocks/db.go
@@ -532,18 +532,18 @@ func (mr *MockDatabaseMockRecorder) GetAllAssetGroups(arg0, arg1, arg2 interface
 }
 
 // GetAllAuthTokens mocks base method.
-func (m *MockDatabase) GetAllAuthTokens(arg0 string, arg1 model.SQLFilter) (model.AuthTokens, error) {
+func (m *MockDatabase) GetAllAuthTokens(arg0 context.Context, arg1 string, arg2 model.SQLFilter) (model.AuthTokens, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAllAuthTokens", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetAllAuthTokens", arg0, arg1, arg2)
 	ret0, _ := ret[0].(model.AuthTokens)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetAllAuthTokens indicates an expected call of GetAllAuthTokens.
-func (mr *MockDatabaseMockRecorder) GetAllAuthTokens(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockDatabaseMockRecorder) GetAllAuthTokens(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllAuthTokens", reflect.TypeOf((*MockDatabase)(nil).GetAllAuthTokens), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllAuthTokens", reflect.TypeOf((*MockDatabase)(nil).GetAllAuthTokens), arg0, arg1, arg2)
 }
 
 // GetAllConfigurationParameters mocks base method.

--- a/cmd/api/src/database/mocks/db.go
+++ b/cmd/api/src/database/mocks/db.go
@@ -1044,22 +1044,6 @@ func (mr *MockDatabaseMockRecorder) HasInstallation() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasInstallation", reflect.TypeOf((*MockDatabase)(nil).HasInstallation))
 }
 
-// InitializeSAMLAuth mocks base method.
-func (m *MockDatabase) InitializeSAMLAuth(arg0 model.User, arg1 model.SAMLProvider) (model.SAMLProvider, model.Installation, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InitializeSAMLAuth", arg0, arg1)
-	ret0, _ := ret[0].(model.SAMLProvider)
-	ret1, _ := ret[1].(model.Installation)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
-}
-
-// InitializeSAMLAuth indicates an expected call of InitializeSAMLAuth.
-func (mr *MockDatabaseMockRecorder) InitializeSAMLAuth(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InitializeSAMLAuth", reflect.TypeOf((*MockDatabase)(nil).InitializeSAMLAuth), arg0, arg1)
-}
-
 // InitializeSecretAuth mocks base method.
 func (m *MockDatabase) InitializeSecretAuth(arg0 model.User, arg1 model.AuthSecret) (model.Installation, error) {
 	m.ctrl.T.Helper()

--- a/cmd/api/src/database/mocks/db.go
+++ b/cmd/api/src/database/mocks/db.go
@@ -1307,17 +1307,17 @@ func (mr *MockDatabaseMockRecorder) UpdateAuthSecret(arg0, arg1 interface{}) *go
 }
 
 // UpdateAuthToken mocks base method.
-func (m *MockDatabase) UpdateAuthToken(arg0 model.AuthToken) error {
+func (m *MockDatabase) UpdateAuthToken(arg0 context.Context, arg1 model.AuthToken) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateAuthToken", arg0)
+	ret := m.ctrl.Call(m, "UpdateAuthToken", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpdateAuthToken indicates an expected call of UpdateAuthToken.
-func (mr *MockDatabaseMockRecorder) UpdateAuthToken(arg0 interface{}) *gomock.Call {
+func (mr *MockDatabaseMockRecorder) UpdateAuthToken(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAuthToken", reflect.TypeOf((*MockDatabase)(nil).UpdateAuthToken), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAuthToken", reflect.TypeOf((*MockDatabase)(nil).UpdateAuthToken), arg0, arg1)
 }
 
 // UpdateFileUploadJob mocks base method.

--- a/cmd/api/src/database/mocks/db.go
+++ b/cmd/api/src/database/mocks/db.go
@@ -1015,18 +1015,18 @@ func (mr *MockDatabaseMockRecorder) GetUserSession(arg0 interface{}) *gomock.Cal
 }
 
 // GetUserToken mocks base method.
-func (m *MockDatabase) GetUserToken(arg0, arg1 uuid.UUID) (model.AuthToken, error) {
+func (m *MockDatabase) GetUserToken(arg0 context.Context, arg1, arg2 uuid.UUID) (model.AuthToken, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetUserToken", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetUserToken", arg0, arg1, arg2)
 	ret0, _ := ret[0].(model.AuthToken)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetUserToken indicates an expected call of GetUserToken.
-func (mr *MockDatabaseMockRecorder) GetUserToken(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockDatabaseMockRecorder) GetUserToken(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserToken", reflect.TypeOf((*MockDatabase)(nil).GetUserToken), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserToken", reflect.TypeOf((*MockDatabase)(nil).GetUserToken), arg0, arg1, arg2)
 }
 
 // HasInstallation mocks base method.


### PR DESCRIPTION
## Description

Plumb context into gorm auth token / secrets  db methods
https://gorm.io/docs/context.html#Context-Timeout

**There is quite a bit of cleanup in this PR, removed the following unused methods**

Db Methods
- ListUsersTokens
- InitializeSAMLAuth

## Motivation and Context

Currently as it stands any endpoints that rely on purely gorm do not respect `request.Context` and as such timeouts are not respected either. While we want to eventually get to the removal of the gorm dependency altogether, that is a long way and a lot of effort away and this I think this approach would give us that much room to maneuver while we get there.

## How Has This Been Tested?

Using a rest client and the prefer header
Add a sleep inside of the handler
Look for the `500 request timed out` after exceeding the timeout. (Note: the request will take as long as the sleep is set, it's not tied to the prefer header)

## Types of changes

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [x] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
