### PR TITLE
BED-4570: Resolve panics with IngestibleRelationship

### DIFF
--- a/cmd/api/src/daemons/datapipe/convertors.go
+++ b/cmd/api/src/daemons/datapipe/convertors.go
@@ -189,14 +189,20 @@ func convertCertTemplateData(certtemplate ein.CertTemplate, converted *Converted
 func convertIssuancePolicy(issuancePolicy ein.IssuancePolicy, converted *ConvertedData) {
 	props := ein.ConvertObjectToNode(issuancePolicy.IngestBase, ad.IssuancePolicy)
 	if issuancePolicy.GroupLink.ObjectIdentifier != "" {
-		converted.RelProps = append(converted.RelProps, ein.IngestibleRelationship{
-			Source:     issuancePolicy.ObjectIdentifier,
-			SourceType: ad.IssuancePolicy,
-			TargetType: issuancePolicy.GroupLink.Kind(),
-			Target:     issuancePolicy.GroupLink.ObjectIdentifier,
-			RelProps:   map[string]any{"isacl": false},
-			RelType:    ad.OIDGroupLink,
-		})
+		converted.RelProps = append(converted.RelProps, ein.NewIngestibleRelationship(
+			ein.IngestibleSource{
+				Source:     issuancePolicy.ObjectIdentifier,
+				SourceType: ad.IssuancePolicy,
+			},
+			ein.IngestibleTarget{
+				Target:     issuancePolicy.GroupLink.ObjectIdentifier,
+				TargetType: issuancePolicy.GroupLink.Kind(),
+			},
+			ein.IngestibleRel{
+				RelProps: map[string]any{"isacl": false},
+				RelType:  ad.OIDGroupLink,
+			},
+		))
 		props.PropertyMap[ad.GroupLinkID.String()] = issuancePolicy.GroupLink.ObjectIdentifier
 	}
 

--- a/packages/go/ein/ad.go
+++ b/packages/go/ein/ad.go
@@ -60,7 +60,7 @@ func ParseObjectContainer(item IngestBase, itemType graph.Kind) IngestibleRelati
 		}
 	}
 
-	return IngestibleRelationship{}
+	return NewIngestibleRelationship()
 }
 
 func ParsePrimaryGroup(item IngestBase, itemType graph.Kind, primaryGroupSid string) IngestibleRelationship {
@@ -75,7 +75,7 @@ func ParsePrimaryGroup(item IngestBase, itemType graph.Kind, primaryGroupSid str
 		}
 	}
 
