### PR TITLE
handle nil pointer for saml user session validation

### DIFF
--- a/cmd/api/src/api/middleware/auth.go
+++ b/cmd/api/src/api/middleware/auth.go
@@ -67,7 +67,7 @@ func AuthMiddleware(authenticator api.Authenticator) mux.MiddlewareFunc {
 				switch authScheme {
 				case api.AuthorizationSchemeBearer:
 					if userAuth, err := authenticator.ValidateSession(request.Context(), schemeParameter); err != nil {
-						api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusUnauthorized, err.Error(), request), response)
+						api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusUnauthorized, api.ErrorResponseDetailsAuthenticationInvalid, request), response)
 						return
 					} else {
 						bhCtx := ctx.Get(request.Context())


### PR DESCRIPTION
## Description

When a `User` is updated to be SAML, its `AuthSecret` is set to nil. Thereafter in `ValidateSessions`, we call a method on the nil `AuthSecret` leading to a panic in the logs. This MR adds logic to handle that case gracefully.

I also updated the Auth Middleware to return the actual error upon `ValidateSession` failure, as we were just discarding this information and returning a blanket failure statement before.

## How Has This Been Tested?
Manual testing

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
