### PR TITLE
BED-4551: Add Domain Entity Paths to OAPI Spec

### DIFF
--- a/packages/go/openapi/src/openapi.yaml
+++ b/packages/go/openapi/src/openapi.yaml
@@ -381,35 +381,35 @@ paths:
 
   # domains
   /api/v2/domains/{object_id}:
-    $ref: './paths/domains/domains.id.yaml'
+    $ref: './paths/domains.domains.id.yaml'
   /api/v2/domains/{object_id}/computers:
-    $ref: './paths/domains/domains.id.computers.yaml'
+    $ref: './paths/domains.domains.id.computers.yaml'
   /api/v2/domains/{object_id}/controllers:
-    $ref: './paths/domains/domains.id.controllers.yaml'
+    $ref: './paths/domains.domains.id.controllers.yaml'
   /api/v2/domains/{object_id}/dc-syncers:
-    $ref: './paths/domains/domains.id.dc-syncers.yaml'
+    $ref: './paths/domains.domains.id.dc-syncers.yaml'
   /api/v2/domains/{object_id}/foreign-admins:
-    $ref: './paths/domains/domains.id.foreign-admins.yaml'
+    $ref: './paths/domains.domains.id.foreign-admins.yaml'
   /api/v2/domains/{object_id}/foreign-gpo-controllers:
-    $ref: './paths/domains/domains.id.foreign-gpo-controllers.yaml'
+    $ref: './paths/domains.domains.id.foreign-gpo-controllers.yaml'
   /api/v2/domains/{object_id}/foreign-groups:
-    $ref: './paths/domains/domains.id.foreign-groups.yaml'
+    $ref: './paths/domains.domains.id.foreign-groups.yaml'
   /api/v2/domains/{object_id}/foreign-users:
-    $ref: './paths/domains/domains.id.foreign-users.yaml'
+    $ref: './paths/domains.domains.id.foreign-users.yaml'
   /api/v2/domains/{object_id}/gpos:
-    $ref: './paths/domains/domains.id.gpos.yaml'
+    $ref: './paths/domains.domains.id.gpos.yaml'
   /api/v2/domains/{object_id}/groups:
-    $ref: './paths/domains/domains.id.groups.yaml'
+    $ref: './paths/domains.domains.id.groups.yaml'
   /api/v2/domains/{object_id}/inbound-trusts:
-    $ref: './paths/domains/domains.id.inbound-trusts.yaml'
+    $ref: './paths/domains.domains.id.inbound-trusts.yaml'
   /api/v2/domains/{object_id}/linked-gpos:
-    $ref: './paths/domains/domains.id.linked-gpos.yaml'
+    $ref: './paths/domains.domains.id.linked-gpos.yaml'
   /api/v2/domains/{object_id}/ous:
-    $ref: './paths/domains/domains.id.ous.yaml'
+    $ref: './paths/domains.domains.id.ous.yaml'
   /api/v2/domains/{object_id}/outbound-trusts:
-    $ref: './paths/domains/domains.id.outbound-trusts.yaml'
+    $ref: './paths/domains.domains.id.outbound-trusts.yaml'
   /api/v2/domains/{object_id}/users:
-    $ref: './paths/domains/domains.id.users.yaml'
+    $ref: './paths/domains.domains.id.users.yaml'
 
   # gpos
   /api/v2/gpos/{object_id}:

--- a/packages/go/openapi/src/paths/domains.domains.id.computers.yaml
+++ b/packages/go/openapi/src/paths/domains.domains.id.computers.yaml
@@ -1,0 +1,45 @@
+# Copyright 2024 Specter Ops, Inc.
+#
+# Licensed under the Apache License, Version 2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+parameters:
+  - $ref: './../parameters/header.prefer.yaml'
+  - $ref: './../parameters/path.object-id.yaml'
+get:
+  operationId: GetDomainEntityComputers
+  summary: Get domain entity computers
+  description: Get a list or count of the computers that belong to this domain.
+  tags:
+    - Domains
+    - Community
+    - Enterprise
+  parameters:
+    - $ref: './../parameters/query.entity.skip.yaml'
+    - $ref: './../parameters/query.entity.limit.yaml'
+    - $ref: './../parameters/query.entity.type.yaml'
+    - $ref: './../parameters/query.entity.sort-by.yaml'
+  responses:
+    200:
+      $ref: './../responses/related-entity-query-results.yaml'
+    400:
+      $ref: './../responses/bad-request.yaml'
+    401:
+      $ref: './../responses/unauthorized.yaml'
+    403:
+      $ref: './../responses/forbidden.yaml'
+    429:
+      $ref: './../responses/too-many-requests.yaml'
+    500:
+      $ref: './../responses/internal-server-error.yaml'

