### PR TITLE
fix: plumb ctx into feature flag db methods

### DIFF
--- a/cmd/api/src/api/middleware/middleware.go
+++ b/cmd/api/src/api/middleware/middleware.go
@@ -271,7 +271,7 @@ func SecureHandlerMiddleware(cfg config.Configuration, contentSecurityPolicy str
 func FeatureFlagMiddleware(db database.Database, flagKey string) mux.MiddlewareFunc {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
-			if flag, err := db.GetFlagByKey(flagKey); err != nil {
+			if flag, err := db.GetFlagByKey(request.Context(), flagKey); err != nil {
 				api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusInternalServerError, fmt.Sprintf("error retrieving %s feature flag: %s", flagKey, err), request), response)
 			} else if flag.Enabled {
 				next.ServeHTTP(response, request)

--- a/cmd/api/src/api/tools/flag.go
+++ b/cmd/api/src/api/tools/flag.go
@@ -20,9 +20,9 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/go-chi/chi/v5"
 	"github.com/specterops/bloodhound/src/api"
 	"github.com/specterops/bloodhound/src/database"
-	"github.com/go-chi/chi/v5"
 )
 
 const (
@@ -42,7 +42,7 @@ func NewToolContainer(db database.Database) ToolContainer {
 }
 
 func (s ToolContainer) GetFlags(response http.ResponseWriter, request *http.Request) {
-	if flags, err := s.db.GetAllFlags(); err != nil {
+	if flags, err := s.db.GetAllFlags(request.Context()); err != nil {
 		api.HandleDatabaseError(request, response, err)
 	} else {
 		api.WriteBasicResponse(request.Context(), flags, http.StatusOK, response)

--- a/cmd/api/src/api/tools/flag.go
+++ b/cmd/api/src/api/tools/flag.go
@@ -54,7 +54,7 @@ func (s ToolContainer) ToggleFlag(response http.ResponseWriter, request *http.Re
 
 	if featureID, err := strconv.ParseInt(rawFeatureID, 10, 32); err != nil {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, api.ErrorResponseDetailsIDMalformed, request), response)
-	} else if featureFlag, err := s.db.GetFlag(int32(featureID)); err != nil {
+	} else if featureFlag, err := s.db.GetFlag(request.Context(), int32(featureID)); err != nil {
 		api.HandleDatabaseError(request, response, err)
 	} else {
 		featureFlag.Enabled = !featureFlag.Enabled

--- a/cmd/api/src/api/tools/flag.go
+++ b/cmd/api/src/api/tools/flag.go
@@ -59,7 +59,7 @@ func (s ToolContainer) ToggleFlag(response http.ResponseWriter, request *http.Re
 	} else {
 		featureFlag.Enabled = !featureFlag.Enabled
 
-		if err := s.db.SetFlag(featureFlag); err != nil {
+		if err := s.db.SetFlag(request.Context(), featureFlag); err != nil {
 			api.HandleDatabaseError(request, response, err)
 		} else {
 			api.WriteBasicResponse(request.Context(), ToggleFlagResponse{

--- a/cmd/api/src/api/v2/ad_related_entity.go
+++ b/cmd/api/src/api/v2/ad_related_entity.go
@@ -38,7 +38,7 @@ import (
 func (s *Resources) handleAdRelatedEntityQuery(response http.ResponseWriter, request *http.Request, queryName string, pathDelegate any, listDelegate any) {
 	if params, err := queries.BuildEntityQueryParams(request, queryName, pathDelegate, listDelegate); err != nil {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, fmt.Sprintf(api.FmtErrorResponseDetailsBadQueryParameters, err), request), response)
-	} else if entityPanelCachingFlag, err := s.DB.GetFlagByKey(appcfg.FeatureEntityPanelCaching); err != nil {
+	} else if entityPanelCachingFlag, err := s.DB.GetFlagByKey(request.Context(), appcfg.FeatureEntityPanelCaching); err != nil {
 		api.HandleDatabaseError(request, response, err)
 	} else if results, count, err := s.GraphQuery.GetADEntityQueryResult(request.Context(), params, entityPanelCachingFlag.Enabled); err != nil {
 		if errors.Is(err, queries.ErrGraphUnsupported) || errors.Is(err, queries.ErrUnsupportedDataType) {

--- a/cmd/api/src/api/v2/ad_related_entity_test.go
+++ b/cmd/api/src/api/v2/ad_related_entity_test.go
@@ -60,7 +60,7 @@ func setupCases(mockGraph *graphMocks.MockGraph, mockDB *dbMocks.MockDatabase) [
 					GetADEntityQueryResult(gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(nil, 0, queries.ErrGraphUnsupported)
 				mockDB.EXPECT().
-					GetFlagByKey("entity_panel_cache").
+					GetFlagByKey(gomock.Any(), "entity_panel_cache").
 					Return(appcfg.FeatureFlag{Enabled: true}, nil)
 			},
 			Test: func(output apitest.Output) {
@@ -78,7 +78,7 @@ func setupCases(mockGraph *graphMocks.MockGraph, mockDB *dbMocks.MockDatabase) [
 					GetADEntityQueryResult(gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(nil, 0, queries.ErrUnsupportedDataType)
 				mockDB.EXPECT().
-					GetFlagByKey("entity_panel_cache").
+					GetFlagByKey(gomock.Any(), "entity_panel_cache").
 					Return(appcfg.FeatureFlag{Enabled: true}, nil)
 			},
 			Test: func(output apitest.Output) {
@@ -96,7 +96,7 @@ func setupCases(mockGraph *graphMocks.MockGraph, mockDB *dbMocks.MockDatabase) [
 					GetADEntityQueryResult(gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(nil, 0, ops.ErrTraversalMemoryLimit)
 				mockDB.EXPECT().
-					GetFlagByKey("entity_panel_cache").
+					GetFlagByKey(gomock.Any(), "entity_panel_cache").
 					Return(appcfg.FeatureFlag{Enabled: true}, nil)
 			},
 			Test: func(output apitest.Output) {
@@ -114,7 +114,7 @@ func setupCases(mockGraph *graphMocks.MockGraph, mockDB *dbMocks.MockDatabase) [
 					GetADEntityQueryResult(gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(nil, 0, errors.New("any other error"))
 				mockDB.EXPECT().
-					GetFlagByKey("entity_panel_cache").
+					GetFlagByKey(gomock.Any(), "entity_panel_cache").
 					Return(appcfg.FeatureFlag{Enabled: true}, nil)
 			},
 			Test: func(output apitest.Output) {
@@ -132,7 +132,7 @@ func setupCases(mockGraph *graphMocks.MockGraph, mockDB *dbMocks.MockDatabase) [
 					GetADEntityQueryResult(gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(nil, 0, nil)
 				mockDB.EXPECT().
-					GetFlagByKey("entity_panel_cache").
+					GetFlagByKey(gomock.Any(), "entity_panel_cache").
 					Return(appcfg.FeatureFlag{Enabled: true}, nil)
 			},
 			Test: func(output apitest.Output) {

--- a/cmd/api/src/api/v2/flag.go
+++ b/cmd/api/src/api/v2/flag.go
@@ -31,7 +31,7 @@ type ListFlagsResponse struct {
 }
 
 func (s Resources) GetFlags(response http.ResponseWriter, request *http.Request) {
-	if flags, err := s.DB.GetAllFlags(); err != nil {
+	if flags, err := s.DB.GetAllFlags(request.Context()); err != nil {
 		api.HandleDatabaseError(request, response, err)
 	} else {
 		api.WriteBasicResponse(request.Context(), flags, http.StatusOK, response)

--- a/cmd/api/src/api/v2/flag.go
+++ b/cmd/api/src/api/v2/flag.go
@@ -47,7 +47,7 @@ func (s Resources) ToggleFlag(response http.ResponseWriter, request *http.Reques
 
 	if featureID, err := strconv.ParseInt(rawFeatureID, 10, 32); err != nil {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, api.ErrorResponseDetailsIDMalformed, request), response)
-	} else if featureFlag, err := s.DB.GetFlag(int32(featureID)); err != nil {
+	} else if featureFlag, err := s.DB.GetFlag(request.Context(), int32(featureID)); err != nil {
 		api.HandleDatabaseError(request, response, err)
 	} else if !featureFlag.UserUpdatable {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusForbidden, fmt.Sprintf("Feature flag %s(%d) is not user updatable.", featureFlag.Key, featureID), request), response)

--- a/cmd/api/src/api/v2/flag.go
+++ b/cmd/api/src/api/v2/flag.go
@@ -54,7 +54,7 @@ func (s Resources) ToggleFlag(response http.ResponseWriter, request *http.Reques
 	} else {
 		featureFlag.Enabled = !featureFlag.Enabled
 
-		if err := s.DB.SetFlag(featureFlag); err != nil {
+		if err := s.DB.SetFlag(request.Context(), featureFlag); err != nil {
 			api.HandleDatabaseError(request, response, err)
 		} else {
 			// TODO: Cleanup #ADCSFeatureFlag after full launch.

--- a/cmd/api/src/api/v2/flag_test.go
+++ b/cmd/api/src/api/v2/flag_test.go
@@ -80,13 +80,13 @@ func TestResources_ToggleFlag(t *testing.T) {
 
 	defer mockCtrl.Finish()
 
-	mockDB.EXPECT().GetFlag(featureID).Return(appcfg.FeatureFlag{
+	mockDB.EXPECT().GetFlag(gomock.Any(), featureID).Return(appcfg.FeatureFlag{
 		UserUpdatable: false,
 	}, nil)
 
 	requestSetup.Require().ResponseStatusCode(http.StatusForbidden)
 
-	mockDB.EXPECT().GetFlag(featureID).Return(appcfg.FeatureFlag{
+	mockDB.EXPECT().GetFlag(gomock.Any(), featureID).Return(appcfg.FeatureFlag{
 		UserUpdatable: true,
 	}, nil)
 	mockDB.EXPECT().SetFlag(gomock.Any()).Return(nil)

--- a/cmd/api/src/api/v2/flag_test.go
+++ b/cmd/api/src/api/v2/flag_test.go
@@ -89,7 +89,7 @@ func TestResources_ToggleFlag(t *testing.T) {
 	mockDB.EXPECT().GetFlag(gomock.Any(), featureID).Return(appcfg.FeatureFlag{
 		UserUpdatable: true,
 	}, nil)
-	mockDB.EXPECT().SetFlag(gomock.Any()).Return(nil)
+	mockDB.EXPECT().SetFlag(gomock.Any(), gomock.Any()).Return(nil)
 
 	requestSetup.Require().
 		ResponseStatusCode(http.StatusOK).

--- a/cmd/api/src/api/v2/flag_test.go
+++ b/cmd/api/src/api/v2/flag_test.go
@@ -39,7 +39,7 @@ func TestResources_GetFlags(t *testing.T) {
 
 	defer mockCtrl.Finish()
 
-	mockDB.EXPECT().GetAllFlags().Return([]appcfg.FeatureFlag{}, nil)
+	mockDB.EXPECT().GetAllFlags(gomock.Any()).Return([]appcfg.FeatureFlag{}, nil)
 
 	test.Request(t).
 		WithMethod(http.MethodGet).
@@ -51,7 +51,7 @@ func TestResources_GetFlags(t *testing.T) {
 			Data: []appcfg.FeatureFlag{},
 		})
 
-	mockDB.EXPECT().GetAllFlags().Return(nil, errors.Error("db error"))
+	mockDB.EXPECT().GetAllFlags(gomock.Any()).Return(nil, errors.Error("db error"))
 
 	test.Request(t).
 		WithMethod(http.MethodGet).

--- a/cmd/api/src/daemons/datapipe/analysis.go
+++ b/cmd/api/src/daemons/datapipe/analysis.go
@@ -76,7 +76,7 @@ func RunAnalysisOperations(ctx context.Context, db database.Database, graphDB gr
 	)
 
 	// TODO: Cleanup #ADCSFeatureFlag after full launch.
-	if adcsFlag, err := db.GetFlagByKey(appcfg.FeatureAdcs); err != nil {
+	if adcsFlag, err := db.GetFlagByKey(ctx, appcfg.FeatureAdcs); err != nil {
 		collectedErrors = append(collectedErrors, fmt.Errorf("error retrieving ADCS feature flag: %w", err))
 	} else if stats, err := ad.Post(ctx, graphDB, adcsFlag.Enabled); err != nil {
 		collectedErrors = append(collectedErrors, fmt.Errorf("error during ad post: %w", err))

--- a/cmd/api/src/daemons/datapipe/datapipe.go
+++ b/cmd/api/src/daemons/datapipe/datapipe.go
@@ -115,7 +115,7 @@ func (s *Daemon) analyze() {
 	} else {
 		CompleteAnalyzedFileUploadJobs(s.ctx, s.db)
 
-		if entityPanelCachingFlag, err := s.db.GetFlagByKey(appcfg.FeatureEntityPanelCaching); err != nil {
+		if entityPanelCachingFlag, err := s.db.GetFlagByKey(s.ctx, appcfg.FeatureEntityPanelCaching); err != nil {
 			log.Errorf("Error retrieving entity panel caching flag: %v", err)
 		} else {
 			resetCache(s.cache, entityPanelCachingFlag.Enabled)

--- a/cmd/api/src/database/app_config.go
+++ b/cmd/api/src/database/app_config.go
@@ -27,9 +27,9 @@ func (s *BloodhoundDB) GetFlag(ctx context.Context, id int32) (appcfg.FeatureFla
 	return flag, CheckError(s.db.WithContext(ctx).Find(&flag, id))
 }
 
-func (s *BloodhoundDB) GetFlagByKey(key string) (appcfg.FeatureFlag, error) {
+func (s *BloodhoundDB) GetFlagByKey(ctx context.Context, key string) (appcfg.FeatureFlag, error) {
 	var flag appcfg.FeatureFlag
-	return flag, CheckError(s.db.Where("key = ?", key).First(&flag))
+	return flag, CheckError(s.db.WithContext(ctx).Where("key = ?", key).First(&flag))
 }
 
 func (s *BloodhoundDB) GetAllFlags(ctx context.Context) ([]appcfg.FeatureFlag, error) {

--- a/cmd/api/src/database/app_config.go
+++ b/cmd/api/src/database/app_config.go
@@ -22,9 +22,9 @@ import (
 	"gorm.io/gorm/clause"
 )
 
-func (s *BloodhoundDB) GetFlag(id int32) (appcfg.FeatureFlag, error) {
+func (s *BloodhoundDB) GetFlag(ctx context.Context, id int32) (appcfg.FeatureFlag, error) {
 	var flag appcfg.FeatureFlag
-	return flag, CheckError(s.db.Find(&flag, id))
+	return flag, CheckError(s.db.WithContext(ctx).Find(&flag, id))
 }
 
 func (s *BloodhoundDB) GetFlagByKey(key string) (appcfg.FeatureFlag, error) {

--- a/cmd/api/src/database/app_config.go
+++ b/cmd/api/src/database/app_config.go
@@ -37,8 +37,8 @@ func (s *BloodhoundDB) GetAllFlags(ctx context.Context) ([]appcfg.FeatureFlag, e
 	return flags, CheckError(s.db.WithContext(ctx).Find(&flags))
 }
 
-func (s *BloodhoundDB) SetFlag(flag appcfg.FeatureFlag) error {
-	return CheckError(s.db.Save(&flag))
+func (s *BloodhoundDB) SetFlag(ctx context.Context, flag appcfg.FeatureFlag) error {
+	return CheckError(s.db.WithContext(ctx).Save(&flag))
 }
 
 func (s *BloodhoundDB) GetAllConfigurationParameters(ctx context.Context) (appcfg.Parameters, error) {

--- a/cmd/api/src/database/app_config.go
+++ b/cmd/api/src/database/app_config.go
@@ -32,9 +32,9 @@ func (s *BloodhoundDB) GetFlagByKey(key string) (appcfg.FeatureFlag, error) {
 	return flag, CheckError(s.db.Where("key = ?", key).First(&flag))
 }
 
-func (s *BloodhoundDB) GetAllFlags() ([]appcfg.FeatureFlag, error) {
+func (s *BloodhoundDB) GetAllFlags(ctx context.Context) ([]appcfg.FeatureFlag, error) {
 	var flags []appcfg.FeatureFlag
-	return flags, CheckError(s.db.Find(&flags))
+	return flags, CheckError(s.db.WithContext(ctx).Find(&flags))
 }
 
 func (s *BloodhoundDB) SetFlag(flag appcfg.FeatureFlag) error {

--- a/cmd/api/src/database/mocks/db.go
+++ b/cmd/api/src/database/mocks/db.go
@@ -578,18 +578,18 @@ func (mr *MockDatabaseMockRecorder) GetAllFileUploadJobs(arg0, arg1, arg2, arg3,
 }
 
 // GetAllFlags mocks base method.
-func (m *MockDatabase) GetAllFlags() ([]appcfg.FeatureFlag, error) {
+func (m *MockDatabase) GetAllFlags(arg0 context.Context) ([]appcfg.FeatureFlag, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAllFlags")
+	ret := m.ctrl.Call(m, "GetAllFlags", arg0)
 	ret0, _ := ret[0].([]appcfg.FeatureFlag)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetAllFlags indicates an expected call of GetAllFlags.
-func (mr *MockDatabaseMockRecorder) GetAllFlags() *gomock.Call {
+func (mr *MockDatabaseMockRecorder) GetAllFlags(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllFlags", reflect.TypeOf((*MockDatabase)(nil).GetAllFlags))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllFlags", reflect.TypeOf((*MockDatabase)(nil).GetAllFlags), arg0)
 }
 
 // GetAllIngestTasks mocks base method.

--- a/cmd/api/src/database/mocks/db.go
+++ b/cmd/api/src/database/mocks/db.go
@@ -1195,17 +1195,17 @@ func (mr *MockDatabaseMockRecorder) SetConfigurationParameter(arg0, arg1 interfa
 }
 
 // SetFlag mocks base method.
-func (m *MockDatabase) SetFlag(arg0 appcfg.FeatureFlag) error {
+func (m *MockDatabase) SetFlag(arg0 context.Context, arg1 appcfg.FeatureFlag) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetFlag", arg0)
+	ret := m.ctrl.Call(m, "SetFlag", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetFlag indicates an expected call of SetFlag.
-func (mr *MockDatabaseMockRecorder) SetFlag(arg0 interface{}) *gomock.Call {
+func (mr *MockDatabaseMockRecorder) SetFlag(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetFlag", reflect.TypeOf((*MockDatabase)(nil).SetFlag), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetFlag", reflect.TypeOf((*MockDatabase)(nil).SetFlag), arg0, arg1)
 }
 
 // SweepAssetGroupCollections mocks base method.

--- a/cmd/api/src/database/mocks/db.go
+++ b/cmd/api/src/database/mocks/db.go
@@ -835,18 +835,18 @@ func (mr *MockDatabaseMockRecorder) GetFlag(arg0, arg1 interface{}) *gomock.Call
 }
 
 // GetFlagByKey mocks base method.
-func (m *MockDatabase) GetFlagByKey(arg0 string) (appcfg.FeatureFlag, error) {
+func (m *MockDatabase) GetFlagByKey(arg0 context.Context, arg1 string) (appcfg.FeatureFlag, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetFlagByKey", arg0)
+	ret := m.ctrl.Call(m, "GetFlagByKey", arg0, arg1)
 	ret0, _ := ret[0].(appcfg.FeatureFlag)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetFlagByKey indicates an expected call of GetFlagByKey.
-func (mr *MockDatabaseMockRecorder) GetFlagByKey(arg0 interface{}) *gomock.Call {
+func (mr *MockDatabaseMockRecorder) GetFlagByKey(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFlagByKey", reflect.TypeOf((*MockDatabase)(nil).GetFlagByKey), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFlagByKey", reflect.TypeOf((*MockDatabase)(nil).GetFlagByKey), arg0, arg1)
 }
 
 // GetIngestTasksForJob mocks base method.

--- a/cmd/api/src/database/mocks/db.go
+++ b/cmd/api/src/database/mocks/db.go
@@ -820,18 +820,18 @@ func (mr *MockDatabaseMockRecorder) GetFileUploadJobsWithStatus(arg0, arg1 inter
 }
 
 // GetFlag mocks base method.
-func (m *MockDatabase) GetFlag(arg0 int32) (appcfg.FeatureFlag, error) {
+func (m *MockDatabase) GetFlag(arg0 context.Context, arg1 int32) (appcfg.FeatureFlag, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetFlag", arg0)
+	ret := m.ctrl.Call(m, "GetFlag", arg0, arg1)
 	ret0, _ := ret[0].(appcfg.FeatureFlag)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetFlag indicates an expected call of GetFlag.
-func (mr *MockDatabaseMockRecorder) GetFlag(arg0 interface{}) *gomock.Call {
+func (mr *MockDatabaseMockRecorder) GetFlag(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFlag", reflect.TypeOf((*MockDatabase)(nil).GetFlag), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFlag", reflect.TypeOf((*MockDatabase)(nil).GetFlag), arg0, arg1)
 }
 
 // GetFlagByKey mocks base method.

--- a/cmd/api/src/model/appcfg/flag.go
+++ b/cmd/api/src/model/appcfg/flag.go
@@ -124,7 +124,7 @@ type FeatureFlagService interface {
 	GetFlag(ctx context.Context, id int32) (FeatureFlag, error)
 
 	// GetFlagByKey attempts to fetch a FeatureFlag by its key.
-	GetFlagByKey(key string) (FeatureFlag, error)
+	GetFlagByKey(ctx context.Context, key string) (FeatureFlag, error)
 
 	// SetFlag attempts to store or update the given FeatureFlag by its feature Key.
 	SetFlag(value FeatureFlag) error

--- a/cmd/api/src/model/appcfg/flag.go
+++ b/cmd/api/src/model/appcfg/flag.go
@@ -121,7 +121,7 @@ type FeatureFlagService interface {
 	GetAllFlags(ctx context.Context) ([]FeatureFlag, error)
 
 	// GetFlag attempts to fetch a FeatureFlag by its ID.
-	GetFlag(id int32) (FeatureFlag, error)
+	GetFlag(ctx context.Context, id int32) (FeatureFlag, error)
 
 	// GetFlagByKey attempts to fetch a FeatureFlag by its key.
 	GetFlagByKey(key string) (FeatureFlag, error)

--- a/cmd/api/src/model/appcfg/flag.go
+++ b/cmd/api/src/model/appcfg/flag.go
@@ -16,7 +16,10 @@
 
 package appcfg
 
-import "github.com/specterops/bloodhound/src/model"
+import (
+	"context"
+	"github.com/specterops/bloodhound/src/model"
+)
 
 const (
 	FeatureButterflyAnalysis   = "butterfly_analysis"
@@ -115,7 +118,7 @@ type FeatureFlagSet map[string]FeatureFlag
 // FeatureFlagService defines a contract for fetching and setting feature flags.
 type FeatureFlagService interface {
 	// GetAllFlags gets all available runtime feature flags as a FeatureFlagSet for the application.
-	GetAllFlags() ([]FeatureFlag, error)
+	GetAllFlags(ctx context.Context) ([]FeatureFlag, error)
 
 	// GetFlag attempts to fetch a FeatureFlag by its ID.
 	GetFlag(id int32) (FeatureFlag, error)

--- a/cmd/api/src/model/appcfg/flag.go
+++ b/cmd/api/src/model/appcfg/flag.go
@@ -127,5 +127,5 @@ type FeatureFlagService interface {
 	GetFlagByKey(ctx context.Context, key string) (FeatureFlag, error)
 
 	// SetFlag attempts to store or update the given FeatureFlag by its feature Key.
-	SetFlag(value FeatureFlag) error
+	SetFlag(ctx context.Context, value FeatureFlag) error
 }


### PR DESCRIPTION
## Description

Plumb context into gorm feature flag db methods
https://gorm.io/docs/context.html#Context-Timeout

## Motivation and Context

Currently as it stands any endpoints that rely on purely gorm do not respect `request.Context` and as such timeouts are not respected either. While we want to eventually get to the removal of the gorm dependency altogether, that is a long way and a lot of effort away and this I think this approach would give us that much room to maneuver while we get there.

## How Has This Been Tested?

Using a rest client and the prefer header
Add a sleep inside of the handler
Look for the `500 request timed out` after exceeding the timeout. (Note: the request will take as long as the sleep is set, it's not tied to the prefer header)

## Types of changes

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [x] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
