### PR TITLE
feat: add RoleSeparationEnabled property

### DIFF
--- a/cmd/ui/src/ducks/entityinfo/types.ts
+++ b/cmd/ui/src/ducks/entityinfo/types.ts
@@ -138,6 +138,8 @@ export interface EnterpriseCAInfo extends EntityInfo {
         hasenrollmentagentrestrictions?: boolean;
         isuserspecifiessanenabled?: boolean;
         isuserspecifiessanenabledcollected: boolean;
+        roleseparationenabled?: boolean;
+        roleseparationenabledcollected: boolean;
         description?: string;
     };
     controllables: number;

--- a/packages/cue/bh/ad/ad.cue
+++ b/packages/cue/bh/ad/ad.cue
@@ -98,6 +98,20 @@ IsUserSpecifiesSanEnabledCollected: types.#StringEnum & {
 	representation: "isuserspecifiessanenabledcollected"
 }
 
+RoleSeparationEnabled: types.#StringEnum & {
+	symbol: 		"RoleSeparationEnabled"
+	schema: 		"ad"
+	name:           "Role Separation Enabled"
+	representation: "roleseparationenabled"
+}
+
+RoleSeparationEnabledCollected: types.#StringEnum & {
+	symbol: 		"RoleSeparationEnabledCollected"
+	schema: 		"ad"
+	name:           "Role Separation Enabled Collected"
+	representation: "roleseparationenabledcollected"
+}
+
 HasBasicConstraints: types.#StringEnum & {
 	symbol: 		"HasBasicConstraints"
 	schema: 		"ad"
