### PR TITLE
Supports 4489: add ISO_8601 date format

### DIFF
--- a/packages/javascript/bh-shared-ui/src/utils/datetime.ts
+++ b/packages/javascript/bh-shared-ui/src/utils/datetime.ts
@@ -21,6 +21,7 @@ export const LUXON_DATETIME_REGEX = /(\d\d\d\d)-(\d||\d\d)-(\d||\d\d) (\d||\d\d)
 export enum LuxonFormat {
     DATETIME = "yyyy-MM-dd T ZZZZ '(GMT'ZZZ')'",
     DATETIME_WITHOUT_TIMEZONE = 'yyyy-MM-dd T',
+    ISO_8601 = 'yyyy-MM-dd',
     TIMEZONE_AND_GMT_OFFSET = "ZZZZ '(GMT'ZZZ')'",
     TIME = "T ZZZZ' (GMT'ZZZ')'",
     DATETIME_WITH_LINEBREAKS = "yyyy-MM-dd '\n'T ZZZZ\n'(GMT'ZZZ')'",


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description
Adds `ISO_8601` to luxon datetime formats

## Motivation and Context

This PR supports: BED-4489

*Why is this change required? What problem does it solve?*

This format supports the ISO 8601 date format which is `yyyy-mm-dd`

## How Has This Been Tested?

*Please describe in detail how you tested your changes.
Manually tested that the format string works as expected.

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