-	return IngestibleRelationship{}
+	return NewIngestibleRelationship()
 }
 
 func ParseGroupMembershipData(group Group) ParsedGroupMembershipData {
@@ -133,7 +133,7 @@ func ParseACEData(aces []ACE, targetID string, targetType graph.Kind) []Ingestib
 }
 
 func convertSPNData(spns []SPNTarget, sourceID string) []IngestibleRelationship {
-	converted := make([]IngestibleRelationship, len(spns))
+	converted := make([]IngestibleRelationship, 0, len(spns))
 
 	for i, s := range spns {
 		if kind, err := analysis.ParseKind(s.Service); err != nil {
@@ -187,7 +187,7 @@ func ParseUserMiscData(user User) []IngestibleRelationship {
 }
 
 func ParseChildObjects(data []TypedPrincipal, containerId string, containerType graph.Kind) []IngestibleRelationship {
-	relationships := make([]IngestibleRelationship, len(data))
+	relationships := make([]IngestibleRelationship, 0, len(data))
 	for i, childObject := range data {
 		relationships[i] = IngestibleRelationship{
 			Source:     containerId,
@@ -202,7 +202,7 @@ func ParseChildObjects(data []TypedPrincipal, containerId string, containerType 
 	return relationships
 }
 func ParseGpLinks(links []GPLink, itemIdentifier string, itemType graph.Kind) []IngestibleRelationship {
-	relationships := make([]IngestibleRelationship, len(links))
+	relationships := make([]IngestibleRelationship, 0, len(links))
 	for i, gpLink := range links {
 		relationships[i] = IngestibleRelationship{
 			Source:     gpLink.Guid,

--- a/packages/go/ein/ad.go
+++ b/packages/go/ein/ad.go
@@ -50,53 +50,81 @@ func ConvertObjectToNode(item IngestBase, itemType graph.Kind) IngestibleNode {
 func ParseObjectContainer(item IngestBase, itemType graph.Kind) IngestibleRelationship {
 	containingPrincipal := item.ContainedBy
 	if containingPrincipal.ObjectIdentifier != "" {
-		return IngestibleRelationship{
-			Source:     containingPrincipal.ObjectIdentifier,
-			SourceType: containingPrincipal.Kind(),
-			TargetType: itemType,
-			Target:     item.ObjectIdentifier,
-			RelProps:   map[string]any{"isacl": false},
-			RelType:    ad.Contains,
-		}
+		return NewIngestibleRelationship(
+			IngestibleSource{
+				Source:     containingPrincipal.ObjectIdentifier,
+				SourceType: containingPrincipal.Kind(),
+			},
+			IngestibleTarget{
+				Target:     item.ObjectIdentifier,
+				TargetType: itemType,
+			},
+			IngestibleRel{
+				RelProps: map[string]any{"isacl": false},
+				RelType:  ad.Contains,
+			},
+		)
 	}
 
-	return NewIngestibleRelationship()
+	// TODO: Decide if we even want empty rels in the first place
+	return NewIngestibleRelationship(IngestibleSource{}, IngestibleTarget{}, IngestibleRel{})
 }
 
 func ParsePrimaryGroup(item IngestBase, itemType graph.Kind, primaryGroupSid string) IngestibleRelationship {
 	if primaryGroupSid != "" {
-		return IngestibleRelationship{
-			Source:     item.ObjectIdentifier,
-			SourceType: itemType,
-			TargetType: ad.Group,
-			Target:     primaryGroupSid,
-			RelProps:   map[string]any{"isacl": false, "isprimarygroup": true},
-			RelType:    ad.MemberOf,
-		}
+		return NewIngestibleRelationship(
+			IngestibleSource{
+				Source:     item.ObjectIdentifier,
+				SourceType: itemType,
+			},
+			IngestibleTarget{
+				Target:     primaryGroupSid,
+				TargetType: ad.Group,
+			},
+			IngestibleRel{
+				RelProps: map[string]any{"isacl": false, "isprimarygroup": true},
+				RelType:  ad.MemberOf,
+			},
+		)
 	}
 
-	return NewIngestibleRelationship()
+	// TODO: Decide if we even want empty rels in the first place
+	return NewIngestibleRelationship(IngestibleSource{}, IngestibleTarget{}, IngestibleRel{})
 }
 
 func ParseGroupMembershipData(group Group) ParsedGroupMembershipData {
 	result := ParsedGroupMembershipData{}
 	for _, member := range group.Members {
 		if strings.HasPrefix(member.ObjectIdentifier, "DN=") {
-			result.DistinguishedNameMembers = append(result.DistinguishedNameMembers, IngestibleRelationship{
-				Source:     member.ObjectIdentifier,
-				SourceType: member.Kind(),
-				Target:     group.ObjectIdentifier,
-				TargetType: ad.Group,
-				RelProps:   map[string]any{"isacl": false, "isprimarygroup": false},
-				RelType:    ad.MemberOf})
+			result.DistinguishedNameMembers = append(result.DistinguishedNameMembers, NewIngestibleRelationship(
+				IngestibleSource{
+					Source:     member.ObjectIdentifier,
+					SourceType: member.Kind(),
+				},
+				IngestibleTarget{
+					Target:     group.ObjectIdentifier,
+					TargetType: ad.Group,
+				},
+				IngestibleRel{
+					RelProps: map[string]any{"isacl": false, "isprimarygroup": false},
+					RelType:  ad.MemberOf,
+				},
+			))
 		} else {
-			result.RegularMembers = append(result.RegularMembers, IngestibleRelationship{
-				Source:     member.ObjectIdentifier,
-				SourceType: member.Kind(),
-				Target:     group.ObjectIdentifier,
-				TargetType: ad.Group,
-				RelProps:   map[string]any{"isacl": false, "isprimarygroup": false},
-				RelType:    ad.MemberOf})
+			result.RegularMembers = append(result.RegularMembers, NewIngestibleRelationship(
+				IngestibleSource{
+					Source:     member.ObjectIdentifier,
+					SourceType: member.Kind(),
+				},
+				IngestibleTarget{
+					Target:     group.ObjectIdentifier,
+					TargetType: ad.Group,
+				},
+				IngestibleRel{
+					RelProps: map[string]any{"isacl": false, "isprimarygroup": false},
+					RelType:  ad.MemberOf,
+				},
+			))
 		}
 	}
 
@@ -118,14 +146,20 @@ func ParseACEData(aces []ACE, targetID string, targetType graph.Kind) []Ingestib
 			log.Errorf("Non-ace edge type given to process aces: %s", ace.RightName)
 			continue
 		} else {
-			converted = append(converted, IngestibleRelationship{
-				Source:     ace.PrincipalSID,
-				SourceType: ace.Kind(),
-				Target:     targetID,
-				TargetType: targetType,
-				RelProps:   map[string]any{"isacl": true, "isinherited": ace.IsInherited},
-				RelType:    rightKind,
-			})
+			converted = append(converted, NewIngestibleRelationship(
+				IngestibleSource{
+					Source:     ace.PrincipalSID,
+					SourceType: ace.Kind(),
+				},
+				IngestibleTarget{
+					Target:     targetID,
+					TargetType: targetType,
+				},
+				IngestibleRel{
+					RelProps: map[string]any{"isacl": true, "isinherited": ace.IsInherited},
+					RelType:  rightKind,
+				},
+			))
 		}
 	}
 
@@ -135,18 +169,24 @@ func ParseACEData(aces []ACE, targetID string, targetType graph.Kind) []Ingestib
 func convertSPNData(spns []SPNTarget, sourceID string) []IngestibleRelationship {
 	converted := make([]IngestibleRelationship, 0, len(spns))
 
-	for i, s := range spns {
+	for _, s := range spns {
 		if kind, err := analysis.ParseKind(s.Service); err != nil {
 			log.Errorf("Error during processSPNTargets: %v", err)
 		} else {
-			converted[i] = IngestibleRelationship{
-				Source:     sourceID,
-				Target:     s.ComputerSID,
-				SourceType: ad.User,
-				TargetType: ad.Computer,
-				RelProps:   map[string]any{"isacl": true, "port": s.Port},
-				RelType:    kind,
-			}
+			converted = append(converted, NewIngestibleRelationship(
+				IngestibleSource{
+					Source:     sourceID,
+					SourceType: ad.User,
+				},
+				IngestibleTarget{
+					Target:     s.ComputerSID,
+					TargetType: ad.Computer,
+				},
+				IngestibleRel{
+					RelProps: map[string]any{"isacl": true, "port": s.Port},
+					RelType:  kind,
+				},
+			))
 		}
 	}
 
@@ -162,25 +202,37 @@ func ParseUserMiscData(user User) []IngestibleRelationship {
 	}
 
 	for _, target := range user.AllowedToDelegate {
-		data = append(data, IngestibleRelationship{
-			Source:     user.ObjectIdentifier,
-			SourceType: ad.User,
-			Target:     target.ObjectIdentifier,
-			TargetType: target.Kind(),
-			RelType:    ad.AllowedToDelegate,
-			RelProps:   map[string]any{"isacl": false},
-		})
+		data = append(data, NewIngestibleRelationship(
+			IngestibleSource{
+				Source:     user.ObjectIdentifier,
+				SourceType: ad.User,
+			},
+			IngestibleTarget{
+				Target:     target.ObjectIdentifier,
+				TargetType: target.Kind(),
+			},
+			IngestibleRel{
+				RelProps: map[string]any{"isacl": false},
+				RelType:  ad.AllowedToDelegate,
+			},
+		))
 	}
 
 	for _, target := range user.HasSIDHistory {
-		data = append(data, IngestibleRelationship{
-			Source:     user.ObjectIdentifier,
-			SourceType: ad.User,
-			Target:     target.ObjectIdentifier,
-			TargetType: target.Kind(),
-			RelType:    ad.HasSIDHistory,
-			RelProps:   map[string]any{"isacl": false},
-		})
+		data = append(data, NewIngestibleRelationship(
+			IngestibleSource{
+				Source:     user.ObjectIdentifier,
+				SourceType: ad.User,
+			},
+			IngestibleTarget{
+				Target:     target.ObjectIdentifier,
+				TargetType: target.Kind(),
+			},
+			IngestibleRel{
+				RelProps: map[string]any{"isacl": false},
+				RelType:  ad.HasSIDHistory,
+			},
+		))
 	}
 
 	return data
@@ -188,30 +240,42 @@ func ParseUserMiscData(user User) []IngestibleRelationship {
 
 func ParseChildObjects(data []TypedPrincipal, containerId string, containerType graph.Kind) []IngestibleRelationship {
 	relationships := make([]IngestibleRelationship, 0, len(data))
-	for i, childObject := range data {
-		relationships[i] = IngestibleRelationship{
-			Source:     containerId,
-			SourceType: containerType,
-			TargetType: childObject.Kind(),
-			Target:     childObject.ObjectIdentifier,
-			RelProps:   map[string]any{"isacl": false},
-			RelType:    ad.Contains,
-		}
+	for _, childObject := range data {
+		relationships = append(relationships, NewIngestibleRelationship(
+			IngestibleSource{
+				Source:     containerId,
+				SourceType: containerType,
+			},
+			IngestibleTarget{
+				Target:     childObject.ObjectIdentifier,
+				TargetType: childObject.Kind(),
+			},
+			IngestibleRel{
+				RelProps: map[string]any{"isacl": false},
+				RelType:  ad.Contains,
+			},
+		))
 	}
 
 	return relationships
 }
 func ParseGpLinks(links []GPLink, itemIdentifier string, itemType graph.Kind) []IngestibleRelationship {
 	relationships := make([]IngestibleRelationship, 0, len(links))
-	for i, gpLink := range links {
-		relationships[i] = IngestibleRelationship{
-			Source:     gpLink.Guid,
-			SourceType: ad.GPO,
-			Target:     itemIdentifier,
-			TargetType: itemType,
-			RelProps:   map[string]any{"isacl": false, "enforced": gpLink.IsEnforced},
-			RelType:    ad.GPLink,
-		}
+	for _, gpLink := range links {
+		relationships = append(relationships, NewIngestibleRelationship(
+			IngestibleSource{
+				Source:     gpLink.Guid,
+				SourceType: ad.GPO,
+			},
+			IngestibleTarget{
+				Target:     itemIdentifier,
+				TargetType: itemType,
+			},
+			IngestibleRel{
+				RelProps: map[string]any{"isacl": false, "enforced": gpLink.IsEnforced},
+				RelType:  ad.GPLink,
+			},
+		))
 	}
 
 	return relationships
@@ -228,33 +292,45 @@ func ParseDomainTrusts(domain Domain) ParsedDomainTrustData {
 
 		var dir = trust.TrustDirection
 		if dir == TrustDirectionInbound || dir == TrustDirectionBidirectional {
-			parsedData.TrustRelationships = append(parsedData.TrustRelationships, IngestibleRelationship{
-				Source:     domain.ObjectIdentifier,
-				SourceType: ad.Domain,
-				Target:     trust.TargetDomainSid,
-				TargetType: ad.Domain,
-				RelProps: map[string]any{
-					"isacl":        false,
-					"sidfiltering": trust.SidFilteringEnabled,
-					"trusttype":    trust.TrustType,
-					"transitive":   trust.IsTransitive},
-				RelType: ad.TrustedBy,
-			})
+			parsedData.TrustRelationships = append(parsedData.TrustRelationships, NewIngestibleRelationship(
+				IngestibleSource{
+					Source:     domain.ObjectIdentifier,
+					SourceType: ad.Domain,
+				},
+				IngestibleTarget{
+					Target:     trust.TargetDomainSid,
+					TargetType: ad.Domain,
+				},
+				IngestibleRel{
+					RelProps: map[string]any{
+						"isacl":        false,
+						"sidfiltering": trust.SidFilteringEnabled,
+						"trusttype":    trust.TrustType,
+						"transitive":   trust.IsTransitive},
+					RelType: ad.TrustedBy,
+				},
+			))
 		}
 
 		if dir == TrustDirectionOutbound || dir == TrustDirectionBidirectional {
-			parsedData.TrustRelationships = append(parsedData.TrustRelationships, IngestibleRelationship{
-				Source:     trust.TargetDomainSid,
-				SourceType: ad.Domain,
-				Target:     domain.ObjectIdentifier,
-				TargetType: ad.Domain,
-				RelProps: map[string]any{
-					"isacl":        false,
-					"sidfiltering": trust.SidFilteringEnabled,
-					"trusttype":    trust.TrustType,
-					"transitive":   trust.IsTransitive},
-				RelType: ad.TrustedBy,
-			})
+			parsedData.TrustRelationships = append(parsedData.TrustRelationships, NewIngestibleRelationship(
+				IngestibleSource{
+					Source:     trust.TargetDomainSid,
+					SourceType: ad.Domain,
+				},
+				IngestibleTarget{
+					Target:     domain.ObjectIdentifier,
+					TargetType: ad.Domain,
+				},
+				IngestibleRel{
+					RelProps: map[string]any{
+						"isacl":        false,
+						"sidfiltering": trust.SidFilteringEnabled,
+						"trusttype":    trust.TrustType,
+						"transitive":   trust.IsTransitive},
+					RelType: ad.TrustedBy,
+				},
+			))
 		}
 	}
 
@@ -265,97 +341,145 @@ func ParseDomainTrusts(domain Domain) ParsedDomainTrustData {
 func ParseComputerMiscData(computer Computer) []IngestibleRelationship {
 	relationships := make([]IngestibleRelationship, 0)
 	for _, target := range computer.AllowedToDelegate {
-		relationships = append(relationships, IngestibleRelationship{
-			Source:     computer.ObjectIdentifier,
-			SourceType: ad.Computer,
-			Target:     target.ObjectIdentifier,
-			TargetType: target.Kind(),
-			RelType:    ad.AllowedToDelegate,
-			RelProps:   map[string]any{"isacl": false},
-		})
+		relationships = append(relationships, NewIngestibleRelationship(
+			IngestibleSource{
+				Source:     computer.ObjectIdentifier,
+				SourceType: ad.Computer,
+			},
+			IngestibleTarget{
+				Target:     target.ObjectIdentifier,
+				TargetType: target.Kind(),
+			},
+			IngestibleRel{
+				RelProps: map[string]any{"isacl": false},
+				RelType:  ad.AllowedToDelegate,
+			},
+		))
 	}
 
 	for _, actor := range computer.AllowedToAct {
-		relationships = append(relationships, IngestibleRelationship{
-			Source:     actor.ObjectIdentifier,
-			SourceType: actor.Kind(),
-			Target:     computer.ObjectIdentifier,
-			TargetType: ad.Computer,
-			RelType:    ad.AllowedToAct,
-			RelProps:   map[string]any{"isacl": false},
-		})
+		relationships = append(relationships, NewIngestibleRelationship(
+			IngestibleSource{
+				Source:     actor.ObjectIdentifier,
+				SourceType: actor.Kind(),
+			},
+			IngestibleTarget{
+				Target:     computer.ObjectIdentifier,
+				TargetType: ad.Computer,
+			},
+			IngestibleRel{
+				RelProps: map[string]any{"isacl": false},
+				RelType:  ad.AllowedToAct,
+			},
+		))
 	}
 
 	for _, target := range computer.DumpSMSAPassword {
-		relationships = append(relationships, IngestibleRelationship{
-			Source:     computer.ObjectIdentifier,
-			SourceType: ad.Computer,
-			Target:     target.ObjectIdentifier,
-			TargetType: target.Kind(),
-			RelType:    ad.DumpSMSAPassword,
-			RelProps:   map[string]any{"isacl": false},
-		})
+		relationships = append(relationships, NewIngestibleRelationship(
+			IngestibleSource{
+				Source:     computer.ObjectIdentifier,
+				SourceType: ad.Computer,
+			},
+			IngestibleTarget{
+				Target:     target.ObjectIdentifier,
+				TargetType: target.Kind(),
+			},
+			IngestibleRel{
+				RelProps: map[string]any{"isacl": false},
+				RelType:  ad.DumpSMSAPassword,
+			},
+		))
 	}
 
 	for _, target := range computer.HasSIDHistory {
-		relationships = append(relationships, IngestibleRelationship{
-			Source:     computer.ObjectIdentifier,
-			SourceType: ad.Computer,
-			Target:     target.ObjectIdentifier,
-			TargetType: target.Kind(),
-			RelType:    ad.HasSIDHistory,
-			RelProps:   map[string]any{"isacl": false},
-		})
+		relationships = append(relationships, NewIngestibleRelationship(
+			IngestibleSource{
+				Source:     computer.ObjectIdentifier,
+				SourceType: ad.Computer,
+			},
+			IngestibleTarget{
+				Target:     target.ObjectIdentifier,
+				TargetType: target.Kind(),
+			},
+			IngestibleRel{
+				RelProps: map[string]any{"isacl": false},
+				RelType:  ad.HasSIDHistory,
+			},
+		))
 	}
 
 	if computer.Sessions.Collected {
 		for _, session := range computer.Sessions.Results {
-			relationships = append(relationships, IngestibleRelationship{
-				Source:     session.ComputerSID,
-				SourceType: ad.Computer,
-				Target:     session.UserSID,
-				TargetType: ad.User,
-				RelType:    ad.HasSession,
-				RelProps:   map[string]any{"isacl": false},
-			})
+			relationships = append(relationships, NewIngestibleRelationship(
+				IngestibleSource{
+					Source:     session.ComputerSID,
+					SourceType: ad.Computer,
+				},
+				IngestibleTarget{
+					Target:     session.UserSID,
+					TargetType: ad.User,
+				},
+				IngestibleRel{
+					RelProps: map[string]any{"isacl": false},
+					RelType:  ad.HasSession,
+				},
+			))
 		}
 	}
 
 	if computer.PrivilegedSessions.Collected {
 		for _, session := range computer.PrivilegedSessions.Results {
-			relationships = append(relationships, IngestibleRelationship{
-				Source:     session.ComputerSID,
-				SourceType: ad.Computer,
-				Target:     session.UserSID,
-				TargetType: ad.User,
-				RelType:    ad.HasSession,
-				RelProps:   map[string]any{"isacl": false},
-			})
+			relationships = append(relationships, NewIngestibleRelationship(
+				IngestibleSource{
+					Source:     session.ComputerSID,
+					SourceType: ad.Computer,
+				},
+				IngestibleTarget{
+					Target:     session.UserSID,
+					TargetType: ad.User,
+				},
+				IngestibleRel{
+					RelProps: map[string]any{"isacl": false},
+					RelType:  ad.HasSession,
+				},
+			))
 		}
 	}
 
 	if computer.RegistrySessions.Collected {
 		for _, session := range computer.RegistrySessions.Results {
-			relationships = append(relationships, IngestibleRelationship{
-				Source:     session.ComputerSID,
-				SourceType: ad.Computer,
-				Target:     session.UserSID,
-				TargetType: ad.User,
-				RelType:    ad.HasSession,
-				RelProps:   map[string]any{"isacl": false},
-			})
+			relationships = append(relationships, NewIngestibleRelationship(
+				IngestibleSource{
+					Source:     session.ComputerSID,
+					SourceType: ad.Computer,
+				},
+				IngestibleTarget{
+					Target:     session.UserSID,
+					TargetType: ad.User,
+				},
+				IngestibleRel{
+					RelProps: map[string]any{"isacl": false},
+					RelType:  ad.HasSession,
+				},
+			))
 		}
 	}
 
 	if computer.IsDC && computer.DomainSID != "" {
-		relationships = append(relationships, IngestibleRelationship{
-			Source:     computer.ObjectIdentifier,
-			SourceType: ad.Computer,
-			TargetType: ad.Domain,
-			Target:     computer.DomainSID,
-			RelProps:   map[string]any{"isacl": false},
-			RelType:    ad.DCFor,
-		})
+		relationships = append(relationships, NewIngestibleRelationship(
+			IngestibleSource{
+				Source:     computer.ObjectIdentifier,
+				SourceType: ad.Computer,
+			},
+			IngestibleTarget{
+				Target:     computer.DomainSID,
+				TargetType: ad.Domain,
+			},
+			IngestibleRel{
+				RelProps: map[string]any{"isacl": false},
+				RelType:  ad.DCFor,
+			},
+		))
 	}
 
 	return relationships
@@ -373,24 +497,36 @@ func ConvertLocalGroup(localGroup LocalGroupAPIResult, computer Computer) Parsed
 		})
 	}
 
-	parsedData.Relationships = append(parsedData.Relationships, IngestibleRelationship{
-		Source:     localGroup.ObjectIdentifier,
-		SourceType: ad.LocalGroup,
-		TargetType: ad.Computer,
-		Target:     computer.ObjectIdentifier,
-		RelProps:   map[string]any{"isacl": false},
-		RelType:    ad.LocalToComputer,
-	})
+	parsedData.Relationships = append(parsedData.Relationships, NewIngestibleRelationship(
+		IngestibleSource{
+			Source:     localGroup.ObjectIdentifier,
+			SourceType: ad.LocalGroup,
+		},
+		IngestibleTarget{
+			Target:     computer.ObjectIdentifier,
+			TargetType: ad.Computer,
+		},
+		IngestibleRel{
+			RelProps: map[string]any{"isacl": false},
+			RelType:  ad.LocalToComputer,
+		},
+	))
 
 	for _, member := range localGroup.Results {
-		parsedData.Relationships = append(parsedData.Relationships, IngestibleRelationship{
-			Source:     member.ObjectIdentifier,
-			SourceType: member.Kind(),
-			TargetType: ad.LocalGroup,
-			Target:     localGroup.ObjectIdentifier,
-			RelProps:   map[string]any{"isacl": false},
-			RelType:    ad.MemberOfLocalGroup,
-		})
+		parsedData.Relationships = append(parsedData.Relationships, NewIngestibleRelationship(
+			IngestibleSource{
+				Source:     member.ObjectIdentifier,
+				SourceType: member.Kind(),
+			},
+			IngestibleTarget{
+				Target:     localGroup.ObjectIdentifier,
+				TargetType: ad.LocalGroup,
+			},
+			IngestibleRel{
+				RelProps: map[string]any{"isacl": false},
+				RelType:  ad.MemberOfLocalGroup,
+			},
+		))
 	}
 
 	for _, name := range localGroup.LocalNames {
@@ -410,14 +546,20 @@ func ParseUserRightData(userRight UserRightsAssignmentAPIResult, computer Comput
 	relationships := make([]IngestibleRelationship, 0)
 
 	for _, grant := range userRight.Results {
-		relationships = append(relationships, IngestibleRelationship{
-			Source:     grant.ObjectIdentifier,
-			SourceType: grant.Kind(),
-			TargetType: ad.Computer,
-			Target:     computer.ObjectIdentifier,
-			RelProps:   map[string]any{"isacl": false},
-			RelType:    right,
-		})
+		relationships = append(relationships, NewIngestibleRelationship(
+			IngestibleSource{
+				Source:     grant.ObjectIdentifier,
+				SourceType: grant.Kind(),
+			},
+			IngestibleTarget{
+				Target:     computer.ObjectIdentifier,
+				TargetType: ad.Computer,
+			},
+			IngestibleRel{
+				RelProps: map[string]any{"isacl": false},
+				RelType:  right,
+			},
+		))
 	}
 
 	return relationships
@@ -461,25 +603,37 @@ func ParseEnterpriseCAMiscData(enterpriseCA EnterpriseCA) []IngestibleRelationsh
 
 	for _, actor := range enterpriseCA.EnabledCertTemplates {
 		enabledCertTemplates = append(enabledCertTemplates, actor.ObjectIdentifier)
-		relationships = append(relationships, IngestibleRelationship{
-			Source:     actor.ObjectIdentifier,
-			SourceType: ad.CertTemplate,
-			Target:     enterpriseCA.ObjectIdentifier,
-			TargetType: ad.EnterpriseCA,
-			RelType:    ad.PublishedTo,
-			RelProps:   map[string]any{"isacl": false},
-		})
+		relationships = append(relationships, NewIngestibleRelationship(
+			IngestibleSource{
+				Source:     actor.ObjectIdentifier,
+				SourceType: ad.CertTemplate,
+			},
+			IngestibleTarget{
+				Target:     enterpriseCA.ObjectIdentifier,
+				TargetType: ad.EnterpriseCA,
+			},
+			IngestibleRel{
+				RelProps: map[string]any{"isacl": false},
+				RelType:  ad.PublishedTo,
+			},
+		))
 	}
 
 	if enterpriseCA.HostingComputer != "" {
-		relationships = append(relationships, IngestibleRelationship{
-			Source:     enterpriseCA.HostingComputer,
-			SourceType: ad.Computer,
-			Target:     enterpriseCA.ObjectIdentifier,
-			TargetType: ad.EnterpriseCA,
-			RelType:    ad.HostsCAService,
-			RelProps:   map[string]any{"isacl": false},
-		})
+		relationships = append(relationships, NewIngestibleRelationship(
+			IngestibleSource{
+				Source:     enterpriseCA.HostingComputer,
+				SourceType: ad.Computer,
+			},
+			IngestibleTarget{
+				Target:     enterpriseCA.ObjectIdentifier,
+				TargetType: ad.EnterpriseCA,
+			},
+			IngestibleRel{
+				RelProps: map[string]any{"isacl": false},
+				RelType:  ad.HostsCAService,
+			},
+		))
 	}
 
 	relationships = handleEnterpriseCAEnrollmentAgentRestrictions(enterpriseCA, relationships, enabledCertTemplates)
@@ -501,14 +655,20 @@ func handleEnterpriseCAEnrollmentAgentRestrictions(enterpriseCA EnterpriseCA, re
 				}
 
 				for _, template := range templates {
-					relationships = append(relationships, IngestibleRelationship{
-						Source:     restriction.Agent.ObjectIdentifier,
-						SourceType: restriction.Agent.Kind(),
-						Target:     template,
-						TargetType: ad.CertTemplate,
-						RelType:    ad.DelegatedEnrollmentAgent,
-						RelProps:   map[string]any{"isacl": false},
-					})
+					relationships = append(relationships, NewIngestibleRelationship(
+						IngestibleSource{
+							Source:     restriction.Agent.ObjectIdentifier,
+							SourceType: restriction.Agent.Kind(),
+						},
+						IngestibleTarget{
+							Target:     template,
+							TargetType: ad.CertTemplate,
+						},
+						IngestibleRel{
+							RelProps: map[string]any{"isacl": false},
+							RelType:  ad.DelegatedEnrollmentAgent,
+						},
+					))
 
 				}
 			}
@@ -560,14 +720,20 @@ func ParseRootCAMiscData(rootCA RootCA) []IngestibleRelationship {
 	)
 
 	if domainsid != "" {
-		relationships = append(relationships, IngestibleRelationship{
-			Source:     rootCA.ObjectIdentifier,
-			SourceType: ad.RootCA,
-			Target:     domainsid,
-			TargetType: ad.Domain,
-			RelType:    ad.RootCAFor,
-			RelProps:   map[string]any{"isacl": false},
-		})
+		relationships = append(relationships, NewIngestibleRelationship(
+			IngestibleSource{
+				Source:     rootCA.ObjectIdentifier,
+				SourceType: ad.RootCA,
+			},
+			IngestibleTarget{
+				Target:     domainsid,
+				TargetType: ad.Domain,
+			},
+			IngestibleRel{
+				RelProps: map[string]any{"isacl": false},
+				RelType:  ad.RootCAFor,
+			},
+		))
 	}
 
 	return relationships
@@ -580,14 +746,20 @@ func ParseNTAuthStoreData(ntAuthStore NTAuthStore) []IngestibleRelationship {
 	)
 
 	if domainsid != "" {
-		relationships = append(relationships, IngestibleRelationship{
-			Source:     ntAuthStore.ObjectIdentifier,
-			SourceType: ad.NTAuthStore,
-			Target:     domainsid,
-			TargetType: ad.Domain,
-			RelType:    ad.NTAuthStoreFor,
-			RelProps:   map[string]any{"isacl": false},
-		})
+		relationships = append(relationships, NewIngestibleRelationship(
+			IngestibleSource{
+				Source:     ntAuthStore.ObjectIdentifier,
+				SourceType: ad.NTAuthStore,
+			},
+			IngestibleTarget{
+				Target:     domainsid,
+				TargetType: ad.Domain,
+			},
+			IngestibleRel{
+				RelProps: map[string]any{"isacl": false},
+				RelType:  ad.NTAuthStoreFor,
+			},
+		))
 	}
 
 	return relationships

--- a/packages/go/ein/azure.go
+++ b/packages/go/ein/azure.go
@@ -62,14 +62,22 @@ func ConvertAZAppToNode(app models.App) IngestibleNode {
 }
 
 func ConvertAZAppRelationships(app models.App) []IngestibleRelationship {
-	return []IngestibleRelationship{{
-		Source:     strings.ToUpper(app.TenantId),
-		SourceType: azure.Tenant,
-		TargetType: azure.App,
-		Target:     strings.ToUpper(app.AppId),
-		RelProps:   map[string]any{},
-		RelType:    azure.Contains,
-	}}
+	return []IngestibleRelationship{
+		NewIngestibleRelationship(
+			IngestibleSource{
+				Source:     strings.ToUpper(app.TenantId),
+				SourceType: azure.Tenant,
+			},
+			IngestibleTarget{
+				TargetType: azure.App,
+				Target:     strings.ToUpper(app.AppId),
+			},
+			IngestibleRel{
+				RelProps: map[string]any{},
+				RelType:  azure.Contains,
+			},
+		),
+	}
 }
 
 func ConvertAZDeviceToNode(device models.Device) IngestibleNode {
@@ -89,14 +97,22 @@ func ConvertAZDeviceToNode(device models.Device) IngestibleNode {
 }
 
 func ConvertAZDeviceRelationships(device models.Device) []IngestibleRelationship {
-	return []IngestibleRelationship{{
-		Source:     strings.ToUpper(device.TenantId),
-		SourceType: azure.Tenant,
-		TargetType: azure.Device,
-		Target:     strings.ToUpper(device.Id),
-		RelProps:   map[string]any{},
-		RelType:    azure.Contains,
-	}}
+	return []IngestibleRelationship{
+		NewIngestibleRelationship(
+			IngestibleSource{
+				Source:     strings.ToUpper(device.TenantId),
+				SourceType: azure.Tenant,
+			},
+			IngestibleTarget{
+				TargetType: azure.Device,
+				Target:     strings.ToUpper(device.Id),
+			},
+			IngestibleRel{
+				RelProps: map[string]any{},
+				RelType:  azure.Contains,
+			},
+		),
+	}
 }
 
 func ConvertAZVMScaleSetToNode(scaleSet models.VMScaleSet) IngestibleNode {
@@ -112,38 +128,56 @@ func ConvertAZVMScaleSetToNode(scaleSet models.VMScaleSet) IngestibleNode {
 
 func ConvertAZVMScaleSetRelationships(scaleSet models.VMScaleSet) []IngestibleRelationship {
 	relationships := make([]IngestibleRelationship, 0)
-	relationships = append(relationships, IngestibleRelationship{
-		Source:     strings.ToUpper(scaleSet.ResourceGroupId),
-		SourceType: azure.ResourceGroup,
-		TargetType: azure.VMScaleSet,
-		Target:     strings.ToUpper(scaleSet.Id),
-		RelProps:   map[string]any{},
-		RelType:    azure.Contains,
-	})
+	relationships = append(relationships, NewIngestibleRelationship(
+		IngestibleSource{
+			Source:     strings.ToUpper(scaleSet.ResourceGroupId),
+			SourceType: azure.ResourceGroup,
+		},
+		IngestibleTarget{
+			TargetType: azure.VMScaleSet,
+			Target:     strings.ToUpper(scaleSet.Id),
+		},
+		IngestibleRel{
+			RelProps: map[string]any{},
+			RelType:  azure.Contains,
+		},
+	))
 
 	// Enumerate System Assigned Identities
 	if scaleSet.Identity.PrincipalId != "" {
-		relationships = append(relationships, IngestibleRelationship{
-			Source:     strings.ToUpper(scaleSet.Id),
-			SourceType: azure.VMScaleSet,
-			TargetType: azure.ServicePrincipal,
-			Target:     strings.ToUpper(scaleSet.Identity.PrincipalId),
-			RelProps:   map[string]any{},
-			RelType:    azure.ManagedIdentity,
-		})
+		relationships = append(relationships, NewIngestibleRelationship(
+			IngestibleSource{
+				Source:     strings.ToUpper(scaleSet.Id),
+				SourceType: azure.VMScaleSet,
+			},
+			IngestibleTarget{
+				TargetType: azure.ServicePrincipal,
+				Target:     strings.ToUpper(scaleSet.Identity.PrincipalId),
+			},
+			IngestibleRel{
+				RelProps: map[string]any{},
+				RelType:  azure.ManagedIdentity,
+			},
+		))
 	}
 
 	// Enumerate User Assigned Identities
 	for _, identity := range scaleSet.Identity.UserAssignedIdentities {
 		if identity.ClientId != "" {
-			relationships = append(relationships, IngestibleRelationship{
-				Source:     strings.ToUpper(scaleSet.Id),
-				SourceType: azure.VMScaleSet,
-				TargetType: azure.ServicePrincipal,
-				Target:     strings.ToUpper(identity.PrincipalId),
-				RelProps:   map[string]any{},
-				RelType:    azure.ManagedIdentity,
-			})
+			relationships = append(relationships, NewIngestibleRelationship(
+				IngestibleSource{
+					Source:     strings.ToUpper(scaleSet.Id),
+					SourceType: azure.VMScaleSet,
+				},
+				IngestibleTarget{
+					TargetType: azure.ServicePrincipal,
+					Target:     strings.ToUpper(identity.PrincipalId),
+				},
+				IngestibleRel{
+					RelProps: map[string]any{},
+					RelType:  azure.ManagedIdentity,
+				},
+			))
 		}
 	}
 
@@ -160,14 +194,20 @@ func ConvertAzureVMScaleSetRoleAssignment(data models.AzureRoleAssignments) []In
 				constants.ContributorRoleID,
 				constants.VirtualMachineContributorRoleID,
 			}, strings.ToLower(raw.RoleDefinitionId)) {
-				relationships = append(relationships, IngestibleRelationship{
-					Source:     strings.ToUpper(raw.Assignee.GetPrincipalId()),
-					SourceType: azure.Entity,
-					TargetType: azure.VMScaleSet,
-					Target:     strings.ToUpper(data.ObjectId),
-					RelProps:   map[string]any{},
-					RelType:    KindFromRoleId(raw.RoleDefinitionId),
-				})
+				relationships = append(relationships, NewIngestibleRelationship(
+					IngestibleSource{
+						Source:     strings.ToUpper(raw.Assignee.GetPrincipalId()),
+						SourceType: azure.Entity,
+					},
+					IngestibleTarget{
+						TargetType: azure.VMScaleSet,
+						Target:     strings.ToUpper(data.ObjectId),
+					},
+					IngestibleRel{
+						RelProps: map[string]any{},
+						RelType:  KindFromRoleId(raw.RoleDefinitionId),
+					},
+				))
 			}
 		}
 	}
@@ -176,14 +216,20 @@ func ConvertAzureVMScaleSetRoleAssignment(data models.AzureRoleAssignments) []In
 }
 
 func ConvertAzureOwnerToRel(directoryObject azure2.DirectoryObject, ownerType graph.Kind, targetType graph.Kind, targetId string) IngestibleRelationship {
-	return IngestibleRelationship{
-		Source:     strings.ToUpper(directoryObject.Id),
-		SourceType: ownerType,
-		TargetType: targetType,
-		Target:     strings.ToUpper(targetId),
-		RelProps:   map[string]any{},
-		RelType:    azure.Owns,
-	}
+	return NewIngestibleRelationship(
+		IngestibleSource{
+			Source:     strings.ToUpper(directoryObject.Id),
+			SourceType: ownerType,
+		},
+		IngestibleTarget{
+			TargetType: targetType,
+			Target:     strings.ToUpper(targetId),
+		},
+		IngestibleRel{
+			RelProps: map[string]any{},
+			RelType:  azure.Owns,
+		},
+	)
 }
 
 func ConvertAzureAppRoleAssignmentToNodes(data models.AppRoleAssignment) []IngestibleNode {
@@ -212,24 +258,36 @@ func ConvertAzureAppRoleAssignmentToNodes(data models.AppRoleAssignment) []Inges
 
 func ConvertAzureAppRoleAssignmentToRel(data models.AppRoleAssignment) IngestibleRelationship {
 	if appRoleKind, hasAppRoleKind := azure.RelationshipKindByAppRoleID[strings.ToLower(data.AppRoleId.String())]; hasAppRoleKind {
-		return IngestibleRelationship{
-			Source:     strings.ToUpper(data.PrincipalId.String()),
-			SourceType: azure.ServicePrincipal,
-			TargetType: azure.ServicePrincipal,
-			Target:     strings.ToUpper(data.ResourceId),
-			RelProps:   map[string]any{},
-			RelType:    appRoleKind,
-		}
+		return NewIngestibleRelationship(
+			IngestibleSource{
+				Source:     strings.ToUpper(data.PrincipalId.String()),
+				SourceType: azure.ServicePrincipal,
+			},
+			IngestibleTarget{
+				TargetType: azure.ServicePrincipal,
+				Target:     strings.ToUpper(data.ResourceId),
+			},
+			IngestibleRel{
+				RelProps: map[string]any{},
+				RelType:  appRoleKind,
+			},
+		)
 	}
 
-	return IngestibleRelationship{
-		Source:     "",
-		SourceType: nil,
-		TargetType: nil,
-		Target:     "",
-		RelProps:   nil,
-		RelType:    nil,
-	}
+	return NewIngestibleRelationship(
+		IngestibleSource{
+			Source:     "",
+			SourceType: nil,
+		},
+		IngestibleTarget{
+			TargetType: nil,
+			Target:     "",
+		},
+		IngestibleRel{
+			RelProps: nil,
+			RelType:  nil,
+		},
+	)
 }
 
 func ConvertAzureFunctionAppToNode(data models.FunctionApp) IngestibleNode {
@@ -245,38 +303,56 @@ func ConvertAzureFunctionAppToNode(data models.FunctionApp) IngestibleNode {
 
 func ConvertAzureFunctionAppToRels(data models.FunctionApp) []IngestibleRelationship {
 	relationships := make([]IngestibleRelationship, 0)
-	relationships = append(relationships, IngestibleRelationship{
-		Source:     strings.ToUpper(data.ResourceGroupId),
-		SourceType: azure.ResourceGroup,
-		TargetType: azure.FunctionApp,
-		Target:     strings.ToUpper(data.Id),
-		RelProps:   map[string]any{},
-		RelType:    azure.Contains,
-	})
+	relationships = append(relationships, NewIngestibleRelationship(
+		IngestibleSource{
+			Source:     strings.ToUpper(data.ResourceGroupId),
+			SourceType: azure.ResourceGroup,
+		},
+		IngestibleTarget{
+			TargetType: azure.FunctionApp,
+			Target:     strings.ToUpper(data.Id),
+		},
+		IngestibleRel{
+			RelProps: map[string]any{},
+			RelType:  azure.Contains,
+		},
+	))
 
 	// Enumerate System Assigned Identities
 	if data.Identity.PrincipalId != "" {
-		relationships = append(relationships, IngestibleRelationship{
-			Source:     strings.ToUpper(data.Id),
-			SourceType: azure.FunctionApp,
-			TargetType: azure.ServicePrincipal,
-			Target:     strings.ToUpper(data.Identity.PrincipalId),
-			RelProps:   map[string]any{},
-			RelType:    azure.ManagedIdentity,
-		})
+		relationships = append(relationships, NewIngestibleRelationship(
+			IngestibleSource{
+				Source:     strings.ToUpper(data.Id),
+				SourceType: azure.FunctionApp,
+			},
+			IngestibleTarget{
+				TargetType: azure.ServicePrincipal,
+				Target:     strings.ToUpper(data.Identity.PrincipalId),
+			},
+			IngestibleRel{
+				RelProps: map[string]any{},
+				RelType:  azure.ManagedIdentity,
+			},
+		))
 	}
 
 	// Enumerate User Assigned Identities
 	for _, identity := range data.Identity.UserAssignedIdentities {
 		if identity.ClientId != "" {
-			relationships = append(relationships, IngestibleRelationship{
-				Source:     strings.ToUpper(data.Id),
-				SourceType: azure.FunctionApp,
-				TargetType: azure.ServicePrincipal,
-				Target:     strings.ToUpper(identity.PrincipalId),
-				RelProps:   map[string]any{},
-				RelType:    azure.ManagedIdentity,
-			})
+			relationships = append(relationships, NewIngestibleRelationship(
+				IngestibleSource{
+					Source:     strings.ToUpper(data.Id),
+					SourceType: azure.FunctionApp,
+				},
+				IngestibleTarget{
+					TargetType: azure.ServicePrincipal,
+					Target:     strings.ToUpper(identity.PrincipalId),
+				},
+				IngestibleRel{
+					RelProps: map[string]any{},
+					RelType:  azure.ManagedIdentity,
+				},
+			))
 		}
 	}
 
@@ -293,14 +369,20 @@ func ConvertAzureFunctionAppRoleAssignmentToRels(data models.AzureRoleAssignment
 				constants.ContributorRoleID,
 				constants.WebsiteContributorRoleID,
 			}, strings.ToLower(raw.RoleDefinitionId)) {
-				relationships = append(relationships, IngestibleRelationship{
-					Source:     strings.ToUpper(raw.Assignee.GetPrincipalId()),
-					SourceType: azure.Entity,
-					TargetType: azure.FunctionApp,
-					Target:     strings.ToUpper(data.ObjectId),
-					RelProps:   map[string]any{},
-					RelType:    KindFromRoleId(raw.RoleDefinitionId),
-				})
+				relationships = append(relationships, NewIngestibleRelationship(
+					IngestibleSource{
+						Source:     strings.ToUpper(raw.Assignee.GetPrincipalId()),
+						SourceType: azure.Entity,
+					},
+					IngestibleTarget{
+						TargetType: azure.FunctionApp,
+						Target:     strings.ToUpper(data.ObjectId),
+					},
+					IngestibleRel{
+						RelProps: map[string]any{},
+						RelType:  KindFromRoleId(raw.RoleDefinitionId),
+					},
+				))
 			}
 		}
 	}
@@ -344,14 +426,20 @@ func ConvertAzureGroupToOnPremisesNode(data models.Group) IngestibleNode {
 }
 
 func ConvertAzureGroupToRel(data models.Group) IngestibleRelationship {
-	return IngestibleRelationship{
-		Source:     strings.ToUpper(data.TenantId),
-		SourceType: azure.Tenant,
-		TargetType: azure.Group,
-		Target:     strings.ToUpper(data.Id),
-		RelProps:   map[string]any{},
-		RelType:    azure.Contains,
-	}
+	return NewIngestibleRelationship(
+		IngestibleSource{
+			Source:     strings.ToUpper(data.TenantId),
+			SourceType: azure.Tenant,
+		},
+		IngestibleTarget{
+			TargetType: azure.Group,
+			Target:     strings.ToUpper(data.Id),
+		},
+		IngestibleRel{
+			RelProps: map[string]any{},
+			RelType:  azure.Contains,
+		},
+	)
 }
 
 func ConvertAzureGroupMembersToRels(data models.GroupMembers) []IngestibleRelationship {
@@ -366,14 +454,20 @@ func ConvertAzureGroupMembersToRels(data models.GroupMembers) []IngestibleRelati
 		} else if memberType, err := ExtractTypeFromDirectoryObject(member); err != nil {
 			log.Errorf(ExtractError, err)
 		} else {
-			relationships = append(relationships, IngestibleRelationship{
-				Source:     strings.ToUpper(member.Id),
-				SourceType: memberType,
-				TargetType: azure.Group,
-				Target:     strings.ToUpper(data.GroupId),
-				RelProps:   map[string]any{},
-				RelType:    azure.MemberOf,
-			})
+			relationships = append(relationships, NewIngestibleRelationship(
+				IngestibleSource{
+					Source:     strings.ToUpper(member.Id),
+					SourceType: memberType,
+				},
+				IngestibleTarget{
+					TargetType: azure.Group,
+					Target:     strings.ToUpper(data.GroupId),
+				},
+				IngestibleRel{
+					RelProps: map[string]any{},
+					RelType:  azure.MemberOf,
+				},
+			))
 		}
 	}
 
@@ -392,14 +486,20 @@ func ConvertAzureGroupOwnerToRels(data models.GroupOwners) []IngestibleRelations
 		} else if ownerType, err := ExtractTypeFromDirectoryObject(owner); err != nil {
 			log.Errorf(ExtractError, err)
 		} else {
-			relationships = append(relationships, IngestibleRelationship{
-				Source:     strings.ToUpper(owner.Id),
-				SourceType: ownerType,
-				TargetType: azure.Group,
-				Target:     strings.ToUpper(data.GroupId),
-				RelProps:   map[string]any{},
-				RelType:    azure.Owns,
-			})
+			relationships = append(relationships, NewIngestibleRelationship(
+				IngestibleSource{
+					Source:     strings.ToUpper(owner.Id),
+					SourceType: ownerType,
+				},
+				IngestibleTarget{
+					TargetType: azure.Group,
+					Target:     strings.ToUpper(data.GroupId),
+				},
+				IngestibleRel{
+					RelProps: map[string]any{},
+					RelType:  azure.Owns,
+				},
+			))
 		}
 	}
 
@@ -416,28 +516,40 @@ func ConvertAzureKeyVault(data models.KeyVault) (IngestibleNode, IngestibleRelat
 			},
 			Label: azure.KeyVault,
 		},
-		IngestibleRelationship{
-			Source:     strings.ToUpper(data.ResourceGroup),
-			SourceType: azure.ResourceGroup,
-			TargetType: azure.KeyVault,
-			Target:     strings.ToUpper(data.Id),
-			RelProps:   map[string]any{},
-			RelType:    azure.Contains,
-		}
+		NewIngestibleRelationship(
+			IngestibleSource{
+				Source:     strings.ToUpper(data.ResourceGroup),
+				SourceType: azure.ResourceGroup,
+			},
+			IngestibleTarget{
+				TargetType: azure.KeyVault,
+				Target:     strings.ToUpper(data.Id),
+			},
+			IngestibleRel{
+				RelProps: map[string]any{},
+				RelType:  azure.Contains,
+			},
+		)
 }
 
 func ConvertAzureKeyVaultAccessPolicy(data models.KeyVaultAccessPolicy) []IngestibleRelationship {
 	relationships := make([]IngestibleRelationship, 0)
 
 	for _, relType := range getKeyVaultPermissions(data) {
-		relationships = append(relationships, IngestibleRelationship{
-			Source:     strings.ToUpper(data.ObjectId),
-			SourceType: azure.Entity,
-			TargetType: azure.KeyVault,
-			Target:     strings.ToUpper(data.KeyVaultId),
-			RelProps:   map[string]any{},
-			RelType:    relType,
-		})
+		relationships = append(relationships, NewIngestibleRelationship(
+			IngestibleSource{
+				Source:     strings.ToUpper(data.ObjectId),
+				SourceType: azure.Entity,
+			},
+			IngestibleTarget{
+				TargetType: azure.KeyVault,
+				Target:     strings.ToUpper(data.KeyVaultId),
+			},
+			IngestibleRel{
+				RelProps: map[string]any{},
+				RelType:  relType,
+			},
+		))
 	}
 
 	return relationships
@@ -448,14 +560,20 @@ func ConvertAzureKeyVaultContributor(data models.KeyVaultContributors) []Ingesti
 
 	for _, raw := range data.Contributors {
 		if data.KeyVaultId == raw.Contributor.Properties.Scope {
-			relationships = append(relationships, IngestibleRelationship{
-				Source:     strings.ToUpper(raw.Contributor.GetPrincipalId()),
-				SourceType: azure.Entity,
-				TargetType: azure.KeyVault,
-				Target:     strings.ToUpper(data.KeyVaultId),
-				RelProps:   map[string]any{},
-				RelType:    azure.Contributor,
-			})
+			relationships = append(relationships, NewIngestibleRelationship(
+				IngestibleSource{
+					Source:     strings.ToUpper(raw.Contributor.GetPrincipalId()),
+					SourceType: azure.Entity,
+				},
+				IngestibleTarget{
+					TargetType: azure.KeyVault,
+					Target:     strings.ToUpper(data.KeyVaultId),
+				},
+				IngestibleRel{
+					RelProps: map[string]any{},
+					RelType:  azure.Contributor,
+				},
+			))
 		}
 	}
 
@@ -467,14 +585,20 @@ func ConvertAzureKeyVaultKVContributor(data models.KeyVaultKVContributors) []Ing
 
 	for _, raw := range data.KVContributors {
 		if data.KeyVaultId == raw.KVContributor.Properties.Scope {
-			relationships = append(relationships, IngestibleRelationship{
-				Source:     strings.ToUpper(raw.KVContributor.GetPrincipalId()),
-				SourceType: azure.Entity,
-				TargetType: azure.KeyVault,
-				Target:     strings.ToUpper(data.KeyVaultId),
-				RelProps:   map[string]any{},
-				RelType:    azure.KeyVaultContributor,
-			})
+			relationships = append(relationships, NewIngestibleRelationship(
+				IngestibleSource{
+					Source:     strings.ToUpper(raw.KVContributor.GetPrincipalId()),
+					SourceType: azure.Entity,
+				},
+				IngestibleTarget{
+					TargetType: azure.KeyVault,
+					Target:     strings.ToUpper(data.KeyVaultId),
+				},
+				IngestibleRel{
+					RelProps: map[string]any{},
+					RelType:  azure.KeyVaultContributor,
+				},
+			))
 		}
 	}
 
@@ -486,14 +610,20 @@ func ConvertAzureKeyVaultOwnerToRels(data models.KeyVaultOwners) []IngestibleRel
 
 	for _, raw := range data.Owners {
 		if data.KeyVaultId == raw.Owner.Properties.Scope {
-			relationships = append(relationships, IngestibleRelationship{
-				Source:     strings.ToUpper(raw.Owner.Properties.PrincipalId),
-				SourceType: azure.Entity,
-				TargetType: azure.KeyVault,
-				Target:     strings.ToUpper(data.KeyVaultId),
-				RelProps:   map[string]any{},
-				RelType:    azure.Owner,
-			})
+			relationships = append(relationships, NewIngestibleRelationship(
+				IngestibleSource{
+					Source:     strings.ToUpper(raw.Owner.Properties.PrincipalId),
+					SourceType: azure.Entity,
+				},
+				IngestibleTarget{
+					TargetType: azure.KeyVault,
+					Target:     strings.ToUpper(data.KeyVaultId),
+				},
+				IngestibleRel{
+					RelProps: map[string]any{},
+					RelType:  azure.Owner,
+				},
+			))
 		}
 	}
 
@@ -504,14 +634,20 @@ func ConvertAzureKeyVaultUserAccessAdminToRels(data models.KeyVaultUserAccessAdm
 	relationships := make([]IngestibleRelationship, 0)
 	for _, raw := range data.UserAccessAdmins {
 		if data.KeyVaultId == raw.UserAccessAdmin.Properties.Scope {
-			relationships = append(relationships, IngestibleRelationship{
-				Source:     strings.ToUpper(raw.UserAccessAdmin.Properties.PrincipalId),
-				SourceType: azure.Entity,
-				TargetType: azure.KeyVault,
-				Target:     strings.ToUpper(data.KeyVaultId),
-				RelProps:   map[string]any{},
-				RelType:    azure.UserAccessAdministrator,
-			})
+			relationships = append(relationships, NewIngestibleRelationship(
+				IngestibleSource{
+					Source:     strings.ToUpper(raw.UserAccessAdmin.Properties.PrincipalId),
+					SourceType: azure.Entity,
+				},
+				IngestibleTarget{
+					TargetType: azure.KeyVault,
+					Target:     strings.ToUpper(data.KeyVaultId),
+				},
+				IngestibleRel{
+					RelProps: map[string]any{},
+					RelType:  azure.UserAccessAdministrator,
+				},
+			))
 		}
 	}
 
@@ -519,28 +655,40 @@ func ConvertAzureKeyVaultUserAccessAdminToRels(data models.KeyVaultUserAccessAdm
 }
 
 func ConvertAzureManagementGroupDescendantToRel(data azure2.DescendantInfo) IngestibleRelationship {
-	return IngestibleRelationship{
-		Source:     strings.ToUpper(data.Properties.Parent.Id),
-		SourceType: azure.ManagementGroup,
-		TargetType: azure.Entity,
-		Target:     strings.ToUpper(data.Id),
-		RelProps:   map[string]any{},
-		RelType:    azure.Contains,
-	}
+	return NewIngestibleRelationship(
+		IngestibleSource{
+			Source:     strings.ToUpper(data.Properties.Parent.Id),
+			SourceType: azure.ManagementGroup,
+		},
+		IngestibleTarget{
+			TargetType: azure.Entity,
+			Target:     strings.ToUpper(data.Id),
+		},
+		IngestibleRel{
+			RelProps: map[string]any{},
+			RelType:  azure.Contains,
+		},
+	)
 }
 
 func ConvertAzureManagementGroupOwnerToRels(data models.ManagementGroupOwners) []IngestibleRelationship {
 	relationships := make([]IngestibleRelationship, 0)
 	for _, raw := range data.Owners {
 		if data.ManagementGroupId == raw.Owner.Properties.Scope {
-			relationships = append(relationships, IngestibleRelationship{
-				Source:     strings.ToUpper(raw.Owner.GetPrincipalId()),
-				SourceType: azure.Entity,
-				TargetType: azure.ManagementGroup,
-				Target:     strings.ToUpper(data.ManagementGroupId),
-				RelProps:   map[string]any{},
-				RelType:    azure.Owner,
-			})
+			relationships = append(relationships, NewIngestibleRelationship(
+				IngestibleSource{
+					Source:     strings.ToUpper(raw.Owner.GetPrincipalId()),
+					SourceType: azure.Entity,
+				},
+				IngestibleTarget{
+					TargetType: azure.ManagementGroup,
+					Target:     strings.ToUpper(data.ManagementGroupId),
+				},
+				IngestibleRel{
+					RelProps: map[string]any{},
+					RelType:  azure.Owner,
+				},
+			))
 		}
 	}
 
@@ -551,14 +699,20 @@ func ConvertAzureManagementGroupUserAccessAdminToRels(data models.ManagementGrou
 	relationships := make([]IngestibleRelationship, 0)
 	for _, raw := range data.UserAccessAdmins {
 		if data.ManagementGroupId == raw.UserAccessAdmin.Properties.Scope {
-			relationships = append(relationships, IngestibleRelationship{
-				Source:     strings.ToUpper(raw.UserAccessAdmin.GetPrincipalId()),
-				SourceType: azure.Entity,
-				TargetType: azure.ManagementGroup,
-				Target:     strings.ToUpper(data.ManagementGroupId),
-				RelProps:   map[string]any{},
-				RelType:    azure.UserAccessAdministrator,
-			})
+			relationships = append(relationships, NewIngestibleRelationship(
+				IngestibleSource{
+					Source:     strings.ToUpper(raw.UserAccessAdmin.GetPrincipalId()),
+					SourceType: azure.Entity,
+				},
+				IngestibleTarget{
+					TargetType: azure.ManagementGroup,
+					Target:     strings.ToUpper(data.ManagementGroupId),
+				},
+				IngestibleRel{
+					RelProps: map[string]any{},
+					RelType:  azure.UserAccessAdministrator,
+				},
+			))
 		}
 	}
 	return relationships
@@ -572,14 +726,20 @@ func ConvertAzureManagementGroup(data models.ManagementGroup) (IngestibleNode, I
 				azure.TenantID.String(): strings.ToUpper(data.TenantId),
 			},
 			Label: azure.ManagementGroup,
-		}, IngestibleRelationship{
-			Source:     strings.ToUpper(data.TenantId),
-			SourceType: azure.Tenant,
-			TargetType: azure.ManagementGroup,
-			Target:     strings.ToUpper(data.Id),
-			RelProps:   map[string]any{},
-			RelType:    azure.Contains,
-		}
+		}, NewIngestibleRelationship(
+			IngestibleSource{
+				Source:     strings.ToUpper(data.TenantId),
+				SourceType: azure.Tenant,
+			},
+			IngestibleTarget{
+				TargetType: azure.ManagementGroup,
+				Target:     strings.ToUpper(data.Id),
+			},
+			IngestibleRel{
+				RelProps: map[string]any{},
+				RelType:  azure.Contains,
+			},
+		)
 }
 
 func ConvertAzureResourceGroup(data models.ResourceGroup) (IngestibleNode, IngestibleRelationship) {
@@ -590,28 +750,40 @@ func ConvertAzureResourceGroup(data models.ResourceGroup) (IngestibleNode, Inges
 				azure.TenantID.String(): strings.ToUpper(data.TenantId),
 			},
 			Label: azure.ResourceGroup,
-		}, IngestibleRelationship{
-			Source:     strings.ToUpper(data.SubscriptionId),
-			SourceType: azure.Subscription,
-			TargetType: azure.ResourceGroup,
-			Target:     strings.ToUpper(data.Id),
-			RelProps:   map[string]any{},
-			RelType:    azure.Contains,
-		}
+		}, NewIngestibleRelationship(
+			IngestibleSource{
+				Source:     strings.ToUpper(data.SubscriptionId),
+				SourceType: azure.Subscription,
+			},
+			IngestibleTarget{
+				TargetType: azure.ResourceGroup,
+				Target:     strings.ToUpper(data.Id),
+			},
+			IngestibleRel{
+				RelProps: map[string]any{},
+				RelType:  azure.Contains,
+			},
+		)
 }
 
 func ConvertAzureResourceGroupOwnerToRels(data models.ResourceGroupOwners) []IngestibleRelationship {
 	relationships := make([]IngestibleRelationship, 0)
 	for _, raw := range data.Owners {
 		if data.ResourceGroupId == raw.Owner.Properties.Scope {
-			relationships = append(relationships, IngestibleRelationship{
-				Source:     strings.ToUpper(raw.Owner.Properties.PrincipalId),
-				SourceType: azure.Entity,
-				TargetType: azure.ResourceGroup,
-				Target:     strings.ToUpper(data.ResourceGroupId),
-				RelProps:   map[string]any{},
-				RelType:    azure.Owner,
-			})
+			relationships = append(relationships, NewIngestibleRelationship(
+				IngestibleSource{
+					Source:     strings.ToUpper(raw.Owner.Properties.PrincipalId),
+					SourceType: azure.Entity,
+				},
+				IngestibleTarget{
+					TargetType: azure.ResourceGroup,
+					Target:     strings.ToUpper(data.ResourceGroupId),
+				},
+				IngestibleRel{
+					RelProps: map[string]any{},
+					RelType:  azure.Owner,
+				},
+			))
 		}
 	}
 
@@ -622,14 +794,20 @@ func ConvertAzureResourceGroupUserAccessAdminToRels(data models.ResourceGroupUse
 	relationships := make([]IngestibleRelationship, 0)
 	for _, raw := range data.UserAccessAdmins {
 		if data.ResourceGroupId == raw.UserAccessAdmin.Properties.Scope {
-			relationships = append(relationships, IngestibleRelationship{
-				Source:     strings.ToUpper(raw.UserAccessAdmin.Properties.PrincipalId),
-				SourceType: azure.Entity,
-				TargetType: azure.ResourceGroup,
-				Target:     strings.ToUpper(data.ResourceGroupId),
-				RelProps:   map[string]any{},
-				RelType:    azure.UserAccessAdministrator,
-			})
+			relationships = append(relationships, NewIngestibleRelationship(
+				IngestibleSource{
+					Source:     strings.ToUpper(raw.UserAccessAdmin.Properties.PrincipalId),
+					SourceType: azure.Entity,
+				},
+				IngestibleTarget{
+					TargetType: azure.ResourceGroup,
+					Target:     strings.ToUpper(data.ResourceGroupId),
+				},
+				IngestibleRel{
+					RelProps: map[string]any{},
+					RelType:  azure.UserAccessAdministrator,
+				},
+			))
 		}
 	}
 
@@ -650,14 +828,20 @@ func ConvertAzureRole(data models.Role) (IngestibleNode, IngestibleRelationship)
 				azure.TenantID.String():       strings.ToUpper(data.TenantId),
 			},
 			Label: azure.Role,
-		}, IngestibleRelationship{
-			Source:     strings.ToUpper(data.TenantId),
-			SourceType: azure.Tenant,
-			TargetType: azure.Role,
-			Target:     roleObjectId,
-			RelProps:   map[string]any{},
-			RelType:    azure.Contains,
-		}
+		}, NewIngestibleRelationship(
+			IngestibleSource{
+				Source:     strings.ToUpper(data.TenantId),
+				SourceType: azure.Tenant,
+			},
+			IngestibleTarget{
+				TargetType: azure.Role,
+				Target:     roleObjectId,
+			},
+			IngestibleRel{
+				RelProps: map[string]any{},
+				RelType:  azure.Contains,
+			},
+		)
 }
 
 func ConvertAzureRoleAssignmentToRels(roleAssignment azure2.UnifiedRoleAssignment, data models.RoleAssignments, roleObjectId string) []IngestibleRelationship {
@@ -676,26 +860,38 @@ func ConvertAzureRoleAssignmentToRels(roleAssignment azure2.UnifiedRoleAssignmen
 		if relType, err := GetAddSecretRoleKind(roleAssignment.RoleDefinitionId); err != nil {
 			log.Errorf("Error processing role assignment for role %s: %v", roleObjectId, err)
 		} else {
-			relationships = append(relationships, IngestibleRelationship{
-				Source:     strings.ToUpper(roleAssignment.PrincipalId),
-				SourceType: azure.Entity,
-				TargetType: azure.Entity,
-				Target:     scope,
-				RelProps:   map[string]any{},
-				RelType:    relType,
-			})
+			relationships = append(relationships, NewIngestibleRelationship(
+				IngestibleSource{
+					Source:     strings.ToUpper(roleAssignment.PrincipalId),
+					SourceType: azure.Entity,
+				},
+				IngestibleTarget{
+					TargetType: azure.Entity,
+					Target:     scope,
+				},
+				IngestibleRel{
+					RelProps: map[string]any{},
+					RelType:  relType,
+				},
+			))
 		}
 	} else {
-		relationships = append(relationships, IngestibleRelationship{
-			Source:     strings.ToUpper(roleAssignment.PrincipalId),
-			SourceType: azure.Entity,
-			TargetType: azure.Role,
-			Target:     roleObjectId,
-			RelProps: map[string]any{
-				azure.Scope.String(): scope,
+		relationships = append(relationships, NewIngestibleRelationship(
+			IngestibleSource{
+				Source:     strings.ToUpper(roleAssignment.PrincipalId),
+				SourceType: azure.Entity,
 			},
-			RelType: azure.HasRole,
-		})
+			IngestibleTarget{
+				TargetType: azure.Role,
+				Target:     roleObjectId,
+			},
+			IngestibleRel{
+				RelProps: map[string]any{
+					azure.Scope.String(): scope,
+				},
+				RelType: azure.HasRole,
+			},
+		))
 	}
 
 	return relationships
@@ -730,23 +926,35 @@ func ConvertAzureServicePrincipal(data models.ServicePrincipal) ([]IngestibleNod
 		Label: azure.App,
 	})
 
-	relationships = append(relationships, IngestibleRelationship{
-		Source:     strings.ToUpper(data.AppId),
-		SourceType: azure.App,
-		TargetType: azure.ServicePrincipal,
-		Target:     strings.ToUpper(data.Id),
-		RelProps:   map[string]any{},
-		RelType:    azure.RunsAs,
-	})
+	relationships = append(relationships, NewIngestibleRelationship(
+		IngestibleSource{
+			Source:     strings.ToUpper(data.AppId),
+			SourceType: azure.App,
+		},
+		IngestibleTarget{
+			TargetType: azure.ServicePrincipal,
+			Target:     strings.ToUpper(data.Id),
+		},
+		IngestibleRel{
+			RelProps: map[string]any{},
+			RelType:  azure.RunsAs,
+		},
+	))
 
-	relationships = append(relationships, IngestibleRelationship{
-		Source:     strings.ToUpper(data.TenantId),
-		SourceType: azure.Tenant,
-		TargetType: azure.ServicePrincipal,
-		Target:     strings.ToUpper(data.Id),
-		RelProps:   map[string]any{},
-		RelType:    azure.Contains,
-	})
+	relationships = append(relationships, NewIngestibleRelationship(
+		IngestibleSource{
+			Source:     strings.ToUpper(data.TenantId),
+			SourceType: azure.Tenant,
+		},
+		IngestibleTarget{
+			TargetType: azure.ServicePrincipal,
+			Target:     strings.ToUpper(data.Id),
+		},
+		IngestibleRel{
+			RelProps: map[string]any{},
+			RelType:  azure.Contains,
+		},
+	))
 
 	return nodes, relationships
 }
@@ -762,38 +970,56 @@ func ConvertAzureLogicApp(logicApp models.LogicApp) (IngestibleNode, []Ingestibl
 	}
 
 	relationships := make([]IngestibleRelationship, 0)
-	relationships = append(relationships, IngestibleRelationship{
-		Source:     strings.ToUpper(logicApp.ResourceGroupId),
-		SourceType: azure.ResourceGroup,
-		TargetType: azure.LogicApp,
-		Target:     strings.ToUpper(logicApp.Id),
-		RelProps:   map[string]any{},
-		RelType:    azure.Contains,
-	})
+	relationships = append(relationships, NewIngestibleRelationship(
+		IngestibleSource{
+			Source:     strings.ToUpper(logicApp.ResourceGroupId),
+			SourceType: azure.ResourceGroup,
+		},
+		IngestibleTarget{
+			TargetType: azure.LogicApp,
+			Target:     strings.ToUpper(logicApp.Id),
+		},
+		IngestibleRel{
+			RelProps: map[string]any{},
+			RelType:  azure.Contains,
+		},
+	))
 
 	// Enumerate System Assigned Identities
 	if logicApp.Identity.PrincipalId != "" {
-		relationships = append(relationships, IngestibleRelationship{
-			Source:     strings.ToUpper(logicApp.Id),
-			SourceType: azure.LogicApp,
-			TargetType: azure.ServicePrincipal,
-			Target:     strings.ToUpper(logicApp.Identity.PrincipalId),
-			RelProps:   map[string]any{},
-			RelType:    azure.ManagedIdentity,
-		})
+		relationships = append(relationships, NewIngestibleRelationship(
+			IngestibleSource{
+				Source:     strings.ToUpper(logicApp.Id),
+				SourceType: azure.LogicApp,
+			},
+			IngestibleTarget{
+				TargetType: azure.ServicePrincipal,
+				Target:     strings.ToUpper(logicApp.Identity.PrincipalId),
+			},
+			IngestibleRel{
+				RelProps: map[string]any{},
+				RelType:  azure.ManagedIdentity,
+			},
+		))
 	}
 
 	// Enumerate User Assigned Identities
 	for _, identity := range logicApp.Identity.UserAssignedIdentities {
 		if identity.ClientId != "" {
-			relationships = append(relationships, IngestibleRelationship{
-				Source:     strings.ToUpper(logicApp.Id),
-				SourceType: azure.LogicApp,
-				TargetType: azure.ServicePrincipal,
-				Target:     strings.ToUpper(identity.PrincipalId),
-				RelProps:   map[string]any{},
-				RelType:    azure.ManagedIdentity,
-			})
+			relationships = append(relationships, NewIngestibleRelationship(
+				IngestibleSource{
+					Source:     strings.ToUpper(logicApp.Id),
+					SourceType: azure.LogicApp,
+				},
+				IngestibleTarget{
+					TargetType: azure.ServicePrincipal,
+					Target:     strings.ToUpper(identity.PrincipalId),
+				},
+				IngestibleRel{
+					RelProps: map[string]any{},
+					RelType:  azure.ManagedIdentity,
+				},
+			))
 		}
 	}
 
@@ -810,14 +1036,20 @@ func ConvertAzureLogicAppRoleAssignment(roleAssignment models.AzureRoleAssignmen
 				constants.ContributorRoleID,
 				constants.LogicAppContributorRoleID,
 			}, strings.ToLower(raw.RoleDefinitionId)) {
-				relationships = append(relationships, IngestibleRelationship{
-					Source:     strings.ToUpper(raw.Assignee.GetPrincipalId()),
-					SourceType: azure.Entity,
-					TargetType: azure.LogicApp,
-					Target:     strings.ToUpper(roleAssignment.ObjectId),
-					RelProps:   map[string]any{},
-					RelType:    KindFromRoleId(raw.RoleDefinitionId),
-				})
+				relationships = append(relationships, NewIngestibleRelationship(
+					IngestibleSource{
+						Source:     strings.ToUpper(raw.Assignee.GetPrincipalId()),
+						SourceType: azure.Entity,
+					},
+					IngestibleTarget{
+						TargetType: azure.LogicApp,
+						Target:     strings.ToUpper(roleAssignment.ObjectId),
+					},
+					IngestibleRel{
+						RelProps: map[string]any{},
+						RelType:  KindFromRoleId(raw.RoleDefinitionId),
+					},
+				))
 			}
 		}
 	}
@@ -837,14 +1069,20 @@ func ConvertAzureServicePrincipalOwnerToRels(data models.ServicePrincipalOwners)
 		} else if ownerType, err := ExtractTypeFromDirectoryObject(owner); err != nil {
 			log.Errorf(ExtractError, err)
 		} else {
-			relationships = append(relationships, IngestibleRelationship{
-				Source:     strings.ToUpper(owner.Id),
-				SourceType: ownerType,
-				TargetType: azure.ServicePrincipal,
-				Target:     strings.ToUpper(data.ServicePrincipalId),
-				RelProps:   map[string]any{},
-				RelType:    azure.Owns,
-			})
+			relationships = append(relationships, NewIngestibleRelationship(
+				IngestibleSource{
+					Source:     strings.ToUpper(owner.Id),
+					SourceType: ownerType,
+				},
+				IngestibleTarget{
+					TargetType: azure.ServicePrincipal,
+					Target:     strings.ToUpper(data.ServicePrincipalId),
+				},
+				IngestibleRel{
+					RelProps: map[string]any{},
+					RelType:  azure.Owns,
+				},
+			))
 		}
 	}
 	return relationships
@@ -861,14 +1099,20 @@ func ConvertAzureSubscription(data azure2.Subscription) (IngestibleNode, Ingesti
 			},
 			Label: azure.Subscription,
 		},
-		IngestibleRelationship{
-			Source:     strings.ToUpper(data.TenantId),
-			SourceType: azure.Tenant,
-			TargetType: azure.Subscription,
-			Target:     strings.ToUpper(data.Id),
-			RelProps:   map[string]any{},
-			RelType:    azure.Contains,
-		}
+		NewIngestibleRelationship(
+			IngestibleSource{
+				Source:     strings.ToUpper(data.TenantId),
+				SourceType: azure.Tenant,
+			},
+			IngestibleTarget{
+				TargetType: azure.Subscription,
+				Target:     strings.ToUpper(data.Id),
+			},
+			IngestibleRel{
+				RelProps: map[string]any{},
+				RelType:  azure.Contains,
+			},
+		)
 }
 
 func ConvertAzureSubscriptionOwnerToRels(data models.SubscriptionOwners) []IngestibleRelationship {
@@ -876,14 +1120,20 @@ func ConvertAzureSubscriptionOwnerToRels(data models.SubscriptionOwners) []Inges
 
 	for _, raw := range data.Owners {
 		if data.SubscriptionId == raw.Owner.Properties.Scope {
-			relationships = append(relationships, IngestibleRelationship{
-				Source:     strings.ToUpper(raw.Owner.Properties.PrincipalId),
-				SourceType: azure.Entity,
-				TargetType: azure.Subscription,
-				Target:     strings.ToUpper(data.SubscriptionId),
-				RelProps:   map[string]any{},
-				RelType:    azure.Owner,
-			})
+			relationships = append(relationships, NewIngestibleRelationship(
+				IngestibleSource{
+					Source:     strings.ToUpper(raw.Owner.Properties.PrincipalId),
+					SourceType: azure.Entity,
+				},
+				IngestibleTarget{
+					TargetType: azure.Subscription,
+					Target:     strings.ToUpper(data.SubscriptionId),
+				},
+				IngestibleRel{
+					RelProps: map[string]any{},
+					RelType:  azure.Owner,
+				},
+			))
 		}
 	}
 
@@ -895,14 +1145,20 @@ func ConvertAzureSubscriptionUserAccessAdminToRels(data models.SubscriptionUserA
 
 	for _, raw := range data.UserAccessAdmins {
 		if data.SubscriptionId == raw.UserAccessAdmin.Properties.Scope {
-			relationships = append(relationships, IngestibleRelationship{
-				Source:     strings.ToUpper(raw.UserAccessAdmin.Properties.PrincipalId),
-				SourceType: azure.Entity,
-				TargetType: azure.Subscription,
-				Target:     strings.ToUpper(data.SubscriptionId),
-				RelProps:   map[string]any{},
-				RelType:    azure.UserAccessAdministrator,
-			})
+			relationships = append(relationships, NewIngestibleRelationship(
+				IngestibleSource{
+					Source:     strings.ToUpper(raw.UserAccessAdmin.Properties.PrincipalId),
+					SourceType: azure.Entity,
+				},
+				IngestibleTarget{
+					TargetType: azure.Subscription,
+					Target:     strings.ToUpper(data.SubscriptionId),
+				},
+				IngestibleRel{
+					RelProps: map[string]any{},
+					RelType:  azure.UserAccessAdministrator,
+				},
+			))
 		}
 	}
 
@@ -956,14 +1212,20 @@ func ConvertAzureUser(data models.User) (IngestibleNode, IngestibleNode, Ingesti
 				azure.TenantID.String():          strings.ToUpper(data.TenantId),
 			},
 			Label: azure.User,
-		}, onPremNode, IngestibleRelationship{
-			Source:     strings.ToUpper(data.TenantId),
-			SourceType: azure.Tenant,
-			TargetType: azure.User,
-			Target:     strings.ToUpper(data.Id),
-			RelProps:   map[string]any{},
-			RelType:    azure.Contains,
-		}
+		}, onPremNode, NewIngestibleRelationship(
+			IngestibleSource{
+				Source:     strings.ToUpper(data.TenantId),
+				SourceType: azure.Tenant,
+			},
+			IngestibleTarget{
+				TargetType: azure.User,
+				Target:     strings.ToUpper(data.Id),
+			},
+			IngestibleRel{
+				RelProps: map[string]any{},
+				RelType:  azure.Contains,
+			},
+		)
 }
 
 func ConvertAzureVirtualMachine(data models.VirtualMachine) (IngestibleNode, []IngestibleRelationship) {
@@ -979,38 +1241,56 @@ func ConvertAzureVirtualMachine(data models.VirtualMachine) (IngestibleNode, []I
 		Label: azure.VM,
 	}
 
-	relationships = append(relationships, IngestibleRelationship{
-		Source:     strings.ToUpper(data.ResourceGroupId),
-		SourceType: azure.ResourceGroup,
-		TargetType: azure.VM,
-		Target:     strings.ToUpper(data.Id),
-		RelProps:   map[string]any{},
-		RelType:    azure.Contains,
-	})
+	relationships = append(relationships, NewIngestibleRelationship(
+		IngestibleSource{
+			Source:     strings.ToUpper(data.ResourceGroupId),
+			SourceType: azure.ResourceGroup,
+		},
+		IngestibleTarget{
+			TargetType: azure.VM,
+			Target:     strings.ToUpper(data.Id),
+		},
+		IngestibleRel{
+			RelProps: map[string]any{},
+			RelType:  azure.Contains,
+		},
+	))
 
 	// Enumerate System Assigned Identities
 	if data.Identity.PrincipalId != "" {
-		relationships = append(relationships, IngestibleRelationship{
-			Source:     strings.ToUpper(data.Id),
-			SourceType: azure.VM,
-			TargetType: azure.ServicePrincipal,
-			Target:     strings.ToUpper(data.Identity.PrincipalId),
-			RelProps:   map[string]any{},
-			RelType:    azure.ManagedIdentity,
-		})
+		relationships = append(relationships, NewIngestibleRelationship(
+			IngestibleSource{
+				Source:     strings.ToUpper(data.Id),
+				SourceType: azure.VM,
+			},
+			IngestibleTarget{
+				TargetType: azure.ServicePrincipal,
+				Target:     strings.ToUpper(data.Identity.PrincipalId),
+			},
+			IngestibleRel{
+				RelProps: map[string]any{},
+				RelType:  azure.ManagedIdentity,
+			},
+		))
 	}
 
 	// Enumerate User Assigned Identities
 	for _, identity := range data.Identity.UserAssignedIdentities {
 		if identity.ClientId != "" {
-			relationships = append(relationships, IngestibleRelationship{
-				Source:     strings.ToUpper(data.Id),
-				SourceType: azure.VM,
-				TargetType: azure.ServicePrincipal,
-				Target:     strings.ToUpper(identity.PrincipalId),
-				RelProps:   map[string]any{},
-				RelType:    azure.ManagedIdentity,
-			})
+			relationships = append(relationships, NewIngestibleRelationship(
+				IngestibleSource{
+					Source:     strings.ToUpper(data.Id),
+					SourceType: azure.VM,
+				},
+				IngestibleTarget{
+					TargetType: azure.ServicePrincipal,
+					Target:     strings.ToUpper(identity.PrincipalId),
+				},
+				IngestibleRel{
+					RelProps: map[string]any{},
+					RelType:  azure.ManagedIdentity,
+				},
+			))
 		}
 	}
 
@@ -1021,14 +1301,20 @@ func ConvertAzureVirtualMachineAdminLoginToRels(data models.VirtualMachineAdminL
 	relationships := make([]IngestibleRelationship, 0)
 	for _, raw := range data.AdminLogins {
 		if ResourceWithinScope(data.VirtualMachineId, raw.AdminLogin.Properties.Scope) {
-			relationships = append(relationships, IngestibleRelationship{
-				Source:     strings.ToUpper(raw.AdminLogin.GetPrincipalId()),
-				SourceType: azure.Entity,
-				TargetType: azure.VM,
-				Target:     strings.ToUpper(data.VirtualMachineId),
-				RelProps:   map[string]any{},
-				RelType:    azure.VMAdminLogin,
-			})
+			relationships = append(relationships, NewIngestibleRelationship(
+				IngestibleSource{
+					Source:     strings.ToUpper(raw.AdminLogin.GetPrincipalId()),
+					SourceType: azure.Entity,
+				},
+				IngestibleTarget{
+					TargetType: azure.VM,
+					Target:     strings.ToUpper(data.VirtualMachineId),
+				},
+				IngestibleRel{
+					RelProps: map[string]any{},
+					RelType:  azure.VMAdminLogin,
+				},
+			))
 		}
 	}
 	return relationships
@@ -1038,14 +1324,20 @@ func ConvertAzureVirtualMachineAvereContributorToRels(data models.VirtualMachine
 	relationships := make([]IngestibleRelationship, 0)
 	for _, raw := range data.AvereContributors {
 		if data.VirtualMachineId == raw.AvereContributor.Properties.Scope {
-			relationships = append(relationships, IngestibleRelationship{
-				Source:     strings.ToUpper(raw.AvereContributor.GetPrincipalId()),
-				SourceType: azure.Entity,
-				TargetType: azure.VM,
-				Target:     strings.ToUpper(data.VirtualMachineId),
-				RelProps:   map[string]any{},
-				RelType:    azure.AvereContributor,
-			})
+			relationships = append(relationships, NewIngestibleRelationship(
+				IngestibleSource{
+					Source:     strings.ToUpper(raw.AvereContributor.GetPrincipalId()),
+					SourceType: azure.Entity,
+				},
+				IngestibleTarget{
+					TargetType: azure.VM,
+					Target:     strings.ToUpper(data.VirtualMachineId),
+				},
+				IngestibleRel{
+					RelProps: map[string]any{},
+					RelType:  azure.AvereContributor,
+				},
+			))
 		}
 	}
 	return relationships
@@ -1055,14 +1347,20 @@ func ConvertAzureVirtualMachineContributorToRels(data models.VirtualMachineContr
 	relationships := make([]IngestibleRelationship, 0)
 	for _, raw := range data.Contributors {
 		if ResourceWithinScope(data.VirtualMachineId, raw.Contributor.Properties.Scope) {
-			relationships = append(relationships, IngestibleRelationship{
-				Source:     strings.ToUpper(raw.Contributor.GetPrincipalId()),
-				SourceType: azure.Entity,
-				TargetType: azure.VM,
-				Target:     strings.ToUpper(data.VirtualMachineId),
-				RelProps:   map[string]any{},
-				RelType:    azure.Contributor,
-			})
+			relationships = append(relationships, NewIngestibleRelationship(
+				IngestibleSource{
+					Source:     strings.ToUpper(raw.Contributor.GetPrincipalId()),
+					SourceType: azure.Entity,
+				},
+				IngestibleTarget{
+					TargetType: azure.VM,
+					Target:     strings.ToUpper(data.VirtualMachineId),
+				},
+				IngestibleRel{
+					RelProps: map[string]any{},
+					RelType:  azure.Contributor,
+				},
+			))
 		}
 	}
 	return relationships
@@ -1072,14 +1370,20 @@ func ConvertAzureVirtualMachineVMContributorToRels(data models.VirtualMachineVMC
 	relationships := make([]IngestibleRelationship, 0)
 	for _, raw := range data.VMContributors {
 		if ResourceWithinScope(data.VirtualMachineId, raw.VMContributor.Properties.Scope) {
-			relationships = append(relationships, IngestibleRelationship{
-				Source:     strings.ToUpper(raw.VMContributor.GetPrincipalId()),
-				SourceType: azure.Entity,
-				TargetType: azure.VM,
-				Target:     strings.ToUpper(data.VirtualMachineId),
-				RelProps:   map[string]any{},
-				RelType:    azure.VMContributor,
-			})
+			relationships = append(relationships, NewIngestibleRelationship(
+				IngestibleSource{
+					Source:     strings.ToUpper(raw.VMContributor.GetPrincipalId()),
+					SourceType: azure.Entity,
+				},
+				IngestibleTarget{
+					TargetType: azure.VM,
+					Target:     strings.ToUpper(data.VirtualMachineId),
+				},
+				IngestibleRel{
+					RelProps: map[string]any{},
+					RelType:  azure.VMContributor,
+				},
+			))
 		}
 	}
 	return relationships
@@ -1089,14 +1393,20 @@ func ConvertAzureVirtualMachineOwnerToRels(data models.VirtualMachineOwners) []I
 	relationships := make([]IngestibleRelationship, 0)
 	for _, raw := range data.Owners {
 		if ResourceWithinScope(data.VirtualMachineId, raw.Owner.Properties.Scope) {
-			relationships = append(relationships, IngestibleRelationship{
-				Source:     strings.ToUpper(raw.Owner.GetPrincipalId()),
-				SourceType: azure.Entity,
-				TargetType: azure.VM,
-				Target:     strings.ToUpper(data.VirtualMachineId),
-				RelProps:   map[string]any{},
-				RelType:    azure.Owner,
-			})
+			relationships = append(relationships, NewIngestibleRelationship(
+				IngestibleSource{
+					Source:     strings.ToUpper(raw.Owner.GetPrincipalId()),
+					SourceType: azure.Entity,
+				},
+				IngestibleTarget{
+					TargetType: azure.VM,
+					Target:     strings.ToUpper(data.VirtualMachineId),
+				},
+				IngestibleRel{
+					RelProps: map[string]any{},
+					RelType:  azure.Owner,
+				},
+			))
 		}
 	}
 	return relationships
@@ -1106,14 +1416,20 @@ func ConvertAzureVirtualMachineUserAccessAdminToRels(data models.VirtualMachineU
 	relationships := make([]IngestibleRelationship, 0)
 	for _, raw := range data.UserAccessAdmins {
 		if ResourceWithinScope(data.VirtualMachineId, raw.UserAccessAdmin.Properties.Scope) {
-			relationships = append(relationships, IngestibleRelationship{
-				Source:     strings.ToUpper(raw.UserAccessAdmin.Properties.PrincipalId),
-				SourceType: azure.Entity,
-				TargetType: azure.VM,
-				Target:     strings.ToUpper(data.VirtualMachineId),
-				RelProps:   map[string]any{},
-				RelType:    azure.UserAccessAdministrator,
-			})
+			relationships = append(relationships, NewIngestibleRelationship(
+				IngestibleSource{
+					Source:     strings.ToUpper(raw.UserAccessAdmin.Properties.PrincipalId),
+					SourceType: azure.Entity,
+				},
+				IngestibleTarget{
+					TargetType: azure.VM,
+					Target:     strings.ToUpper(data.VirtualMachineId),
+				},
+				IngestibleRel{
+					RelProps: map[string]any{},
+					RelType:  azure.UserAccessAdministrator,
+				},
+			))
 		}
 	}
 	return relationships
@@ -1131,23 +1447,35 @@ func ConvertAzureManagedCluster(data models.ManagedCluster, nodeResourceGroupID 
 		Label: azure.ManagedCluster,
 	}
 
-	relationships = append(relationships, IngestibleRelationship{
-		Source:     strings.ToUpper(data.ResourceGroupId),
-		SourceType: azure.ResourceGroup,
-		TargetType: azure.ManagedCluster,
-		Target:     strings.ToUpper(data.Id),
-		RelProps:   map[string]any{},
-		RelType:    azure.Contains,
-	})
+	relationships = append(relationships, NewIngestibleRelationship(
+		IngestibleSource{
+			Source:     strings.ToUpper(data.ResourceGroupId),
+			SourceType: azure.ResourceGroup,
+		},
+		IngestibleTarget{
+			TargetType: azure.ManagedCluster,
+			Target:     strings.ToUpper(data.Id),
+		},
+		IngestibleRel{
+			RelProps: map[string]any{},
+			RelType:  azure.Contains,
+		},
+	))
 
-	relationships = append(relationships, IngestibleRelationship{
-		Source:     strings.ToUpper(data.Id),
-		SourceType: azure.ManagedCluster,
-		TargetType: azure.ResourceGroup,
-		Target:     strings.ToUpper(nodeResourceGroupID),
-		RelProps:   map[string]any{},
-		RelType:    azure.NodeResourceGroup,
-	})
+	relationships = append(relationships, NewIngestibleRelationship(
+		IngestibleSource{
+			Source:     strings.ToUpper(data.Id),
+			SourceType: azure.ManagedCluster,
+		},
+		IngestibleTarget{
+			TargetType: azure.ResourceGroup,
+			Target:     strings.ToUpper(nodeResourceGroupID),
+		},
+		IngestibleRel{
+			RelProps: map[string]any{},
+			RelType:  azure.NodeResourceGroup,
+		},
+	))
 
 	return node, relationships
 }
@@ -1162,14 +1490,20 @@ func ConvertAzureManagedClusterRoleAssignmentToRels(data models.AzureRoleAssignm
 				azure.ContributorRole,
 				azure.AKSContributorRole,
 			}, strings.ToLower(raw.RoleDefinitionId)) {
-				relationships = append(relationships, IngestibleRelationship{
-					Source:     strings.ToUpper(raw.Assignee.GetPrincipalId()),
-					SourceType: azure.Entity,
-					TargetType: azure.ManagedCluster,
-					Target:     strings.ToUpper(data.ObjectId),
-					RelProps:   map[string]any{},
-					RelType:    KindFromRoleId(raw.RoleDefinitionId),
-				})
+				relationships = append(relationships, NewIngestibleRelationship(
+					IngestibleSource{
+						Source:     strings.ToUpper(raw.Assignee.GetPrincipalId()),
+						SourceType: azure.Entity,
+					},
+					IngestibleTarget{
+						TargetType: azure.ManagedCluster,
+						Target:     strings.ToUpper(data.ObjectId),
+					},
+					IngestibleRel{
+						RelProps: map[string]any{},
+						RelType:  KindFromRoleId(raw.RoleDefinitionId),
+					},
+				))
 			}
 		}
 	}
@@ -1187,38 +1521,56 @@ func ConvertAzureContainerRegistry(data models.ContainerRegistry) (IngestibleNod
 		Label: azure.ContainerRegistry,
 	}
 
-	relationships = append(relationships, IngestibleRelationship{
-		Source:     strings.ToUpper(data.ResourceGroupId),
-		SourceType: azure.ResourceGroup,
-		TargetType: azure.ContainerRegistry,
-		Target:     strings.ToUpper(data.Id),
-		RelProps:   map[string]any{},
-		RelType:    azure.Contains,
-	})
+	relationships = append(relationships, NewIngestibleRelationship(
+		IngestibleSource{
+			Source:     strings.ToUpper(data.ResourceGroupId),
+			SourceType: azure.ResourceGroup,
+		},
+		IngestibleTarget{
+			TargetType: azure.ContainerRegistry,
+			Target:     strings.ToUpper(data.Id),
+		},
+		IngestibleRel{
+			RelProps: map[string]any{},
+			RelType:  azure.Contains,
+		},
+	))
 
 	// Enumerate System Assigned Identities
 	if data.Identity.PrincipalId != "" {
-		relationships = append(relationships, IngestibleRelationship{
-			Source:     strings.ToUpper(data.Id),
-			SourceType: azure.ContainerRegistry,
-			TargetType: azure.ServicePrincipal,
-			Target:     strings.ToUpper(data.Identity.PrincipalId),
-			RelProps:   map[string]any{},
-			RelType:    azure.ManagedIdentity,
-		})
+		relationships = append(relationships, NewIngestibleRelationship(
+			IngestibleSource{
+				Source:     strings.ToUpper(data.Id),
+				SourceType: azure.ContainerRegistry,
+			},
+			IngestibleTarget{
+				TargetType: azure.ServicePrincipal,
+				Target:     strings.ToUpper(data.Identity.PrincipalId),
+			},
+			IngestibleRel{
+				RelProps: map[string]any{},
+				RelType:  azure.ManagedIdentity,
+			},
+		))
 	}
 
 	// Enumerate User Assigned Identities
 	for _, identity := range data.Identity.UserAssignedIdentities {
 		if identity.ClientId != "" {
-			relationships = append(relationships, IngestibleRelationship{
-				Source:     strings.ToUpper(data.Id),
-				SourceType: azure.ContainerRegistry,
-				TargetType: azure.ServicePrincipal,
-				Target:     strings.ToUpper(identity.PrincipalId),
-				RelProps:   map[string]any{},
-				RelType:    azure.ManagedIdentity,
-			})
+			relationships = append(relationships, NewIngestibleRelationship(
+				IngestibleSource{
+					Source:     strings.ToUpper(data.Id),
+					SourceType: azure.ContainerRegistry,
+				},
+				IngestibleTarget{
+					TargetType: azure.ServicePrincipal,
+					Target:     strings.ToUpper(identity.PrincipalId),
+				},
+				IngestibleRel{
+					RelProps: map[string]any{},
+					RelType:  azure.ManagedIdentity,
+				},
+			))
 		}
 	}
 
@@ -1236,38 +1588,56 @@ func ConvertAzureWebApp(webApp models.WebApp) (IngestibleNode, []IngestibleRelat
 	}
 
 	relationships := make([]IngestibleRelationship, 0)
-	relationships = append(relationships, IngestibleRelationship{
-		Source:     strings.ToUpper(webApp.ResourceGroupId),
-		SourceType: azure.ResourceGroup,
-		TargetType: azure.WebApp,
-		Target:     strings.ToUpper(webApp.Id),
-		RelProps:   map[string]any{},
-		RelType:    azure.Contains,
-	})
+	relationships = append(relationships, NewIngestibleRelationship(
+		IngestibleSource{
+			Source:     strings.ToUpper(webApp.ResourceGroupId),
+			SourceType: azure.ResourceGroup,
+		},
+		IngestibleTarget{
+			TargetType: azure.WebApp,
+			Target:     strings.ToUpper(webApp.Id),
+		},
+		IngestibleRel{
+			RelProps: map[string]any{},
+			RelType:  azure.Contains,
+		},
+	))
 
 	// Enumerate System Assigned Identities
 	if webApp.Identity.PrincipalId != "" {
-		relationships = append(relationships, IngestibleRelationship{
-			Source:     strings.ToUpper(webApp.Id),
-			SourceType: azure.WebApp,
-			TargetType: azure.ServicePrincipal,
-			Target:     strings.ToUpper(webApp.Identity.PrincipalId),
-			RelProps:   map[string]any{},
-			RelType:    azure.ManagedIdentity,
-		})
+		relationships = append(relationships, NewIngestibleRelationship(
+			IngestibleSource{
+				Source:     strings.ToUpper(webApp.Id),
+				SourceType: azure.WebApp,
+			},
+			IngestibleTarget{
+				TargetType: azure.ServicePrincipal,
+				Target:     strings.ToUpper(webApp.Identity.PrincipalId),
+			},
+			IngestibleRel{
+				RelProps: map[string]any{},
+				RelType:  azure.ManagedIdentity,
+			},
+		))
 	}
 
 	// Enumerate User Assigned Identities
 	for _, identity := range webApp.Identity.UserAssignedIdentities {
 		if identity.ClientId != "" {
-			relationships = append(relationships, IngestibleRelationship{
-				Source:     strings.ToUpper(webApp.Id),
-				SourceType: azure.WebApp,
-				TargetType: azure.ServicePrincipal,
-				Target:     strings.ToUpper(identity.PrincipalId),
-				RelProps:   map[string]any{},
-				RelType:    azure.ManagedIdentity,
-			})
+			relationships = append(relationships, NewIngestibleRelationship(
+				IngestibleSource{
+					Source:     strings.ToUpper(webApp.Id),
+					SourceType: azure.WebApp,
+				},
+				IngestibleTarget{
+					TargetType: azure.ServicePrincipal,
+					Target:     strings.ToUpper(identity.PrincipalId),
+				},
+				IngestibleRel{
+					RelProps: map[string]any{},
+					RelType:  azure.ManagedIdentity,
+				},
+			))
 		}
 	}
 
@@ -1284,14 +1654,20 @@ func ConvertAzureAutomationAccountRoleAssignment(roleAssignments models.AzureRol
 				constants.ContributorRoleID,
 				constants.AutomationContributorRoleID,
 			}, strings.ToLower(raw.RoleDefinitionId)) {
-				relationships = append(relationships, IngestibleRelationship{
-					Source:     strings.ToUpper(raw.Assignee.GetPrincipalId()),
-					SourceType: azure.Entity,
-					TargetType: azure.AutomationAccount,
-					Target:     strings.ToUpper(roleAssignments.ObjectId),
-					RelProps:   map[string]any{},
-					RelType:    KindFromRoleId(raw.RoleDefinitionId),
-				})
+				relationships = append(relationships, NewIngestibleRelationship(
+					IngestibleSource{
+						Source:     strings.ToUpper(raw.Assignee.GetPrincipalId()),
+						SourceType: azure.Entity,
+					},
+					IngestibleTarget{
+						TargetType: azure.AutomationAccount,
+						Target:     strings.ToUpper(roleAssignments.ObjectId),
+					},
+					IngestibleRel{
+						RelProps: map[string]any{},
+						RelType:  KindFromRoleId(raw.RoleDefinitionId),
+					},
+				))
 			}
 		}
 	}
