### PR TITLE
feat: allow setting a node kind when editing searches for adorning with an icon without making an API call

### DIFF
--- a/cmd/ui/src/views/Explore/ExploreSearch/NodeSearch.tsx
+++ b/cmd/ui/src/views/Explore/ExploreSearch/NodeSearch.tsx
@@ -26,6 +26,7 @@ const NodeSearch = () => {
 
     const handleNodeEdited = (edit: string): SourceNodeEditedAction =>
         dispatch(searchbarActions.sourceNodeEdited(edit));
+
     const handleNodeSelected = (selected?: SearchValue): SourceNodeSelectedAction =>
         dispatch(searchbarActions.sourceNodeSelected(selected));
 
@@ -34,6 +35,7 @@ const NodeSearch = () => {
             labelText={'Search Nodes'}
             inputValue={searchTerm}
             selectedItem={selectedItem || null}
+            nodeKind={primary.kind}
             handleNodeEdited={handleNodeEdited}
             handleNodeSelected={handleNodeSelected}
         />

--- a/cmd/ui/src/views/Explore/ExploreSearch/PathfindingSearch.tsx
+++ b/cmd/ui/src/views/Explore/ExploreSearch/PathfindingSearch.tsx
@@ -62,6 +62,7 @@ const PathfindingSearch = () => {
                     handleNodeEdited={handleSourceNodeEdited}
                     handleNodeSelected={handleSourceNodeSelected}
                     inputValue={sourceInputValue}
+                    nodeKind={primary.kind}
                     selectedItem={sourceSelectedItem || null}
                     labelText='Start Node'
                 />
@@ -69,6 +70,7 @@ const PathfindingSearch = () => {
                     handleNodeEdited={handleDestinationNodeEdited}
                     handleNodeSelected={handleDestinationNodeSelected}
                     inputValue={destinationInputValue}
+                    nodeKind={secondary.kind}
                     selectedItem={destinationSelectedItem || null}
                     labelText='Destination Node'
                 />

--- a/cmd/ui/src/views/Explore/ExploreSearchCombobox/ExploreSearchCombobox.tsx
+++ b/cmd/ui/src/views/Explore/ExploreSearchCombobox/ExploreSearchCombobox.tsx
@@ -23,6 +23,7 @@ import {
     getEmptyResultsText,
     getKeywordAndTypeValues,
     useSearch,
+    EntityKinds,
 } from 'bh-shared-ui';
 import { useCombobox } from 'downshift';
 
@@ -32,12 +33,15 @@ const ExploreSearchCombobox: React.FC<{
     selectedItem: SearchValue | null;
     handleNodeEdited: (edit: string) => any;
     handleNodeSelected: (selection: SearchValue) => any;
+    nodeKind?: EntityKinds;
     disabled?: boolean;
-}> = ({ labelText, inputValue, selectedItem, handleNodeEdited, handleNodeSelected, disabled = false }) => {
+}> = ({ labelText, inputValue, selectedItem, handleNodeEdited, handleNodeSelected, nodeKind, disabled = false }) => {
     const theme = useTheme();
 
     const { keyword, type } = getKeywordAndTypeValues(inputValue);
     const { data, error, isError, isLoading, isFetching } = useSearch(keyword, type);
+
+    const kind = selectedItem?.type || nodeKind;
 
     const { isOpen, getMenuProps, getInputProps, getComboboxProps, highlightedIndex, getItemProps, openMenu } =
         useCombobox({
@@ -79,7 +83,7 @@ const ExploreSearchCombobox: React.FC<{
                         backgroundColor: disabled ? theme.palette.action.disabled : 'inherit',
                         fontSize: theme.typography.pxToRem(14),
                     },
-                    startAdornment: selectedItem?.type && <NodeIcon nodeType={selectedItem?.type} />,
+                    startAdornment: kind && <NodeIcon nodeType={kind} />,
                 }}
                 {...getInputProps({
                     onFocus: openMenu,

--- a/packages/javascript/bh-shared-ui/src/store/searchbar/actions.ts
+++ b/packages/javascript/bh-shared-ui/src/store/searchbar/actions.ts
@@ -16,6 +16,7 @@
 
 import * as types from './types';
 import { EdgeCheckboxType } from '../../views/Explore/ExploreSearch/edgeTypes';
+import { EntityKinds } from '../../utils';
 
 export const primarySearch = () => {
     return {
@@ -63,10 +64,11 @@ export const tabChanged = (tabName: types.TabNames) => {
     };
 };
 
-export const sourceNodeEdited = (searchTerm: string): types.SourceNodeEditedAction => {
+export const sourceNodeEdited = (searchTerm: string, kind?: EntityKinds): types.SourceNodeEditedAction => {
     return {
         type: types.SOURCE_NODE_EDITED,
         searchTerm,
+        kind,
     };
 };
 
@@ -81,10 +83,11 @@ export const sourceNodeSelected = (
     };
 };
 
-export const destinationNodeEdited = (searchTerm: string): types.DestinationNodeEditedAction => {
+export const destinationNodeEdited = (searchTerm: string, kind?: EntityKinds): types.DestinationNodeEditedAction => {
     return {
         type: types.DESTINATION_NODE_EDITED,
         searchTerm,
+        kind,
     };
 };
 

--- a/packages/javascript/bh-shared-ui/src/store/searchbar/reducer.ts
+++ b/packages/javascript/bh-shared-ui/src/store/searchbar/reducer.ts
@@ -93,6 +93,7 @@ export const searchReducer = (state = initialSearchState, action: types.Searchba
                 draft.primary.searchTerm = action.searchTerm;
                 draft.primary.loading = true;
                 draft.primary.options = [];
+                draft.primary.kind = action.kind;
 
                 // any edits to the source node should clear out the previously saved primary.value
                 draft.primary.value = undefined;
@@ -111,6 +112,7 @@ export const searchReducer = (state = initialSearchState, action: types.Searchba
                 draft.secondary.searchTerm = action.searchTerm;
                 draft.secondary.loading = true;
                 draft.secondary.options = [];
+                draft.secondary.kind = action.kind;
 
                 // any edits to the destination node should clear out the previously saved destination.value
                 draft.secondary.value = undefined;

--- a/packages/javascript/bh-shared-ui/src/store/searchbar/types.ts
+++ b/packages/javascript/bh-shared-ui/src/store/searchbar/types.ts
@@ -65,6 +65,7 @@ export interface SearchBarState {
     //value is set to optional to safeguard against possibly passing undefined when the value
     //is not derived from direct user interaction with the search input
     value?: SearchValue;
+    kind?: EntityKinds;
 }
 
 export interface SearchNodeType {
@@ -120,6 +121,7 @@ export interface SourceNodeSelectedAction {
 export interface SourceNodeEditedAction {
     type: typeof SOURCE_NODE_EDITED;
     searchTerm: string;
+    kind?: EntityKinds;
 }
 
 export interface DestinationNodeSelectedAction {
@@ -130,6 +132,7 @@ export interface DestinationNodeSelectedAction {
 export interface DestinationNodeEditedAction {
     type: typeof DESTINATION_NODE_EDITED;
     searchTerm: string;
+    kind?: EntityKinds;
 }
 
 export enum EndPoints {


### PR DESCRIPTION
## Description
This changeset enables adorning the search inputs in the explore page with a node icon without making a selection and having to make an API call. 
<!--- Describe your changes in detail -->

## Motivation and Context
There are instances when we populate these fields from elsewhere without user interaction where we already know the node kind. This makes it so that we don't have to call the API in order to show an icon.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
