### PR TITLE
fix: handle undefined input in explore search input

### DIFF
--- a/cmd/ui/src/ducks/index.ts
+++ b/cmd/ui/src/ducks/index.ts
@@ -16,7 +16,6 @@
 
 export { default as global } from './global';
 export { default as explore } from './explore';
-export { default as search } from './searchbar';
 export { default as entityinfo } from './entityinfo';
 export { default as tierzero } from './tierzero';
 export { default as assetgroups } from './assetgroups';

--- a/cmd/ui/src/store.ts
+++ b/cmd/ui/src/store.ts
@@ -21,7 +21,7 @@ import throttle from 'lodash/throttle';
 import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux';
 import createSagaMiddleware from 'redux-saga';
 import * as reducers from 'src/ducks';
-import { edgeinfo } from 'bh-shared-ui';
+import { edgeinfo, searchReducer as search } from 'bh-shared-ui';
 import rootSaga from 'src/rootSaga';
 
 enableMapSet();
@@ -31,6 +31,7 @@ const sagaMiddleware = createSagaMiddleware();
 const appReducer = combineReducers({
     ...reducers,
     edgeinfo,
+    search,
 });
 
 export const rootReducer = (state: any, action: any) => {

--- a/cmd/ui/src/views/Explore/BasicObjectInfoFields.tsx
+++ b/cmd/ui/src/views/Explore/BasicObjectInfoFields.tsx
@@ -15,9 +15,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Box } from '@mui/material';
-import { NodeIcon, Field, AzureNodeKind, EntityKinds } from 'bh-shared-ui';
+import { AzureNodeKind, EntityKinds, Field, NodeIcon, searchbarActions } from 'bh-shared-ui';
 import { TIER_ZERO_TAG } from 'src/constants';