@@ -1308,14 +1684,20 @@ func ConvertAzureContainerRegistryRoleAssignment(roleAssignment models.AzureRole
 				constants.UserAccessAdminRoleID,
 				constants.ContributorRoleID,
 			}, strings.ToLower(raw.RoleDefinitionId)) {
-				relationships = append(relationships, IngestibleRelationship{
-					Source:     strings.ToUpper(raw.Assignee.GetPrincipalId()),
-					SourceType: azure.Entity,
-					TargetType: azure.ContainerRegistry,
-					Target:     strings.ToUpper(roleAssignment.ObjectId),
-					RelProps:   map[string]any{},
-					RelType:    KindFromRoleId(raw.RoleDefinitionId),
-				})
+				relationships = append(relationships, NewIngestibleRelationship(
+					IngestibleSource{
+						Source:     strings.ToUpper(raw.Assignee.GetPrincipalId()),
+						SourceType: azure.Entity,
+					},
+					IngestibleTarget{
+						TargetType: azure.ContainerRegistry,
+						Target:     strings.ToUpper(roleAssignment.ObjectId),
+					},
+					IngestibleRel{
+						RelProps: map[string]any{},
+						RelType:  KindFromRoleId(raw.RoleDefinitionId),
+					},
+				))
 			}
 		}
 	}
