### PR TITLE
fix: plumb ctx into saved queries db methods 

### DIFF
--- a/cmd/api/src/api/v2/saved_queries.go
+++ b/cmd/api/src/api/v2/saved_queries.go
@@ -134,7 +134,7 @@ func (s Resources) DeleteSavedQuery(response http.ResponseWriter, request *http.
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, "No associated user found", request), response)
 	} else if savedQueryID, err := strconv.Atoi(rawSavedQueryID); err != nil {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, api.ErrorResponseDetailsIDMalformed, request), response)
-	} else if savedQueryBelongsToUser, err := s.DB.SavedQueryBelongsToUser(user.ID, savedQueryID); errors.Is(err, database.ErrNotFound) {
+	} else if savedQueryBelongsToUser, err := s.DB.SavedQueryBelongsToUser(request.Context(), user.ID, savedQueryID); errors.Is(err, database.ErrNotFound) {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusNotFound, "query does not exist", request), response)
 	} else if err != nil {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusInternalServerError, api.ErrorResponseDetailsInternalServerError, request), response)

--- a/cmd/api/src/api/v2/saved_queries.go
+++ b/cmd/api/src/api/v2/saved_queries.go
@@ -140,7 +140,7 @@ func (s Resources) DeleteSavedQuery(response http.ResponseWriter, request *http.
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusInternalServerError, api.ErrorResponseDetailsInternalServerError, request), response)
 	} else if !savedQueryBelongsToUser {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, "invalid saved_query_id supplied", request), response)
-	} else if err := s.DB.DeleteSavedQuery(savedQueryID); errors.Is(err, database.ErrNotFound) {
+	} else if err := s.DB.DeleteSavedQuery(request.Context(), savedQueryID); errors.Is(err, database.ErrNotFound) {
 		// This is an edge case and can only occur if the database has a concurrent operation that deletes the saved query
 		// after the check at s.DB.SavedQueryBelongsToUser but before getting here.
 		// Still, adding in the same check for good measure.

--- a/cmd/api/src/api/v2/saved_queries.go
+++ b/cmd/api/src/api/v2/saved_queries.go
@@ -114,7 +114,7 @@ func (s Resources) CreateSavedQuery(response http.ResponseWriter, request *http.
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, err.Error(), request), response)
 	} else if createRequest.Name == "" || createRequest.Query == "" {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, "the name and/or query field is empty", request), response)
