### PR TITLE
BED-4435: Enforce AG name tag uniqueness

### DIFF
--- a/cmd/api/src/api/error.go
+++ b/cmd/api/src/api/error.go
@@ -63,6 +63,7 @@ const (
 	ErrorResponseAGNameTagEmpty						= "asset group name or tag must not be empty"
 	ErrorResponseAGDuplicateName					= "asset group name must be unique"
 	ErrorResponseAGDuplicateTag						= "asset group tag must be unique"
+	ErrorResponseDetailsUniqueViolation 			= "A unique constraint was violated"
 
 	FmtErrorResponseDetailsBadQueryParameters = "there are errors in the query parameters: %v"
 )
@@ -121,10 +122,6 @@ func HandleDatabaseError(request *http.Request, response http.ResponseWriter, er
 		WriteErrorResponse(request.Context(), BuildErrorResponse(http.StatusNotFound, ErrorResponseDetailsResourceNotFound, request), response)
 	} else if errors.Is(err, context.DeadlineExceeded) {
 		WriteErrorResponse(request.Context(), BuildErrorResponse(http.StatusInternalServerError, ErrorResponseRequestTimeout, request), response)
-	} else if err.Error() == "asset group with this name already exists" {
-		WriteErrorResponse(request.Context(), BuildErrorResponse(http.StatusConflict, ErrorResponseAGDuplicateName, request), response)
-	} else if err.Error() == "asset group with this tag already exists" {
-		WriteErrorResponse(request.Context(), BuildErrorResponse(http.StatusConflict, ErrorResponseAGDuplicateTag, request), response)
 	} else {
 		log.Errorf("Unexpected database error: %v", err)
 		WriteErrorResponse(request.Context(), BuildErrorResponse(http.StatusInternalServerError, ErrorResponseDetailsInternalServerError, request), response)

--- a/cmd/api/src/api/error.go
+++ b/cmd/api/src/api/error.go
@@ -63,7 +63,7 @@ const (
 	ErrorResponseAGNameTagEmpty						= "asset group name or tag must not be empty"
 	ErrorResponseAGDuplicateName					= "asset group name must be unique"
 	ErrorResponseAGDuplicateTag						= "asset group tag must be unique"
-	ErrorResponseDetailsUniqueViolation 			= "A unique constraint was violated"
+	ErrorResponseDetailsUniqueViolation 			= "unique constraint was violated"
 
 	FmtErrorResponseDetailsBadQueryParameters = "there are errors in the query parameters: %v"
 )

--- a/cmd/api/src/api/error.go
+++ b/cmd/api/src/api/error.go
@@ -60,6 +60,9 @@ const (
 	ErrorResponseRequestTimeout                     = "request timed out"
 	ErrorResponseUserSelfDisable                    = "user attempted to disable themselves"
 	ErrorResponseAGTagWhiteSpace                    = "asset group tags must not contain whitespace"
+	ErrorResponseAGNameTagEmpty						= "asset group name or tag must not be empty"
+	ErrorResponseAGDuplicateName					= "asset group name must be unique"
+	ErrorResponseAGDuplicateTag						= "asset group tag must be unique"
 
 	FmtErrorResponseDetailsBadQueryParameters = "there are errors in the query parameters: %v"
 )
@@ -118,6 +121,10 @@ func HandleDatabaseError(request *http.Request, response http.ResponseWriter, er
 		WriteErrorResponse(request.Context(), BuildErrorResponse(http.StatusNotFound, ErrorResponseDetailsResourceNotFound, request), response)
 	} else if errors.Is(err, context.DeadlineExceeded) {
 		WriteErrorResponse(request.Context(), BuildErrorResponse(http.StatusInternalServerError, ErrorResponseRequestTimeout, request), response)
+	} else if err.Error() == "asset group with this name already exists" {
+		WriteErrorResponse(request.Context(), BuildErrorResponse(http.StatusConflict, ErrorResponseAGDuplicateName, request), response)
+	} else if err.Error() == "asset group with this tag already exists" {
+		WriteErrorResponse(request.Context(), BuildErrorResponse(http.StatusConflict, ErrorResponseAGDuplicateTag, request), response)
 	} else {
 		log.Errorf("Unexpected database error: %v", err)
 		WriteErrorResponse(request.Context(), BuildErrorResponse(http.StatusInternalServerError, ErrorResponseDetailsInternalServerError, request), response)

--- a/cmd/api/src/api/v2/agi.go
+++ b/cmd/api/src/api/v2/agi.go
@@ -200,7 +200,7 @@ func (s Resources) UpdateAssetGroup(response http.ResponseWriter, request *http.
 }
 
 func (s Resources) CreateAssetGroup(response http.ResponseWriter, request *http.Request) {
-	var createRequest CreateAssetGroupRequest
+    var createRequest CreateAssetGroupRequest
 
     if err := api.ReadJSONRequestPayloadLimited(&createRequest, request); err != nil {
         api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, err.Error(), request), response)

--- a/cmd/api/src/api/v2/agi.go
+++ b/cmd/api/src/api/v2/agi.go
@@ -202,6 +202,8 @@ func (s Resources) CreateAssetGroup(response http.ResponseWriter, request *http.
 
 	if err := api.ReadJSONRequestPayloadLimited(&createRequest, request); err != nil {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, err.Error(), request), response)
+	} else if strings.TrimSpace(createRequest.Name) == "" || strings.TrimSpace(createRequest.Tag) == "" {
+		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, api.ErrorResponseAGNameTagEmpty, request), response)
 	} else if hasSpace, err := regexp.MatchString(`\s`, createRequest.Tag); err != nil {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusInternalServerError, err.Error(), request), response)
 	} else if hasSpace {

--- a/cmd/api/src/api/v2/agi_test.go
+++ b/cmd/api/src/api/v2/agi_test.go
@@ -417,7 +417,13 @@ func TestResources_CreateAssetGroup(t *testing.T) {
 		WithBody(jsonBody).
 		OnHandlerFunc(resources.CreateAssetGroup).
 		Require().
-		ResponseStatusCode(http.StatusBadRequest)
+		ResponseStatusCode(http.StatusBadRequest).		
+		ResponseJSONBody(api.ErrorWrapper{
+			HTTPStatus: http.StatusBadRequest,
+			Errors: []api.ErrorDetails{{
+				Message: api.ErrorResponseAGNameTagEmpty,
+			}},
+		})
 
 	// Empty asset group tag
 	jsonBody, err = json.Marshal(v2.CreateAssetGroupRequest{Name: "Valid Name", Tag: ""})
@@ -430,7 +436,13 @@ func TestResources_CreateAssetGroup(t *testing.T) {
 		WithBody(jsonBody).
 		OnHandlerFunc(resources.CreateAssetGroup).
 		Require().
-		ResponseStatusCode(http.StatusBadRequest)
+		ResponseStatusCode(http.StatusBadRequest).		
+		ResponseJSONBody(api.ErrorWrapper{
+			HTTPStatus: http.StatusBadRequest,
+			Errors: []api.ErrorDetails{{
+				Message: api.ErrorResponseAGNameTagEmpty,
+			}},
+		})
 
 	// Whitespace in asset group tag must error
 	jsonBody, err = json.Marshal(v2.CreateAssetGroupRequest{Tag: "one space"})

--- a/cmd/api/src/api/v2/agi_test.go
+++ b/cmd/api/src/api/v2/agi_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/specterops/bloodhound/graphschema/common"
 	"github.com/specterops/bloodhound/headers"
 	"github.com/specterops/bloodhound/mediatypes"
+	"github.com/specterops/bloodhound/src/database"
 	"github.com/specterops/bloodhound/src/api"
 	v2 "github.com/specterops/bloodhound/src/api/v2"
 	"github.com/specterops/bloodhound/src/api/v2/apitest"
@@ -478,7 +479,7 @@ func TestResources_CreateAssetGroup(t *testing.T) {
 		ResponseStatusCode(http.StatusInternalServerError)
 	
 	// Test duplicate name
-	mockDB.EXPECT().CreateAssetGroup(gomock.Any(), "DuplicateName", gomock.Any(), false).Return(model.AssetGroup{}, errors.New("asset group with this name already exists"))
+	mockDB.EXPECT().CreateAssetGroup(gomock.Any(), "DuplicateName", gomock.Any(), false).Return(model.AssetGroup{}, fmt.Errorf("%w: %v", database.ErrDuplicateAGName, errors.New("ERROR: duplicate key value violates unique constraint \"asset_groups_name_key\" (SQLSTATE 23505)")))
 
 	requestTemplate.
 		WithBody(v2.CreateAssetGroupRequest{Name: "DuplicateName", Tag: "UniqueTag"}).
@@ -487,7 +488,7 @@ func TestResources_CreateAssetGroup(t *testing.T) {
 		ResponseStatusCode(http.StatusConflict)
 
 	// Test duplicate tag
-	mockDB.EXPECT().CreateAssetGroup(gomock.Any(), gomock.Any(), "DuplicateTag", false).Return(model.AssetGroup{}, errors.New("asset group with this tag already exists"))
+	mockDB.EXPECT().CreateAssetGroup(gomock.Any(), gomock.Any(), "DuplicateTag", false).Return(model.AssetGroup{}, fmt.Errorf("%w: %v", database.ErrDuplicateAGTag, errors.New("ERROR: duplicate key value violates unique constraint \"asset_groups_tag_key\" (SQLSTATE 23505)")))
 
 	requestTemplate.
 		WithBody(v2.CreateAssetGroupRequest{Name: "UniqueName", Tag: "DuplicateTag"}).

--- a/cmd/api/src/api/v2/agi_test.go
+++ b/cmd/api/src/api/v2/agi_test.go
@@ -36,7 +36,6 @@ import (
 	"github.com/specterops/bloodhound/graphschema/common"
 	"github.com/specterops/bloodhound/headers"
 	"github.com/specterops/bloodhound/mediatypes"
-	"github.com/specterops/bloodhound/src/database"
 	"github.com/specterops/bloodhound/src/api"
 	v2 "github.com/specterops/bloodhound/src/api/v2"
 	"github.com/specterops/bloodhound/src/api/v2/apitest"

--- a/cmd/api/src/api/v2/agi_test.go
+++ b/cmd/api/src/api/v2/agi_test.go
@@ -25,6 +25,8 @@ import (
 	"net/url"
 	"testing"
 
+	
+	"github.com/specterops/bloodhound/src/database"
 	"github.com/gofrs/uuid"
 	"github.com/gorilla/mux"
 	"github.com/specterops/bloodhound/dawgs/graph"

--- a/cmd/api/src/api/v2/agi_test.go
+++ b/cmd/api/src/api/v2/agi_test.go
@@ -485,7 +485,13 @@ func TestResources_CreateAssetGroup(t *testing.T) {
 		WithBody(v2.CreateAssetGroupRequest{Name: "DuplicateName", Tag: "UniqueTag"}).
 		OnHandlerFunc(resources.CreateAssetGroup).
 		Require().
-		ResponseStatusCode(http.StatusConflict)
+		ResponseStatusCode(http.StatusConflict).
+		ResponseJSONBody(api.ErrorWrapper{
+			HTTPStatus: http.StatusConflict,
+			Errors: []api.ErrorDetails{{
+				Message: api.ErrorResponseAGDuplicateName,
+			}},
+		})
 
 	// Test duplicate tag
 	mockDB.EXPECT().CreateAssetGroup(gomock.Any(), gomock.Any(), "DuplicateTag", false).Return(model.AssetGroup{}, fmt.Errorf("%w: %v", database.ErrDuplicateAGTag, errors.New("ERROR: duplicate key value violates unique constraint \"asset_groups_tag_key\" (SQLSTATE 23505)")))
@@ -494,7 +500,13 @@ func TestResources_CreateAssetGroup(t *testing.T) {
 		WithBody(v2.CreateAssetGroupRequest{Name: "UniqueName", Tag: "DuplicateTag"}).
 		OnHandlerFunc(resources.CreateAssetGroup).
 		Require().
-		ResponseStatusCode(http.StatusConflict)
+		ResponseStatusCode(http.StatusConflict).
+		ResponseJSONBody(api.ErrorWrapper{
+			HTTPStatus: http.StatusConflict,
+			Errors: []api.ErrorDetails{{
+				Message: api.ErrorResponseAGDuplicateTag,
+			}},
+		})
 
 	// Success
 	mockDB.EXPECT().CreateAssetGroup(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(model.AssetGroup{}, nil)

--- a/cmd/api/src/api/v2/agi_test.go
+++ b/cmd/api/src/api/v2/agi_test.go
@@ -25,7 +25,6 @@ import (
 	"net/url"
 	"testing"
 
-	
 	"github.com/specterops/bloodhound/src/database"
 	"github.com/gofrs/uuid"
 	"github.com/gorilla/mux"

--- a/cmd/api/src/database/agi.go
+++ b/cmd/api/src/database/agi.go
@@ -56,8 +56,8 @@ func (s *BloodhoundDB) CreateAssetGroup(ctx context.Context, name, tag string, s
                 return fmt.Errorf("%w: %v", ErrDuplicateAGTag, err)
             }
         }
-		return err
-	})
+        return err
+    })
 
 	return assetGroup, err
 }

--- a/cmd/api/src/database/agi.go
+++ b/cmd/api/src/database/agi.go
@@ -25,7 +25,6 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/specterops/bloodhound/errors"
-	"github.com/specterops/bloodhound/log"
 	"github.com/specterops/bloodhound/src/database/types"
 	"github.com/specterops/bloodhound/src/model"
 )
@@ -49,7 +48,6 @@ func (s *BloodhoundDB) CreateAssetGroup(ctx context.Context, name, tag string, s
     err = s.AuditableTransaction(ctx, auditEntry, func(tx *gorm.DB) error {
         err := tx.Create(&assetGroup).Error
         if err != nil {
-            log.Infof("Error creating asset group: %v", err)
             if strings.Contains(err.Error(), "duplicate key value violates unique constraint \"asset_groups_name_key\"") {
                 return fmt.Errorf("%w: %v", ErrDuplicateAGName, err)
             } else if strings.Contains(err.Error(), "duplicate key value violates unique constraint \"asset_groups_tag_key\"") {

--- a/cmd/api/src/database/db.go
+++ b/cmd/api/src/database/db.go
@@ -43,6 +43,11 @@ const (
 	ErrNotFound = errors.Error("entity not found")
 )
 
+var (
+    ErrDuplicateAGName = errors.New("duplicate asset group name")
+    ErrDuplicateAGTag  = errors.New("duplicate asset group tag")
+)
+
 func IsUnexpectedDatabaseError(err error) bool {
 	return err != nil && err != ErrNotFound
 }

--- a/cmd/api/src/database/migration/asset_group_constraints_test.go
+++ b/cmd/api/src/database/migration/asset_group_constraints_test.go
@@ -1,0 +1,38 @@
+package migration_test
+
+import (
+    "context"
+    "testing"
+    "github.com/specterops/bloodhound/src/test/integration"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+func TestAssetGroupConstraints(t *testing.T) {
+    ctx := context.Background()
+    dbInst := integration.SetupDB(t)
+
+    t.Run("Duplicate Name", func(t *testing.T) {
+        // Create initial asset group
+        _, err := dbInst.CreateAssetGroup(ctx, "Test Group", "test_tag", false)
+        require.NoError(t, err)
+
+        // Attempt to create asset group with duplicate name
+        _, err = dbInst.CreateAssetGroup(ctx, "Test Group", "different_tag", false)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "duplicate key value violates unique constraint")
+		assert.Contains(t, err.Error(), "asset_groups_name_key")
+    })
+
+    t.Run("Duplicate Tag", func(t *testing.T) {
+        // Create initial asset group
+        _, err := dbInst.CreateAssetGroup(ctx, "Another Group", "another_tag", false)
+        require.NoError(t, err)
+
+        // Attempt to create asset group with duplicate tag
+        _, err = dbInst.CreateAssetGroup(ctx, "Different Group", "another_tag", false)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "duplicate key value violates unique constraint")
+		assert.Contains(t, err.Error(), "asset_groups_tag_key")
+    })
+}

--- a/cmd/api/src/database/migration/migrations/schema.sql
+++ b/cmd/api/src/database/migration/migrations/schema.sql
@@ -123,8 +123,8 @@ CREATE SEQUENCE IF NOT EXISTS asset_group_selectors_id_seq
 ALTER SEQUENCE asset_group_selectors_id_seq OWNED BY asset_group_selectors.id;
 
 CREATE TABLE IF NOT EXISTS asset_groups (
-    name text UNIQUE NOT NULL,
-    tag text UNIQUE NOT NULL,
+    name text,
+    tag text,
     system_group boolean,
     id integer NOT NULL,
     created_at timestamp with time zone,

--- a/cmd/api/src/database/migration/migrations/schema.sql
+++ b/cmd/api/src/database/migration/migrations/schema.sql
@@ -123,8 +123,8 @@ CREATE SEQUENCE IF NOT EXISTS asset_group_selectors_id_seq
 ALTER SEQUENCE asset_group_selectors_id_seq OWNED BY asset_group_selectors.id;
 
 CREATE TABLE IF NOT EXISTS asset_groups (
-    name text,
-    tag text,
+    name text UNIQUE NOT NULL,
+    tag text UNIQUE NOT NULL,
     system_group boolean,
     id integer NOT NULL,
     created_at timestamp with time zone,

--- a/cmd/api/src/database/migration/migrations/v5.12.0.sql
+++ b/cmd/api/src/database/migration/migrations/v5.12.0.sql
@@ -28,27 +28,23 @@ VALUES
     ('idle', NOW ())
 ON CONFLICT DO NOTHING;
 
-ALTER TABLE user_sessions
+ALTER TABLE IF EXISTS user_sessions
     ADD COLUMN IF NOT EXISTS flags jsonb;
 
--- New changes for asset_groups table
-ALTER TABLE asset_groups
+-- Set 'name' and 'tag' columns to not allow null values
+ALTER TABLE IF EXISTS asset_groups
     ALTER COLUMN name SET NOT NULL,
     ALTER COLUMN tag SET NOT NULL;
 
--- Drop constraints if they exist, then add them
-ALTER TABLE asset_groups
+-- Ensure unique values for 'name' and 'tag' in asset_groups
+ALTER TABLE IF EXISTS asset_groups
     DROP CONSTRAINT IF EXISTS asset_groups_name_key;
 
-ALTER TABLE asset_groups
+ALTER TABLE IF EXISTS asset_groups
     ADD CONSTRAINT asset_groups_name_key UNIQUE (name);
 
-ALTER TABLE asset_groups
+ALTER TABLE IF EXISTS asset_groups
     DROP CONSTRAINT IF EXISTS asset_groups_tag_key;
 
-ALTER TABLE asset_groups
+ALTER TABLE IF EXISTS asset_groups
     ADD CONSTRAINT asset_groups_tag_key UNIQUE (tag);
-
--- TODO: Handle existing duplicate entries by appending a number
-
--- TODO: Existing null entries handling

--- a/cmd/api/src/database/migration/migrations/v5.12.0.sql
+++ b/cmd/api/src/database/migration/migrations/v5.12.0.sql
@@ -31,8 +31,24 @@ ON CONFLICT DO NOTHING;
 ALTER TABLE user_sessions
     ADD COLUMN IF NOT EXISTS flags jsonb;
 
+-- New changes for asset_groups table
 ALTER TABLE asset_groups
-ALTER COLUMN name SET NOT NULL,
-ALTER COLUMN tag SET NOT NULL,
-ADD CONSTRAINT asset_groups_name_key UNIQUE (name),
-ADD CONSTRAINT asset_groups_tag_key UNIQUE (tag);
+    ALTER COLUMN name SET NOT NULL,
+    ALTER COLUMN tag SET NOT NULL;
+
+-- Drop constraints if they exist, then add them
+ALTER TABLE asset_groups
+    DROP CONSTRAINT IF EXISTS asset_groups_name_key;
+
+ALTER TABLE asset_groups
+    ADD CONSTRAINT asset_groups_name_key UNIQUE (name);
+
+ALTER TABLE asset_groups
+    DROP CONSTRAINT IF EXISTS asset_groups_tag_key;
+
+ALTER TABLE asset_groups
+    ADD CONSTRAINT asset_groups_tag_key UNIQUE (tag);
+
+-- TODO: Handle existing duplicate entries by appending a number
+
+-- TODO: Existing null entries handling

--- a/cmd/api/src/database/migration/migrations/v5.12.0.sql
+++ b/cmd/api/src/database/migration/migrations/v5.12.0.sql
@@ -30,3 +30,9 @@ ON CONFLICT DO NOTHING;
 
 ALTER TABLE user_sessions
     ADD COLUMN IF NOT EXISTS flags jsonb;
+
+ALTER TABLE asset_groups
+ALTER COLUMN name SET NOT NULL,
+ALTER COLUMN tag SET NOT NULL,
+ADD CONSTRAINT asset_groups_name_key UNIQUE (name),
+ADD CONSTRAINT asset_groups_tag_key UNIQUE (tag);


### PR DESCRIPTION
## Description

Modified DB schema to prevent creation of asset groups with empty names/tags or duplicate tags.


## Motivation and Context

Previously, asset groups could be created with tags that duplicate existing tags or with empty names/tags. This could potentially cause widespread bugs in analysis and display given our extensive reliance on string matching for these tags.


## How Has This Been Tested?

- Updated application layer unit test function `TestResources_CreateAssetGroup`
- Added new test cases for:
  - Empty asset group name
  - Empty asset group tag
  - Whitespace in asset group tag
- Added new test file DB layer unit test function `migration/asset_group_constraints_test.go` to validate new schema constraints
- Verified compatibility with existing DB migration tests for asset groups
- Manually verified functionality through API Explorer UI

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [x] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [x] My changes include a database migration.
