### PR TITLE
fix: BED-4283 - fixed invalid json syntax in swagger doc json

### DIFF
--- a/cmd/api/src/api/v2/docs.go
+++ b/cmd/api/src/api/v2/docs.go
@@ -39,7 +39,7 @@ var (
 		BasePath:     "/",
 		Schemes:      []string{},
 		Title:        "BloodHound API",
-		Description:  "This is the API that drives BloodHound Enterprise and Community Edition.\nEndpoint availability is denoted using the `Community` and `Enterprise` tags.\n\nContact information listed is for BloodHound Enterprise customers. To get help with\nBloodHound Community Edition, please join our\n[Slack community](https://ghst.ly/BHSlack/).",
+		Description:  "This is the API that drives BloodHound Enterprise and Community Edition.\\nEndpoint availability is denoted using the `Community` and `Enterprise` tags.\\n\\nContact information listed is for BloodHound Enterprise customers. To get help with BloodHound Community Edition, please join our [Slack community](https://ghst.ly/BHSlack/).",
 		SupportName:  "BloodHound Enterprise Support",
 		SupportUrl:   "https://support.bloodhoundenterprise.io/",
 		SupportEmail: "support@specterops.io",


### PR DESCRIPTION
## Description

Fixed invalid JSON in swagger doc

## Motivation and Context

The JSON was invalid and would break a JSON parser.

## How Has This Been Tested?

Manual testing

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
