### PR TITLE
fix: plumb ctx into file uploads db methods

### DIFF
--- a/cmd/api/src/api/v2/file_uploads.go
+++ b/cmd/api/src/api/v2/file_uploads.go
@@ -117,7 +117,7 @@ func (s Resources) StartFileUploadJob(response http.ResponseWriter, request *htt
 
 	if user, valid := auth.GetUserFromAuthCtx(reqCtx.AuthCtx); !valid {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusUnauthorized, api.ErrorResponseDetailsAuthenticationInvalid, request), response)
-	} else if fileUploadJob, err := fileupload.StartFileUploadJob(s.DB, user); err != nil {
+	} else if fileUploadJob, err := fileupload.StartFileUploadJob(request.Context(), s.DB, user); err != nil {
 		api.HandleDatabaseError(request, response, err)
 	} else {
 		api.WriteBasicResponse(request.Context(), fileUploadJob, http.StatusCreated, response)

--- a/cmd/api/src/api/v2/file_uploads.go
+++ b/cmd/api/src/api/v2/file_uploads.go
@@ -132,7 +132,7 @@ func (s Resources) ProcessFileUpload(response http.ResponseWriter, request *http
 
 	if fileUploadJobID, err := strconv.Atoi(fileUploadJobIdString); err != nil {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, api.ErrorResponseDetailsIDMalformed, request), response)
-	} else if fileUploadJob, err := fileupload.GetFileUploadJobByID(s.DB, int64(fileUploadJobID)); err != nil {
+	} else if fileUploadJob, err := fileupload.GetFileUploadJobByID(request.Context(), s.DB, int64(fileUploadJobID)); err != nil {
 		api.HandleDatabaseError(request, response, err)
 	} else if fileName, err := fileupload.SaveIngestFile(s.Config.TempDirectory(), request.Body); errors.Is(err, fileupload.ErrInvalidJSON) {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, fmt.Sprintf("Error saving ingest file: %v", err), request), response)
@@ -154,7 +154,7 @@ func (s Resources) EndFileUploadJob(response http.ResponseWriter, request *http.
 
 	if fileUploadJobID, err := strconv.Atoi(fileUploadJobIdString); err != nil {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, api.ErrorResponseDetailsIDMalformed, request), response)
-	} else if fileUploadJob, err := fileupload.GetFileUploadJobByID(s.DB, int64(fileUploadJobID)); err != nil {
+	} else if fileUploadJob, err := fileupload.GetFileUploadJobByID(request.Context(), s.DB, int64(fileUploadJobID)); err != nil {
 		api.HandleDatabaseError(request, response, err)
 	} else if fileUploadJob.Status != model.JobStatusRunning {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, "job must be in running status to end", request), response)

--- a/cmd/api/src/api/v2/file_uploads.go
+++ b/cmd/api/src/api/v2/file_uploads.go
@@ -103,7 +103,7 @@ func (s Resources) ListFileUploadJobs(response http.ResponseWriter, request *htt
 			api.WriteErrorResponse(request.Context(), ErrBadQueryParameter(request, model.PaginationQueryParameterSkip, err), response)
 		} else if limit, err := ParseLimitQueryParameter(queryParams, 100); err != nil {
 			api.WriteErrorResponse(request.Context(), ErrBadQueryParameter(request, model.PaginationQueryParameterLimit, err), response)
-		} else if fileUploadJobs, count, err := fileupload.GetAllFileUploadJobs(s.DB, skip, limit, strings.Join(order, ", "), sqlFilter); err != nil {
+		} else if fileUploadJobs, count, err := fileupload.GetAllFileUploadJobs(request.Context(), s.DB, skip, limit, strings.Join(order, ", "), sqlFilter); err != nil {
 			api.HandleDatabaseError(request, response, err)
 		} else {
 			api.WriteResponseWrapperWithPagination(request.Context(), fileUploadJobs, limit, skip, count, http.StatusOK, response)

--- a/cmd/api/src/api/v2/file_uploads.go
+++ b/cmd/api/src/api/v2/file_uploads.go
@@ -140,7 +140,7 @@ func (s Resources) ProcessFileUpload(response http.ResponseWriter, request *http
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusInternalServerError, fmt.Sprintf("Error saving ingest file: %v", err), request), response)
 	} else if _, err = ingest.CreateIngestTask(request.Context(), s.DB, fileName, requestId, int64(fileUploadJobID)); err != nil {
 		api.HandleDatabaseError(request, response, err)
-	} else if err = fileupload.TouchFileUploadJobLastIngest(s.DB, fileUploadJob); err != nil {
+	} else if err = fileupload.TouchFileUploadJobLastIngest(request.Context(), s.DB, fileUploadJob); err != nil {
 		api.HandleDatabaseError(request, response, err)
 	} else {
 		response.WriteHeader(http.StatusAccepted)
@@ -158,7 +158,7 @@ func (s Resources) EndFileUploadJob(response http.ResponseWriter, request *http.
 		api.HandleDatabaseError(request, response, err)
 	} else if fileUploadJob.Status != model.JobStatusRunning {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, "job must be in running status to end", request), response)