@@ -1333,14 +1715,20 @@ func ConvertAzureWebAppRoleAssignment(roleAssignment models.AzureRoleAssignments
 				constants.ContributorRoleID,
 				constants.WebsiteContributorRoleID,
 			}, strings.ToLower(raw.RoleDefinitionId)) {
-				relationships = append(relationships, IngestibleRelationship{
-					Source:     strings.ToUpper(raw.Assignee.GetPrincipalId()),
-					SourceType: azure.Entity,
-					TargetType: azure.WebApp,
-					Target:     strings.ToUpper(roleAssignment.ObjectId),
-					RelProps:   map[string]any{},
-					RelType:    KindFromRoleId(raw.RoleDefinitionId),
-				})
+				relationships = append(relationships, NewIngestibleRelationship(
+					IngestibleSource{
+						Source:     strings.ToUpper(raw.Assignee.GetPrincipalId()),
+						SourceType: azure.Entity,
+					},
+					IngestibleTarget{
+						TargetType: azure.WebApp,
+						Target:     strings.ToUpper(roleAssignment.ObjectId),
+					},
+					IngestibleRel{
+						RelProps: map[string]any{},
+						RelType:  KindFromRoleId(raw.RoleDefinitionId),
+					},
+				))
 			}
 		}
 	}
