### PR TITLE
BED-4555: added analysis related paths to openapi spec

### DIFF
--- a/packages/go/openapi/src/openapi.yaml
+++ b/packages/go/openapi/src/openapi.yaml
@@ -293,21 +293,21 @@ paths:
 
   # asset isolation
   /api/v2/asset-groups:
-    $ref: './paths/asset-isolation/asset-groups.yaml'
+    $ref: './paths/asset-isolation.asset-groups.yaml'
   /api/v2/asset-groups/{asset_group_id}:
-    $ref: './paths/asset-isolation/asset-groups.id.yaml'
+    $ref: './paths/asset-isolation.asset-groups.id.yaml'
   /api/v2/asset-groups/{asset_group_id}/collections:
-    $ref: './paths/asset-isolation/asset-groups.id.collections.yaml'
+    $ref: './paths/asset-isolation.asset-groups.id.collections.yaml'
   /api/v2/asset-groups/{asset_group_id}/selectors:
-    $ref: './paths/asset-isolation/asset-groups.id.selectors.yaml'
+    $ref: './paths/asset-isolation.asset-groups.id.selectors.yaml'
   /api/v2/asset-groups/{asset_group_id}/selectors/{asset_group_selector_id}:
-    $ref: './paths/asset-isolation/asset-groups.id.selectors.id.yaml'
+    $ref: './paths/asset-isolation.asset-groups.id.selectors.id.yaml'
   /api/v2/asset-groups/{asset_group_id}/custom-selectors:
-    $ref: './paths/asset-isolation/asset-groups.id.custom-selectors.yaml'
+    $ref: './paths/asset-isolation.asset-groups.id.custom-selectors.yaml'
   /api/v2/asset-groups/{asset_group_id}/members:
-    $ref: './paths/asset-isolation/asset-groups.id.members.yaml'
+    $ref: './paths/asset-isolation.asset-groups.id.members.yaml'
   /api/v2/asset-groups/{asset_group_id}/members/counts:
-    $ref: './paths/asset-isolation/asset-groups.id.members.counts.yaml'
+    $ref: './paths/asset-isolation.asset-groups.id.members.counts.yaml'
 
   # graph
   /api/v2/pathfinding:
@@ -553,11 +553,11 @@ paths:
 
   # analysis
   /api/v2/meta-nodes/{domain_id}:
-    $ref: './paths/analysis/meta-nodes.id.yaml'
+    $ref: './paths/analysis.meta-nodes.id.yaml'
   /api/v2/meta-trees/{domain_id}:
-    $ref: './paths/analysis/meta-trees.id.yaml'
+    $ref: './paths/analysis.meta-trees.id.yaml'
   /api/v2/asset-groups/{asset_group_id}/combo-node:
-    $ref: './paths/analysis/asset-groups.id.combo-node.yaml'
+    $ref: './paths/analysis.asset-groups.id.combo-node.yaml'
 
   # client ingest
   /api/v2/ingest:
@@ -631,23 +631,23 @@ paths:
 
   # attack paths
   /api/v2/domains/{domain_id}/attack-path-findings:
-    $ref: './paths/attack-paths/domains.id.attack-path-findings.yaml'
+    $ref: './paths/attack-paths.domains.id.attack-path-findings.yaml'
   /api/v2/attack-path-types:
-    $ref: './paths/attack-paths/attack-path-types.yaml'
+    $ref: './paths/attack-paths.attack-path-types.yaml'
   /api/v2/attack-paths:
-    $ref: './paths/attack-paths/attack-paths.yaml'
+    $ref: './paths/attack-paths.attack-paths.yaml'
   /api/v2/domains/{domain_id}/available-types:
-    $ref: './paths/attack-paths/domains.id.available-types.yaml'
+    $ref: './paths/attack-paths.domains.id.available-types.yaml'
   /api/v2/domains/{domain_id}/details:
-    $ref: './paths/attack-paths/domains.id.details.yaml'
+    $ref: './paths/attack-paths.domains.id.details.yaml'
   /api/v2/domains/{domain_id}/sparkline:
-    $ref: './paths/attack-paths/domains.id.sparkline.yaml'
+    $ref: './paths/attack-paths.domains.id.sparkline.yaml'
   /api/v2/attack-paths/{attack_path_id}/acceptance:
-    $ref: './paths/attack-paths/attack-paths.id.acceptance.yaml'
+    $ref: './paths/attack-paths.attack-paths.id.acceptance.yaml'
 
   # risk posture
   /api/v2/posture-stats:
-    $ref: './paths/risk-posture/posture-stats.yaml'
+    $ref: './paths/risk-posture.posture-stats.yaml'
 
   # meta entity
   /api/v2/meta/{object_id}:

--- a/packages/go/openapi/src/paths/analysis.asset-groups.id.combo-node.yaml
+++ b/packages/go/openapi/src/paths/analysis.asset-groups.id.combo-node.yaml
@@ -1,0 +1,61 @@
+# Copyright 2024 Specter Ops, Inc.
+#
+# Licensed under the Apache License, Version 2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+parameters:
+  - $ref: './../parameters/header.prefer.yaml'
+  - name: asset_group_id
+    description: Asset Group Object ID
+    in: path
+    required: true
+    schema:
+      type: integer
+      format: int32
+get:
+  operationId: GetAssetGroupComboNode
+  deprecated: true
+  summary: Get the combo tree for an asset group
+  description: Gets the combo tree for an asset group
+  tags:
+    - Analysis
+    - Enterprise
+  parameters:
+    - name: domainsid
+      description: Filter by Domain security identifier.
+      in: query
+      schema:
+        type: string
+  responses:
+    200:
+      description: OK
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              data:
+                $ref: './../schemas/model.bh-graph.graph.yaml'
+    400:
+      $ref: './../responses/bad-request.yaml'
+    401:
+      $ref: './../responses/unauthorized.yaml'
+    403:
+      $ref: './../responses/forbidden.yaml'
+    404:
+      $ref: './../responses/not-found.yaml'
+    429:
+      $ref: './../responses/too-many-requests.yaml'
+    500:
+      $ref: './../responses/internal-server-error.yaml'