-	} else if err := fileupload.EndFileUploadJob(s.DB, fileUploadJob); err != nil {
+	} else if err := fileupload.EndFileUploadJob(request.Context(), s.DB, fileUploadJob); err != nil {
 		api.HandleDatabaseError(request, response, err)
 	} else {
 		response.WriteHeader(http.StatusOK)

--- a/cmd/api/src/api/v2/file_uploads_test.go
+++ b/cmd/api/src/api/v2/file_uploads_test.go
@@ -123,7 +123,7 @@ func TestResources_StartFileUploadJob(t *testing.T) {
 					apitest.SetContext(input, userCtx)
 				},
 				Setup: func() {
-					mockDB.EXPECT().CreateFileUploadJob(gomock.Any()).Return(model.FileUploadJob{}, errors.New("db error"))
+					mockDB.EXPECT().CreateFileUploadJob(gomock.Any(), gomock.Any()).Return(model.FileUploadJob{}, errors.New("db error"))
 				},
 				Test: func(output apitest.Output) {
 					apitest.StatusCode(output, http.StatusInternalServerError)
@@ -135,7 +135,7 @@ func TestResources_StartFileUploadJob(t *testing.T) {
 					apitest.SetContext(input, userCtx)
 				},
 				Setup: func() {
-					mockDB.EXPECT().CreateFileUploadJob(gomock.Any()).Return(model.FileUploadJob{}, nil)
+					mockDB.EXPECT().CreateFileUploadJob(gomock.Any(), gomock.Any()).Return(model.FileUploadJob{}, nil)
 				},
 				Test: func(output apitest.Output) {
 					apitest.StatusCode(output, http.StatusCreated)

--- a/cmd/api/src/api/v2/file_uploads_test.go
+++ b/cmd/api/src/api/v2/file_uploads_test.go
@@ -201,7 +201,7 @@ func TestResources_EndFileUploadJob(t *testing.T) {
 					mockDB.EXPECT().GetFileUploadJob(gomock.Any()).Return(model.FileUploadJob{
 						Status: model.JobStatusRunning,
 					}, nil)
-					mockDB.EXPECT().UpdateFileUploadJob(gomock.Any()).Return(errors.New("database error"))
+					mockDB.EXPECT().UpdateFileUploadJob(gomock.Any(), gomock.Any()).Return(errors.New("database error"))
 				},
 				Test: func(output apitest.Output) {
 					apitest.StatusCode(output, http.StatusInternalServerError)
@@ -216,7 +216,7 @@ func TestResources_EndFileUploadJob(t *testing.T) {
 					mockDB.EXPECT().GetFileUploadJob(gomock.Any()).Return(model.FileUploadJob{
 						Status: model.JobStatusRunning,
 					}, nil)
-					mockDB.EXPECT().UpdateFileUploadJob(gomock.Any()).Return(nil)
+					mockDB.EXPECT().UpdateFileUploadJob(gomock.Any(), gomock.Any()).Return(nil)
 				},
 				Test: func(output apitest.Output) {
 					apitest.StatusCode(output, http.StatusOK)

--- a/cmd/api/src/api/v2/file_uploads_test.go
+++ b/cmd/api/src/api/v2/file_uploads_test.go
@@ -73,7 +73,7 @@ func TestResources_ListFileUploadJobs(t *testing.T) {
 			{
 				Name: "GetAllFileUploadJobsDatabaseError",
 				Setup: func() {
-					mockDB.EXPECT().GetAllFileUploadJobs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, 0, errors.New("database error"))
+					mockDB.EXPECT().GetAllFileUploadJobs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, 0, errors.New("database error"))
 				},
 				Test: func(output apitest.Output) {
 					apitest.StatusCode(output, http.StatusInternalServerError)
@@ -88,7 +88,7 @@ func TestResources_ListFileUploadJobs(t *testing.T) {
 					apitest.AddQueryParam(input, "user_id", "eq:123")
 				},
 				Setup: func() {
-					mockDB.EXPECT().GetAllFileUploadJobs(1, 2, "start_time", model.SQLFilter{SQLString: "user_id = ?", Params: []any{"123"}}).Return([]model.FileUploadJob{}, 0, nil)
+					mockDB.EXPECT().GetAllFileUploadJobs(gomock.Any(), 1, 2, "start_time", model.SQLFilter{SQLString: "user_id = ?", Params: []any{"123"}}).Return([]model.FileUploadJob{}, 0, nil)
 				},
 				Test: func(output apitest.Output) {
 					apitest.StatusCode(output, http.StatusOK)

--- a/cmd/api/src/api/v2/file_uploads_test.go
+++ b/cmd/api/src/api/v2/file_uploads_test.go
@@ -171,7 +171,7 @@ func TestResources_EndFileUploadJob(t *testing.T) {
 					apitest.SetURLVar(input, v2.FileUploadJobIdPathParameterName, "123")
 				},
 				Setup: func() {
-					mockDB.EXPECT().GetFileUploadJob(gomock.Any()).Return(model.FileUploadJob{}, errors.New("db error"))
+					mockDB.EXPECT().GetFileUploadJob(gomock.Any(), gomock.Any()).Return(model.FileUploadJob{}, errors.New("db error"))
 				},
 				Test: func(output apitest.Output) {
 					apitest.StatusCode(output, http.StatusInternalServerError)
@@ -183,7 +183,7 @@ func TestResources_EndFileUploadJob(t *testing.T) {
 					apitest.SetURLVar(input, v2.FileUploadJobIdPathParameterName, "123")
 				},
 				Setup: func() {
-					mockDB.EXPECT().GetFileUploadJob(gomock.Any()).Return(model.FileUploadJob{
+					mockDB.EXPECT().GetFileUploadJob(gomock.Any(), gomock.Any()).Return(model.FileUploadJob{
 						Status: model.JobStatusComplete,
 					}, nil)
 				},
@@ -198,7 +198,7 @@ func TestResources_EndFileUploadJob(t *testing.T) {
 					apitest.SetURLVar(input, v2.FileUploadJobIdPathParameterName, "123")
 				},
 				Setup: func() {
-					mockDB.EXPECT().GetFileUploadJob(gomock.Any()).Return(model.FileUploadJob{
+					mockDB.EXPECT().GetFileUploadJob(gomock.Any(), gomock.Any()).Return(model.FileUploadJob{
 						Status: model.JobStatusRunning,
 					}, nil)
 					mockDB.EXPECT().UpdateFileUploadJob(gomock.Any(), gomock.Any()).Return(errors.New("database error"))
@@ -213,7 +213,7 @@ func TestResources_EndFileUploadJob(t *testing.T) {
 					apitest.SetURLVar(input, v2.FileUploadJobIdPathParameterName, "123")
 				},
 				Setup: func() {
-					mockDB.EXPECT().GetFileUploadJob(gomock.Any()).Return(model.FileUploadJob{
+					mockDB.EXPECT().GetFileUploadJob(gomock.Any(), gomock.Any()).Return(model.FileUploadJob{
 						Status: model.JobStatusRunning,
 					}, nil)
 					mockDB.EXPECT().UpdateFileUploadJob(gomock.Any(), gomock.Any()).Return(nil)

--- a/cmd/api/src/daemons/datapipe/datapipe.go
+++ b/cmd/api/src/daemons/datapipe/datapipe.go
@@ -168,7 +168,7 @@ func (s *Daemon) Start() {
 			ProcessIngestedFileUploadJobs(s.ctx, s.db)
 
 			// If there are completed file upload jobs or if analysis was user-requested, perform analysis.
-			if hasJobsWaitingForAnalysis, err := HasFileUploadJobsWaitingForAnalysis(s.db); err != nil {
+			if hasJobsWaitingForAnalysis, err := HasFileUploadJobsWaitingForAnalysis(s.ctx, s.db); err != nil {
 				log.Errorf("Failed looking up jobs waiting for analysis: %v", err)
 			} else if hasJobsWaitingForAnalysis || s.getAnalysisRequested() {
 				s.analyze()

--- a/cmd/api/src/daemons/datapipe/jobs.go
+++ b/cmd/api/src/daemons/datapipe/jobs.go
@@ -47,7 +47,7 @@ func FailAnalyzedFileUploadJobs(ctx context.Context, db database.Database) {
 		log.Errorf("Failed to load file upload jobs under analysis: %v", err)
 	} else {
 		for _, job := range fileUploadJobsUnderAnalysis {
-			if err := fileupload.UpdateFileUploadJobStatus(db, job, model.JobStatusFailed, "Analysis failed"); err != nil {
+			if err := fileupload.UpdateFileUploadJobStatus(ctx, db, job, model.JobStatusFailed, "Analysis failed"); err != nil {
 				log.Errorf("Failed updating file upload job %d to failed status: %v", job.ID, err)
 			}
 		}
@@ -65,7 +65,7 @@ func PartialCompleteFileUploadJobs(ctx context.Context, db database.Database) {
 		log.Errorf("Failed to load file upload jobs under analysis: %v", err)
 	} else {
 		for _, job := range fileUploadJobsUnderAnalysis {
-			if err := fileupload.UpdateFileUploadJobStatus(db, job, model.JobStatusPartiallyComplete, "Partially Completed"); err != nil {
+			if err := fileupload.UpdateFileUploadJobStatus(ctx, db, job, model.JobStatusPartiallyComplete, "Partially Completed"); err != nil {
 				log.Errorf("Failed updating file upload job %d to partially completed status: %v", job.ID, err)
 			}
 		}
@@ -83,7 +83,7 @@ func CompleteAnalyzedFileUploadJobs(ctx context.Context, db database.Database) {
 		log.Errorf("Failed to load file upload jobs under analysis: %v", err)
 	} else {
 		for _, job := range fileUploadJobsUnderAnalysis {
-			if err := fileupload.UpdateFileUploadJobStatus(db, job, model.JobStatusComplete, "Complete"); err != nil {
+			if err := fileupload.UpdateFileUploadJobStatus(ctx, db, job, model.JobStatusComplete, "Complete"); err != nil {
 				log.Errorf("Error updating fileupload job %d: %v", job.ID, err)
 			}
 		}
@@ -104,7 +104,7 @@ func ProcessIngestedFileUploadJobs(ctx context.Context, db database.Database) {
 			if remainingIngestTasks, err := db.GetIngestTasksForJob(ctx, ingestingFileUploadJob.ID); err != nil {
 				log.Errorf("Failed looking up remaining ingest tasks for file upload job %d: %v", ingestingFileUploadJob.ID, err)
 			} else if len(remainingIngestTasks) == 0 {
-				if err := fileupload.UpdateFileUploadJobStatus(db, ingestingFileUploadJob, model.JobStatusAnalyzing, "Analyzing"); err != nil {
+				if err := fileupload.UpdateFileUploadJobStatus(ctx, db, ingestingFileUploadJob, model.JobStatusAnalyzing, "Analyzing"); err != nil {
 					log.Errorf("Error updating fileupload job %d: %v", ingestingFileUploadJob.ID, err)
 				}
 			}

--- a/cmd/api/src/daemons/datapipe/jobs.go
+++ b/cmd/api/src/daemons/datapipe/jobs.go
@@ -28,8 +28,8 @@ import (
 	"github.com/specterops/bloodhound/src/services/fileupload"
 )
 
-func HasFileUploadJobsWaitingForAnalysis(db database.Database) (bool, error) {
-	if fileUploadJobsUnderAnalysis, err := db.GetFileUploadJobsWithStatus(model.JobStatusAnalyzing); err != nil {
+func HasFileUploadJobsWaitingForAnalysis(ctx context.Context, db database.Database) (bool, error) {
+	if fileUploadJobsUnderAnalysis, err := db.GetFileUploadJobsWithStatus(ctx, model.JobStatusAnalyzing); err != nil {
 		return false, err
 	} else {
 		return len(fileUploadJobsUnderAnalysis) > 0, nil
@@ -43,7 +43,7 @@ func FailAnalyzedFileUploadJobs(ctx context.Context, db database.Database) {
 		return
 	}
 
-	if fileUploadJobsUnderAnalysis, err := db.GetFileUploadJobsWithStatus(model.JobStatusAnalyzing); err != nil {
+	if fileUploadJobsUnderAnalysis, err := db.GetFileUploadJobsWithStatus(ctx, model.JobStatusAnalyzing); err != nil {
 		log.Errorf("Failed to load file upload jobs under analysis: %v", err)
 	} else {
 		for _, job := range fileUploadJobsUnderAnalysis {
@@ -61,7 +61,7 @@ func PartialCompleteFileUploadJobs(ctx context.Context, db database.Database) {
 		return
 	}
 
-	if fileUploadJobsUnderAnalysis, err := db.GetFileUploadJobsWithStatus(model.JobStatusAnalyzing); err != nil {
+	if fileUploadJobsUnderAnalysis, err := db.GetFileUploadJobsWithStatus(ctx, model.JobStatusAnalyzing); err != nil {
 		log.Errorf("Failed to load file upload jobs under analysis: %v", err)
 	} else {
 		for _, job := range fileUploadJobsUnderAnalysis {
@@ -79,7 +79,7 @@ func CompleteAnalyzedFileUploadJobs(ctx context.Context, db database.Database) {
 		return
 	}
 
-	if fileUploadJobsUnderAnalysis, err := db.GetFileUploadJobsWithStatus(model.JobStatusAnalyzing); err != nil {
+	if fileUploadJobsUnderAnalysis, err := db.GetFileUploadJobsWithStatus(ctx, model.JobStatusAnalyzing); err != nil {
 		log.Errorf("Failed to load file upload jobs under analysis: %v", err)
 	} else {
 		for _, job := range fileUploadJobsUnderAnalysis {
@@ -97,7 +97,7 @@ func ProcessIngestedFileUploadJobs(ctx context.Context, db database.Database) {
 		return
 	}
 
-	if ingestingFileUploadJobs, err := db.GetFileUploadJobsWithStatus(model.JobStatusIngesting); err != nil {
+	if ingestingFileUploadJobs, err := db.GetFileUploadJobsWithStatus(ctx, model.JobStatusIngesting); err != nil {
 		log.Errorf("Failed to look up finished file upload jobs: %v", err)
 	} else {
 		for _, ingestingFileUploadJob := range ingestingFileUploadJobs {

--- a/cmd/api/src/daemons/datapipe/jobs_test.go
+++ b/cmd/api/src/daemons/datapipe/jobs_test.go
@@ -35,18 +35,18 @@ func TestHasJobsWaitingForAnalysis(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	t.Run("Has Jobs Waiting for Analysis", func(t *testing.T) {
-		dbMock.EXPECT().GetFileUploadJobsWithStatus(model.JobStatusAnalyzing).Return([]model.FileUploadJob{{}}, nil)
+		dbMock.EXPECT().GetFileUploadJobsWithStatus(gomock.Any(), model.JobStatusAnalyzing).Return([]model.FileUploadJob{{}}, nil)
 
-		hasJobs, err := datapipe.HasFileUploadJobsWaitingForAnalysis(dbMock)
+		hasJobs, err := datapipe.HasFileUploadJobsWaitingForAnalysis(context.Background(), dbMock)
 
 		require.True(t, hasJobs)
 		require.Nil(t, err)
 	})
 
 	t.Run("Has No Jobs Waiting for Analysis", func(t *testing.T) {
-		dbMock.EXPECT().GetFileUploadJobsWithStatus(model.JobStatusAnalyzing).Return([]model.FileUploadJob{}, nil)
+		dbMock.EXPECT().GetFileUploadJobsWithStatus(gomock.Any(), model.JobStatusAnalyzing).Return([]model.FileUploadJob{}, nil)
 
-		hasJobs, err := datapipe.HasFileUploadJobsWaitingForAnalysis(dbMock)
+		hasJobs, err := datapipe.HasFileUploadJobsWaitingForAnalysis(context.Background(), dbMock)
 
 		require.False(t, hasJobs)
 		require.Nil(t, err)
@@ -64,7 +64,7 @@ func TestFailAnalyzedFileUploadJobs(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	t.Run("Fail Analyzed File Upload Jobs", func(t *testing.T) {
-		dbMock.EXPECT().GetFileUploadJobsWithStatus(model.JobStatusAnalyzing).Return([]model.FileUploadJob{{
+		dbMock.EXPECT().GetFileUploadJobsWithStatus(gomock.Any(), model.JobStatusAnalyzing).Return([]model.FileUploadJob{{
 			BigSerial: model.BigSerial{
 				ID: jobID,
 			},
@@ -91,7 +91,7 @@ func TestCompleteAnalyzedFileUploadJobs(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	t.Run("Complete Analyzed File Upload Jobs", func(t *testing.T) {
-		dbMock.EXPECT().GetFileUploadJobsWithStatus(model.JobStatusAnalyzing).Return([]model.FileUploadJob{{
+		dbMock.EXPECT().GetFileUploadJobsWithStatus(gomock.Any(), model.JobStatusAnalyzing).Return([]model.FileUploadJob{{
 			BigSerial: model.BigSerial{
 				ID: jobID,
 			},
@@ -118,7 +118,7 @@ func TestProcessIngestedFileUploadJobs(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	t.Run("Transition Jobs with No Remaining Ingest Tasks", func(t *testing.T) {
-		dbMock.EXPECT().GetFileUploadJobsWithStatus(model.JobStatusIngesting).Return([]model.FileUploadJob{{
+		dbMock.EXPECT().GetFileUploadJobsWithStatus(gomock.Any(), model.JobStatusIngesting).Return([]model.FileUploadJob{{
 			BigSerial: model.BigSerial{
 				ID: jobID,
 			},
@@ -135,7 +135,7 @@ func TestProcessIngestedFileUploadJobs(t *testing.T) {
 	})
 
 	t.Run("Don't Transition Jobs with Remaining Ingest Tasks", func(t *testing.T) {
-		dbMock.EXPECT().GetFileUploadJobsWithStatus(model.JobStatusIngesting).Return([]model.FileUploadJob{{
+		dbMock.EXPECT().GetFileUploadJobsWithStatus(gomock.Any(), model.JobStatusIngesting).Return([]model.FileUploadJob{{
 			BigSerial: model.BigSerial{
 				ID: jobID,
 			},

--- a/cmd/api/src/daemons/datapipe/jobs_test.go
+++ b/cmd/api/src/daemons/datapipe/jobs_test.go
@@ -71,7 +71,7 @@ func TestFailAnalyzedFileUploadJobs(t *testing.T) {
 			Status: model.JobStatusAnalyzing,
 		}}, nil)
 
-		dbMock.EXPECT().UpdateFileUploadJob(gomock.Any()).DoAndReturn(func(fileUploadJob model.FileUploadJob) error {
+		dbMock.EXPECT().UpdateFileUploadJob(gomock.Any(), gomock.Any()).DoAndReturn(func(fileUploadJob model.FileUploadJob) error {
 			require.Equal(t, model.JobStatusFailed, fileUploadJob.Status)
 			return nil
 		})
@@ -98,7 +98,7 @@ func TestCompleteAnalyzedFileUploadJobs(t *testing.T) {
 			Status: model.JobStatusAnalyzing,
 		}}, nil)
 
-		dbMock.EXPECT().UpdateFileUploadJob(gomock.Any()).DoAndReturn(func(fileUploadJob model.FileUploadJob) error {
+		dbMock.EXPECT().UpdateFileUploadJob(gomock.Any(), gomock.Any()).DoAndReturn(func(fileUploadJob model.FileUploadJob) error {
 			require.Equal(t, model.JobStatusComplete, fileUploadJob.Status)
 			return nil
 		})
@@ -126,7 +126,7 @@ func TestProcessIngestedFileUploadJobs(t *testing.T) {
 		}}, nil)
 
 		dbMock.EXPECT().GetIngestTasksForJob(gomock.Any(), jobID).Return([]model.IngestTask{}, nil)
-		dbMock.EXPECT().UpdateFileUploadJob(gomock.Any()).DoAndReturn(func(fileUploadJob model.FileUploadJob) error {
+		dbMock.EXPECT().UpdateFileUploadJob(gomock.Any(), gomock.Any()).DoAndReturn(func(fileUploadJob model.FileUploadJob) error {
 			require.Equal(t, model.JobStatusAnalyzing, fileUploadJob.Status)
 			return nil
 		})

--- a/cmd/api/src/daemons/datapipe/jobs_test.go
+++ b/cmd/api/src/daemons/datapipe/jobs_test.go
@@ -71,7 +71,7 @@ func TestFailAnalyzedFileUploadJobs(t *testing.T) {
 			Status: model.JobStatusAnalyzing,
 		}}, nil)
 
-		dbMock.EXPECT().UpdateFileUploadJob(gomock.Any(), gomock.Any()).DoAndReturn(func(fileUploadJob model.FileUploadJob) error {
+		dbMock.EXPECT().UpdateFileUploadJob(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, fileUploadJob model.FileUploadJob) error {
 			require.Equal(t, model.JobStatusFailed, fileUploadJob.Status)
 			return nil
 		})
@@ -98,7 +98,7 @@ func TestCompleteAnalyzedFileUploadJobs(t *testing.T) {
 			Status: model.JobStatusAnalyzing,
 		}}, nil)
 
-		dbMock.EXPECT().UpdateFileUploadJob(gomock.Any(), gomock.Any()).DoAndReturn(func(fileUploadJob model.FileUploadJob) error {
+		dbMock.EXPECT().UpdateFileUploadJob(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, fileUploadJob model.FileUploadJob) error {
 			require.Equal(t, model.JobStatusComplete, fileUploadJob.Status)
 			return nil
 		})
@@ -126,7 +126,7 @@ func TestProcessIngestedFileUploadJobs(t *testing.T) {
 		}}, nil)
 
 		dbMock.EXPECT().GetIngestTasksForJob(gomock.Any(), jobID).Return([]model.IngestTask{}, nil)
-		dbMock.EXPECT().UpdateFileUploadJob(gomock.Any(), gomock.Any()).DoAndReturn(func(fileUploadJob model.FileUploadJob) error {
+		dbMock.EXPECT().UpdateFileUploadJob(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, fileUploadJob model.FileUploadJob) error {
 			require.Equal(t, model.JobStatusAnalyzing, fileUploadJob.Status)
 			return nil
 		})

--- a/cmd/api/src/database/db.go
+++ b/cmd/api/src/database/db.go
@@ -144,11 +144,6 @@ type Database interface {
 
 	// File Uploads
 	fileupload.FileUploadData
-	UpdateFileUploadJob(job model.FileUploadJob) error
-	GetFileUploadJob(id int64) (model.FileUploadJob, error)
-	GetAllFileUploadJobs(skip int, limit int, order string, filter model.SQLFilter) ([]model.FileUploadJob, int, error)
-	GetFileUploadJobsWithStatus(status model.JobStatus) ([]model.FileUploadJob, error)
-	DeleteAllFileUploads(ctx context.Context) error
 
 	ListSavedQueries(userID uuid.UUID, order string, filter model.SQLFilter, skip, limit int) (model.SavedQueries, int, error)
 	CreateSavedQuery(userID uuid.UUID, name string, query string) (model.SavedQuery, error)

--- a/cmd/api/src/database/db.go
+++ b/cmd/api/src/database/db.go
@@ -142,7 +142,7 @@ type Database interface {
 	GetAzureDataQualityAggregations(start time.Time, end time.Time, sort_by string, limit int, skip int) (model.AzureDataQualityAggregations, int, error)
 	DeleteAllDataQuality(ctx context.Context) error
 
-	// File Uploads
+	// File Upload
 	fileupload.FileUploadData
 
 	ListSavedQueries(userID uuid.UUID, order string, filter model.SQLFilter, skip, limit int) (model.SavedQueries, int, error)

--- a/cmd/api/src/database/db.go
+++ b/cmd/api/src/database/db.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/specterops/bloodhound/src/services/agi"
+	"github.com/specterops/bloodhound/src/services/fileupload"
 	"github.com/specterops/bloodhound/src/services/ingest"
 	"time"
 
@@ -140,12 +141,15 @@ type Database interface {
 	CreateAzureDataQualityAggregation(aggregation model.AzureDataQualityAggregation) (model.AzureDataQualityAggregation, error)
 	GetAzureDataQualityAggregations(start time.Time, end time.Time, sort_by string, limit int, skip int) (model.AzureDataQualityAggregations, int, error)
 	DeleteAllDataQuality(ctx context.Context) error
-	CreateFileUploadJob(job model.FileUploadJob) (model.FileUploadJob, error)
+
+	// File Uploads
+	fileupload.FileUploadData
 	UpdateFileUploadJob(job model.FileUploadJob) error
 	GetFileUploadJob(id int64) (model.FileUploadJob, error)
 	GetAllFileUploadJobs(skip int, limit int, order string, filter model.SQLFilter) ([]model.FileUploadJob, int, error)
 	GetFileUploadJobsWithStatus(status model.JobStatus) ([]model.FileUploadJob, error)
 	DeleteAllFileUploads(ctx context.Context) error
+
 	ListSavedQueries(userID uuid.UUID, order string, filter model.SQLFilter, skip, limit int) (model.SavedQueries, int, error)
 	CreateSavedQuery(userID uuid.UUID, name string, query string) (model.SavedQuery, error)
 	DeleteSavedQuery(id int) error

--- a/cmd/api/src/database/file_upload.go
+++ b/cmd/api/src/database/file_upload.go
@@ -23,8 +23,8 @@ import (
 	"gorm.io/gorm"
 )
 
-func (s *BloodhoundDB) UpdateFileUploadJob(job model.FileUploadJob) error {
-	result := s.db.Save(&job)
+func (s *BloodhoundDB) UpdateFileUploadJob(ctx context.Context, job model.FileUploadJob) error {
+	result := s.db.WithContext(ctx).Save(&job)
 	return CheckError(result)
 }
 

--- a/cmd/api/src/database/file_upload.go
+++ b/cmd/api/src/database/file_upload.go
@@ -33,9 +33,9 @@ func (s *BloodhoundDB) CreateFileUploadJob(ctx context.Context, job model.FileUp
 	return job, CheckError(result)
 }
 
-func (s *BloodhoundDB) GetFileUploadJob(id int64) (model.FileUploadJob, error) {
+func (s *BloodhoundDB) GetFileUploadJob(ctx context.Context, id int64) (model.FileUploadJob, error) {
 	var job model.FileUploadJob
-	if result := s.db.Preload("User").First(&job, id); result.Error != nil {
+	if result := s.db.Preload("User").WithContext(ctx).First(&job, id); result.Error != nil {
 		return job, CheckError(result)
 	} else {
 		return job, nil

--- a/cmd/api/src/database/file_upload.go
+++ b/cmd/api/src/database/file_upload.go
@@ -49,7 +49,7 @@ func (s *BloodhoundDB) GetFileUploadJobsWithStatus(status model.JobStatus) ([]mo
 	return jobs, CheckError(result)
 }
 
-func (s *BloodhoundDB) GetAllFileUploadJobs(skip int, limit int, order string, filter model.SQLFilter) ([]model.FileUploadJob, int, error) {
+func (s *BloodhoundDB) GetAllFileUploadJobs(ctx context.Context, skip int, limit int, order string, filter model.SQLFilter) ([]model.FileUploadJob, int, error) {
 	var (
 		jobs   []model.FileUploadJob
 		result *gorm.DB
@@ -61,9 +61,9 @@ func (s *BloodhoundDB) GetAllFileUploadJobs(skip int, limit int, order string, f
 	}
 
 	if filter.SQLString != "" {
-		result = s.db.Model(model.FileUploadJob{}).Where(filter.SQLString, filter.Params).Count(&count)
+		result = s.db.Model(model.FileUploadJob{}).WithContext(ctx).Where(filter.SQLString, filter.Params).Count(&count)
 	} else {
-		result = s.db.Model(model.FileUploadJob{}).Count(&count)
+		result = s.db.Model(model.FileUploadJob{}).WithContext(ctx).Count(&count)
 	}
 
 	if result.Error != nil {
@@ -71,9 +71,9 @@ func (s *BloodhoundDB) GetAllFileUploadJobs(skip int, limit int, order string, f
 	}
 
 	if filter.SQLString != "" {
-		result = s.Scope(Paginate(skip, limit)).Preload("User").Where(filter.SQLString, filter.Params).Order(order).Find(&jobs)
+		result = s.Scope(Paginate(skip, limit)).WithContext(ctx).Preload("User").Where(filter.SQLString, filter.Params).Order(order).Find(&jobs)
 	} else {
-		result = s.Scope(Paginate(skip, limit)).Preload("User").Order(order).Find(&jobs)
+		result = s.Scope(Paginate(skip, limit)).WithContext(ctx).Preload("User").Order(order).Find(&jobs)
 	}
 
 	if result.Error != nil {

--- a/cmd/api/src/database/file_upload.go
+++ b/cmd/api/src/database/file_upload.go
@@ -42,9 +42,9 @@ func (s *BloodhoundDB) GetFileUploadJob(ctx context.Context, id int64) (model.Fi
 	}
 }
 
-func (s *BloodhoundDB) GetFileUploadJobsWithStatus(status model.JobStatus) ([]model.FileUploadJob, error) {
+func (s *BloodhoundDB) GetFileUploadJobsWithStatus(ctx context.Context, status model.JobStatus) ([]model.FileUploadJob, error) {
 	var jobs model.FileUploadJobs
-	result := s.db.Where("status = ?", status).Find(&jobs)
+	result := s.db.WithContext(ctx).Where("status = ?", status).Find(&jobs)
 
 	return jobs, CheckError(result)
 }

--- a/cmd/api/src/database/file_upload.go
+++ b/cmd/api/src/database/file_upload.go
@@ -28,8 +28,8 @@ func (s *BloodhoundDB) UpdateFileUploadJob(job model.FileUploadJob) error {
 	return CheckError(result)
 }
 
-func (s *BloodhoundDB) CreateFileUploadJob(job model.FileUploadJob) (model.FileUploadJob, error) {
-	result := s.db.Create(&job)
+func (s *BloodhoundDB) CreateFileUploadJob(ctx context.Context, job model.FileUploadJob) (model.FileUploadJob, error) {
+	result := s.db.WithContext(ctx).Create(&job)
 	return job, CheckError(result)
 }
 

--- a/cmd/api/src/database/mocks/db.go
+++ b/cmd/api/src/database/mocks/db.go
@@ -790,18 +790,18 @@ func (mr *MockDatabaseMockRecorder) GetConfigurationParameter(arg0, arg1 interfa
 }
 
 // GetFileUploadJob mocks base method.
-func (m *MockDatabase) GetFileUploadJob(arg0 int64) (model.FileUploadJob, error) {
+func (m *MockDatabase) GetFileUploadJob(arg0 context.Context, arg1 int64) (model.FileUploadJob, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetFileUploadJob", arg0)
+	ret := m.ctrl.Call(m, "GetFileUploadJob", arg0, arg1)
 	ret0, _ := ret[0].(model.FileUploadJob)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetFileUploadJob indicates an expected call of GetFileUploadJob.
-func (mr *MockDatabaseMockRecorder) GetFileUploadJob(arg0 interface{}) *gomock.Call {
+func (mr *MockDatabaseMockRecorder) GetFileUploadJob(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFileUploadJob", reflect.TypeOf((*MockDatabase)(nil).GetFileUploadJob), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFileUploadJob", reflect.TypeOf((*MockDatabase)(nil).GetFileUploadJob), arg0, arg1)
 }
 
 // GetFileUploadJobsWithStatus mocks base method.

--- a/cmd/api/src/database/mocks/db.go
+++ b/cmd/api/src/database/mocks/db.go
@@ -214,18 +214,18 @@ func (mr *MockDatabaseMockRecorder) CreateAzureDataQualityStats(arg0 interface{}
 }
 
 // CreateFileUploadJob mocks base method.
-func (m *MockDatabase) CreateFileUploadJob(arg0 model.FileUploadJob) (model.FileUploadJob, error) {
+func (m *MockDatabase) CreateFileUploadJob(arg0 context.Context, arg1 model.FileUploadJob) (model.FileUploadJob, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateFileUploadJob", arg0)
+	ret := m.ctrl.Call(m, "CreateFileUploadJob", arg0, arg1)
 	ret0, _ := ret[0].(model.FileUploadJob)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateFileUploadJob indicates an expected call of CreateFileUploadJob.
-func (mr *MockDatabaseMockRecorder) CreateFileUploadJob(arg0 interface{}) *gomock.Call {
+func (mr *MockDatabaseMockRecorder) CreateFileUploadJob(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateFileUploadJob", reflect.TypeOf((*MockDatabase)(nil).CreateFileUploadJob), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateFileUploadJob", reflect.TypeOf((*MockDatabase)(nil).CreateFileUploadJob), arg0, arg1)
 }
 
 // CreateIngestTask mocks base method.

--- a/cmd/api/src/database/mocks/db.go
+++ b/cmd/api/src/database/mocks/db.go
@@ -805,18 +805,18 @@ func (mr *MockDatabaseMockRecorder) GetFileUploadJob(arg0, arg1 interface{}) *go
 }
 
 // GetFileUploadJobsWithStatus mocks base method.
-func (m *MockDatabase) GetFileUploadJobsWithStatus(arg0 model.JobStatus) ([]model.FileUploadJob, error) {
+func (m *MockDatabase) GetFileUploadJobsWithStatus(arg0 context.Context, arg1 model.JobStatus) ([]model.FileUploadJob, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetFileUploadJobsWithStatus", arg0)
+	ret := m.ctrl.Call(m, "GetFileUploadJobsWithStatus", arg0, arg1)
 	ret0, _ := ret[0].([]model.FileUploadJob)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetFileUploadJobsWithStatus indicates an expected call of GetFileUploadJobsWithStatus.
-func (mr *MockDatabaseMockRecorder) GetFileUploadJobsWithStatus(arg0 interface{}) *gomock.Call {
+func (mr *MockDatabaseMockRecorder) GetFileUploadJobsWithStatus(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFileUploadJobsWithStatus", reflect.TypeOf((*MockDatabase)(nil).GetFileUploadJobsWithStatus), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFileUploadJobsWithStatus", reflect.TypeOf((*MockDatabase)(nil).GetFileUploadJobsWithStatus), arg0, arg1)
 }
 
 // GetFlag mocks base method.

--- a/cmd/api/src/database/mocks/db.go
+++ b/cmd/api/src/database/mocks/db.go
@@ -562,9 +562,9 @@ func (mr *MockDatabaseMockRecorder) GetAllConfigurationParameters(arg0 interface
 }
 
 // GetAllFileUploadJobs mocks base method.
-func (m *MockDatabase) GetAllFileUploadJobs(arg0, arg1 int, arg2 string, arg3 model.SQLFilter) ([]model.FileUploadJob, int, error) {
+func (m *MockDatabase) GetAllFileUploadJobs(arg0 context.Context, arg1, arg2 int, arg3 string, arg4 model.SQLFilter) ([]model.FileUploadJob, int, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAllFileUploadJobs", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "GetAllFileUploadJobs", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].([]model.FileUploadJob)
 	ret1, _ := ret[1].(int)
 	ret2, _ := ret[2].(error)
@@ -572,9 +572,9 @@ func (m *MockDatabase) GetAllFileUploadJobs(arg0, arg1 int, arg2 string, arg3 mo
 }
 
 // GetAllFileUploadJobs indicates an expected call of GetAllFileUploadJobs.
-func (mr *MockDatabaseMockRecorder) GetAllFileUploadJobs(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockDatabaseMockRecorder) GetAllFileUploadJobs(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllFileUploadJobs", reflect.TypeOf((*MockDatabase)(nil).GetAllFileUploadJobs), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllFileUploadJobs", reflect.TypeOf((*MockDatabase)(nil).GetAllFileUploadJobs), arg0, arg1, arg2, arg3, arg4)
 }
 
 // GetAllFlags mocks base method.

--- a/cmd/api/src/database/mocks/db.go
+++ b/cmd/api/src/database/mocks/db.go
@@ -1290,17 +1290,17 @@ func (mr *MockDatabaseMockRecorder) UpdateAuthToken(arg0, arg1 interface{}) *gom
 }
 
 // UpdateFileUploadJob mocks base method.
-func (m *MockDatabase) UpdateFileUploadJob(arg0 model.FileUploadJob) error {
+func (m *MockDatabase) UpdateFileUploadJob(arg0 context.Context, arg1 model.FileUploadJob) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateFileUploadJob", arg0)
+	ret := m.ctrl.Call(m, "UpdateFileUploadJob", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpdateFileUploadJob indicates an expected call of UpdateFileUploadJob.
-func (mr *MockDatabaseMockRecorder) UpdateFileUploadJob(arg0 interface{}) *gomock.Call {
+func (mr *MockDatabaseMockRecorder) UpdateFileUploadJob(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateFileUploadJob", reflect.TypeOf((*MockDatabase)(nil).UpdateFileUploadJob), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateFileUploadJob", reflect.TypeOf((*MockDatabase)(nil).UpdateFileUploadJob), arg0, arg1)
 }
 
 // UpdateSAMLIdentityProvider mocks base method.

--- a/cmd/api/src/services/fileupload/file_upload.go
+++ b/cmd/api/src/services/fileupload/file_upload.go
@@ -38,7 +38,7 @@ type FileUploadData interface {
 	CreateFileUploadJob(ctx context.Context, job model.FileUploadJob) (model.FileUploadJob, error)
 	UpdateFileUploadJob(ctx context.Context, job model.FileUploadJob) error
 	GetFileUploadJob(ctx context.Context, id int64) (model.FileUploadJob, error)
-	GetAllFileUploadJobs(skip int, limit int, order string, filter model.SQLFilter) ([]model.FileUploadJob, int, error)
+	GetAllFileUploadJobs(ctx context.Context, skip int, limit int, order string, filter model.SQLFilter) ([]model.FileUploadJob, int, error)
 	GetFileUploadJobsWithStatus(status model.JobStatus) ([]model.FileUploadJob, error)
 	DeleteAllFileUploads(ctx context.Context) error
 }
@@ -73,8 +73,8 @@ func ProcessStaleFileUploadJobs(ctx context.Context, db FileUploadData) {
 	}
 }
 
-func GetAllFileUploadJobs(db FileUploadData, skip int, limit int, order string, filter model.SQLFilter) ([]model.FileUploadJob, int, error) {
-	return db.GetAllFileUploadJobs(skip, limit, order, filter)
+func GetAllFileUploadJobs(ctx context.Context, db FileUploadData, skip int, limit int, order string, filter model.SQLFilter) ([]model.FileUploadJob, int, error) {
+	return db.GetAllFileUploadJobs(ctx, skip, limit, order, filter)
 }
 
 func StartFileUploadJob(ctx context.Context, db FileUploadData, user model.User) (model.FileUploadJob, error) {

--- a/cmd/api/src/services/fileupload/file_upload.go
+++ b/cmd/api/src/services/fileupload/file_upload.go
@@ -35,7 +35,7 @@ const jobActivityTimeout = time.Minute * 20
 var ErrInvalidJSON = errors.New("file is not valid json")
 
 type FileUploadData interface {
-	CreateFileUploadJob(job model.FileUploadJob) (model.FileUploadJob, error)
+	CreateFileUploadJob(ctx context.Context, job model.FileUploadJob) (model.FileUploadJob, error)
 	UpdateFileUploadJob(job model.FileUploadJob) error
 	GetFileUploadJob(id int64) (model.FileUploadJob, error)
 	GetAllFileUploadJobs(skip int, limit int, order string, filter model.SQLFilter) ([]model.FileUploadJob, int, error)
@@ -77,7 +77,7 @@ func GetAllFileUploadJobs(db FileUploadData, skip int, limit int, order string, 
 	return db.GetAllFileUploadJobs(skip, limit, order, filter)
 }
 
-func StartFileUploadJob(db FileUploadData, user model.User) (model.FileUploadJob, error) {
+func StartFileUploadJob(ctx context.Context, db FileUploadData, user model.User) (model.FileUploadJob, error) {
 	job := model.FileUploadJob{
 		UserID:     user.ID,
 		User:       user,
@@ -85,7 +85,7 @@ func StartFileUploadJob(db FileUploadData, user model.User) (model.FileUploadJob
 		StartTime:  time.Now().UTC(),
 		LastIngest: time.Now().UTC(),
 	}
-	return db.CreateFileUploadJob(job)
+	return db.CreateFileUploadJob(ctx, job)
 }
 
 func GetFileUploadJobByID(db FileUploadData, jobID int64) (model.FileUploadJob, error) {

--- a/cmd/api/src/services/fileupload/file_upload.go
+++ b/cmd/api/src/services/fileupload/file_upload.go
@@ -39,7 +39,7 @@ type FileUploadData interface {
 	UpdateFileUploadJob(ctx context.Context, job model.FileUploadJob) error
 	GetFileUploadJob(ctx context.Context, id int64) (model.FileUploadJob, error)
 	GetAllFileUploadJobs(ctx context.Context, skip int, limit int, order string, filter model.SQLFilter) ([]model.FileUploadJob, int, error)
-	GetFileUploadJobsWithStatus(status model.JobStatus) ([]model.FileUploadJob, error)
+	GetFileUploadJobsWithStatus(ctx context.Context, status model.JobStatus) ([]model.FileUploadJob, error)
 	DeleteAllFileUploads(ctx context.Context) error
 }
 
@@ -55,7 +55,7 @@ func ProcessStaleFileUploadJobs(ctx context.Context, db FileUploadData) {
 		threshold = now.Add(-jobActivityTimeout)
 	)
 
-	if jobs, err := db.GetFileUploadJobsWithStatus(model.JobStatusRunning); err != nil {
+	if jobs, err := db.GetFileUploadJobsWithStatus(ctx, model.JobStatusRunning); err != nil {
 		log.Errorf("Error getting running jobs: %v", err)
 	} else {
 		for _, job := range jobs {

--- a/cmd/api/src/services/fileupload/file_upload.go
+++ b/cmd/api/src/services/fileupload/file_upload.go
@@ -37,7 +37,7 @@ var ErrInvalidJSON = errors.New("file is not valid json")
 type FileUploadData interface {
 	CreateFileUploadJob(ctx context.Context, job model.FileUploadJob) (model.FileUploadJob, error)
 	UpdateFileUploadJob(ctx context.Context, job model.FileUploadJob) error
-	GetFileUploadJob(id int64) (model.FileUploadJob, error)
+	GetFileUploadJob(ctx context.Context, id int64) (model.FileUploadJob, error)
 	GetAllFileUploadJobs(skip int, limit int, order string, filter model.SQLFilter) ([]model.FileUploadJob, int, error)
 	GetFileUploadJobsWithStatus(status model.JobStatus) ([]model.FileUploadJob, error)
 	DeleteAllFileUploads(ctx context.Context) error
@@ -88,8 +88,8 @@ func StartFileUploadJob(ctx context.Context, db FileUploadData, user model.User)
 	return db.CreateFileUploadJob(ctx, job)
 }
 
-func GetFileUploadJobByID(db FileUploadData, jobID int64) (model.FileUploadJob, error) {
-	return db.GetFileUploadJob(jobID)
+func GetFileUploadJobByID(ctx context.Context, db FileUploadData, jobID int64) (model.FileUploadJob, error) {
+	return db.GetFileUploadJob(ctx, jobID)
 }
 
 func WriteAndValidateJSON(src io.Reader, dst io.Writer) error {
@@ -138,7 +138,7 @@ func UpdateFileUploadJobStatus(ctx context.Context, db FileUploadData, fileUploa
 }
 
 func TimeOutUploadJob(ctx context.Context, db FileUploadData, jobID int64, message string) error {
-	if job, err := db.GetFileUploadJob(jobID); err != nil {
+	if job, err := db.GetFileUploadJob(ctx, jobID); err != nil {
 		return err
 	} else {
 		job.Status = model.JobStatusTimedOut

--- a/cmd/api/src/services/fileupload/mocks/mock.go
+++ b/cmd/api/src/services/fileupload/mocks/mock.go
@@ -112,18 +112,18 @@ func (mr *MockFileUploadDataMockRecorder) GetFileUploadJob(arg0, arg1 interface{
 }
 
 // GetFileUploadJobsWithStatus mocks base method.
-func (m *MockFileUploadData) GetFileUploadJobsWithStatus(arg0 model.JobStatus) ([]model.FileUploadJob, error) {
+func (m *MockFileUploadData) GetFileUploadJobsWithStatus(arg0 context.Context, arg1 model.JobStatus) ([]model.FileUploadJob, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetFileUploadJobsWithStatus", arg0)
+	ret := m.ctrl.Call(m, "GetFileUploadJobsWithStatus", arg0, arg1)
 	ret0, _ := ret[0].([]model.FileUploadJob)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetFileUploadJobsWithStatus indicates an expected call of GetFileUploadJobsWithStatus.
-func (mr *MockFileUploadDataMockRecorder) GetFileUploadJobsWithStatus(arg0 interface{}) *gomock.Call {
+func (mr *MockFileUploadDataMockRecorder) GetFileUploadJobsWithStatus(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFileUploadJobsWithStatus", reflect.TypeOf((*MockFileUploadData)(nil).GetFileUploadJobsWithStatus), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFileUploadJobsWithStatus", reflect.TypeOf((*MockFileUploadData)(nil).GetFileUploadJobsWithStatus), arg0, arg1)
 }
 
 // UpdateFileUploadJob mocks base method.

--- a/cmd/api/src/services/fileupload/mocks/mock.go
+++ b/cmd/api/src/services/fileupload/mocks/mock.go
@@ -81,9 +81,9 @@ func (mr *MockFileUploadDataMockRecorder) DeleteAllFileUploads(arg0 interface{})
 }
 
 // GetAllFileUploadJobs mocks base method.
-func (m *MockFileUploadData) GetAllFileUploadJobs(arg0, arg1 int, arg2 string, arg3 model.SQLFilter) ([]model.FileUploadJob, int, error) {
+func (m *MockFileUploadData) GetAllFileUploadJobs(arg0 context.Context, arg1, arg2 int, arg3 string, arg4 model.SQLFilter) ([]model.FileUploadJob, int, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAllFileUploadJobs", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "GetAllFileUploadJobs", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].([]model.FileUploadJob)
 	ret1, _ := ret[1].(int)
 	ret2, _ := ret[2].(error)
@@ -91,9 +91,9 @@ func (m *MockFileUploadData) GetAllFileUploadJobs(arg0, arg1 int, arg2 string, a
 }
 
 // GetAllFileUploadJobs indicates an expected call of GetAllFileUploadJobs.
-func (mr *MockFileUploadDataMockRecorder) GetAllFileUploadJobs(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockFileUploadDataMockRecorder) GetAllFileUploadJobs(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllFileUploadJobs", reflect.TypeOf((*MockFileUploadData)(nil).GetAllFileUploadJobs), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllFileUploadJobs", reflect.TypeOf((*MockFileUploadData)(nil).GetAllFileUploadJobs), arg0, arg1, arg2, arg3, arg4)
 }
 
 // GetFileUploadJob mocks base method.

--- a/cmd/api/src/services/fileupload/mocks/mock.go
+++ b/cmd/api/src/services/fileupload/mocks/mock.go
@@ -97,18 +97,18 @@ func (mr *MockFileUploadDataMockRecorder) GetAllFileUploadJobs(arg0, arg1, arg2,
 }
 
 // GetFileUploadJob mocks base method.
-func (m *MockFileUploadData) GetFileUploadJob(arg0 int64) (model.FileUploadJob, error) {
+func (m *MockFileUploadData) GetFileUploadJob(arg0 context.Context, arg1 int64) (model.FileUploadJob, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetFileUploadJob", arg0)
+	ret := m.ctrl.Call(m, "GetFileUploadJob", arg0, arg1)
 	ret0, _ := ret[0].(model.FileUploadJob)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetFileUploadJob indicates an expected call of GetFileUploadJob.
-func (mr *MockFileUploadDataMockRecorder) GetFileUploadJob(arg0 interface{}) *gomock.Call {
+func (mr *MockFileUploadDataMockRecorder) GetFileUploadJob(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFileUploadJob", reflect.TypeOf((*MockFileUploadData)(nil).GetFileUploadJob), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFileUploadJob", reflect.TypeOf((*MockFileUploadData)(nil).GetFileUploadJob), arg0, arg1)
 }
 
 // GetFileUploadJobsWithStatus mocks base method.

--- a/cmd/api/src/services/fileupload/mocks/mock.go
+++ b/cmd/api/src/services/fileupload/mocks/mock.go
@@ -127,15 +127,15 @@ func (mr *MockFileUploadDataMockRecorder) GetFileUploadJobsWithStatus(arg0 inter
 }
 
 // UpdateFileUploadJob mocks base method.
-func (m *MockFileUploadData) UpdateFileUploadJob(arg0 model.FileUploadJob) error {
+func (m *MockFileUploadData) UpdateFileUploadJob(arg0 context.Context, arg1 model.FileUploadJob) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateFileUploadJob", arg0)
+	ret := m.ctrl.Call(m, "UpdateFileUploadJob", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpdateFileUploadJob indicates an expected call of UpdateFileUploadJob.
-func (mr *MockFileUploadDataMockRecorder) UpdateFileUploadJob(arg0 interface{}) *gomock.Call {
+func (mr *MockFileUploadDataMockRecorder) UpdateFileUploadJob(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateFileUploadJob", reflect.TypeOf((*MockFileUploadData)(nil).UpdateFileUploadJob), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateFileUploadJob", reflect.TypeOf((*MockFileUploadData)(nil).UpdateFileUploadJob), arg0, arg1)
 }

--- a/cmd/api/src/services/fileupload/mocks/mock.go
+++ b/cmd/api/src/services/fileupload/mocks/mock.go
@@ -52,18 +52,18 @@ func (m *MockFileUploadData) EXPECT() *MockFileUploadDataMockRecorder {
 }
 
 // CreateFileUploadJob mocks base method.
-func (m *MockFileUploadData) CreateFileUploadJob(arg0 model.FileUploadJob) (model.FileUploadJob, error) {
+func (m *MockFileUploadData) CreateFileUploadJob(arg0 context.Context, arg1 model.FileUploadJob) (model.FileUploadJob, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateFileUploadJob", arg0)
+	ret := m.ctrl.Call(m, "CreateFileUploadJob", arg0, arg1)
 	ret0, _ := ret[0].(model.FileUploadJob)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateFileUploadJob indicates an expected call of CreateFileUploadJob.
-func (mr *MockFileUploadDataMockRecorder) CreateFileUploadJob(arg0 interface{}) *gomock.Call {
+func (mr *MockFileUploadDataMockRecorder) CreateFileUploadJob(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateFileUploadJob", reflect.TypeOf((*MockFileUploadData)(nil).CreateFileUploadJob), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateFileUploadJob", reflect.TypeOf((*MockFileUploadData)(nil).CreateFileUploadJob), arg0, arg1)
 }
 
 // DeleteAllFileUploads mocks base method.


### PR DESCRIPTION
## Description

Plumb context into gorm file uploads  db methods
https://gorm.io/docs/context.html#Context-Timeout

## Motivation and Context

Currently as it stands any endpoints that rely on purely gorm do not respect `request.Context` and as such timeouts are not respected either. While we want to eventually get to the removal of the gorm dependency altogether, that is a long way and a lot of effort away and this I think this approach would give us that much room to maneuver while we get there.

## How Has This Been Tested?

Using a rest client and the prefer header
Add a sleep inside of the handler
Look for the `500 request timed out` after exceeding the timeout. (Note: the request will take as long as the sleep is set, it's not tied to the prefer header)

## Types of changes

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [x] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
