### PR TITLE
feat: move dark mode behind feature flag

### DIFF
--- a/cmd/api/src/model/appcfg/flag.go
+++ b/cmd/api/src/model/appcfg/flag.go
@@ -33,6 +33,7 @@ const (
 	FeatureClearGraphData             = "clear_graph_data"
 	FeatureRiskExposureNewCalculation = "risk_exposure_new_calculation"
 	FeatureFedRAMPEULA                = "fedramp_eula"
+	FeatureDarkMode                   = "dark_mode"
 )
 
 // AvailableFlags returns a FeatureFlagSet of expected feature flags. Feature flag defaults introduced here will become the initial
@@ -108,6 +109,13 @@ func AvailableFlags() FeatureFlagSet {
 			Description:   "Enables showing the FedRAMP EULA on every login. (Enterprise only)",
 			Enabled:       false,
 			UserUpdatable: false,
+		},
+		FeatureDarkMode: {
+			Key:           FeatureDarkMode,
+			Name:          "Dark Mode",
+			Description:   "Reveals a toggle in the settings menu that can be used to toggle dark mode on and off",
+			Enabled:       false,
+			UserUpdatable: true,
 		},
 	}
 }

--- a/cmd/api/src/model/appcfg/flag.go
+++ b/cmd/api/src/model/appcfg/flag.go
@@ -113,7 +113,7 @@ func AvailableFlags() FeatureFlagSet {
 		FeatureDarkMode: {
 			Key:           FeatureDarkMode,
 			Name:          "Dark Mode",
-			Description:   "Reveals a toggle in the settings menu that can be used to toggle dark mode on and off",
+			Description:   "Allows users to enable or disable dark mode via a toggle in the settings menu",
 			Enabled:       false,
 			UserUpdatable: true,
 		},

--- a/cmd/ui/src/components/SettingsMenu.tsx
+++ b/cmd/ui/src/components/SettingsMenu.tsx
@@ -38,6 +38,7 @@ import { logout } from 'src/ducks/auth/authSlice';
 import { setDarkMode } from 'src/ducks/global/actions.ts';
 import * as routes from 'src/ducks/global/routes';
 import { useAppDispatch, useAppSelector } from 'src/store';
+import FeatureFlag from './FeatureFlag';
 
 interface Props {
     anchorEl: null | HTMLElement;
@@ -155,13 +156,19 @@ const SettingsMenu: React.FC<Props> = ({ anchorEl, handleClose }) => {
                     <ListItemText primary='BloodHound Enterprise' />
                 </MenuItem>
 
-                <MenuItem onClick={toggleDarkMode} data-testid={'global_header_settings-menu_nav-logout'}>
-                    <ListItemIcon>
-                        <FontAwesomeIcon icon={faCircleHalfStroke} />
-                    </ListItemIcon>
-                    <ListItemText primary={'Dark Mode'} />
-                    <Switch checked={darkMode}>Dark Mode</Switch>
-                </MenuItem>
+                <FeatureFlag
+                    flagKey='dark_mode'
+                    enabled={
+                        <MenuItem onClick={toggleDarkMode} data-testid={'global_header_settings-menu_nav-logout'}>
+                            <ListItemIcon>
+                                <FontAwesomeIcon icon={faCircleHalfStroke} />
+                            </ListItemIcon>
+                            <ListItemText primary={'Dark Mode'} />
+                            <Switch checked={darkMode}>Dark Mode</Switch>
+                        </MenuItem>
+                    }
+                    disabled={null}
+                />
 
                 <Box my={1}>
                     <Divider />

--- a/cmd/ui/src/store.ts
+++ b/cmd/ui/src/store.ts
@@ -64,7 +64,7 @@ const loadState = (): PreloadedState<RootState> => {
 
 type PersistedState = {
     auth: { sessionToken: string | null };
-    global: { view: { darkMode: boolean } };
+    global: { view: { darkMode: boolean; notifications: string[] } };
 };
 
 const saveState = (state: PersistedState) => {
@@ -106,6 +106,7 @@ store.subscribe(
             global: {
                 view: {
                     darkMode: state.global.view.darkMode,
+                    notifications: [],
                 },
             },
         });

--- a/cmd/ui/src/views/EarlyAccessFeatures/EarlyAccessFeatures.tsx
+++ b/cmd/ui/src/views/EarlyAccessFeatures/EarlyAccessFeatures.tsx
@@ -33,7 +33,9 @@ import {
 import { PageWithTitle } from 'bh-shared-ui';
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { setDarkMode } from 'src/ducks/global/actions';
 import { Flag, useFeatureFlags, useToggleFeatureFlag } from 'src/hooks/useFeatureFlags';
+import { useAppDispatch } from 'src/store';
 
 export const EarlyAccessFeatureToggle: React.FC<{
     flag: Flag;
@@ -110,6 +112,7 @@ const EarlyAccessFeatures: React.FC = () => {
     const { data, isLoading, isError } = useFeatureFlags();
     const toggleFeatureFlag = useToggleFeatureFlag();
     const [showWarningDialog, setShowWarningDialog] = useState(true);
+    const dispatch = useAppDispatch();
 
     return (
         <>
@@ -160,6 +163,11 @@ const EarlyAccessFeatures: React.FC = () => {
                                     <EarlyAccessFeatureToggle
                                         flag={flag}
                                         onClick={(flagId) => {
+                                            if (flag.key === 'dark_mode') {
+                                                const body = document.getElementsByTagName('body')[0];
+                                                body.setAttribute('class', 'light');
+                                                dispatch(setDarkMode(false));
+                                            }
                                             toggleFeatureFlag.mutate(flagId);
                                         }}
                                         disabled={showWarningDialog}


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description
Adds a dark mode feature flag and hides the dark mode toggle until the feature is enabled.

## Motivation and Context
This is going to be behind a feature flag for now and addresses BED-4546

## How Has This Been Tested?
Local testing only at the moment.

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->
- New feature (non-breaking change which adds functionality)
- Database Migrations

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [ ] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