@@ -565,6 +579,8 @@ Properties: [
 	EnrollmentAgentRestrictionsCollected,
 	IsUserSpecifiesSanEnabled,
 	IsUserSpecifiesSanEnabledCollected,
+	RoleSeparationEnabled,
+	RoleSeparationEnabledCollected,
 	HasBasicConstraints,
 	BasicConstraintPathLength,
 	DNSHostname,

--- a/packages/go/ein/ad.go
+++ b/packages/go/ein/ad.go
@@ -441,6 +441,11 @@ func ParseCARegistryProperties(enterpriseCA EnterpriseCA) IngestibleNode {
 		propMap[ad.IsUserSpecifiesSanEnabled.String()] = enterpriseCA.CARegistryData.IsUserSpecifiesSanEnabled.Value
 	}
 
+	// RoleSeparationEnabled
+	if enterpriseCA.CARegistryData.RoleSeparationEnabled.Collected {
+		propMap[ad.RoleSeparationEnabled.String()] = enterpriseCA.CARegistryData.RoleSeparationEnabled.Value
+	}
+
 	return IngestibleNode{
 		ObjectID:    enterpriseCA.ObjectIdentifier,
 		PropertyMap: propMap,

--- a/packages/go/ein/incoming_models.go
+++ b/packages/go/ein/incoming_models.go
@@ -120,10 +120,16 @@ type IsUserSpecifiesSanEnabled struct {
 	Value bool
 }
 
+type RoleSeparationEnabled struct {
+	APIResult
+	Value bool
+}
+
 type CARegistryData struct {
 	CASecurity                  CASecurity
 	EnrollmentAgentRestrictions EnrollmentAgentRestrictions
 	IsUserSpecifiesSanEnabled   IsUserSpecifiesSanEnabled
+	RoleSeparationEnabled       RoleSeparationEnabled
 }
 
 type DCRegistryData struct {

--- a/packages/go/graphschema/ad/ad.go
+++ b/packages/go/graphschema/ad/ad.go
@@ -126,6 +126,8 @@ const (
 	EnrollmentAgentRestrictionsCollected   Property = "enrollmentagentrestrictionscollected"
 	IsUserSpecifiesSanEnabled              Property = "isuserspecifiessanenabled"
 	IsUserSpecifiesSanEnabledCollected     Property = "isuserspecifiessanenabledcollected"
+	RoleSeparationEnabled                  Property = "roleseparationenabled"
+	RoleSeparationEnabledCollected         Property = "roleseparationenabledcollected"
 	HasBasicConstraints                    Property = "hasbasicconstraints"
 	BasicConstraintPathLength              Property = "basicconstraintpathlength"
 	DNSHostname                            Property = "dnshostname"
@@ -193,7 +195,7 @@ const (
 )
 
 func AllProperties() []Property {
-	return []Property{AdminCount, CASecurityCollected, CAName, CertChain, CertName, CertThumbprint, CertThumbprints, HasEnrollmentAgentRestrictions, EnrollmentAgentRestrictionsCollected, IsUserSpecifiesSanEnabled, IsUserSpecifiesSanEnabledCollected, HasBasicConstraints, BasicConstraintPathLength, DNSHostname, CrossCertificatePair, DistinguishedName, DomainFQDN, DomainSID, Sensitive, HighValue, BlocksInheritance, IsACL, IsACLProtected, IsDeleted, Enforced, Department, HasCrossCertificatePair, HasSPN, UnconstrainedDelegation, LastLogon, LastLogonTimestamp, IsPrimaryGroup, HasLAPS, DontRequirePreAuth, LogonType, HasURA, PasswordNeverExpires, PasswordNotRequired, FunctionalLevel, TrustType, SidFiltering, TrustedToAuth, SamAccountName, CertificateMappingMethodsRaw, CertificateMappingMethods, StrongCertificateBindingEnforcementRaw, StrongCertificateBindingEnforcement, EKUs, SubjectAltRequireUPN, SubjectAltRequireDNS, SubjectAltRequireDomainDNS, SubjectAltRequireEmail, SubjectAltRequireSPN, SubjectRequireEmail, AuthorizedSignatures, ApplicationPolicies, IssuancePolicies, SchemaVersion, RequiresManagerApproval, AuthenticationEnabled, EnrolleeSuppliesSubject, CertificateApplicationPolicy, CertificateNameFlag, EffectiveEKUs, EnrollmentFlag, Flags, NoSecurityExtension, RenewalPeriod, ValidityPeriod, OID, HomeDirectory, CertificatePolicy, CertTemplateOID, GroupLinkID, ObjectGUID}
+	return []Property{AdminCount, CASecurityCollected, CAName, CertChain, CertName, CertThumbprint, CertThumbprints, HasEnrollmentAgentRestrictions, EnrollmentAgentRestrictionsCollected, IsUserSpecifiesSanEnabled, IsUserSpecifiesSanEnabledCollected, RoleSeparationEnabled, RoleSeparationEnabledCollected, HasBasicConstraints, BasicConstraintPathLength, DNSHostname, CrossCertificatePair, DistinguishedName, DomainFQDN, DomainSID, Sensitive, HighValue, BlocksInheritance, IsACL, IsACLProtected, IsDeleted, Enforced, Department, HasCrossCertificatePair, HasSPN, UnconstrainedDelegation, LastLogon, LastLogonTimestamp, IsPrimaryGroup, HasLAPS, DontRequirePreAuth, LogonType, HasURA, PasswordNeverExpires, PasswordNotRequired, FunctionalLevel, TrustType, SidFiltering, TrustedToAuth, SamAccountName, CertificateMappingMethodsRaw, CertificateMappingMethods, StrongCertificateBindingEnforcementRaw, StrongCertificateBindingEnforcement, EKUs, SubjectAltRequireUPN, SubjectAltRequireDNS, SubjectAltRequireDomainDNS, SubjectAltRequireEmail, SubjectAltRequireSPN, SubjectRequireEmail, AuthorizedSignatures, ApplicationPolicies, IssuancePolicies, SchemaVersion, RequiresManagerApproval, AuthenticationEnabled, EnrolleeSuppliesSubject, CertificateApplicationPolicy, CertificateNameFlag, EffectiveEKUs, EnrollmentFlag, Flags, NoSecurityExtension, RenewalPeriod, ValidityPeriod, OID, HomeDirectory, CertificatePolicy, CertTemplateOID, GroupLinkID, ObjectGUID}
 }
 func ParseProperty(source string) (Property, error) {
 	switch source {
@@ -219,6 +221,10 @@ func ParseProperty(source string) (Property, error) {
 		return IsUserSpecifiesSanEnabled, nil
 	case "isuserspecifiessanenabledcollected":
 		return IsUserSpecifiesSanEnabledCollected, nil
+	case "roleseparationenabled":
+		return RoleSeparationEnabled, nil
+	case "roleseparationenabledcollected":
+		return RoleSeparationEnabledCollected, nil
 	case "hasbasicconstraints":
 		return HasBasicConstraints, nil
 	case "basicconstraintpathlength":
@@ -375,6 +381,10 @@ func (s Property) String() string {
 		return string(IsUserSpecifiesSanEnabled)
 	case IsUserSpecifiesSanEnabledCollected:
 		return string(IsUserSpecifiesSanEnabledCollected)
+	case RoleSeparationEnabled:
+		return string(RoleSeparationEnabled)
+	case RoleSeparationEnabledCollected:
+		return string(RoleSeparationEnabledCollected)
 	case HasBasicConstraints:
 		return string(HasBasicConstraints)
 	case BasicConstraintPathLength:
@@ -531,6 +541,10 @@ func (s Property) Name() string {
 		return "Is User Specifies San Enabled"
 	case IsUserSpecifiesSanEnabledCollected:
 		return "Is User Specifies San Enabled Collected"
+	case RoleSeparationEnabled:
+		return "Role Separation Enabled"
+	case RoleSeparationEnabledCollected:
+		return "Role Separation Enabled Collected"
 	case HasBasicConstraints:
 		return "Has Basic Constraints"
 	case BasicConstraintPathLength:

--- a/packages/javascript/bh-shared-ui/src/graphSchema.ts
+++ b/packages/javascript/bh-shared-ui/src/graphSchema.ts
@@ -311,6 +311,8 @@ export enum ActiveDirectoryKindProperties {
     EnrollmentAgentRestrictionsCollected = 'enrollmentagentrestrictionscollected',
     IsUserSpecifiesSanEnabled = 'isuserspecifiessanenabled',
     IsUserSpecifiesSanEnabledCollected = 'isuserspecifiessanenabledcollected',
+    RoleSeparationEnabled = 'roleseparationenabled',
+    RoleSeparationEnabledCollected = 'roleseparationenabledcollected',
     HasBasicConstraints = 'hasbasicconstraints',
     BasicConstraintPathLength = 'basicconstraintpathlength',
     DNSHostname = 'dnshostname',
@@ -400,6 +402,10 @@ export function ActiveDirectoryKindPropertiesToDisplay(value: ActiveDirectoryKin
             return 'Is User Specifies San Enabled';
         case ActiveDirectoryKindProperties.IsUserSpecifiesSanEnabledCollected:
             return 'Is User Specifies San Enabled Collected';
+        case ActiveDirectoryKindProperties.RoleSeparationEnabled:
+            return 'Role Separation Enabled';
+        case ActiveDirectoryKindProperties.RoleSeparationEnabledCollected:
+            return 'Role Separation Enabled Collected';
         case ActiveDirectoryKindProperties.HasBasicConstraints:
             return 'Has Basic Constraints';
         case ActiveDirectoryKindProperties.BasicConstraintPathLength:


### PR DESCRIPTION
## Description

Add EnterpriseCA property RoleSeparationEnabled
Ticket: BED-4351

## Motivation and Context

If this setting is enabled, you cannot perform any CA actions if you have both ManageCA and ManageCertificates permissions. Only CA admins can modify the setting.

We need it for the ESC7 implementation, as some attack narratives require both ManageCA and ManageCertificates and could therefore be blocked by this setting.

More info on the setting: [Q: How can I make sure that a given Windows account is assigned only](https://www.itprotoday.com/security/q-how-can-i-make-sure-given-windows-account-assigned-only-single-certification-authority-ca)

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

With this SharpHound data [20240426013313_BloodHound.zip](https://github.com/BloodHoundAD/SharpHoundCommon/files/15128061/20240426013313_BloodHound.zip)

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![image](https://github.com/SpecterOps/BloodHound/assets/12843299/b3d517da-cee5-4d9f-a7e0-8e2c2ac72ab1)
![image](https://github.com/SpecterOps/BloodHound/assets/12843299/c9aa1f5b-b6a8-4fad-9454-4aa41dc969da)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] My changes include a database migration.
