### PR TITLE
Don't filter T0 assets from DCSync edges

### DIFF
--- a/packages/go/analysis/ad/esc3.go
+++ b/packages/go/analysis/ad/esc3.go
@@ -504,7 +504,7 @@ func GetADCSESC3EdgeComposition(ctx context.Context, db graph.Database, edge *gr
 						log.Errorf("Error getting hasenrollmentagentrestrictions for ca %d: %v", eca2.ID, err)
 					} else if hasRestrictions {
 						if p6, err := getDelegatedEnrollmentAgentPath(ctx, startNode, ct2, db); err != nil {
-							log.Infof("Error getting p6 for composition: %v", err)
+							log.Warnf("Error getting p6 for composition: %v", err)
 						} else if p6.Len() > 0 {
 							for _, p4 := range enterpriseCASegments[eca1.ID] {
 								paths.AddPath(p4.Path())

--- a/packages/go/analysis/ad/post.go
+++ b/packages/go/analysis/ad/post.go
@@ -111,7 +111,7 @@ func PostDCSync(ctx context.Context, db graph.Database) (*analysis.AtomicPostPro
 		for _, domain := range domainNodes {
 			innerDomain := domain
 			operation.Operation.SubmitReader(func(ctx context.Context, tx graph.Transaction, outC chan<- analysis.CreatePostRelationshipJob) error {
-				if dcSyncers, err := analysis.GetDCSyncers(tx, innerDomain, true); err != nil {
+				if dcSyncers, err := analysis.GetDCSyncers(tx, innerDomain); err != nil {
 					return err
 				} else if len(dcSyncers) == 0 {
 					return nil

--- a/packages/go/analysis/analysis.go
+++ b/packages/go/analysis/analysis.go
@@ -204,8 +204,8 @@ func ExpandGroupMembership(tx graph.Transaction, candidates graph.NodeSet) (grap
 
 func GetLAPSSyncers(tx graph.Transaction, domain *graph.Node) ([]*graph.Node, error) {
 	var (
-		getChangesQuery         = fromEntityToEntityWithRelationshipKind(tx, domain, ad.GetChanges, false)
-		getChangesFilteredQuery = fromEntityToEntityWithRelationshipKind(tx, domain, ad.GetChangesInFilteredSet, false)
+		getChangesQuery         = fromEntityToEntityWithRelationshipKind(tx, domain, ad.GetChanges)
+		getChangesFilteredQuery = fromEntityToEntityWithRelationshipKind(tx, domain, ad.GetChangesInFilteredSet)
 	)
 
 	if getChangesNodes, err := ops.FetchStartNodes(getChangesQuery); err != nil {
@@ -241,8 +241,8 @@ func GetLAPSSyncers(tx graph.Transaction, domain *graph.Node) ([]*graph.Node, er
 
 func GetDCSyncers(tx graph.Transaction, domain *graph.Node) ([]*graph.Node, error) {
 	var (
-		getChangesQuery    = fromEntityToEntityWithRelationshipKind(tx, domain, ad.GetChanges, false)
-		getChangesAllQuery = fromEntityToEntityWithRelationshipKind(tx, domain, ad.GetChangesAll, false)
+		getChangesQuery    = fromEntityToEntityWithRelationshipKind(tx, domain, ad.GetChanges)
+		getChangesAllQuery = fromEntityToEntityWithRelationshipKind(tx, domain, ad.GetChangesAll)
 	)
 
 	if getChangesNodes, err := ops.FetchStartNodes(getChangesQuery); err != nil {
@@ -276,18 +276,12 @@ func GetDCSyncers(tx graph.Transaction, domain *graph.Node) ([]*graph.Node, erro
 	}
 }
 
-func fromEntityToEntityWithRelationshipKind(tx graph.Transaction, target *graph.Node, relKind graph.Kind, filterTierZero bool) graph.RelationshipQuery {
+func fromEntityToEntityWithRelationshipKind(tx graph.Transaction, target *graph.Node, relKind graph.Kind) graph.RelationshipQuery {
 	return tx.Relationships().Filterf(func() graph.Criteria {
 		filters := []graph.Criteria{
 			query.Kind(query.Start(), ad.Entity),
 			query.Kind(query.Relationship(), relKind),
 			query.Equals(query.EndID(), target.ID),
-		}
-
-		if filterTierZero {
-			filters = append(filters, query.Not(
-				query.StringContains(query.StartProperty(common.SystemTags.String()), ad.AdminTierZero),
-			))
 		}
 
 		return query.And(filters...)


### PR DESCRIPTION
## Description

This PR prevents T0 assets from being incorrectly excluded from creating `DCSync` edges. The filtering was unintended and has been removed.

I also fixed an unrelated log message that I noticed had the incorrect log level. This should help prevent it from getting lost when parsing logs.

## Motivation and Context

* Ensure `DCSync` edges are present for T0 assets

## How Has This Been Tested?

* Updated the associated test for the new logic and ensured it was passing

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
