### PR TITLE
Move graph deletion to datapipe

### DIFF
--- a/cmd/api/src/api/v2/database_wipe.go
+++ b/cmd/api/src/api/v2/database_wipe.go
@@ -97,11 +97,8 @@ func (s Resources) HandleDatabaseWipe(response http.ResponseWriter, request *htt
 
 	// delete graph
 	if payload.DeleteCollectedGraphData {
-		if failed := s.deleteCollectedGraphData(request.Context(), auditEntry); failed {
-			errors = append(errors, "collected graph data")
-		} else {
-			kickoffAnalysis = true
-		}
+		s.TaskNotifier.RequestDeletion()
+		s.handleAuditLogForDatabaseWipe(request.Context(), auditEntry, true, "collected graph data")
 	}
 
 	// delete asset group selectors

--- a/cmd/api/src/api/v2/database_wipe.go
+++ b/cmd/api/src/api/v2/database_wipe.go
@@ -23,8 +23,6 @@ import (
 	"strings"
 
 	"github.com/gofrs/uuid"
-	"github.com/specterops/bloodhound/dawgs/graph"
-	"github.com/specterops/bloodhound/dawgs/ops"
 	"github.com/specterops/bloodhound/log"
 	"github.com/specterops/bloodhound/src/api"
 	"github.com/specterops/bloodhound/src/model"
@@ -143,39 +141,6 @@ func (s Resources) HandleDatabaseWipe(response http.ResponseWriter, request *htt
 
 }
 
-func (s Resources) deleteCollectedGraphData(ctx context.Context, auditEntry *model.AuditEntry) (failure bool) {
-	var nodeIDs []graph.ID
-
-	if err := s.Graph.ReadTransaction(ctx,
-		func(tx graph.Transaction) error {
-			fetchedNodeIDs, err := ops.FetchNodeIDs(tx.Nodes())
-
-			nodeIDs = append(nodeIDs, fetchedNodeIDs...)
-			return err
-		},
-	); err != nil {
-		log.Errorf("%s: %s", "error fetching all nodes", err.Error())
-		s.handleAuditLogForDatabaseWipe(ctx, auditEntry, false, "collected graph data")
-		return true
-	} else if err := s.Graph.BatchOperation(ctx, func(batch graph.Batch) error {
-		for _, nodeId := range nodeIDs {
-			// deleting a node also deletes all of its edges due to a sql trigger
-			if err := batch.DeleteNode(nodeId); err != nil {
-				return err
-			}
-		}
-		return nil
-	}); err != nil {
-		log.Errorf("%s: %s", "error deleting all nodes", err.Error())
-		s.handleAuditLogForDatabaseWipe(ctx, auditEntry, false, "collected graph data")
-		return true
-	} else {
-		// if successful, handle audit log and kick off analysis
-		s.handleAuditLogForDatabaseWipe(ctx, auditEntry, true, "collected graph data")
-		return false
-	}
-}
-
 func (s Resources) deleteHighValueSelectors(ctx context.Context, auditEntry *model.AuditEntry, assetGroupIDs []int) (failure bool) {
 
 	if err := s.DB.DeleteAssetGroupSelectorsForAssetGroups(ctx, assetGroupIDs); err != nil {
@@ -215,7 +180,7 @@ func (s Resources) handleAuditLogForDatabaseWipe(ctx context.Context, auditEntry
 	if success {
 		auditEntry.Status = model.AuditLogStatusSuccess
 		auditEntry.Model = model.AuditData{
-			"delete_successful": msg,
+			"delete_request_successful": msg,
 		}
 	} else {
 		auditEntry.Status = model.AuditLogStatusFailure

--- a/cmd/api/src/api/v2/database_wipe_test.go
+++ b/cmd/api/src/api/v2/database_wipe_test.go
@@ -80,57 +80,17 @@ func TestDatabaseWipe(t *testing.T) {
 				},
 			},
 			{
-				Name: "failed fetching nodes during attempt to delete collected graph data",
+				Name: "deletion of collected graph data kicks off tasker",
 				Input: func(input *apitest.Input) {
 					apitest.SetHeader(input, headers.ContentType.String(), mediatypes.ApplicationJson.String())
 					apitest.BodyStruct(input, v2.DatabaseWipe{DeleteCollectedGraphData: true})
 				},
 				Setup: func() {
+					taskerIntent := mockTasker.EXPECT().RequestDeletion().Times(1)
 					successfulAuditLogIntent := mockDB.EXPECT().AppendAuditLog(gomock.Any(), gomock.Any()).Return(nil).Times(1)
-					failedFetchNodesToDelete := mockGraph.EXPECT().ReadTransaction(gomock.Any(), gomock.Any()).Return(errors.New("oopsy!")).Times(1)
-					successfulAuditLogFailure := mockDB.EXPECT().AppendAuditLog(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+					successfulAuditLogWipe := mockDB.EXPECT().AppendAuditLog(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 
-					gomock.InOrder(successfulAuditLogIntent, failedFetchNodesToDelete, successfulAuditLogFailure)
-				},
-				Test: func(output apitest.Output) {
-					apitest.StatusCode(output, http.StatusInternalServerError)
-					apitest.BodyContains(output, "We encountered an error while deleting collected graph data")
-				},
-			},
-			{
-				Name: "failed batch operation to delete nodes during attempt to delete collected graph data",
-				Input: func(input *apitest.Input) {
-					apitest.SetHeader(input, headers.ContentType.String(), mediatypes.ApplicationJson.String())
-					apitest.BodyStruct(input, v2.DatabaseWipe{DeleteCollectedGraphData: true})
-				},
-				Setup: func() {
-					successfulAuditLogIntent := mockDB.EXPECT().AppendAuditLog(gomock.Any(), gomock.Any()).Return(nil).Times(1)
-					successfulFetchNodesToDelete := mockGraph.EXPECT().ReadTransaction(gomock.Any(), gomock.Any()).Return(nil).Times(1)
-					failedBatchDelete := mockGraph.EXPECT().BatchOperation(gomock.Any(), gomock.Any()).Return(errors.New("oopsy!")).Times(1)
-					successfulAuditLogFailure := mockDB.EXPECT().AppendAuditLog(gomock.Any(), gomock.Any()).Return(nil).Times(1)
-
-					gomock.InOrder(successfulAuditLogIntent, successfulFetchNodesToDelete, failedBatchDelete, successfulAuditLogFailure)
-
-				},
-				Test: func(output apitest.Output) {
-					apitest.StatusCode(output, http.StatusInternalServerError)
-					apitest.BodyContains(output, "We encountered an error while deleting collected graph data")
-				},
-			},
-			{
-				Name: "succesful deletion of collected graph data kicks of analysis",
-				Input: func(input *apitest.Input) {
-					apitest.SetHeader(input, headers.ContentType.String(), mediatypes.ApplicationJson.String())
-					apitest.BodyStruct(input, v2.DatabaseWipe{DeleteCollectedGraphData: true})
-				},
-				Setup: func() {
-					successfulAuditLogIntent := mockDB.EXPECT().AppendAuditLog(gomock.Any(), gomock.Any()).Return(nil).Times(1)
-					successfulFetchNodesToDelete := mockGraph.EXPECT().ReadTransaction(gomock.Any(), gomock.Any()).Return(nil).Times(1)
-					successfulBatchDelete := mockGraph.EXPECT().BatchOperation(gomock.Any(), gomock.Any()).Return(nil).Times(1)
-					successfulAuditLogSuccess := mockDB.EXPECT().AppendAuditLog(gomock.Any(), gomock.Any()).Return(nil).Times(1)
-					sucsessfulAnalysisKickoff := mockTasker.EXPECT().RequestAnalysis().Times(1)
-
-					gomock.InOrder(successfulAuditLogIntent, successfulFetchNodesToDelete, successfulBatchDelete, successfulAuditLogSuccess, sucsessfulAnalysisKickoff)
+					gomock.InOrder(successfulAuditLogIntent, taskerIntent, successfulAuditLogWipe)
 
 				},
 				Test: func(output apitest.Output) {
@@ -287,10 +247,9 @@ func TestDatabaseWipe(t *testing.T) {
 					successfulAuditLogIntent := mockDB.EXPECT().AppendAuditLog(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 
 					// collected graph data operations
-					fetchNodesToDelete := mockGraph.EXPECT().ReadTransaction(gomock.Any(), gomock.Any()).Return(nil).Times(1)
-					batchDelete := mockGraph.EXPECT().BatchOperation(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+					taskerIntent := mockTasker.EXPECT().RequestDeletion().Times(1)
 					nodesDeletedAuditLog := mockDB.EXPECT().AppendAuditLog(gomock.Any(), gomock.Any()).Return(nil).Times(1)
-					gomock.InOrder(successfulAuditLogIntent, fetchNodesToDelete, batchDelete, nodesDeletedAuditLog)
+					gomock.InOrder(successfulAuditLogIntent, taskerIntent, nodesDeletedAuditLog)
 
 					// high value selector operations
 					assetGroupSelectorsDelete := mockDB.EXPECT().DeleteAssetGroupSelectorsForAssetGroups(gomock.Any(), gomock.Any()).Return(nil).Times(1)

--- a/cmd/api/src/daemons/datapipe/datapipe.go
+++ b/cmd/api/src/daemons/datapipe/datapipe.go
@@ -40,6 +40,7 @@ const (
 
 type Tasker interface {
 	RequestAnalysis()
+	RequestDeletion()
 	GetStatus() model.DatapipeStatusWrapper
 }
 
@@ -49,6 +50,7 @@ type Daemon struct {
 	cache               cache.Cache
 	cfg                 config.Configuration
 	analysisRequested   *atomic.Bool
+	deletionRequested   *atomic.Bool
 	tickInterval        time.Duration
 	status              model.DatapipeStatusWrapper
 	ctx                 context.Context
@@ -66,6 +68,7 @@ func NewDaemon(ctx context.Context, cfg config.Configuration, connections bootst
 		cache:               cache,
 		cfg:                 cfg,
 		ctx:                 ctx,
+		deletionRequested:   &atomic.Bool{},
 		analysisRequested:   &atomic.Bool{},
 		orphanedFileSweeper: NewOrphanFileSweeper(NewOSFileOperations(), cfg.TempDirectory()),
 		tickInterval:        tickInterval,
@@ -77,7 +80,16 @@ func NewDaemon(ctx context.Context, cfg config.Configuration, connections bootst
 }
 
 func (s *Daemon) RequestAnalysis() {
+	if s.getDeletionRequested() {
+		log.Warnf("Rejecting analysis request as deletion is in progress")
+		return
+	}
 	s.setAnalysisRequested(true)
+}
+
+func (s *Daemon) RequestDeletion() {
+	s.setDeletionRequested(true)
+	s.setAnalysisRequested(false)
 }
 
 func (s *Daemon) GetStatus() model.DatapipeStatusWrapper {
@@ -90,6 +102,14 @@ func (s *Daemon) getAnalysisRequested() bool {
 
 func (s *Daemon) setAnalysisRequested(requested bool) {
 	s.analysisRequested.Store(requested)
+}
+
+func (s *Daemon) setDeletionRequested(requested bool) {
+	s.deletionRequested.Store(requested)
+}
+
+func (s *Daemon) getDeletionRequested() bool {
+	return s.deletionRequested.Load()
 }
 
 func (s *Daemon) analyze() {
@@ -158,6 +178,10 @@ func (s *Daemon) Start(ctx context.Context) {
 			s.clearOrphanedData()
 
 		case <-datapipeLoopTimer.C:
+			if s.getDeletionRequested() {
+				s.deleteData()
+			}
+
 			// Ingest all available ingest tasks
 			s.ingestAvailableTasks()
 
@@ -179,6 +203,21 @@ func (s *Daemon) Start(ctx context.Context) {
 		case <-s.ctx.Done():
 			return
 		}
+	}
+}
+
+func (s *Daemon) deleteData() {
+	defer func() {
+		s.setDeletionRequested(false)
+		s.setAnalysisRequested(true)
+	}()
+
+	if err := s.db.CancelAllFileUploads(s.ctx); err != nil {
+		log.Errorf("error cancelling jobs during data deletion: %v", err)
+	} else if err := s.db.DeleteAllIngestTasks(s.ctx); err != nil {
+		log.Errorf("error deleting ingest tasks during data deletion: %v", err)
+	} else if err := DeleteCollectedGraphData(s.ctx, s.graphdb); err != nil {
+		log.Errorf("error deleting graph data: %v", err)
 	}
 }
 

--- a/cmd/api/src/daemons/datapipe/datapipe.go
+++ b/cmd/api/src/daemons/datapipe/datapipe.go
@@ -208,16 +208,20 @@ func (s *Daemon) Start(ctx context.Context) {
 
 func (s *Daemon) deleteData() {
 	defer func() {
+		s.status.Update(model.DatapipeStatusIdle, false)
 		s.setDeletionRequested(false)
 		s.setAnalysisRequested(true)
 	}()
+	defer log.Measure(log.LevelInfo, "Purge Graph Data Completed")()
+	s.status.Update(model.DatapipeStatusPurging, false)
+	log.Infof("Begin Purge Graph Data")
 
 	if err := s.db.CancelAllFileUploads(s.ctx); err != nil {
-		log.Errorf("error cancelling jobs during data deletion: %v", err)
+		log.Errorf("Error cancelling jobs during data deletion: %v", err)
 	} else if err := s.db.DeleteAllIngestTasks(s.ctx); err != nil {
-		log.Errorf("error deleting ingest tasks during data deletion: %v", err)
+		log.Errorf("Error deleting ingest tasks during data deletion: %v", err)
 	} else if err := DeleteCollectedGraphData(s.ctx, s.graphdb); err != nil {
-		log.Errorf("error deleting graph data: %v", err)
+		log.Errorf("Error deleting graph data: %v", err)
 	}
 }
 

--- a/cmd/api/src/daemons/datapipe/datapipe.go
+++ b/cmd/api/src/daemons/datapipe/datapipe.go
@@ -88,8 +88,8 @@ func (s *Daemon) RequestAnalysis() {
 }
 
 func (s *Daemon) RequestDeletion() {
-	s.setDeletionRequested(true)
 	s.setAnalysisRequested(false)
+	s.setDeletionRequested(true)
 }
 
 func (s *Daemon) GetStatus() model.DatapipeStatusWrapper {

--- a/cmd/api/src/daemons/datapipe/delete.go
+++ b/cmd/api/src/daemons/datapipe/delete.go
@@ -30,7 +30,6 @@ func DeleteCollectedGraphData(ctx context.Context, graphDB graph.Database) error
 	}); err != nil {
 		return fmt.Errorf("error deleting all nodes: %w", err)
 	} else {
-		// if successful, handle audit log and kick off analysis
 		return nil
 	}
 }

--- a/cmd/api/src/daemons/datapipe/delete.go
+++ b/cmd/api/src/daemons/datapipe/delete.go
@@ -1,0 +1,36 @@
+package datapipe
+
+import (
+	"context"
+	"fmt"
+	"github.com/specterops/bloodhound/dawgs/graph"
+	"github.com/specterops/bloodhound/dawgs/ops"
+)
+
+func DeleteCollectedGraphData(ctx context.Context, graphDB graph.Database) error {
+	var nodeIDs []graph.ID
+
+	if err := graphDB.ReadTransaction(ctx,
+		func(tx graph.Transaction) error {
+			fetchedNodeIDs, err := ops.FetchNodeIDs(tx.Nodes())
+
+			nodeIDs = append(nodeIDs, fetchedNodeIDs...)
+			return err
+		},
+	); err != nil {
+		return fmt.Errorf("error fetching all nodes: %w", err)
+	} else if err := graphDB.BatchOperation(ctx, func(batch graph.Batch) error {
+		for _, nodeId := range nodeIDs {
+			// deleting a node also deletes all of its edges due to a sql trigger
+			if err := batch.DeleteNode(nodeId); err != nil {
+				return err
+			}
+		}
+		return nil
+	}); err != nil {
+		return fmt.Errorf("error deleting all nodes: %w", err)
+	} else {
+		// if successful, handle audit log and kick off analysis
+		return nil
+	}
+}

--- a/cmd/api/src/daemons/datapipe/mocks/tasker.go
+++ b/cmd/api/src/daemons/datapipe/mocks/tasker.go
@@ -75,3 +75,15 @@ func (mr *MockTaskerMockRecorder) RequestAnalysis() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RequestAnalysis", reflect.TypeOf((*MockTasker)(nil).RequestAnalysis))
 }
+
+// RequestDeletion mocks base method.
+func (m *MockTasker) RequestDeletion() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "RequestDeletion")
+}
+
+// RequestDeletion indicates an expected call of RequestDeletion.
+func (mr *MockTaskerMockRecorder) RequestDeletion() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RequestDeletion", reflect.TypeOf((*MockTasker)(nil).RequestDeletion))
+}

--- a/cmd/api/src/database/file_upload.go
+++ b/cmd/api/src/database/file_upload.go
@@ -98,5 +98,5 @@ func (s *BloodhoundDB) DeleteAllFileUploads(ctx context.Context) error {
 }
 
 func (s *BloodhoundDB) DeleteAllIngestTasks(ctx context.Context) error {
-	return CheckError(s.db.WithContext(ctx).Delete(&model.IngestTask{}))
+	return CheckError(s.db.WithContext(ctx).Exec("DELETE FROM ingest_tasks"))
 }

--- a/cmd/api/src/database/file_upload.go
+++ b/cmd/api/src/database/file_upload.go
@@ -49,6 +49,11 @@ func (s *BloodhoundDB) GetFileUploadJobsWithStatus(ctx context.Context, status m
 	return jobs, CheckError(result)
 }
 
+func (s *BloodhoundDB) CancelAllFileUploads(ctx context.Context) error {
+	runningStates := []model.JobStatus{model.JobStatusAnalyzing, model.JobStatusRunning, model.JobStatusIngesting}
+	return CheckError(s.db.Model(model.FileUploadJob{}).WithContext(ctx).Where("status in ?", runningStates).Update("status", model.JobStatusCanceled))
+}
+
 func (s *BloodhoundDB) GetAllFileUploadJobs(ctx context.Context, skip int, limit int, order string, filter model.SQLFilter) ([]model.FileUploadJob, int, error) {
 	var (
 		jobs   []model.FileUploadJob
@@ -90,4 +95,8 @@ func (s *BloodhoundDB) DeleteAllFileUploads(ctx context.Context) error {
 	return CheckError(
 		s.db.WithContext(ctx).Exec("DELETE FROM file_upload_jobs"),
 	)
+}
+
+func (s *BloodhoundDB) DeleteAllIngestTasks(ctx context.Context) error {
+	return CheckError(s.db.WithContext(ctx).Delete(&model.IngestTask{}))
 }

--- a/cmd/api/src/database/mocks/db.go
+++ b/cmd/api/src/database/mocks/db.go
@@ -68,6 +68,20 @@ func (mr *MockDatabaseMockRecorder) AppendAuditLog(arg0, arg1 interface{}) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppendAuditLog", reflect.TypeOf((*MockDatabase)(nil).AppendAuditLog), arg0, arg1)
 }
 
+// CancelAllFileUploads mocks base method.
+func (m *MockDatabase) CancelAllFileUploads(arg0 context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CancelAllFileUploads", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CancelAllFileUploads indicates an expected call of CancelAllFileUploads.
+func (mr *MockDatabaseMockRecorder) CancelAllFileUploads(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelAllFileUploads", reflect.TypeOf((*MockDatabase)(nil).CancelAllFileUploads), arg0)
+}
+
 // Close mocks base method.
 func (m *MockDatabase) Close(arg0 context.Context) {
 	m.ctrl.T.Helper()
@@ -344,6 +358,20 @@ func (m *MockDatabase) DeleteAllFileUploads(arg0 context.Context) error {
 func (mr *MockDatabaseMockRecorder) DeleteAllFileUploads(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAllFileUploads", reflect.TypeOf((*MockDatabase)(nil).DeleteAllFileUploads), arg0)
+}
+
+// DeleteAllIngestTasks mocks base method.
+func (m *MockDatabase) DeleteAllIngestTasks(arg0 context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteAllIngestTasks", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteAllIngestTasks indicates an expected call of DeleteAllIngestTasks.
+func (mr *MockDatabaseMockRecorder) DeleteAllIngestTasks(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAllIngestTasks", reflect.TypeOf((*MockDatabase)(nil).DeleteAllIngestTasks), arg0)
 }
 
 // DeleteAssetGroup mocks base method.

--- a/cmd/api/src/model/datapipe_status.go
+++ b/cmd/api/src/model/datapipe_status.go
@@ -1,17 +1,17 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 package model
@@ -24,6 +24,7 @@ const (
 	DatapipeStatusIdle      DatapipeStatus = "idle"
 	DatapipeStatusIngesting DatapipeStatus = "ingesting"
 	DatapipeStatusAnalyzing DatapipeStatus = "analyzing"
+	DatapipeStatusPurging   DatapipeStatus = "purging"
 )
 
 type DatapipeStatusWrapper struct {

--- a/cmd/api/src/services/fileupload/file_upload.go
+++ b/cmd/api/src/services/fileupload/file_upload.go
@@ -52,6 +52,8 @@ type FileUploadData interface {
 	GetAllFileUploadJobs(ctx context.Context, skip int, limit int, order string, filter model.SQLFilter) ([]model.FileUploadJob, int, error)
 	GetFileUploadJobsWithStatus(ctx context.Context, status model.JobStatus) ([]model.FileUploadJob, error)
 	DeleteAllFileUploads(ctx context.Context) error
+	CancelAllFileUploads(ctx context.Context) error
+	DeleteAllIngestTasks(ctx context.Context) error
 }
 
 func ProcessStaleFileUploadJobs(ctx context.Context, db FileUploadData) {
@@ -82,6 +84,14 @@ func ProcessStaleFileUploadJobs(ctx context.Context, db FileUploadData) {
 			}
 		}
 	}
+}
+
+func CancelAllFileUploads(ctx context.Context, db FileUploadData) error {
+	return db.CancelAllFileUploads(ctx)
+}
+
+func DeleteAllIngestTasks(ctx context.Context, db FileUploadData) error {
+	return db.DeleteAllIngestTasks(ctx)
 }
 
 func GetAllFileUploadJobs(ctx context.Context, db FileUploadData, skip int, limit int, order string, filter model.SQLFilter) ([]model.FileUploadJob, int, error) {

--- a/cmd/api/src/services/fileupload/mocks/mock.go
+++ b/cmd/api/src/services/fileupload/mocks/mock.go
@@ -51,6 +51,20 @@ func (m *MockFileUploadData) EXPECT() *MockFileUploadDataMockRecorder {
 	return m.recorder
 }
 
+// CancelAllFileUploads mocks base method.
+func (m *MockFileUploadData) CancelAllFileUploads(arg0 context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CancelAllFileUploads", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CancelAllFileUploads indicates an expected call of CancelAllFileUploads.
+func (mr *MockFileUploadDataMockRecorder) CancelAllFileUploads(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelAllFileUploads", reflect.TypeOf((*MockFileUploadData)(nil).CancelAllFileUploads), arg0)
+}
+
 // CreateFileUploadJob mocks base method.
 func (m *MockFileUploadData) CreateFileUploadJob(arg0 context.Context, arg1 model.FileUploadJob) (model.FileUploadJob, error) {
 	m.ctrl.T.Helper()
@@ -78,6 +92,20 @@ func (m *MockFileUploadData) DeleteAllFileUploads(arg0 context.Context) error {
 func (mr *MockFileUploadDataMockRecorder) DeleteAllFileUploads(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAllFileUploads", reflect.TypeOf((*MockFileUploadData)(nil).DeleteAllFileUploads), arg0)
+}
+
+// DeleteAllIngestTasks mocks base method.
+func (m *MockFileUploadData) DeleteAllIngestTasks(arg0 context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteAllIngestTasks", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteAllIngestTasks indicates an expected call of DeleteAllIngestTasks.
+func (mr *MockFileUploadDataMockRecorder) DeleteAllIngestTasks(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAllIngestTasks", reflect.TypeOf((*MockFileUploadData)(nil).DeleteAllIngestTasks), arg0)
 }
 
 // GetAllFileUploadJobs mocks base method.

--- a/justfile
+++ b/justfile
@@ -99,7 +99,7 @@ update-favicon:
 
 # run go commands in the context of the api project
 go *ARGS:
-  @cd cmd/api/src && GODEBUG=cgocheck=2 go {{ARGS}}
+  @cd cmd/api/src && go {{ARGS}}
 
 # run yarn commands in the context of the workspace root
 yarn-local *ARGS="":


### PR DESCRIPTION
## Description
Moves logic for graph deletion to the datapipe to prevent deadlocks

<!--- Describe your changes in detail -->

## Motivation and Context
The existing logic for clearing the DB was handled by the api handler in resources. However, if concurrent graph modifications were being performed in datapipe, this would lead to graph deadlocks. This MR moves the graph deletion logic into datapipe

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://specterops.atlassian.net/browse/BED-4286
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local testing

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
