### PR TITLE
fix: plumb ctx into session db methods

### DIFF
--- a/cmd/api/src/api/auth.go
+++ b/cmd/api/src/api/auth.go
@@ -64,7 +64,7 @@ func parseRequestDate(rawDate string) (time.Time, error) {
 
 type Authenticator interface {
 	LoginWithSecret(ctx context.Context, loginRequest LoginRequest) (LoginDetails, error)
-	Logout(userSession model.UserSession)
+	Logout(ctx context.Context, userSession model.UserSession)
 	ValidateSecret(ctx context.Context, secret string, authSecret model.AuthSecret) error
 	ValidateRequestSignature(tokenID uuid.UUID, request *http.Request, serverTime time.Time) (auth.Context, int, error)
 	CreateSession(ctx context.Context, user model.User, authProvider any) (string, error)
@@ -163,8 +163,8 @@ func (s authenticator) LoginWithSecret(ctx context.Context, loginRequest LoginRe
 	}
 }
 
-func (s authenticator) Logout(userSession model.UserSession) {
-	s.db.EndUserSession(userSession)
+func (s authenticator) Logout(ctx context.Context, userSession model.UserSession) {
+	s.db.EndUserSession(ctx, userSession)
 }
 
 func (s authenticator) ValidateSecret(ctx context.Context, secret string, authSecret model.AuthSecret) error {

--- a/cmd/api/src/api/middleware/auth.go
+++ b/cmd/api/src/api/middleware/auth.go
@@ -66,7 +66,7 @@ func AuthMiddleware(authenticator api.Authenticator) mux.MiddlewareFunc {
 			} else {
 				switch authScheme {
 				case api.AuthorizationSchemeBearer:
-					if userAuth, err := authenticator.ValidateSession(schemeParameter); err != nil {
+					if userAuth, err := authenticator.ValidateSession(request.Context(), schemeParameter); err != nil {
 						api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusUnauthorized, api.ErrorResponseDetailsAuthenticationInvalid, request), response)
 						return
 					} else {

--- a/cmd/api/src/api/mocks/authenticator.go
+++ b/cmd/api/src/api/mocks/authenticator.go
@@ -87,15 +87,15 @@ func (mr *MockAuthenticatorMockRecorder) LoginWithSecret(arg0, arg1 interface{})
 }
 
 // Logout mocks base method.
-func (m *MockAuthenticator) Logout(arg0 model.UserSession) {
+func (m *MockAuthenticator) Logout(arg0 context.Context, arg1 model.UserSession) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Logout", arg0)
+	m.ctrl.Call(m, "Logout", arg0, arg1)
 }
 
 // Logout indicates an expected call of Logout.
-func (mr *MockAuthenticatorMockRecorder) Logout(arg0 interface{}) *gomock.Call {
+func (mr *MockAuthenticatorMockRecorder) Logout(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Logout", reflect.TypeOf((*MockAuthenticator)(nil).Logout), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Logout", reflect.TypeOf((*MockAuthenticator)(nil).Logout), arg0, arg1)
 }
 
 // ValidateRequestSignature mocks base method.

--- a/cmd/api/src/api/mocks/authenticator.go
+++ b/cmd/api/src/api/mocks/authenticator.go
@@ -57,18 +57,18 @@ func (m *MockAuthenticator) EXPECT() *MockAuthenticatorMockRecorder {
 }
 
 // CreateSession mocks base method.
-func (m *MockAuthenticator) CreateSession(arg0 model.User, arg1 interface{}) (string, error) {
+func (m *MockAuthenticator) CreateSession(arg0 context.Context, arg1 model.User, arg2 interface{}) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateSession", arg0, arg1)
+	ret := m.ctrl.Call(m, "CreateSession", arg0, arg1, arg2)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateSession indicates an expected call of CreateSession.
-func (mr *MockAuthenticatorMockRecorder) CreateSession(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockAuthenticatorMockRecorder) CreateSession(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSession", reflect.TypeOf((*MockAuthenticator)(nil).CreateSession), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSession", reflect.TypeOf((*MockAuthenticator)(nil).CreateSession), arg0, arg1, arg2)
 }
 
 // LoginWithSecret mocks base method.

--- a/cmd/api/src/api/mocks/authenticator.go
+++ b/cmd/api/src/api/mocks/authenticator.go
@@ -129,16 +129,16 @@ func (mr *MockAuthenticatorMockRecorder) ValidateSecret(arg0, arg1, arg2 interfa
 }
 
 // ValidateSession mocks base method.
-func (m *MockAuthenticator) ValidateSession(arg0 string) (auth.Context, error) {
+func (m *MockAuthenticator) ValidateSession(arg0 context.Context, arg1 string) (auth.Context, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ValidateSession", arg0)
+	ret := m.ctrl.Call(m, "ValidateSession", arg0, arg1)
 	ret0, _ := ret[0].(auth.Context)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ValidateSession indicates an expected call of ValidateSession.
-func (mr *MockAuthenticatorMockRecorder) ValidateSession(arg0 interface{}) *gomock.Call {
+func (mr *MockAuthenticatorMockRecorder) ValidateSession(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateSession", reflect.TypeOf((*MockAuthenticator)(nil).ValidateSession), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateSession", reflect.TypeOf((*MockAuthenticator)(nil).ValidateSession), arg0, arg1)
 }

--- a/cmd/api/src/api/saml/saml.go
+++ b/cmd/api/src/api/saml/saml.go
@@ -285,7 +285,7 @@ func (s ProviderResource) createSessionFromAssertion(request *http.Request, resp
 		default:
 			s.writeAPIErrorResponse(request, response, http.StatusInternalServerError, "session creation failure")
 		}
-	} else if sessionJWT, err := s.authenticator.CreateSession(user, s.serviceProvider.Config); err != nil {
+	} else if sessionJWT, err := s.authenticator.CreateSession(request.Context(), user, s.serviceProvider.Config); err != nil {
 		if locationURL := api.URLJoinPath(hostURL, api.UserDisabledPath); err == ErrorUserDisabled {
 			response.Header().Add(headers.Location.String(), locationURL.String())
 			response.WriteHeader(http.StatusFound)

--- a/cmd/api/src/api/saml/saml_internal_test.go
+++ b/cmd/api/src/api/saml/saml_internal_test.go
@@ -115,7 +115,7 @@ func TestProviderResource_createSessionFromAssertion(t *testing.T) {
 
 	// Test happy path
 	mockDB.EXPECT().LookupUser(gomock.Any(), goodUsername).Return(goodUser, nil)
-	mockAuthenticator.EXPECT().CreateSession(goodUser, gomock.Any()).Return(goodJWT, nil)
+	mockAuthenticator.EXPECT().CreateSession(gomock.Any(), goodUser, gomock.Any()).Return(goodJWT, nil)
 
 	resource.createSessionFromAssertion(httpRequest, response, expires, testAssertion)
 

--- a/cmd/api/src/api/v2/auth/auth.go
+++ b/cmd/api/src/api/v2/auth/auth.go
@@ -539,7 +539,7 @@ func (s ManagementResource) UpdateUser(response http.ResponseWriter, request *ht
 				return
 			} else {
 				for _, session := range userSessions {
-					s.db.EndUserSession(session)
+					s.db.EndUserSession(request.Context(), session)
 				}
 			}
 		}

--- a/cmd/api/src/api/v2/auth/auth.go
+++ b/cmd/api/src/api/v2/auth/auth.go
@@ -534,7 +534,7 @@ func (s ManagementResource) UpdateUser(response http.ResponseWriter, request *ht
 			if loggedInUser, _ := auth.GetUserFromAuthCtx(context.AuthCtx); user.ID == loggedInUser.ID {
 				api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, api.ErrorResponseUserSelfDisable, request), response)
 				return
-			} else if userSessions, err := s.db.LookupActiveSessionsByUser(user); err != nil {
+			} else if userSessions, err := s.db.LookupActiveSessionsByUser(request.Context(), user); err != nil {
 				api.HandleDatabaseError(request, response, err)
 				return
 			} else {

--- a/cmd/api/src/api/v2/auth/auth_test.go
+++ b/cmd/api/src/api/v2/auth/auth_test.go
@@ -1575,7 +1575,7 @@ func TestManagementResource_UpdateUser_LookupActiveSessionsError(t *testing.T) {
 		}},
 		Serial: model.Serial{},
 	}}, nil)
-	mockDB.EXPECT().LookupActiveSessionsByUser(gomock.Any()).Return([]model.UserSession{}, fmt.Errorf("foo"))
+	mockDB.EXPECT().LookupActiveSessionsByUser(gomock.Any(), gomock.Any()).Return([]model.UserSession{}, fmt.Errorf("foo"))
 
 	ctx := context.WithValue(context.Background(), ctx.ValueKey, &ctx.Context{})
 	input := v2.CreateUserRequest{
@@ -1881,7 +1881,7 @@ func TestManagementResource_UpdateUser_Success(t *testing.T) {
 		}},
 		Serial: model.Serial{},
 	}}, nil)
