### PR TITLE
feat: add parameter parsing support to cypher frontend

### DIFF
--- a/packages/go/cypher/frontend/expression.go
+++ b/packages/go/cypher/frontend/expression.go
@@ -1,17 +1,17 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 package frontend
@@ -53,14 +53,8 @@ func (s *PropertiesVisitor) EnterOC_Parameter(ctx *parser.OC_ParameterContext) {
 }
 
 func (s *PropertiesVisitor) ExitOC_Parameter(ctx *parser.OC_ParameterContext) {
-	if symbolicName := s.ctx.Exit().(*SymbolicNameOrReservedWordVisitor).Name; symbolicName == "" {
-		s.Properties.Parameter = &model.Parameter{
-			Symbol: strings.TrimPrefix(ctx.GetText(), "$"),
-		}
-	} else {
-		s.Properties.Parameter = &model.Parameter{
-			Symbol: symbolicName,
-		}
+	s.Properties.Parameter = &model.Parameter{
+		Symbol: extractParameterSymbol(s.ctx, ctx),
 	}
 }
 

--- a/packages/go/cypher/test/cases/positive_tests.json
+++ b/packages/go/cypher/test/cases/positive_tests.json
@@ -74,6 +74,22 @@
             }
         },
         {
+            "name": "Run query with parameters",
+            "type": "string_match",
+            "details": {
+                "query": "match (p:Person) where p.name = $name return p.born.year",
+                "complexity": 2
+            }
+        },
+        {
+            "name": "Run query with complex parameters",
+            "type": "string_match",
+            "details": {
+                "query": "match (p:Person {value: $test}) where p.name = $1 and p.other in $array return p.name, p.born.year",
+                "complexity": 2
+            }
+        },
+        {
             "name": "Retrieve multiple node properties",
             "type": "string_match",
             "details": {


### PR DESCRIPTION
## Description

This is a minor change to support parsing out parameters from openCypher.

## Motivation and Context

This is applicable to upcoming openCypher translation work and is inline with other work currently under way in the openCypher parser frontend.

## How Has This Been Tested?

Added some additional test cases in the JSON query tests.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [x] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
