### PR TITLE
BED-4574: Dark Mode early access fix

### DIFF
--- a/cmd/ui/src/App.tsx
+++ b/cmd/ui/src/App.tsx
@@ -114,7 +114,7 @@ const Inner: React.FC = () => {
 
     // remove dark_mode if feature flag is disabled
     useEffect(() => {
-        // TODO: Consider adding flag keys to cue files so we don't use random strings. Consider adding more flexibility/composability to side effects for toggling feature flags on and off
+        // TODO: Consider adding more flexibility/composability to side effects for toggling feature flags on and off
         if (!featureFlagsRes.data) return;
         const darkModeFeatureFlag = featureFlagsRes.data.find((flag) => flag.key === 'dark_mode');
 

--- a/cmd/ui/src/App.tsx
+++ b/cmd/ui/src/App.tsx
@@ -112,7 +112,7 @@ const Inner: React.FC = () => {
         }
     }, [dispatch, authState.isInitialized]);
 
-    // initialize theme
+    // remove dark_mode if feature flag is disabled
     useEffect(() => {
         // TODO: Consider adding flag keys to cue files so we don't use random strings. Consider adding more flexibility/composability to side effects for toggling feature flags on and off
         if (!featureFlagsRes.data) return;

--- a/cmd/ui/src/App.tsx
+++ b/cmd/ui/src/App.tsx
@@ -34,17 +34,19 @@ import { unstable_HistoryRouter as BrowserRouter, useLocation } from 'react-rout
 import Header from 'src/components/Header';
 import { initialize } from 'src/ducks/auth/authSlice';
 import { ROUTE_EXPIRED_PASSWORD, ROUTE_LOGIN, ROUTE_USER_DISABLED } from 'src/ducks/global/routes';
-import { featureFlagKeys, getFeatureFlags } from 'src/hooks/useFeatureFlags';
+import { useFeatureFlags } from 'src/hooks/useFeatureFlags';
 import { useAppDispatch, useAppSelector } from 'src/store';
 import { initializeBHEClient } from 'src/utils';
 import Content from 'src/views/Content';
 import Notifier from './components/Notifier';
+import { setDarkMode } from './ducks/global/actions';
 
 const Inner: React.FC = () => {
     const dispatch = useAppDispatch();
     const authState = useAppSelector((state) => state.auth);
     const queryClient = useQueryClient();
     const location = useLocation();
+    const featureFlagsRes = useFeatureFlags();
 
     const darkMode = useAppSelector((state) => state.global.view.darkMode);
 
@@ -110,10 +112,16 @@ const Inner: React.FC = () => {
         }
     }, [dispatch, authState.isInitialized]);
 
-    // prefetch feature flags
+    // initialize theme
     useEffect(() => {
-        queryClient.prefetchQuery(featureFlagKeys.all, getFeatureFlags);
-    }, [queryClient]);
+        // TODO: Consider adding flag keys to cue files so we don't use random strings. Consider adding more flexibility/composability to side effects for toggling feature flags on and off
+        if (!featureFlagsRes.data) return;
+        const darkModeFeatureFlag = featureFlagsRes.data.find((flag) => flag.key === 'dark_mode');
+
+        if (!darkModeFeatureFlag?.enabled) {
+            dispatch(setDarkMode(false));
+        }
+    }, [dispatch, queryClient, featureFlagsRes.data, darkMode]);
 
     // block rendering until authentication initialization is complete
     if (!authState.isInitialized) {


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description
fixes edge case where dark_mode feature flag is turned off remotely, leaving other users stuck in dark mode.

## Motivation and Context

This PR addresses: BED-4574

If dark_mode feature flag is not enabled then all users should be on light mode by default

## How Has This Been Tested?
manual tests

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->
- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