--- a/packages/go/openapi/src/paths/analysis.meta-nodes.id.yaml
+++ b/packages/go/openapi/src/paths/analysis.meta-nodes.id.yaml
@@ -1,0 +1,53 @@
+# Copyright 2024 Specter Ops, Inc.
+#
+# Licensed under the Apache License, Version 2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+parameters:
+  - $ref: './../parameters/header.prefer.yaml'
+  - name: domain_id
+    description: Domain ID
+    in: path
+    required: true
+    schema:
+      type: string
+get:
+  operationId: GetLatestTierZeroComboNode
+  summary: Get latest tier zero combo node
+  description: Get latest tier zero combo node
+  tags:
+    - Analysis
+    - Enterprise
+  responses:
+    200:
+      description: OK
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              data:
+                type: object
+                additionalProperties:
+                  $ref: './../schemas/model.bh-graph.node.yaml'
+    401:
+      $ref: './../responses/unauthorized.yaml'
+    403:
+      $ref: './../responses/forbidden.yaml'
+    404:
+      $ref: './../responses/not-found.yaml'
+    429:
+      $ref: './../responses/too-many-requests.yaml'
+    500:
+      $ref: './../responses/internal-server-error.yaml'

--- a/packages/go/openapi/src/paths/analysis.meta-trees.id.yaml
+++ b/packages/go/openapi/src/paths/analysis.meta-trees.id.yaml
@@ -1,0 +1,60 @@
+# Copyright 2024 Specter Ops, Inc.
+#
+# Licensed under the Apache License, Version 2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+parameters:
+  - $ref: './../parameters/header.prefer.yaml'
+  - name: domain_id
+    description: Domain ID
+    in: path
+    required: true
+    schema:
+      type: string
+get:
+  operationId: GetComboTreeGraph
+  summary: Get the graph for meta tree
+  # TODO: Somebody who understands this endpoint better should improve this description
+  # It appears to do two different things base on whether node_id is set
+  description: Gets meta nodes and connecting edges
+  tags:
+    - Analysis
+    - Enterprise
+  parameters:
+    - name: node_id
+      description: Node ID # TODO: improve the description to explain what this does
+      in: query
+      schema:
+        type: integer
+        format: int64
+  responses:
+    200:
+      description: OK
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              data:
+                $ref: './../schemas/model.bh-graph.graph.yaml'
+    400:
+      $ref: './../responses/bad-request.yaml'
+    401:
+      $ref: './../responses/unauthorized.yaml'
+    403:
+      $ref: './../responses/forbidden.yaml'
+    429:
+      $ref: './../responses/too-many-requests.yaml'
+    500:
+      $ref: './../responses/internal-server-error.yaml'

--- a/packages/go/openapi/src/paths/asset-isolation.asset-groups.id.collections.yaml
+++ b/packages/go/openapi/src/paths/asset-isolation.asset-groups.id.collections.yaml
@@ -1,0 +1,70 @@
+# Copyright 2024 Specter Ops, Inc.
+#
+# Licensed under the Apache License, Version 2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+parameters:
+  - $ref: './../parameters/header.prefer.yaml'
+  - name: asset_group_id
+    description: ID of the asset_group record to retrieve
+    in: path
+    required: true
+    schema:
+      type: integer
+      format: int32
+
+get:
+  operationId: ListAssetGroupCollections
+  summary: List asset group collections
+  description: Returns all historical memberships if no URL params are specified.
+  tags:
+    - Asset Isolation
+    - Community
+    - Enterprise
+  parameters:
+    - name: sort_by
+      in: query
+      schema:
+        $ref: './../schemas/api.params.query.sort-by.yaml'
+    - name: id
+      in: query
+      schema:
+        $ref: './../schemas/api.params.predicate.filter.integer.yaml'
+    - $ref: './../parameters/query.created-at.yaml'
+    - $ref: './../parameters/query.updated-at.yaml'
+    - $ref: './../parameters/query.deleted-at.yaml'
+  responses:
+    200:
+      description: OK
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              data:
+                type: array
+                items:
+                  $ref: './../schemas/model.asset-group-collection.yaml'
+    400:
+      $ref: './../responses/bad-request.yaml'
+    401:
+      $ref: './../responses/unauthorized.yaml'
+    403:
+      $ref: './../responses/forbidden.yaml'
+    404:
+      $ref: './../responses/not-found.yaml'
+    429:
+      $ref: './../responses/too-many-requests.yaml'
+    500:
+      $ref: './../responses/internal-server-error.yaml'

--- a/packages/go/openapi/src/paths/asset-isolation.asset-groups.id.custom-selectors.yaml
+++ b/packages/go/openapi/src/paths/asset-isolation.asset-groups.id.custom-selectors.yaml
@@ -1,0 +1,55 @@
+# Copyright 2024 Specter Ops, Inc.
+#
+# Licensed under the Apache License, Version 2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+parameters:
+  - $ref: './../parameters/header.prefer.yaml'
+  - name: asset_group_id
+    description: ID of the asset_group record to retrieve
+    in: path
+    required: true
+    schema:
+      type: integer
+      format: int32
+get:
+  operationId: GetAssetGroupCustomMemberCount
+  summary: Get asset group custom member count
+  description: Get asset group custom member count
+  tags:
+    - Asset Isolation
+    - Community
+    - Enterprise
+  responses:
+    200:
+      description: OK
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              custom_member_count:
+                type: integer
+    400:
+      $ref: './../responses/bad-request.yaml'
+    401:
+      $ref: './../responses/unauthorized.yaml'
+    403:
+      $ref: './../responses/forbidden.yaml'
+    404:
+      $ref: './../responses/not-found.yaml'
+    429:
+      $ref: './../responses/too-many-requests.yaml'
+    500:
+      $ref: './../responses/internal-server-error.yaml'

