### PR TITLE
BED-3852 - Pathfinding search when primary and destination node selected

### DIFF
--- a/cmd/ui/src/views/Explore/ExploreSearch/PathfindingSearch.test.tsx
+++ b/cmd/ui/src/views/Explore/ExploreSearch/PathfindingSearch.test.tsx
@@ -26,13 +26,18 @@ describe('Pathfinding: interaction', () => {
     const comboboxLookaheadOptions = {
         data: [
             {
-                name: 'admin',
+                name: 'admin1',
                 objectid: '1',
                 type: 'User',
             },
             {
-                name: 'computer',
+                name: 'admin2',
                 objectid: '2',
+                type: 'User',
+            },
+            {
+                name: 'computer',
+                objectid: '3',
                 type: 'Computer',
             },
         ],
@@ -61,14 +66,14 @@ describe('Pathfinding: interaction', () => {
         expect(swapButton).toBeDisabled();
 
         const startInput = screen.getByPlaceholderText(/start node/i);
-        await user.type(startInput, 'admin');
-        await user.click(await screen.findByRole('option', { name: /admin/i }));
+        await user.type(startInput, 'admin1');
+        await user.click(await screen.findByRole('option', { name: /admin1/i }));
 
         expect(swapButton).toBeDisabled();
 
         const destinationInput = screen.getByPlaceholderText(/destination node/i);
-        await user.type(destinationInput, 'admin');
-        await user.click(await screen.findByRole('option', { name: /admin/i }));
+        await user.type(destinationInput, 'admin1');
+        await user.click(await screen.findByRole('option', { name: /admin1/i }));
 
         expect(swapButton).toBeEnabled();
     });
@@ -80,20 +85,20 @@ describe('Pathfinding: interaction', () => {
         expect(swapButton).toBeDisabled();
 
         const startInput = screen.getByPlaceholderText(/start node/i);
-        await user.type(startInput, 'admin');
-        await user.click(await screen.findByRole('option', { name: /admin/i }));
+        await user.type(startInput, 'admin1');
+        await user.click(await screen.findByRole('option', { name: /admin1/i }));
 
         const destinationInput = screen.getByPlaceholderText(/destination node/i);
         await user.type(destinationInput, 'computer');
         await user.click(await screen.findByRole('option', { name: /computer/i }));
 
-        expect(startInput).toHaveValue('admin');
+        expect(startInput).toHaveValue('admin1');
         expect(destinationInput).toHaveValue('computer');
 
         await user.click(swapButton);
 
         expect(startInput).toHaveValue('computer');
-        expect(destinationInput).toHaveValue('admin');
+        expect(destinationInput).toHaveValue('admin1');
     });
 
     it('executes a primary search when only a source node is provided', async () => {
@@ -101,11 +106,11 @@ describe('Pathfinding: interaction', () => {
         const spy = vi.spyOn(actions, 'sourceNodeSelected');
 
         const startInput = screen.getByPlaceholderText(/start node/i);
-        await user.type(startInput, 'admin');
-        await user.click(await screen.findByRole('option', { name: /admin/i }));
+        await user.type(startInput, 'admin1');
+        await user.click(await screen.findByRole('option', { name: /admin1/i }));
 
         expect(spy).toHaveBeenCalledTimes(1);
-        expect(spy).toHaveBeenCalledWith(comboboxLookaheadOptions.data[0]);
+        expect(spy).toHaveBeenCalledWith(comboboxLookaheadOptions.data[0], false);
     });
 
     it('executes a pathfinding search when both a source and destination node are provided', async () => {
@@ -114,17 +119,26 @@ describe('Pathfinding: interaction', () => {
         const destinationNodeSelectedSpy = vi.spyOn(actions, 'destinationNodeSelected');
 
         const startInput = screen.getByPlaceholderText(/start node/i);
-        await user.type(startInput, 'admin');
-        await user.click(await screen.findByRole('option', { name: /admin/i }));
+        await user.type(startInput, 'admin1');
+        await user.click(await screen.findByRole('option', { name: /admin1/i }));
 
+        // doPathfindSearch is false because a destination is not yet selected
         expect(sourceNodeSelectedSpy).toHaveBeenCalledTimes(1);
-        expect(sourceNodeSelectedSpy).toHaveBeenCalledWith(comboboxLookaheadOptions.data[0]);
+        expect(sourceNodeSelectedSpy).toHaveBeenCalledWith(comboboxLookaheadOptions.data[0], false);
 
         const destinationInput = screen.getByPlaceholderText(/destination node/i);
         await user.type(destinationInput, 'computer');
         await user.click(await screen.findByRole('option', { name: /computer/i }));
 
         expect(destinationNodeSelectedSpy).toHaveBeenCalledTimes(1);
-        expect(destinationNodeSelectedSpy).toHaveBeenCalledWith(comboboxLookaheadOptions.data[1]);
+        expect(destinationNodeSelectedSpy).toHaveBeenCalledWith(comboboxLookaheadOptions.data[2]);
+
+        await user.clear(startInput);
+        await user.type(startInput, 'admin2');
+        await user.click(await screen.findByRole('option', { name: /admin2/i }));
+
+        // doPathfindingSearch is true because destination has been selected
+        expect(sourceNodeSelectedSpy).toHaveBeenCalledTimes(2);
+        expect(sourceNodeSelectedSpy).toHaveBeenCalledWith(comboboxLookaheadOptions.data[1], true);
     });
 });

--- a/cmd/ui/src/views/Explore/ExploreSearch/PathfindingSearch.tsx
+++ b/cmd/ui/src/views/Explore/ExploreSearch/PathfindingSearch.tsx
@@ -45,8 +45,10 @@ const PathfindingSearch = () => {
     const handleDestinationNodeEdited = (edit: string): DestinationNodeEditedAction =>
         dispatch(searchbarActions.destinationNodeEdited(edit));
 
-    const handleSourceNodeSelected = (selected: SearchValue): SourceNodeSelectedAction =>
-        dispatch(searchbarActions.sourceNodeSelected(selected));
+    const handleSourceNodeSelected = (selected: SearchValue): SourceNodeSelectedAction => {
+        const doPathfindSearch = !!destinationSelectedItem;
+        return dispatch(searchbarActions.sourceNodeSelected(selected, doPathfindSearch));
+    };
 
     const handleDestinationNodeSelected = (selected: SearchValue): DestinationNodeSelectedAction =>
         dispatch(searchbarActions.destinationNodeSelected(selected));


### PR DESCRIPTION
## Description
Fixes bug where editing the primary search field from the pathfinding search tab would actually do a single node search regardless of the destination search value. This fixes it so pathfinding tab always does a pathfinding search when editing that field.

## Motivation and Context


## How Has This Been Tested?
manual tests and updated unit tests

## Screenshots (if appropriate):
### Bug:
https://github.com/SpecterOps/BloodHound/assets/66393111/aea15ea6-b05e-45d6-b377-972b67033ebe

### Fix:
https://github.com/SpecterOps/BloodHound/assets/66393111/42787a10-7e02-452f-8301-76d9593cec8c

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (a change that does not modify the application functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Documentation updates are needed, and have been made accordingly.
- [ ] I have added and/or updated tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] My changes include a database migration.