### PR TITLE
BED-4431 -- Add webgl compatibility check to Explore page

### DIFF
--- a/cmd/api/src/api/auth_test.go
+++ b/cmd/api/src/api/auth_test.go
@@ -1,3 +1,19 @@
+// Copyright 2024 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package api_test
 
 import (

--- a/cmd/ui/src/views/Explore/GraphView.tsx
+++ b/cmd/ui/src/views/Explore/GraphView.tsx
@@ -146,11 +146,7 @@ const GraphView: FC = () => {
     if (isError) throw new Error();
 
     if (!isWebGLEnabled()) {
-        return (
-            <Box position={'relative'} height={'100%'} width={'100%'} overflow={'hidden'}>
-                <WebGLDisabledAlert />
-            </Box>
-        );
+        return <WebGLDisabledAlert />;
     }
 
     if (!data.length)

--- a/cmd/ui/src/views/Explore/GraphView.tsx
+++ b/cmd/ui/src/views/Explore/GraphView.tsx
@@ -23,6 +23,8 @@ import {
     setEdgeInfoOpen,
     setSelectedEdge,
     useAvailableDomains,
+    isWebGLEnabled,
+    WebGLDisabledAlert,
 } from 'bh-shared-ui';
 import { MultiDirectedGraph } from 'graphology';
 import { random } from 'graphology-layout';
@@ -142,6 +144,14 @@ const GraphView: FC = () => {
     );
 
     if (isError) throw new Error();
+
+    if (!isWebGLEnabled()) {
+        return (
+            <Box position={'relative'} height={'100%'} width={'100%'} overflow={'hidden'}>
+                <WebGLDisabledAlert />
+            </Box>
+        );
+    }
 
     if (!data.length)
         return (

--- a/packages/javascript/bh-shared-ui/src/components/WebGLDisabledAlert/WebGLDisabledAlert.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/WebGLDisabledAlert/WebGLDisabledAlert.tsx
@@ -1,0 +1,34 @@
+// Copyright 2024 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { Alert, AlertTitle, Box, useTheme } from '@mui/material';
+
+const WebGLDisabledAlert = () => {
+    const theme = useTheme();
+    return (
+        <Box display={'flex'} justifyContent={'center'} mt={theme.spacing(8)} mx={theme.spacing(4)}>
+            <Alert severity={'error'}>
+                <AlertTitle>WebGL Not Supported</AlertTitle>
+                <p>
+                    This page requires WebGL to render. Please enable WebGL in your browser settings or switch to a
+                    browser that supports this feature.
+                </p>
+            </Alert>
+        </Box>
+    );
+};
+
+export default WebGLDisabledAlert;

--- a/packages/javascript/bh-shared-ui/src/components/WebGLDisabledAlert/index.ts
+++ b/packages/javascript/bh-shared-ui/src/components/WebGLDisabledAlert/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2023 Specter Ops, Inc.
+// Copyright 2024 Specter Ops, Inc.
 //
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
@@ -14,14 +14,4 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-export * from './api';
-export * from './compatibility';
-export * from './content';
-export * from './datetime';
-export * from './exportGraphData';
-export * from './entityInfoDisplay';
-export * from './passwd';
-export * from './user';
-export * from './icons';
-export * from './permissions';
-export * from './copyToClipboard';
+export { default } from './WebGLDisabledAlert';

--- a/packages/javascript/bh-shared-ui/src/components/index.ts
+++ b/packages/javascript/bh-shared-ui/src/components/index.ts
@@ -143,3 +143,6 @@ export { default as GroupManagementContent } from './GroupManagementContent';
 
 export * from './FileIngest';
 export { default as FileIngest } from './FileIngest';
+
+export * from './WebGLDisabledAlert';
+export { default as WebGLDisabledAlert } from './WebGLDisabledAlert';

--- a/packages/javascript/bh-shared-ui/src/mocks/index.ts
+++ b/packages/javascript/bh-shared-ui/src/mocks/index.ts
@@ -15,3 +15,4 @@
 // SPDX-License-Identifier: Apache-2.0
 
 export * from './factories';
+export * from './webgl';

--- a/packages/javascript/bh-shared-ui/src/mocks/webgl.ts
+++ b/packages/javascript/bh-shared-ui/src/mocks/webgl.ts
@@ -1,0 +1,43 @@
+// Copyright 2024 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// This mock can be used in tests for components that contain webGL functionality, and will cause our built-in
+// compatibility checks to behave as if webGL is enabled.
+export const setupWebGLMocks = () => {
+    const originalRenderingContext = window.WebGLRenderingContext;
+    const originalCreateElement = document.createElement.bind(document);
+
+    const enableWebGLMocks = () => {
+        window.WebGLRenderingContext = true as any;
+
+        document.createElement = vi.fn((tagName: string) => {
+            if (tagName === 'canvas') {
+                return {
+                    getContext: (contextName: string) => !!(contextName === 'webgl'),
+                };
+            } else {
+                return originalCreateElement(tagName);
+            }
+        }) as any;
+    };
+
+    const disableWebGLMocks = () => {
+        window.WebGLRenderingContext = originalRenderingContext;
+        document.createElement = originalCreateElement;
+    };
+
+    return { enableWebGLMocks, disableWebGLMocks };
+};

--- a/packages/javascript/bh-shared-ui/src/utils/compatibility.test.ts
+++ b/packages/javascript/bh-shared-ui/src/utils/compatibility.test.ts
@@ -15,41 +15,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { isWebGLEnabled } from '.';
-
-const setupMocks = () => {
-    const originalRenderingContext = window.WebGLRenderingContext;
-    const originalCreateElement = document.createElement;
-
-    const enableWebGLMock = () => {
-        window.WebGLRenderingContext = true as any;
-
-        document.createElement = vi.fn((tagName: string) => {
-            if (tagName === 'canvas') {
-                return {
-                    getContext: (contextName: string) => {
-                        return !!(contextName === 'webgl');
-                    },
-                };
-            } else {
-                return originalCreateElement(tagName);
-            }
-        }) as any;
-    };
-
-    const disableWebGLMock = () => {
-        window.WebGLRenderingContext = originalRenderingContext;
-        document.createElement = originalCreateElement;
-    };
-
-    return { enableWebGLMock, disableWebGLMock };
-};
+import { setupWebGLMocks } from '../mocks';
 
 describe('WebGL compatibility check', () => {
-    const mocks = setupMocks();
-    afterEach(() => mocks.disableWebGLMock());
+    const mocks = setupWebGLMocks();
+    afterEach(() => mocks.disableWebGLMocks());
 
     it('returns true when WebGL is available in the current browser context', () => {
-        mocks.enableWebGLMock();
+        mocks.enableWebGLMocks();
         expect(isWebGLEnabled()).toBe(true);
     });
 

--- a/packages/javascript/bh-shared-ui/src/utils/compatibility.test.ts
+++ b/packages/javascript/bh-shared-ui/src/utils/compatibility.test.ts
@@ -27,11 +27,7 @@ const setupMocks = () => {
             if (tagName === 'canvas') {
                 return {
                     getContext: (contextName: string) => {
-                        if (contextName === 'webgl') {
-                            return true;
-                        } else {
-                            return false;
-                        }
+                        return !!(contextName === 'webgl');
                     },
                 };
             } else {

--- a/packages/javascript/bh-shared-ui/src/utils/compatibility.test.ts
+++ b/packages/javascript/bh-shared-ui/src/utils/compatibility.test.ts
@@ -1,0 +1,63 @@
+// Copyright 2024 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { isWebGLEnabled } from '.';
+
+const setupMocks = () => {
+    const originalRenderingContext = window.WebGLRenderingContext;
+    const originalCreateElement = document.createElement;
+
+    const enableWebGLMock = () => {
+        window.WebGLRenderingContext = true as any;
+
+        document.createElement = vi.fn((tagName: string) => {
+            if (tagName === 'canvas') {
+                return {
+                    getContext: (contextName: string) => {
+                        if (contextName === 'webgl') {
+                            return true;
+                        } else {
+                            return false;
+                        }
+                    },
+                };
+            } else {
+                return originalCreateElement(tagName);
+            }
+        }) as any;
+    };
+
+    const disableWebGLMock = () => {
+        window.WebGLRenderingContext = originalRenderingContext;
+        document.createElement = originalCreateElement;
+    };
+
+    return { enableWebGLMock, disableWebGLMock };
+};
+
+describe('WebGL compatibility check', () => {
+    const mocks = setupMocks();
+    afterEach(() => mocks.disableWebGLMock());
+
+    it('returns true when WebGL is available in the current browser context', () => {
+        mocks.enableWebGLMock();
+        expect(isWebGLEnabled()).toBe(true);
+    });
+
+    it('returns false when WebGL is not available in the current browser context', () => {
+        expect(isWebGLEnabled()).toBe(false);
+    });
+});

--- a/packages/javascript/bh-shared-ui/src/utils/compatibility.ts
+++ b/packages/javascript/bh-shared-ui/src/utils/compatibility.ts
@@ -1,4 +1,4 @@
-// Copyright 2023 Specter Ops, Inc.
+// Copyright 2024 Specter Ops, Inc.
 //
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
@@ -14,14 +14,11 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-export * from './api';
-export * from './compatibility';
-export * from './content';
-export * from './datetime';
-export * from './exportGraphData';
-export * from './entityInfoDisplay';
-export * from './passwd';
-export * from './user';
-export * from './icons';
-export * from './permissions';
-export * from './copyToClipboard';
+export const isWebGLEnabled = (): boolean => {
+    try {
+        const canvas = document.createElement('canvas');
+        return !!(window.WebGLRenderingContext && canvas.getContext('webgl'));
+    } catch (error) {
+        return false;
+    }
+};


### PR DESCRIPTION
## Description
Our graph view on the Explore page requires WebGL to render correctly; currently, if a user tries to visit the explore page without WebGL enabled on their browser, the application crashes without a helpful error message. This PR adds a compatibility check to the Explore page and will render a more descriptive error message if the WebGL rendering context is not available.

## Motivation and Context
Users currently do not have a way to differ between errors caused by their browser not having webGL enabled and other errors that could lead to the Explore page crashing.

## How Has This Been Tested?
Added a test for the compatibility check in the shared-ui project.

## Screenshots (if appropriate):
<img width="1107" alt="Screenshot 2024-05-28 at 4 57 21 PM" src="https://github.com/SpecterOps/BloodHound/assets/16313351/7b82681f-cd08-4272-b6f3-09e9eaaf0835">

## Types of changes
-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
-   [ ] Documentation updates are needed, and have been made accordingly.
-   [x] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