--- a/packages/go/openapi/src/paths/asset-isolation.asset-groups.id.members.counts.yaml
+++ b/packages/go/openapi/src/paths/asset-isolation.asset-groups.id.members.counts.yaml
@@ -1,0 +1,88 @@
+# Copyright 2024 Specter Ops, Inc.
+#
+# Licensed under the Apache License, Version 2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+parameters:
+  - $ref: './../parameters/header.prefer.yaml'
+  - name: asset_group_id
+    description: ID of the asset_group record to retrieve
+    in: path
+    required: true
+    schema:
+      type: integer
+      format: int32
+
+get:
+  operationId: ListAssetGroupMemberCountByKind
+  summary: List asset group member count by kind
+  description: List counts of members of an asset isolation group by primary kind.
+  tags:
+    - Asset Isolation
+    - Community
+    - Enterprise
+  parameters:
+    - name: object_id
+      in: query
+      schema:
+        $ref: './../schemas/api.params.predicate.filter.string.yaml'
+    - name: environment_id
+      in: query
+      schema:
+        $ref: './../schemas/api.params.predicate.filter.string.yaml'
+    - name: primary_kind
+      in: query
+      schema:
+        $ref: './../schemas/api.params.predicate.filter.string.yaml'
+    - name: environment_kind
+      in: query
+      schema:
+        $ref: './../schemas/api.params.predicate.filter.string.yaml'
+    - name: name
+      in: query
+      schema:
+        $ref: './../schemas/api.params.predicate.filter.string.yaml'
+    - name: custom_member
+      in: query
+      schema:
+        $ref: './../schemas/api.params.predicate.filter.string.yaml'
+  responses:
+    200:
+      description: OK
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              data:
+                type: object
+                properties:
+                  total_count:
+                    type: integer
+                  counts:
+                    type: object
+                    additionalProperties:
+                      type: integer
+    400:
+      $ref: './../responses/bad-request.yaml'
+    401:
+      $ref: './../responses/unauthorized.yaml'
+    403:
+      $ref: './../responses/forbidden.yaml'
+    404:
+      $ref: './../responses/not-found.yaml'
+    429:
+      $ref: './../responses/too-many-requests.yaml'
+    500:
+      $ref: './../responses/internal-server-error.yaml'

--- a/packages/go/openapi/src/paths/asset-isolation.asset-groups.id.members.yaml
+++ b/packages/go/openapi/src/paths/asset-isolation.asset-groups.id.members.yaml
@@ -1,0 +1,97 @@
+# Copyright 2024 Specter Ops, Inc.
+#
+# Licensed under the Apache License, Version 2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+parameters:
+  - $ref: './../parameters/header.prefer.yaml'
+  - name: asset_group_id
+    description: ID of the asset_group record to retrieve
+    in: path
+    required: true
+    schema:
+      type: integer
+      format: int32
+
+get:
+  operationId: ListAssetGroupMembers
+  summary: List all asset isolation group members
+  description: List all members of an asset isolation group.
+  tags:
+    - Asset Isolation
+    - Community
+    - Enterprise
+  parameters:
+    - $ref: './../parameters/query.skip.yaml'
+    - $ref: './../parameters/query.limit.yaml'
+    - name: sort_by
+      in: query
+      description: >
+        Sortable columns are `object_id`, `asset_group_id`, `primary_kind`, `environment_id`,
+        `environment_kind`, and `name`.
+      schema:
+        $ref: './../schemas/api.params.query.sort-by.yaml'
+    - name: object_id
+      in: query
+      schema:
+        $ref: './../schemas/api.params.predicate.filter.string.yaml'
+    - name: primary_kind
+      in: query
+      schema:
+        $ref: './../schemas/api.params.predicate.filter.string.yaml'
+    - name: environment_id
+      in: query
+      schema:
+        $ref: './../schemas/api.params.predicate.filter.string.yaml'
+    - name: environment_kind
+      in: query
+      schema:
+        $ref: './../schemas/api.params.predicate.filter.string.yaml'
+    - name: name
+      in: query
+      schema:
+        $ref: './../schemas/api.params.predicate.filter.string.yaml'
+    - name: custom_member
+      in: query
+      schema:
+        $ref: './../schemas/api.params.predicate.filter.string.yaml'
+  responses:
+    200:
+      description: OK
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: './../schemas/api.response.pagination.yaml'
+            type: object
+            properties:
+              data:
+                type: object
+                properties:
+                  members:
+                    type: array
+                    items:
+                      $ref: './../schemas/model.asset-group-member.yaml'
+    400:
+      $ref: './../responses/bad-request.yaml'
+    401:
+      $ref: './../responses/unauthorized.yaml'
+    403:
+      $ref: './../responses/forbidden.yaml'
+    404:
+      $ref: './../responses/not-found.yaml'
+    429:
+      $ref: './../responses/too-many-requests.yaml'
+    500:
+      $ref: './../responses/internal-server-error.yaml'

--- a/packages/go/openapi/src/paths/asset-isolation.asset-groups.id.selectors.id.yaml
+++ b/packages/go/openapi/src/paths/asset-isolation.asset-groups.id.selectors.id.yaml
@@ -1,0 +1,71 @@
+# Copyright 2024 Specter Ops, Inc.
+#
+# Licensed under the Apache License, Version 2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+parameters:
+  - $ref: './../parameters/header.prefer.yaml'
+  - name: asset_group_id
+    description: ID of the asset_group record to retrieve
+    in: path
+    required: true
+    schema:
+      type: integer
+      format: int32
+  - name: asset_group_selector_id
+    description: ID of the asset_group_selector record to retrieve
+    in: path
+    required: true
+    schema:
+      type: integer
+      format: int32
+
+delete:
+  operationId: DeleteAssetGroupSelector
+  summary: Delete an asset group selector
+  description: Deletes an asset group selector
+  tags:
+    - Asset Isolation
+    - Community
+    - Enterprise
+  responses:
+    200:
+      $ref: './../responses/no-content.yaml'
+    400:
+      $ref: './../responses/bad-request.yaml'
+    401:
+      $ref: './../responses/unauthorized.yaml'
+    403:
+      $ref: './../responses/forbidden.yaml'
+    404:
+      $ref: './../responses/not-found.yaml'
+    409:
+      description: |
+        **Conflict**
+        System defined asset group selectors cannot be deleted.
+      content:
+        application/json:
+          schema:
+            $ref: './../schemas/api.error-wrapper.yaml'
+          example:
+            http_status: 409
+            timestamp: 2024-02-19T19:27:43.866Z
+            request_id: 3fa85f64-5717-4562-b3fc-2c963f66afa6
+            errors:
+              - context: agi
+                message: Cannot delete system defined asset group selector.
+    429:
+      $ref: './../responses/too-many-requests.yaml'
+    500:
+      $ref: './../responses/internal-server-error.yaml'

