### PR TITLE
Resolve vulnerabilities in neo4j container

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -71,6 +71,8 @@ services:
 
   graph-db:
     build:
+      args:
+        memconfig: true
       context: tools/docker-compose
       dockerfile: neo4j.Dockerfile
     environment:

--- a/docker-compose.testing.yml
+++ b/docker-compose.testing.yml
@@ -31,7 +31,9 @@ services:
 
   testgraph:
     restart: unless-stopped
-    image: neo4j:4.4.0
+    build:
+      context: tools/docker-compose
+      dockerfile: neo4j.Dockerfile
     environment:
       - NEO4J_AUTH=neo4j/bloodhoundcommunityedition
       - NEO4J_dbms_security_auth__enabled=false

--- a/tools/docker-compose/neo4j.Dockerfile
+++ b/tools/docker-compose/neo4j.Dockerfile
@@ -14,7 +14,9 @@
 # 
 # SPDX-License-Identifier: Apache-2.0
 
-FROM docker.io/library/neo4j:4.4.31 as neo4j
+FROM docker.io/library/neo4j:4.4.31 as base
+
+ARG memconfig
 
 # Install version 1.26.1 of commons-compress direct from Apache to address vulnerabilities
 RUN wget https://dlcdn.apache.org//commons/compress/binaries/commons-compress-1.26.1-bin.tar.gz && \
@@ -26,7 +28,8 @@ RUN wget https://dlcdn.apache.org//commons/compress/binaries/commons-compress-1.
 RUN echo "dbms.security.auth_enabled=false" >> /var/lib/neo4j/conf/neo4j.conf && \
     # Restrict allowed procedures only to what is used to mitigate CVE-2023-23926
     echo "dbms.security.procedures.unrestricted=apoc.periodic.*,specterops.*" >> /var/lib/neo4j/conf/neo4j.conf && \
-    echo "dbms.security.procedures.allowlist=apoc.periodic.*,specterops.*" >> /var/lib/neo4j/conf/neo4j.conf && \
-    neo4j-admin memrec >> /var/lib/neo4j/conf/neo4j.conf
+    echo "dbms.security.procedures.allowlist=apoc.periodic.*,specterops.*" >> /var/lib/neo4j/conf/neo4j.conf
+
+RUN if [ "$memconfig" = "true" ]; then neo4j-admin memrec >> /var/lib/neo4j/conf/neo4j.conf; fi
 
 RUN cp /var/lib/neo4j/labs/apoc-4.4.0.25-core.jar /var/lib/neo4j/plugins/apoc-4.4.0.25-core.jar

--- a/tools/docker-compose/neo4j.Dockerfile
+++ b/tools/docker-compose/neo4j.Dockerfile
@@ -14,16 +14,9 @@
 # 
 # SPDX-License-Identifier: Apache-2.0
 
-FROM docker.io/library/neo4j:4.4.31 as base
+FROM docker.io/library/neo4j:4.4.32 as base
 
 ARG memconfig
-
-# Install version 1.26.1 of commons-compress direct from Apache to address vulnerabilities
-RUN wget https://dlcdn.apache.org//commons/compress/binaries/commons-compress-1.26.1-bin.tar.gz && \
-    tar xvf commons-compress-1.26.1-bin.tar.gz && cd commons-compress-1.26.1/ && \
-    cp commons-compress-1.26.1.jar /var/lib/neo4j/lib/commons-compress-1.26.1.jar && \
-    rm /var/lib/neo4j/lib/commons-compress-1.21.jar && \
-    rm -r /var/lib/neo4j/commons-compress-1.26.1/
 
 RUN echo "dbms.security.auth_enabled=false" >> /var/lib/neo4j/conf/neo4j.conf && \
     # Restrict allowed procedures only to what is used to mitigate CVE-2023-23926
@@ -32,4 +25,4 @@ RUN echo "dbms.security.auth_enabled=false" >> /var/lib/neo4j/conf/neo4j.conf &&
 
 RUN if [ "$memconfig" = "true" ]; then neo4j-admin memrec >> /var/lib/neo4j/conf/neo4j.conf; fi
 
-RUN cp /var/lib/neo4j/labs/apoc-4.4.0.25-core.jar /var/lib/neo4j/plugins/apoc-4.4.0.25-core.jar
+RUN cp /var/lib/neo4j/labs/apoc-4.4.0.26-core.jar /var/lib/neo4j/plugins/apoc-4.4.0.26-core.jar


### PR DESCRIPTION
## Description

## Description
This PR updates vulnerable libraries in our neo4j container used in development. I made the following fixes/changes to get down to only 1 "medium" vulnerability.

- Bump neo4j base image to 4.4.31
- Set the `allowlist` for procedures to only allow calls to `apoc.periodic.*` to mitigate CVE-2023-23926
- Updated `apoc` to 4.4.0.25
- Combined Docker commands to reduce the amount of layers needed for the container
- Added conditional command to add `memrec` to the neo4j config. This is configurable by setting the build arg `memconfig` to true. This is enabled by default in development docker compose deployments, but not testing.
- Updated the testing infrastructure to use BloodHound's custom neo4j container instead of the base image from Docker Hub

Note that this change means that we will now need to explicitly allow any procedures that we may want to run in the neo4j config file. 

## Motivation and Context
* Make our containers more secure

## How Has This Been Tested?
* Verified basic graph functionality in BloodHound still functions as expected
* Verified that calls to `apoc.periodic.*` procedures still function as expected
* Verified that calls to `apoc.import.graphml` do not function

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] My changes include a database migration.