@@ -1359,38 +1747,56 @@ func ConvertAzureAutomationAccount(account models.AutomationAccount) (Ingestible
 	}
 
 	relationships := make([]IngestibleRelationship, 0)
-	relationships = append(relationships, IngestibleRelationship{
-		Source:     strings.ToUpper(account.ResourceGroupId),
-		SourceType: azure.ResourceGroup,
-		TargetType: azure.AutomationAccount,
-		Target:     strings.ToUpper(account.Id),
-		RelProps:   map[string]any{},
-		RelType:    azure.Contains,
-	})
+	relationships = append(relationships, NewIngestibleRelationship(
+		IngestibleSource{
+			Source:     strings.ToUpper(account.ResourceGroupId),
+			SourceType: azure.ResourceGroup,
+		},
+		IngestibleTarget{
+			TargetType: azure.AutomationAccount,
+			Target:     strings.ToUpper(account.Id),
+		},
+		IngestibleRel{
+			RelProps: map[string]any{},
+			RelType:  azure.Contains,
+		},
+	))
 
 	// Enumerate System Assigned Identities
 	if account.Identity.PrincipalId != "" {
-		relationships = append(relationships, IngestibleRelationship{
-			Source:     strings.ToUpper(account.Id),
-			SourceType: azure.AutomationAccount,
-			TargetType: azure.ServicePrincipal,
-			Target:     strings.ToUpper(account.Identity.PrincipalId),
-			RelProps:   map[string]any{},
-			RelType:    azure.ManagedIdentity,
-		})
+		relationships = append(relationships, NewIngestibleRelationship(
+			IngestibleSource{
+				Source:     strings.ToUpper(account.Id),
+				SourceType: azure.AutomationAccount,
+			},
+			IngestibleTarget{
+				TargetType: azure.ServicePrincipal,
+				Target:     strings.ToUpper(account.Identity.PrincipalId),
+			},
+			IngestibleRel{
+				RelProps: map[string]any{},
+				RelType:  azure.ManagedIdentity,
+			},
+		))
 	}
 
 	// Enumerate User Assigned Identities
 	for _, identity := range account.Identity.UserAssignedIdentities {
 		if identity.ClientId != "" {
-			relationships = append(relationships, IngestibleRelationship{
-				Source:     strings.ToUpper(account.Id),
-				SourceType: azure.AutomationAccount,
-				TargetType: azure.ServicePrincipal,
-				Target:     strings.ToUpper(identity.PrincipalId),
-				RelProps:   map[string]any{},
-				RelType:    azure.ManagedIdentity,
-			})
+			relationships = append(relationships, NewIngestibleRelationship(
+				IngestibleSource{
+					Source:     strings.ToUpper(account.Id),
+					SourceType: azure.AutomationAccount,
+				},
+				IngestibleTarget{
+					TargetType: azure.ServicePrincipal,
+					Target:     strings.ToUpper(identity.PrincipalId),
+				},
+				IngestibleRel{
+					RelProps: map[string]any{},
+					RelType:  azure.ManagedIdentity,
+				},
+			))
 		}
 	}
 