--- a/packages/go/openapi/src/paths/asset-isolation.asset-groups.id.selectors.yaml
+++ b/packages/go/openapi/src/paths/asset-isolation.asset-groups.id.selectors.yaml
@@ -1,0 +1,126 @@
+# Copyright 2024 Specter Ops, Inc.
+#
+# Licensed under the Apache License, Version 2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+parameters:
+  - $ref: './../parameters/header.prefer.yaml'
+  - name: asset_group_id
+    description: ID of the asset_group record to retrieve
+    in: path
+    required: true
+    schema:
+      type: integer
+      format: int32
+
+post:
+  operationId: UpdateAssetGroupSelectorsDeprecated
+  deprecated: true
+  summary: Update asset group selectors
+  description: DEPRECATED use PUT instead. Updates asset group selectors.
+  tags:
+    - Asset Isolation
+    - Community
+    - Enterprise
+  requestBody:
+    description: The request body for updating asset group selectors
+    required: true
+    content:
+      application/json:
+        schema:
+          type: array
+          items:
+            $ref: './../schemas/model.asset-group-selector-spec.yaml'
+  responses:
+    201:
+      description: Created
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              data:
+                type: object
+                properties:
+                  added_selectors:
+                    type: array
+                    items:
+                      $ref: './../schemas/model.asset-group-selector.yaml'
+                  removed_selectors:
+                    type: array
+                    items:
+                      $ref: './../schemas/model.asset-group-selector.yaml'
+
+    400:
+      $ref: './../responses/bad-request.yaml'
+    401:
+      $ref: './../responses/unauthorized.yaml'
+    403:
+      $ref: './../responses/forbidden.yaml'
+    404:
+      $ref: './../responses/not-found.yaml'
+    429:
+      $ref: './../responses/too-many-requests.yaml'
+    500:
+      $ref: './../responses/internal-server-error.yaml'
+
+put:
+  operationId: UpdateAssetGroupSelectors
+  summary: Update asset group selectors
+  description: Updates asset group selectors
+  tags:
+    - Asset Isolation
+    - Community
+    - Enterprise
+  requestBody:
+    description: The request body for updating asset group selectors
+    required: true
+    content:
+      application/json:
+        schema:
+          type: array
+          items:
+            $ref: './../schemas/model.asset-group-selector-spec.yaml'
+  responses:
+    201:
+      description: Created
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              data:
+                type: object
+                properties:
+                  added_selectors:
+                    type: array
+                    items:
+                      $ref: './../schemas/model.asset-group-selector.yaml'
+                  removed_selectors:
+                    type: array
+                    items:
+                      $ref: './../schemas/model.asset-group-selector.yaml'
+
+    400:
+      $ref: './../responses/bad-request.yaml'
+    401:
+      $ref: './../responses/unauthorized.yaml'
+    403:
+      $ref: './../responses/forbidden.yaml'
+    404:
+      $ref: './../responses/not-found.yaml'
+    429:
+      $ref: './../responses/too-many-requests.yaml'
+    500:
+      $ref: './../responses/internal-server-error.yaml'

--- a/packages/go/openapi/src/paths/asset-isolation.asset-groups.id.yaml
+++ b/packages/go/openapi/src/paths/asset-isolation.asset-groups.id.yaml
@@ -1,0 +1,136 @@
+# Copyright 2024 Specter Ops, Inc.
+#
+# Licensed under the Apache License, Version 2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+parameters:
+  - $ref: './../parameters/header.prefer.yaml'
+  - name: asset_group_id
+    description: ID of the asset group record to retrieve
+    in: path
+    required: true
+    schema:
+      type: integer
+      format: int32
+
+get:
+  operationId: GetAssetGroup
+  summary: Get asset group by ID
+  description: Retrieve asset group by ID
+  tags:
+    - Asset Isolation
+    - Community
+    - Enterprise
+  responses:
+    200:
+      description: OK
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              data:
+                $ref: './../schemas/model.asset-group.yaml'
+    400:
+      $ref: './../responses/bad-request.yaml'
+    401:
+      $ref: './../responses/unauthorized.yaml'
+    403:
+      $ref: './../responses/forbidden.yaml'
+    404:
+      $ref: './../responses/not-found.yaml'
+    429:
+      $ref: './../responses/too-many-requests.yaml'
+    500:
+      $ref: './../responses/internal-server-error.yaml'
+
+put:
+  operationId: UpdateAssetGroup
+  summary: Update an asset group
+  description: Updates an asset group
+  tags:
+    - Asset Isolation
+    - Community
+    - Enterprise
+  requestBody:
+    description: The request body for updating an asset group.
+    required: true
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            name:
+              type: string
+  responses:
+    200:
+      description: OK
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              data:
+                $ref: './../schemas/model.asset-group.yaml'
+    400:
+      $ref: './../responses/bad-request.yaml'
+    401:
+      $ref: './../responses/unauthorized.yaml'
+    403:
+      $ref: './../responses/forbidden.yaml'
+    404:
+      $ref: './../responses/not-found.yaml'
+    429:
+      $ref: './../responses/too-many-requests.yaml'
+    500:
+      $ref: './../responses/internal-server-error.yaml'
+
+delete:
+  operationId: DeleteAssetGroup
+  summary: Delete an asset group
+  description: Deletes an asset group
+  tags:
+    - Asset Isolation
+    - Community
+    - Enterprise
+  responses:
+    200:
+      $ref: './../responses/no-content.yaml'
+    400:
+      $ref: './../responses/bad-request.yaml'
+    401:
+      $ref: './../responses/unauthorized.yaml'
+    403:
+      $ref: './../responses/forbidden.yaml'
+    404:
+      $ref: './../responses/not-found.yaml'
+    409:
+      description: |
+        **Conflict**
+        The client tried to delete a system defined asset group.
+      content:
+        application/json:
+          schema:
+            $ref: './../schemas/api.error-wrapper.yaml'
+          example:
+            http_status: 409
+            timestamp: 2024-02-19T19:27:43.866Z
+            request_id: 3fa85f64-5717-4562-b3fc-2c963f66afa6
+            errors:
+              - context: agi
+                message: Cannot delete a system defined asset group.
+    429:
+      $ref: './../responses/too-many-requests.yaml'
+    500:
+      $ref: './../responses/internal-server-error.yaml'