-	mockDB.EXPECT().LookupActiveSessionsByUser(gomock.Any()).Return([]model.UserSession{}, nil)
+	mockDB.EXPECT().LookupActiveSessionsByUser(gomock.Any(), gomock.Any()).Return([]model.UserSession{}, nil)
 	mockDB.EXPECT().UpdateUser(gomock.Any(), gomock.Any()).Return(nil)
 
 	ctx := context.WithValue(context.Background(), ctx.ValueKey, &ctx.Context{})

--- a/cmd/api/src/api/v2/auth/login.go
+++ b/cmd/api/src/api/v2/auth/login.go
@@ -103,7 +103,7 @@ func (s LoginResource) patchEULAAcceptance(ctx context.Context, username string)
 
 func (s LoginResource) Logout(response http.ResponseWriter, request *http.Request) {
 	bhCtx := ctx.FromRequest(request)
-	s.authenticator.Logout(bhCtx.AuthCtx.Session)
+	s.authenticator.Logout(request.Context(), bhCtx.AuthCtx.Session)
 	redirectURL := api.URLJoinPath(*bhCtx.Host, api.UserInterfacePath)
 	http.Redirect(response, request, redirectURL.String(), http.StatusOK)
 }

--- a/cmd/api/src/bootstrap/initializer.go
+++ b/cmd/api/src/bootstrap/initializer.go
@@ -67,7 +67,7 @@ func (s Initializer[DBType, GraphType]) Launch(parentCtx context.Context, handle
 		defer databaseConnections.RDMS.Close(ctx)
 		defer databaseConnections.Graph.Close(ctx)
 
-		daemonManager.Start(daemonInstances...)
+		daemonManager.Start(ctx, daemonInstances...)
 	}
 
 	// Log successful start and wait for a signal to exit