--- a/packages/go/ein/models.go
+++ b/packages/go/ein/models.go
@@ -26,8 +26,8 @@ func NewIngestibleRelationship(source IngestibleSource, target IngestibleTarget,
 
 	return IngestibleRelationship{
 		Source:     source.Source,
-		Target:     target.Target,
 		SourceType: source.SourceType,
+		Target:     target.Target,
 		TargetType: target.TargetType,
 		RelProps:   rel.RelProps,
 		RelType:    rel.RelType,

--- a/packages/go/ein/models.go
+++ b/packages/go/ein/models.go
@@ -18,11 +18,35 @@ package ein
 
 import "github.com/specterops/bloodhound/dawgs/graph"
 
-// Initialize an empty IngestibleRelationship to ensure the map isn't nil
-func NewIngestibleRelationship() IngestibleRelationship {
-	return IngestibleRelationship{
-		RelProps: make(map[string]any),
+// Initialize IngestibleRelationship to ensure the RelProps map can't be nil
+func NewIngestibleRelationship(source IngestibleSource, target IngestibleTarget, rel IngestibleRel) IngestibleRelationship {
+	if rel.RelProps == nil {
+		rel.RelProps = make(map[string]any)
 	}
+
+	return IngestibleRelationship{
+		Source:     source.Source,
+		Target:     target.Target,
+		SourceType: source.SourceType,
+		TargetType: target.TargetType,
+		RelProps:   rel.RelProps,
+		RelType:    rel.RelType,
+	}
+}
+
+type IngestibleSource struct {
+	Source     string
+	SourceType graph.Kind
+}
+
+type IngestibleTarget struct {
+	Target     string
+	TargetType graph.Kind
+}
+
+type IngestibleRel struct {
+	RelProps map[string]any
+	RelType  graph.Kind
 }
 
 type IngestibleRelationship struct {
@@ -35,7 +59,7 @@ type IngestibleRelationship struct {
 }
 
 func (s IngestibleRelationship) IsValid() bool {
-	return s.Target != "" && s.Source != ""
+	return s.Target != "" && s.Source != "" && s.RelProps != nil
 }
 
 type IngestibleSession struct {

--- a/packages/go/ein/models.go
+++ b/packages/go/ein/models.go
@@ -1,22 +1,29 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 package ein
 
 import "github.com/specterops/bloodhound/dawgs/graph"
+
+// Initialize an empty IngestibleRelationship to ensure the map isn't nil
+func NewIngestibleRelationship() IngestibleRelationship {
+	return IngestibleRelationship{
+		RelProps: make(map[string]any),
+	}
+}
 
 type IngestibleRelationship struct {
 	Source     string


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

- Moved to an initializer for ein.IngestibleRelationship, and refactored all current uses to that initializer.
- Fixes some cases where we explicitly created empty ein.IngestibleRelationship structs, which would contain a nil map
- Fixed issues with some `make([]IngestibleRelationship...)` to ensure that the slice length is set to 0 even if the capacity was set to another number, removing the chance of having empty IngestibleRelationship structs in those slices.

## Motivation and Context

This PR addresses: BED-4570 | #695 

*Why is this change required? What problem does it solve?*

Removes chances for panics when invalid data is ingested

## How Has This Been Tested?

Local testing with reproduction steps from original GitHub issue

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)
- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
