### PR TITLE
fix: errantly adding AZHasRole edge to non-tenant scoped principals

### DIFF
--- a/packages/go/analysis/azure/azure.go
+++ b/packages/go/analysis/azure/azure.go
@@ -104,13 +104,3 @@ func AzureNonDescentKinds() graph.Kinds {
 		azure.RunsAs,
 	}
 }
-
-func AzureIgnoredKinds() graph.Kinds {
-	return []graph.Kind{
-		azure.ScopedTo,
-		azure.Contains,
-		azure.GlobalAdmin,
-		azure.PrivilegedRoleAdmin,
-		azure.PrivilegedAuthAdmin,
-	}
-}

--- a/packages/go/ein/azure.go
+++ b/packages/go/ein/azure.go
@@ -672,17 +672,6 @@ func ConvertAzureRoleAssignmentToRels(roleAssignment azure2.UnifiedRoleAssignmen
 		scope = strings.ToUpper(roleAssignment.DirectoryScopeId[1:])
 	}
 
-	relationships = append(relationships, IngestibleRelationship{
-		Source:     strings.ToUpper(roleAssignment.PrincipalId),
-		SourceType: azure.Entity,
-		TargetType: azure.Role,
-		Target:     roleObjectId,
-		RelProps: map[string]any{
-			azure.Scope.String(): scope,
-		},
-		RelType: azure.HasRole,
-	})
-
 	if CanAddSecret(roleAssignment.RoleDefinitionId) && roleAssignment.DirectoryScopeId != "/" {
 		if relType, err := GetAddSecretRoleKind(roleAssignment.RoleDefinitionId); err != nil {
 			log.Errorf("Error processing role assignment for role %s: %v", roleObjectId, err)
@@ -696,6 +685,17 @@ func ConvertAzureRoleAssignmentToRels(roleAssignment azure2.UnifiedRoleAssignmen
 				RelType:    relType,
 			})
 		}
+	} else {
+		relationships = append(relationships, IngestibleRelationship{
+			Source:     strings.ToUpper(roleAssignment.PrincipalId),
+			SourceType: azure.Entity,
+			TargetType: azure.Role,
+			Target:     roleObjectId,
+			RelProps: map[string]any{
+				azure.Scope.String(): scope,
+			},
+			RelType: azure.HasRole,
+		})
 	}
 
 	return relationships


### PR DESCRIPTION
Closes BED-4380
## Description

Stop `AZHasRole` edge from being created for appadmin / cloudappadmin for app scoped relationships
Also cleaned up some unused constants found

## Motivation and Context

These edges were errantly created and shouldn't exist.

## How Has This Been Tested?

Ran Azurehound and verified edge wasn't created.

Run the following in explore
```
match p = ()-[:AZAppAdmin|:AZCloudAppAdmin]->()
return p
```
Pick one and find the path from principal to the app service principal. The edge for `AZHasRole `should be removed

## Types of changes

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
