### PR TITLE
feat: add esc13 edge info content

### DIFF
--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/ADCSESC13/ADCSESC13.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/ADCSESC13/ADCSESC13.tsx
@@ -1,0 +1,33 @@
+// Copyright 2024 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import General from './General';
+import WindowsAbuse from './WindowsAbuse';
+import LinuxAbuse from './LinuxAbuse';
+import Opsec from './Opsec';
+import References from './References';
+import Composition from '../ADCSESC6a/Composition';
+
+const ADCSESC13 = {
+    general: General,
+    windowsAbuse: WindowsAbuse,
+    linuxAbuse: LinuxAbuse,
+    opsec: Opsec,
+    references: References,
+    composition: Composition,
+};
+
+export default ADCSESC13;

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/ADCSESC13/General.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/ADCSESC13/General.tsx
@@ -1,0 +1,35 @@
+// Copyright 2024 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { FC } from 'react';
+import { EdgeInfoProps } from '../index';
+import { Typography } from '@mui/material';
+
+const General: FC<EdgeInfoProps> = ({ sourceName, sourceType }) => {
+    return (
+        <Typography variant='body2'>
+            The {sourceType} {sourceName} has the privileges to perform the ADCS ESC13 abuse against the target AD
+            group. The principal has enrollment rights on a certificate template configured with an issuance policy
+            extension. The issuance policy has an OID group link to an AD group. The principal also has enrollment
+            permission for an enterprise CA with the necessary template published. This enterprise CA is trusted for NT
+            authentication and chains up to a root CA for the forest. This setup allows the principal to enroll a
+            certificate that the principal can use to obtain access to the environment as a member of the group
+            specified in the OID group link.
+        </Typography>
+    );
+};
+
+export default General;

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/ADCSESC13/LinuxAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/ADCSESC13/LinuxAbuse.tsx
@@ -1,0 +1,49 @@
+// Copyright 2024 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { FC } from 'react';
+import { Typography } from '@mui/material';
+
+const LinuxAbuse: FC = () => {
+    return (
+        <>
+            <Typography variant='body2'>An attacker may perform this attack in the following steps:</Typography>
+            <Typography variant='body2'>
+                <b>Step 1</b>: Use Certipy to request enrollment in the affected template, specifying the affected
+                enterprise CA:
+            </Typography>
+            <Typography component={'pre'}>
+                {'certipy req -u john@corp.local -p Passw0rd -ca corp-DC-CA -target ca.corp.local -template ESC13'}
+            </Typography>
+            <Typography variant='body2'>
+                If the enrollment fails with an error message stating that the Email or DNS name is unavailable and
+                cannot be added to the Subject or Subject Alternate name, then it is because the enrollee principal does
+                not have their 'mail' or 'dNSHostName' attribute set, which is required by the certificate template. The
+                'mail' attribute can be set on both user and computer objects but the 'dNSHostName' attribute can only
+                be set on computer objects. Computers have validated write permission to their own 'dNSHostName'
+                attribute by default, but neither users nor computers can write to their own 'mail' attribute by
+                default.
+            </Typography>
+            <Typography variant='body2'>
+                <b>Step 2</b>: Request a ticket granting ticket (TGT) from the domain, specifying the certificate
+                created in Step 1 and the IP of a domain controller:
+            </Typography>
+            <Typography component={'pre'}>{'certipy auth -pfx john.pfx -dc-ip 172.16.126.128'}</Typography>
+        </>
+    );
+};
+
+export default LinuxAbuse;

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/ADCSESC13/Opsec.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/ADCSESC13/Opsec.tsx
@@ -1,0 +1,30 @@
+// Copyright 2024 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { FC } from 'react';
+import { Typography } from '@mui/material';
+
+const Opsec: FC = () => {
+    return (
+        <Typography variant='body2'>
+            When the affected certificate authority issues the certificate to the attacker, it will retain a local copy
+            of that certificate in its issued certificates store. Defenders may analyze those issued certificates to
+            identify illegitimately issued certificates and identify the principal that requested the certificate.
+        </Typography>
+    );
+};
+
+export default Opsec;

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/ADCSESC13/References.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/ADCSESC13/References.tsx
@@ -1,0 +1,71 @@
+// Copyright 2024 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import React, { FC } from 'react';
+import { Link, Box } from '@mui/material';
+
+const References: FC = () => {
+    const references = [
+        {
+            label: 'Abuse Elevation Control Mechanism',
+            link: 'https://attack.mitre.org/techniques/T1548/',
+        },
+        {
+            label: 'ADCS ESC13 Abuse Technique',
+            link: 'https://posts.specterops.io/adcs-esc13-abuse-technique-fda4272fbd53',
+        },
+        {
+            label: 'Certified Pre-Owned - Abusing Active Directory Certificate Services',
+            link: 'https://specterops.io/wp-content/uploads/sites/3/2022/06/Certified_Pre-Owned.pdf',
+        },
+        {
+            label: 'Certipy',
+            link: 'https://github.com/ly4k/Certipy',
+        },
+        {
+            label: 'Certify',
+            link: 'https://github.com/GhostPack/Certify',
+        },
+        {
+            label: 'Rubeus',
+            link: 'https://github.com/GhostPack/Rubeus',
+        },
+        {
+            label: 'Authentication Mechanism Assurance for AD DS in Windows Server 2008 R2 Step-by-Step Guide',
+            link: 'https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/dd378897(v=ws.10)?redirectedfrom=MSDN',
+        },
+        {
+            label: 'Use Authentication Mechanism Assurance (AMA) to secure administrative account logins',
+            link: 'https://www.gradenegger.eu/en/using-authentication-mechanism-assurance-ama-to-secure-the-login-of-administrative-accounts/',
+        },
+    ];
+    return (
+        <Box sx={{ overflowX: 'auto' }}>
+            {references.map((reference) => {
+                return (
+                    <React.Fragment key={reference.link}>
+                        <Link target='_blank' rel='noopener' href={reference.link}>
+                            {reference.label}
+                        </Link>
+                        <br />
+                    </React.Fragment>
+                );
+            })}
+        </Box>
+    );
+};
+
+export default References;

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/ADCSESC13/WindowsAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/ADCSESC13/WindowsAbuse.tsx
@@ -1,0 +1,66 @@
+// Copyright 2024 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { FC } from 'react';
+import { Typography } from '@mui/material';
+
+const WindowsAbuse: FC = () => {
+    return (
+        <>
+            <Typography variant='body2'>
+                The principal can now perform an ESC13 abuse with the following steps:
+            </Typography>
+            <Typography variant='body2'>
+                <b>Step 1</b>: Use Certify to request enrollment in the affected template, specifying the affected
+                certification authority:
+            </Typography>
+            <Typography component={'pre'}>
+                {'Certify.exe request /ca:rootdomaindc.forestroot.com\\forestroot-RootDomainDC-CA /template:"ESC13"'}
+            </Typography>
+            <Typography variant='body2'>
+                If the enrollment fails with an error message stating that the Email or DNS name is unavailable and
+                cannot be added to the Subject or Subject Alternate name, then it is because the enrollee principal does
+                not have their 'mail' or 'dNSHostName' attribute set, which is required by the certificate template. The
+                'mail' attribute can be set on both user and computer objects but the 'dNSHostName' attribute can only
+                be set on computer objects. Computers have validated write permission to their own 'dNSHostName'
+                attribute by default, but neither users nor computers can write to their own 'mail' attribute by
+                default.
+            </Typography>
+            <Typography variant='body2'>Save the certificate as cert.pem and the private key as cert.key.</Typography>
+            <Typography variant='body2'>
+                <b>Step 2</b>: Convert the emitted certificate to PFX format:
+            </Typography>
+            <Typography component={'pre'}>{'certutil.exe -MergePFX .\\cert.pem .\\cert.pfx'}</Typography>
+            <Typography variant='body2'>
+                <b>Step 3</b>: Optionally purge all kerberos tickets from memory:
+            </Typography>
+            <Typography component={'pre'}>{'klist purge'}</Typography>
+            <Typography variant='body2'>
+                <b>Step 4</b>: Use Rubeus to request a ticket granting ticket (TGT) from the domain, specifying the
+                attacker identity, the PFX-formatted certificate created in Step 2, and the certificate password:
+            </Typography>
+            <Typography component={'pre'}>
+                {'Rubeus asktgt /user:"forestroot\\attacker" /certificate:cert.pfx /password:asdf /ptt'}
+            </Typography>
+            <Typography variant='body2'>
+                <b>Step 5</b>: Optionally verify the TGT by listing it with the klist command:
+            </Typography>
+            <Typography component={'pre'}>{'klist'}</Typography>
+        </>
+    );
+};
+
+export default WindowsAbuse;

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/index.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/index.tsx
@@ -116,6 +116,7 @@ import ADCSESC9a from './ADCSESC9a/ADCSESC9a';
 import ADCSESC9b from './ADCSESC9b/ADCSESC9b';
 import ADCSESC10a from './ADCSESC10a/ADCSESC10a';
 import ADCSESC10b from './ADCSESC10b/ADCSESC10b';
+import ADCSESC13 from './ADCSESC13/ADCSESC13';
 
 export type EdgeInfoProps = {
     edgeName?: string;
@@ -225,6 +226,7 @@ const EdgeInfoComponents = {
     ADCSESC9b: ADCSESC9b,
     ADCSESC10a: ADCSESC10a,
     ADCSESC10b: ADCSESC10b,
+    ADCSESC13: ADCSESC13,
     ManageCA: ManageCA,
     ManageCertificates: ManageCertificates,
     WritePKIEnrollmentFlag: WritePKIEnrollmentFlag,


### PR DESCRIPTION
## Description
Adds the components for the ESC13 edge information pane.
<!--- Describe your changes in detail -->

## Motivation and Context
ESC13 is in the works and this changeset introduces the components that will render the edge information when clicking on this edge in the Explore page.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
This edge is not yet implemented so this will preemptively have these components available once the edge is being generated. There are no additional requirements or blockers.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
