### PR TITLE
fix: align node icons for AIACA nodes

### DIFF
--- a/cmd/api/src/api/bloodhoundgraph/bloodhoundgraph.go
+++ b/cmd/api/src/api/bloodhoundgraph/bloodhoundgraph.go
@@ -16,6 +16,8 @@
 
 package bloodhoundgraph
 
+//TODO: Move styling responsibilites to the UI or move shared styling definitions to a cue file to generate from one source of truth
+
 type BloodHoundGraphGlyph struct {
 	Angle    int                        `json:"angle,omitempty"`
 	Blink    bool                       `json:"blink,omitempty"`
@@ -234,7 +236,7 @@ func (s *BloodHoundGraphNode) SetIcon(nType string) {
 		}
 	case "AIACA":
 		s.FontIcon = &BloodHoundGraphFontIcon{
-			Text: "fa-box",
+			Text: "fa-arrows-left-right-to-line",
 		}
 	case "RootCA":
 		s.FontIcon = &BloodHoundGraphFontIcon{


### PR DESCRIPTION
## Description
The AIACA node icon for graph rendering has been updated to match the icon that is used in the rest of the UI.
<!--- Describe your changes in detail -->

## Motivation and Context
This styling is defined in the API and was not matching the UI's definitions so different icons were shown in the regular UI components vs the graph.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] My changes include a database migration.