--- a/packages/go/openapi/src/paths/domains.domains.id.controllers.yaml
+++ b/packages/go/openapi/src/paths/domains.domains.id.controllers.yaml
@@ -1,0 +1,45 @@
+# Copyright 2024 Specter Ops, Inc.
+#
+# Licensed under the Apache License, Version 2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+parameters:
+  - $ref: './../parameters/header.prefer.yaml'
+  - $ref: './../parameters/path.object-id.yaml'
+get:
+  operationId: GetDomainEntityControllers
+  summary: Get domain entity controllers
+  description: Get a list, graph, or count of the principals that can control this domain.
+  tags:
+    - Domains
+    - Community
+    - Enterprise
+  parameters:
+    - $ref: './../parameters/query.entity.skip.yaml'
+    - $ref: './../parameters/query.entity.limit.yaml'
+    - $ref: './../parameters/query.entity.type.yaml'
+    - $ref: './../parameters/query.entity.sort-by.yaml'
+  responses:
+    200:
+      $ref: './../responses/related-entity-query-results.yaml'
+    400:
+      $ref: './../responses/bad-request.yaml'
+    401:
+      $ref: './../responses/unauthorized.yaml'
+    403:
+      $ref: './../responses/forbidden.yaml'
+    429:
+      $ref: './../responses/too-many-requests.yaml'
+    500:
+      $ref: './../responses/internal-server-error.yaml'

--- a/packages/go/openapi/src/paths/domains.domains.id.dc-syncers.yaml
+++ b/packages/go/openapi/src/paths/domains.domains.id.dc-syncers.yaml
@@ -1,0 +1,45 @@
+# Copyright 2024 Specter Ops, Inc.
+#
+# Licensed under the Apache License, Version 2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+parameters:
+  - $ref: './../parameters/header.prefer.yaml'
+  - $ref: './../parameters/path.object-id.yaml'
+get:
+  operationId: GetDomainEntityDcSyncers
+  summary: Get domain entity DC Syncers
+  description: Get a list, graph, or count of the principals that can DC sync this domain.
+  tags:
+    - Domains
+    - Community
+    - Enterprise
+  parameters:
+    - $ref: './../parameters/query.entity.skip.yaml'
+    - $ref: './../parameters/query.entity.limit.yaml'
+    - $ref: './../parameters/query.entity.type.yaml'
+    - $ref: './../parameters/query.entity.sort-by.yaml'
+  responses:
+    200:
+      $ref: './../responses/related-entity-query-results.yaml'
+    400:
+      $ref: './../responses/bad-request.yaml'
+    401:
+      $ref: './../responses/unauthorized.yaml'
+    403:
+      $ref: './../responses/forbidden.yaml'
+    429:
+      $ref: './../responses/too-many-requests.yaml'
+    500:
+      $ref: './../responses/internal-server-error.yaml'

--- a/packages/go/openapi/src/paths/domains.domains.id.foreign-admins.yaml
+++ b/packages/go/openapi/src/paths/domains.domains.id.foreign-admins.yaml
@@ -1,0 +1,47 @@
+# Copyright 2024 Specter Ops, Inc.
+#
+# Licensed under the Apache License, Version 2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+parameters:
+  - $ref: './../parameters/header.prefer.yaml'
+  - $ref: './../parameters/path.object-id.yaml'
+get:
+  operationId: GetDomainEntityForeignAdmins
+  summary: Get domain entity foreign admins
+  description: |
+    Get a list, graph, or count of the principals outside of this domain that have admin
+    rights on principals in this domain.
+  tags:
+    - Domains
+    - Community
+    - Enterprise
+  parameters:
+    - $ref: './../parameters/query.entity.skip.yaml'
+    - $ref: './../parameters/query.entity.limit.yaml'
+    - $ref: './../parameters/query.entity.type.yaml'
+    - $ref: './../parameters/query.entity.sort-by.yaml'
+  responses:
+    200:
+      $ref: './../responses/related-entity-query-results.yaml'
+    400:
+      $ref: './../responses/bad-request.yaml'
+    401:
+      $ref: './../responses/unauthorized.yaml'
+    403:
+      $ref: './../responses/forbidden.yaml'
+    429:
+      $ref: './../responses/too-many-requests.yaml'
+    500:
+      $ref: './../responses/internal-server-error.yaml'