--- a/cmd/api/src/daemons/api/bhapi/api.go
+++ b/cmd/api/src/daemons/api/bhapi/api.go
@@ -1,17 +1,17 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 package bhapi
@@ -21,8 +21,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/specterops/bloodhound/src/config"
 	"github.com/specterops/bloodhound/log"
+	"github.com/specterops/bloodhound/src/config"
 )
 
 // Daemon holds data relevant to the API daemon
@@ -54,7 +54,7 @@ func (s Daemon) Name() string {
 }
 
 // Start begins the daemon and waits for a stop signal in the exit channel
-func (s Daemon) Start() {
+func (s Daemon) Start(ctx context.Context) {
 	if s.cfg.TLS.Enabled() {
 		if err := s.server.ListenAndServeTLS(s.cfg.TLS.CertFile, s.cfg.TLS.KeyFile); err != nil {
 			if err != http.ErrServerClosed {

--- a/cmd/api/src/daemons/api/toolapi/api.go
+++ b/cmd/api/src/daemons/api/toolapi/api.go
@@ -97,7 +97,7 @@ func (s Daemon) Name() string {
 }
 
 // Start begins the daemon and waits for a stop signal in the exit channel
-func (s Daemon) Start() {
+func (s Daemon) Start(ctx context.Context) {
 	if s.cfg.TLS.Enabled() {
 		if err := s.server.ListenAndServeTLS(s.cfg.TLS.CertFile, s.cfg.TLS.KeyFile); err != nil {
 			if err != http.ErrServerClosed {

--- a/cmd/api/src/daemons/daemon.go
+++ b/cmd/api/src/daemons/daemon.go
@@ -1,17 +1,17 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 package daemons
@@ -25,7 +25,7 @@ import (
 )
 
 type Daemon interface {
-	Start()
+	Start(ctx context.Context)
 	Name() string
 	Stop(ctx context.Context) error
 }
@@ -43,13 +43,13 @@ func NewManager(shutdownTimeout time.Duration) *Manager {
 	}
 }
 
-func (s *Manager) Start(daemons ...Daemon) {
+func (s *Manager) Start(ctx context.Context, daemons ...Daemon) {
 	s.daemonsLock.Lock()
 	defer s.daemonsLock.Unlock()
 
 	for _, daemon := range daemons {
 		log.Infof("Starting daemon %s", daemon.Name())
-		go daemon.Start()
+		go daemon.Start(ctx)
 
 		s.daemons = append(s.daemons, daemon)
 	}

--- a/cmd/api/src/daemons/datapipe/datapipe.go
+++ b/cmd/api/src/daemons/datapipe/datapipe.go
@@ -141,7 +141,7 @@ func (s *Daemon) ingestAvailableTasks() {
 	}
 }
 
-func (s *Daemon) Start() {
+func (s *Daemon) Start(ctx context.Context) {
 	var (
 		datapipeLoopTimer = time.NewTimer(s.tickInterval)
 		pruningTicker     = time.NewTicker(pruningInterval)

--- a/cmd/api/src/daemons/gc/data_pruning.go
+++ b/cmd/api/src/daemons/gc/data_pruning.go
@@ -1,17 +1,17 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 package gc
@@ -43,21 +43,21 @@ func (s *Daemon) Name() string {
 }
 
 // Start begins the daemon and waits for a stop signal in the exit channel
-func (s *Daemon) Start() {
+func (s *Daemon) Start(ctx context.Context) {
 	ticker := time.NewTicker(24 * time.Hour)
 
 	defer close(s.exitC)
 	defer ticker.Stop()
 
 	// prune sessions and collections once when the daemon starts up
-	s.db.SweepSessions()
+	s.db.SweepSessions(ctx)
 	s.db.SweepAssetGroupCollections()
 
 	// thereafter, prune conditionally once a day
 	for {
 		select {
 		case <-ticker.C:
-			s.db.SweepSessions()
+			s.db.SweepSessions(ctx)
 			s.db.SweepAssetGroupCollections()
 
 		case <-s.exitC:

--- a/cmd/api/src/daemons/gc/data_pruning.go
+++ b/cmd/api/src/daemons/gc/data_pruning.go
@@ -51,14 +51,14 @@ func (s *Daemon) Start(ctx context.Context) {
 
 	// prune sessions and collections once when the daemon starts up
 	s.db.SweepSessions(ctx)
-	s.db.SweepAssetGroupCollections()
+	s.db.SweepAssetGroupCollections(ctx)
 
 	// thereafter, prune conditionally once a day
 	for {
 		select {
 		case <-ticker.C:
 			s.db.SweepSessions(ctx)
-			s.db.SweepAssetGroupCollections()
+			s.db.SweepAssetGroupCollections(ctx)
 
 		case <-s.exitC:
 			return

--- a/cmd/api/src/daemons/gc/data_pruning_test.go
+++ b/cmd/api/src/daemons/gc/data_pruning_test.go
@@ -17,6 +17,7 @@
 package gc
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -50,7 +51,7 @@ func TestGC_Start(t *testing.T) {
 
 	mockDB := mocks.NewMockDatabase(mockCtrl)
 
-	mockDB.EXPECT().SweepSessions().Do(func() {
+	mockDB.EXPECT().SweepSessions(gomock.Any()).Do(func(ctx context.Context) {
 		// simulate some work being done
 		time.Sleep(1 * time.Millisecond)
 	})
@@ -67,5 +68,5 @@ func TestGC_Start(t *testing.T) {
 		daemon.exitC <- struct{}{}
 	}()
 
-	daemon.Start()
+	daemon.Start(context.Background())
 }

--- a/cmd/api/src/daemons/gc/data_pruning_test.go
+++ b/cmd/api/src/daemons/gc/data_pruning_test.go
@@ -55,7 +55,7 @@ func TestGC_Start(t *testing.T) {
 		// simulate some work being done
 		time.Sleep(1 * time.Millisecond)
 	})
-	mockDB.EXPECT().SweepAssetGroupCollections().Do(func() {
+	mockDB.EXPECT().SweepAssetGroupCollections(gomock.Any()).Do(func(ctx context.Context) {
 		time.Sleep(1 * time.Millisecond)
 	})
 

--- a/cmd/api/src/database/agi.go
+++ b/cmd/api/src/database/agi.go
@@ -118,8 +118,8 @@ func (s *BloodhoundDB) GetAllAssetGroups(ctx context.Context, order string, filt
 	return assetGroups, nil
 }
 
-func (s *BloodhoundDB) SweepAssetGroupCollections() {
-	s.db.Where("created_at < now() - INTERVAL '30 DAYS'").Delete(&model.AssetGroupCollection{})
+func (s *BloodhoundDB) SweepAssetGroupCollections(ctx context.Context) {
+	s.db.WithContext(ctx).Where("created_at < now() - INTERVAL '30 DAYS'").Delete(&model.AssetGroupCollection{})
 }
 
 func (s *BloodhoundDB) GetAssetGroupCollections(ctx context.Context, assetGroupID int32, order string, filter model.SQLFilter) (model.AssetGroupCollections, error) {

--- a/cmd/api/src/database/auth.go
+++ b/cmd/api/src/database/auth.go
@@ -583,6 +583,6 @@ func (s *BloodhoundDB) GetUserSession(ctx context.Context, id int64) (model.User
 }
 
 // SweepSessions deletes all sessions that have already expired
-func (s *BloodhoundDB) SweepSessions() {
-	s.db.Where("expires_at < NOW()").Delete(&model.UserSession{})
+func (s *BloodhoundDB) SweepSessions(ctx context.Context) {
+	s.db.WithContext(ctx).Where("expires_at < NOW()").Delete(&model.UserSession{})
 }

--- a/cmd/api/src/database/auth.go
+++ b/cmd/api/src/database/auth.go
@@ -573,10 +573,10 @@ func (s *BloodhoundDB) LookupActiveSessionsByUser(ctx context.Context, user mode
 
 // GetUserSession retrieves the UserSession row associated with the provided ID
 // SELECT * FROM user_sessions WHERE id = ...
-func (s *BloodhoundDB) GetUserSession(id int64) (model.UserSession, error) {
+func (s *BloodhoundDB) GetUserSession(ctx context.Context, id int64) (model.UserSession, error) {
 	var (
 		userSession model.UserSession
-		result      = s.preload(model.UserSessionAssociations()).Find(&userSession, id)
+		result      = s.preload(model.UserSessionAssociations()).WithContext(ctx).Find(&userSession, id)
 	)
 
 	return userSession, CheckError(result)

--- a/cmd/api/src/database/auth.go
+++ b/cmd/api/src/database/auth.go
@@ -549,10 +549,10 @@ func (s *BloodhoundDB) GetSAMLProviderUsers(ctx context.Context, id int32) (mode
 
 // CreateUserSession creates a new UserSession row
 // INSERT INTO user_sessions (...) VALUES (..)
-func (s *BloodhoundDB) CreateUserSession(userSession model.UserSession) (model.UserSession, error) {
+func (s *BloodhoundDB) CreateUserSession(ctx context.Context, userSession model.UserSession) (model.UserSession, error) {
 	var (
 		newUserSession = userSession
-		result         = s.db.Create(&newUserSession)
+		result         = s.db.WithContext(ctx).Create(&newUserSession)
 	)
 
 	return newUserSession, CheckError(result)

--- a/cmd/api/src/database/auth.go
+++ b/cmd/api/src/database/auth.go
@@ -564,10 +564,10 @@ func (s *BloodhoundDB) EndUserSession(userSession model.UserSession) {
 	s.db.Model(&userSession).Update("expires_at", gorm.Expr("NOW()"))
 }
 
-func (s *BloodhoundDB) LookupActiveSessionsByUser(user model.User) ([]model.UserSession, error) {
+func (s *BloodhoundDB) LookupActiveSessionsByUser(ctx context.Context, user model.User) ([]model.UserSession, error) {
 	var userSessions []model.UserSession
 
-	result := s.db.Where("expires_at >= NOW() AND user_id = ?", user.ID).Find(&userSessions)
+	result := s.db.WithContext(ctx).Where("expires_at >= NOW() AND user_id = ?", user.ID).Find(&userSessions)
 	return userSessions, CheckError(result)
 }
 

--- a/cmd/api/src/database/auth.go
+++ b/cmd/api/src/database/auth.go
@@ -560,8 +560,8 @@ func (s *BloodhoundDB) CreateUserSession(ctx context.Context, userSession model.
 
 // EndUserSession terminates the provided session
 // UPDATE user_sessions SET expires_at = <now> WHERE user_id = ...
-func (s *BloodhoundDB) EndUserSession(userSession model.UserSession) {
-	s.db.Model(&userSession).Update("expires_at", gorm.Expr("NOW()"))
+func (s *BloodhoundDB) EndUserSession(ctx context.Context, userSession model.UserSession) {
+	s.db.Model(&userSession).WithContext(ctx).Update("expires_at", gorm.Expr("NOW()"))
 }
 
 func (s *BloodhoundDB) LookupActiveSessionsByUser(ctx context.Context, user model.User) ([]model.UserSession, error) {

--- a/cmd/api/src/database/auth_test.go
+++ b/cmd/api/src/database/auth_test.go
@@ -362,6 +362,7 @@ func TestDatabase_CreateUpdateDeleteSAMLProvider(t *testing.T) {
 
 func TestDatabase_CreateUserSession(t *testing.T) {
 	var (
+		testCtx      = context.Background()
 		dbInst, user = initAndCreateUser(t)
 		userSession  = model.UserSession{
 			User:      user,
@@ -370,7 +371,7 @@ func TestDatabase_CreateUserSession(t *testing.T) {
 		}
 	)
 
-	if newUserSession, err := dbInst.CreateUserSession(userSession); err != nil {
+	if newUserSession, err := dbInst.CreateUserSession(testCtx, userSession); err != nil {
 		t.Fatalf("Failed to create new user session: %v", err)
 	} else if newUserSession.Expired() {
 		t.Fatalf("Expected user session to remain valid. Session expires at: %s", newUserSession.ExpiresAt)
@@ -381,7 +382,7 @@ func TestDatabase_CreateUserSession(t *testing.T) {
 	// Test expiry
 	userSession.ExpiresAt = time.Now().UTC().Add(-time.Hour)
 
-	if newUserSession, err := dbInst.CreateUserSession(userSession); err != nil {
+	if newUserSession, err := dbInst.CreateUserSession(testCtx, userSession); err != nil {
 		t.Fatalf("Failed to create new user session: %v", err)
 	} else if !newUserSession.Expired() {
 		t.Fatalf("Expected user session to be expired. Session expires at: %s", newUserSession.ExpiresAt)

--- a/cmd/api/src/database/db.go
+++ b/cmd/api/src/database/db.go
@@ -132,7 +132,7 @@ type Database interface {
 	LookupActiveSessionsByUser(ctx context.Context, user model.User) ([]model.UserSession, error)
 	EndUserSession(ctx context.Context, userSession model.UserSession)
 	GetUserSession(ctx context.Context, id int64) (model.UserSession, error)
-	SweepSessions()
+	SweepSessions(ctx context.Context)
 
 	// Data Quality
 	dataquality.DataQualityData

--- a/cmd/api/src/database/db.go
+++ b/cmd/api/src/database/db.go
@@ -68,7 +68,7 @@ type Database interface {
 	CreateAssetGroup(ctx context.Context, name, tag string, systemGroup bool) (model.AssetGroup, error)
 	UpdateAssetGroup(ctx context.Context, assetGroup model.AssetGroup) error
 	DeleteAssetGroup(ctx context.Context, assetGroup model.AssetGroup) error
-	SweepAssetGroupCollections()
+	SweepAssetGroupCollections(ctx context.Context)
 	GetAssetGroupCollections(ctx context.Context, assetGroupID int32, order string, filter model.SQLFilter) (model.AssetGroupCollections, error)
 	GetLatestAssetGroupCollection(ctx context.Context, assetGroupID int32) (model.AssetGroupCollection, error)
 	GetTimeRangedAssetGroupCollections(ctx context.Context, assetGroupID int32, from int64, to int64, order string) (model.AssetGroupCollections, error)

--- a/cmd/api/src/database/db.go
+++ b/cmd/api/src/database/db.go
@@ -129,7 +129,7 @@ type Database interface {
 
 	// Sessions
 	CreateUserSession(ctx context.Context, userSession model.UserSession) (model.UserSession, error)
-	LookupActiveSessionsByUser(user model.User) ([]model.UserSession, error)
+	LookupActiveSessionsByUser(ctx context.Context, user model.User) ([]model.UserSession, error)
 	EndUserSession(userSession model.UserSession)
 	GetUserSession(id int64) (model.UserSession, error)
 	SweepSessions()

--- a/cmd/api/src/database/db.go
+++ b/cmd/api/src/database/db.go
@@ -127,7 +127,8 @@ type Database interface {
 	GetSAMLProviderUsers(ctx context.Context, id int32) (model.Users, error)
 	DeleteSAMLProvider(ctx context.Context, samlProvider model.SAMLProvider) error
 
-	CreateUserSession(userSession model.UserSession) (model.UserSession, error)
+	// Sessions
+	CreateUserSession(ctx context.Context, userSession model.UserSession) (model.UserSession, error)
 	LookupActiveSessionsByUser(user model.User) ([]model.UserSession, error)
 	EndUserSession(userSession model.UserSession)
 	GetUserSession(id int64) (model.UserSession, error)

--- a/cmd/api/src/database/db.go
+++ b/cmd/api/src/database/db.go
@@ -131,7 +131,7 @@ type Database interface {
 	CreateUserSession(ctx context.Context, userSession model.UserSession) (model.UserSession, error)
 	LookupActiveSessionsByUser(ctx context.Context, user model.User) ([]model.UserSession, error)
 	EndUserSession(ctx context.Context, userSession model.UserSession)
-	GetUserSession(id int64) (model.UserSession, error)
+	GetUserSession(ctx context.Context, id int64) (model.UserSession, error)
 	SweepSessions()
 
 	// Data Quality

--- a/cmd/api/src/database/db.go
+++ b/cmd/api/src/database/db.go
@@ -130,7 +130,7 @@ type Database interface {
 	// Sessions
 	CreateUserSession(ctx context.Context, userSession model.UserSession) (model.UserSession, error)
 	LookupActiveSessionsByUser(ctx context.Context, user model.User) ([]model.UserSession, error)
-	EndUserSession(userSession model.UserSession)
+	EndUserSession(ctx context.Context, userSession model.UserSession)
 	GetUserSession(id int64) (model.UserSession, error)
 	SweepSessions()
 

--- a/cmd/api/src/database/mocks/db.go
+++ b/cmd/api/src/database/mocks/db.go
@@ -473,15 +473,15 @@ func (mr *MockDatabaseMockRecorder) DeleteUser(arg0, arg1 interface{}) *gomock.C
 }
 
 // EndUserSession mocks base method.
-func (m *MockDatabase) EndUserSession(arg0 model.UserSession) {
+func (m *MockDatabase) EndUserSession(arg0 context.Context, arg1 model.UserSession) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "EndUserSession", arg0)
+	m.ctrl.Call(m, "EndUserSession", arg0, arg1)
 }
 
 // EndUserSession indicates an expected call of EndUserSession.
-func (mr *MockDatabaseMockRecorder) EndUserSession(arg0 interface{}) *gomock.Call {
+func (mr *MockDatabaseMockRecorder) EndUserSession(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EndUserSession", reflect.TypeOf((*MockDatabase)(nil).EndUserSession), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EndUserSession", reflect.TypeOf((*MockDatabase)(nil).EndUserSession), arg0, arg1)
 }
 
 // GetADDataQualityAggregations mocks base method.

--- a/cmd/api/src/database/mocks/db.go
+++ b/cmd/api/src/database/mocks/db.go
@@ -304,18 +304,18 @@ func (mr *MockDatabaseMockRecorder) CreateUser(arg0, arg1 interface{}) *gomock.C
 }
 
 // CreateUserSession mocks base method.
-func (m *MockDatabase) CreateUserSession(arg0 model.UserSession) (model.UserSession, error) {
+func (m *MockDatabase) CreateUserSession(arg0 context.Context, arg1 model.UserSession) (model.UserSession, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateUserSession", arg0)
+	ret := m.ctrl.Call(m, "CreateUserSession", arg0, arg1)
 	ret0, _ := ret[0].(model.UserSession)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateUserSession indicates an expected call of CreateUserSession.
-func (mr *MockDatabaseMockRecorder) CreateUserSession(arg0 interface{}) *gomock.Call {
+func (mr *MockDatabaseMockRecorder) CreateUserSession(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateUserSession", reflect.TypeOf((*MockDatabase)(nil).CreateUserSession), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateUserSession", reflect.TypeOf((*MockDatabase)(nil).CreateUserSession), arg0, arg1)
 }
 
 // DeleteAllDataQuality mocks base method.

--- a/cmd/api/src/database/mocks/db.go
+++ b/cmd/api/src/database/mocks/db.go
@@ -1092,18 +1092,18 @@ func (mr *MockDatabaseMockRecorder) ListSavedQueries(arg0, arg1, arg2, arg3, arg
 }
 
 // LookupActiveSessionsByUser mocks base method.
-func (m *MockDatabase) LookupActiveSessionsByUser(arg0 model.User) ([]model.UserSession, error) {
+func (m *MockDatabase) LookupActiveSessionsByUser(arg0 context.Context, arg1 model.User) ([]model.UserSession, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "LookupActiveSessionsByUser", arg0)
+	ret := m.ctrl.Call(m, "LookupActiveSessionsByUser", arg0, arg1)
 	ret0, _ := ret[0].([]model.UserSession)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // LookupActiveSessionsByUser indicates an expected call of LookupActiveSessionsByUser.
-func (mr *MockDatabaseMockRecorder) LookupActiveSessionsByUser(arg0 interface{}) *gomock.Call {
+func (mr *MockDatabaseMockRecorder) LookupActiveSessionsByUser(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LookupActiveSessionsByUser", reflect.TypeOf((*MockDatabase)(nil).LookupActiveSessionsByUser), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LookupActiveSessionsByUser", reflect.TypeOf((*MockDatabase)(nil).LookupActiveSessionsByUser), arg0, arg1)
 }
 
 // LookupSAMLProviderByName mocks base method.

--- a/cmd/api/src/database/mocks/db.go
+++ b/cmd/api/src/database/mocks/db.go
@@ -1209,15 +1209,15 @@ func (mr *MockDatabaseMockRecorder) SetFlag(arg0, arg1 interface{}) *gomock.Call
 }
 
 // SweepAssetGroupCollections mocks base method.
-func (m *MockDatabase) SweepAssetGroupCollections() {
+func (m *MockDatabase) SweepAssetGroupCollections(arg0 context.Context) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SweepAssetGroupCollections")
+	m.ctrl.Call(m, "SweepAssetGroupCollections", arg0)
 }
 
 // SweepAssetGroupCollections indicates an expected call of SweepAssetGroupCollections.
-func (mr *MockDatabaseMockRecorder) SweepAssetGroupCollections() *gomock.Call {
+func (mr *MockDatabaseMockRecorder) SweepAssetGroupCollections(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SweepAssetGroupCollections", reflect.TypeOf((*MockDatabase)(nil).SweepAssetGroupCollections))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SweepAssetGroupCollections", reflect.TypeOf((*MockDatabase)(nil).SweepAssetGroupCollections), arg0)
 }
 
 // SweepSessions mocks base method.

--- a/cmd/api/src/database/mocks/db.go
+++ b/cmd/api/src/database/mocks/db.go
@@ -1221,15 +1221,15 @@ func (mr *MockDatabaseMockRecorder) SweepAssetGroupCollections() *gomock.Call {
 }
 
 // SweepSessions mocks base method.
-func (m *MockDatabase) SweepSessions() {
+func (m *MockDatabase) SweepSessions(arg0 context.Context) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SweepSessions")
+	m.ctrl.Call(m, "SweepSessions", arg0)
 }
 
 // SweepSessions indicates an expected call of SweepSessions.
-func (mr *MockDatabaseMockRecorder) SweepSessions() *gomock.Call {
+func (mr *MockDatabaseMockRecorder) SweepSessions(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SweepSessions", reflect.TypeOf((*MockDatabase)(nil).SweepSessions))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SweepSessions", reflect.TypeOf((*MockDatabase)(nil).SweepSessions), arg0)
 }
 
 // UpdateAssetGroup mocks base method.

--- a/cmd/api/src/database/mocks/db.go
+++ b/cmd/api/src/database/mocks/db.go
@@ -1000,18 +1000,18 @@ func (mr *MockDatabaseMockRecorder) GetUser(arg0, arg1 interface{}) *gomock.Call
 }
 
 // GetUserSession mocks base method.
-func (m *MockDatabase) GetUserSession(arg0 int64) (model.UserSession, error) {
+func (m *MockDatabase) GetUserSession(arg0 context.Context, arg1 int64) (model.UserSession, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetUserSession", arg0)
+	ret := m.ctrl.Call(m, "GetUserSession", arg0, arg1)
 	ret0, _ := ret[0].(model.UserSession)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetUserSession indicates an expected call of GetUserSession.
-func (mr *MockDatabaseMockRecorder) GetUserSession(arg0 interface{}) *gomock.Call {
+func (mr *MockDatabaseMockRecorder) GetUserSession(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserSession", reflect.TypeOf((*MockDatabase)(nil).GetUserSession), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserSession", reflect.TypeOf((*MockDatabase)(nil).GetUserSession), arg0, arg1)
 }
 
 // GetUserToken mocks base method.


### PR DESCRIPTION
## Description

Plumb context into gorm session db methods
https://gorm.io/docs/context.html#Context-Timeout

## Motivation and Context

Currently as it stands any endpoints that rely on purely gorm do not respect `request.Context` and as such timeouts are not respected either. While we want to eventually get to the removal of the gorm dependency altogether, that is a long way and a lot of effort away and this I think this approach would give us that much room to maneuver while we get there.

## How Has This Been Tested?

Using a rest client and the prefer header
Add a sleep inside of the handler
Look for the `500 request timed out` after exceeding the timeout. (Note: the request will take as long as the sleep is set, it's not tied to the prefer header)

## Types of changes

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [x] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