-	} else if savedQuery, err := s.DB.CreateSavedQuery(user.ID, createRequest.Name, createRequest.Query); err != nil {
+	} else if savedQuery, err := s.DB.CreateSavedQuery(request.Context(), user.ID, createRequest.Name, createRequest.Query); err != nil {
 		if strings.Contains(err.Error(), "duplicate key value violates unique constraint") {
 			api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, "duplicate name for saved query: please choose a different name", request), response)
 		} else {

--- a/cmd/api/src/api/v2/saved_queries.go
+++ b/cmd/api/src/api/v2/saved_queries.go
@@ -89,7 +89,7 @@ func (s Resources) ListSavedQueries(response http.ResponseWriter, request *http.
 			api.WriteErrorResponse(request.Context(), ErrBadQueryParameter(request, model.PaginationQueryParameterSkip, err), response)
 		} else if limit, err := ParseLimitQueryParameter(queryParams, 10000); err != nil {
 			api.WriteErrorResponse(request.Context(), ErrBadQueryParameter(request, model.PaginationQueryParameterLimit, err), response)
-		} else if queries, count, err := s.DB.ListSavedQueries(user.ID, strings.Join(order, ", "), sqlFilter, skip, limit); err != nil {
+		} else if queries, count, err := s.DB.ListSavedQueries(request.Context(), user.ID, strings.Join(order, ", "), sqlFilter, skip, limit); err != nil {
 			api.HandleDatabaseError(request, response, err)
 		} else {
 			api.WriteResponseWrapperWithPagination(request.Context(), queries, limit, skip, count, http.StatusOK, response)

--- a/cmd/api/src/api/v2/saved_queries_test.go
+++ b/cmd/api/src/api/v2/saved_queries_test.go
@@ -329,7 +329,7 @@ func TestResources_CreateSavedQuery_DuplicateName(t *testing.T) {
 	userId, err := uuid2.NewV4()
 	require.Nil(t, err)
 
-	mockDB.EXPECT().CreateSavedQuery(gomock.Any(), gomock.Any(), gomock.Any()).Return(model.SavedQuery{}, fmt.Errorf("duplicate key value violates unique constraint \"idx_saved_queries_composite_index\""))
+	mockDB.EXPECT().CreateSavedQuery(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(model.SavedQuery{}, fmt.Errorf("duplicate key value violates unique constraint \"idx_saved_queries_composite_index\""))
 
 	payload := v2.CreateSavedQueryRequest{
 		Query: "Match(n) return n",
@@ -367,7 +367,7 @@ func TestResources_CreateSavedQuery_CreateFailure(t *testing.T) {
 		Name:  "myCustomQuery1",
 	}
 
-	mockDB.EXPECT().CreateSavedQuery(userId, payload.Name, payload.Query).Return(model.SavedQuery{}, fmt.Errorf("foo"))
+	mockDB.EXPECT().CreateSavedQuery(gomock.Any(), userId, payload.Name, payload.Query).Return(model.SavedQuery{}, fmt.Errorf("foo"))
 
 	req, err := http.NewRequestWithContext(createContextWithOwnerId(userId), "POST", endpoint, must.MarshalJSONReader(payload))
 	require.Nil(t, err)
@@ -399,7 +399,7 @@ func TestResources_CreateSavedQuery(t *testing.T) {
 		Name:  "myCustomQuery1",
 	}
 
-	mockDB.EXPECT().CreateSavedQuery(userId, payload.Name, payload.Query).Return(model.SavedQuery{
+	mockDB.EXPECT().CreateSavedQuery(gomock.Any(), userId, payload.Name, payload.Query).Return(model.SavedQuery{
 		UserID: userId.String(),
 		Name:   payload.Name,
 		Query:  payload.Query,

--- a/cmd/api/src/api/v2/saved_queries_test.go
+++ b/cmd/api/src/api/v2/saved_queries_test.go
@@ -204,7 +204,7 @@ func TestResources_ListSavedQueries_DBError(t *testing.T) {
 	userId, err := uuid2.NewV4()
 	require.Nil(t, err)
 
-	mockDB.EXPECT().ListSavedQueries(userId, "", model.SQLFilter{}, 0, 10000).Return(model.SavedQueries{}, 0, fmt.Errorf("foo"))
+	mockDB.EXPECT().ListSavedQueries(gomock.Any(), userId, "", model.SQLFilter{}, 0, 10000).Return(model.SavedQueries{}, 0, fmt.Errorf("foo"))
 
 	if req, err := http.NewRequestWithContext(createContextWithOwnerId(userId), "GET", endpoint, nil); err != nil {
 		t.Fatal(err)
@@ -233,7 +233,7 @@ func TestResources_ListSavedQueries(t *testing.T) {
 	userId, err := uuid2.NewV4()
 	require.Nil(t, err)
 
-	mockDB.EXPECT().ListSavedQueries(userId, gomock.Any(), gomock.Any(), 1, 10).Return(model.SavedQueries{
+	mockDB.EXPECT().ListSavedQueries(gomock.Any(), userId, gomock.Any(), gomock.Any(), 1, 10).Return(model.SavedQueries{
 		{
 			UserID: userId.String(),
 			Name:   "myQuery",

--- a/cmd/api/src/api/v2/saved_queries_test.go
+++ b/cmd/api/src/api/v2/saved_queries_test.go
@@ -457,7 +457,7 @@ func TestResources_DeleteSavedQuery_DBError(t *testing.T) {
 	endpoint := "/api/v2/saved-queries/%s"
 	savedQueryId := "1"
 
-	mockDB.EXPECT().SavedQueryBelongsToUser(gomock.Any(), gomock.Any()).Return(false, fmt.Errorf("foo"))
+	mockDB.EXPECT().SavedQueryBelongsToUser(gomock.Any(), gomock.Any(), gomock.Any()).Return(false, fmt.Errorf("foo"))
 
 	req, err := http.NewRequestWithContext(createContextWithOwnerId(userId), "DELETE", fmt.Sprintf(endpoint, savedQueryId), nil)
 	require.Nil(t, err)
@@ -486,7 +486,7 @@ func TestResources_DeleteSavedQuery_QueryDoesNotBelongToUser(t *testing.T) {
 	endpoint := "/api/v2/saved-queries/%s"
 	savedQueryId := "1"
 
-	mockDB.EXPECT().SavedQueryBelongsToUser(gomock.Any(), gomock.Any()).Return(false, nil)
+	mockDB.EXPECT().SavedQueryBelongsToUser(gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
 
 	req, err := http.NewRequestWithContext(createContextWithOwnerId(userId), "DELETE", fmt.Sprintf(endpoint, savedQueryId), nil)
 	require.Nil(t, err)
@@ -516,7 +516,7 @@ func TestResources_DeleteSavedQuery_RecordNotFound(t *testing.T) {
 	endpoint := "/api/v2/saved-queries/%s"
 	savedQueryId := "1"
 
-	mockDB.EXPECT().SavedQueryBelongsToUser(gomock.Any(), gomock.Any()).Return(false, database.ErrNotFound)
+	mockDB.EXPECT().SavedQueryBelongsToUser(gomock.Any(), gomock.Any(), gomock.Any()).Return(false, database.ErrNotFound)
 
 	req, err := http.NewRequestWithContext(createContextWithOwnerId(userId), "DELETE", fmt.Sprintf(endpoint, savedQueryId), nil)
 	require.Nil(t, err)
@@ -546,7 +546,7 @@ func TestResources_DeleteSavedQuery_RecordNotFound_EdgeCase(t *testing.T) {
 	endpoint := "/api/v2/saved-queries/%s"
 	savedQueryId := "1"
 
-	mockDB.EXPECT().SavedQueryBelongsToUser(gomock.Any(), gomock.Any()).Return(true, nil)
+	mockDB.EXPECT().SavedQueryBelongsToUser(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil)
 	mockDB.EXPECT().DeleteSavedQuery(gomock.Any(), gomock.Any()).Return(database.ErrNotFound)
 
 	req, err := http.NewRequestWithContext(createContextWithOwnerId(userId), "DELETE", fmt.Sprintf(endpoint, savedQueryId), nil)
@@ -577,7 +577,7 @@ func TestResources_DeleteSavedQuery_DeleteError(t *testing.T) {
 	endpoint := "/api/v2/saved-queries/%s"
 	savedQueryId := "1"
 
-	mockDB.EXPECT().SavedQueryBelongsToUser(gomock.Any(), gomock.Any()).Return(true, nil)
+	mockDB.EXPECT().SavedQueryBelongsToUser(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil)
 	mockDB.EXPECT().DeleteSavedQuery(gomock.Any(), gomock.Any()).Return(fmt.Errorf("foo"))
 
 	req, err := http.NewRequestWithContext(createContextWithOwnerId(userId), "DELETE", fmt.Sprintf(endpoint, savedQueryId), nil)
@@ -608,7 +608,7 @@ func TestResources_DeleteSavedQuery(t *testing.T) {
 	endpoint := "/api/v2/saved-queries/%s"
 	savedQueryId := "1"
 
-	mockDB.EXPECT().SavedQueryBelongsToUser(gomock.Any(), gomock.Any()).Return(true, nil)
+	mockDB.EXPECT().SavedQueryBelongsToUser(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil)
 	mockDB.EXPECT().DeleteSavedQuery(gomock.Any(), gomock.Any()).Return(nil)
 
 	req, err := http.NewRequestWithContext(createContextWithOwnerId(userId), "DELETE", fmt.Sprintf(endpoint, savedQueryId), nil)

--- a/cmd/api/src/api/v2/saved_queries_test.go
+++ b/cmd/api/src/api/v2/saved_queries_test.go
@@ -547,7 +547,7 @@ func TestResources_DeleteSavedQuery_RecordNotFound_EdgeCase(t *testing.T) {
 	savedQueryId := "1"
 
 	mockDB.EXPECT().SavedQueryBelongsToUser(gomock.Any(), gomock.Any()).Return(true, nil)
-	mockDB.EXPECT().DeleteSavedQuery(gomock.Any()).Return(database.ErrNotFound)
+	mockDB.EXPECT().DeleteSavedQuery(gomock.Any(), gomock.Any()).Return(database.ErrNotFound)
 
 	req, err := http.NewRequestWithContext(createContextWithOwnerId(userId), "DELETE", fmt.Sprintf(endpoint, savedQueryId), nil)
 	require.Nil(t, err)
@@ -578,7 +578,7 @@ func TestResources_DeleteSavedQuery_DeleteError(t *testing.T) {
 	savedQueryId := "1"
 
 	mockDB.EXPECT().SavedQueryBelongsToUser(gomock.Any(), gomock.Any()).Return(true, nil)
-	mockDB.EXPECT().DeleteSavedQuery(gomock.Any()).Return(fmt.Errorf("foo"))
+	mockDB.EXPECT().DeleteSavedQuery(gomock.Any(), gomock.Any()).Return(fmt.Errorf("foo"))
 
 	req, err := http.NewRequestWithContext(createContextWithOwnerId(userId), "DELETE", fmt.Sprintf(endpoint, savedQueryId), nil)
 	require.Nil(t, err)
@@ -609,7 +609,7 @@ func TestResources_DeleteSavedQuery(t *testing.T) {
 	savedQueryId := "1"
 
 	mockDB.EXPECT().SavedQueryBelongsToUser(gomock.Any(), gomock.Any()).Return(true, nil)
-	mockDB.EXPECT().DeleteSavedQuery(gomock.Any()).Return(nil)
+	mockDB.EXPECT().DeleteSavedQuery(gomock.Any(), gomock.Any()).Return(nil)
 
 	req, err := http.NewRequestWithContext(createContextWithOwnerId(userId), "DELETE", fmt.Sprintf(endpoint, savedQueryId), nil)
 	require.Nil(t, err)

--- a/cmd/api/src/database/db.go
+++ b/cmd/api/src/database/db.go
@@ -147,7 +147,7 @@ type Database interface {
 
 	// Saved Queries
 	ListSavedQueries(ctx context.Context, userID uuid.UUID, order string, filter model.SQLFilter, skip, limit int) (model.SavedQueries, int, error)
-	CreateSavedQuery(userID uuid.UUID, name string, query string) (model.SavedQuery, error)
+	CreateSavedQuery(ctx context.Context, userID uuid.UUID, name string, query string) (model.SavedQuery, error)
 	DeleteSavedQuery(id int) error
 	SavedQueryBelongsToUser(userID uuid.UUID, savedQueryID int) (bool, error)
 	DeleteAssetGroupSelectorsForAssetGroups(ctx context.Context, assetGroupIds []int) error

--- a/cmd/api/src/database/db.go
+++ b/cmd/api/src/database/db.go
@@ -149,7 +149,7 @@ type Database interface {
 	ListSavedQueries(ctx context.Context, userID uuid.UUID, order string, filter model.SQLFilter, skip, limit int) (model.SavedQueries, int, error)
 	CreateSavedQuery(ctx context.Context, userID uuid.UUID, name string, query string) (model.SavedQuery, error)
 	DeleteSavedQuery(ctx context.Context, id int) error
-	SavedQueryBelongsToUser(userID uuid.UUID, savedQueryID int) (bool, error)
+	SavedQueryBelongsToUser(ctx context.Context, userID uuid.UUID, savedQueryID int) (bool, error)
 	DeleteAssetGroupSelectorsForAssetGroups(ctx context.Context, assetGroupIds []int) error
 }
 

--- a/cmd/api/src/database/db.go
+++ b/cmd/api/src/database/db.go
@@ -144,7 +144,9 @@ type Database interface {
 
 	// File Upload
 	fileupload.FileUploadData
-	ListSavedQueries(userID uuid.UUID, order string, filter model.SQLFilter, skip, limit int) (model.SavedQueries, int, error)
+
+	// Saved Queries
+	ListSavedQueries(ctx context.Context, userID uuid.UUID, order string, filter model.SQLFilter, skip, limit int) (model.SavedQueries, int, error)
 	CreateSavedQuery(userID uuid.UUID, name string, query string) (model.SavedQuery, error)
 	DeleteSavedQuery(id int) error
 	SavedQueryBelongsToUser(userID uuid.UUID, savedQueryID int) (bool, error)

--- a/cmd/api/src/database/db.go
+++ b/cmd/api/src/database/db.go
@@ -148,7 +148,7 @@ type Database interface {
 	// Saved Queries
 	ListSavedQueries(ctx context.Context, userID uuid.UUID, order string, filter model.SQLFilter, skip, limit int) (model.SavedQueries, int, error)
 	CreateSavedQuery(ctx context.Context, userID uuid.UUID, name string, query string) (model.SavedQuery, error)
-	DeleteSavedQuery(id int) error
+	DeleteSavedQuery(ctx context.Context, id int) error
 	SavedQueryBelongsToUser(userID uuid.UUID, savedQueryID int) (bool, error)
 	DeleteAssetGroupSelectorsForAssetGroups(ctx context.Context, assetGroupIds []int) error
 }

--- a/cmd/api/src/database/mocks/db.go
+++ b/cmd/api/src/database/mocks/db.go
@@ -274,18 +274,18 @@ func (mr *MockDatabaseMockRecorder) CreateSAMLIdentityProvider(arg0, arg1 interf
 }
 
 // CreateSavedQuery mocks base method.
-func (m *MockDatabase) CreateSavedQuery(arg0 uuid.UUID, arg1, arg2 string) (model.SavedQuery, error) {
+func (m *MockDatabase) CreateSavedQuery(arg0 context.Context, arg1 uuid.UUID, arg2, arg3 string) (model.SavedQuery, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateSavedQuery", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "CreateSavedQuery", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(model.SavedQuery)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateSavedQuery indicates an expected call of CreateSavedQuery.
-func (mr *MockDatabaseMockRecorder) CreateSavedQuery(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockDatabaseMockRecorder) CreateSavedQuery(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSavedQuery", reflect.TypeOf((*MockDatabase)(nil).CreateSavedQuery), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSavedQuery", reflect.TypeOf((*MockDatabase)(nil).CreateSavedQuery), arg0, arg1, arg2, arg3)
 }
 
 // CreateUser mocks base method.

--- a/cmd/api/src/database/mocks/db.go
+++ b/cmd/api/src/database/mocks/db.go
@@ -1076,9 +1076,9 @@ func (mr *MockDatabaseMockRecorder) ListAuditLogs(arg0, arg1, arg2, arg3, arg4, 
 }
 
 // ListSavedQueries mocks base method.
-func (m *MockDatabase) ListSavedQueries(arg0 uuid.UUID, arg1 string, arg2 model.SQLFilter, arg3, arg4 int) (model.SavedQueries, int, error) {
+func (m *MockDatabase) ListSavedQueries(arg0 context.Context, arg1 uuid.UUID, arg2 string, arg3 model.SQLFilter, arg4, arg5 int) (model.SavedQueries, int, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListSavedQueries", arg0, arg1, arg2, arg3, arg4)
+	ret := m.ctrl.Call(m, "ListSavedQueries", arg0, arg1, arg2, arg3, arg4, arg5)
 	ret0, _ := ret[0].(model.SavedQueries)
 	ret1, _ := ret[1].(int)
 	ret2, _ := ret[2].(error)
@@ -1086,9 +1086,9 @@ func (m *MockDatabase) ListSavedQueries(arg0 uuid.UUID, arg1 string, arg2 model.
 }
 
 // ListSavedQueries indicates an expected call of ListSavedQueries.
-func (mr *MockDatabaseMockRecorder) ListSavedQueries(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+func (mr *MockDatabaseMockRecorder) ListSavedQueries(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSavedQueries", reflect.TypeOf((*MockDatabase)(nil).ListSavedQueries), arg0, arg1, arg2, arg3, arg4)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSavedQueries", reflect.TypeOf((*MockDatabase)(nil).ListSavedQueries), arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
 // LookupActiveSessionsByUser mocks base method.

--- a/cmd/api/src/database/mocks/db.go
+++ b/cmd/api/src/database/mocks/db.go
@@ -1166,18 +1166,18 @@ func (mr *MockDatabaseMockRecorder) RequiresMigration() *gomock.Call {
 }
 
 // SavedQueryBelongsToUser mocks base method.
-func (m *MockDatabase) SavedQueryBelongsToUser(arg0 uuid.UUID, arg1 int) (bool, error) {
+func (m *MockDatabase) SavedQueryBelongsToUser(arg0 context.Context, arg1 uuid.UUID, arg2 int) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SavedQueryBelongsToUser", arg0, arg1)
+	ret := m.ctrl.Call(m, "SavedQueryBelongsToUser", arg0, arg1, arg2)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // SavedQueryBelongsToUser indicates an expected call of SavedQueryBelongsToUser.
-func (mr *MockDatabaseMockRecorder) SavedQueryBelongsToUser(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockDatabaseMockRecorder) SavedQueryBelongsToUser(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SavedQueryBelongsToUser", reflect.TypeOf((*MockDatabase)(nil).SavedQueryBelongsToUser), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SavedQueryBelongsToUser", reflect.TypeOf((*MockDatabase)(nil).SavedQueryBelongsToUser), arg0, arg1, arg2)
 }
 
 // SetConfigurationParameter mocks base method.

--- a/cmd/api/src/database/mocks/db.go
+++ b/cmd/api/src/database/mocks/db.go
@@ -445,17 +445,17 @@ func (mr *MockDatabaseMockRecorder) DeleteSAMLProvider(arg0, arg1 interface{}) *
 }
 
 // DeleteSavedQuery mocks base method.
-func (m *MockDatabase) DeleteSavedQuery(arg0 int) error {
+func (m *MockDatabase) DeleteSavedQuery(arg0 context.Context, arg1 int) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteSavedQuery", arg0)
+	ret := m.ctrl.Call(m, "DeleteSavedQuery", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteSavedQuery indicates an expected call of DeleteSavedQuery.
-func (mr *MockDatabaseMockRecorder) DeleteSavedQuery(arg0 interface{}) *gomock.Call {
+func (mr *MockDatabaseMockRecorder) DeleteSavedQuery(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSavedQuery", reflect.TypeOf((*MockDatabase)(nil).DeleteSavedQuery), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSavedQuery", reflect.TypeOf((*MockDatabase)(nil).DeleteSavedQuery), arg0, arg1)
 }
 
 // DeleteUser mocks base method.

--- a/cmd/api/src/database/saved_queries.go
+++ b/cmd/api/src/database/saved_queries.go
@@ -17,24 +17,25 @@
 package database
 
 import (
+	"context"
 	"github.com/gofrs/uuid"
 	"github.com/specterops/bloodhound/src/model"
 	"gorm.io/gorm"
 )
 
-func (s *BloodhoundDB) ListSavedQueries(userID uuid.UUID, order string, filter model.SQLFilter, skip, limit int) (model.SavedQueries, int, error) {
+func (s *BloodhoundDB) ListSavedQueries(ctx context.Context, userID uuid.UUID, order string, filter model.SQLFilter, skip, limit int) (model.SavedQueries, int, error) {
 	var (
 		queries model.SavedQueries
 		result  *gorm.DB
 		count   int64
-		cursor  = s.Scope(Paginate(skip, limit)).Where("user_id = ?", userID)
+		cursor  = s.Scope(Paginate(skip, limit)).WithContext(ctx).Where("user_id = ?", userID)
 	)
 
 	if filter.SQLString != "" {
 		cursor = cursor.Where(filter.SQLString, filter.Params)
-		result = s.db.Model(&queries).Where("user_id = ?", userID).Where(filter.SQLString, filter.Params).Count(&count)
+		result = s.db.Model(&queries).WithContext(ctx).Where("user_id = ?", userID).Where(filter.SQLString, filter.Params).Count(&count)
 	} else {
-		result = s.db.Model(&queries).Where("user_id = ?", userID).Count(&count)
+		result = s.db.Model(&queries).WithContext(ctx).Where("user_id = ?", userID).Count(&count)
 	}
 
 	if result.Error != nil {

--- a/cmd/api/src/database/saved_queries.go
+++ b/cmd/api/src/database/saved_queries.go
@@ -50,14 +50,14 @@ func (s *BloodhoundDB) ListSavedQueries(ctx context.Context, userID uuid.UUID, o
 	return queries, int(count), CheckError(result)
 }
 
-func (s *BloodhoundDB) CreateSavedQuery(userID uuid.UUID, name string, query string) (model.SavedQuery, error) {
+func (s *BloodhoundDB) CreateSavedQuery(ctx context.Context, userID uuid.UUID, name string, query string) (model.SavedQuery, error) {
 	savedQuery := model.SavedQuery{
 		UserID: userID.String(),
 		Name:   name,
 		Query:  query,
 	}
 
-	return savedQuery, CheckError(s.db.Create(&savedQuery))
+	return savedQuery, CheckError(s.db.WithContext(ctx).Create(&savedQuery))
 }
 
 func (s *BloodhoundDB) DeleteSavedQuery(id int) error {

--- a/cmd/api/src/database/saved_queries.go
+++ b/cmd/api/src/database/saved_queries.go
@@ -60,8 +60,8 @@ func (s *BloodhoundDB) CreateSavedQuery(ctx context.Context, userID uuid.UUID, n
 	return savedQuery, CheckError(s.db.WithContext(ctx).Create(&savedQuery))
 }
 
-func (s *BloodhoundDB) DeleteSavedQuery(id int) error {
-	return CheckError(s.db.Delete(&model.SavedQuery{}, id))
+func (s *BloodhoundDB) DeleteSavedQuery(ctx context.Context, id int) error {
+	return CheckError(s.db.WithContext(ctx).Delete(&model.SavedQuery{}, id))
 }
 
 func (s *BloodhoundDB) SavedQueryBelongsToUser(userID uuid.UUID, savedQueryID int) (bool, error) {

--- a/cmd/api/src/database/saved_queries.go
+++ b/cmd/api/src/database/saved_queries.go
@@ -64,9 +64,9 @@ func (s *BloodhoundDB) DeleteSavedQuery(ctx context.Context, id int) error {
 	return CheckError(s.db.WithContext(ctx).Delete(&model.SavedQuery{}, id))
 }
 
-func (s *BloodhoundDB) SavedQueryBelongsToUser(userID uuid.UUID, savedQueryID int) (bool, error) {
+func (s *BloodhoundDB) SavedQueryBelongsToUser(ctx context.Context, userID uuid.UUID, savedQueryID int) (bool, error) {
 	var savedQuery model.SavedQuery
-	if result := s.db.First(&savedQuery, savedQueryID); result.Error != nil {
+	if result := s.db.WithContext(ctx).First(&savedQuery, savedQueryID); result.Error != nil {
 		return false, CheckError(result)
 	} else if savedQuery.UserID == userID.String() {
 		return true, nil

--- a/cmd/api/src/database/saved_queries_test.go
+++ b/cmd/api/src/database/saved_queries_test.go
@@ -51,7 +51,7 @@ func TestSavedQueries_ListSavedQueries(t *testing.T) {
 	require.Nil(t, err)
 
 	for i := 0; i < 7; i++ {
-		if _, err := dbInst.CreateSavedQuery(userUUID, fmt.Sprintf("saved_query_%d", i), ""); err != nil {
+		if _, err := dbInst.CreateSavedQuery(testCtx, userUUID, fmt.Sprintf("saved_query_%d", i), ""); err != nil {
 			t.Fatalf("Error creating audit log: %v", err)
 		}
 	}

--- a/cmd/api/src/database/saved_queries_test.go
+++ b/cmd/api/src/database/saved_queries_test.go
@@ -20,6 +20,7 @@
 package database_test
 
 import (
+	"context"
 	"fmt"
 	"github.com/gofrs/uuid"
 	"github.com/specterops/bloodhound/src/model"
@@ -30,7 +31,8 @@ import (
 
 func TestSavedQueries_ListSavedQueries(t *testing.T) {
 	var (
-		dbInst = integration.OpenDatabase(t)
+		testCtx = context.Background()
+		dbInst  = integration.OpenDatabase(t)
 
 		savedQueriesFilter = model.QueryParameterFilter{
 			Name:         "id",
@@ -54,14 +56,14 @@ func TestSavedQueries_ListSavedQueries(t *testing.T) {
 		}
 	}
 
-	if _, count, err := dbInst.ListSavedQueries(userUUID, "", model.SQLFilter{}, 0, 10); err != nil {
+	if _, count, err := dbInst.ListSavedQueries(testCtx, userUUID, "", model.SQLFilter{}, 0, 10); err != nil {
 		t.Fatalf("Failed to list all saved queries: %v", err)
 	} else if count != 7 {
 		t.Fatalf("Expected 7 saved queries to be returned")
 	} else if filter, err := savedQueriesFilterMap.BuildSQLFilter(); err != nil {
 		t.Fatalf("Failed to generate SQL Filter: %v", err)
 		// Limit is set to 1 to verify that count is total filtered count, not response size
-	} else if _, count, err = dbInst.ListSavedQueries(userUUID, "", filter, 0, 1); err != nil {
+	} else if _, count, err = dbInst.ListSavedQueries(testCtx, userUUID, "", filter, 0, 1); err != nil {
 		t.Fatalf("Failed to list filtered saved queries: %v", err)
 	} else if count != 3 {
 		t.Fatalf("Expected 3 saved queries to be returned")


### PR DESCRIPTION
## Description

Plumb context into gorm saved queries db methods
https://gorm.io/docs/context.html#Context-Timeout

## Motivation and Context

Currently as it stands any endpoints that rely on purely gorm do not respect `request.Context` and as such timeouts are not respected either. While we want to eventually get to the removal of the gorm dependency altogether, that is a long way and a lot of effort away and this I think this approach would give us that much room to maneuver while we get there.

## How Has This Been Tested?

Using a rest client and the prefer header
Add a sleep inside of the handler
Look for the `500 request timed out` after exceeding the timeout. (Note: the request will take as long as the sleep is set, it's not tied to the prefer header)

## Types of changes

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [x] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