-import { sourceNodeSelected } from 'src/ducks/searchbar/actions';
 import { useAppDispatch } from 'src/store';
 
 interface BasicObjectInfoFieldsProps {
@@ -42,7 +41,7 @@ const RelatedKindField = (fieldLabel: string, relatedKind: EntityKinds, id: stri
                 <Box
                     onClick={() => {
                         dispatch(
-                            sourceNodeSelected({
+                            searchbarActions.sourceNodeSelected({
                                 objectid: id,
                                 type: relatedKind,
                                 name: name || '',

--- a/cmd/ui/src/views/Explore/ContextMenu/ContextMenu.test.tsx
+++ b/cmd/ui/src/views/Explore/ContextMenu/ContextMenu.test.tsx
@@ -14,13 +14,13 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+import userEvent from '@testing-library/user-event';
+import { rest } from 'msw';
+import { setupServer } from 'msw/node';
 import { act } from 'react-dom/test-utils';
 import { render, screen, waitFor } from 'src/test-utils';
-import userEvent from '@testing-library/user-event';
 import ContextMenu from './ContextMenu';
-import * as actions from 'src/ducks/searchbar/actions';
-import { setupServer } from 'msw/node';
-import { rest } from 'msw';
+import { searchbarActions as actions } from 'bh-shared-ui';
 
 describe('ContextMenu', async () => {
     const server = setupServer(

--- a/cmd/ui/src/views/Explore/ContextMenu/ContextMenu.tsx
+++ b/cmd/ui/src/views/Explore/ContextMenu/ContextMenu.tsx
@@ -16,10 +16,10 @@
 
 import { Menu, MenuItem } from '@mui/material';
 
+import { searchbarActions } from 'bh-shared-ui';
 import { FC } from 'react';
-import { destinationNodeSelected, sourceNodeSelected, tabChanged } from 'src/ducks/searchbar/actions';
-import { useAppDispatch, useAppSelector } from 'src/store';
 import { selectOwnedAssetGroupId, selectTierZeroAssetGroupId } from 'src/ducks/assetgroups/reducer';
+import { useAppDispatch, useAppSelector } from 'src/store';
 import AssetGroupMenuItem from './AssetGroupMenuItem';
 import CopyMenuItem from './CopyMenuItem';
 
@@ -36,9 +36,9 @@ const ContextMenu: FC<{ contextMenu: { mouseX: number; mouseY: number } | null; 
 
     const handleSetStartingNode = () => {
         if (selectedNode) {
-            dispatch(tabChanged('secondary'));
+            dispatch(searchbarActions.tabChanged('secondary'));
             dispatch(
-                sourceNodeSelected(
+                searchbarActions.sourceNodeSelected(
                     {
                         name: selectedNode.name,
                         objectid: selectedNode.id,
@@ -52,9 +52,9 @@ const ContextMenu: FC<{ contextMenu: { mouseX: number; mouseY: number } | null; 
 
     const handleSetEndingNode = () => {
         if (selectedNode) {
-            dispatch(tabChanged('secondary'));
+            dispatch(searchbarActions.tabChanged('secondary'));
             dispatch(
-                destinationNodeSelected({
+                searchbarActions.destinationNodeSelected({
                     name: selectedNode.name,
                     objectid: selectedNode.id,
                     type: selectedNode.type,

--- a/cmd/ui/src/views/Explore/EntityInfo/EntityInfoDataTable.tsx
+++ b/cmd/ui/src/views/Explore/EntityInfo/EntityInfoDataTable.tsx
@@ -14,13 +14,17 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { EntityInfoDataTableProps, InfiniteScrollingTable, abortEntitySectionRequest } from 'bh-shared-ui';
+import {
+    EntityInfoDataTableProps,
+    InfiniteScrollingTable,
+    abortEntitySectionRequest,
+    searchbarActions,
+} from 'bh-shared-ui';
 import { useQuery } from 'react-query';
 import { useDispatch } from 'react-redux';
 import { NODE_GRAPH_RENDER_LIMIT } from 'src/constants';
 import { putGraphData, putGraphError, saveResponseForExport, setGraphLoading } from 'src/ducks/explore/actions';
 import { addSnackbar } from 'src/ducks/global/actions';
-import { sourceNodeSelected } from 'src/ducks/searchbar/actions';
 import { transformFlatGraphResponse } from 'src/utils';
 import EntityInfoCollapsibleSection from './EntityInfoCollapsibleSection';
 
@@ -69,7 +73,7 @@ const EntityInfoDataTable: React.FC<EntityInfoDataTableProps> = ({ id, label, en
 
     const handleOnClick = (item: any) => {
         dispatch(
-            sourceNodeSelected({
+            searchbarActions.sourceNodeSelected({
                 objectid: item.id,
                 type: item.type,
                 name: item.name,

--- a/cmd/ui/src/views/Explore/ExploreSearch/CommonSearches.tsx
+++ b/cmd/ui/src/views/Explore/ExploreSearch/CommonSearches.tsx
@@ -14,12 +14,16 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { Box, Tabs, Tab, Typography } from '@mui/material';
-import { useState } from 'react';
-import { PrebuiltSearchList, CommonSearches as prebuiltSearchList, PersonalSearchList } from 'bh-shared-ui';
+import { Box, Tab, Tabs, Typography } from '@mui/material';
 import makeStyles from '@mui/styles/makeStyles';
+import {
+    PersonalSearchList,
+    PrebuiltSearchList,
+    searchbarActions,
+    CommonSearches as prebuiltSearchList,
+} from 'bh-shared-ui';
+import { useState } from 'react';
 import { useDispatch } from 'react-redux';
-import { cypherQueryEdited } from 'src/ducks/searchbar/actions';
 import { startCypherQuery } from 'src/ducks/explore/actions';
 
 const AD_TAB = 'Active Directory';
@@ -64,7 +68,7 @@ const CommonSearches = () => {
         .map(({ subheader, queries }) => ({ subheader, lineItems: queries }));
 
     const handleClick = (query: string) => {
-        dispatch(cypherQueryEdited(query));
+        dispatch(searchbarActions.cypherQueryEdited(query));
         dispatch(startCypherQuery(query));
     };
 

--- a/cmd/ui/src/views/Explore/ExploreSearch/CypherSearch.tsx
+++ b/cmd/ui/src/views/Explore/ExploreSearch/CypherSearch.tsx
@@ -28,14 +28,14 @@ import {
     AzureNodeKind,
     AzureRelationshipKind,
     CommonKindProperties,
+    searchbarActions,
     useCreateSavedQuery,
 } from 'bh-shared-ui';
 import { useState } from 'react';
-import { cypherQueryEdited, cypherSearch } from 'src/ducks/searchbar/actions';
+import { addSnackbar } from 'src/ducks/global/actions';
 import { useAppDispatch, useAppSelector } from 'src/store';
 import CommonSearches from './CommonSearches';
 import SaveQueryDialog from './SaveQueryDialog';
-import { addSnackbar } from 'src/ducks/global/actions';
 
 const useStyles = makeStyles((theme) => ({
     button: {
@@ -86,9 +86,9 @@ const useCypherEditor = () => {
 
     const dispatch = useAppDispatch();
 
-    const setCypherQuery = (query: string) => dispatch(cypherQueryEdited(query));
+    const setCypherQuery = (query: string) => dispatch(searchbarActions.cypherQueryEdited(query));
 
-    const performSearch = () => dispatch(cypherSearch(cypherQuery));
+    const performSearch = () => dispatch(searchbarActions.cypherSearch(cypherQuery));
 
     return {
         cypherQuery,

--- a/cmd/ui/src/views/Explore/ExploreSearch/EdgeFilter.tsx
+++ b/cmd/ui/src/views/Explore/ExploreSearch/EdgeFilter.tsx
@@ -18,10 +18,10 @@ import { faFilter } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Button } from '@mui/material';
 import makeStyles from '@mui/styles/makeStyles';
+import { EdgeCheckboxType, searchbarActions } from 'bh-shared-ui';
 import { useEffect, useRef, useState } from 'react';
-import EdgeFilteringDialog, { EdgeCheckboxType } from './EdgeFilteringDialog';
 import { useAppDispatch, useAppSelector } from 'src/store';
-import { pathfindingSearch, pathFiltersSaved } from 'src/ducks/searchbar/actions';
+import EdgeFilteringDialog from './EdgeFilteringDialog';
 
 const useStyles = makeStyles((theme) => ({
     pathfindingButton: {
@@ -55,7 +55,7 @@ const EdgeFilter = () => {
     }, [pathFilters]);
 
     const handlePathfindingSearch = () => {
-        dispatch(pathfindingSearch());
+        dispatch(searchbarActions.pathfindingSearch());
     };
 
     return (
@@ -76,7 +76,7 @@ const EdgeFilter = () => {
                     setIsOpenDialog(false);
 
                     // rollback changes made in dialog.
-                    dispatch(pathFiltersSaved(initialFilterState.current));
+                    dispatch(searchbarActions.pathFiltersSaved(initialFilterState.current));
                 }}
                 handleApply={() => {
                     setIsOpenDialog(false);

--- a/cmd/ui/src/views/Explore/ExploreSearch/EdgeFilteringDialog.tsx
+++ b/cmd/ui/src/views/Explore/ExploreSearch/EdgeFilteringDialog.tsx
@@ -14,7 +14,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { useTheme } from '@mui/material/styles';
+import { faChevronDown, faChevronUp } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
     Box,
     Button,
@@ -36,11 +37,9 @@ import {
     SvgIcon,
     Typography,
 } from '@mui/material';
+import { useTheme } from '@mui/material/styles';
+import { AllEdgeTypes, Category, EdgeCheckboxType, Subcategory, searchbarActions } from 'bh-shared-ui';
 import { useState } from 'react';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faChevronDown, faChevronUp } from '@fortawesome/free-solid-svg-icons';
-import { pathFiltersSaved } from 'src/ducks/searchbar/actions';
-import { AllEdgeTypes, Category, Subcategory } from 'bh-shared-ui';
 import { useAppDispatch, useAppSelector } from 'src/store';
 
 interface EdgeFilteringDialogProps {
@@ -83,13 +82,6 @@ const EdgeFilteringDialog = ({ isOpen, handleCancel, handleApply }: EdgeFilterin
     );
 };
 
-export type EdgeCheckboxType = {
-    category: string;
-    subcategory: string;
-    edgeType: string;
-    checked: boolean;
-};
-
 interface CategoryListProps {
     selectedFilters: Array<EdgeCheckboxType>;
 }
@@ -106,7 +98,9 @@ const CategoryList = ({ selectedFilters }: CategoryListProps) => {
                         key={categoryName}
                         category={category}
                         checked={selectedFilters}
-                        setChecked={(checked: EdgeCheckboxType[]) => dispatch(pathFiltersSaved(checked))}
+                        setChecked={(checked: EdgeCheckboxType[]) =>
+                            dispatch(searchbarActions.pathFiltersSaved(checked))
+                        }
                     />
                 );
             })}

--- a/cmd/ui/src/views/Explore/ExploreSearch/ExploreSearch.test.tsx
+++ b/cmd/ui/src/views/Explore/ExploreSearch/ExploreSearch.test.tsx
@@ -15,13 +15,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import userEvent from '@testing-library/user-event';
+import {
+    CYPHER_SEARCH,
+    PATHFINDING_SEARCH,
+    PRIMARY_SEARCH,
+    initialSearchState,
+    searchbarActions as actions,
+} from 'bh-shared-ui';
+import { rest } from 'msw';
+import { setupServer } from 'msw/node';
 import { act, render, screen, waitFor } from 'src/test-utils';
 import ExploreSearch from '.';
-import { setupServer } from 'msw/node';
-import { rest } from 'msw';
-import * as actions from 'src/ducks/searchbar/actions';
-import { PRIMARY_SEARCH, PATHFINDING_SEARCH, CYPHER_SEARCH } from 'src/ducks/searchbar/types';
-import { initialSearchState } from 'src/ducks/searchbar/reducer';
 
 describe('ExploreSearch rendering per tab', async () => {
     let container: HTMLElement;

--- a/cmd/ui/src/views/Explore/ExploreSearch/ExploreSearch.tsx
+++ b/cmd/ui/src/views/Explore/ExploreSearch/ExploreSearch.tsx
@@ -18,14 +18,12 @@ import { faCode, faDirections, faMinus, faPlus, faSearch } from '@fortawesome/fr
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Box, Collapse, Paper, Tab, Tabs, Theme, useMediaQuery, useTheme } from '@mui/material';
 import makeStyles from '@mui/styles/makeStyles';
-import { Icon } from 'bh-shared-ui';
+import { CYPHER_SEARCH, Icon, PATHFINDING_SEARCH, PRIMARY_SEARCH, searchbarActions } from 'bh-shared-ui';
 import React, { useState } from 'react';
-import { CYPHER_SEARCH, PATHFINDING_SEARCH, PRIMARY_SEARCH } from 'src/ducks/searchbar/types';
 import { useAppDispatch, useAppSelector } from 'src/store';
 import CypherSearch from './CypherSearch';
 import NodeSearch from './NodeSearch';
 import PathfindingSearch from './PathfindingSearch';
-import { tabChanged, primarySearch, pathfindingSearch, cypherSearch } from 'src/ducks/searchbar/actions';
 
 const useStyles = makeStyles((theme) => ({
     menuButton: {
@@ -68,14 +66,14 @@ const ExploreSearch = ({ handleColumns }: ExploreSearchProps) => {
     const handleTabChange = (newTabIndex: number) => {
         switch (newTabIndex) {
             case 0:
-                dispatch(primarySearch());
-                return dispatch(tabChanged(PRIMARY_SEARCH));
+                dispatch(searchbarActions.primarySearch());
+                return dispatch(searchbarActions.tabChanged(PRIMARY_SEARCH));
             case 1:
-                dispatch(pathfindingSearch());
-                return dispatch(tabChanged(PATHFINDING_SEARCH));
+                dispatch(searchbarActions.pathfindingSearch());
+                return dispatch(searchbarActions.tabChanged(PATHFINDING_SEARCH));
             case 2:
-                dispatch(cypherSearch());
-                return dispatch(tabChanged(CYPHER_SEARCH));
+                dispatch(searchbarActions.cypherSearch());
+                return dispatch(searchbarActions.tabChanged(CYPHER_SEARCH));
         }
 
         const cypherTabIndex = 2;

--- a/cmd/ui/src/views/Explore/ExploreSearch/NodeSearch.tsx
+++ b/cmd/ui/src/views/Explore/ExploreSearch/NodeSearch.tsx
@@ -14,10 +14,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import ExploreSearchCombobox from '../ExploreSearchCombobox';
-import { SearchNodeType, SourceNodeEditedAction, SourceNodeSelectedAction } from 'src/ducks/searchbar/types';
+import { SearchValue, SourceNodeEditedAction, SourceNodeSelectedAction, searchbarActions } from 'bh-shared-ui';
 import { useAppDispatch, useAppSelector } from 'src/store';
-import { sourceNodeEdited, sourceNodeSelected } from 'src/ducks/searchbar/actions';
+import ExploreSearchCombobox from '../ExploreSearchCombobox';
 
 const NodeSearch = () => {
     const dispatch = useAppDispatch();
@@ -25,15 +24,16 @@ const NodeSearch = () => {
     const primary = useAppSelector((state) => state.search.primary);
     const { searchTerm, value: selectedItem } = primary;
 
-    const handleNodeEdited = (edit: string): SourceNodeEditedAction => dispatch(sourceNodeEdited(edit));
-    const handleNodeSelected = (selected: SearchNodeType): SourceNodeSelectedAction =>
-        dispatch(sourceNodeSelected(selected));
+    const handleNodeEdited = (edit: string): SourceNodeEditedAction =>
+        dispatch(searchbarActions.sourceNodeEdited(edit));
+    const handleNodeSelected = (selected?: SearchValue): SourceNodeSelectedAction =>
+        dispatch(searchbarActions.sourceNodeSelected(selected));
 
     return (
         <ExploreSearchCombobox
             labelText={'Search Nodes'}
             inputValue={searchTerm}
-            selectedItem={selectedItem}
+            selectedItem={selectedItem || null}
             handleNodeEdited={handleNodeEdited}
             handleNodeSelected={handleNodeSelected}
         />

--- a/cmd/ui/src/views/Explore/ExploreSearch/PathfindingSearch.test.tsx
+++ b/cmd/ui/src/views/Explore/ExploreSearch/PathfindingSearch.test.tsx
@@ -14,13 +14,13 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+import userEvent from '@testing-library/user-event';
+import { searchbarActions as actions } from 'bh-shared-ui';
+import { rest } from 'msw';
+import { setupServer } from 'msw/node';
 import { act } from 'react-dom/test-utils';
 import { render, screen } from 'src/test-utils';
 import PathfindingSearch from './PathfindingSearch';
-import userEvent from '@testing-library/user-event';
-import { setupServer } from 'msw/node';
-import { rest } from 'msw';
-import * as actions from 'src/ducks/searchbar/actions';
 
 describe('Pathfinding: interaction', () => {
     const comboboxLookaheadOptions = {

--- a/cmd/ui/src/views/Explore/ExploreSearch/PathfindingSearch.tsx
+++ b/cmd/ui/src/views/Explore/ExploreSearch/PathfindingSearch.tsx
@@ -14,26 +14,21 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { Box } from '@mui/material';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faBullseye, faCircle } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { Box } from '@mui/material';
 import {
-    SourceNodeEditedAction,
-    SearchNodeType,
-    SourceNodeSelectedAction,
     DestinationNodeEditedAction,
     DestinationNodeSelectedAction,
-} from 'src/ducks/searchbar/types';
-import EdgeFilter from './EdgeFilter';
-import ExploreSearchCombobox from '../ExploreSearchCombobox';
-import PathfindingSwapButton from './PathfindingSwapButton';
+    SearchValue,
+    SourceNodeEditedAction,
+    SourceNodeSelectedAction,
+    searchbarActions,
+} from 'bh-shared-ui';
 import { useAppDispatch, useAppSelector } from 'src/store';
-import {
-    destinationNodeEdited,
-    destinationNodeSelected,
-    sourceNodeEdited,
-    sourceNodeSelected,
-} from 'src/ducks/searchbar/actions';
+import ExploreSearchCombobox from '../ExploreSearchCombobox';
+import EdgeFilter from './EdgeFilter';
+import PathfindingSwapButton from './PathfindingSwapButton';
 
 const PathfindingSearch = () => {
     const dispatch = useAppDispatch();
@@ -44,16 +39,17 @@ const PathfindingSearch = () => {
     const { searchTerm: sourceInputValue, value: sourceSelectedItem } = primary;
     const { searchTerm: destinationInputValue, value: destinationSelectedItem } = secondary;
 
-    const handleSourceNodeEdited = (edit: string): SourceNodeEditedAction => dispatch(sourceNodeEdited(edit));
+    const handleSourceNodeEdited = (edit: string): SourceNodeEditedAction =>
+        dispatch(searchbarActions.sourceNodeEdited(edit));
 
     const handleDestinationNodeEdited = (edit: string): DestinationNodeEditedAction =>
-        dispatch(destinationNodeEdited(edit));
+        dispatch(searchbarActions.destinationNodeEdited(edit));
 
-    const handleSourceNodeSelected = (selected: SearchNodeType): SourceNodeSelectedAction =>
-        dispatch(sourceNodeSelected(selected));
+    const handleSourceNodeSelected = (selected: SearchValue): SourceNodeSelectedAction =>
+        dispatch(searchbarActions.sourceNodeSelected(selected));
 
-    const handleDestinationNodeSelected = (selected: SearchNodeType): DestinationNodeSelectedAction =>
-        dispatch(destinationNodeSelected(selected));
+    const handleDestinationNodeSelected = (selected: SearchValue): DestinationNodeSelectedAction =>
+        dispatch(searchbarActions.destinationNodeSelected(selected));
 
     return (
         <Box display={'flex'} alignItems={'center'} gap={1}>
@@ -64,14 +60,14 @@ const PathfindingSearch = () => {
                     handleNodeEdited={handleSourceNodeEdited}
                     handleNodeSelected={handleSourceNodeSelected}
                     inputValue={sourceInputValue}
-                    selectedItem={sourceSelectedItem}
+                    selectedItem={sourceSelectedItem || null}
                     labelText='Start Node'
                 />
                 <ExploreSearchCombobox
                     handleNodeEdited={handleDestinationNodeEdited}
                     handleNodeSelected={handleDestinationNodeSelected}
                     inputValue={destinationInputValue}
-                    selectedItem={destinationSelectedItem}
+                    selectedItem={destinationSelectedItem || null}
                     labelText='Destination Node'
                 />
             </Box>

--- a/cmd/ui/src/views/Explore/ExploreSearch/PathfindingSwapButton.tsx
+++ b/cmd/ui/src/views/Explore/ExploreSearch/PathfindingSwapButton.tsx
@@ -18,8 +18,8 @@ import { faExchangeAlt } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Button } from '@mui/material';
 import makeStyles from '@mui/styles/makeStyles';
+import { searchbarActions } from 'bh-shared-ui';
 import { useCallback } from 'react';
-import { destinationNodeSelected, sourceNodeSelected } from 'src/ducks/searchbar/actions';
 import { useAppDispatch, useAppSelector } from 'src/store';
 
 const useStyles = makeStyles((theme) => ({
@@ -44,8 +44,8 @@ const PathfindingSwapButton = () => {
         const newSourceNode = secondary.value;
         const newDestinationNode = primary.value;
 
-        dispatch(sourceNodeSelected(newSourceNode));
-        dispatch(destinationNodeSelected(newDestinationNode));
+        dispatch(searchbarActions.sourceNodeSelected(newSourceNode));
+        dispatch(searchbarActions.destinationNodeSelected(newDestinationNode));
     }, [primary, secondary, dispatch]);
 
     return (

--- a/cmd/ui/src/views/Explore/ExploreSearchCombobox/ExploreSearchCombobox.tsx
+++ b/cmd/ui/src/views/Explore/ExploreSearchCombobox/ExploreSearchCombobox.tsx
@@ -15,25 +15,25 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { List, ListItem, ListItemText, Paper, TextField, useTheme } from '@mui/material';
-import { useCombobox } from 'downshift';
 import {
     NodeIcon,
+    SearchValue,
+    SearchResult,
     SearchResultItem,
     getEmptyResultsText,
     getKeywordAndTypeValues,
-    SearchResult,
     useSearch,
 } from 'bh-shared-ui';
-import { SearchNodeType } from 'src/ducks/searchbar/types';
+import { useCombobox } from 'downshift';
 
 const ExploreSearchCombobox: React.FC<{
     labelText: string;
-    disabled?: boolean;
     inputValue: string;
-    selectedItem: SearchNodeType | null;
+    selectedItem: SearchValue | null;
     handleNodeEdited: (edit: string) => any;
-    handleNodeSelected: (selection: SearchNodeType) => any;
-}> = ({ labelText, disabled = false, inputValue, selectedItem, handleNodeEdited, handleNodeSelected }) => {
+    handleNodeSelected: (selection: SearchValue) => any;
+    disabled?: boolean;
+}> = ({ labelText, inputValue, selectedItem, handleNodeEdited, handleNodeSelected, disabled = false }) => {
     const theme = useTheme();
 
     const { keyword, type } = getKeywordAndTypeValues(inputValue);
@@ -46,10 +46,10 @@ const ExploreSearchCombobox: React.FC<{
             selectedItem,
             onSelectedItemChange: ({ type, selectedItem }) => {
                 if (selectedItem) {
-                    handleNodeSelected(selectedItem as SearchNodeType);
+                    handleNodeSelected(selectedItem);
                 }
             },
-            itemToString: (item) => (item ? item.name || item.objectid : ''),
+            itemToString: (item) => item?.name || item?.objectid || '',
         });
 
     const disabledText: string = getEmptyResultsText(

--- a/cmd/ui/src/views/GroupManagement/GroupManagement.tsx
+++ b/cmd/ui/src/views/GroupManagement/GroupManagement.tsx
@@ -14,18 +14,17 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import EntityInfoPanel from '../Explore/EntityInfo/EntityInfoPanel';
-import { DropdownOption, GroupManagementContent, EntityKinds } from 'bh-shared-ui';
-import { SelectedNode } from 'src/ducks/entityinfo/types';
-import { useState } from 'react';
-import { AssetGroup, AssetGroupMember } from 'js-client-library';
 import { faGem } from '@fortawesome/free-solid-svg-icons';
-import { setSelectedNode } from 'src/ducks/entityinfo/actions';
+import { DropdownOption, EntityKinds, GroupManagementContent, searchbarActions } from 'bh-shared-ui';
+import { AssetGroup, AssetGroupMember } from 'js-client-library';
+import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { ROUTE_EXPLORE } from 'src/ducks/global/routes';
-import { sourceNodeSelected } from 'src/ducks/searchbar/actions';
 import { TIER_ZERO_LABEL, TIER_ZERO_TAG } from 'src/constants';
+import { setSelectedNode } from 'src/ducks/entityinfo/actions';
+import { SelectedNode } from 'src/ducks/entityinfo/types';
+import { ROUTE_EXPLORE } from 'src/ducks/global/routes';
 import { useAppDispatch, useAppSelector } from 'src/store';
+import EntityInfoPanel from '../Explore/EntityInfo/EntityInfoPanel';
 import { dataCollectionMessage } from '../QA/utils';
 
 const GroupManagement = () => {
@@ -52,7 +51,7 @@ const GroupManagement = () => {
                 label: openNode.name,
                 ...openNode,
             };
-            dispatch(sourceNodeSelected(searchNode));
+            dispatch(searchbarActions.sourceNodeSelected(searchNode));
             dispatch(setSelectedNode(openNode));
 
             navigate(ROUTE_EXPLORE);

--- a/packages/javascript/bh-shared-ui/rollup.config.js
+++ b/packages/javascript/bh-shared-ui/rollup.config.js
@@ -62,7 +62,9 @@ export default {
         'swagger-ui-react/swagger-ui.css',
         'prop-types',
         'immutable',
+        'immer',
         'react-immutable-proptypes',
         'lodash/toString',
+        'lodash/cloneDeep',
     ],
 };

--- a/packages/javascript/bh-shared-ui/src/components/FileValidationStatus/FileValidationStatus.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/FileValidationStatus/FileValidationStatus.tsx
@@ -16,7 +16,7 @@
 
 import { faCheck, faSync, faTimes } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { Avatar, Box, Typography } from '@mui/material';
+import { Avatar, Box } from '@mui/material';
 import { FileForIngest, FileStatus } from '../FileUploadDialog/types';
 
 const FileValidationStatus: React.FC<{ file: FileForIngest }> = ({ file }) => {

--- a/packages/javascript/bh-shared-ui/src/hooks/useSearch/useSearch.test.ts
+++ b/packages/javascript/bh-shared-ui/src/hooks/useSearch/useSearch.test.ts
@@ -85,7 +85,11 @@ describe('Getting the text for the disabled item display for a search when there
 });
 
 describe('Parsing the debounced input for type and keyword values', () => {
-    test('No input is provided', () => {
+    test('`undefined` input is provided', () => {
+        expect(getKeywordAndTypeValues(undefined)).toEqual({ keyword: '', type: undefined });
+    });
+
+    test('Empty input is provided', () => {
         expect(getKeywordAndTypeValues('')).toEqual({ keyword: '', type: undefined });
     });
 

--- a/packages/javascript/bh-shared-ui/src/hooks/useSearch/useSearch.tsx
+++ b/packages/javascript/bh-shared-ui/src/hooks/useSearch/useSearch.tsx
@@ -52,7 +52,7 @@ export const useSearch = (keyword: string, type: ActiveDirectoryNodeKind | Azure
 };
 
 export const getKeywordAndTypeValues = (
-    inputValue: string
+    inputValue = ''
 ): { keyword: string; type: ActiveDirectoryNodeKind | AzureNodeKind | undefined } => {
     const splitValue = inputValue.split(':');
 

--- a/packages/javascript/bh-shared-ui/src/store/index.ts
+++ b/packages/javascript/bh-shared-ui/src/store/index.ts
@@ -16,3 +16,5 @@
 
 export * from './edgeinfo/edgeSlice';
 export { default as edgeinfo } from './edgeinfo/edgeSlice';
+
+export * from './searchbar/index';

--- a/packages/javascript/bh-shared-ui/src/store/searchbar/actions.ts
+++ b/packages/javascript/bh-shared-ui/src/store/searchbar/actions.ts
@@ -14,8 +14,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { EdgeCheckboxType } from 'src/views/Explore/ExploreSearch/EdgeFilteringDialog';
 import * as types from './types';
+import { EdgeCheckboxType } from '../../views/Explore/ExploreSearch/edgeTypes';
 
 export const primarySearch = () => {
     return {
@@ -71,7 +71,7 @@ export const sourceNodeEdited = (searchTerm: string): types.SourceNodeEditedActi
 };
 
 export const sourceNodeSelected = (
-    node: types.SearchNodeType | null,
+    node?: types.SearchValue,
     doPathfindSearch: boolean = false // sometimes, selecting a source node should trigger a pathfinding search, and other times it should only trigger a single node search
 ): types.SourceNodeSelectedAction => {
     return {
@@ -88,7 +88,7 @@ export const destinationNodeEdited = (searchTerm: string): types.DestinationNode
     };
 };
 
-export const destinationNodeSelected = (node: types.SearchNodeType | null): types.DestinationNodeSelectedAction => {
+export const destinationNodeSelected = (node?: types.SearchValue): types.DestinationNodeSelectedAction => {
     return {
         type: types.DESTINATION_NODE_SELECTED,
         node,

--- a/packages/javascript/bh-shared-ui/src/store/searchbar/index.ts
+++ b/packages/javascript/bh-shared-ui/src/store/searchbar/index.ts
@@ -14,6 +14,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import searchReducer from './reducer';
-
-export default searchReducer;
+export * as searchbarActions from './actions';
+export * from './reducer';
+export * from './types';

--- a/packages/javascript/bh-shared-ui/src/store/searchbar/reducer.ts
+++ b/packages/javascript/bh-shared-ui/src/store/searchbar/reducer.ts
@@ -16,9 +16,8 @@
 
 import { produce } from 'immer';
 import cloneDeep from 'lodash/cloneDeep';
-import * as types from 'src/ducks/searchbar/types';
-import { EdgeCheckboxType } from 'src/views/Explore/ExploreSearch/EdgeFilteringDialog';
-import { AllEdgeTypes, Category, Subcategory } from 'bh-shared-ui';
+import { AllEdgeTypes, Category, EdgeCheckboxType, Subcategory } from '../../views/Explore/ExploreSearch/edgeTypes';
+import * as types from './types';
 
 // by default: all checkboxes are selected
 const initialPathFilters: EdgeCheckboxType[] = [];
@@ -42,13 +41,13 @@ export const initialSearchState: types.SearchState = {
     primary: {
         searchTerm: '',
         loading: false,
-        value: null,
+        value: undefined,
         options: [],
     },
     secondary: {
         searchTerm: '',
         loading: false,
-        value: null,
+        value: undefined,
         options: [],
     },
     cypher: {
@@ -58,7 +57,7 @@ export const initialSearchState: types.SearchState = {
     activeTab: 'primary',
 };
 
-const searchReducer = (state = initialSearchState, action: types.SearchbarActionTypes) => {
+export const searchReducer = (state = initialSearchState, action: types.SearchbarActionTypes) => {
     switch (action.type) {
         case types.SEARCH_RESET: {
             return cloneDeep(initialSearchState);
@@ -96,20 +95,15 @@ const searchReducer = (state = initialSearchState, action: types.SearchbarAction
                 draft.primary.options = [];
 
                 // any edits to the source node should clear out the previously saved primary.value
-                draft.primary.value = null;
+                draft.primary.value = undefined;
                 break;
             }
 
             case types.SOURCE_NODE_SELECTED: {
                 draft.searchType = types.SEARCH_TYPE_EXACT;
-
                 draft.primary.value = action.node;
+                draft.primary.searchTerm = action.node?.name || action.node?.objectid || '';
 
-                if (action.node) {
-                    draft.primary.searchTerm = action.node.name;
-                } else {
-                    draft.primary.searchTerm = '';
-                }
                 break;
             }
 
@@ -119,25 +113,18 @@ const searchReducer = (state = initialSearchState, action: types.SearchbarAction
                 draft.secondary.options = [];
 
                 // any edits to the destination node should clear out the previously saved destination.value
-                draft.secondary.value = null;
+                draft.secondary.value = undefined;
 
                 break;
             }
 
             case types.DESTINATION_NODE_SELECTED: {
                 draft.searchType = types.SEARCH_TYPE_EXACT;
-
                 draft.secondary.value = action.node;
+                draft.secondary.searchTerm = action.node?.name || action.node?.objectid || '';
 
-                if (action.node) {
-                    draft.secondary.searchTerm = action.node.name;
-                } else {
-                    draft.secondary.searchTerm = '';
-                }
                 break;
             }
         }
     });
 };
-
-export default searchReducer;

--- a/packages/javascript/bh-shared-ui/src/store/searchbar/types.ts
+++ b/packages/javascript/bh-shared-ui/src/store/searchbar/types.ts
@@ -14,8 +14,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { EntityKinds } from 'bh-shared-ui';
-import { EdgeCheckboxType } from 'src/views/Explore/ExploreSearch/EdgeFilteringDialog';
+import { EntityKinds } from '../../utils/content';
+import { EdgeCheckboxType } from '../../views/Explore/ExploreSearch/edgeTypes';
+import { SearchResult } from '../../hooks/useSearch';
 
 const SEARCH_RESET = 'app/search/RESET';
 const CYPHER_QUERY_EDITED = 'app/search/CYPHER_QUERY_EDITED';
@@ -52,16 +53,24 @@ export {
     PATH_FILTERS_SAVED,
 };
 
+//The search value usually aligns with the results from hitting the search endpoint but when
+//we are pulling the data from a different page and filling out the value ourselves it might
+//not conform to our expected type
+export type SearchValue = SearchNodeType | SearchResult;
+
 export interface SearchBarState {
-    options: SearchNodeType[];
+    options: SearchResult[];
     searchTerm: string;
     loading: boolean;
-    value: SearchNodeType | null;
+    //value is set to optional to safeguard against possibly passing undefined when the value
+    //is not derived from direct user interaction with the search input
+    value?: SearchValue;
 }
+
 export interface SearchNodeType {
     objectid: string;
-    type: EntityKinds;
-    name: string;
+    type?: EntityKinds;
+    name?: string;
 }
 
 export interface CypherSearchState {
@@ -104,7 +113,7 @@ export interface CypherQueryEditedAction {
 
 export interface SourceNodeSelectedAction {
     type: typeof SOURCE_NODE_SELECTED;
-    node: SearchNodeType | null;
+    node?: SearchValue;
     doPathfindSearch: boolean;
 }
 
@@ -115,7 +124,7 @@ export interface SourceNodeEditedAction {
 
 export interface DestinationNodeSelectedAction {
     type: typeof DESTINATION_NODE_SELECTED;
-    node: SearchNodeType | null;
+    node?: SearchValue;
 }
 
 export interface DestinationNodeEditedAction {

--- a/packages/javascript/bh-shared-ui/src/views/Explore/ExploreSearch/edgeTypes.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/Explore/ExploreSearch/edgeTypes.tsx
@@ -16,6 +16,13 @@
 
 import { ActiveDirectoryRelationshipKind, AzureRelationshipKind } from '../../../graphSchema';
 
+export type EdgeCheckboxType = {
+    category: string;
+    subcategory: string;
+    edgeType: string;
+    checked: boolean;
+};
+
 export type Category = {
     categoryName: string;
     subcategories: Subcategory[];


### PR DESCRIPTION
## Description
This changeset adds handling for `undefined` input in the explore search. Additionally, the search reducer is moved to the shared-ui since it is used in both community and enterprise.

<!--- Describe your changes in detail -->

## Motivation and Context
We have a flow in BHE where search input state is filled in from information outside of the expected search results data format. The data that was passed in was incomplete and causing the app to reach the error boundary as there was no other explicit handling for the unexpectedly incomplete data. Empty defaults and checks for undefined input have been added for circumventing reaching an error state.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
A unit test was added at the point where the runtime error was encountered.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [x] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
