### PR TITLE
feat: collect unresolved published cert templates

### DIFF
--- a/cmd/ui/src/ducks/entityinfo/types.ts
+++ b/cmd/ui/src/ducks/entityinfo/types.ts
@@ -140,6 +140,7 @@ export interface EnterpriseCAInfo extends EntityInfo {
         isuserspecifiessanenabledcollected: boolean;
         roleseparationenabled?: boolean;
         roleseparationenabledcollected: boolean;
+        unresolvedpublishedtemplates: string[];
         description?: string;
     };
     controllables: number;

--- a/packages/cue/bh/ad/ad.cue
+++ b/packages/cue/bh/ad/ad.cue
@@ -126,6 +126,13 @@ BasicConstraintPathLength: types.#StringEnum & {
 	representation: "basicconstraintpathlength"
 }
 
+UnresolvedPublishedTemplates: types.#StringEnum & {
+	symbol: 		"UnresolvedPublishedTemplates"
+	schema: 		"ad"
+	name:           "Unresolved Published Certificate Templates"
+	representation: "unresolvedpublishedtemplates"
+}
+
 DNSHostname: types.#StringEnum & {
 	symbol: 		"DNSHostname"
 	schema: 		"ad"
@@ -583,6 +590,7 @@ Properties: [
 	RoleSeparationEnabledCollected,
 	HasBasicConstraints,
 	BasicConstraintPathLength,
+	UnresolvedPublishedTemplates,
 	DNSHostname,
 	CrossCertificatePair,
 	DistinguishedName,

--- a/packages/go/graphschema/ad/ad.go
+++ b/packages/go/graphschema/ad/ad.go
@@ -130,6 +130,7 @@ const (
 	RoleSeparationEnabledCollected         Property = "roleseparationenabledcollected"
 	HasBasicConstraints                    Property = "hasbasicconstraints"
 	BasicConstraintPathLength              Property = "basicconstraintpathlength"
+	UnresolvedPublishedTemplates           Property = "unresolvedpublishedtemplates"
 	DNSHostname                            Property = "dnshostname"
 	CrossCertificatePair                   Property = "crosscertificatepair"
 	DistinguishedName                      Property = "distinguishedname"
@@ -195,7 +196,7 @@ const (
 )
 
 func AllProperties() []Property {
-	return []Property{AdminCount, CASecurityCollected, CAName, CertChain, CertName, CertThumbprint, CertThumbprints, HasEnrollmentAgentRestrictions, EnrollmentAgentRestrictionsCollected, IsUserSpecifiesSanEnabled, IsUserSpecifiesSanEnabledCollected, RoleSeparationEnabled, RoleSeparationEnabledCollected, HasBasicConstraints, BasicConstraintPathLength, DNSHostname, CrossCertificatePair, DistinguishedName, DomainFQDN, DomainSID, Sensitive, HighValue, BlocksInheritance, IsACL, IsACLProtected, IsDeleted, Enforced, Department, HasCrossCertificatePair, HasSPN, UnconstrainedDelegation, LastLogon, LastLogonTimestamp, IsPrimaryGroup, HasLAPS, DontRequirePreAuth, LogonType, HasURA, PasswordNeverExpires, PasswordNotRequired, FunctionalLevel, TrustType, SidFiltering, TrustedToAuth, SamAccountName, CertificateMappingMethodsRaw, CertificateMappingMethods, StrongCertificateBindingEnforcementRaw, StrongCertificateBindingEnforcement, EKUs, SubjectAltRequireUPN, SubjectAltRequireDNS, SubjectAltRequireDomainDNS, SubjectAltRequireEmail, SubjectAltRequireSPN, SubjectRequireEmail, AuthorizedSignatures, ApplicationPolicies, IssuancePolicies, SchemaVersion, RequiresManagerApproval, AuthenticationEnabled, EnrolleeSuppliesSubject, CertificateApplicationPolicy, CertificateNameFlag, EffectiveEKUs, EnrollmentFlag, Flags, NoSecurityExtension, RenewalPeriod, ValidityPeriod, OID, HomeDirectory, CertificatePolicy, CertTemplateOID, GroupLinkID, ObjectGUID}
+	return []Property{AdminCount, CASecurityCollected, CAName, CertChain, CertName, CertThumbprint, CertThumbprints, HasEnrollmentAgentRestrictions, EnrollmentAgentRestrictionsCollected, IsUserSpecifiesSanEnabled, IsUserSpecifiesSanEnabledCollected, RoleSeparationEnabled, RoleSeparationEnabledCollected, HasBasicConstraints, BasicConstraintPathLength, UnresolvedPublishedTemplates, DNSHostname, CrossCertificatePair, DistinguishedName, DomainFQDN, DomainSID, Sensitive, HighValue, BlocksInheritance, IsACL, IsACLProtected, IsDeleted, Enforced, Department, HasCrossCertificatePair, HasSPN, UnconstrainedDelegation, LastLogon, LastLogonTimestamp, IsPrimaryGroup, HasLAPS, DontRequirePreAuth, LogonType, HasURA, PasswordNeverExpires, PasswordNotRequired, FunctionalLevel, TrustType, SidFiltering, TrustedToAuth, SamAccountName, CertificateMappingMethodsRaw, CertificateMappingMethods, StrongCertificateBindingEnforcementRaw, StrongCertificateBindingEnforcement, EKUs, SubjectAltRequireUPN, SubjectAltRequireDNS, SubjectAltRequireDomainDNS, SubjectAltRequireEmail, SubjectAltRequireSPN, SubjectRequireEmail, AuthorizedSignatures, ApplicationPolicies, IssuancePolicies, SchemaVersion, RequiresManagerApproval, AuthenticationEnabled, EnrolleeSuppliesSubject, CertificateApplicationPolicy, CertificateNameFlag, EffectiveEKUs, EnrollmentFlag, Flags, NoSecurityExtension, RenewalPeriod, ValidityPeriod, OID, HomeDirectory, CertificatePolicy, CertTemplateOID, GroupLinkID, ObjectGUID}
 }
 func ParseProperty(source string) (Property, error) {
 	switch source {
@@ -229,6 +230,8 @@ func ParseProperty(source string) (Property, error) {
 		return HasBasicConstraints, nil
 	case "basicconstraintpathlength":
 		return BasicConstraintPathLength, nil
+	case "unresolvedpublishedtemplates":
+		return UnresolvedPublishedTemplates, nil
 	case "dnshostname":
 		return DNSHostname, nil
 	case "crosscertificatepair":
@@ -389,6 +392,8 @@ func (s Property) String() string {
 		return string(HasBasicConstraints)
 	case BasicConstraintPathLength:
 		return string(BasicConstraintPathLength)
+	case UnresolvedPublishedTemplates:
+		return string(UnresolvedPublishedTemplates)
 	case DNSHostname:
 		return string(DNSHostname)
 	case CrossCertificatePair:
@@ -549,6 +554,8 @@ func (s Property) Name() string {
 		return "Has Basic Constraints"
 	case BasicConstraintPathLength:
 		return "Basic Constraint Path Length"
+	case UnresolvedPublishedTemplates:
+		return "Unresolved Published Certificate Templates"
 	case DNSHostname:
 		return "DNS Hostname"
 	case CrossCertificatePair:

--- a/packages/javascript/bh-shared-ui/src/graphSchema.ts
+++ b/packages/javascript/bh-shared-ui/src/graphSchema.ts
@@ -315,6 +315,7 @@ export enum ActiveDirectoryKindProperties {
     RoleSeparationEnabledCollected = 'roleseparationenabledcollected',
     HasBasicConstraints = 'hasbasicconstraints',
     BasicConstraintPathLength = 'basicconstraintpathlength',
+    UnresolvedPublishedTemplates = 'unresolvedpublishedtemplates',
     DNSHostname = 'dnshostname',
     CrossCertificatePair = 'crosscertificatepair',
     DistinguishedName = 'distinguishedname',
@@ -410,6 +411,8 @@ export function ActiveDirectoryKindPropertiesToDisplay(value: ActiveDirectoryKin
             return 'Has Basic Constraints';
         case ActiveDirectoryKindProperties.BasicConstraintPathLength:
             return 'Basic Constraint Path Length';
+        case ActiveDirectoryKindProperties.UnresolvedPublishedTemplates:
+            return 'Unresolved Published Certificate Templates';
         case ActiveDirectoryKindProperties.DNSHostname:
             return 'DNS Hostname';
         case ActiveDirectoryKindProperties.CrossCertificatePair:


### PR DESCRIPTION
## Description

Ingest unresolved published cert templates for EnterpriseCAs.

## Motivation and Context

Unresolved published cert templates are interesting, as an attacker can create or rename a cert template to have one of these names and then it will be published automatically.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

Collected in my lab with one EnterpriseCA with no unresolved cert templates and another with.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

![image](https://github.com/BloodHoundAD/SharpHoundCommon/assets/12843299/fe4a67c0-5f66-4f41-a763-3103030384cf)

![image](https://github.com/SpecterOps/BloodHound/assets/12843299/8f55b899-599f-45c5-99db-289abc799350)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.