--- a/packages/go/openapi/src/paths/domains.domains.id.foreign-gpo-controllers.yaml
+++ b/packages/go/openapi/src/paths/domains.domains.id.foreign-gpo-controllers.yaml
@@ -1,0 +1,47 @@
+# Copyright 2024 Specter Ops, Inc.
+#
+# Licensed under the Apache License, Version 2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+parameters:
+  - $ref: './../parameters/header.prefer.yaml'
+  - $ref: './../parameters/path.object-id.yaml'
+get:
+  operationId: GetDomainEntityForeignGpoControllers
+  summary: Get domain entity foreign GPO controllers
+  description: |
+    Get a list, graph, or count of the principals outside of this domain that can control
+    GPOs inside this domain.
+  tags:
+    - Domains
+    - Community
+    - Enterprise
+  parameters:
+    - $ref: './../parameters/query.entity.skip.yaml'
+    - $ref: './../parameters/query.entity.limit.yaml'
+    - $ref: './../parameters/query.entity.type.yaml'
+    - $ref: './../parameters/query.entity.sort-by.yaml'
+  responses:
+    200:
+      $ref: './../responses/related-entity-query-results.yaml'
+    400:
+      $ref: './../responses/bad-request.yaml'
+    401:
+      $ref: './../responses/unauthorized.yaml'
+    403:
+      $ref: './../responses/forbidden.yaml'
+    429:
+      $ref: './../responses/too-many-requests.yaml'
+    500:
+      $ref: './../responses/internal-server-error.yaml'

--- a/packages/go/openapi/src/paths/domains.domains.id.foreign-groups.yaml
+++ b/packages/go/openapi/src/paths/domains.domains.id.foreign-groups.yaml
@@ -1,0 +1,47 @@
+# Copyright 2024 Specter Ops, Inc.
+#
+# Licensed under the Apache License, Version 2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+parameters:
+  - $ref: './../parameters/header.prefer.yaml'
+  - $ref: './../parameters/path.object-id.yaml'
+get:
+  operationId: GetDomainEntityForeignGroups
+  summary: Get domain entity foregin groups
+  description: |
+    Get a list, graph, or count of the groups outside of this domain that are members
+    of groups inside this domain.
+  tags:
+    - Domains
+    - Community
+    - Enterprise
+  parameters:
+    - $ref: './../parameters/query.entity.skip.yaml'
+    - $ref: './../parameters/query.entity.limit.yaml'
+    - $ref: './../parameters/query.entity.type.yaml'
+    - $ref: './../parameters/query.entity.sort-by.yaml'
+  responses:
+    200:
+      $ref: './../responses/related-entity-query-results.yaml'
+    400:
+      $ref: './../responses/bad-request.yaml'
+    401:
+      $ref: './../responses/unauthorized.yaml'
+    403:
+      $ref: './../responses/forbidden.yaml'
+    429:
+      $ref: './../responses/too-many-requests.yaml'
+    500:
+      $ref: './../responses/internal-server-error.yaml'

--- a/packages/go/openapi/src/paths/domains.domains.id.foreign-users.yaml
+++ b/packages/go/openapi/src/paths/domains.domains.id.foreign-users.yaml
@@ -1,0 +1,47 @@
+# Copyright 2024 Specter Ops, Inc.
+#
+# Licensed under the Apache License, Version 2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+parameters:
+  - $ref: './../parameters/header.prefer.yaml'
+  - $ref: './../parameters/path.object-id.yaml'
+get:
+  operationId: GetDomainEntityForeignUsers
+  summary: Get domain entity foreign users
+  description: |
+    Get a list, graph, or count of the users outside of this domain that are members
+    of groups inside this domain.
+  tags:
+    - Domains
+    - Community
+    - Enterprise
+  parameters:
+    - $ref: './../parameters/query.entity.skip.yaml'
+    - $ref: './../parameters/query.entity.limit.yaml'
+    - $ref: './../parameters/query.entity.type.yaml'
+    - $ref: './../parameters/query.entity.sort-by.yaml'
+  responses:
+    200:
+      $ref: './../responses/related-entity-query-results.yaml'
+    400:
+      $ref: './../responses/bad-request.yaml'
+    401:
+      $ref: './../responses/unauthorized.yaml'
+    403:
+      $ref: './../responses/forbidden.yaml'
+    429:
+      $ref: './../responses/too-many-requests.yaml'
+    500:
+      $ref: './../responses/internal-server-error.yaml'