--- a/packages/go/openapi/src/paths/asset-isolation.asset-groups.yaml
+++ b/packages/go/openapi/src/paths/asset-isolation.asset-groups.yaml
@@ -1,0 +1,116 @@
+# Copyright 2024 Specter Ops, Inc.
+#
+# Licensed under the Apache License, Version 2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+parameters:
+  - $ref: './../parameters/header.prefer.yaml'
+get:
+  operationId: ListAssetGroups
+  summary: List all asset isolation groups
+  description: Lists all asset isolation groups.
+  tags:
+    - Asset Isolation
+    - Community
+    - Enterprise
+  parameters:
+    - name: sort_by
+      description: Sortable columns are `name`, `tag`, and `member_count`.
+      in: query
+      schema:
+        $ref: './../schemas/api.params.query.sort-by.yaml'
+    - name: name
+      in: query
+      schema:
+        $ref: './../schemas/api.params.predicate.filter.string.yaml'
+    - name: tag
+      in: query
+      schema:
+        $ref: './../schemas/api.params.predicate.filter.string.yaml'
+    - name: system_group
+      in: query
+      schema:
+        $ref: './../schemas/api.params.predicate.filter.string.yaml'
+    - name: member_count
+      in: query
+      schema:
+        $ref: './../schemas/api.params.predicate.filter.integer.yaml'
+    - name: id
+      in: query
+      schema:
+        $ref: './../schemas/api.params.predicate.filter.integer.yaml'
+    - $ref: './../parameters/query.created-at.yaml'
+    - $ref: './../parameters/query.updated-at.yaml'
+    - $ref: './../parameters/query.deleted-at.yaml'
+  responses:
+    200:
+      description: OK
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              data:
+                type: object
+                properties:
+                  asset_groups:
+                    type: array
+                    items:
+                      $ref: './../schemas/model.asset-group.yaml'
+    400:
+      $ref: './../responses/bad-request.yaml'
+    401:
+      $ref: './../responses/unauthorized.yaml'
+    403:
+      $ref: './../responses/forbidden.yaml'
+    429:
+      $ref: './../responses/too-many-requests.yaml'
+    500:
+      $ref: './../responses/internal-server-error.yaml'
+
+post:
+  operationId: CreateAssetGroup
+  summary: Create an asset group
+  description: Creates an asset group
+  tags:
+    - Asset Isolation
+    - Community
+    - Enterprise
+  requestBody:
+    description: The request body for creating an asset group
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: './../schemas/model.asset-group.yaml'
+  responses:
+    200:
+      description: OK
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              data:
+                $ref: './../schemas/model.asset-group.yaml'
+    400:
+      $ref: './../responses/bad-request.yaml'
+    401:
+      $ref: './../responses/unauthorized.yaml'
+    403:
+      $ref: './../responses/forbidden.yaml'
+    429:
+      $ref: './../responses/too-many-requests.yaml'
+    500:
+      $ref: './../responses/internal-server-error.yaml'

--- a/packages/go/openapi/src/paths/attack-paths.attack-path-types.yaml
+++ b/packages/go/openapi/src/paths/attack-paths.attack-path-types.yaml
@@ -1,0 +1,57 @@
+# Copyright 2024 Specter Ops, Inc.
+#
+# Licensed under the Apache License, Version 2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+parameters:
+  - $ref: './../parameters/header.prefer.yaml'
+get:
+  operationId: ListAttackPathTypes
+  summary: List all attack path types
+  description: Lists all possible attack path types
+  tags:
+    - Attack Paths
+    - Enterprise
+  parameters:
+    - name: sort_by
+      description: Sort by column. The only sortable column is `finding`.
+      in: query
+      schema:
+        $ref: './../schemas/api.params.query.sort-by.yaml'
+    - name: finding
+      in: query
+      schema:
+        $ref: './../schemas/api.params.predicate.filter.string.yaml'
+  responses:
+    200:
+      description: OK
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              data:
+                type: array
+                items:
+                  type: string
+    400:
+      $ref: './../responses/bad-request.yaml'
+    401:
+      $ref: './../responses/unauthorized.yaml'
+    404:
+      $ref: './../responses/not-found.yaml'
+    429:
+      $ref: './../responses/too-many-requests.yaml'
+    500:
+      $ref: './../responses/internal-server-error.yaml'

--- a/packages/go/openapi/src/paths/attack-paths.attack-paths.id.acceptance.yaml
+++ b/packages/go/openapi/src/paths/attack-paths.attack-paths.id.acceptance.yaml
@@ -1,0 +1,71 @@
+# Copyright 2024 Specter Ops, Inc.
+#
+# Licensed under the Apache License, Version 2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+parameters:
+  - $ref: './../parameters/header.prefer.yaml'
+  - name: attack_path_id
+    description: Attack Path ID
+    in: path
+    required: true
+    schema:
+      type: integer
+      format: int64
+put:
+  operationId: UpdateAttackPathRisk
+  summary: Update attack path risk
+  description: Updates an attack path as an accepted or unaccepted risk until a given time.
+  tags:
+    - Attack Paths
+    - Enterprise
+  requestBody:
+    description: The request body for updating risk acceptance
+    required: true
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            risk_type:
+              type: string
+            accept_until:
+              type: string
+              format: date-time
+            accepted:
+              type: boolean
+  responses:
+    200:
+      description: OK
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              data:
+                oneOf:
+                  - $ref: './../schemas/model.list-finding.yaml'
+                  - $ref: './../schemas/model.relationship-finding.yaml'
+    400:
+      $ref: './../responses/bad-request.yaml'
+    401:
+      $ref: './../responses/unauthorized.yaml'
+    403:
+      $ref: './../responses/forbidden.yaml'
+    404:
+      $ref: './../responses/not-found.yaml'
+    429:
+      $ref: './../responses/too-many-requests.yaml'
+    500:
+      $ref: './../responses/internal-server-error.yaml'

--- a/packages/go/openapi/src/paths/attack-paths.attack-paths.yaml
+++ b/packages/go/openapi/src/paths/attack-paths.attack-paths.yaml
@@ -1,0 +1,36 @@
+# Copyright 2024 Specter Ops, Inc.
+#
+# Licensed under the Apache License, Version 2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+parameters:
+  - $ref: './../parameters/header.prefer.yaml'
+put:
+  operationId: StartAnalysisBhe
+  summary: Start analysis
+  description: Starts generating attack paths
+  tags:
+    - Attack Paths
+    - Enterprise
+  responses:
+    202:
+      $ref: './../responses/no-content.yaml'
+    401:
+      $ref: './../responses/unauthorized.yaml'
+    403:
+      $ref: './../responses/forbidden.yaml'
+    429:
+      $ref: './../responses/too-many-requests.yaml'
+    500:
+      $ref: './../responses/internal-server-error.yaml'

