### PR TITLE
BED-4358: add merge clause to supported cypher

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -14,8 +14,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-version: '3'
-
 services:
   # devcontainer entrypoint
   app:

--- a/.gitignore
+++ b/.gitignore
@@ -445,3 +445,6 @@ local-harnesses/*
 !local-harnesses/README.md
 !local-harnesses/collectors
 !local-harnesses/*.template
+
+# folder used by antlr4 VSCode extension
+.antlr

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -17,7 +17,6 @@
         "golang.go",
         "bierner.markdown-checkbox",
         "ryu1kn.partial-diff",
-        "jebbs.plantuml",
         "ms-ossdata.vscode-postgresql",
         "ms-python.vscode-pylance",
         "ms-python.python",
@@ -32,6 +31,7 @@
         "esbenp.prettier-vscode",
         "prisma.prisma",
         "kokakiwi.vscode-just",
-        "github.vscode-github-actions"
+        "github.vscode-github-actions",
+        "mike-lischke.vscode-antlr4"
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,14 @@
     "version": "0.2.0",
     "configurations": [
         {
+            "type": "antlr-debug",
+            "request": "launch",
+            "name": "Debug Cypher Grammar",
+            "input": "${file}",
+            "grammar": "${workspaceFolder}/packages/go/cypher/grammar/Cypher.g4",
+            "visualParseTree": true
+        },
+        {
             "name": "Launch Go file",
             "type": "go",
             "request": "launch",

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -14,8 +14,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-version: '3'
-
 services:
   proxy:
     image: docker.io/library/traefik:latest

--- a/docker-compose.testing.yml
+++ b/docker-compose.testing.yml
@@ -14,7 +14,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-version: '3'
 services:
   testdb:
     restart: unless-stopped

--- a/docker-compose.watch.yml
+++ b/docker-compose.watch.yml
@@ -14,8 +14,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-version: '3'
-
 services:
   bh-ui:
     develop:

--- a/examples/docker-compose/docker-compose.yml
+++ b/examples/docker-compose/docker-compose.yml
@@ -14,7 +14,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-version: '3'
 services:
   app-db:
     image: docker.io/library/postgres:13.2

--- a/packages/go/cypher/backend/cypher/format.go
+++ b/packages/go/cypher/backend/cypher/format.go
@@ -933,6 +933,44 @@ func (s Emitter) formatCreate(output io.Writer, create *model.Create) error {
 	return s.formatPattern(output, create.Pattern)
 }
 
+func (s Emitter) formatMerge(output io.Writer, merge *model.Merge) error {
+	if _, err := io.WriteString(output, "merge "); err != nil {
+		return err
+	}
+
+	if err := s.formatPatternPart(output, merge.PatternPart); err != nil {
+		return err
+	}
+
+	if err := s.formatMergeActions(output, merge.MergeActions); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s Emitter) formatMergeActions(output io.Writer, mergeActions []*model.MergeAction) error {
+	for _, mergeAction := range mergeActions {
+		if mergeAction.OnCreate {
+			if _, err := io.WriteString(output, "on create "); err != nil {
+				return err
+			}
+		}
+
+		if mergeAction.OnMatch {
+			if _, err := io.WriteString(output, "on match "); err != nil {
+				return err
+			}
+		}
+
+		if err := s.formatSet(output, mergeAction.Set); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (s Emitter) formatUpdatingClause(output io.Writer, updatingClause *model.UpdatingClause) error {
 	switch typedClause := updatingClause.Clause.(type) {
 	case *model.Create:
@@ -946,6 +984,9 @@ func (s Emitter) formatUpdatingClause(output io.Writer, updatingClause *model.Up
 
 	case *model.Delete:
 		return s.formatDelete(output, typedClause)
+
+	case *model.Merge:
+		return s.formatMerge(output, typedClause)
 
 	default:
 		return fmt.Errorf("unsupported updating clause type: %T", updatingClause)

--- a/packages/go/cypher/backend/cypher/format.go
+++ b/packages/go/cypher/backend/cypher/format.go
@@ -951,6 +951,10 @@ func (s Emitter) formatMerge(output io.Writer, merge *model.Merge) error {
 
 func (s Emitter) formatMergeActions(output io.Writer, mergeActions []*model.MergeAction) error {
 	for _, mergeAction := range mergeActions {
+		if _, err := io.WriteString(output, " "); err != nil {
+			return err
+		}
+
 		if mergeAction.OnCreate {
 			if _, err := io.WriteString(output, "on create "); err != nil {
 				return err

--- a/packages/go/cypher/frontend/expression.go
+++ b/packages/go/cypher/frontend/expression.go
@@ -74,12 +74,6 @@ func NewExpressionVisitor() Visitor {
 	return &ExpressionVisitor{}
 }
 
-func (s *ExpressionVisitor) EnterOC_Expression(ctx *parser.OC_ExpressionContext) {
-}
-
-func (s *ExpressionVisitor) ExitOC_Expression(ctx *parser.OC_ExpressionContext) {
-}
-
 func (s *ExpressionVisitor) EnterOC_NonArithmeticOperatorExpression(ctx *parser.OC_NonArithmeticOperatorExpressionContext) {
 	s.ctx.Enter(&NonArithmeticOperatorExpressionVisitor{})
 }
@@ -327,9 +321,6 @@ func (s *StringListNullPredicateExpressionVisitor) EnterOC_RegularExpression(ctx
 	}
 }
 
-func (s *StringListNullPredicateExpressionVisitor) ExitOC_RegularExpression(ctx *parser.OC_RegularExpressionContext) {
-}
-
 func (s *StringListNullPredicateExpressionVisitor) EnterOC_ListPredicateExpression(ctx *parser.OC_ListPredicateExpressionContext) {
 	if ctx.GetToken(parser.CypherLexerIN, 0) != nil {
 		s.Expression = &model.Comparison{
@@ -339,9 +330,6 @@ func (s *StringListNullPredicateExpressionVisitor) EnterOC_ListPredicateExpressi
 			}},
 		}
 	}
-}
-
-func (s *StringListNullPredicateExpressionVisitor) ExitOC_ListPredicateExpression(ctx *parser.OC_ListPredicateExpressionContext) {
 }
 
 func (s *StringListNullPredicateExpressionVisitor) EnterOC_NullPredicateExpression(ctx *parser.OC_NullPredicateExpressionContext) {
@@ -370,9 +358,6 @@ func (s *StringListNullPredicateExpressionVisitor) EnterOC_NullPredicateExpressi
 	}
 }
 
-func (s *StringListNullPredicateExpressionVisitor) ExitOC_NullPredicateExpression(ctx *parser.OC_NullPredicateExpressionContext) {
-}
-
 func (s *StringListNullPredicateExpressionVisitor) EnterOC_StringPredicateExpression(ctx *parser.OC_StringPredicateExpressionContext) {
 	if HasTokens(ctx, parser.CypherLexerSTARTS, parser.CypherLexerWITH) {
 		s.Expression = &model.Comparison{
@@ -398,9 +383,6 @@ func (s *StringListNullPredicateExpressionVisitor) EnterOC_StringPredicateExpres
 	}
 }
 
-func (s *StringListNullPredicateExpressionVisitor) ExitOC_StringPredicateExpression(ctx *parser.OC_StringPredicateExpressionContext) {
-}
-
 // oC_Atom ( ( SP? oC_ListOperatorExpression ) | ( SP? oC_PropertyLookup ) )* ( SP? oC_NodeLabels )?
 type NonArithmeticOperatorExpressionVisitor struct {
 	BaseVisitor
@@ -413,9 +395,6 @@ func (s *NonArithmeticOperatorExpressionVisitor) EnterOC_NodeLabels(ctx *parser.
 	s.Expression = &model.KindMatcher{
 		Reference: s.Expression,
 	}
-}
-
-func (s *NonArithmeticOperatorExpressionVisitor) ExitOC_NodeLabels(ctx *parser.OC_NodeLabelsContext) {
 }
 
 func (s *NonArithmeticOperatorExpressionVisitor) EnterOC_NodeLabel(ctx *parser.OC_NodeLabelContext) {

--- a/packages/go/cypher/frontend/function.go
+++ b/packages/go/cypher/frontend/function.go
@@ -31,9 +31,6 @@ func (s *NamespaceVisitor) EnterOC_SymbolicName(ctx *parser.OC_SymbolicNameConte
 	s.Namespace = append(s.Namespace, ctx.GetText())
 }
 
-func (s *NamespaceVisitor) ExitOC_SymbolicName(ctx *parser.OC_SymbolicNameContext) {
-}
-
 type FunctionInvocationVisitor struct {
 	BaseVisitor
 
@@ -48,12 +45,6 @@ func NewFunctionInvocationVisitor(ctx *parser.OC_FunctionInvocationContext) *Fun
 	}
 }
 
-func (s *FunctionInvocationVisitor) EnterOC_FunctionName(ctx *parser.OC_FunctionNameContext) {
-}
-
-func (s *FunctionInvocationVisitor) ExitOC_FunctionName(ctx *parser.OC_FunctionNameContext) {
-}
-
 func (s *FunctionInvocationVisitor) EnterOC_Namespace(ctx *parser.OC_NamespaceContext) {
 	s.ctx.Enter(&NamespaceVisitor{})
 }
@@ -64,9 +55,6 @@ func (s *FunctionInvocationVisitor) ExitOC_Namespace(ctx *parser.OC_NamespaceCon
 
 func (s *FunctionInvocationVisitor) EnterOC_SymbolicName(ctx *parser.OC_SymbolicNameContext) {
 	s.FunctionInvocation.Name = ctx.GetText()
-}
-
-func (s *FunctionInvocationVisitor) ExitOC_SymbolicName(ctx *parser.OC_SymbolicNameContext) {
 }
 
 func (s *FunctionInvocationVisitor) EnterOC_Expression(ctx *parser.OC_ExpressionContext) {

--- a/packages/go/cypher/frontend/literal.go
+++ b/packages/go/cypher/frontend/literal.go
@@ -30,31 +30,16 @@ type SymbolicNameOrReservedWordVisitor struct {
 	Name string
 }
 
-func (s *SymbolicNameOrReservedWordVisitor) EnterOC_LabelName(ctx *parser.OC_LabelNameContext) {
-}
-
-func (s *SymbolicNameOrReservedWordVisitor) ExitOC_LabelName(ctx *parser.OC_LabelNameContext) {
-}
-
 func (s *SymbolicNameOrReservedWordVisitor) EnterOC_SchemaName(ctx *parser.OC_SchemaNameContext) {
 	s.Name = ctx.GetText()
-}
-
-func (s *SymbolicNameOrReservedWordVisitor) ExitOC_SchemaName(ctx *parser.OC_SchemaNameContext) {
 }
 
 func (s *SymbolicNameOrReservedWordVisitor) EnterOC_SymbolicName(ctx *parser.OC_SymbolicNameContext) {
 	s.Name = ctx.GetText()
 }
 
-func (s *SymbolicNameOrReservedWordVisitor) ExitOC_SymbolicName(ctx *parser.OC_SymbolicNameContext) {
-}
-
 func (s *SymbolicNameOrReservedWordVisitor) EnterOC_ReservedWord(ctx *parser.OC_ReservedWordContext) {
 	s.Name = ctx.GetText()
-}
-
-func (s *SymbolicNameOrReservedWordVisitor) ExitOC_ReservedWord(ctx *parser.OC_ReservedWordContext) {
 }
 
 type MapLiteralVisitor struct {
@@ -118,12 +103,6 @@ func NewLiteralVisitor() *LiteralVisitor {
 	}
 }
 
-func (s *LiteralVisitor) EnterOC_NumberLiteral(ctx *parser.OC_NumberLiteralContext) {
-}
-
-func (s *LiteralVisitor) ExitOC_NumberLiteral(ctx *parser.OC_NumberLiteralContext) {
-}
-
 func (s *LiteralVisitor) EnterOC_IntegerLiteral(ctx *parser.OC_IntegerLiteralContext) {
 	text := ctx.GetText()
 
@@ -132,9 +111,6 @@ func (s *LiteralVisitor) EnterOC_IntegerLiteral(ctx *parser.OC_IntegerLiteralCon
 	} else {
 		s.Literal.Set(parsedInt64)
 	}
-}
-
-func (s *LiteralVisitor) ExitOC_IntegerLiteral(ctx *parser.OC_IntegerLiteralContext) {
 }
 
 func (s *LiteralVisitor) EnterOC_BooleanLiteral(ctx *parser.OC_BooleanLiteralContext) {
@@ -147,9 +123,6 @@ func (s *LiteralVisitor) EnterOC_BooleanLiteral(ctx *parser.OC_BooleanLiteralCon
 	}
 }
 
-func (s *LiteralVisitor) ExitOC_BooleanLiteral(ctx *parser.OC_BooleanLiteralContext) {
-}
-
 func (s *LiteralVisitor) EnterOC_DoubleLiteral(ctx *parser.OC_DoubleLiteralContext) {
 	text := ctx.GetText()
 
@@ -158,9 +131,6 @@ func (s *LiteralVisitor) EnterOC_DoubleLiteral(ctx *parser.OC_DoubleLiteralConte
 	} else {
 		s.Literal.Set(parsedFloat64)
 	}
-}
-
-func (s *LiteralVisitor) ExitOC_DoubleLiteral(ctx *parser.OC_DoubleLiteralContext) {
 }
 
 func (s *LiteralVisitor) EnterOC_MapLiteral(ctx *parser.OC_MapLiteralContext) {

--- a/packages/go/cypher/frontend/pattern.go
+++ b/packages/go/cypher/frontend/pattern.go
@@ -161,9 +161,6 @@ func (s *RelationshipPatternVisitor) EnterOC_RangeLiteral(ctx *parser.OC_RangeLi
 	}
 }
 
-func (s *RelationshipPatternVisitor) ExitOC_RangeLiteral(ctx *parser.OC_RangeLiteralContext) {
-}
-
 func (s *RelationshipPatternVisitor) EnterOC_Properties(ctx *parser.OC_PropertiesContext) {
 	s.ctx.Enter(NewPropertiesVisitor())
 }

--- a/packages/go/cypher/frontend/pattern.go
+++ b/packages/go/cypher/frontend/pattern.go
@@ -18,11 +18,12 @@ package frontend
 
 import (
 	"fmt"
+	"strconv"
+
 	"github.com/antlr4-go/antlr/v4"
 	"github.com/specterops/bloodhound/cypher/model"
 	"github.com/specterops/bloodhound/cypher/parser"
 	"github.com/specterops/bloodhound/dawgs/graph"
-	"strconv"
 )
 
 type WhereVisitor struct {
@@ -319,3 +320,75 @@ func (s *PatternVisitor) EnterOC_RelationshipPattern(ctx *parser.OC_Relationship
 func (s *PatternVisitor) ExitOC_RelationshipPattern(ctx *parser.OC_RelationshipPatternContext) {
 	s.currentPart.AddPatternElements(s.ctx.Exit().(*RelationshipPatternVisitor).RelationshipPattern)
 }
+
+// type PatternPartVisitor struct {
+// 	BaseVisitor
+
+// 	PatternPart *model.PatternPart
+// }
+
+// func (s *PatternPartVisitor) EnterOC_AnonymousPatternPart(ctx *parser.OC_AnonymousPatternPartContext) {
+// }
+
+// func (s *PatternPartVisitor) ExitOC_AnonymousPatternPart(ctx *parser.OC_AnonymousPatternPartContext) {
+// }
+
+// func (s *PatternPartVisitor) EnterOC_PatternElementChain(ctx *parser.OC_PatternElementChainContext) {
+// }
+
+// func (s *PatternPartVisitor) ExitOC_PatternElementChain(ctx *parser.OC_PatternElementChainContext) {
+// }
+
+// func (s *PatternPartVisitor) EnterOC_PatternElement(ctx *parser.OC_PatternElementContext) {
+// }
+
+// func (s *PatternPartVisitor) ExitOC_PatternElement(ctx *parser.OC_PatternElementContext) {
+// }
+
+// func (s *PatternPartVisitor) EnterOC_PatternPart(ctx *parser.OC_PatternPartContext) {
+// 	s.PatternPart = &model.PatternPart{}
+// }
+
+// func (s *PatternPartVisitor) ExitOC_PatternPart(ctx *parser.OC_PatternPartContext) {
+// }
+
+// func (s *PatternPartVisitor) EnterOC_ShortestPathPattern(ctx *parser.OC_ShortestPathPatternContext) {
+// 	if HasTokens(ctx, parser.CypherLexerSHORTESTPATH) {
+// 		s.PatternPart.ShortestPathPattern = true
+// 	} else if HasTokens(ctx, parser.CypherLexerALLSHORTESTPATHS) {
+// 		s.PatternPart.AllShortestPathsPattern = true
+// 	}
+// }
+
+// func (s *PatternPartVisitor) ExitOC_ShortestPathPattern(ctx *parser.OC_ShortestPathPatternContext) {
+// }
+
+// func (s *PatternPartVisitor) EnterOC_Variable(ctx *parser.OC_VariableContext) {
+// 	s.ctx.Enter(NewVariableVisitor())
+// }
+
+// func (s *PatternPartVisitor) ExitOC_Variable(ctx *parser.OC_VariableContext) {
+// 	s.PatternPart.Binding = s.ctx.Exit().(*VariableVisitor).Variable
+// }
+
+// func (s *PatternPartVisitor) EnterOC_NodePattern(ctx *parser.OC_NodePatternContext) {
+// 	s.ctx.Enter(&NodePatternVisitor{
+// 		NodePattern: &model.NodePattern{},
+// 	})
+// }
+
+// func (s *PatternPartVisitor) ExitOC_NodePattern(ctx *parser.OC_NodePatternContext) {
+// 	s.PatternPart.AddPatternElements(s.ctx.Exit().(*NodePatternVisitor).NodePattern)
+// }
+
+// func (s *PatternPartVisitor) EnterOC_RelationshipPattern(ctx *parser.OC_RelationshipPatternContext) {
+// 	s.ctx.Enter(&RelationshipPatternVisitor{
+// 		RelationshipPattern: &model.RelationshipPattern{
+// 			Direction: graph.DirectionBoth,
+// 		},
+// 	})
+// }
+
+// func (s *PatternPartVisitor) ExitOC_RelationshipPattern(ctx *parser.OC_RelationshipPatternContext) {
+// 	s.PatternPart.AddPatternElements(s.ctx.Exit().(*RelationshipPatternVisitor).RelationshipPattern)
+// }

--- a/packages/go/cypher/frontend/pattern.go
+++ b/packages/go/cypher/frontend/pattern.go
@@ -60,18 +60,6 @@ func (s *NodePatternVisitor) ExitOC_Variable(ctx *parser.OC_VariableContext) {
 	s.NodePattern.Binding = s.ctx.Exit().(*VariableVisitor).Variable
 }
 
-func (s *NodePatternVisitor) EnterOC_NodeLabels(ctx *parser.OC_NodeLabelsContext) {
-}
-
-func (s *NodePatternVisitor) ExitOC_NodeLabels(ctx *parser.OC_NodeLabelsContext) {
-}
-
-func (s *NodePatternVisitor) EnterOC_NodeLabel(ctx *parser.OC_NodeLabelContext) {
-}
-
-func (s *NodePatternVisitor) ExitOC_NodeLabel(ctx *parser.OC_NodeLabelContext) {
-}
-
 func (s *NodePatternVisitor) EnterOC_LabelName(ctx *parser.OC_LabelNameContext) {
 	s.ctx.Enter(&SymbolicNameOrReservedWordVisitor{})
 }
@@ -93,24 +81,6 @@ type RelationshipPatternVisitor struct {
 	BaseVisitor
 
 	RelationshipPattern *model.RelationshipPattern
-}
-
-func (s *RelationshipPatternVisitor) EnterOC_RelationshipTypes(ctx *parser.OC_RelationshipTypesContext) {
-}
-
-func (s *RelationshipPatternVisitor) ExitOC_RelationshipTypes(ctx *parser.OC_RelationshipTypesContext) {
-}
-
-func (s *RelationshipPatternVisitor) EnterOC_Dash(ctx *parser.OC_DashContext) {
-}
-
-func (s *RelationshipPatternVisitor) ExitOC_Dash(ctx *parser.OC_DashContext) {
-}
-
-func (s *RelationshipPatternVisitor) EnterOC_RelationshipDetail(ctx *parser.OC_RelationshipDetailContext) {
-}
-
-func (s *RelationshipPatternVisitor) ExitOC_RelationshipDetail(ctx *parser.OC_RelationshipDetailContext) {
 }
 
 func (s *RelationshipPatternVisitor) EnterOC_RelTypeName(ctx *parser.OC_RelTypeNameContext) {
@@ -143,9 +113,6 @@ func (s *RelationshipPatternVisitor) EnterOC_RightArrowHead(ctx *parser.OC_Right
 	} else {
 		s.RelationshipPattern.Direction = graph.DirectionOutbound
 	}
-}
-
-func (s *RelationshipPatternVisitor) ExitOC_RightArrowHead(ctx *parser.OC_RightArrowHeadContext) {
 }
 
 func (s *RelationshipPatternVisitor) EnterOC_RangeLiteral(ctx *parser.OC_RangeLiteralContext) {
@@ -242,74 +209,56 @@ func (s *PatternPredicateVisitor) ExitOC_RelationshipPattern(ctx *parser.OC_Rela
 type PatternVisitor struct {
 	BaseVisitor
 
-	currentPart  *model.PatternPart
 	PatternParts []*model.PatternPart
 }
 
-func (s *PatternVisitor) EnterOC_AnonymousPatternPart(ctx *parser.OC_AnonymousPatternPartContext) {
-}
-
-func (s *PatternVisitor) ExitOC_AnonymousPatternPart(ctx *parser.OC_AnonymousPatternPartContext) {
-}
-
-func (s *PatternVisitor) EnterOC_PatternElementChain(ctx *parser.OC_PatternElementChainContext) {
-}
-
-func (s *PatternVisitor) ExitOC_PatternElementChain(ctx *parser.OC_PatternElementChainContext) {
-}
-
-func (s *PatternVisitor) EnterOC_PatternElement(ctx *parser.OC_PatternElementContext) {
-}
-
-func (s *PatternVisitor) ExitOC_PatternElement(ctx *parser.OC_PatternElementContext) {
-}
-
-func (s *PatternVisitor) EnterOC_RelationshipsPattern(ctx *parser.OC_RelationshipsPatternContext) {
-	s.currentPart = &model.PatternPart{}
-}
-
-func (s *PatternVisitor) ExitOC_RelationshipsPattern(ctx *parser.OC_RelationshipsPatternContext) {
-	s.PatternParts = append(s.PatternParts, s.currentPart)
-}
-
 func (s *PatternVisitor) EnterOC_PatternPart(ctx *parser.OC_PatternPartContext) {
-	s.currentPart = &model.PatternPart{}
+	s.ctx.Enter(&PatternPartVisitor{
+		PatternPart: &model.PatternPart{},
+	})
 }
 
 func (s *PatternVisitor) ExitOC_PatternPart(ctx *parser.OC_PatternPartContext) {
-	s.PatternParts = append(s.PatternParts, s.currentPart)
+	s.PatternParts = append(s.PatternParts, s.ctx.Exit().(*PatternPartVisitor).PatternPart)
 }
 
-func (s *PatternVisitor) EnterOC_ShortestPathPattern(ctx *parser.OC_ShortestPathPatternContext) {
+type PatternPartVisitor struct {
+	BaseVisitor
+
+	PatternPart *model.PatternPart
+}
+
+func (s *PatternPartVisitor) EnterOC_PatternPart(ctx *parser.OC_PatternPartContext) {
+	s.PatternPart = &model.PatternPart{}
+}
+
+func (s *PatternPartVisitor) EnterOC_ShortestPathPattern(ctx *parser.OC_ShortestPathPatternContext) {
 	if HasTokens(ctx, parser.CypherLexerSHORTESTPATH) {
-		s.currentPart.ShortestPathPattern = true
+		s.PatternPart.ShortestPathPattern = true
 	} else if HasTokens(ctx, parser.CypherLexerALLSHORTESTPATHS) {
-		s.currentPart.AllShortestPathsPattern = true
+		s.PatternPart.AllShortestPathsPattern = true
 	}
 }
 
-func (s *PatternVisitor) ExitOC_ShortestPathPattern(ctx *parser.OC_ShortestPathPatternContext) {
-}
-
-func (s *PatternVisitor) EnterOC_Variable(ctx *parser.OC_VariableContext) {
+func (s *PatternPartVisitor) EnterOC_Variable(ctx *parser.OC_VariableContext) {
 	s.ctx.Enter(NewVariableVisitor())
 }
 
-func (s *PatternVisitor) ExitOC_Variable(ctx *parser.OC_VariableContext) {
-	s.currentPart.Binding = s.ctx.Exit().(*VariableVisitor).Variable
+func (s *PatternPartVisitor) ExitOC_Variable(ctx *parser.OC_VariableContext) {
+	s.PatternPart.Binding = s.ctx.Exit().(*VariableVisitor).Variable
 }
 
-func (s *PatternVisitor) EnterOC_NodePattern(ctx *parser.OC_NodePatternContext) {
+func (s *PatternPartVisitor) EnterOC_NodePattern(ctx *parser.OC_NodePatternContext) {
 	s.ctx.Enter(&NodePatternVisitor{
 		NodePattern: &model.NodePattern{},
 	})
 }
 
-func (s *PatternVisitor) ExitOC_NodePattern(ctx *parser.OC_NodePatternContext) {
-	s.currentPart.AddPatternElements(s.ctx.Exit().(*NodePatternVisitor).NodePattern)
+func (s *PatternPartVisitor) ExitOC_NodePattern(ctx *parser.OC_NodePatternContext) {
+	s.PatternPart.AddPatternElements(s.ctx.Exit().(*NodePatternVisitor).NodePattern)
 }
 
-func (s *PatternVisitor) EnterOC_RelationshipPattern(ctx *parser.OC_RelationshipPatternContext) {
+func (s *PatternPartVisitor) EnterOC_RelationshipPattern(ctx *parser.OC_RelationshipPatternContext) {
 	s.ctx.Enter(&RelationshipPatternVisitor{
 		RelationshipPattern: &model.RelationshipPattern{
 			Direction: graph.DirectionBoth,
@@ -317,78 +266,6 @@ func (s *PatternVisitor) EnterOC_RelationshipPattern(ctx *parser.OC_Relationship
 	})
 }
 
-func (s *PatternVisitor) ExitOC_RelationshipPattern(ctx *parser.OC_RelationshipPatternContext) {
-	s.currentPart.AddPatternElements(s.ctx.Exit().(*RelationshipPatternVisitor).RelationshipPattern)
+func (s *PatternPartVisitor) ExitOC_RelationshipPattern(ctx *parser.OC_RelationshipPatternContext) {
+	s.PatternPart.AddPatternElements(s.ctx.Exit().(*RelationshipPatternVisitor).RelationshipPattern)
 }
-
-// type PatternPartVisitor struct {
-// 	BaseVisitor
-
-// 	PatternPart *model.PatternPart
-// }
-
-// func (s *PatternPartVisitor) EnterOC_AnonymousPatternPart(ctx *parser.OC_AnonymousPatternPartContext) {
-// }
-
-// func (s *PatternPartVisitor) ExitOC_AnonymousPatternPart(ctx *parser.OC_AnonymousPatternPartContext) {
-// }
-
-// func (s *PatternPartVisitor) EnterOC_PatternElementChain(ctx *parser.OC_PatternElementChainContext) {
-// }
-
-// func (s *PatternPartVisitor) ExitOC_PatternElementChain(ctx *parser.OC_PatternElementChainContext) {
-// }
-
-// func (s *PatternPartVisitor) EnterOC_PatternElement(ctx *parser.OC_PatternElementContext) {
-// }
-
-// func (s *PatternPartVisitor) ExitOC_PatternElement(ctx *parser.OC_PatternElementContext) {
-// }
-
-// func (s *PatternPartVisitor) EnterOC_PatternPart(ctx *parser.OC_PatternPartContext) {
-// 	s.PatternPart = &model.PatternPart{}
-// }
-
-// func (s *PatternPartVisitor) ExitOC_PatternPart(ctx *parser.OC_PatternPartContext) {
-// }
-
-// func (s *PatternPartVisitor) EnterOC_ShortestPathPattern(ctx *parser.OC_ShortestPathPatternContext) {
-// 	if HasTokens(ctx, parser.CypherLexerSHORTESTPATH) {
-// 		s.PatternPart.ShortestPathPattern = true
-// 	} else if HasTokens(ctx, parser.CypherLexerALLSHORTESTPATHS) {
-// 		s.PatternPart.AllShortestPathsPattern = true
-// 	}
-// }
-
-// func (s *PatternPartVisitor) ExitOC_ShortestPathPattern(ctx *parser.OC_ShortestPathPatternContext) {
-// }
-
-// func (s *PatternPartVisitor) EnterOC_Variable(ctx *parser.OC_VariableContext) {
-// 	s.ctx.Enter(NewVariableVisitor())
-// }
-
-// func (s *PatternPartVisitor) ExitOC_Variable(ctx *parser.OC_VariableContext) {
-// 	s.PatternPart.Binding = s.ctx.Exit().(*VariableVisitor).Variable
-// }
-
-// func (s *PatternPartVisitor) EnterOC_NodePattern(ctx *parser.OC_NodePatternContext) {
-// 	s.ctx.Enter(&NodePatternVisitor{
-// 		NodePattern: &model.NodePattern{},
-// 	})
-// }
-
-// func (s *PatternPartVisitor) ExitOC_NodePattern(ctx *parser.OC_NodePatternContext) {
-// 	s.PatternPart.AddPatternElements(s.ctx.Exit().(*NodePatternVisitor).NodePattern)
-// }
-
-// func (s *PatternPartVisitor) EnterOC_RelationshipPattern(ctx *parser.OC_RelationshipPatternContext) {
-// 	s.ctx.Enter(&RelationshipPatternVisitor{
-// 		RelationshipPattern: &model.RelationshipPattern{
-// 			Direction: graph.DirectionBoth,
-// 		},
-// 	})
-// }
-
-// func (s *PatternPartVisitor) ExitOC_RelationshipPattern(ctx *parser.OC_RelationshipPatternContext) {
-// 	s.PatternPart.AddPatternElements(s.ctx.Exit().(*RelationshipPatternVisitor).RelationshipPattern)
-// }

--- a/packages/go/cypher/frontend/query.go
+++ b/packages/go/cypher/frontend/query.go
@@ -559,6 +559,20 @@ func (s *CreateVisitor) ExitOC_Pattern(ctx *parser.OC_PatternContext) {
 	s.Create.Pattern = s.ctx.Exit().(*PatternVisitor).PatternParts
 }
 
+// type MergeVisitor struct {
+// 	BaseVisitor
+
+// 	Merge *model.Merge
+// }
+
+// func (s *MergeVisitor) EnterOC_PatternPart(ctx *parser.OC_PatternPartContext) {
+// 	s.ctx.Enter(&PatternVisitor{})
+// }
+
+// func (s *MergeVisitor) ExitOC_PatternPart(ctx *parser.OC_PatternPartContext) {
+// 	s.Merge.PatternPart = s.ctx.Exit().(*PatternPartVisitor).PatternPart
+// }
+
 type UpdatingClauseVisitor struct {
 	BaseVisitor
 
@@ -614,6 +628,16 @@ func (s *UpdatingClauseVisitor) EnterOC_Set(ctx *parser.OC_SetContext) {
 func (s *UpdatingClauseVisitor) ExitOC_Set(ctx *parser.OC_SetContext) {
 	s.UpdatingClause.Clause = s.ctx.Exit().(*SetVisitor).Set
 }
+
+// func (s *UpdatingClauseVisitor) EnterOC_Merge(ctx *parser.OC_MergeContext) {
+// 	s.ctx.Enter(&MergeVisitor{
+// 		Merge: &model.Merge{},
+// 	})
+// }
+
+// func (s *UpdatingClauseVisitor) ExitOC_Merge(ctx *parser.OC_MergeContext) {
+// 	s.UpdatingClause.Clause = s.ctx.Exit().(*MergeVisitor).Merge
+// }
 
 type NodeLabelsVisitor struct {
 	BaseVisitor

--- a/packages/go/cypher/frontend/query.go
+++ b/packages/go/cypher/frontend/query.go
@@ -434,42 +434,12 @@ type QueryVisitor struct {
 	Query *model.RegularQuery
 }
 
-func (s *QueryVisitor) EnterOC_Cypher(ctx *parser.OC_CypherContext) {
-}
-
-func (s *QueryVisitor) ExitOC_Cypher(ctx *parser.OC_CypherContext) {
-}
-
-func (s *QueryVisitor) EnterOC_Query(ctx *parser.OC_QueryContext) {
-}
-
-func (s *QueryVisitor) ExitOC_Query(ctx *parser.OC_QueryContext) {
-}
-
-func (s *QueryVisitor) EnterOC_Statement(ctx *parser.OC_StatementContext) {
-}
-
-func (s *QueryVisitor) ExitOC_Statement(ctx *parser.OC_StatementContext) {
-}
-
-func (s *QueryVisitor) EnterOC_QueryOptions(ctx *parser.OC_QueryOptionsContext) {
-}
-
-func (s *QueryVisitor) ExitOC_QueryOptions(ctx *parser.OC_QueryOptionsContext) {
-}
-
 func (s *QueryVisitor) EnterOC_RegularQuery(ctx *parser.OC_RegularQueryContext) {
 	s.Query = model.NewRegularQuery()
 }
 
-func (s *QueryVisitor) ExitOC_RegularQuery(ctx *parser.OC_RegularQueryContext) {
-}
-
 func (s *QueryVisitor) EnterOC_SingleQuery(ctx *parser.OC_SingleQueryContext) {
 	s.Query.SingleQuery = model.NewSingleQuery()
-}
-
-func (s *QueryVisitor) ExitOC_SingleQuery(ctx *parser.OC_SingleQueryContext) {
 }
 
 func (s *QueryVisitor) EnterOC_MultiPartQuery(ctx *parser.OC_MultiPartQueryContext) {
@@ -559,19 +529,21 @@ func (s *CreateVisitor) ExitOC_Pattern(ctx *parser.OC_PatternContext) {
 	s.Create.Pattern = s.ctx.Exit().(*PatternVisitor).PatternParts
 }
 
-// type MergeVisitor struct {
-// 	BaseVisitor
+type MergeVisitor struct {
+	BaseVisitor
 
-// 	Merge *model.Merge
-// }
+	Merge *model.Merge
+}
 
-// func (s *MergeVisitor) EnterOC_PatternPart(ctx *parser.OC_PatternPartContext) {
-// 	s.ctx.Enter(&PatternVisitor{})
-// }
+func (s *MergeVisitor) EnterOC_PatternPart(ctx *parser.OC_PatternPartContext) {
+	s.ctx.Enter(&PatternPartVisitor{
+		PatternPart: &model.PatternPart{},
+	})
+}
 
-// func (s *MergeVisitor) ExitOC_PatternPart(ctx *parser.OC_PatternPartContext) {
-// 	s.Merge.PatternPart = s.ctx.Exit().(*PatternPartVisitor).PatternPart
-// }
+func (s *MergeVisitor) ExitOC_PatternPart(ctx *parser.OC_PatternPartContext) {
+	s.Merge.PatternPart = s.ctx.Exit().(*PatternPartVisitor).PatternPart
+}
 
 type UpdatingClauseVisitor struct {
 	BaseVisitor
@@ -629,26 +601,20 @@ func (s *UpdatingClauseVisitor) ExitOC_Set(ctx *parser.OC_SetContext) {
 	s.UpdatingClause.Clause = s.ctx.Exit().(*SetVisitor).Set
 }
 
-// func (s *UpdatingClauseVisitor) EnterOC_Merge(ctx *parser.OC_MergeContext) {
-// 	s.ctx.Enter(&MergeVisitor{
-// 		Merge: &model.Merge{},
-// 	})
-// }
+func (s *UpdatingClauseVisitor) EnterOC_Merge(ctx *parser.OC_MergeContext) {
+	s.ctx.Enter(&MergeVisitor{
+		Merge: &model.Merge{},
+	})
+}
 
-// func (s *UpdatingClauseVisitor) ExitOC_Merge(ctx *parser.OC_MergeContext) {
-// 	s.UpdatingClause.Clause = s.ctx.Exit().(*MergeVisitor).Merge
-// }
+func (s *UpdatingClauseVisitor) ExitOC_Merge(ctx *parser.OC_MergeContext) {
+	s.UpdatingClause.Clause = s.ctx.Exit().(*MergeVisitor).Merge
+}
 
 type NodeLabelsVisitor struct {
 	BaseVisitor
 
 	Kinds graph.Kinds
-}
-
-func (s *NodeLabelsVisitor) EnterOC_NodeLabel(ctx *parser.OC_NodeLabelContext) {
-}
-
-func (s *NodeLabelsVisitor) ExitOC_NodeLabel(ctx *parser.OC_NodeLabelContext) {
 }
 
 func (s *NodeLabelsVisitor) EnterOC_LabelName(ctx *parser.OC_LabelNameContext) {

--- a/packages/go/cypher/frontend/query.go
+++ b/packages/go/cypher/frontend/query.go
@@ -545,6 +545,35 @@ func (s *MergeVisitor) ExitOC_PatternPart(ctx *parser.OC_PatternPartContext) {
 	s.Merge.PatternPart = s.ctx.Exit().(*PatternPartVisitor).PatternPart
 }
 
+func (s *MergeVisitor) EnterOC_MergeAction(ctx *parser.OC_MergeActionContext) {
+	s.ctx.Enter(&MergeActionVisitor{
+		MergeAction: &model.MergeAction{
+			OnCreate: HasTokens(ctx, parser.CypherLexerON, parser.CypherLexerCREATE),
+			OnMatch:  HasTokens(ctx, parser.CypherLexerON, parser.CypherLexerMATCH),
+		},
+	})
+}
+
+func (s *MergeVisitor) ExitOC_MergeAction(ctx *parser.OC_MergeActionContext) {
+	s.Merge.MergeActions = append(s.Merge.MergeActions, s.ctx.Exit().(*MergeActionVisitor).MergeAction)
+}
+
+type MergeActionVisitor struct {
+	BaseVisitor
+
+	MergeAction *model.MergeAction
+}
+
+func (s *MergeActionVisitor) EnterOC_Set(ctx *parser.OC_SetContext) {
+	s.ctx.Enter(&SetVisitor{
+		Set: &model.Set{},
+	})
+}
+
+func (s *MergeActionVisitor) ExitOC_Set(ctx *parser.OC_SetContext) {
+	s.MergeAction.Set = s.ctx.Exit().(*SetVisitor).Set
+}
+
 type UpdatingClauseVisitor struct {
 	BaseVisitor
 

--- a/packages/go/cypher/frontend/query.go
+++ b/packages/go/cypher/frontend/query.go
@@ -41,9 +41,6 @@ func (s *VariableVisitor) EnterOC_SymbolicName(ctx *parser.OC_SymbolicNameContex
 	s.Variable.Symbol = ctx.GetText()
 }
 
-func (s *VariableVisitor) ExitOC_SymbolicName(ctx *parser.OC_SymbolicNameContext) {
-}
-
 type ProjectionVisitor struct {
 	BaseVisitor
 
@@ -61,9 +58,6 @@ func NewProjectionVisitor(ctx *parser.OC_ProjectionBodyContext) *ProjectionVisit
 	return &ProjectionVisitor{
 		Projection: model.NewProjection(distinct),
 	}
-}
-
-func (s *ProjectionVisitor) EnterOC_ProjectionBody(ctx *parser.OC_ProjectionBodyContext) {
 }
 
 func (s *ProjectionVisitor) ExitOC_ProjectionBody(ctx *parser.OC_ProjectionBodyContext) {
@@ -86,9 +80,6 @@ func (s *ProjectionVisitor) EnterOC_ProjectionItems(ctx *parser.OC_ProjectionIte
 	}
 }
 
-func (s *ProjectionVisitor) ExitOC_ProjectionItems(ctx *parser.OC_ProjectionItemsContext) {
-}
-
 func (s *ProjectionVisitor) EnterOC_ProjectionItem(ctx *parser.OC_ProjectionItemContext) {
 	s.currentItem = model.NewProjectionItem()
 }
@@ -107,9 +98,6 @@ func (s *ProjectionVisitor) ExitOC_Variable(ctx *parser.OC_VariableContext) {
 
 func (s *ProjectionVisitor) EnterOC_Order(ctx *parser.OC_OrderContext) {
 	s.Projection.Order = &model.Order{}
-}
-
-func (s *ProjectionVisitor) ExitOC_Order(ctx *parser.OC_OrderContext) {
 }
 
 func (s ProjectionVisitor) EnterOC_SortItem(ctx *parser.OC_SortItemContext) {
@@ -200,9 +188,6 @@ func (s *RangeLiteralVisitor) EnterOC_IntegerLiteral(ctx *parser.OC_IntegerLiter
 	} else {
 		s.PatternRange.EndIndex = &value
 	}
-}
-
-func (s *RangeLiteralVisitor) ExitOC_IntegerLiteral(ctx *parser.OC_IntegerLiteralContext) {
 }
 
 type WithVisitor struct {
@@ -337,9 +322,6 @@ func NewSinglePartQueryVisitor() *SinglePartQueryVisitor {
 
 func (s *SinglePartQueryVisitor) EnterOC_Return(ctx *parser.OC_ReturnContext) {
 	s.Query.Return = &model.Return{}
-}
-
-func (s *SinglePartQueryVisitor) ExitOC_Return(ctx *parser.OC_ReturnContext) {
 }
 
 func (s *SinglePartQueryVisitor) EnterOC_ProjectionBody(ctx *parser.OC_ProjectionBodyContext) {
@@ -730,12 +712,6 @@ func (s *PropertyExpressionVisitor) EnterOC_Atom(ctx *parser.OC_AtomContext) {
 
 func (s *PropertyExpressionVisitor) ExitOC_Atom(ctx *parser.OC_AtomContext) {
 	s.PropertyLookup.Atom = s.ctx.Exit().(*AtomVisitor).Atom
-}
-
-func (s *PropertyExpressionVisitor) EnterOC_PropertyLookup(ctx *parser.OC_PropertyLookupContext) {
-}
-
-func (s *PropertyExpressionVisitor) ExitOC_PropertyLookup(ctx *parser.OC_PropertyLookupContext) {
 }
 
 func (s *PropertyExpressionVisitor) EnterOC_PropertyKeyName(ctx *parser.OC_PropertyKeyNameContext) {

--- a/packages/go/cypher/model/copy.go
+++ b/packages/go/cypher/model/copy.go
@@ -18,6 +18,7 @@ package model
 
 import (
 	"fmt"
+
 	"github.com/specterops/bloodhound/dawgs/graph"
 )
 
@@ -137,6 +138,9 @@ func Copy[T any](value T, extensions ...CopyExtension[T]) T {
 	case *Create:
 		return any(typedValue.copy()).(T)
 
+	case *Merge:
+		return any(typedValue.copy()).(T)
+
 	case *KindMatcher:
 		return any(typedValue.copy()).(T)
 
@@ -219,6 +223,9 @@ func Copy[T any](value T, extensions ...CopyExtension[T]) T {
 		return any(copySlice(typedValue)).(T)
 
 	case []*ReadingClause:
+		return any(copySlice(typedValue)).(T)
+
+	case []*MergeAction:
 		return any(copySlice(typedValue)).(T)
 
 	case []Expression:

--- a/packages/go/cypher/model/model.go
+++ b/packages/go/cypher/model/model.go
@@ -410,7 +410,7 @@ type UpdatingClause struct {
 	Clause Expression
 }
 
-func NewUpdatingClause[T *Delete | *Remove | *Set | *Create](clause T) *UpdatingClause {
+func NewUpdatingClause[T *Delete | *Remove | *Set | *Create | *Merge](clause T) *UpdatingClause {
 	return &UpdatingClause{
 		Clause: clause,
 	}
@@ -427,6 +427,40 @@ func (s *UpdatingClause) copy() *UpdatingClause {
 		},
 
 		Clause: Copy(s.Clause),
+	}
+}
+
+type MergeAction struct {
+	OnCreate bool
+	OnMatch  bool
+	Set      *Set
+}
+
+func (s *MergeAction) copy() *MergeAction {
+	if s == nil {
+		return nil
+	}
+
+	return &MergeAction{
+		OnCreate: s.OnCreate,
+		OnMatch:  s.OnMatch,
+		Set:      Copy(s.Set),
+	}
+}
+
+type Merge struct {
+	PatternPart  *PatternPart
+	MergeActions []*MergeAction
+}
+
+func (s *Merge) copy() *Merge {
+	if s == nil {
+		return nil
+	}
+
+	return &Merge{
+		PatternPart:  Copy(s.PatternPart),
+		MergeActions: Copy(s.MergeActions),
 	}
 }
 

--- a/packages/go/cypher/model/walk.go
+++ b/packages/go/cypher/model/walk.go
@@ -269,7 +269,10 @@ func cypherModelCollect(nextCursor *WalkCursor, expression Expression) bool {
 
 	case *Merge:
 		Collect(nextCursor, typedExpr.PatternPart)
-		CollectExpression(nextCursor, typedExpr.MergeActions)
+		CollectSlice(nextCursor, typedExpr.MergeActions)
+
+	case *MergeAction:
+		Collect(nextCursor, typedExpr.Set)
 
 	case *Delete:
 		CollectExpressions(nextCursor, typedExpr.Expressions)

--- a/packages/go/cypher/model/walk.go
+++ b/packages/go/cypher/model/walk.go
@@ -18,6 +18,7 @@ package model
 
 import (
 	"fmt"
+
 	"github.com/specterops/bloodhound/dawgs/graph"
 )
 
@@ -265,6 +266,10 @@ func cypherModelCollect(nextCursor *WalkCursor, expression Expression) bool {
 
 	case *PartialArithmeticExpression:
 		CollectExpression(nextCursor, typedExpr.Right)
+
+	case *Merge:
+		Collect(nextCursor, typedExpr.PatternPart)
+		CollectExpression(nextCursor, typedExpr.MergeActions)
 
 	case *Delete:
 		CollectExpressions(nextCursor, typedExpr.Expressions)


### PR DESCRIPTION
## Description

Adds necessary plumbing to enable cypher MERGE clauses in our interpreter. This also means they are available when using the Cypher Search box in BloodHound, if `enable_cypher_mutations` is enabled.

## Motivation and Context

We are working on cost modeling for mutation queries (BED-4358), and this was a prerequisite since it turned out we hadn't wired in support for MERGE yet.

## How Has This Been Tested?

Ran through multiple scenarios manually:
- `MERGE (n:Hello {objectid:'hello'}) RETURN n` (x2 to ensure that an existing node prevents a node creation)
- `MERGE (n:Hello {objectid:'hello'}) SET n.hello = 'hello' RETURN n`
- `MERGE (n:Hello {objectid:'goodbye'}) ON CREATE SET n.hello = 'goodbye' RETURN n`
- `MERGE (n:Hello {objectid:'goodbye'}) ON MATCH SET n.hello = 'hello' RETURN n`
- `MERGE (n:Hello {objectid:'goodbye'}) ON CREATE SET n.hello = 'created' ON MATCH SET n.hello = 'matched' RETURN n`
- `MERGE (n:Hello {objectid:'goodbye'}) ON CREATE SET n.hello = 'created' ON MATCH SET n.hello = 'matched' SET n.always = 'always' RETURN n`
- `MERGE (n:Hello {objectid:'goodbye'}) ON CREATE SET n.hello = 'created' ON CREATE SET n.goodbye = 'created' ON MATCH n.hello = 'matched' ON MATCH SET n.goodbye = 'matched RETURN n`

No these are not good queries, but they do help exercise all parts of MERGE's formal grammar.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
