### PR TITLE
Open password reset dialog when updating user to use username/password based authentication

### DIFF
--- a/cmd/ui/src/ducks/auth/types.ts
+++ b/cmd/ui/src/ducks/auth/types.ts
@@ -91,16 +91,6 @@ export interface UpdatedUser {
     roles: number[];
 }
 
-export interface UpdateUserRequest {
-    firstName: string;
-    lastName: string;
-    emailAddress: string;
-    principal: string;
-    roles: number[];
-    SAMLProviderId?: string;
-    is_disabled?: boolean;
-}
-
 export interface SharpHoundUserType extends Auditable {
     AuthSecret: string;
     roles: SharpHoundRoleType[] | null;

--- a/cmd/ui/src/ducks/auth/types.ts
+++ b/cmd/ui/src/ducks/auth/types.ts
@@ -91,6 +91,16 @@ export interface UpdatedUser {
     roles: number[];
 }
 
+export interface UpdateUserRequest {
+    firstName: string;
+    lastName: string;
+    emailAddress: string;
+    principal: string;
+    roles: number[];
+    SAMLProviderId?: string;
+    is_disabled?: boolean;
+}
+
 export interface SharpHoundUserType extends Auditable {
     AuthSecret: string;
     roles: SharpHoundRoleType[] | null;

--- a/cmd/ui/src/views/Users/Users.test.tsx
+++ b/cmd/ui/src/views/Users/Users.test.tsx
@@ -1,0 +1,206 @@
+import { rest } from 'msw';
+import { setupServer } from 'msw/node';
+import { render, screen, within } from 'src/test-utils';
+import Users from '.';
+import userEvent from '@testing-library/user-event';
+
+const testAuthenticatedUser = {
+    saml_provider_id: null,
+    AuthSecret: {
+        digest_method: 'argon2',
+        expires_at: '2025-01-01T12:00:00Z',
+        totp_activated: false,
+        id: 31,
+        created_at: '2024-01-01T12:00:00Z',
+        updated_at: '2024-01-01T12:00:00Z',
+        deleted_at: { Time: '0001-01-01T00:00:00Z', Valid: false },
+    },
+    roles: [
+        {
+            name: 'Administrator',
+            description: 'Administrator',
+            permissions: [],
+            id: 4,
+            created_at: '2024-01-01T12:00:00Z',
+            updated_at: '2024-01-01T12:00:00Z',
+            deleted_at: { Time: '0001-01-01T00:00:00Z', Valid: false },
+        },
+    ],
+    first_name: 'Test',
+    last_name: 'Admin',
+    email_address: 'test_admin@specterops.io',
+    principal_name: 'test_admin',
+    last_login: '0001-01-01T00:00:00Z',
+    is_disabled: false,
+    eula_accepted: true,
+    id: '0',
+    created_at: '2024-01-01T12:00:00Z',
+    updated_at: '2024-01-01T12:00:00Z',
+    deleted_at: { Time: '0001-01-01T00:00:00Z', Valid: false },
+};
+
+const testMarshallLaw = {
+    saml_provider_id: 1,
+    AuthSecret: {
+        digest_method: 'argon2',
+        expires_at: '2025-01-01T12:00:00Z',
+        totp_activated: false,
+        id: 31,
+        created_at: '2024-01-01T12:00:00Z',
+        updated_at: '2024-01-01T12:00:00Z',
+        deleted_at: { Time: '0001-01-01T00:00:00Z', Valid: false },
+    },
+    roles: [
+        {
+            name: 'User',
+            description: 'User',
+            permissions: [],
+            id: 4,
+            created_at: '2024-01-01T12:00:00Z',
+            updated_at: '2024-01-01T12:00:00Z',
+            deleted_at: { Time: '0001-01-01T00:00:00Z', Valid: false },
+        },
+    ],
+    first_name: 'Marshal',
+    last_name: 'Law',
+    email_address: 'mlaw@specterops.io',
+    principal_name: 'mlaw',
+    last_login: '0001-01-01T00:00:00Z',
+    is_disabled: false,
+    eula_accepted: true,
+    id: '1',
+    created_at: '2024-01-01T12:00:00Z',
+    updated_at: '2024-01-01T12:00:00Z',
+    deleted_at: { Time: '0001-01-01T00:00:00Z', Valid: false },
+};
+
+const testBloodHoundUsers = [testAuthenticatedUser, testMarshallLaw];
+
+const testSAMLProviders = [
+    {
+        name: 'saml-provider',
+        display_name: 'saml-provider',
+        idp_issuer_uri: 'urn:saml-provider.com',
+        idp_sso_uri: 'https://saml-provider.com/saml',
+        principal_attribute_mappings: null,
+        sp_issuer_uri: 'https://test.bloodhoundenterprise.io/api/v1/login/saml/saml-provider',
+        sp_sso_uri: 'https://test.bloodhoundenterprise.io/api/v1/login/saml/saml-provider/sso',
+        sp_metadata_uri: 'https://test.bloodhoundenterprise.io/api/v1/login/saml/saml-provider/metadata',
+        sp_acs_uri: 'https://test.bloodhoundenterprise.io/api/v1/login/saml/saml-provider/acs',
+        id: 1,
+        created_at: '2024-01-01T12:00:00Z',
+        updated_at: '2024-01-01T12:00:00Z',
+        deleted_at: { Time: '0001-01-01T00:00:00Z', Valid: false },
+    },
+];
+
+const testRoles = {
+    roles: [
+        {
+            name: 'User',
+            description: 'User',
+            permissions: [],
+            id: 3,
+            created_at: '2024-01-01T12:00:00Z',
+            updated_at: '2024-01-01T12:00:00Z',
+            deleted_at: { Time: '0001-01-01T00:00:00Z', Valid: false },
+        },
+        {
+            name: 'Administrator',
+            description: 'Administrator',
+            permissions: [],
+            id: 4,
+            created_at: '2024-01-01T12:00:00Z',
+            updated_at: '2024-01-01T12:00:00Z',
+            deleted_at: { Time: '0001-01-01T00:00:00Z', Valid: false },
+        },
+    ],
+};
+
+const server = setupServer(
+    rest.get('/api/v2/self', (req, res, ctx) => {
+        return res(
+            ctx.json({
+                data: testAuthenticatedUser,
+            })
+        );
+    }),
+    rest.get('/api/v2/bloodhound-users', (req, res, ctx) => {
+        return res(
+            ctx.json({
+                data: {
+                    users: testBloodHoundUsers,
+                },
+            })
+        );
+    }),
+    rest.get('/api/v2/bloodhound-users/1', (req, res, ctx) => {
+        return res(
+            ctx.json({
+                data: testMarshallLaw,
+            })
+        );
+    }),
+    rest.get('/api/v2/saml', (req, res, ctx) => {
+        return res(
+            ctx.json({
+                data: {
+                    saml_providers: testSAMLProviders,
+                },
+            })
+        );
+    }),
+    rest.get('/api/v2/roles', (req, res, ctx) => {
+        return res(ctx.json({ data: testRoles }));
+    }),
+    rest.patch('/api/v2/bloodhound-users/1', (req, res, ctx) => {
+        return res(ctx.json({ data: { ...testMarshallLaw, saml_provider_id: null, AuthSecret: null } }));
+    })
+);
+
+beforeAll(() => server.listen());
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+describe('Users', () => {
+    it('The password reset dialog is opened when switching a user from SAML based authentication to username/password based authentication', async () => {
+        render(<Users />);
+
+        expect(screen.getByText('Manage Users')).toBeInTheDocument();
+
+        // wait for the table data to load
+        await screen.findByText(testBloodHoundUsers[0].principal_name);
+
+        // this table row contains the data for "Marshall Law" aka testBloodHoundUsers[1]
+        const testUserRow = screen.getAllByRole('row')[2];
+
+        expect(within(testUserRow).getByText(testBloodHoundUsers[1].principal_name)).toBeInTheDocument();
+        expect(within(testUserRow).getByText(testBloodHoundUsers[1].email_address)).toBeInTheDocument();
+        expect(
+            within(testUserRow).getByText(`${testBloodHoundUsers[1].first_name} ${testBloodHoundUsers[1].last_name}`)
+        ).toBeInTheDocument();
+        expect(within(testUserRow).getByText('2024-01-01 04:00 PST (GMT-0800)')).toBeInTheDocument();
+        expect(within(testUserRow).getByText('User')).toBeInTheDocument();
+        expect(within(testUserRow).getByText('Active')).toBeInTheDocument();
+        expect(within(testUserRow).getByText(`SAML: ${testSAMLProviders[0].name}`)).toBeInTheDocument();
+        expect(within(testUserRow).getByRole('button')).toBeInTheDocument();
+
+        // open the update user dialog for Marshall
+        await userEvent.click(within(testUserRow).getByRole('button', { name: 'bars' }));
+        await screen.findByRole('menuitem', { name: /update user/i, hidden: false });
+        await userEvent.click(screen.getByRole('menuitem', { name: /update user/i, hidden: false }));
+        expect(await screen.findByTestId('update-user-dialog')).toBeVisible();
+
+        // update Marshall to use username/password based authentication and save the changes
+        await userEvent.click(screen.getByLabelText('Authentication Method'));
+        await userEvent.click(screen.getByRole('option', { name: 'Username / Password' }));
+        await userEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+        // the update user dialog should close and the password reset dialog should open
+        expect(await screen.findByTestId('update-user-dialog')).not.toBeVisible();
+        expect(await screen.findByTestId('password-dialog')).toBeVisible();
+
+        // the force password reset option should be checked
+        expect(screen.getByLabelText('Force Password Reset?')).toBeChecked();
+    });
+});

--- a/cmd/ui/src/views/Users/Users.test.tsx
+++ b/cmd/ui/src/views/Users/Users.test.tsx
@@ -61,7 +61,7 @@ const testMarshallLaw = {
             deleted_at: { Time: '0001-01-01T00:00:00Z', Valid: false },
         },
     ],
-    first_name: 'Marshal',
+    first_name: 'Marshall',
     last_name: 'Law',
     email_address: 'mlaw@specterops.io',
     principal_name: 'mlaw',

--- a/cmd/ui/src/views/Users/Users.tsx
+++ b/cmd/ui/src/views/Users/Users.tsx
@@ -18,7 +18,6 @@ import { Box, Button, Paper } from '@mui/material';
 import { DateTime } from 'luxon';
 import { useState } from 'react';
 import { useMutation, useQuery } from 'react-query';
-
 import {
     ConfirmationDialog,
     DataTable,
@@ -30,7 +29,10 @@ import {
     apiClient,
     Disable2FADialog,
 } from 'bh-shared-ui';
-import { NewUser, UpdateUserRequest } from 'src/ducks/auth/types';
+import { UpdateUserRequest } from 'js-client-library';
+import find from 'lodash/find';
+import isEmpty from 'lodash/isEmpty';
+import { NewUser } from 'src/ducks/auth/types';
 import { addSnackbar } from 'src/ducks/global/actions';
 import useToggle from 'src/hooks/useToggle';
 import { User } from 'src/hooks/useUsers';
@@ -38,8 +40,6 @@ import { useAppDispatch, useAppSelector } from 'src/store';
 import CreateUserDialog from 'src/views/Users/CreateUserDialog';
 import UpdateUserDialog from 'src/views/Users/UpdateUserDialog';
 import UserActionsMenu from 'src/views/Users/UserActionsMenu';
-import find from 'lodash/find';
-import isEmpty from 'lodash/isEmpty';
 
 const Users = () => {
     const dispatch = useAppDispatch();

--- a/packages/javascript/bh-shared-ui/src/components/PasswordDialog/PasswordDialog.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/PasswordDialog/PasswordDialog.tsx
@@ -43,6 +43,7 @@ const PasswordDialog: React.FC<{
     onClose: () => void;
     userId: string;
     showNeedsPasswordReset?: boolean;
+    initialNeedsPasswordReset?: boolean;
     onSave: ({
         userId,
         secret,
@@ -52,11 +53,13 @@ const PasswordDialog: React.FC<{
         secret: string;
         needsPasswordReset: boolean;
     }) => void;
-}> = ({ open, userId, onClose, showNeedsPasswordReset = false, onSave }) => {
+}> = ({ open, userId, onClose, showNeedsPasswordReset = false, initialNeedsPasswordReset = false, onSave }) => {
     const {
         control,
         handleSubmit,
         getValues,
+        setValue,
+        watch,
         formState: { errors },
         reset,
     } = useForm<ChangePasswordFormInputs>({
@@ -68,8 +71,11 @@ const PasswordDialog: React.FC<{
     });
 
     React.useEffect(() => {
-        if (open) reset();
-    }, [open, reset]);
+        if (open) {
+            reset();
+            setValue('needsPasswordReset', initialNeedsPasswordReset);
+        }
+    }, [open, reset, initialNeedsPasswordReset, setValue]);
 
     const handleOnSave = (data: { password: string; confirmPassword: string; needsPasswordReset: boolean }) => {
         return onSave({
@@ -160,6 +166,7 @@ const PasswordDialog: React.FC<{
                                             control={
                                                 <Checkbox
                                                     {...field}
+                                                    checked={watch('needsPasswordReset').valueOf()}
                                                     onChange={(e) => field.onChange(e.target.checked)}
                                                     color='primary'
                                                     data-testid='password-dialog_checkbox-needs-password-reset'

--- a/packages/javascript/js-client-library/src/client.ts
+++ b/packages/javascript/js-client-library/src/client.ts
@@ -717,19 +717,7 @@ class BHEAPIClient {
             options
         );
 
-    updateUser = (
-        userId: string,
-        user: {
-            firstName: string;
-            lastName: string;
-            emailAddress: string;
-            principal: string;
-            roles: number[];
-            SAMLProviderId?: string;
-            is_disabled?: boolean;
-        },
-        options?: types.RequestOptions
-    ) =>
+    updateUser = (userId: string, user: types.UpdateUserRequest, options?: types.RequestOptions) =>
         this.baseClient.patch(
             `/api/v2/bloodhound-users/${userId}`,
             {

--- a/packages/javascript/js-client-library/src/types.ts
+++ b/packages/javascript/js-client-library/src/types.ts
@@ -260,3 +260,13 @@ export interface ClearDatabaseRequest {
     deleteDataQualityHistory: boolean;
     deleteAssetGroupSelectors: number[];
 }
+
+export interface UpdateUserRequest {
+    firstName: string;
+    lastName: string;
+    emailAddress: string;
+    principal: string;
+    roles: number[];
+    SAMLProviderId?: string;
+    is_disabled?: boolean;
+}


### PR DESCRIPTION
## Description
In the Administration/Manage Users page, Administrators who update a user to use username/password based authentication when the user had previously used SAML are now presented with the password reset dialog to help ensure that the user has a valid secret before attempting their next login.

## Motivation and Context
Users lose their auth secret when not using username/password based authentication. If a user is updated to use username/password based authentication they can be left in a state where they cannot log in because there is no valid password for them to use. This change prompts admins to supply a password for these users to avoid this scenario.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
New tests have been added to cover this behavior

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [x] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