--- a/packages/go/openapi/src/paths/attack-paths.domains.id.attack-path-findings.yaml
+++ b/packages/go/openapi/src/paths/attack-paths.domains.id.attack-path-findings.yaml
@@ -1,0 +1,63 @@
+# Copyright 2024 Specter Ops, Inc.
+#
+# Licensed under the Apache License, Version 2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+parameters:
+  - $ref: './../parameters/header.prefer.yaml'
+  - name: domain_id
+    description: Domain ID
+    in: path
+    required: true
+    schema:
+      type: string
+get:
+  operationId: ExportAttackPathFindings
+  summary: Export attack path findings
+  description: Export the finding table for a given attack path
+  tags:
+    - Attack Paths
+    - Enterprise
+  parameters:
+    - name: finding
+      description: Finding Type
+      in: query
+      required: true
+      schema:
+        type: string
+    - name: filterAccepted
+      description: Risk acceptance filter
+      in: query
+      schema:
+        $ref: './../schemas/enum.risk-acceptance.yaml'
+    - name: sort_by
+      description: Sort by column. The only sortable column is `finding`.
+      in: query
+      schema:
+        $ref: './../schemas/api.params.query.sort-by.yaml'
+  responses:
+    200:
+      $ref: './../responses/csv-response.yaml'
+    400:
+      $ref: './../responses/bad-request.yaml'
+    401:
+      $ref: './../responses/unauthorized.yaml'
+    403:
+      $ref: './../responses/forbidden.yaml'
+    404:
+      $ref: './../responses/not-found.yaml'
+    429:
+      $ref: './../responses/too-many-requests.yaml'
+    500:
+      $ref: './../responses/internal-server-error.yaml'

--- a/packages/go/openapi/src/paths/attack-paths.domains.id.available-types.yaml
+++ b/packages/go/openapi/src/paths/attack-paths.domains.id.available-types.yaml
@@ -1,0 +1,65 @@
+# Copyright 2024 Specter Ops, Inc.
+#
+# Licensed under the Apache License, Version 2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+parameters:
+  - $ref: './../parameters/header.prefer.yaml'
+  - name: domain_id
+    description: Domain ID
+    in: path
+    required: true
+    schema:
+      type: string
+get:
+  operationId: ListAvailableAttackPathTypesForDomain
+  summary: List available attack paths
+  description: Lists available attack path types for a domain
+  tags:
+    - Attack Paths
+    - Enterprise
+  parameters:
+    - name: sort_by
+      description: Sort by column. The only sortable column is `finding`.
+      in: query
+      schema:
+        $ref: './../schemas/api.params.query.sort-by.yaml'
+    - name: finding
+      in: query
+      schema:
+        $ref: './../schemas/api.params.predicate.filter.string.yaml'
+  responses:
+    200:
+      description: OK
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              data:
+                type: array
+                items:
+                  type: string
+    400:
+      $ref: './../responses/bad-request.yaml'
+    401:
+      $ref: './../responses/unauthorized.yaml'
+    403:
+      $ref: './../responses/forbidden.yaml'
+    404:
+      $ref: './../responses/not-found.yaml'
+    429:
+      $ref: './../responses/too-many-requests.yaml'
+    500:
+      $ref: './../responses/internal-server-error.yaml'

--- a/packages/go/openapi/src/paths/attack-paths.domains.id.details.yaml
+++ b/packages/go/openapi/src/paths/attack-paths.domains.id.details.yaml
@@ -1,0 +1,145 @@
+# Copyright 2024 Specter Ops, Inc.
+#
+# Licensed under the Apache License, Version 2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+parameters:
+  - $ref: './../parameters/header.prefer.yaml'
+  - name: domain_id
+    description: Domain ID
+    in: path
+    required: true
+    schema:
+      type: string
+get:
+  operationId: ListDomainAttackPathsDetails
+  summary: List domain attack paths details
+  description: Lists detailed data about attack paths for a domain.
+  tags:
+    - Attack Paths
+    - Enterprise
+  parameters:
+    - name: finding
+      in: query
+      schema:
+        $ref: './../schemas/api.params.predicate.filter.string.yaml'
+    - name: sort_by
+      description: Sortable columns are `domain_sid`, `index`, `AcceptedUntil`,
+        `id`, `created_at`, `updated_at`, `deleted_at`. Relationship risks can be sorted on
+        `FromPrincipal` and `ToPrincipal` in addition to the sortable columns for List
+        Risks.
+      in: query
+      schema:
+        $ref: './../schemas/api.params.query.sort-by.yaml'
+    - name: FromPrincipal
+      deprecated: true
+      in: query
+      schema:
+        $ref: './../schemas/api.params.predicate.filter.string.yaml'
+    - name: ToPrincipal
+      deprecated: true
+      in: query
+      schema:
+        $ref: './../schemas/api.params.predicate.filter.string.yaml'
+    - name: from_principal
+      in: query
+      schema:
+        $ref: './../schemas/api.params.predicate.filter.string.yaml'
+    - name: to_principal
+      in: query
+      schema:
+        $ref: './../schemas/api.params.predicate.filter.string.yaml'
+    - name: principals_hash
+      in: query
+      schema:
+        $ref: './../schemas/api.params.predicate.filter.string.yaml'
+    - name: Accepted
+      in: query
+      schema:
+        $ref: './../schemas/api.params.predicate.filter.string.yaml'
+    - name: AcceptedUntil
+      deprecated: true
+      in: query
+      schema:
+        $ref: './../schemas/api.params.predicate.filter.time.yaml'
+    - name: accepted_until
+      in: query
+      schema:
+        $ref: './../schemas/api.params.predicate.filter.time.yaml'
+    - name: Principal
+      in: query
+      schema:
+        $ref: './../schemas/api.params.predicate.filter.string.yaml'
+    - name: Finding
+      in: query
+      schema:
+        $ref: './../schemas/api.params.predicate.filter.string.yaml'
+    - name: domain_sid
+      in: query
+      schema:
+        $ref: './../schemas/api.params.predicate.filter.string.yaml'
+    - name: id
+      in: query
+      schema:
+        $ref: './../schemas/api.params.predicate.filter.integer.yaml'
+    - $ref: './../parameters/query.created-at.yaml'
+    - $ref: './../parameters/query.updated-at.yaml'
+    - $ref: './../parameters/query.deleted-at.yaml'
+    - $ref: './../parameters/query.skip.yaml'
+    - $ref: './../parameters/query.limit.yaml'
+  responses:
+    200:
+      description: OK
+      content:
+        application/json:
+          schema:
+            oneOf:
+              - allOf: # display relationship finding with pagination
+                  - $ref: './../schemas/api.response.pagination.yaml'
+                  - type: object
+                    properties:
+                      data:
+                        type: array
+                        items:
+                          allOf:
+                            - $ref: './../schemas/model.relationship-finding.yaml'
+                            - type: object
+                              properties:
+                                Accepted:
+                                  type: boolean
+              - allOf: # display list finding with pagination
+                  - $ref: './../schemas/api.response.pagination.yaml'
+                  - type: object
+                    properties:
+                      data:
+                        type: array
+                        items:
+                          allOf:
+                            - $ref: './../schemas/model.list-finding.yaml'
+                            - type: object
+                              properties:
+                                Accepted:
+                                  type: boolean
+    400:
+      $ref: './../responses/bad-request.yaml'
+    401:
+      $ref: './../responses/unauthorized.yaml'
+    403:
+      $ref: './../responses/forbidden.yaml'
+    404:
+      $ref: './../responses/not-found.yaml'
+    429:
+      $ref: './../responses/too-many-requests.yaml'
+    500:
+      $ref: './../responses/internal-server-error.yaml'

