### PR TITLE
Strip UTF-8 BOM from json files

### DIFF
--- a/cmd/api/src/services/fileupload/file_upload.go
+++ b/cmd/api/src/services/fileupload/file_upload.go
@@ -18,6 +18,7 @@
 package fileupload
 
 import (
+	"bufio"
 	"context"
 	"errors"
 	"fmt"
@@ -34,6 +35,8 @@ import (
 )
 
 const jobActivityTimeout = time.Minute * 20
+
+var UTF8BOMBytes = []byte{0xef, 0xbb, 0xbf}
 
 var ErrInvalidJSON = errors.New("file is not valid json")
 
@@ -102,7 +105,17 @@ func WriteAndValidateZip(src io.Reader, dst io.Writer) error {
 
 func WriteAndValidateJSON(src io.Reader, dst io.Writer) error {
 	tr := io.TeeReader(src, dst)
-	_, err := ValidateMetaTag(tr, true)
+	bufReader := bufio.NewReader(tr)
+	if b, err := bufReader.Peek(3); err != nil {
+		return err
+	} else {
+		if b[0] == UTF8BOMBytes[0] && b[1] == UTF8BOMBytes[1] && b[2] == UTF8BOMBytes[2] {
+			if _, err := bufReader.Discard(3); err != nil {
+				return err
+			}
+		}
+	}
+	_, err := ValidateMetaTag(bufReader, true)
 	return err
 }
 

--- a/cmd/api/src/services/fileupload/file_upload.go
+++ b/cmd/api/src/services/fileupload/file_upload.go
@@ -36,7 +36,11 @@ import (
 
 const jobActivityTimeout = time.Minute * 20
 
-var UTF8BOMBytes = []byte{0xef, 0xbb, 0xbf}
+const (
+	UTF8BOM1 = 0xef
+	UTF8BOM2 = 0xbb
+	UTF8BMO3 = 0xbf
+)
 
 var ErrInvalidJSON = errors.New("file is not valid json")
 
@@ -109,7 +113,7 @@ func WriteAndValidateJSON(src io.Reader, dst io.Writer) error {
 	if b, err := bufReader.Peek(3); err != nil {
 		return err
 	} else {
-		if b[0] == UTF8BOMBytes[0] && b[1] == UTF8BOMBytes[1] && b[2] == UTF8BOMBytes[2] {
+		if b[0] == UTF8BOM1 && b[1] == UTF8BOM2 && b[2] == UTF8BMO3 {
 			if _, err := bufReader.Discard(3); err != nil {
 				return err
 			}

--- a/cmd/api/src/services/fileupload/file_upload_test.go
+++ b/cmd/api/src/services/fileupload/file_upload_test.go
@@ -38,10 +38,21 @@ func TestWriteAndValidateJSON(t *testing.T) {
 
 	t.Run("succeed on good json", func(t *testing.T) {
 		var (
-			writer  = bytes.Buffer{}
+			writer   = bytes.Buffer{}
 			goodJSON = strings.NewReader(`{"meta": {"methods": 0, "type": "sessions", "count": 0, "version": 5}, "data": []}`)
 		)
 		err := WriteAndValidateJSON(goodJSON, &writer)
+		assert.Nil(t, err)
+	})
+
+	t.Run("succeed on utf-8 BOM json", func(t *testing.T) {
+		var (
+			writer = bytes.Buffer{}
+		)
+
+		file, err := os.Open("../../test/fixtures/fixtures/utf8bomjson.json")
+		assert.Nil(t, err)
+		err = WriteAndValidateJSON(io.Reader(file), &writer)
 		assert.Nil(t, err)
 	})
 }

--- a/cmd/api/src/test/fixtures/fixtures/utf8bomjson.json
+++ b/cmd/api/src/test/fixtures/fixtures/utf8bomjson.json
@@ -1,0 +1,1 @@
+﻿{"meta": {"methods": 0, "type": "sessions", "count": 0, "version": 5}, "data": []}


### PR DESCRIPTION
## Description
Removes the UTF-8 BOM from json files when processing on the API, as this is invalid regardless
<!--- Describe your changes in detail -->

## Motivation and Context
https://github.com/SpecterOps/BloodHound/issues/30

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Integration tests + local testing
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
