### PR TITLE
chore: BED-4141 - Added common responses to openapi spec src

### DIFF
--- a/packages/go/openapi/src/responses/bad-request.yaml
+++ b/packages/go/openapi/src/responses/bad-request.yaml
@@ -1,0 +1,33 @@
+# Copyright 2024 Specter Ops, Inc.
+#
+# Licensed under the Apache License, Version 2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  **Bad Request**
+  This could be due to one of the following reasons:
+  - JSON payload is missing or malformed
+  - Path or query parameters are missing or invalid/malformed
+  - The data sent is not valid (ex- sending a `string` in an `integer` field)
+content:
+  application/json:
+    schema:
+      $ref: './../schemas/api.error-wrapper.yaml'
+    example:
+      http_status: 400
+      timestamp: 2024-02-19T19:27:43.866Z
+      request_id: 3fa85f64-5717-4562-b3fc-2c963f66afa6
+      errors:
+        - context: clients
+          message: The JSON payload could not be unmarshalled.

--- a/packages/go/openapi/src/responses/binary-response.yaml
+++ b/packages/go/openapi/src/responses/binary-response.yaml
@@ -1,0 +1,29 @@
+# Copyright 2024 Specter Ops, Inc.
+#
+# Licensed under the Apache License, Version 2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  **OK**
+  This response will contain binary content.
+headers:
+  Content-Disposition:
+    schema:
+      type: string
+content:
+  application/octet-stream:
+    schema:
+      type: string
+      format: binary
+    example: '[this request has a binary response]'

--- a/packages/go/openapi/src/responses/csv-response.yaml
+++ b/packages/go/openapi/src/responses/csv-response.yaml
@@ -1,0 +1,28 @@
+# Copyright 2024 Specter Ops, Inc.
+#
+# Licensed under the Apache License, Version 2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  **OK**
+  This response will contain csv text content.
+content:
+  text/csv:
+    schema:
+      type: string
+    example: |
+      header1,header2,header3
+      cell1,cell2,cell3
+      cell4,cell5,cell6
+      ...

--- a/packages/go/openapi/src/responses/error-response.yaml
+++ b/packages/go/openapi/src/responses/error-response.yaml
@@ -1,0 +1,21 @@
+# Copyright 2024 Specter Ops, Inc.
+#
+# Licensed under the Apache License, Version 2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+description: The standard error response wrapper.
+content:
+  application/json:
+    schema:
+      $ref: './../schemas/api.error-wrapper.yaml'

--- a/packages/go/openapi/src/responses/forbidden.yaml
+++ b/packages/go/openapi/src/responses/forbidden.yaml
@@ -1,0 +1,31 @@
+# Copyright 2024 Specter Ops, Inc.
+#
+# Licensed under the Apache License, Version 2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  **Forbidden**
+  This is most commonly caused by an authenticated client trying to
+  access a resource that it does not have permission for.
+content:
+  application/json:
+    schema:
+      $ref: './../schemas/api.error-wrapper.yaml'
+    example:
+      http_status: 403
+      timestamp: 2024-02-19T19:27:43.866Z
+      request_id: 3fa85f64-5717-4562-b3fc-2c963f66afa6
+      errors:
+        - context: clients
+          message: You do not have permission to access this resource

--- a/packages/go/openapi/src/responses/internal-server-error.yaml
+++ b/packages/go/openapi/src/responses/internal-server-error.yaml
@@ -1,0 +1,32 @@
+# Copyright 2024 Specter Ops, Inc.
+#
+# Licensed under the Apache License, Version 2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  **Internal Server Error**
+  This is usually the result of either an unexpected database or application error.
+  The client may try modifying or resending the request, but the error is likely not related to the client
+  doing something wrong.
+content:
+  application/json:
+    schema:
+      $ref: './../schemas/api.error-wrapper.yaml'
+    example:
+      http_status: 500
+      timestamp: 2024-02-19T19:27:43.866Z
+      request_id: 3fa85f64-5717-4562-b3fc-2c963f66afa6
+      errors:
+        - context: clients
+          message: The request could not be handled due to an unexpected database error.

