### PR TITLE
fix: revert response shape for type=graph related entity queries

### DIFF
--- a/cmd/api/src/api/v2/ad_related_entity.go
+++ b/cmd/api/src/api/v2/ad_related_entity.go
@@ -26,6 +26,7 @@ import (
 	"github.com/specterops/bloodhound/dawgs/ops"
 	"github.com/specterops/bloodhound/graphschema/ad"
 	"github.com/specterops/bloodhound/src/api"
+	"github.com/specterops/bloodhound/src/model"
 	"github.com/specterops/bloodhound/src/model/appcfg"
 	"github.com/specterops/bloodhound/src/queries"
 )
@@ -48,6 +49,8 @@ func (s *Resources) handleAdRelatedEntityQuery(response http.ResponseWriter, req
 		} else {
 			api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusInternalServerError, "an unknown error occurred during the request", request), response)
 		}
+	} else if params.RequestedType == model.DataTypeGraph {
+		api.WriteJSONResponse(request.Context(), results, http.StatusOK, response)
 	} else {
 		api.WriteResponseWrapperWithPagination(request.Context(), results, params.Limit, params.Skip, count, http.StatusOK, response)
 	}

--- a/cmd/api/src/queries/graph_integration_test.go
+++ b/cmd/api/src/queries/graph_integration_test.go
@@ -160,7 +160,7 @@ func TestSearchNodesByName_ExactMatch_ObjectID(t *testing.T) {
 		})
 }
 
-func TestGetEntityResults_ListTypeParam(t *testing.T) {
+func TestGetEntityResults(t *testing.T) {
 	testContext := integration.NewGraphTestContext(t, schema.DefaultGraphSchema())
 	queryCache, err := cache.NewCache(cache.Config{MaxSize: 1})
 	require.Nil(t, err)
@@ -191,37 +191,6 @@ func TestGetEntityResults_ListTypeParam(t *testing.T) {
 		require.Equal(t, 0, queryCache.Len())
 	})
 }
-
-// func TestGetEntityResults_GraphTypeParam(t *testing.T) {
-// 	testContext := integration.NewGraphTestContext(t, schema.DefaultGraphSchema())
-// 	queryCache, err := cache.NewCache(cache.Config{MaxSize: 1})
-// 	require.Nil(t, err)
-
-// 	testContext.DatabaseTest(func(harness integration.HarnessDetails, db graph.Database) {
-// 		objectID, err := harness.InboundControl.ControlledUser.Properties.Get(common.ObjectID.String()).String()
-// 		require.Nil(t, err)
-
-// 		graphQuery := queries.GraphQuery{
-// 			Graph: db,
-// 			Cache: queryCache,
-// 		}
-// 		params := queries.EntityQueryParameters{
-// 			QueryName:     "InboundADEntityController",
-// 			ObjectID:      objectID,
-// 			RequestedType: 0,
-// 			PathDelegate:  adAnalysis.FetchInboundADEntityControllerPaths,
-// 			ListDelegate:  adAnalysis.FetchInboundADEntityControllers,
-// 		}
-
-// 		results, count, err := graphQuery.GetADEntityQueryResult(context.Background(), params, false)
-// 		require.Nil(t, err)
-
-// 		require.Equal(t, 4, count)
-// 		require.Len(t, results, 2)
-// 		require.Nil(t, results.data)
-// 		require.Equal(t, 0, queryCache.Len())
-// 	})
-// }
 
 func TestGetEntityResults_QueryShorterThanSlowQueryThreshold(t *testing.T) {
 	testContext := integration.NewGraphTestContext(t, schema.DefaultGraphSchema())

--- a/cmd/api/src/queries/graph_integration_test.go
+++ b/cmd/api/src/queries/graph_integration_test.go
@@ -21,9 +21,10 @@ package queries_test
 
 import (
 	"context"
+	"testing"
+
 	schema "github.com/specterops/bloodhound/graphschema"
 	"github.com/specterops/bloodhound/src/config"
-	"testing"
 
 	adAnalysis "github.com/specterops/bloodhound/analysis/ad"
 	"github.com/specterops/bloodhound/cache"
@@ -159,7 +160,7 @@ func TestSearchNodesByName_ExactMatch_ObjectID(t *testing.T) {
 		})
 }
 
-func TestGetEntityResults(t *testing.T) {
+func TestGetEntityResults_ListTypeParam(t *testing.T) {
 	testContext := integration.NewGraphTestContext(t, schema.DefaultGraphSchema())
 	queryCache, err := cache.NewCache(cache.Config{MaxSize: 1})
 	require.Nil(t, err)
@@ -190,6 +191,37 @@ func TestGetEntityResults(t *testing.T) {
 		require.Equal(t, 0, queryCache.Len())
 	})
 }
+
+// func TestGetEntityResults_GraphTypeParam(t *testing.T) {
+// 	testContext := integration.NewGraphTestContext(t, schema.DefaultGraphSchema())
+// 	queryCache, err := cache.NewCache(cache.Config{MaxSize: 1})
+// 	require.Nil(t, err)
+
+// 	testContext.DatabaseTest(func(harness integration.HarnessDetails, db graph.Database) {
+// 		objectID, err := harness.InboundControl.ControlledUser.Properties.Get(common.ObjectID.String()).String()
+// 		require.Nil(t, err)
+
+// 		graphQuery := queries.GraphQuery{
+// 			Graph: db,
+// 			Cache: queryCache,
+// 		}
+// 		params := queries.EntityQueryParameters{
+// 			QueryName:     "InboundADEntityController",
+// 			ObjectID:      objectID,
+// 			RequestedType: 0,
+// 			PathDelegate:  adAnalysis.FetchInboundADEntityControllerPaths,
+// 			ListDelegate:  adAnalysis.FetchInboundADEntityControllers,
+// 		}
+
+// 		results, count, err := graphQuery.GetADEntityQueryResult(context.Background(), params, false)
+// 		require.Nil(t, err)
+
+// 		require.Equal(t, 4, count)
+// 		require.Len(t, results, 2)
+// 		require.Nil(t, results.data)
+// 		require.Equal(t, 0, queryCache.Len())
+// 	})
+// }
 
 func TestGetEntityResults_QueryShorterThanSlowQueryThreshold(t *testing.T) {
 	testContext := integration.NewGraphTestContext(t, schema.DefaultGraphSchema())


### PR DESCRIPTION
## Description
The response shape for related entity queries with url param `type=graph` has been reverted in order to maintain the current api contract for this kind of request.
<!--- Describe your changes in detail -->

## Motivation and Context
This endpoint response changes shape based on the params that are passed in the request. While it is better and something that we should have in place to standardize these response shapes, normalizing this response resulted in a breaking change for viewing a node's relationships in the graph from the entity panel. The response was previously flat and was not sent back as pagination results and so the UI was looking in the wrong place for the data to render in the graph. Reverting this shape allows these graphs to render in the UI again.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Tests have been added asserting on the response shape for both graph type and list type queries. A local instance was spun up and graphs were able to be rendered from the entity panel drop downs in the UI.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):


https://github.com/SpecterOps/BloodHound/assets/16910931/11ae9d85-477e-4e55-af82-17af9b7f8d22


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [x] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
