### PR TITLE
Update the AZUserAccessAdministrator help text

### DIFF
--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/AZUserAccessAdministrator/Abuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/AZUserAccessAdministrator/Abuse.tsx
@@ -19,11 +19,35 @@ import { Typography } from '@mui/material';
 
 const Abuse: FC = () => {
     return (
-        <Typography variant='body2'>
-            This role can be used to grant yourself or another principal any privilege you want against Automation
-            Accounts, VMs, Key Vaults, and Resource Groups. Use the Azure portal to add a new, abusable role assignment
-            against the target object for yourself.
-        </Typography>
+        <>
+            <Typography variant='body2'>
+                This role can be used to grant yourself or another principal any privilege you want against Automation
+                Accounts, VMs, Key Vaults, and Resource Groups. For example, you can make yourself an administrator of 
+                an Azure Subscription by assigning the Owner role at the Subscription scope.
+            </Typography>
+
+            <Typography variant='body2'>
+                The simplest way to execute this attack is to use the Azure portal to add a new, abusable role 
+                assignment against the target object for yourself. 
+            </Typography>
+
+            <Typography variant='body2'>
+                If this role is assigned to a Service Principal, you won't be able to authenticate directly to the 
+                Azure portal. In this case:
+            </Typography>
+
+            <Typography variant='body2'>
+                You'll need to acquire a bearer token for the service principal with AzureRM as the audience. 
+                This can be done using BARK's Get-AzureRMTokenWithClientCredentials cmdlet.
+                
+            </Typography>
+
+            <Typography variant='body2'>
+                Using that token, you can make a call to the AzureRM API to create a new role assignment on the
+                target object, such as assigning yourself the Owner role. This can be done using BARK's 
+                New-AzureRMRoleAssignment cmdlet.
+            </Typography>
+        </>
     );
 };
 

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/AZUserAccessAdministrator/General.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/AZUserAccessAdministrator/General.tsx
@@ -19,7 +19,10 @@ import { Typography } from '@mui/material';
 
 const General: FC = () => {
     return (
-        <Typography variant='body2'>The User Access Admin role can edit roles against many other objects</Typography>
+        <Typography variant='body2'>
+            The User Access Administrator role can manage user access to Azure resources, assign roles in Azure RBAC, 
+            and assign the Owner role to themselves or others.
+        </Typography>
     );
 };
 


### PR DESCRIPTION
## Description

Update the AZUserAccessAdministrator help text to reflect abuse from the perspective of a Service Principal.

## Motivation and Context

The current AZUserAccessAdministrator Abuse help text seems to indicate that the attack path can only be performed via the Azure portal. In the case where this role is assigned to a Service Principal, which cannot authenticate to the Azure portal, it is unclear if the path is abusable. This change adds some additional context and references to BARK functions which were provided by Andy Robbins (@_wald0).

## How Has This Been Tested?

Configure local developmnent environment as per documentation: https://github.com/SpecterOps/BloodHound/wiki/Development.

Tested the changes by viewing the updated AZUserAccessAdministrator Help Text in the BloodHound UI. 

## Screenshots (if appropriate):

![old](https://github.com/SpecterOps/BloodHound/assets/27876907/e8b3b7f3-0441-4066-a56c-ab932ce9f7d2)

![new](https://github.com/SpecterOps/BloodHound/assets/27876907/2e9b987e-2391-4784-aee3-696a4d8d5945)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] My changes include a database migration.
