### PR TITLE
fix: update kinds slice in graphstats for effectively saving kind stat counts

### DIFF
--- a/cmd/api/src/analysis/azure/queries.go
+++ b/cmd/api/src/analysis/azure/queries.go
@@ -38,8 +38,7 @@ func GraphStats(ctx context.Context, db graph.Database) (model.AzureDataQualityS
 		stats       = model.AzureDataQualityStats{}
 		runID       string
 
-		kinds = graph.Kinds{azure.User, azure.Group, azure.App, azure.ServicePrincipal, azure.Device,
-			azure.ManagementGroup, azure.Subscription, azure.ResourceGroup, azure.VM, azure.KeyVault}
+		kinds = azure.NodeKinds()
 	)
 
 	if newUUID, err := uuid.NewV4(); err != nil {
@@ -154,6 +153,8 @@ func GraphStats(ctx context.Context, db graph.Database) (model.AzureDataQualityS
 								case azure.WebApp:
 									stat.WebApps = int(count)
 									aggregation.WebApps += int(count)
+								case azure.Tenant:
+									// Do nothing. Only AzureDataQualityAggregation stats have tenant stats and the tenants stats are handled in the outer tenant loop
 								}
 								mutex.Unlock()
 								return nil


### PR DESCRIPTION
## Description
The kinds slice is updated in the graph stats method.
<!--- Describe your changes in detail -->

## Motivation and Context
The missing azure stat kinds were not updated in the kinds slice which meant that the counts were not being accumulated so were being saved as zero counts. This changeset updates these kinds to be based on the list that is output from the azure cue schema.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Ran a local collection and verified the stat counts against the graph db. 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

![image](https://github.com/SpecterOps/BloodHound/assets/16910931/535d8899-9cc6-42a3-9ad3-c3db5006359c)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
