### PR TITLE
remove hardcoded python version from dockerfile

### DIFF
--- a/cmd/api/src/api/auth.go
+++ b/cmd/api/src/api/auth.go
@@ -269,7 +269,7 @@ func (s authenticator) ValidateRequestSignature(tokenID uuid.UUID, request *http
 			}
 		}
 
-		if digestNow, err := NewRequestSignature(sha256.New, authToken.Key, requestDate.Format(time.RFC3339), request.Method, request.RequestURI, teeReader); err != nil {
+		if digestNow, err := NewRequestSignature(request.Context(), sha256.New, authToken.Key, requestDate.Format(time.RFC3339), request.Method, request.RequestURI, teeReader); err != nil {
 			if readCloser != nil {
 				readCloser.Close()
 			}

--- a/cmd/api/src/api/auth_internal_test.go
+++ b/cmd/api/src/api/auth_internal_test.go
@@ -213,7 +213,7 @@ func TestValidateRequestSignature(t *testing.T) {
 		require.NoError(t, err)
 
 		req.Header.Add(headers.RequestDate.String(), time.Now().Format(time.RFC3339))
-		signature, err := NewRequestSignature(sha256.New, "token", time.Now().Format(time.RFC3339), req.Method, req.RequestURI, nil)
+		signature, err := NewRequestSignature(context.Background(), sha256.New, "token", time.Now().Format(time.RFC3339), req.Method, req.RequestURI, nil)
 		require.NoError(t, err)
 		req.Header.Add(headers.Signature.String(), base64.StdEncoding.EncodeToString(signature))
 
@@ -235,7 +235,7 @@ func TestValidateRequestSignature(t *testing.T) {
 		require.NoError(t, err)
 
 		req.Header.Add(headers.RequestDate.String(), time.Now().Format(time.RFC3339))
-		signature, err := NewRequestSignature(sha256.New, "token", time.Now().Format(time.RFC3339), req.Method, req.RequestURI, nil)
+		signature, err := NewRequestSignature(context.Background(), sha256.New, "token", time.Now().Format(time.RFC3339), req.Method, req.RequestURI, nil)
 		require.NoError(t, err)
 		req.Header.Add(headers.Signature.String(), base64.StdEncoding.EncodeToString(signature))
 
@@ -260,7 +260,7 @@ func TestValidateRequestSignature(t *testing.T) {
 		require.NoError(t, err)
 
 		req.Header.Add(headers.RequestDate.String(), time.Now().Format(time.RFC3339))
-		signature, err := NewRequestSignature(sha256.New, "token", time.Now().Format(time.RFC3339), req.Method, req.RequestURI, nil)
+		signature, err := NewRequestSignature(context.Background(), sha256.New, "token", time.Now().Format(time.RFC3339), req.Method, req.RequestURI, nil)
 		require.NoError(t, err)
 		req.Header.Add(headers.Signature.String(), base64.StdEncoding.EncodeToString(signature))
 
@@ -290,7 +290,7 @@ func TestValidateRequestSignature(t *testing.T) {
 
 		badRequestDate := time.Now().Add(-1 * time.Hour).Format(time.RFC3339)
 		req.Header.Add(headers.RequestDate.String(), badRequestDate)
-		signature, err := NewRequestSignature(sha256.New, "token", time.Now().Format(time.RFC3339), req.Method, req.RequestURI, nil)
+		signature, err := NewRequestSignature(context.Background(), sha256.New, "token", time.Now().Format(time.RFC3339), req.Method, req.RequestURI, nil)
 		require.NoError(t, err)
 		req.Header.Add(headers.Signature.String(), base64.StdEncoding.EncodeToString(signature))
 
@@ -317,7 +317,7 @@ func TestValidateRequestSignature(t *testing.T) {
 
 		req.ContentLength = int64(len(payload))
 		req.Header.Add(headers.RequestDate.String(), time.Now().Format(time.RFC3339))
-		signature, err := NewRequestSignature(sha256.New, "token", time.Now().Format(time.RFC3339), req.Method, req.RequestURI, bytes.NewBuffer(payload))
+		signature, err := NewRequestSignature(context.Background(), sha256.New, "token", time.Now().Format(time.RFC3339), req.Method, req.RequestURI, bytes.NewBuffer(payload))
 		require.NoError(t, err)
 		req.Header.Add(headers.Signature.String(), base64.StdEncoding.EncodeToString(signature))
 
@@ -359,7 +359,7 @@ func TestValidateRequestSignature(t *testing.T) {
 
 		req.ContentLength = int64(len(payload) - 1)
 		req.Header.Add(headers.RequestDate.String(), time.Now().Format(time.RFC3339))
-		signature, err := NewRequestSignature(sha256.New, "token", time.Now().Format(time.RFC3339), req.Method, req.RequestURI, bytes.NewBuffer(payload))
+		signature, err := NewRequestSignature(context.Background(), sha256.New, "token", time.Now().Format(time.RFC3339), req.Method, req.RequestURI, bytes.NewBuffer(payload))
 		require.NoError(t, err)
 		req.Header.Add(headers.Signature.String(), base64.StdEncoding.EncodeToString(signature))
 
@@ -392,7 +392,7 @@ func TestValidateRequestSignature(t *testing.T) {
 
 		datetime := time.Now().Format(time.RFC3339)
 		req.Header.Add(headers.RequestDate.String(), datetime)
-		signature, err := NewRequestSignature(sha256.New, "badtoken", datetime, http.MethodGet, req.RequestURI, nil)
+		signature, err := NewRequestSignature(context.Background(), sha256.New, "badtoken", datetime, http.MethodGet, req.RequestURI, nil)
 		require.NoError(t, err)
 		req.Header.Add(headers.Signature.String(), base64.StdEncoding.EncodeToString(signature))
 
@@ -420,7 +420,7 @@ func TestValidateRequestSignature(t *testing.T) {
 
 		datetime := time.Now().Format(time.RFC3339)
 		req.Header.Add(headers.RequestDate.String(), datetime)
-		signature, err := NewRequestSignature(sha256.New, "token", datetime, req.Method, req.RequestURI, nil)
+		signature, err := NewRequestSignature(context.Background(), sha256.New, "token", datetime, req.Method, req.RequestURI, nil)
 		require.NoError(t, err)
 		req.Header.Add(headers.Signature.String(), base64.StdEncoding.EncodeToString(signature))
 

--- a/cmd/api/src/api/auth_test.go
+++ b/cmd/api/src/api/auth_test.go
@@ -1,0 +1,64 @@
+package api_test
+
+import (
+	"context"
+	"crypto/sha256"
+	"github.com/specterops/bloodhound/headers"
+	"github.com/specterops/bloodhound/src/api"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func Test_NewRequestSignature(t *testing.T) {
+	t.Run("returns error on context timeout", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		req, err := http.NewRequest(http.MethodGet, "http://teapotsrus.dev", nil)
+		require.NoError(t, err)
+
+		req.Header.Add(headers.RequestDate.String(), time.Now().Format(time.RFC3339))
+
+		goCtx, cancel := context.WithDeadline(context.Background(), time.Now())
+		defer cancel()
+		time.Sleep(1 * time.Microsecond)
+		_, err = api.NewRequestSignature(goCtx, sha256.New, "token", time.Now().Format(time.RFC3339), req.Method, req.RequestURI, nil)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "context deadline exceeded")
+	})
+
+	t.Run("returns error on empty hmac signature", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		req, err := http.NewRequest(http.MethodGet, "http://teapotsrus.dev", nil)
+		require.NoError(t, err)
+
+		req.Header.Add(headers.RequestDate.String(), time.Now().Format(time.RFC3339))
+
+		goCtx, cancel := context.WithDeadline(context.Background(), time.Now().Add(5*time.Second))
+		defer cancel()
+		_, err = api.NewRequestSignature(goCtx, nil, "token", time.Now().Format(time.RFC3339), req.Method, req.RequestURI, nil)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "hasher must not be nil")
+	})
+
+	t.Run("success", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		req, err := http.NewRequest(http.MethodGet, "http://teapotsrus.dev", nil)
+		require.NoError(t, err)
+
+		req.Header.Add(headers.RequestDate.String(), time.Now().Format(time.RFC3339))
+
+		goCtx, cancel := context.WithDeadline(context.Background(), time.Now().Add(5*time.Second))
+		defer cancel()
+		signature, err := api.NewRequestSignature(goCtx, sha256.New, "token", time.Now().Format(time.RFC3339), req.Method, req.RequestURI, nil)
+		require.Nil(t, err)
+		require.NotEmpty(t, signature)
+	})
+}

--- a/cmd/api/src/api/middleware/middleware.go
+++ b/cmd/api/src/api/middleware/middleware.go
@@ -85,7 +85,7 @@ func getScheme(request *http.Request) string {
 	}
 }
 
-func requestWaitDuration(request *http.Request) (time.Duration, error) {
+func RequestWaitDuration(request *http.Request) (time.Duration, error) {
 	var (
 		requestedWaitDuration time.Duration
 		err                   error
@@ -114,7 +114,7 @@ func ContextMiddleware(next http.Handler) http.Handler {
 			requestID = newUUID.String()
 		}
 
-		if requestedWaitDuration, err := requestWaitDuration(request); err != nil {
+		if requestedWaitDuration, err := RequestWaitDuration(request); err != nil {
 			// If there is a failure or other expectation mismatch with the client, respond right away with the relevant
 			// error information
 			api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, fmt.Sprintf("Prefer header has an invalid value: %v", err), request), response)

--- a/cmd/api/src/api/middleware/middleware_internal_test.go
+++ b/cmd/api/src/api/middleware/middleware_internal_test.go
@@ -60,7 +60,7 @@ func TestRequestWaitDuration_Failure(t *testing.T) {
 	req.Header.Set(headers.Prefer.String(), "wait=1.5")
 	req.URL.RawQuery = q.Encode()
 
-	_, err = requestWaitDuration(req)
+	_, err = RequestWaitDuration(req)
 	require.NotNil(t, err)
 }
 
@@ -74,7 +74,7 @@ func TestRequestWaitDuration(t *testing.T) {
 	req.Header.Set(headers.Prefer.String(), "wait=1")
 	req.URL.RawQuery = q.Encode()
 
-	requestedWaitDuration, err := requestWaitDuration(req)
+	requestedWaitDuration, err := RequestWaitDuration(req)
 	require.Nil(t, err)
 	require.Equal(t, 1*time.Second, requestedWaitDuration)
 }

--- a/cmd/api/src/api/registration/registration.go
+++ b/cmd/api/src/api/registration/registration.go
@@ -40,7 +40,7 @@ func RegisterFossGlobalMiddleware(routerInst *router.Router, cfg config.Configur
 
 	// Set up logging. This must be done after ContextMiddleware is initialized so the context can be accessed in the log logic
 	if cfg.EnableAPILogging {
-		routerInst.UsePrerouting(middleware.LoggingMiddleware(cfg, identityResolver, db))
+		routerInst.UsePrerouting(middleware.LoggingMiddleware(identityResolver))
 	}
 
 	routerInst.UsePostrouting(

--- a/cmd/api/src/api/v2/file_uploads.go
+++ b/cmd/api/src/api/v2/file_uploads.go
@@ -19,12 +19,6 @@ package v2
 import (
 	"errors"
 	"fmt"
-	"mime"
-	"net/http"
-	"slices"
-	"strconv"
-	"strings"
-
 	"github.com/gorilla/mux"
 	"github.com/specterops/bloodhound/headers"
 	"github.com/specterops/bloodhound/log"
@@ -35,6 +29,11 @@ import (
 	ingestModel "github.com/specterops/bloodhound/src/model/ingest"
 	"github.com/specterops/bloodhound/src/services/fileupload"
 	"github.com/specterops/bloodhound/src/services/ingest"
+	"mime"
+	"net/http"
+	"slices"
+	"strconv"
+	"strings"
 )
 
 const FileUploadJobIdPathParameterName = "file_upload_job_id"

--- a/cmd/api/src/config/config.go
+++ b/cmd/api/src/config/config.go
@@ -142,7 +142,6 @@ type DefaultAdminConfiguration struct {
 type Configuration struct {
 	Version                      int                       `json:"version"`
 	BindAddress                  string                    `json:"bind_addr"`
-	NetTimeoutSeconds            int                       `json:"net_timeout_seconds"`
 	SlowQueryThreshold           int64                     `json:"slow_query_threshold"`
 	MaxGraphQueryCacheSize       int                       `json:"max_graphdb_cache_size"`
 	MaxAPICacheSize              int                       `json:"max_api_cache_size"`

--- a/cmd/api/src/config/default.go
+++ b/cmd/api/src/config/default.go
@@ -36,7 +36,6 @@ func NewDefaultConfiguration() (Configuration, error) {
 		return Configuration{
 			Version:                      0,
 			BindAddress:                  "127.0.0.1",
-			NetTimeoutSeconds:            70,  // Default timeout to avoid race conditions with 60 second gateway timeouts
 			SlowQueryThreshold:           100, // Threshold in ms for caching queries
 			MaxGraphQueryCacheSize:       100, // Number of cache items for graph queries
 			MaxAPICacheSize:              200, // Number of cache items for API utilities

--- a/cmd/api/src/daemons/api/bhapi/api.go
+++ b/cmd/api/src/daemons/api/bhapi/api.go
@@ -18,12 +18,10 @@ package bhapi
 
 import (
 	"context"
-	"net/http"
-	"time"
-
 	"github.com/specterops/bloodhound/errors"
 	"github.com/specterops/bloodhound/log"
 	"github.com/specterops/bloodhound/src/config"
+	"net/http"
 )
 
 // Daemon holds data relevant to the API daemon
@@ -34,17 +32,12 @@ type Daemon struct {
 
 // NewDaemon creates a new API daemon
 func NewDaemon(cfg config.Configuration, handler http.Handler) Daemon {
-	networkTimeout := time.Duration(cfg.NetTimeoutSeconds) * time.Second
-
 	return Daemon{
 		cfg: cfg,
 		server: &http.Server{
-			Addr:         cfg.BindAddress,
-			Handler:      handler,
-			WriteTimeout: networkTimeout,
-			ReadTimeout:  networkTimeout,
-			IdleTimeout:  networkTimeout,
-			ErrorLog:     log.Adapter(log.LevelError, "BHAPI", 0),
+			Addr:     cfg.BindAddress,
+			Handler:  handler,
+			ErrorLog: log.Adapter(log.LevelError, "BHAPI", 0),
 		},
 	}
 }

--- a/cmd/api/src/daemons/api/toolapi/api.go
+++ b/cmd/api/src/daemons/api/toolapi/api.go
@@ -18,14 +18,12 @@ package toolapi
 
 import (
 	"context"
-	"net/http"
-	"net/http/pprof"
-	"time"
-
 	"github.com/specterops/bloodhound/dawgs/graph"
 	"github.com/specterops/bloodhound/errors"
 	"github.com/specterops/bloodhound/src/bootstrap"
 	"github.com/specterops/bloodhound/src/database"
+	"net/http"
+	"net/http/pprof"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -42,10 +40,9 @@ type Daemon struct {
 
 func NewDaemon[DBType database.Database](ctx context.Context, connections bootstrap.DatabaseConnections[DBType, *graph.DatabaseSwitch], cfg config.Configuration, graphSchema graph.Schema, extensions ...func(router *chi.Mux)) Daemon {
 	var (
-		networkTimeout = time.Duration(cfg.NetTimeoutSeconds) * time.Second
-		pgMigrator     = tools.NewPGMigrator(ctx, cfg, graphSchema, connections.Graph)
-		router         = chi.NewRouter()
-		toolContainer  = tools.NewToolContainer(connections.RDMS)
+		pgMigrator    = tools.NewPGMigrator(ctx, cfg, graphSchema, connections.Graph)
+		router        = chi.NewRouter()
+		toolContainer = tools.NewToolContainer(connections.RDMS)
 	)
 
 	router.Mount("/metrics", promhttp.Handler())
@@ -82,12 +79,9 @@ func NewDaemon[DBType database.Database](ctx context.Context, connections bootst
 	return Daemon{
 		cfg: cfg,
 		server: &http.Server{
-			Addr:         cfg.MetricsPort,
-			Handler:      router,
-			WriteTimeout: networkTimeout,
-			ReadTimeout:  networkTimeout,
-			IdleTimeout:  networkTimeout,
-			ErrorLog:     log.Adapter(log.LevelError, "ToolAPI", 0),
+			Addr:     cfg.MetricsPort,
+			Handler:  router,
+			ErrorLog: log.Adapter(log.LevelError, "ToolAPI", 0),
 		},
 	}
 }

--- a/cmd/api/src/model/appcfg/flag.go
+++ b/cmd/api/src/model/appcfg/flag.go
@@ -32,6 +32,7 @@ const (
 	FeatureAdcs                       = "adcs"
 	FeatureClearGraphData             = "clear_graph_data"
 	FeatureRiskExposureNewCalculation = "risk_exposure_new_calculation"
+	FeatureFedRAMPEULA                = "fedramp_eula"
 )
 
 // AvailableFlags returns a FeatureFlagSet of expected feature flags. Feature flag defaults introduced here will become the initial
@@ -98,6 +99,13 @@ func AvailableFlags() FeatureFlagSet {
 			Key:           FeatureRiskExposureNewCalculation,
 			Name:          "Use new tier zero risk exposure calculation",
 			Description:   "Enables the use of new tier zero risk exposure metatree metrics.",
+			Enabled:       false,
+			UserUpdatable: false,
+		},
+		FeatureFedRAMPEULA: {
+			Key:           FeatureFedRAMPEULA,
+			Name:          "FedRAMP EULA",
+			Description:   "Enables showing the FedRAMP EULA on every login. (Enterprise only)",
 			Enabled:       false,
 			UserUpdatable: false,
 		},

--- a/cmd/api/src/queries/graph_integration_test.go
+++ b/cmd/api/src/queries/graph_integration_test.go
@@ -287,6 +287,35 @@ func TestGetAssetGroupComboNode(t *testing.T) {
 	})
 }
 
+func TestGetAssetGroupNodes(t *testing.T) {
+	testContext := integration.NewGraphTestContext(t, schema.DefaultGraphSchema())
+	testContext.DatabaseTestWithSetup(func(harness *integration.HarnessDetails) error {
+		harness.AssetGroupNodesHarness.Setup(testContext)
+		return nil
+	}, func(harness integration.HarnessDetails, db graph.Database) {
+		graphQuery := queries.NewGraphQuery(db, cache.Cache{}, config.Configuration{})
+
+		tierZeroNodes, err := graphQuery.GetAssetGroupNodes(context.Background(), harness.AssetGroupNodesHarness.TierZeroTag)
+		require.Nil(t, err)
+
+		customGroup1Nodes, err := graphQuery.GetAssetGroupNodes(context.Background(), harness.AssetGroupNodesHarness.CustomTag1)
+		require.Nil(t, err)
+
+		customGroup2Nodes, err := graphQuery.GetAssetGroupNodes(context.Background(), harness.AssetGroupNodesHarness.CustomTag2)
+		require.Nil(t, err)
+
+		require.True(t, tierZeroNodes.Contains(harness.AssetGroupNodesHarness.GroupB))
+		require.True(t, tierZeroNodes.Contains(harness.AssetGroupNodesHarness.GroupC))
+		require.Equal(t, 2, len(tierZeroNodes))
+
+		require.True(t, customGroup1Nodes.Contains(harness.AssetGroupNodesHarness.GroupD))
+		require.Equal(t, 1, len(customGroup1Nodes))
+
+		require.True(t, customGroup2Nodes.Contains(harness.AssetGroupNodesHarness.GroupE))
+		require.Equal(t, 1, len(customGroup2Nodes))
+	})
+}
+
 func TestGraphQuery_GetAllShortestPaths(t *testing.T) {
 	testContext := integration.NewGraphTestContext(t, schema.DefaultGraphSchema())
 	testContext.DatabaseTestWithSetup(

--- a/cmd/api/src/test/integration/harnesses.go
+++ b/cmd/api/src/test/integration/harnesses.go
@@ -330,6 +330,42 @@ func (s *AssetGroupComboNodeHarness) Setup(testCtx *GraphTestContext) {
 	testCtx.NewRelationship(s.GroupA, s.GroupB, ad.MemberOf)
 }
 
+type AssetGroupNodesHarness struct {
+	GroupA      *graph.Node
+	GroupB      *graph.Node
+	GroupC      *graph.Node
+	GroupD      *graph.Node
+	GroupE      *graph.Node
+	TierZeroTag string
+	CustomTag1  string
+	CustomTag2  string
+}
+
+func (s *AssetGroupNodesHarness) Setup(testCtx *GraphTestContext) {
+	domainSID := RandomDomainSID()
+
+	// use one tag value that contains the other as a substring to test that we only match exactly
+	s.TierZeroTag = ad.AdminTierZero
+	s.CustomTag1 = "custom_tag"
+	s.CustomTag2 = "another_custom_tag"
+
+	s.GroupA = testCtx.NewActiveDirectoryGroup("GroupA", domainSID)
+	s.GroupB = testCtx.NewActiveDirectoryGroup("GroupB", domainSID)
+	s.GroupC = testCtx.NewActiveDirectoryGroup("GroupC", domainSID)
+	s.GroupD = testCtx.NewActiveDirectoryGroup("GroupD", domainSID)
+	s.GroupE = testCtx.NewActiveDirectoryGroup("GroupE", domainSID)
+
+	s.GroupB.Properties.Set(common.SystemTags.String(), s.TierZeroTag)
+	s.GroupC.Properties.Set(common.SystemTags.String(), s.TierZeroTag)
+	s.GroupD.Properties.Set(common.UserTags.String(), s.CustomTag1)
+	s.GroupE.Properties.Set(common.UserTags.String(), s.CustomTag2)
+
+	testCtx.UpdateNode(s.GroupB)
+	testCtx.UpdateNode(s.GroupC)
+	testCtx.UpdateNode(s.GroupD)
+	testCtx.UpdateNode(s.GroupE)
+}
+
 type InboundControlHarness struct {
 	ControlledUser  *graph.Node
 	ControlledGroup *graph.Node
@@ -6833,6 +6869,7 @@ type HarnessDetails struct {
 	OutboundControl                                 OutboundControlHarness
 	InboundControl                                  InboundControlHarness
 	AssetGroupComboNodeHarness                      AssetGroupComboNodeHarness
+	AssetGroupNodesHarness                          AssetGroupNodesHarness
 	OUHarness                                       OUContainedHarness
 	MembershipHarness                               MembershipHarness
 	ForeignHarness                                  ForeignDomainHarness

--- a/dockerfiles/bloodhound.Dockerfile
+++ b/dockerfiles/bloodhound.Dockerfile
@@ -32,7 +32,7 @@ ENV CHECKOUT_HASH=${checkout_hash}
 WORKDIR /bloodhound
 
 RUN apk add --update --no-cache python3 git go
-RUN rm /usr/lib/python3.11/EXTERNALLY-MANAGED
+RUN find /usr/lib -name EXTERNALLY-MANAGED -delete
 RUN python3 -m ensurepip
 RUN pip3 install --no-cache --upgrade pip setuptools
 


### PR DESCRIPTION
## Description
A recent run of the "Publish Edge Build" action failed after a merge: https://github.com/SpecterOps/BloodHound/actions/runs/9197923729/job/25299465051

The error was a python version conflict in our dockerfile between the version installed by the `apk add python3` command (v3.12) and a hardcoded reference to v3.11 later in the file. That reference existed to remove the `EXTERNALLY_MANAGED` python flag, fixing another bug that was originally addressed here: https://github.com/SpecterOps/BloodHound/pull/267

This fix updates the command to remove that flag with a command that does not rely on an exact version number.

## Motivation and Context
Will allow our build to run successfully regardless of what version of python is installed.

## How Has This Been Tested?
Tested by building locally: `docker build . -f dockerfiles/bloodhound.Dockerfile`

## Screenshots (if appropriate):

## Types of changes
-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