--- a/packages/go/openapi/src/paths/attack-paths.domains.id.sparkline.yaml
+++ b/packages/go/openapi/src/paths/attack-paths.domains.id.sparkline.yaml
@@ -1,0 +1,80 @@
+# Copyright 2024 Specter Ops, Inc.
+#
+# Licensed under the Apache License, Version 2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+parameters:
+  - $ref: './../parameters/header.prefer.yaml'
+  - name: domain_id
+    description: Domain ID
+    in: path
+    required: true
+    schema:
+      type: string
+get:
+  operationId: ListAttackPathSparklineValues
+  summary: List attack path sparkline values
+  description: List the values that represent the sparklines for individual attack
+    paths
+  tags:
+    - Attack Paths
+    - Enterprise
+  parameters:
+    - name: sort_by
+      description: Sortable columns are `CompositeRisk`, `FindingCount`, `ImpactedAssetCount`,
+        `domain_sid`, `id`, `created_at`, `updated_at`, `deleted_at`.
+      in: query
+      schema:
+        $ref: './../schemas/api.params.query.sort-by.yaml'
+    - name: finding
+      in: query
+      required: true
+      schema:
+        $ref: './../schemas/api.params.predicate.filter.string.yaml'
+    - name: from
+      description: Beginning datetime of range (inclusive) in RFC-3339 format; Defaults
+        to current datetime minus 30 days
+      schema:
+        $ref: './../schemas/api.params.predicate.filter.time.yaml'
+      in: query
+    - name: to
+      description: Ending datetime of range (exclusive) in RFC-3339 format; Defaults
+        to current datetime
+      schema:
+        $ref: './../schemas/api.params.predicate.filter.time.yaml'
+      in: query
+  responses:
+    200:
+      description: OK
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: './../schemas/api.response.time-window.yaml'
+              - type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: './../schemas/model.risk-counts.yaml'
+    400:
+      $ref: './../responses/bad-request.yaml'
+    401:
+      $ref: './../responses/unauthorized.yaml'
+    403:
+      $ref: './../responses/forbidden.yaml'
+    429:
+      $ref: './../responses/too-many-requests.yaml'
+    500:
+      $ref: './../responses/internal-server-error.yaml'

--- a/packages/go/openapi/src/paths/risk-posture.posture-stats.yaml
+++ b/packages/go/openapi/src/paths/risk-posture.posture-stats.yaml
@@ -1,0 +1,95 @@
+# Copyright 2024 Specter Ops, Inc.
+#
+# Licensed under the Apache License, Version 2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+parameters:
+  - $ref: './../parameters/header.prefer.yaml'
+get:
+  operationId: GetPostureStats
+  summary: Get Posture Statistics
+  description: Gets the history of database stats saved in the database
+  tags:
+    - Risk Posture
+    - Enterprise
+  parameters:
+    - name: sort_by
+      description: Sortable columns are `domain_sid`, `exposure_index`, `tier_zero_count`,
+        `critical_risk_count`, `id`, `created_at`, `updated_at`, `deleted_at`.
+      in: query
+      schema:
+        $ref: './../schemas/api.params.query.sort-by.yaml'
+    - name: from
+      deprecated: true
+      description: Lower bound for created_at; to return posture stats starting at
+        a specific date/time
+      in: query
+      schema:
+        type: string
+        format: date-time
+    - name: to
+      deprecated: true
+      description: Upper bound for created_at; to return posture stats upto a specific
+        date/time
+      in: query
+      schema:
+        type: string
+        format: date-time
+    - name: domain_sid
+      in: query
+      schema:
+        $ref: './../schemas/api.params.predicate.filter.string.yaml'
+    - name: exposure_index
+      in: query
+      schema:
+        $ref: './../schemas/api.params.predicate.filter.integer.yaml'
+    - name: tier_zero_count
+      in: query
+      schema:
+        $ref: './../schemas/api.params.predicate.filter.integer.yaml'
+    - name: critical_risk_count
+      in: query
+      schema:
+        $ref: './../schemas/api.params.predicate.filter.integer.yaml'
+    - name: id
+      in: query
+      schema:
+        $ref: './../schemas/api.params.predicate.filter.integer.yaml'
+  responses:
+    200:
+      description: OK
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: './../schemas/api.response.pagination.yaml'
+              - $ref: './../schemas/api.response.time-window.yaml'
+              - type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: './../schemas/model.risk-posture-stat.yaml'
+    400:
+      $ref: './../responses/bad-request.yaml'
+    401:
+      $ref: './../responses/unauthorized.yaml'
+    403:
+      $ref: './../responses/forbidden.yaml'
+    404:
+      $ref: './../responses/not-found.yaml'
+    429:
+      $ref: './../responses/too-many-requests.yaml'
+    500:
+      $ref: './../responses/internal-server-error.yaml'

--- a/packages/go/openapi/src/schemas/model.asset-group-collection-entry.yaml
+++ b/packages/go/openapi/src/schemas/model.asset-group-collection-entry.yaml
@@ -1,0 +1,34 @@
+# Copyright 2024 Specter Ops, Inc.
+#
+# Licensed under the Apache License, Version 2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+allOf:
+  - $ref: './model.components.int64.id.yaml'
+  - $ref: './model.components.timestamps.yaml'
+type: object
+properties:
+  asset_group_collection_id:
+    type: integer
+    format: int64
+    writeOnly: true
+  object_id:
+    type: string
+    readOnly: true
+  node_label:
+    type: string
+    readOnly: true
+  properties:
+    type: object
+    readOnly: true