--- a/packages/go/openapi/src/responses/no-content.yaml
+++ b/packages/go/openapi/src/responses/no-content.yaml
@@ -1,0 +1,24 @@
+# Copyright 2024 Specter Ops, Inc.
+#
+# Licensed under the Apache License, Version 2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  **No Content**
+  This response will contain no response body.
+content:
+  text/plain:
+    schema:
+      type: string
+    example: '[this request has no response data]'

--- a/packages/go/openapi/src/responses/not-found.yaml
+++ b/packages/go/openapi/src/responses/not-found.yaml
@@ -1,0 +1,31 @@
+# Copyright 2024 Specter Ops, Inc.
+#
+# Licensed under the Apache License, Version 2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  **Not Found**
+  This error typically comes from operations where a valid ID was passed to the request
+  to look up an entity but the entity could not be found.
+content:
+  application/json:
+    schema:
+      $ref: './../schemas/api.error-wrapper.yaml'
+    example:
+      http_status: 404
+      timestamp: 2024-02-19T19:27:43.866Z
+      request_id: 3fa85f64-5717-4562-b3fc-2c963f66afa6
+      errors:
+        - context: clients
+          message: The requested client could not be found.

--- a/packages/go/openapi/src/responses/too-many-requests.yaml
+++ b/packages/go/openapi/src/responses/too-many-requests.yaml
@@ -1,0 +1,31 @@
+# Copyright 2024 Specter Ops, Inc.
+#
+# Licensed under the Apache License, Version 2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  **Too Many Requests**
+  The client has sent too many requests within a certain time window
+  and tripped the rate limiting middleware.
+content:
+  application/json:
+    schema:
+      $ref: './../schemas/api.error-wrapper.yaml'
+    example:
+      http_status: 429
+      timestamp: 2024-02-19T19:27:43.866Z
+      request_id: 3fa85f64-5717-4562-b3fc-2c963f66afa6
+      errors:
+        - context: middleware
+          message: Too many requests. Please try again later.

--- a/packages/go/openapi/src/responses/unauthorized.yaml
+++ b/packages/go/openapi/src/responses/unauthorized.yaml
@@ -1,0 +1,32 @@
+# Copyright 2024 Specter Ops, Inc.
+#
+# Licensed under the Apache License, Version 2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  **Unauthorized**
+  This endpoint failed an authentication requirement. Either the client tried to access
+  a protected endpoint without being authenticated, or an auth validation failed (ex- invalid
+  credentials or expired token).
+content:
+  application/json:
+    schema:
+      $ref: './../schemas/api.error-wrapper.yaml'
+    example:
+      http_status: 401
+      timestamp: 2024-02-19T19:27:43.866Z
+      request_id: 3fa85f64-5717-4562-b3fc-2c963f66afa6
+      errors:
+        - context: login
+          message: Unauthorized

--- a/packages/go/openapi/src/schemas/api.error-detail.yaml
+++ b/packages/go/openapi/src/schemas/api.error-detail.yaml
@@ -1,0 +1,24 @@
+# Copyright 2024 Specter Ops, Inc.
+#
+# Licensed under the Apache License, Version 2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+type: object
+properties:
+  context:
+    type: string
+    description: The context in which the error took place
+  message:
+    type: string
+    description: A human-readable description of the error

--- a/packages/go/openapi/src/schemas/api.error-wrapper.yaml
+++ b/packages/go/openapi/src/schemas/api.error-wrapper.yaml
@@ -1,0 +1,37 @@
+# Copyright 2024 Specter Ops, Inc.
+#
+# Licensed under the Apache License, Version 2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+type: object
+description: ''
+properties:
+  http_status:
+    type: integer
+    description: The HTTP status code
+    minimum: 100
+    maximum: 600
+  timestamp:
+    type: string
+    format: date-time
+    description: The RFC-3339 timestamp in which the error response was sent
+  request_id:
+    type: string
+    format: uuid
+    description: The unique identifier of the request that failed
+  errors:
+    type: array
+    items:
+      "$ref": "./api.error-detail.yaml"
+    description: The error(s) that occurred from processing the request


### PR DESCRIPTION
## Description

This PR adds common responses and supporting schemas to the openapi document source.

## Motivation and Context

Part of an ongoing effort to improve API documentation

## How Has This Been Tested?

Manual testing of openapi generation. Documentation only changes

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
