### PR TITLE
Remove version number from python command in dockerfile

### DIFF
--- a/dockerfiles/bloodhound.Dockerfile
+++ b/dockerfiles/bloodhound.Dockerfile
@@ -32,7 +32,7 @@ ENV CHECKOUT_HASH=${checkout_hash}
 WORKDIR /bloodhound
 
 RUN apk add --update --no-cache python3 git go
-RUN rm /usr/lib/python3.11/EXTERNALLY-MANAGED
+RUN find /usr/lib -name EXTERNALLY-MANAGED -delete
 RUN python3 -m ensurepip
 RUN pip3 install --no-cache --upgrade pip setuptools
 


### PR DESCRIPTION
## Description
A recent run of the "Publish Edge Build" action failed after a merge: https://github.com/SpecterOps/BloodHound/actions/runs/9197923729/job/25299465051

The error was a python version conflict in our dockerfile between the version installed by the `apk add python3` command (v3.12) and a hardcoded reference to v3.11 later in the file. That reference existed to remove the `EXTERNALLY_MANAGED` python flag, fixing another bug that was originally addressed here: https://github.com/SpecterOps/BloodHound/pull/267

This fix updates the command to remove that flag with a command that does not rely on an exact version number.

## Motivation and Context
Will allow our build to run successfully regardless of what version of python is installed.

## How Has This Been Tested?
Tested by building locally: `docker build . -f dockerfiles/bloodhound.Dockerfile`

## Screenshots (if appropriate):

## Types of changes
-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
