### PR TITLE
Sanitize cypher errors from neo4j driver

### DIFF
--- a/packages/go/dawgs/drivers/neo4j/cypher_internal_test.go
+++ b/packages/go/dawgs/drivers/neo4j/cypher_internal_test.go
@@ -1,0 +1,19 @@
+package neo4j
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_StripCypher(t *testing.T) {
+	var (
+		query = "match (u1:User {domain: \"DOMAIN1\"}), (u2:User {domain: \"DOMAIN2\"}) where u1.samaccountname <> \"krbtgt\" and u1.samaccountname = u2.samaccountname with u2 match p1 = (u2)-[*1..]->(g:Group) with p1 match p2 = (u2)-[*1..]->(g:Group) return p1, p2"
+	)
+
+	result := stripCypherQuery(query)
+
+	require.Equalf(t, false, strings.Contains(result, "DOMAIN1"), "Cypher query not sanitized. Contains sensitive value: %s", result)
+	require.Equalf(t, false, strings.Contains(result, "DOMAIN2"), "Cypher query not sanitized. Contains sensitive value: %s", result)
+}

--- a/packages/go/dawgs/drivers/neo4j/node.go
+++ b/packages/go/dawgs/drivers/neo4j/node.go
@@ -160,7 +160,8 @@ func (s *NodeQuery) Update(properties *graph.Properties) error {
 	if err := s.queryBuilder.Prepare(); err != nil {
 		return err
 	} else if cypherQuery, err := s.queryBuilder.Render(); err != nil {
-		return graph.NewError(cypherQuery, err)
+		strippedQuery := stripCypherQuery(cypherQuery)
+		return graph.NewError(strippedQuery, err)
 	} else if result := s.run(cypherQuery, s.queryBuilder.Parameters); result.Error() != nil {
 		return result.Error()
 	}

--- a/packages/go/dawgs/drivers/neo4j/relationship.go
+++ b/packages/go/dawgs/drivers/neo4j/relationship.go
@@ -121,7 +121,8 @@ func (s *RelationshipQuery) Update(properties *graph.Properties) error {
 	if err := s.queryBuilder.Prepare(); err != nil {
 		return err
 	} else if cypherQuery, err := s.queryBuilder.Render(); err != nil {
-		return graph.NewError(cypherQuery, err)
+		strippedQuery := stripCypherQuery(cypherQuery)
+		return graph.NewError(strippedQuery, err)
 	} else {
 		return s.run(cypherQuery, s.queryBuilder.Parameters).Error()
 	}

--- a/packages/go/dawgs/drivers/neo4j/result.go
+++ b/packages/go/dawgs/drivers/neo4j/result.go
@@ -57,7 +57,8 @@ func (s *internalResult) Error() error {
 	}
 
 	if s.driverResult != nil && s.driverResult.Err() != nil {
-		return graph.NewError(s.query, s.driverResult.Err())
+		strippedQuery := stripCypherQuery(s.query)
+		return graph.NewError(strippedQuery, s.driverResult.Err())
 	}
 
 	return nil

--- a/packages/go/dawgs/drivers/neo4j/transaction.go
+++ b/packages/go/dawgs/drivers/neo4j/transaction.go
@@ -20,10 +20,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/specterops/bloodhound/dawgs/drivers"
-	"github.com/specterops/bloodhound/log"
 	"sort"
 	"strings"
+
+	"github.com/specterops/bloodhound/dawgs/drivers"
+	"github.com/specterops/bloodhound/log"
 
 	"github.com/specterops/bloodhound/dawgs/query/neo4j"
 	"github.com/specterops/bloodhound/dawgs/util/size"
@@ -226,7 +227,8 @@ func (s *neo4jTransaction) updateNode(updatedNode *graph.Node) error {
 	if err := queryBuilder.Prepare(); err != nil {
 		return err
 	} else if cypherQuery, err := queryBuilder.Render(); err != nil {
-		return graph.NewError(cypherQuery, err)
+		strippedQuery := stripCypherQuery(cypherQuery)
+		return graph.NewError(strippedQuery, err)
 	} else if result := s.Raw(cypherQuery, queryBuilder.Parameters); result.Error() != nil {
 		return result.Error()
 	}
@@ -454,7 +456,8 @@ func (s *neo4jTransaction) UpdateRelationship(relationship *graph.Relationship) 
 	if err := queryBuilder.Prepare(); err != nil {
 		return err
 	} else if cypherQuery, err := queryBuilder.Render(); err != nil {
-		return graph.NewError(cypherQuery, err)
+		strippedQuery := stripCypherQuery(cypherQuery)
+		return graph.NewError(strippedQuery, err)
 	} else {
 		return s.runAndLog(cypherQuery, queryBuilder.Parameters, 1).Error()
 	}

--- a/packages/go/dawgs/util/errors.go
+++ b/packages/go/dawgs/util/errors.go
@@ -1,26 +1,28 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 package util
 
 import (
 	"errors"
-	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"strings"
 	"sync"
+
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
+	"github.com/specterops/bloodhound/dawgs/graph"
 )
 
 type ErrorCollector interface {
@@ -58,9 +60,14 @@ func (s *errorCollector) Combined() error {
 }
 
 func IsNeoTimeoutError(err error) bool {
-	if castError, ok := err.(*neo4j.Neo4jError); !ok {
+	switch e := err.(type) {
+	case *neo4j.Neo4jError:
+		return strings.Contains(e.Code, "TransactionTimedOut")
+	case graph.Error:
+		return strings.Contains(e.Error(), "Neo.ClientError.Transaction.TransactionTimedOut")
+	case *graph.Error:
+		return strings.Contains(e.Error(), "Neo.ClientError.Transaction.TransactionTimedOut")
+	default:
 		return false
-	} else {
-		return strings.Contains(castError.Code, "TransactionTimedOut")
 	}
 }

--- a/packages/go/dawgs/util/errors_test.go
+++ b/packages/go/dawgs/util/errors_test.go
@@ -1,41 +1,53 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 package util_test
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
+	"github.com/specterops/bloodhound/dawgs/graph"
 	"github.com/specterops/bloodhound/dawgs/util"
 	"github.com/stretchr/testify/require"
 )
 
 func TestIsNeoTimeoutError(t *testing.T) {
-	err := neo4j.Neo4jError{
+	neoTimeOutErr := neo4j.Neo4jError{
 		Code: "Neo.ClientError.Transaction.TransactionTimedOut",
 		Msg:  "The transaction has been terminated. Retry your operation in a new transaction, and you should see a successful result. The transaction has not completed within the specified timeout (dbms.transaction.timeout). You may want to retry with a longer timeout.",
 	}
+	require.True(t, util.IsNeoTimeoutError(&neoTimeOutErr))
 
-	require.True(t, util.IsNeoTimeoutError(&err))
-
-	err = neo4j.Neo4jError{
+	notTimeOutErr := neo4j.Neo4jError{
 		Code: "This.Is.A.Test",
 		Msg:  "Blah",
 	}
+	require.False(t, util.IsNeoTimeoutError(&notTimeOutErr))
 
-	require.False(t, util.IsNeoTimeoutError(&err))
+	driverTimeOutErr := graph.Error{
+		Query:       "match (u1:User {domain: \"ESC6.LOCAL\"}), (u2:User {domain: \"ESC3.LOCAL\"}) where u1.samaccountname <> \"krbtgt\" and u1.samaccountname = u2.samaccountname with u2 match p1 = (u2)-[*1..]->(g:Group) with p1 match p2 = (u2)-[*1..]->(g:Group) return p1, p2",
+		DriverError: errors.New("Neo4jError: Neo.ClientError.Transaction.TransactionTimedOut (The transaction has been terminated. Retry your operation in a new transaction, and you should see a successful result. The transaction has not completed within the specified timeout (dbms.transaction.timeout). You may want to retry with a longer timeout. )"),
+	}
+	require.True(t, util.IsNeoTimeoutError(driverTimeOutErr))
+
+	notDriverTimeOutErr := graph.Error{
+		Query:       "match (u1:User {domain: \"ESC6.LOCAL\"}), (u2:User {domain: \"ESC3.LOCAL\"}) where u1.samaccountname <> \"krbtgt\" and u1.samaccountname = u2.samaccountname with u2 match p1 = (u2)-[*1..]->(g:Group) with p1 match p2 = (u2)-[*1..]->(g:Group) return p1, p2",
+		DriverError: errors.New("Some other error"),
+	}
+	require.False(t, util.IsNeoTimeoutError(notDriverTimeOutErr))
 }


### PR DESCRIPTION
## Description

This PR adds sanitization to errors returned from the neo4j driver for `dawgs`. This fixes #278.

I also noticed that the `IsNeoTimeoutError` was incorrectly returning false when the time out came from the neo4j driver from `dawgs`. I updated that function to properly handle that case and additional test cases, as well.

## Motivation and Context

* Prevent leaking potentially sensitive information in logs

## How Has This Been Tested?

* I reduced the timeout for cypher queries to a low value and ran a complex query to verify sensitive values were stripped
* Added additional test cases for `IsNeoTimeoutError`

## Output:

Before:

```
bhe-api-1       | {"level":"info","user_id":"7f63d6b4-c472-43f2-9ed1-5fac1a0fa6e8","remote_addr":"172.30.0.5:56408","proto":"HTTP/1.1","referer":"http://bhe.localhost/ui/mockServiceWorker.js","user_agent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36","request_id":"42f302d7-b728-4643-8496-6fcc8e606a77","request_bytes":0,"response_bytes":228,"status":200,"elapsed":15.167292,"time":"2024-03-26T18:00:48.440332673Z","message":"GET /api/v2/available-domains"}
bhe-api-1       | {"level":"info","query":"match (u1:User {domain: $STRIPPED}), (u2:User {domain: $STRIPPED}) where u1.samaccountname <> $STRIPPED and u1.samaccountname = u2.samaccountname with u2 match p1 = (u2)-[*1..]->(g:Group) with p1 match p2 = (u2)-[*1..]->(g:Group) return p1, p2","time":"2024-03-26T18:00:49.708330924Z","message":"Executing user cypher query"}
bhe-api-1       | {"level":"info","time":"2024-03-26T18:00:49.708374591Z","message":"Cypher query cost is: 25.00. Reduction factor for query is: 5. Available timeout for query is now set to: 0.20 seconds"}
bhe-api-1       | {"level":"warn","time":"2024-03-26T18:00:50.088584382Z","message":"Writing API Error. Status: 500. Message: [{ driver error: Neo4jError: Neo.ClientError.Transaction.TransactionTimedOut (The transaction has been terminated. Retry your operation in a new transaction, and you should see a successful result. The transaction has not completed within the specified timeout (dbms.transaction.timeout). You may want to retry with a longer timeout. ) - query: match (u1:User {domain: \"ESC6.LOCAL\"}), (u2:User {domain: \"ESC3.LOCAL\"}) where u1.samaccountname <> \"krbtgt\" and u1.samaccountname = u2.samaccountname with u2 match p1 = (u2)-[*1..]->(g:Group) with p1 match p2 = (u2)-[*1..]->(g:Group) return p1, p2}]"}
```

After:
```
bhe-api-1       | {"level":"info","user_id":"7f63d6b4-c472-43f2-9ed1-5fac1a0fa6e8","remote_addr":"172.31.0.4:58282","proto":"HTTP/1.1","referer":"http://bhe.localhost/ui/mockServiceWorker.js","user_agent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36","request_id":"bf768d22-5a8e-4c83-b971-bb1902746ab6","request_bytes":0,"response_bytes":228,"status":200,"elapsed":14.926209,"time":"2024-03-26T18:16:18.675574673Z","message":"GET /api/v2/available-domains"}
bhe-api-1       | {"level":"info","query":"match (u1:User {domain: $STRIPPED}), (u2:User {domain: $STRIPPED}) where u1.samaccountname <> $STRIPPED and u1.samaccountname = u2.samaccountname with u2 match p1 = (u2)-[*1..]->(g:Group) with p1 match p2 = (u2)-[*1..]->(g:Group) return p1, p2","time":"2024-03-26T18:16:20.867006383Z","message":"Executing user cypher query"}
bhe-api-1       | {"level":"info","time":"2024-03-26T18:16:20.867053424Z","message":"Cypher query cost is: 25.00. Reduction factor for query is: 5. Available timeout for query is now set to: 0.20 seconds"}
bhe-api-1       | {"level":"warn","time":"2024-03-26T18:16:22.205627425Z","message":"Writing API Error. Status: 500. Message: [{ driver error: Neo4jError: Neo.ClientError.Transaction.TransactionTimedOut (The transaction has been terminated. Retry your operation in a new transaction, and you should see a successful result. The transaction has not completed within the specified timeout (dbms.transaction.timeout). You may want to retry with a longer timeout. ) - query: match (u1:User {domain: $STRIPPED}), (u2:User {domain: $STRIPPED}) where u1.samaccountname <> $STRIPPED and u1.samaccountname = u2.samaccountname with u2 match p1 = (u2)-[*1..]->(g:Group) with p1 match p2 = (u2)-[*1..]->(g:Group) return p1, p2}]"}
bhe-api-1       | {"level":"info","user_id":"7f63d6b4-c472-43f2-9ed1-5fac1a0fa6e8","remote_addr":"172.31.0.4:58282","proto":"HTTP/1.1","referer":"http://bhe.localhost/ui/mockServiceWorker.js","user_agent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36","request_id":"ebd37231-dab6-4043-bd20-4ff77fa293a9","request_bytes":266,"response_bytes":465,"status":500,"elapsed":1374.180417,"time":"2024-03-26T18:16:22.206038092Z","message":"POST /api/v2/graphs/cypher"}
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
