### PR TITLE
BED-4299  -- Display members of custom asset groups on Group Management

### DIFF
--- a/cmd/api/src/queries/graph_integration_test.go
+++ b/cmd/api/src/queries/graph_integration_test.go
@@ -295,19 +295,24 @@ func TestGetAssetGroupNodes(t *testing.T) {
 	}, func(harness integration.HarnessDetails, db graph.Database) {
 		graphQuery := queries.NewGraphQuery(db, cache.Cache{}, config.Configuration{})
 
-		tierZeroNodes, err := graphQuery.GetAssetGroupNodes(context.Background(), ad.AdminTierZero)
+		tierZeroNodes, err := graphQuery.GetAssetGroupNodes(context.Background(), harness.AssetGroupNodesHarness.TierZeroTag)
 		require.Nil(t, err)
 
-		customGroupNodes, err := graphQuery.GetAssetGroupNodes(context.Background(), "custom_tag")
+		customGroup1Nodes, err := graphQuery.GetAssetGroupNodes(context.Background(), harness.AssetGroupNodesHarness.CustomTag1)
+		require.Nil(t, err)
+
+		customGroup2Nodes, err := graphQuery.GetAssetGroupNodes(context.Background(), harness.AssetGroupNodesHarness.CustomTag2)
 		require.Nil(t, err)
 
 		require.True(t, tierZeroNodes.Contains(harness.AssetGroupNodesHarness.GroupB))
 		require.True(t, tierZeroNodes.Contains(harness.AssetGroupNodesHarness.GroupC))
 		require.Equal(t, 2, len(tierZeroNodes))
 
-		require.True(t, customGroupNodes.Contains(harness.AssetGroupNodesHarness.GroupD))
-		require.True(t, customGroupNodes.Contains(harness.AssetGroupNodesHarness.GroupE))
-		require.Equal(t, 2, len(customGroupNodes))
+		require.True(t, customGroup1Nodes.Contains(harness.AssetGroupNodesHarness.GroupD))
+		require.Equal(t, 1, len(customGroup1Nodes))
+
+		require.True(t, customGroup2Nodes.Contains(harness.AssetGroupNodesHarness.GroupE))
+		require.Equal(t, 1, len(customGroup2Nodes))
 	})
 }
 

--- a/cmd/api/src/test/integration/harnesses.go
+++ b/cmd/api/src/test/integration/harnesses.go
@@ -331,26 +331,34 @@ func (s *AssetGroupComboNodeHarness) Setup(testCtx *GraphTestContext) {
 }
 
 type AssetGroupNodesHarness struct {
-	GroupA *graph.Node
-	GroupB *graph.Node
-	GroupC *graph.Node
-	GroupD *graph.Node
-	GroupE *graph.Node
+	GroupA      *graph.Node
+	GroupB      *graph.Node
+	GroupC      *graph.Node
+	GroupD      *graph.Node
+	GroupE      *graph.Node
+	TierZeroTag string
+	CustomTag1  string
+	CustomTag2  string
 }
 
 func (s *AssetGroupNodesHarness) Setup(testCtx *GraphTestContext) {
 	domainSID := RandomDomainSID()
 
+	// use one tag value that contains the other as a substring to test that we only match exactly
+	s.TierZeroTag = ad.AdminTierZero
+	s.CustomTag1 = "custom_tag"
+	s.CustomTag2 = "another_custom_tag"
+
 	s.GroupA = testCtx.NewActiveDirectoryGroup("GroupA", domainSID)
 	s.GroupB = testCtx.NewActiveDirectoryGroup("GroupB", domainSID)
 	s.GroupC = testCtx.NewActiveDirectoryGroup("GroupC", domainSID)
 	s.GroupD = testCtx.NewActiveDirectoryGroup("GroupD", domainSID)
-	s.GroupE = testCtx.NewActiveDirectoryGroup("GroupD", domainSID)
+	s.GroupE = testCtx.NewActiveDirectoryGroup("GroupE", domainSID)
 
-	s.GroupB.Properties.Set(common.SystemTags.String(), ad.AdminTierZero)
-	s.GroupC.Properties.Set(common.SystemTags.String(), ad.AdminTierZero)
-	s.GroupD.Properties.Set(common.UserTags.String(), "custom_tag")
-	s.GroupE.Properties.Set(common.UserTags.String(), "custom_tag another_tag")
+	s.GroupB.Properties.Set(common.SystemTags.String(), s.TierZeroTag)
+	s.GroupC.Properties.Set(common.SystemTags.String(), s.TierZeroTag)
+	s.GroupD.Properties.Set(common.UserTags.String(), s.CustomTag1)
+	s.GroupE.Properties.Set(common.UserTags.String(), s.CustomTag2)
 
 	testCtx.UpdateNode(s.GroupB)
 	testCtx.UpdateNode(s.GroupC)


### PR DESCRIPTION
## Description
`GET api/v2/asset-groups/{asset_group_id}/members` currently only queries the `system_tags` property to determine AG membership. This means any custom asset groups created through the API will not return any results via this endpoint, since membership in those groups is stored on the `user_tags` property instead.

This fix updates the query to check for the asset group tag in both the `system_tags` and `user_tags` field. I also added a check after the query to filter out nodes that do not have an exact match in the tag list, due to the potential for naming collisions with our `StringContains` query (for example, a custom asset group with tag `test_tag_1` also pulling in nodes with tag `test_tag`).

## Motivation and Context
If a user is creating custom asset groups via the API, we want them to be able to view and modify those asset groups via the Group Management page (or the `api/v2/asset-groups/{asset_group_id}/members` endpoint).

## How Has This Been Tested?
- Added integration tests to our graph query to make sure it returns custom groups
- Manual testing locally by creating a custom asset group, adding members, and checking the endpoint/group management page

## Screenshots (if appropriate):
<img width="1102" alt="Screenshot 2024-05-21 at 2 08 09 PM" src="https://github.com/SpecterOps/BloodHound/assets/16313351/e03f4946-1b8b-4a1d-b4ad-c3f99065b64e">

## Types of changes
-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
-   [ ] Documentation updates are needed, and have been made accordingly.
-   [x] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
