### PR TITLE
chore: move type to api client

### DIFF
--- a/cmd/ui/src/ducks/global/types.ts
+++ b/cmd/ui/src/ducks/global/types.ts
@@ -49,12 +49,6 @@ export interface Notification {
     options: any;
 }
 
-export interface DatapipeStatus {
-    status: 'idle' | 'ingesting' | 'analyzing';
-    updated_at: string;
-    last_complete_analysis_at: string;
-}
-
 export interface GlobalOptionsState {
     domain: Domain | null;
     assetGroups: any[];

--- a/packages/javascript/js-client-library/src/client.ts
+++ b/packages/javascript/js-client-library/src/client.ts
@@ -23,6 +23,7 @@ import {
     AzureDataQualityResponse,
     BasicResponse,
     CreateAuthTokenResponse,
+    DatapipeStatusResponse,
     EndFileIngestResponse,
     ListAuthTokensResponse,
     ListFileIngestJobsResponse,
@@ -49,7 +50,8 @@ class BHEAPIClient {
     version = (options?: types.RequestOptions) => this.baseClient.get('/api/version', options);
 
     /* datapipe status */
-    getDatapipeStatus = (options?: types.RequestOptions) => this.baseClient.get('/api/v2/datapipe/status', options);
+    getDatapipeStatus = (options?: types.RequestOptions) =>
+        this.baseClient.get<DatapipeStatusResponse>('/api/v2/datapipe/status', options);
 
     /* search */
     searchHandler = (keyword: string, type?: string, options?: types.RequestOptions) => {

--- a/packages/javascript/js-client-library/src/responses.ts
+++ b/packages/javascript/js-client-library/src/responses.ts
@@ -98,6 +98,14 @@ type PostureStat = TimestampFields & {
 
 export type PostureResponse = PaginatedResponse<PostureStat[]>;
 
+type DatapipeStatus = {
+    status: 'idle' | 'ingesting' | 'analyzing' | 'purging';
+    last_complete_analysis_at: string;
+    updated_at: string;
+};
+
+export type DatapipeStatusResponse = BasicResponse<DatapipeStatus>;
+
 export type AuthToken = TimestampFields & {
     hmac_method: string;
     id: string;


### PR DESCRIPTION
<!-- README -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description
Updates the type location for datapipestatus to be defined in the client.

## Motivation and Context

This PR addresses: BED-4490 indirectly

*Why is this change required? What problem does it solve?*
Cleaner and consolidated response typing that will be used in the accompanying BHE MR.
## How Has This Been Tested?
No material changes only typing. UI still builds so type checking is good.

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do no apply. -->

- Chore (a change that does not modify the application functionality)

## Checklist:

<!-- Please make sure to you have completed all following checks. -->
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
