### PR TITLE
fix: plumb ctx into remaining bh db methods 

### DIFF
--- a/cmd/api/src/api/v2/integration/api.go
+++ b/cmd/api/src/api/v2/integration/api.go
@@ -85,7 +85,7 @@ func (s *Context) EnableAPI() {
 				Configuration: cfg,
 				DBConnector:   services.ConnectDatabases,
 				Entrypoint: func(ctx context.Context, cfg config.Configuration, databaseConnections bootstrap.DatabaseConnections[*database.BloodhoundDB, *graph.DatabaseSwitch]) ([]daemons.Daemon, error) {
-					if err := databaseConnections.RDMS.Wipe(); err != nil {
+					if err := databaseConnections.RDMS.Wipe(ctx); err != nil {
 						return nil, err
 					}
 

--- a/cmd/api/src/bootstrap/initializer.go
+++ b/cmd/api/src/bootstrap/initializer.go
@@ -64,7 +64,7 @@ func (s Initializer[DBType, GraphType]) Launch(parentCtx context.Context, handle
 		return fmt.Errorf("failed to start services: %w", err)
 	} else {
 		// Ensure that the database instances are closed once we're ready to exit regardless of p
-		defer databaseConnections.RDMS.Close()
+		defer databaseConnections.RDMS.Close(ctx)
 		defer databaseConnections.Graph.Close(context.Background())
 
 		daemonManager.Start(daemonInstances...)

--- a/cmd/api/src/bootstrap/initializer.go
+++ b/cmd/api/src/bootstrap/initializer.go
@@ -65,7 +65,7 @@ func (s Initializer[DBType, GraphType]) Launch(parentCtx context.Context, handle
 	} else {
 		// Ensure that the database instances are closed once we're ready to exit regardless of p
 		defer databaseConnections.RDMS.Close(ctx)
-		defer databaseConnections.Graph.Close(context.Background())
+		defer databaseConnections.Graph.Close(ctx)
 
 		daemonManager.Start(daemonInstances...)
 	}

--- a/cmd/api/src/bootstrap/server.go
+++ b/cmd/api/src/bootstrap/server.go
@@ -71,7 +71,7 @@ func MigrateDB(ctx context.Context, cfg config.Configuration, db database.Databa
 		return err
 	}
 
-	if hasInstallation, err := db.HasInstallation(); err != nil {
+	if hasInstallation, err := db.HasInstallation(ctx); err != nil {
 		return err
 	} else if hasInstallation {
 		return nil

--- a/cmd/api/src/bootstrap/server.go
+++ b/cmd/api/src/bootstrap/server.go
@@ -67,7 +67,7 @@ func MigrateGraph(ctx context.Context, db graph.Database, schema graph.Schema) e
 
 // MigrateDB runs database migrations on PG
 func MigrateDB(ctx context.Context, cfg config.Configuration, db database.Database) error {
-	if err := db.Migrate(); err != nil {
+	if err := db.Migrate(ctx); err != nil {
 		return err
 	}
 

--- a/cmd/api/src/database/agi_test.go
+++ b/cmd/api/src/database/agi_test.go
@@ -23,34 +23,26 @@ import (
 	"slices"
 	"testing"
 
-	"github.com/specterops/bloodhound/src/database"
 	"github.com/specterops/bloodhound/src/model"
 	"github.com/specterops/bloodhound/src/test/integration"
 	"github.com/specterops/bloodhound/src/utils/test"
 )
 
-func setupDB(t *testing.T) database.Database {
-	dbInst := integration.OpenDatabase(t)
-	if err := integration.Prepare(dbInst); err != nil {
-		t.Fatalf("Error preparing DB: %v", err)
-	}
-	return dbInst
-}
-
 func TestCreateGetUpdateDeleteAssetGroup(t *testing.T) {
 	var (
-		dbInst        = setupDB(t)
+		dbInst        = integration.SetupDB(t)
+		testCtx       = context.Background()
 		newAssetGroup model.AssetGroup
 		err           error
 	)
 
-	if newAssetGroup, err = dbInst.CreateAssetGroup(context.Background(), "test asset group", "test", false); err != nil {
+	if newAssetGroup, err = dbInst.CreateAssetGroup(testCtx, "test asset group", "test", false); err != nil {
 		t.Fatalf("Error creating asset group: %v", err)
 	} else if err = test.VerifyAuditLogs(dbInst, "CreateAssetGroup", "asset_group_name", newAssetGroup.Name); err != nil {
 		t.Fatalf("Error verifying CreateAssetGroup audit logs:\n%v", err)
 	}
 
-	if assetGroups, err := dbInst.GetAllAssetGroups(context.Background(), "", model.SQLFilter{}); err != nil {
+	if assetGroups, err := dbInst.GetAllAssetGroups(testCtx, "", model.SQLFilter{}); err != nil {
 		t.Fatalf("Error retrieving asset groups: %v", err)
 	} else if !slices.ContainsFunc(assetGroups, func(ag model.AssetGroup) bool { return ag.Name == "test asset group" }) {
 		t.Fatalf("Created asset group not returned:\n%#v", assetGroups)
@@ -67,13 +59,13 @@ func TestCreateGetUpdateDeleteAssetGroup(t *testing.T) {
 		Collections: newAssetGroup.Collections,
 		MemberCount: newAssetGroup.MemberCount,
 	}
-	if err = dbInst.UpdateAssetGroup(context.Background(), updatedAssetGroup); err != nil {
+	if err = dbInst.UpdateAssetGroup(testCtx, updatedAssetGroup); err != nil {
 		t.Fatalf("Error updating asset group: %v", err)
 	} else if err = test.VerifyAuditLogs(dbInst, "UpdateAssetGroup", "asset_group_name", "updated asset group"); err != nil {
 		t.Fatalf("Error veriying UpdateAssetGroup audit logs:\n%v", err)
 	}
 
-	if err = dbInst.DeleteAssetGroup(context.Background(), updatedAssetGroup); err != nil {
+	if err = dbInst.DeleteAssetGroup(testCtx, updatedAssetGroup); err != nil {
 		t.Fatalf("Error deleting asset group: %v", err)
 	} else if err = test.VerifyAuditLogs(dbInst, "DeleteAssetGroup", "asset_group_name", "updated asset group"); err != nil {
 		t.Fatalf("Error veriying DeleteAssetGroup audit logs:\n%v", err)

--- a/cmd/api/src/database/audit_test.go
+++ b/cmd/api/src/database/audit_test.go
@@ -21,18 +21,18 @@ package database_test
 
 import (
 	"context"
+	"github.com/specterops/bloodhound/src/test/integration"
 	"testing"
 	"time"
 
 	"github.com/specterops/bloodhound/src/auth"
 	"github.com/specterops/bloodhound/src/ctx"
 	"github.com/specterops/bloodhound/src/model"
-	"github.com/specterops/bloodhound/src/test/integration"
 )
 
 func TestDatabase_ListAuditLogs(t *testing.T) {
 	var (
-		dbInst = integration.OpenDatabase(t)
+		dbInst = integration.SetupDB(t)
 
 		auditLogIdFilter = model.QueryParameterFilter{
 			Name:         "id",
@@ -51,10 +51,6 @@ func TestDatabase_ListAuditLogs(t *testing.T) {
 		}
 		testCtx = ctx.Set(context.Background(), &mockCtx)
 	)
-
-	if err := integration.Prepare(dbInst); err != nil {
-		t.Fatalf("Failed preparing DB: %v", err)
-	}
 
 	for i := 0; i < 7; i++ {
 		if err := dbInst.AppendAuditLog(testCtx, model.AuditEntry{Model: &model.User{}, Action: "CreateUser", Status: model.AuditStatusSuccess}); err != nil {

--- a/cmd/api/src/database/auth.go
+++ b/cmd/api/src/database/auth.go
@@ -202,7 +202,7 @@ func (s *BloodhoundDB) InitializeSecretAuth(ctx context.Context, adminUser model
 
 // CreateInstallation creates a new Installation row
 // INSERT INTO installations(....) VALUES (...)
-func (s *BloodhoundDB) CreateInstallation() (model.Installation, error) {
+func (s *BloodhoundDB) CreateInstallation(ctx context.Context) (model.Installation, error) {
 	if newID, err := uuid.NewV4(); err != nil {
 		return model.Installation{}, err
 	} else {
@@ -212,17 +212,17 @@ func (s *BloodhoundDB) CreateInstallation() (model.Installation, error) {
 			},
 		}
 
-		result := s.db.Create(&installation)
+		result := s.db.WithContext(ctx).Create(&installation)
 		return installation, CheckError(result)
 	}
 }
 
 // GetInstallation retrieves the first row from installations
 // SELECT TOP 1 * FROM installations
-func (s *BloodhoundDB) GetInstallation() (model.Installation, error) {
+func (s *BloodhoundDB) GetInstallation(ctx context.Context) (model.Installation, error) {
 	var (
 		installation model.Installation
-		result       = s.db.First(&installation)
+		result       = s.db.WithContext(ctx).First(&installation)
 	)
 
 	return installation, CheckError(result)
@@ -230,8 +230,8 @@ func (s *BloodhoundDB) GetInstallation() (model.Installation, error) {
 
 // HasInstallation checks if an installation exists
 // SELECT CASE WHEN EXISTS (SELECT 1 FROM installations) THEN true ELSE false END
-func (s *BloodhoundDB) HasInstallation() (bool, error) {
-	if _, err := s.GetInstallation(); err != nil {
+func (s *BloodhoundDB) HasInstallation(ctx context.Context) (bool, error) {
+	if _, err := s.GetInstallation(ctx); err != nil {
 		if err == ErrNotFound {
 			return false, nil
 		}

--- a/cmd/api/src/database/auth_test.go
+++ b/cmd/api/src/database/auth_test.go
@@ -21,6 +21,7 @@ package database_test
 
 import (
 	"context"
+	"github.com/specterops/bloodhound/src/test/integration"
 	"github.com/specterops/bloodhound/src/utils/test"
 	"testing"
 	"time"
@@ -29,7 +30,6 @@ import (
 	"github.com/specterops/bloodhound/src/database"
 	"github.com/specterops/bloodhound/src/database/types/null"
 	"github.com/specterops/bloodhound/src/model"
-	"github.com/specterops/bloodhound/src/test/integration"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -40,10 +40,7 @@ const (
 )
 
 func initAndGetRoles(t *testing.T) (database.Database, model.Roles) {
-	dbInst := integration.OpenDatabase(t)
-	if err := integration.Prepare(dbInst); err != nil {
-		t.Fatalf("Failed preparing DB: %v", err)
-	}
+	dbInst := integration.SetupDB(t)
 
 	if roles, err := dbInst.GetAllRoles(context.Background(), "", model.SQLFilter{}); err != nil {
 		t.Fatalf("Error fetching roles: %v", err)
@@ -76,10 +73,7 @@ func initAndCreateUser(t *testing.T) (database.Database, model.User) {
 }
 
 func TestDatabase_Installation(t *testing.T) {
-	dbInst := integration.OpenDatabase(t)
-	if err := integration.Prepare(dbInst); err != nil {
-		t.Fatalf("Failed preparing DB: %v", err)
-	}
+	dbInst := integration.SetupDB(t)
 
 	if installation, err := dbInst.CreateInstallation(); err != nil {
 		t.Fatalf("Error creating installation: %v", err)
@@ -91,10 +85,7 @@ func TestDatabase_Installation(t *testing.T) {
 }
 
 func TestDatabase_InitializePermissions(t *testing.T) {
-	dbInst := integration.OpenDatabase(t)
-	if err := integration.Prepare(dbInst); err != nil {
-		t.Fatalf("Failed preparing DB: %v", err)
-	}
+	dbInst := integration.SetupDB(t)
 
 	if permissions, err := dbInst.GetAllPermissions(context.Background(), "", model.SQLFilter{}); err != nil {
 		t.Fatalf("Error fetching permissions: %v", err)

--- a/cmd/api/src/database/auth_test.go
+++ b/cmd/api/src/database/auth_test.go
@@ -73,11 +73,13 @@ func initAndCreateUser(t *testing.T) (database.Database, model.User) {
 }
 
 func TestDatabase_Installation(t *testing.T) {
-	dbInst := integration.SetupDB(t)
-
-	if installation, err := dbInst.CreateInstallation(); err != nil {
+	var (
+		dbInst  = integration.SetupDB(t)
+		testCtx = context.Background()
+	)
+	if installation, err := dbInst.CreateInstallation(testCtx); err != nil {
 		t.Fatalf("Error creating installation: %v", err)
-	} else if fetchedInstallation, err := dbInst.GetInstallation(); err != nil {
+	} else if fetchedInstallation, err := dbInst.GetInstallation(testCtx); err != nil {
 		t.Fatalf("Failed to fetch installation: %v", err)
 	} else if installation.ID.String() != fetchedInstallation.ID.String() {
 		t.Fatalf("Installation fetched does not match the initially created installation")

--- a/cmd/api/src/database/db.go
+++ b/cmd/api/src/database/db.go
@@ -55,7 +55,7 @@ type Database interface {
 	appcfg.ParameterService
 	appcfg.FeatureFlagService
 
-	Close()
+	Close(ctx context.Context)
 
 	// Ingest
 	ingest.IngestData
@@ -158,8 +158,8 @@ type BloodhoundDB struct {
 	idResolver auth.IdentityResolver // TODO: this really needs to be elsewhere. something something separation of concerns
 }
 
-func (s *BloodhoundDB) Close() {
-	if sqlDBRef, err := s.db.DB(); err != nil {
+func (s *BloodhoundDB) Close(ctx context.Context) {
+	if sqlDBRef, err := s.db.WithContext(ctx).DB(); err != nil {
 		log.Errorf("Failed to fetch SQL DB reference from GORM: %v", err)
 	} else if err := sqlDBRef.Close(); err != nil {
 		log.Errorf("Failed closing database: %v", err)

--- a/cmd/api/src/database/db.go
+++ b/cmd/api/src/database/db.go
@@ -77,8 +77,8 @@ type Database interface {
 	UpdateAssetGroupSelectors(ctx context.Context, assetGroup model.AssetGroup, selectorSpecs []model.AssetGroupSelectorSpec, systemSelector bool) (model.UpdatedAssetGroupSelectors, error)
 
 	Wipe(ctx context.Context) error
-	Migrate() error
-	RequiresMigration() (bool, error)
+	Migrate(ctx context.Context) error
+	RequiresMigration(ctx context.Context) (bool, error)
 
 	// Audit Logs
 	CreateAuditLog(ctx context.Context, auditLog model.AuditLog) error
@@ -227,13 +227,13 @@ func (s *BloodhoundDB) Wipe(ctx context.Context) error {
 	})
 }
 
-func (s *BloodhoundDB) RequiresMigration() (bool, error) {
-	return migration.NewMigrator(s.db).RequiresMigration()
+func (s *BloodhoundDB) RequiresMigration(ctx context.Context) (bool, error) {
+	return migration.NewMigrator(s.db.WithContext(ctx)).RequiresMigration()
 }
 
-func (s *BloodhoundDB) Migrate() error {
+func (s *BloodhoundDB) Migrate(ctx context.Context) error {
 	// Run the migrator
-	if err := migration.NewMigrator(s.db).Migrate(); err != nil {
+	if err := migration.NewMigrator(s.db.WithContext(ctx)).Migrate(); err != nil {
 		log.Errorf("Error during SQL database migration phase: %v", err)
 		return err
 	}

--- a/cmd/api/src/database/db.go
+++ b/cmd/api/src/database/db.go
@@ -76,7 +76,7 @@ type Database interface {
 	DeleteAssetGroupSelector(ctx context.Context, selector model.AssetGroupSelector) error
 	UpdateAssetGroupSelectors(ctx context.Context, assetGroup model.AssetGroup, selectorSpecs []model.AssetGroupSelectorSpec, systemSelector bool) (model.UpdatedAssetGroupSelectors, error)
 
-	Wipe() error
+	Wipe(ctx context.Context) error
 	Migrate() error
 	RequiresMigration() (bool, error)
 
@@ -207,8 +207,8 @@ func (s *BloodhoundDB) RawDelete(value any) error {
 	return CheckError(s.db.Delete(value))
 }
 
-func (s *BloodhoundDB) Wipe() error {
-	return s.db.Transaction(func(tx *gorm.DB) error {
+func (s *BloodhoundDB) Wipe(ctx context.Context) error {
+	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		var tables []string
 
 		if result := tx.Raw("select table_name from information_schema.tables where table_schema = current_schema() and not table_name ilike '%pg_stat%'").Scan(&tables); result.Error != nil {

--- a/cmd/api/src/database/db.go
+++ b/cmd/api/src/database/db.go
@@ -79,6 +79,9 @@ type Database interface {
 	Wipe(ctx context.Context) error
 	Migrate(ctx context.Context) error
 	RequiresMigration(ctx context.Context) (bool, error)
+	CreateInstallation(ctx context.Context) (model.Installation, error)
+	GetInstallation(ctx context.Context) (model.Installation, error)
+	HasInstallation(ctx context.Context) (bool, error)
 
 	// Audit Logs
 	CreateAuditLog(ctx context.Context, auditLog model.AuditLog) error
@@ -93,10 +96,6 @@ type Database interface {
 	// Permissions
 	GetAllPermissions(ctx context.Context, order string, filter model.SQLFilter) (model.Permissions, error)
 	GetPermission(ctx context.Context, id int) (model.Permission, error)
-
-	CreateInstallation() (model.Installation, error)
-	GetInstallation() (model.Installation, error)
-	HasInstallation() (bool, error)
 
 	// Users
 	CreateUser(ctx context.Context, user model.User) (model.User, error)

--- a/cmd/api/src/database/migration/agi_integration_test.go
+++ b/cmd/api/src/database/migration/agi_integration_test.go
@@ -30,10 +30,7 @@ import (
 func TestMigration_AssetGroups(t *testing.T) {
 	// We expect a new DB to have the T0 group and the Owned group
 	expectedNumAssetGroups := 2
-	dbInst := integration.OpenDatabase(t)
-	if err := integration.Prepare(dbInst); err != nil {
-		t.Fatalf("Failed preparing DB: %v", err)
-	}
+	dbInst := integration.SetupDB(t)
 
 	assetGroups, err := dbInst.GetAllAssetGroups(context.Background(), "", model.SQLFilter{})
 	require.Nil(t, err)

--- a/cmd/api/src/database/mocks/db.go
+++ b/cmd/api/src/database/mocks/db.go
@@ -1332,15 +1332,15 @@ func (mr *MockDatabaseMockRecorder) UpdateUser(arg0, arg1 interface{}) *gomock.C
 }
 
 // Wipe mocks base method.
-func (m *MockDatabase) Wipe() error {
+func (m *MockDatabase) Wipe(arg0 context.Context) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Wipe")
+	ret := m.ctrl.Call(m, "Wipe", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Wipe indicates an expected call of Wipe.
-func (mr *MockDatabaseMockRecorder) Wipe() *gomock.Call {
+func (mr *MockDatabaseMockRecorder) Wipe(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Wipe", reflect.TypeOf((*MockDatabase)(nil).Wipe))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Wipe", reflect.TypeOf((*MockDatabase)(nil).Wipe), arg0)
 }

--- a/cmd/api/src/database/mocks/db.go
+++ b/cmd/api/src/database/mocks/db.go
@@ -244,18 +244,18 @@ func (mr *MockDatabaseMockRecorder) CreateIngestTask(arg0, arg1 interface{}) *go
 }
 
 // CreateInstallation mocks base method.
-func (m *MockDatabase) CreateInstallation() (model.Installation, error) {
+func (m *MockDatabase) CreateInstallation(arg0 context.Context) (model.Installation, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateInstallation")
+	ret := m.ctrl.Call(m, "CreateInstallation", arg0)
 	ret0, _ := ret[0].(model.Installation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateInstallation indicates an expected call of CreateInstallation.
-func (mr *MockDatabaseMockRecorder) CreateInstallation() *gomock.Call {
+func (mr *MockDatabaseMockRecorder) CreateInstallation(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateInstallation", reflect.TypeOf((*MockDatabase)(nil).CreateInstallation))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateInstallation", reflect.TypeOf((*MockDatabase)(nil).CreateInstallation), arg0)
 }
 
 // CreateSAMLIdentityProvider mocks base method.
@@ -865,18 +865,18 @@ func (mr *MockDatabaseMockRecorder) GetIngestTasksForJob(arg0, arg1 interface{})
 }
 
 // GetInstallation mocks base method.
-func (m *MockDatabase) GetInstallation() (model.Installation, error) {
+func (m *MockDatabase) GetInstallation(arg0 context.Context) (model.Installation, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetInstallation")
+	ret := m.ctrl.Call(m, "GetInstallation", arg0)
 	ret0, _ := ret[0].(model.Installation)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetInstallation indicates an expected call of GetInstallation.
-func (mr *MockDatabaseMockRecorder) GetInstallation() *gomock.Call {
+func (mr *MockDatabaseMockRecorder) GetInstallation(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInstallation", reflect.TypeOf((*MockDatabase)(nil).GetInstallation))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInstallation", reflect.TypeOf((*MockDatabase)(nil).GetInstallation), arg0)
 }
 
 // GetLatestAssetGroupCollection mocks base method.
@@ -1030,18 +1030,18 @@ func (mr *MockDatabaseMockRecorder) GetUserToken(arg0, arg1, arg2 interface{}) *
 }
 
 // HasInstallation mocks base method.
-func (m *MockDatabase) HasInstallation() (bool, error) {
+func (m *MockDatabase) HasInstallation(arg0 context.Context) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "HasInstallation")
+	ret := m.ctrl.Call(m, "HasInstallation", arg0)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // HasInstallation indicates an expected call of HasInstallation.
-func (mr *MockDatabaseMockRecorder) HasInstallation() *gomock.Call {
+func (mr *MockDatabaseMockRecorder) HasInstallation(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasInstallation", reflect.TypeOf((*MockDatabase)(nil).HasInstallation))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasInstallation", reflect.TypeOf((*MockDatabase)(nil).HasInstallation), arg0)
 }
 
 // InitializeSecretAuth mocks base method.

--- a/cmd/api/src/database/mocks/db.go
+++ b/cmd/api/src/database/mocks/db.go
@@ -69,15 +69,15 @@ func (mr *MockDatabaseMockRecorder) AppendAuditLog(arg0, arg1 interface{}) *gomo
 }
 
 // Close mocks base method.
-func (m *MockDatabase) Close() {
+func (m *MockDatabase) Close(arg0 context.Context) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Close")
+	m.ctrl.Call(m, "Close", arg0)
 }
 
 // Close indicates an expected call of Close.
-func (mr *MockDatabaseMockRecorder) Close() *gomock.Call {
+func (mr *MockDatabaseMockRecorder) Close(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockDatabase)(nil).Close))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockDatabase)(nil).Close), arg0)
 }
 
 // CreateADDataQualityAggregation mocks base method.

--- a/cmd/api/src/database/mocks/db.go
+++ b/cmd/api/src/database/mocks/db.go
@@ -1137,32 +1137,32 @@ func (mr *MockDatabaseMockRecorder) LookupUser(arg0, arg1 interface{}) *gomock.C
 }
 
 // Migrate mocks base method.
-func (m *MockDatabase) Migrate() error {
+func (m *MockDatabase) Migrate(arg0 context.Context) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Migrate")
+	ret := m.ctrl.Call(m, "Migrate", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Migrate indicates an expected call of Migrate.
-func (mr *MockDatabaseMockRecorder) Migrate() *gomock.Call {
+func (mr *MockDatabaseMockRecorder) Migrate(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Migrate", reflect.TypeOf((*MockDatabase)(nil).Migrate))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Migrate", reflect.TypeOf((*MockDatabase)(nil).Migrate), arg0)
 }
 
 // RequiresMigration mocks base method.
-func (m *MockDatabase) RequiresMigration() (bool, error) {
+func (m *MockDatabase) RequiresMigration(arg0 context.Context) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RequiresMigration")
+	ret := m.ctrl.Call(m, "RequiresMigration", arg0)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // RequiresMigration indicates an expected call of RequiresMigration.
-func (mr *MockDatabaseMockRecorder) RequiresMigration() *gomock.Call {
+func (mr *MockDatabaseMockRecorder) RequiresMigration(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RequiresMigration", reflect.TypeOf((*MockDatabase)(nil).RequiresMigration))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RequiresMigration", reflect.TypeOf((*MockDatabase)(nil).RequiresMigration), arg0)
 }
 
 // SavedQueryBelongsToUser mocks base method.

--- a/cmd/api/src/database/saved_queries_test.go
+++ b/cmd/api/src/database/saved_queries_test.go
@@ -32,7 +32,7 @@ import (
 func TestSavedQueries_ListSavedQueries(t *testing.T) {
 	var (
 		testCtx = context.Background()
-		dbInst  = integration.OpenDatabase(t)
+		dbInst  = integration.SetupDB(t)
 
 		savedQueriesFilter = model.QueryParameterFilter{
 			Name:         "id",
@@ -42,10 +42,6 @@ func TestSavedQueries_ListSavedQueries(t *testing.T) {
 		}
 		savedQueriesFilterMap = model.QueryParameterFilterMap{savedQueriesFilter.Name: model.QueryParameterFilters{savedQueriesFilter}}
 	)
-
-	if err := integration.Prepare(dbInst); err != nil {
-		t.Fatalf("Failed preparing DB: %v", err)
-	}
 
 	userUUID, err := uuid.NewV4()
 	require.Nil(t, err)

--- a/cmd/api/src/test/integration/database.go
+++ b/cmd/api/src/test/integration/database.go
@@ -17,6 +17,7 @@
 package integration
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -50,8 +51,16 @@ func OpenCache(t *testing.T) cache.Cache {
 	return cache.Cache{}
 }
 
-func Prepare(db database.Database) error {
-	if err := db.Wipe(); err != nil {
+func SetupDB(t *testing.T) database.Database {
+	dbInst := OpenDatabase(t)
+	if err := Prepare(context.Background(), dbInst); err != nil {
+		t.Fatalf("Error preparing DB: %v", err)
+	}
+	return dbInst
+}
+
+func Prepare(ctx context.Context, db database.Database) error {
+	if err := db.Wipe(ctx); err != nil {
 		return fmt.Errorf("failed to clear database: %v", err)
 	} else if err := db.Migrate(); err != nil {
 		return fmt.Errorf("failed to migrate database: %v", err)

--- a/cmd/api/src/test/integration/database.go
+++ b/cmd/api/src/test/integration/database.go
@@ -62,7 +62,7 @@ func SetupDB(t *testing.T) database.Database {
 func Prepare(ctx context.Context, db database.Database) error {
 	if err := db.Wipe(ctx); err != nil {
 		return fmt.Errorf("failed to clear database: %v", err)
-	} else if err := db.Migrate(); err != nil {
+	} else if err := db.Migrate(ctx); err != nil {
 		return fmt.Errorf("failed to migrate database: %v", err)
 	}
 

--- a/cmd/api/src/test/lab/fixtures/api.go
+++ b/cmd/api/src/test/lab/fixtures/api.go
@@ -56,7 +56,7 @@ func NewApiFixture() *lab.Fixture[bool] {
 						Configuration: cfg,
 						DBConnector:   services.ConnectDatabases,
 						Entrypoint: func(ctx context.Context, cfg config.Configuration, databaseConnections bootstrap.DatabaseConnections[*database.BloodhoundDB, *graph.DatabaseSwitch]) ([]daemons.Daemon, error) {
-							if err := databaseConnections.RDMS.Wipe(); err != nil {
+							if err := databaseConnections.RDMS.Wipe(ctx); err != nil {
 								return nil, err
 							}
 

--- a/cmd/api/src/test/lab/fixtures/postgres.go
+++ b/cmd/api/src/test/lab/fixtures/postgres.go
@@ -30,13 +30,14 @@ import (
 )
 
 var PostgresFixture = lab.NewFixture(func(harness *lab.Harness) (*database.BloodhoundDB, error) {
+	testCtx := context.Background()
 	if config, ok := lab.Unpack(harness, ConfigFixture); !ok {
 		return nil, fmt.Errorf("unable to unpack ConfigFixture")
 	} else if pgdb, err := database.OpenDatabase(config.Database.PostgreSQLConnectionString()); err != nil {
 		return nil, err
-	} else if err := integration.Prepare(database.NewBloodhoundDB(pgdb, auth.NewIdentityResolver())); err != nil {
+	} else if err := integration.Prepare(testCtx, database.NewBloodhoundDB(pgdb, auth.NewIdentityResolver())); err != nil {
 		return nil, fmt.Errorf("failed ensuring database: %v", err)
-	} else if err := bootstrap.MigrateDB(context.Background(), config, database.NewBloodhoundDB(pgdb, auth.NewIdentityResolver())); err != nil {
+	} else if err := bootstrap.MigrateDB(testCtx, config, database.NewBloodhoundDB(pgdb, auth.NewIdentityResolver())); err != nil {
 		return nil, fmt.Errorf("failed migrating database: %v", err)
 	} else {
 		return database.NewBloodhoundDB(pgdb, auth.NewIdentityResolver()), nil


### PR DESCRIPTION
## Description

Plumb context into gorm remaining  db methods
https://gorm.io/docs/context.html#Context-Timeout

## Motivation and Context

Currently as it stands any endpoints that rely on purely gorm do not respect `request.Context` and as such timeouts are not respected either. While we want to eventually get to the removal of the gorm dependency altogether, that is a long way and a lot of effort away and this I think this approach would give us that much room to maneuver while we get there.

## How Has This Been Tested?

Using a rest client and the prefer header
Add a sleep inside of the handler
Look for the `500 request timed out` after exceeding the timeout. (Note: the request will take as long as the sleep is set, it's not tied to the prefer header)

## Types of changes

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [x] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
