### PR TITLE
fix: rootca chain logic, expand processing to uncollected domains, up…

### DIFF
--- a/cmd/api/src/analysis/ad/adcs_integration_test.go
+++ b/cmd/api/src/analysis/ad/adcs_integration_test.go
@@ -62,7 +62,7 @@ func TestADCSESC1(t *testing.T) {
 
 				if cache.DoesCAChainProperlyToDomain(innerEnterpriseCA, innerDomain) {
 					operation.Operation.SubmitReader(func(ctx context.Context, tx graph.Transaction, outC chan<- analysis.CreatePostRelationshipJob) error {
-						if err := ad2.PostADCSESC1(ctx, tx, outC, groupExpansions, enterpriseCA, innerDomain, cache); err != nil {
+						if err := ad2.PostADCSESC1(ctx, tx, outC, groupExpansions, innerEnterpriseCA, innerDomain, cache); err != nil {
 							t.Logf("failed post processing for %s: %v", ad.ADCSESC1.String(), err)
 						}
 						return nil
@@ -122,7 +122,7 @@ func TestGoldenCert(t *testing.T) {
 
 				if cache.DoesCAChainProperlyToDomain(innerEnterpriseCA, innerDomain) {
 					operation.Operation.SubmitReader(func(ctx context.Context, tx graph.Transaction, outC chan<- analysis.CreatePostRelationshipJob) error {
-						if err := ad2.PostGoldenCert(ctx, tx, outC, innerDomain, enterpriseCA); err != nil {
+						if err := ad2.PostGoldenCert(ctx, tx, outC, innerDomain, innerEnterpriseCA); err != nil {
 							t.Logf("failed post processing for %s: %v", ad.GoldenCert.String(), err)
 						}
 						return nil
@@ -470,7 +470,7 @@ func TestADCSESC3(t *testing.T) {
 				if cache.DoesCAChainProperlyToDomain(innerEnterpriseCA, innerDomain) {
 
 					operation.Operation.SubmitReader(func(ctx context.Context, tx graph.Transaction, outC chan<- analysis.CreatePostRelationshipJob) error {
-						if err := ad2.PostADCSESC3(ctx, tx, outC, groupExpansions, enterpriseCA, innerDomain, cache); err != nil {
+						if err := ad2.PostADCSESC3(ctx, tx, outC, groupExpansions, innerEnterpriseCA, innerDomain, cache); err != nil {
 							t.Logf("failed post processing for %s: %v", ad.ADCSESC3.String(), err)
 						}
 						return nil
@@ -516,7 +516,7 @@ func TestADCSESC3(t *testing.T) {
 				if cache.DoesCAChainProperlyToDomain(innerEnterpriseCA, innerDomain) {
 
 					operation.Operation.SubmitReader(func(ctx context.Context, tx graph.Transaction, outC chan<- analysis.CreatePostRelationshipJob) error {
-						if err := ad2.PostADCSESC3(ctx, tx, outC, groupExpansions, enterpriseCA, innerDomain, cache); err != nil {
+						if err := ad2.PostADCSESC3(ctx, tx, outC, groupExpansions, innerEnterpriseCA, innerDomain, cache); err != nil {
 							t.Logf("failed post processing for %s: %v", ad.ADCSESC3.String(), err)
 						}
 						return nil
@@ -574,7 +574,7 @@ func TestADCSESC3(t *testing.T) {
 				if cache.DoesCAChainProperlyToDomain(innerEnterpriseCA, innerDomain) {
 
 					operation.Operation.SubmitReader(func(ctx context.Context, tx graph.Transaction, outC chan<- analysis.CreatePostRelationshipJob) error {
-						if err := ad2.PostADCSESC3(ctx, tx, outC, groupExpansions, enterpriseCA, innerDomain, cache); err != nil {
+						if err := ad2.PostADCSESC3(ctx, tx, outC, groupExpansions, innerEnterpriseCA, innerDomain, cache); err != nil {
 							t.Logf("failed post processing for %s: %v", ad.ADCSESC3.String(), err)
 						}
 						return nil
@@ -632,7 +632,7 @@ func TestADCSESC4(t *testing.T) {
 				if cache.DoesCAChainProperlyToDomain(innerEnterpriseCA, innerDomain) {
 
 					operation.Operation.SubmitReader(func(ctx context.Context, tx graph.Transaction, outC chan<- analysis.CreatePostRelationshipJob) error {
-						if err := ad2.PostADCSESC4(ctx, tx, outC, groupExpansions, enterpriseCA, innerDomain, cache); err != nil {
+						if err := ad2.PostADCSESC4(ctx, tx, outC, groupExpansions, innerEnterpriseCA, innerDomain, cache); err != nil {
 							t.Logf("failed post processing for %s: %v", ad.ADCSESC4.String(), err)
 						}
 						return nil
@@ -693,7 +693,7 @@ func TestADCSESC4(t *testing.T) {
 				if cache.DoesCAChainProperlyToDomain(innerEnterpriseCA, innerDomain) {
 
 					operation.Operation.SubmitReader(func(ctx context.Context, tx graph.Transaction, outC chan<- analysis.CreatePostRelationshipJob) error {
-						if err := ad2.PostADCSESC4(ctx, tx, outC, groupExpansions, enterpriseCA, innerDomain, cache); err != nil {
+						if err := ad2.PostADCSESC4(ctx, tx, outC, groupExpansions, innerEnterpriseCA, innerDomain, cache); err != nil {
 							t.Logf("failed post processing for %s: %v", ad.ADCSESC4.String(), err)
 						}
 						return nil
@@ -759,7 +759,7 @@ func TestADCSESC4(t *testing.T) {
 				if cache.DoesCAChainProperlyToDomain(innerEnterpriseCA, innerDomain) {
 
 					operation.Operation.SubmitReader(func(ctx context.Context, tx graph.Transaction, outC chan<- analysis.CreatePostRelationshipJob) error {
-						if err := ad2.PostADCSESC4(ctx, tx, outC, groupExpansions, enterpriseCA, innerDomain, cache); err != nil {
+						if err := ad2.PostADCSESC4(ctx, tx, outC, groupExpansions, innerEnterpriseCA, innerDomain, cache); err != nil {
 							t.Logf("failed post processing for %s: %v", ad.ADCSESC4.String(), err)
 						}
 						return nil
@@ -806,7 +806,7 @@ func TestADCSESC4(t *testing.T) {
 				if cache.DoesCAChainProperlyToDomain(innerEnterpriseCA, innerDomain) {
 
 					operation.Operation.SubmitReader(func(ctx context.Context, tx graph.Transaction, outC chan<- analysis.CreatePostRelationshipJob) error {
-						if err := ad2.PostADCSESC4(ctx, tx, outC, groupExpansions, enterpriseCA, innerDomain, cache); err != nil {
+						if err := ad2.PostADCSESC4(ctx, tx, outC, groupExpansions, innerEnterpriseCA, innerDomain, cache); err != nil {
 							t.Logf("failed post processing for %s: %v", ad.ADCSESC4.String(), err)
 						}
 						return nil
@@ -860,7 +860,7 @@ func TestADCSESC4Composition(t *testing.T) {
 				if cache.DoesCAChainProperlyToDomain(innerEnterpriseCA, innerDomain) {
 
 					operation.Operation.SubmitReader(func(ctx context.Context, tx graph.Transaction, outC chan<- analysis.CreatePostRelationshipJob) error {
-						if err := ad2.PostADCSESC4(ctx, tx, outC, groupExpansions, enterpriseCA, innerDomain, cache); err != nil {
+						if err := ad2.PostADCSESC4(ctx, tx, outC, groupExpansions, innerEnterpriseCA, innerDomain, cache); err != nil {
 							t.Logf("failed post processing for %s: %v", ad.ADCSESC4.String(), err)
 						}
 						return nil
@@ -1084,7 +1084,7 @@ func TestADCSESC9a(t *testing.T) {
 				if cache.DoesCAChainProperlyToDomain(innerEnterpriseCA, innerDomain) {
 
 					operation.Operation.SubmitReader(func(ctx context.Context, tx graph.Transaction, outC chan<- analysis.CreatePostRelationshipJob) error {
-						if err := ad2.PostADCSESC9a(ctx, tx, outC, groupExpansions, enterpriseCA, innerDomain, cache); err != nil {
+						if err := ad2.PostADCSESC9a(ctx, tx, outC, groupExpansions, innerEnterpriseCA, innerDomain, cache); err != nil {
 							t.Logf("failed post processing for %s: %v", ad.ADCSESC9a.String(), err)
 						}
 						return nil
@@ -1132,7 +1132,7 @@ func TestADCSESC9a(t *testing.T) {
 				if cache.DoesCAChainProperlyToDomain(innerEnterpriseCA, innerDomain) {
 
 					operation.Operation.SubmitReader(func(ctx context.Context, tx graph.Transaction, outC chan<- analysis.CreatePostRelationshipJob) error {
-						if err := ad2.PostADCSESC9a(ctx, tx, outC, groupExpansions, enterpriseCA, innerDomain, cache); err != nil {
+						if err := ad2.PostADCSESC9a(ctx, tx, outC, groupExpansions, innerEnterpriseCA, innerDomain, cache); err != nil {
 							t.Logf("failed post processing for %s: %v", ad.ADCSESC9a.String(), err)
 						}
 						return nil
@@ -1177,7 +1177,7 @@ func TestADCSESC9a(t *testing.T) {
 				if cache.DoesCAChainProperlyToDomain(innerEnterpriseCA, innerDomain) {
 
 					operation.Operation.SubmitReader(func(ctx context.Context, tx graph.Transaction, outC chan<- analysis.CreatePostRelationshipJob) error {
-						if err := ad2.PostADCSESC9a(ctx, tx, outC, groupExpansions, enterpriseCA, innerDomain, cache); err != nil {
+						if err := ad2.PostADCSESC9a(ctx, tx, outC, groupExpansions, innerEnterpriseCA, innerDomain, cache); err != nil {
 							t.Logf("failed post processing for %s: %v", ad.ADCSESC9a.String(), err)
 						}
 						return nil
@@ -1223,7 +1223,7 @@ func TestADCSESC9a(t *testing.T) {
 				if cache.DoesCAChainProperlyToDomain(innerEnterpriseCA, innerDomain) {
 
 					operation.Operation.SubmitReader(func(ctx context.Context, tx graph.Transaction, outC chan<- analysis.CreatePostRelationshipJob) error {
-						if err := ad2.PostADCSESC9a(ctx, tx, outC, groupExpansions, enterpriseCA, innerDomain, cache); err != nil {
+						if err := ad2.PostADCSESC9a(ctx, tx, outC, groupExpansions, innerEnterpriseCA, innerDomain, cache); err != nil {
 							t.Logf("failed post processing for %s: %v", ad.ADCSESC9a.String(), err)
 						}
 						return nil
@@ -1269,7 +1269,7 @@ func TestADCSESC9a(t *testing.T) {
 				if cache.DoesCAChainProperlyToDomain(innerEnterpriseCA, innerDomain) {
 
 					operation.Operation.SubmitReader(func(ctx context.Context, tx graph.Transaction, outC chan<- analysis.CreatePostRelationshipJob) error {
-						if err := ad2.PostADCSESC9a(ctx, tx, outC, groupExpansions, enterpriseCA, innerDomain, cache); err != nil {
+						if err := ad2.PostADCSESC9a(ctx, tx, outC, groupExpansions, innerEnterpriseCA, innerDomain, cache); err != nil {
 							t.Logf("failed post processing for %s: %v", ad.ADCSESC9a.String(), err)
 						}
 						return nil
@@ -1313,7 +1313,7 @@ func TestADCSESC9a(t *testing.T) {
 				if cache.DoesCAChainProperlyToDomain(innerEnterpriseCA, innerDomain) {
 
 					operation.Operation.SubmitReader(func(ctx context.Context, tx graph.Transaction, outC chan<- analysis.CreatePostRelationshipJob) error {
-						if err := ad2.PostADCSESC9a(ctx, tx, outC, groupExpansions, enterpriseCA, innerDomain, cache); err != nil {
+						if err := ad2.PostADCSESC9a(ctx, tx, outC, groupExpansions, innerEnterpriseCA, innerDomain, cache); err != nil {
 							t.Logf("failed post processing for %s: %v", ad.ADCSESC9a.String(), err)
 						}
 						return nil
@@ -1388,7 +1388,7 @@ func TestADCSESC9b(t *testing.T) {
 				if cache.DoesCAChainProperlyToDomain(innerEnterpriseCA, innerDomain) {
 
 					operation.Operation.SubmitReader(func(ctx context.Context, tx graph.Transaction, outC chan<- analysis.CreatePostRelationshipJob) error {
-						if err := ad2.PostADCSESC9b(ctx, tx, outC, groupExpansions, enterpriseCA, innerDomain, cache); err != nil {
+						if err := ad2.PostADCSESC9b(ctx, tx, outC, groupExpansions, innerEnterpriseCA, innerDomain, cache); err != nil {
 							t.Logf("failed post processing for %s: %v", ad.ADCSESC9b.String(), err)
 						}
 						return nil
@@ -1436,7 +1436,7 @@ func TestADCSESC9b(t *testing.T) {
 				if cache.DoesCAChainProperlyToDomain(innerEnterpriseCA, innerDomain) {
 
 					operation.Operation.SubmitReader(func(ctx context.Context, tx graph.Transaction, outC chan<- analysis.CreatePostRelationshipJob) error {
-						if err := ad2.PostADCSESC9b(ctx, tx, outC, groupExpansions, enterpriseCA, innerDomain, cache); err != nil {
+						if err := ad2.PostADCSESC9b(ctx, tx, outC, groupExpansions, innerEnterpriseCA, innerDomain, cache); err != nil {
 							t.Logf("failed post processing for %s: %v", ad.ADCSESC9b.String(), err)
 						}
 						return nil
@@ -1480,7 +1480,7 @@ func TestADCSESC9b(t *testing.T) {
 				if cache.DoesCAChainProperlyToDomain(innerEnterpriseCA, innerDomain) {
 
 					operation.Operation.SubmitReader(func(ctx context.Context, tx graph.Transaction, outC chan<- analysis.CreatePostRelationshipJob) error {
-						if err := ad2.PostADCSESC9b(ctx, tx, outC, groupExpansions, enterpriseCA, innerDomain, cache); err != nil {
+						if err := ad2.PostADCSESC9b(ctx, tx, outC, groupExpansions, innerEnterpriseCA, innerDomain, cache); err != nil {
 							t.Logf("failed post processing for %s: %v", ad.ADCSESC9b.String(), err)
 						}
 						return nil
@@ -1524,7 +1524,7 @@ func TestADCSESC9b(t *testing.T) {
 				if cache.DoesCAChainProperlyToDomain(innerEnterpriseCA, innerDomain) {
 
 					operation.Operation.SubmitReader(func(ctx context.Context, tx graph.Transaction, outC chan<- analysis.CreatePostRelationshipJob) error {
-						if err := ad2.PostADCSESC9b(ctx, tx, outC, groupExpansions, enterpriseCA, innerDomain, cache); err != nil {
+						if err := ad2.PostADCSESC9b(ctx, tx, outC, groupExpansions, innerEnterpriseCA, innerDomain, cache); err != nil {
 							t.Logf("failed post processing for %s: %v", ad.ADCSESC9b.String(), err)
 						}
 						return nil
@@ -1568,7 +1568,7 @@ func TestADCSESC9b(t *testing.T) {
 				if cache.DoesCAChainProperlyToDomain(innerEnterpriseCA, innerDomain) {
 
 					operation.Operation.SubmitReader(func(ctx context.Context, tx graph.Transaction, outC chan<- analysis.CreatePostRelationshipJob) error {
-						if err := ad2.PostADCSESC9b(ctx, tx, outC, groupExpansions, enterpriseCA, innerDomain, cache); err != nil {
+						if err := ad2.PostADCSESC9b(ctx, tx, outC, groupExpansions, innerEnterpriseCA, innerDomain, cache); err != nil {
 							t.Logf("failed post processing for %s: %v", ad.ADCSESC9b.String(), err)
 						}
 						return nil

--- a/cmd/api/src/analysis/ad/adcs_integration_test.go
+++ b/cmd/api/src/analysis/ad/adcs_integration_test.go
@@ -79,7 +79,7 @@ func TestADCSESC1(t *testing.T) {
 			})); err != nil {
 				t.Fatalf("error fetching esc1 edges in integration test; %v", err)
 			} else {
-				assert.Equal(t, 7, len(results))
+				assert.Equal(t, 8, len(results))
 
 				//Domain 1 ESC1 edges created
 				require.True(t, results.Contains(harness.ADCSESC1Harness.User13))
@@ -95,6 +95,9 @@ func TestADCSESC1(t *testing.T) {
 				//Domain 4 ESC1 edges created
 				require.True(t, results.Contains(harness.ADCSESC1Harness.Group42))
 				require.True(t, results.Contains(harness.ADCSESC1Harness.Group43))
+
+				//Group47 has Enroll on EnterpriseCA1 that has a valid chain to Domain1, a domain that is marked as not collected
+				require.True(t, results.Contains(harness.ADCSESC1Harness.Group47))
 
 			}
 			return nil

--- a/cmd/api/src/test/integration/harnesses.go
+++ b/cmd/api/src/test/integration/harnesses.go
@@ -1163,6 +1163,7 @@ type ADCSESC1Harness struct {
 	Group44        *graph.Node
 	Group45        *graph.Node
 	Group46        *graph.Node
+	Group47        *graph.Node
 	EnterpriseCA4  *graph.Node
 	CertTemplate41 *graph.Node
 	CertTemplate42 *graph.Node
@@ -1175,7 +1176,7 @@ type ADCSESC1Harness struct {
 func (s *ADCSESC1Harness) Setup(graphTestContext *GraphTestContext) {
 	emptyEkus := make([]string, 0)
 	sid := RandomDomainSID()
-	s.Domain1 = graphTestContext.NewActiveDirectoryDomain("domain 1", sid, false, true)
+	s.Domain1 = graphTestContext.NewActiveDirectoryDomain("domain 1", sid, false, false)
 	s.AuthStore1 = graphTestContext.NewActiveDirectoryNTAuthStore("ntauthstore 1", sid)
 	s.EnterpriseCA1 = graphTestContext.NewActiveDirectoryEnterpriseCA("eca 1", sid)
 	s.RootCA1 = graphTestContext.NewActiveDirectoryRootCA("rca 1", sid)
@@ -1295,6 +1296,7 @@ func (s *ADCSESC1Harness) Setup(graphTestContext *GraphTestContext) {
 	s.Group44 = graphTestContext.NewActiveDirectoryGroup("group4-4", sid)
 	s.Group45 = graphTestContext.NewActiveDirectoryGroup("group4-5", sid)
 	s.Group46 = graphTestContext.NewActiveDirectoryGroup("group4-6", sid)
+	s.Group47 = graphTestContext.NewActiveDirectoryGroup("group4-7", sid)
 	s.CertTemplate41 = graphTestContext.NewActiveDirectoryCertTemplate("certtemplate 4-1", sid, CertTemplateData{
 		RequiresManagerApproval: false,
 		AuthenticationEnabled:   true,
@@ -1384,6 +1386,10 @@ func (s *ADCSESC1Harness) Setup(graphTestContext *GraphTestContext) {
 	graphTestContext.NewRelationship(s.Group45, s.CertTemplate45, ad.Enroll)
 	graphTestContext.NewRelationship(s.Group46, s.EnterpriseCA4, ad.Enroll)
 	graphTestContext.NewRelationship(s.Group46, s.CertTemplate46, ad.Enroll)
+
+	graphTestContext.NewRelationship(s.Group47, s.EnterpriseCA1, ad.Enroll)
+	graphTestContext.NewRelationship(s.Group47, s.CertTemplate1, ad.Enroll)
+
 	graphTestContext.NewRelationship(s.CertTemplate41, s.EnterpriseCA4, ad.PublishedTo)
 	graphTestContext.NewRelationship(s.CertTemplate42, s.EnterpriseCA4, ad.PublishedTo)
 	graphTestContext.NewRelationship(s.CertTemplate43, s.EnterpriseCA4, ad.PublishedTo)

--- a/packages/go/analysis/ad/adcs.go
+++ b/packages/go/analysis/ad/adcs.go
@@ -54,7 +54,7 @@ func PostADCS(ctx context.Context, db graph.Database, groupExpansions impact.Pat
 		operation.Stats.Merge(step2Stats)
 
 		var cache = NewADCSCache()
-		cache.BuildCache(ctx, db, enterpriseCertAuthorities, certTemplates)
+		cache.BuildCache(ctx, db, enterpriseCertAuthorities, certTemplates, domains)
 
 		for _, domain := range domains {
 			innerDomain := domain

--- a/packages/go/analysis/ad/queries.go
+++ b/packages/go/analysis/ad/queries.go
@@ -1509,15 +1509,14 @@ func FetchEnterpriseCAsTrustedForNTAuthToDomain(tx graph.Transaction, domain *gr
 }
 
 func FetchEnterpriseCAsRootCAForPathToDomain(tx graph.Transaction, domain *graph.Node) (graph.NodeSet, error) {
-	return ops.AcyclicTraverseTerminals(tx, ops.TraversalPlan{
+	return ops.AcyclicTraverseNodes(tx, ops.TraversalPlan{
 		Root:      domain,
 		Direction: graph.DirectionInbound,
 		BranchQuery: func() graph.Criteria {
 			return query.KindIn(query.Relationship(), ad.IssuedSignedBy, ad.EnterpriseCAFor, ad.RootCAFor)
 		},
-		PathFilter: func(ctx *ops.TraversalContext, segment *graph.PathSegment) bool {
-			return segment.Node.Kinds.ContainsOneOf(ad.EnterpriseCA)
-		},
+	}, func(node *graph.Node) bool {
+		return node.Kinds.ContainsOneOf(ad.EnterpriseCA)
 	})
 }
 


### PR DESCRIPTION
…date tests to match post processing logic

## Description
Updates were made to the traversal logic that fetches enterprise ca's with a `RootCAFor` chain to a domain. The adcs cache building function now takes a domain nodeset as a parameter.
<!--- Describe your changes in detail -->

## Motivation and Context
Valid ESC-1 edges were not being created when domains that do not have a `collected` property set to `true` were part of the data set. Additionally, the rootca chain logic was filtering early and not collecting all of the enterprise ca's that chained up to a domain.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
A dataset with the scenario presenting the issue was uploaded and verified to now have the expected ESC-1 edge created during post processing. An integration test was added that covers this scenario.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![image](https://github.com/SpecterOps/BloodHound/assets/16910931/16331eea-1b09-4db4-9b3c-8935b3ad6756)

![Screenshot 2024-04-04 at 13-44-10 BloodHound](https://github.com/SpecterOps/BloodHound/assets/16910931/40209e70-ac80-4cf6-b252-ebc30d962e5b)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [x] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
