### PR TITLE
BED-4568: Update links to point directly to sample data

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The easiest way to get up and running is to use our pre-configured Docker Compos
 NOTE: Going forward, the default `docker-compose.yml` example binds only to localhost (127.0.0.1). If you want to access BloodHound outside of localhost, you'll need to follow the instructions in [examples/docker-compose/README.md](examples/docker-compose/README.md) to configure the host binding for the container.
 
 ### Importing sample data
-The BloodHound team has provided some sample data for testing BloodHound without performing a SharpHound or AzureHound collection. That data may be found [here](examples/sample-data/README.md).
+The BloodHound team has provided some sample data for testing BloodHound without performing a SharpHound or AzureHound collection. That data may be found [here](https://github.com/SpecterOps/BloodHound/wiki/Example-Data).
 
 ## Installation Error Handling
 

--- a/cmd/ui/src/views/Explore/GraphView.tsx
+++ b/cmd/ui/src/views/Explore/GraphView.tsx
@@ -138,7 +138,7 @@ const GraphView: FC = () => {
     );
 
     const sampleDataLink = (
-        <Link target='_blank' href={'https://github.com/SpecterOps/BloodHound/tree/main/examples/sample-data'}>
+        <Link target='_blank' href={'https://github.com/SpecterOps/BloodHound/wiki/Example-Data'}>
             GitHub Sample Collection
         </Link>
     );


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Update links in README.MD and in the Explore help modal to point directly to the new docs location.

## Motivation and Context

This PR addresses: BED-4568

*Why is this change required? What problem does it solve?*

## How Has This Been Tested?

Local environment

## Screenshots (optional):

<img width="1207" alt="image" src="https://github.com/user-attachments/assets/85d07376-4bf1-4144-81d3-486fe3099eec">

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [X] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [X] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [X] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
