### PR TITLE
fix: rm tmp if it exists

### DIFF
--- a/justfile
+++ b/justfile
@@ -47,7 +47,7 @@ build *FLAGS:
 
 # prepare for code review (requires jq)
 prepare-for-codereview:
-  @rm -r tmp
+  @(test -e tmp && rm -r tmp) || echo "skip rm tmp"
   @mkdir -p tmp
   -@just _prep-steps
   @ echo "For more details, see output files in {{absolute_path('./tmp')}}"

--- a/packages/go/stbernard/command/show/show.go
+++ b/packages/go/stbernard/command/show/show.go
@@ -95,8 +95,8 @@ func (s *command) Run() error {
 			fmt.Printf("Current HEAD: %s\n", repo.sha)
 			fmt.Printf("Detected version: %s\n", repo.version)
 			if !repo.clean {
-				fmt.Println("CHANGES DETECTED")
-				return fmt.Errorf("changes detected in git repository")
+				fmt.Println("CHANGES DETECTED - please commit outstanding changes and run the command again")
+				return fmt.Errorf("changes detected in git repository - please commit outstanding changes and run the command again")
 			} else {
 				fmt.Printf("Repository Clean\n\n")
 			}


### PR DESCRIPTION
## Description
Conditionally remove tmp file when running `prepare-for-codreview`

## Motivation and Context
The first time running `just prepare-for-codereview` errors because we try to remove the tmp file. This change just checks if that dir exists before removing it.

## How Has This Been Tested?
Manual tests

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
