### PR TITLE
BED-4439: Broken collected filter

### DIFF
--- a/cmd/api/src/model/filter.go
+++ b/cmd/api/src/model/filter.go
@@ -105,6 +105,7 @@ func (s QueryParameterFilter) BuildGDBNodeFilter() graph.Criteria {
         value       = guessFilterValueType(s.Value)
     )
 
+	// TODO: Investigate whether we can set the collected property for domains that originate from trusts in ParseDomainTrusts
     switch {
     case s.Name == common.Collected.String() && s.Operator == Equals:
         switch s.Value {

--- a/cmd/api/src/model/filter.go
+++ b/cmd/api/src/model/filter.go
@@ -51,7 +51,6 @@ const (
 	FalseString    = "false"
 	IdString       = "id"
 	ObjectIdString = "objectid"
-	CollectedString = "collected"
 
 	ErrNotFiltered = errors.Error("parameter value is not filtered")
 )
@@ -100,13 +99,15 @@ type QueryParameterFilter struct {
 type QueryParameterFilters []QueryParameterFilter
 
 
-func (f QueryParameterFilter) BuildGDBNodeFilter() graph.Criteria {
-    propertyRef := query.NodeProperty(f.Name)
-    value := guessFilterValueType(f.Value)
+func (s QueryParameterFilter) BuildGDBNodeFilter() graph.Criteria {
+    var (
+        propertyRef = query.NodeProperty(s.Name)
+        value       = guessFilterValueType(s.Value)
+    )
 
     switch {
-    case f.Name == common.Collected.String() && f.Operator == Equals:
-        switch f.Value {
+    case s.Name == common.Collected.String() && s.Operator == Equals:
+        switch s.Value {
         case FalseString:
             return query.Or(
                 query.Equals(propertyRef, false),
@@ -117,7 +118,7 @@ func (f QueryParameterFilter) BuildGDBNodeFilter() graph.Criteria {
         }
     }
 
-    switch f.Operator {
+    switch s.Operator {
     case GreaterThan:
         return query.GreaterThan(propertyRef, value)
     case GreaterThanOrEquals:

--- a/cmd/api/src/model/filter.go
+++ b/cmd/api/src/model/filter.go
@@ -27,6 +27,7 @@ import (
 	"github.com/specterops/bloodhound/dawgs/graph"
 	"github.com/specterops/bloodhound/dawgs/query"
 	"github.com/specterops/bloodhound/errors"
+	"github.com/specterops/bloodhound/graphschema/common"
 )
 
 type FilterOperator string
@@ -104,7 +105,7 @@ func (f QueryParameterFilter) BuildGDBNodeFilter() graph.Criteria {
     value := guessFilterValueType(f.Value)
 
     switch {
-    case f.Name == CollectedString && f.Operator == Equals:
+    case f.Name == common.Collected.String() && f.Operator == Equals:
         switch f.Value {
         case FalseString:
             return query.Or(

--- a/cmd/api/src/model/search.go
+++ b/cmd/api/src/model/search.go
@@ -127,34 +127,31 @@ func (s DomainSelectors) GetOrderCriteria(params url.Values) (OrderCriteria, err
 }
 
 func (s DomainSelectors) GetFilterCriteria(request *http.Request) (graph.Criteria, error) {
-	var (
-		queryParameterFilterParser = NewQueryParameterFilterParser()
-		criteria                   graph.Criteria
-	)
+    var (
+        queryParameterFilterParser = NewQueryParameterFilterParser()
+        criteria                   graph.Criteria
+    )
 
-	if queryFilters, err := queryParameterFilterParser.ParseQueryParameterFilters(request); err != nil {
-		return nil, fmt.Errorf(ErrorResponseDetailsBadQueryParameterFilters)
-	} else {
-		for name, filters := range queryFilters {
-			if valid := slices.Contains(s.GetFilterableColumns(), name); !valid {
-				return nil, fmt.Errorf(ErrorResponseDetailsColumnNotFilterable)
-			}
-
-			if validPredicates, err := s.GetValidFilterPredicatesAsStrings(name); err != nil {
-				return nil, fmt.Errorf(ErrorResponseDetailsColumnNotFilterable)
-			} else {
-				for i, filter := range filters {
-					if !slices.Contains(validPredicates, string(filter.Operator)) {
-						return nil, fmt.Errorf(ErrorResponseDetailsFilterPredicateNotSupported)
-					}
-
-					queryFilters[name][i].IsStringData = s.IsString(filter.Name)
-				}
-			}
-		}
+    if queryFilters, err := queryParameterFilterParser.ParseQueryParameterFilters(request); err != nil {
+        return nil, fmt.Errorf(ErrorResponseDetailsBadQueryParameterFilters)
+    } else {
+        for name, filters := range queryFilters {
+            if valid := slices.Contains(s.GetFilterableColumns(), name); !valid {
+                return nil, fmt.Errorf(ErrorResponseDetailsColumnNotFilterable)
+            }
+            if validPredicates, err := s.GetValidFilterPredicatesAsStrings(name); err != nil {
+                return nil, fmt.Errorf(ErrorResponseDetailsColumnNotFilterable)
+            } else {
+                for i, filter := range filters {
+                    if !slices.Contains(validPredicates, string(filter.Operator)) {
+                        return nil, fmt.Errorf(ErrorResponseDetailsFilterPredicateNotSupported)
+                    }
+                    queryFilters[name][i].IsStringData = s.IsString(filter.Name)
+                }
+            }
+        }
 		// ignoring the error here as this would've failed at ParseQueryParameterFilters before getting here
-		criteria = query.And(queryFilters.BuildGDBNodeFilter(), query.KindIn(query.Node(), ad.Domain, azure.Tenant))
-
-		return criteria, nil
-	}
+        criteria = query.And(queryFilters.BuildGDBNodeFilter(), query.KindIn(query.Node(), ad.Domain, azure.Tenant))
+        return criteria, nil
+    }
 }


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Fixes issue where domains without the `collected` property does not show up when filter is set to `collected=false`

## Motivation and Context

Improved functionality from a bugfix

## How Has This Been Tested?

- Manual testing with API Explorer UI
- Passes unit and integration tests

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