--- a/packages/go/openapi/src/paths/domains.domains.id.gpos.yaml
+++ b/packages/go/openapi/src/paths/domains.domains.id.gpos.yaml
@@ -1,0 +1,45 @@
+# Copyright 2024 Specter Ops, Inc.
+#
+# Licensed under the Apache License, Version 2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+parameters:
+  - $ref: './../parameters/header.prefer.yaml'
+  - $ref: './../parameters/path.object-id.yaml'
+get:
+  operationId: GetDomainEntityGpos
+  summary: Get domain entity GPOs
+  description: Get a list or count of the GPOs in this domain.
+  tags:
+    - Domains
+    - Community
+    - Enterprise
+  parameters:
+    - $ref: './../parameters/query.entity.skip.yaml'
+    - $ref: './../parameters/query.entity.limit.yaml'
+    - $ref: './../parameters/query.entity.type.yaml'
+    - $ref: './../parameters/query.entity.sort-by.yaml'
+  responses:
+    200:
+      $ref: './../responses/related-entity-query-results.yaml'
+    400:
+      $ref: './../responses/bad-request.yaml'
+    401:
+      $ref: './../responses/unauthorized.yaml'
+    403:
+      $ref: './../responses/forbidden.yaml'
+    429:
+      $ref: './../responses/too-many-requests.yaml'
+    500:
+      $ref: './../responses/internal-server-error.yaml'

--- a/packages/go/openapi/src/paths/domains.domains.id.groups.yaml
+++ b/packages/go/openapi/src/paths/domains.domains.id.groups.yaml
@@ -1,0 +1,45 @@
+# Copyright 2024 Specter Ops, Inc.
+#
+# Licensed under the Apache License, Version 2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+parameters:
+  - $ref: './../parameters/header.prefer.yaml'
+  - $ref: './../parameters/path.object-id.yaml'
+get:
+  operationId: GetDomainEntityGroups
+  summary: Get domain entity groups
+  description: Get a list or count of the groups in this domain.
+  tags:
+    - Domains
+    - Community
+    - Enterprise
+  parameters:
+    - $ref: './../parameters/query.entity.skip.yaml'
+    - $ref: './../parameters/query.entity.limit.yaml'
+    - $ref: './../parameters/query.entity.type.yaml'
+    - $ref: './../parameters/query.entity.sort-by.yaml'
+  responses:
+    200:
+      $ref: './../responses/related-entity-query-results.yaml'
+    400:
+      $ref: './../responses/bad-request.yaml'
+    401:
+      $ref: './../responses/unauthorized.yaml'
+    403:
+      $ref: './../responses/forbidden.yaml'
+    429:
+      $ref: './../responses/too-many-requests.yaml'
+    500:
+      $ref: './../responses/internal-server-error.yaml'

--- a/packages/go/openapi/src/paths/domains.domains.id.inbound-trusts.yaml
+++ b/packages/go/openapi/src/paths/domains.domains.id.inbound-trusts.yaml
@@ -1,0 +1,45 @@
+# Copyright 2024 Specter Ops, Inc.
+#
+# Licensed under the Apache License, Version 2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+parameters:
+  - $ref: './../parameters/header.prefer.yaml'
+  - $ref: './../parameters/path.object-id.yaml'
+get:
+  operationId: GetDomainEntityInboundTrusts
+  summary: Get domain entity inbound trusts
+  description: Get a list, graph, or count of the inbound trusts for this domain.
+  tags:
+    - Domains
+    - Community
+    - Enterprise
+  parameters:
+    - $ref: './../parameters/query.entity.skip.yaml'
+    - $ref: './../parameters/query.entity.limit.yaml'
+    - $ref: './../parameters/query.entity.type.yaml'
+    - $ref: './../parameters/query.entity.sort-by.yaml'
+  responses:
+    200:
+      $ref: './../responses/related-entity-query-results.yaml'
+    400:
+      $ref: './../responses/bad-request.yaml'
+    401:
+      $ref: './../responses/unauthorized.yaml'
+    403:
+      $ref: './../responses/forbidden.yaml'
+    429:
+      $ref: './../responses/too-many-requests.yaml'
+    500:
+      $ref: './../responses/internal-server-error.yaml'