--- a/packages/go/openapi/src/schemas/model.asset-group-collection.yaml
+++ b/packages/go/openapi/src/schemas/model.asset-group-collection.yaml
@@ -1,0 +1,26 @@
+# Copyright 2024 Specter Ops, Inc.
+#
+# Licensed under the Apache License, Version 2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+allOf:
+  - $ref: './model.components.int64.id.yaml'
+  - $ref: './model.components.timestamps.yaml'
+type: object
+properties:
+  entries:
+    type: array
+    readOnly: true
+    items:
+      $ref: './model.asset-group-collection-entry.yaml'

--- a/packages/go/openapi/src/schemas/model.asset-group-member.yaml
+++ b/packages/go/openapi/src/schemas/model.asset-group-member.yaml
@@ -1,0 +1,36 @@
+# Copyright 2024 Specter Ops, Inc.
+#
+# Licensed under the Apache License, Version 2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+type: object
+properties:
+  asset_group_id:
+    type: integer
+  object_id:
+    type: string
+  primary_kind:
+    type: string
+  kinds:
+    type: array
+    items:
+      type: string
+  environment_id:
+    type: string
+  environment_kind:
+    type: string
+  name:
+    type: string
+  custom_member:
+    type: boolean

--- a/packages/go/openapi/src/schemas/model.asset-group-selector-spec.yaml
+++ b/packages/go/openapi/src/schemas/model.asset-group-selector-spec.yaml
@@ -1,0 +1,27 @@
+# Copyright 2024 Specter Ops, Inc.
+#
+# Licensed under the Apache License, Version 2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+type: object
+properties:
+  selector_name:
+    type: string
+  sid:
+    type: string
+  action:
+    type: string
+    enum:
+      - add
+      - remove

--- a/packages/go/openapi/src/schemas/model.asset-group-selector.yaml
+++ b/packages/go/openapi/src/schemas/model.asset-group-selector.yaml
@@ -1,0 +1,30 @@
+# Copyright 2024 Specter Ops, Inc.
+#
+# Licensed under the Apache License, Version 2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+allOf:
+  - $ref: './model.components.int32.id.yaml'
+  - $ref: './model.components.timestamps.yaml'
+type: object
+properties:
+  asset_group_id:
+    type: integer
+    format: int32
+  name:
+    type: string
+  selector:
+    type: string
+  system_selector:
+    type: boolean

--- a/packages/go/openapi/src/schemas/model.asset-group.yaml
+++ b/packages/go/openapi/src/schemas/model.asset-group.yaml
@@ -1,0 +1,36 @@
+# Copyright 2024 Specter Ops, Inc.
+#
+# Licensed under the Apache License, Version 2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+allOf:
+  - $ref: './model.components.int32.id.yaml'
+  - $ref: './model.components.timestamps.yaml'
+type: object
+properties:
+  name:
+    type: string
+  tag:
+    type: string
+  system_group:
+    type: boolean
+    readOnly: true
+  selectors:
+    type: array
+    readOnly: true
+    items:
+      $ref: './model.asset-group-selector.yaml'
+  member_count:
+    type: integer
+    readOnly: true

--- a/packages/go/openapi/src/schemas/model.list-finding.yaml
+++ b/packages/go/openapi/src/schemas/model.list-finding.yaml
@@ -1,0 +1,36 @@
+# Copyright 2024 Specter Ops, Inc.
+#
+# Licensed under the Apache License, Version 2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+allOf:
+  - $ref: './model.components.int32.id.yaml'
+  - $ref: './model.components.timestamps.yaml'
+type: object
+properties:
+  Principal:
+    type: string
+  PrincipalKind:
+    type: string
+  Finding:
+    type: string
+  DomainSID:
+    type: string
+  Props:
+    type: object
+    additionalProperties:
+      type: object
+  accepted_until:
+    type: string
+    format: date-time

--- a/packages/go/openapi/src/schemas/model.relationship-finding.yaml
+++ b/packages/go/openapi/src/schemas/model.relationship-finding.yaml
@@ -1,0 +1,52 @@
+# Copyright 2024 Specter Ops, Inc.
+#
+# Licensed under the Apache License, Version 2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+allOf:
+  - $ref: './model.components.int32.id.yaml'
+  - $ref: './model.components.timestamps.yaml'
+type: object
+properties:
+  FromPrincipal:
+    type: string
+  ToPrincipal:
+    type: string
+  FromPrincipalProps:
+    type: object
+    additionalProperties:
+      type: object
+  FromPrincipalKind:
+    type: string
+  ToPrincipalProps:
+    type: object
+    additionalProperties:
+      type: object
+  ToPrincipalKind:
+    type: string
+  RelProps:
+    type: object
+    additionalProperties:
+      type: object
+  ComboGraphRelationID:
+    $ref: './null.int64.yaml'
+  Finding:
+    type: string
+  DomainSID:
+    type: string
+  PrincipalHash:
+    type: string
+  AcceptedUntil:
+    type: string
+    format: date-time

--- a/packages/go/openapi/src/schemas/model.risk-counts.yaml
+++ b/packages/go/openapi/src/schemas/model.risk-counts.yaml
@@ -1,0 +1,32 @@
+# Copyright 2024 Specter Ops, Inc.
+#
+# Licensed under the Apache License, Version 2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+allOf:
+  - $ref: './model.components.int64.id.yaml'
+  - $ref: './model.components.timestamps.yaml'
+type: object
+properties:
+  CompositeRisk:
+    type: number
+    format: double
+  FindingCount:
+    type: integer
+  ImpactedAssetCount:
+    type: integer
+  DomainSID:
+    type: string
+  Finding:
+    type: string

--- a/packages/go/openapi/src/schemas/model.risk-posture-stat.yaml
+++ b/packages/go/openapi/src/schemas/model.risk-posture-stat.yaml
@@ -1,0 +1,31 @@
+# Copyright 2024 Specter Ops, Inc.
+#
+# Licensed under the Apache License, Version 2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+allOf:
+  - $ref: './model.components.int64.id.yaml'
+  - $ref: './model.components.timestamps.yaml'
+type: object
+properties:
+  domain_sid:
+    type: string
+  exposure_index:
+    type: number
+    format: double
+  tier_zero_count:
+    type: integer
+    format: int64
+  critical_risk_count:
+    type: integer


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

added openapi spec definitions for paths:
- analysis
- attack-paths
- risk-posture
- asset-isolation

## Motivation and Context

This PR addresses: BED-4141 / BED-4555

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
