### PR TITLE
fix: mixed up order of cert mapping methods

### DIFF
--- a/packages/go/ein/ad.go
+++ b/packages/go/ein/ad.go
@@ -592,8 +592,8 @@ type CertificateMappingMethod int
 
 const (
 	RegistryValueDoesNotExist                                                 = -1
-	CertificateMappingManytoMany                     CertificateMappingMethod = 1
-	CertificateMappingOneToOne                       CertificateMappingMethod = 1 << 1
+	CertificateMappingOneToOne                       CertificateMappingMethod = 1
+	CertificateMappingManytoMany                     CertificateMappingMethod = 1 << 1
 	CertificateMappingUserPrincipalName              CertificateMappingMethod = 1 << 2
 	CertificateMappingKerberosS4UCertificate         CertificateMappingMethod = 1 << 3
 	CertificateMappingKerberosS4UExplicitCertificate CertificateMappingMethod = 1 << 4
@@ -603,8 +603,8 @@ const (
 const (
 	RegValNotExisting = "Registry value does not exist"
 
-	PrettyCertMappingManyToOne                      = "0x01: Many-to-one (issuer certificate)"
-	PrettyCertMappingOneToOne                       = "0x02: One-to-one (subject/issuer)"
+	PrettyCertMappingOneToOne                       = "0x01: One-to-one (subject/issuer)"
+	PrettyCertMappingManyToOne                      = "0x02: Many-to-one (issuer certificate)"
 	PrettyCertMappingUserPrincipalName              = "0x04: User principal name (UPN/SAN)"
 	PrettyCertMappingKerberosS4UCertificate         = "0x08: Kerberos service-for-user (S4U) certificate"
 	PrettyCertMappingKerberosS4UExplicitCertificate = "0x10: Kerberos service-for-user (S4U) explicit certificate"
@@ -625,11 +625,11 @@ func ParseDCRegistryData(computer Computer) IngestibleNode {
 		if computer.DCRegistryData.CertificateMappingMethods.Value == RegistryValueDoesNotExist {
 			prettyMappings = append(prettyMappings, RegValNotExisting)
 		} else {
-			if computer.DCRegistryData.CertificateMappingMethods.Value&int(CertificateMappingManytoMany) != 0 {
-				prettyMappings = append(prettyMappings, PrettyCertMappingManyToOne)
-			}
 			if computer.DCRegistryData.CertificateMappingMethods.Value&int(CertificateMappingOneToOne) != 0 {
 				prettyMappings = append(prettyMappings, PrettyCertMappingOneToOne)
+			}
+			if computer.DCRegistryData.CertificateMappingMethods.Value&int(CertificateMappingManytoMany) != 0 {
+				prettyMappings = append(prettyMappings, PrettyCertMappingManyToOne)
 			}
 			if computer.DCRegistryData.CertificateMappingMethods.Value&int(CertificateMappingUserPrincipalName) != 0 {
 				prettyMappings = append(prettyMappings, PrettyCertMappingUserPrincipalName)


### PR DESCRIPTION
## Description

Fixed the order of cert mapping methods. Documentation for the values:  https://learn.microsoft.com/en-us/windows-server/security/tls/tls-registry-settings?tabs=diffie-hellman#certificatemappingmethods

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] My changes include a database migration.