--- a/packages/go/openapi/src/paths/domains.domains.id.linked-gpos.yaml
+++ b/packages/go/openapi/src/paths/domains.domains.id.linked-gpos.yaml
@@ -1,0 +1,45 @@
+# Copyright 2024 Specter Ops, Inc.
+#
+# Licensed under the Apache License, Version 2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+parameters:
+  - $ref: './../parameters/header.prefer.yaml'
+  - $ref: './../parameters/path.object-id.yaml'
+get:
+  operationId: GetDomainEntityLinkedGpos
+  summary: Get domain entity linked GPOs
+  description: Get a list, graph, or count of the GPOs linked to this domain.
+  tags:
+    - Domains
+    - Community
+    - Enterprise
+  parameters:
+    - $ref: './../parameters/query.entity.skip.yaml'
+    - $ref: './../parameters/query.entity.limit.yaml'
+    - $ref: './../parameters/query.entity.type.yaml'
+    - $ref: './../parameters/query.entity.sort-by.yaml'
+  responses:
+    200:
+      $ref: './../responses/related-entity-query-results.yaml'
+    400:
+      $ref: './../responses/bad-request.yaml'
+    401:
+      $ref: './../responses/unauthorized.yaml'
+    403:
+      $ref: './../responses/forbidden.yaml'
+    429:
+      $ref: './../responses/too-many-requests.yaml'
+    500:
+      $ref: './../responses/internal-server-error.yaml'

--- a/packages/go/openapi/src/paths/domains.domains.id.ous.yaml
+++ b/packages/go/openapi/src/paths/domains.domains.id.ous.yaml
@@ -1,0 +1,45 @@
+# Copyright 2024 Specter Ops, Inc.
+#
+# Licensed under the Apache License, Version 2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+parameters:
+  - $ref: './../parameters/header.prefer.yaml'
+  - $ref: './../parameters/path.object-id.yaml'
+get:
+  operationId: GetDomainEntityOus
+  summary: Get domain entity OUs
+  description: Get a list or count of the OUs in this domain.
+  tags:
+    - Domains
+    - Community
+    - Enterprise
+  parameters:
+    - $ref: './../parameters/query.entity.skip.yaml'
+    - $ref: './../parameters/query.entity.limit.yaml'
+    - $ref: './../parameters/query.entity.type.yaml'
+    - $ref: './../parameters/query.entity.sort-by.yaml'
+  responses:
+    200:
+      $ref: './../responses/related-entity-query-results.yaml'
+    400:
+      $ref: './../responses/bad-request.yaml'
+    401:
+      $ref: './../responses/unauthorized.yaml'
+    403:
+      $ref: './../responses/forbidden.yaml'
+    429:
+      $ref: './../responses/too-many-requests.yaml'
+    500:
+      $ref: './../responses/internal-server-error.yaml'

--- a/packages/go/openapi/src/paths/domains.domains.id.outbound-trusts.yaml
+++ b/packages/go/openapi/src/paths/domains.domains.id.outbound-trusts.yaml
@@ -1,0 +1,45 @@
+# Copyright 2024 Specter Ops, Inc.
+#
+# Licensed under the Apache License, Version 2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+parameters:
+  - $ref: './../parameters/header.prefer.yaml'
+  - $ref: './../parameters/path.object-id.yaml'
+get:
+  operationId: GetDomainEntityOutboundTrusts
+  summary: Get domain entity outbound trusts
+  description: Get a list, graph, or count of the outbound trusts for this domain.
+  tags:
+    - Domains
+    - Community
+    - Enterprise
+  parameters:
+    - $ref: './../parameters/query.entity.skip.yaml'
+    - $ref: './../parameters/query.entity.limit.yaml'
+    - $ref: './../parameters/query.entity.type.yaml'
+    - $ref: './../parameters/query.entity.sort-by.yaml'
+  responses:
+    200:
+      $ref: './../responses/related-entity-query-results.yaml'
+    400:
+      $ref: './../responses/bad-request.yaml'
+    401:
+      $ref: './../responses/unauthorized.yaml'
+    403:
+      $ref: './../responses/forbidden.yaml'
+    429:
+      $ref: './../responses/too-many-requests.yaml'
+    500:
+      $ref: './../responses/internal-server-error.yaml'

