### PR TITLE
fix: missing name property on azure apps spawned by service principals

### DIFF
--- a/cmd/api/src/api/bloodhoundgraph/conversions.go
+++ b/cmd/api/src/api/bloodhoundgraph/conversions.go
@@ -1,17 +1,17 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 package bloodhoundgraph
@@ -19,6 +19,7 @@ package bloodhoundgraph
 import (
 	"github.com/specterops/bloodhound/analysis"
 	"github.com/specterops/bloodhound/dawgs/graph"
+	"github.com/specterops/bloodhound/graphschema/common"
 )
 
 const (
@@ -31,6 +32,7 @@ const (
 func NodeToBloodHoundGraph(node *graph.Node) BloodHoundGraphNode {
 	var (
 		nodeKindLabel       = analysis.GetNodeKindDisplayLabel(node)
+		name, _             = node.Properties.GetWithFallback(common.Name.String(), "NO NAME OR ID", common.ObjectID.String()).String()
 		bloodHoundGraphNode = BloodHoundGraphNode{
 			BloodHoundGraphItem: &BloodHoundGraphItem{
 				Data: getNodeDisplayProperties(node),
@@ -40,7 +42,7 @@ func NodeToBloodHoundGraph(node *graph.Node) BloodHoundGraphNode {
 				Color: defaultNodeBorderColor,
 			},
 			Label: &BloodHoundGraphNodeLabel{
-				Text:            getNodeName(node),
+				Text:            name,
 				BackgroundColor: defaultNodeBackgroundColor,
 				FontSize:        defaultNodeFontSize,
 				Center:          true,

--- a/cmd/api/src/api/bloodhoundgraph/conversions.go
+++ b/cmd/api/src/api/bloodhoundgraph/conversions.go
@@ -32,7 +32,7 @@ const (
 func NodeToBloodHoundGraph(node *graph.Node) BloodHoundGraphNode {
 	var (
 		nodeKindLabel       = analysis.GetNodeKindDisplayLabel(node)
-		name, _             = node.Properties.GetWithFallback(common.Name.String(), "NO NAME OR ID", common.ObjectID.String()).String()
+		name, _             = node.Properties.GetWithFallback(common.Name.String(), "NO NAME OR ID", common.DisplayName.String(), common.ObjectID.String()).String()
 		bloodHoundGraphNode = BloodHoundGraphNode{
 			BloodHoundGraphItem: &BloodHoundGraphItem{
 				Data: getNodeDisplayProperties(node),

--- a/cmd/api/src/api/bloodhoundgraph/properties.go
+++ b/cmd/api/src/api/bloodhoundgraph/properties.go
@@ -1,17 +1,17 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 package bloodhoundgraph
@@ -29,20 +29,6 @@ import (
 // We ignore the property lookup errors here since there's no clear path for a caller to handle it. Logging is also
 // restricted to debug verbosity as anything more permissive could potentially flood centralized infrastructure in
 // production
-
-func getNodeName(target *graph.Node) string {
-	const noNameOrObjectID = "NO NAME OR ID"
-
-	props := target.Properties
-
-	if name, err := props.Get(common.Name.String()).String(); err == nil {
-		return name
-	} else if objectID, err := props.Get(common.ObjectID.String()).String(); err == nil {
-		return objectID
-	}
-
-	return noNameOrObjectID
-}
 
 func getNodeLevel(target *graph.Node) (int, bool) {
 	if startSystemTags, err := target.Properties.Get(common.SystemTags.String()).String(); err == nil {

--- a/cmd/api/src/queries/graph.go
+++ b/cmd/api/src/queries/graph.go
@@ -560,7 +560,7 @@ func applyTimeoutReduction(queryWeight int64, availableRuntime time.Duration) (t
 
 func nodeToSearchResult(node *graph.Node) model.SearchResult {
 	var (
-		name, _              = node.Properties.GetOrDefault(common.Name.String(), "NO NAME").String()
+		name, _              = node.Properties.GetWithFallback(common.Name.String(), "NO NAME", common.DisplayName.String(), common.ObjectID.String()).String()
 		objectID, _          = node.Properties.GetOrDefault(common.ObjectID.String(), "NO OBJECT ID").String()
 		distinguishedName, _ = node.Properties.GetOrDefault(ad.DistinguishedName.String(), "").String()
 		systemTags, _        = node.Properties.GetOrDefault(common.SystemTags.String(), "").String()

--- a/packages/go/dawgs/graph/properties.go
+++ b/packages/go/dawgs/graph/properties.go
@@ -406,11 +406,22 @@ func (s *Properties) Exists(key string) bool {
 // GetOrDefault fetches a value from the Properties by key. If the key is not present in the Properties this
 // function returns the given default value instead.
 func (s *Properties) GetOrDefault(key string, defaultValue any) PropertyValue {
+	return s.GetWithFallback(key, defaultValue)
+}
+
+func (s *Properties) GetWithFallback(key string, defaultValue any, fallbackKeys ...string) PropertyValue {
 	value := defaultValue
 
 	if s.Map != nil {
 		if mapValue, found := s.Map[key]; found && mapValue != nil {
 			value = mapValue
+		} else if !found && len(fallbackKeys) > 0 {
+			for _, fallbackKey := range fallbackKeys {
+				if fallbackValue, fallbackFound := s.Map[fallbackKey]; fallbackFound && fallbackValue != nil {
+					value = fallbackValue
+					break
+				}
+			}
 		}
 	}
 

--- a/packages/go/dawgs/graph/properties_test.go
+++ b/packages/go/dawgs/graph/properties_test.go
@@ -17,10 +17,11 @@
 package graph_test
 
 import (
-	"github.com/specterops/bloodhound/dawgs/graph"
-	"github.com/stretchr/testify/require"
 	"strconv"
 	"testing"
+
+	"github.com/specterops/bloodhound/dawgs/graph"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewProperties(t *testing.T) {
@@ -79,4 +80,29 @@ func TestSizeOfProperties(t *testing.T) {
 
 	require.Equal(t, 1784, int(properties.SizeOf()))
 
+}
+
+func TestGetWithFallbackProperties(t *testing.T) {
+	properties := graph.NewProperties()
+
+	// Set an initial value to force allocation
+	properties.SetAll(map[string]any{"sugar": "Sugar", "spice": "Spice", "everythingNice": "Everything Nice"})
+
+	t.Run("returns property when exists", func(t *testing.T) {
+		value, err := properties.GetWithFallback("sugar", "").String()
+		require.Nil(t, err)
+		require.Equal(t, "Sugar", value)
+	})
+
+	t.Run("returns fallback property when original property doesn't exists", func(t *testing.T) {
+		value, err := properties.GetWithFallback("missing", "", "spice").String()
+		require.Nil(t, err)
+		require.Equal(t, "Spice", value)
+	})
+
+	t.Run("returns default property when neither fallback nor property exists", func(t *testing.T) {
+		value, err := properties.GetWithFallback("", "ChemicalX", "").String()
+		require.Nil(t, err)
+		require.Equal(t, "ChemicalX", value)
+	})
 }


### PR DESCRIPTION
## Description
CLOSES BED-4429

Added a fallback utility fn to graph node properties.
Updated /search response nodes to fallback to display name and then object id if not name property does not exist.

## Motivation and Context

A number of applications are missing names b/c they were ingested via their respective service principal 

## How Has This Been Tested?

Ran locally

## Screenshots
Before:
![image](https://github.com/SpecterOps/BloodHound/assets/26472282/acb9d249-4e2a-4503-94e6-d23ba3696f96)

After
![image](https://github.com/SpecterOps/BloodHound/assets/26472282/f64f6e46-b97b-460e-91cf-005b6faab621)


## Types of changes

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