--- a/packages/go/openapi/src/paths/domains.domains.id.users.yaml
+++ b/packages/go/openapi/src/paths/domains.domains.id.users.yaml
@@ -1,0 +1,45 @@
+# Copyright 2024 Specter Ops, Inc.
+#
+# Licensed under the Apache License, Version 2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+parameters:
+  - $ref: './../parameters/header.prefer.yaml'
+  - $ref: './../parameters/path.object-id.yaml'
+get:
+  operationId: GetDomainEntityUsers
+  summary: Get domain entity users
+  description: Get a list or count of the users in this domain.
+  tags:
+    - Domains
+    - Community
+    - Enterprise
+  parameters:
+    - $ref: './../parameters/query.entity.skip.yaml'
+    - $ref: './../parameters/query.entity.limit.yaml'
+    - $ref: './../parameters/query.entity.type.yaml'
+    - $ref: './../parameters/query.entity.sort-by.yaml'
+  responses:
+    200:
+      $ref: './../responses/related-entity-query-results.yaml'
+    400:
+      $ref: './../responses/bad-request.yaml'
+    401:
+      $ref: './../responses/unauthorized.yaml'
+    403:
+      $ref: './../responses/forbidden.yaml'
+    429:
+      $ref: './../responses/too-many-requests.yaml'
+    500:
+      $ref: './../responses/internal-server-error.yaml'

--- a/packages/go/openapi/src/paths/domains.domains.id.yaml
+++ b/packages/go/openapi/src/paths/domains.domains.id.yaml
@@ -1,0 +1,87 @@
+# Copyright 2024 Specter Ops, Inc.
+#
+# Licensed under the Apache License, Version 2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+parameters:
+  - $ref: './../parameters/header.prefer.yaml'
+  - $ref: './../parameters/path.object-id.yaml'
+get:
+  operationId: GetDomainEntity
+  summary: Get domain entity info
+  description: Get basic info and counts for this domain node.
+  tags:
+    - Domains
+    - Community
+    - Enterprise
+  parameters:
+    - $ref: './../parameters/query.hydrate-counts.yaml'
+  responses:
+    200:
+      $ref: './../responses/entity-info-query-results.yaml'
+    400:
+      $ref: './../responses/bad-request.yaml'
+    401:
+      $ref: './../responses/unauthorized.yaml'
+    403:
+      $ref: './../responses/forbidden.yaml'
+    404:
+      $ref: './../responses/not-found.yaml'
+    429:
+      $ref: './../responses/too-many-requests.yaml'
+    500:
+      $ref: './../responses/internal-server-error.yaml'
+
+patch:
+  operationId: UpdateDomainEntity
+  summary: Update the Domain entity
+  description: Updates the supported properties on the Domain entity.
+  tags:
+    - Domains
+    - Community
+    - Enterprise
+  requestBody:
+    description: The patch request body for updating Domain
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            collected:
+              type: boolean
+  responses:
+    200:
+      description: OK
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              data:
+                type: object
+                properties:
+                  collected:
+                    type: boolean
+    400:
+      $ref: './../responses/bad-request.yaml'
+    401:
+      $ref: './../responses/unauthorized.yaml'
+    403:
+      $ref: './../responses/forbidden.yaml'
+    404:
+      $ref: './../responses/not-found.yaml'
+    429:
+      $ref: './../responses/too-many-requests.yaml'
+    500:
+      $ref: './../responses/internal-server-error.yaml'


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

- Added all of the domains specs

## Motivation and Context

- Ticket: BED-4551
- Subtask above is from here: BED-4141

*Why is this change required? What problem does it solve?*
- Simplifies and improves on our existing OpenAPI spec documentation

## How Has This Been Tested?

- I made sure to check that all refs and paths were correct and led to their proper locations

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
