### PR TITLE
BED-4168: Fixed inaccurate AG member_count value 

### DIFF
--- a/cmd/api/src/database/agi.go
+++ b/cmd/api/src/database/agi.go
@@ -18,14 +18,14 @@ package database
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
-	"errors"
 
-	"gorm.io/gorm"
 	"github.com/specterops/bloodhound/src/database/types"
 	"github.com/specterops/bloodhound/src/model"
+	"gorm.io/gorm"
 )
 
 func (s *BloodhoundDB) CreateAssetGroup(ctx context.Context, name, tag string, systemGroup bool) (model.AssetGroup, error) {
@@ -44,17 +44,17 @@ func (s *BloodhoundDB) CreateAssetGroup(ctx context.Context, name, tag string, s
 		err error
 	)
 
-    err = s.AuditableTransaction(ctx, auditEntry, func(tx *gorm.DB) error {
-        err := tx.Create(&assetGroup).Error
-        if err != nil {
-            if strings.Contains(err.Error(), "duplicate key value violates unique constraint \"asset_groups_name_key\"") {
-                return fmt.Errorf("%w: %v", ErrDuplicateAGName, err)
-            } else if strings.Contains(err.Error(), "duplicate key value violates unique constraint \"asset_groups_tag_key\"") {
-                return fmt.Errorf("%w: %v", ErrDuplicateAGTag, err)
-            }
-        }
-        return err
-    })
+	err = s.AuditableTransaction(ctx, auditEntry, func(tx *gorm.DB) error {
+		err := tx.Create(&assetGroup).Error
+		if err != nil {
+			if strings.Contains(err.Error(), "duplicate key value violates unique constraint \"asset_groups_name_key\"") {
+				return fmt.Errorf("%w: %v", ErrDuplicateAGName, err)
+			} else if strings.Contains(err.Error(), "duplicate key value violates unique constraint \"asset_groups_tag_key\"") {
+				return fmt.Errorf("%w: %v", ErrDuplicateAGTag, err)
+			}
+		}
+		return err
+	})
 
 	return assetGroup, err
 }
@@ -86,58 +86,52 @@ func (s *BloodhoundDB) DeleteAssetGroup(ctx context.Context, assetGroup model.As
 }
 
 func (s *BloodhoundDB) GetAssetGroup(ctx context.Context, id int32) (model.AssetGroup, error) {
-    var assetGroup model.AssetGroup
-    if result := s.preload(model.AssetGroupAssociations()).WithContext(ctx).First(&assetGroup, id); errors.Is(result.Error, gorm.ErrRecordNotFound) {
-        return assetGroup, ErrNotFound
-    } else if result.Error != nil {
-        return assetGroup, result.Error
-    }
-
-    latestCollection, collectionErr := s.GetLatestAssetGroupCollection(ctx, id)
-    if collectionErr != nil {
-        if errors.Is(collectionErr, ErrNotFound) {
-            assetGroup.MemberCount = 0
-            return assetGroup, nil
-        }
-        return assetGroup, fmt.Errorf("error getting latest collection for asset group %s: %w", assetGroup.Name, collectionErr)
-    }
-    assetGroup.MemberCount = len(latestCollection.Entries)
-
-    return assetGroup, nil
+	var assetGroup model.AssetGroup
+	if result := s.preload(model.AssetGroupAssociations()).WithContext(ctx).First(&assetGroup, id); errors.Is(result.Error, gorm.ErrRecordNotFound) {
+		return assetGroup, ErrNotFound
+	} else if result.Error != nil {
+		return assetGroup, result.Error
+	} else if latestCollection, collectionErr := s.GetLatestAssetGroupCollection(ctx, id); errors.Is(collectionErr, ErrNotFound) {
+		assetGroup.MemberCount = 0
+		return assetGroup, nil
+	} else if collectionErr != nil {
+		return assetGroup, fmt.Errorf("error getting latest collection for asset group %s: %w", assetGroup.Name, collectionErr)
+	} else {
+		assetGroup.MemberCount = len(latestCollection.Entries)
+		return assetGroup, nil
+	}
 }
 
 func (s *BloodhoundDB) GetAllAssetGroups(ctx context.Context, order string, filter model.SQLFilter) (model.AssetGroups, error) {
-    var (
-        assetGroups model.AssetGroups
-        result      = s.preload(model.AssetGroupAssociations()).WithContext(ctx)
-    )
+	var (
+		assetGroups model.AssetGroups
+		result      = s.preload(model.AssetGroupAssociations()).WithContext(ctx)
+	)
 
-    if order != "" {
-        result = result.Order(order)
-    }
+	if order != "" {
+		result = result.Order(order)
+	}
 
-    if filter.SQLString != "" {
-        result = result.Where(filter.SQLString, filter.Params)
-    }
+	if filter.SQLString != "" {
+		result = result.Where(filter.SQLString, filter.Params)
+	}
 
-    if result = result.Find(&assetGroups); result.Error != nil {
-		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
-			return assetGroups, ErrNotFound
-		}
+	if result = result.Find(&assetGroups); errors.Is(result.Error, gorm.ErrRecordNotFound) {
+		return assetGroups, ErrNotFound
+	} else if result.Error != nil {
 		return assetGroups, result.Error
 	}
 
-    for idx, assetGroup := range assetGroups {
-        if latestCollection, collectionErr := s.GetLatestAssetGroupCollection(ctx, assetGroup.ID); collectionErr != nil {
-            if !errors.Is(collectionErr, ErrNotFound) {
-                return assetGroups, fmt.Errorf("error getting latest collection for asset group %s: %w", assetGroup.Name, collectionErr)
-            }
-            assetGroups[idx].MemberCount = 0
-        } else {
-            assetGroups[idx].MemberCount = len(latestCollection.Entries)
-        }
-    }
-    return assetGroups, nil
+	for idx := range assetGroups {
+		if latestCollection, collectionErr := s.GetLatestAssetGroupCollection(ctx, assetGroups[idx].ID); errors.Is(collectionErr, ErrNotFound) {
+			assetGroups[idx].MemberCount = 0
+		} else if collectionErr != nil {
+			return assetGroups, fmt.Errorf("error getting latest collection for asset group %s: %w", assetGroups[idx].Name, collectionErr)
+		} else {
+			assetGroups[idx].MemberCount = len(latestCollection.Entries)
+		}
+	}
+	return assetGroups, nil
 }
 
 func (s *BloodhoundDB) SweepAssetGroupCollections(ctx context.Context) {
@@ -163,19 +157,19 @@ func (s *BloodhoundDB) GetAssetGroupCollections(ctx context.Context, assetGroupI
 }
 
 func (s *BloodhoundDB) GetLatestAssetGroupCollection(ctx context.Context, assetGroupID int32) (model.AssetGroupCollection, error) {
-    var (
-        latestCollection model.AssetGroupCollection
-        result           = s.preload(model.AssetGroupCollectionAssociations()).
-                             WithContext(ctx).
-                             Where("asset_group_id = ?", assetGroupID).
-                             Order("created_at DESC").
-                             First(&latestCollection)
-    )
+	var (
+		latestCollection model.AssetGroupCollection
+		result           = s.preload(model.AssetGroupCollectionAssociations()).
+					WithContext(ctx).
+					Where("asset_group_id = ?", assetGroupID).
+					Order("created_at DESC").
+					First(&latestCollection)
+	)
 
-    if errors.Is(result.Error, gorm.ErrRecordNotFound) {
-        return latestCollection, ErrNotFound
-    }
-    return latestCollection, result.Error
+	if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+		return latestCollection, ErrNotFound
+	}
+	return latestCollection, result.Error
 }
 
 func (s *BloodhoundDB) GetTimeRangedAssetGroupCollections(ctx context.Context, assetGroupID int32, from int64, to int64, order string) (model.AssetGroupCollections, error) {

--- a/cmd/api/src/database/agi_test.go
+++ b/cmd/api/src/database/agi_test.go
@@ -79,18 +79,9 @@ func TestAssetGroupMemberCount(t *testing.T) {
 		testCtx = context.Background()
 	)
 
-	// Create a new asset group
 	assetGroup, err := dbInst.CreateAssetGroup(testCtx, "member count test group", "mctest", false)
 	require.Nil(t, err)
 
-	// Test initial member count
-	t.Run("InitialMemberCount", func(t *testing.T) {
-		fetchedGroup, err := dbInst.GetAssetGroup(testCtx, assetGroup.ID)
-		require.Nil(t, err)
-		require.Equal(t, 0, fetchedGroup.MemberCount)
-	})
-
-	// Create an asset group collection with entries
 	collection := model.AssetGroupCollection{
 		AssetGroupID: assetGroup.ID,
 	}
@@ -103,14 +94,12 @@ func TestAssetGroupMemberCount(t *testing.T) {
 	err = dbInst.CreateAssetGroupCollection(testCtx, collection, entries)
 	require.Nil(t, err)
 
-	// Test updated member count
 	t.Run("GetAssetGroup", func(t *testing.T) {
 		fetchedGroup, err := dbInst.GetAssetGroup(testCtx, assetGroup.ID)
 		require.Nil(t, err)
 		require.Equal(t, 4, fetchedGroup.MemberCount)
 	})
 
-	// Test GetAllAssetGroups
 	t.Run("GetAllAssetGroups", func(t *testing.T) {
 		allGroups, err := dbInst.GetAllAssetGroups(testCtx, "", model.SQLFilter{})
 		require.Nil(t, err)

--- a/cmd/api/src/database/agi_test.go
+++ b/cmd/api/src/database/agi_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/specterops/bloodhound/src/model"
 	"github.com/specterops/bloodhound/src/test/integration"
 	"github.com/specterops/bloodhound/src/utils/test"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCreateGetUpdateDeleteAssetGroup(t *testing.T) {
@@ -80,74 +81,49 @@ func TestAssetGroupMemberCount(t *testing.T) {
 
 	// Create a new asset group
 	assetGroup, err := dbInst.CreateAssetGroup(testCtx, "member count test group", "mctest", false)
-	if err != nil {
-		t.Fatalf("Error creating asset group: %v", err)
-	}
+	require.Nil(t, err)
 
 	// Test initial member count
 	t.Run("InitialMemberCount", func(t *testing.T) {
 		fetchedGroup, err := dbInst.GetAssetGroup(testCtx, assetGroup.ID)
-		if err != nil {
-			t.Fatalf("Error fetching asset group: %v", err)
-		}
-		if fetchedGroup.MemberCount != 0 {
-			t.Errorf("Expected initial member count to be 0, got %d", fetchedGroup.MemberCount)
-		}
+		require.Nil(t, err)
+		require.Equal(t, 0, fetchedGroup.MemberCount)
 	})
 
 	// Create an asset group collection with entries
 	collection := model.AssetGroupCollection{
 		AssetGroupID: assetGroup.ID,
-		Entries: model.AssetGroupCollectionEntries{
-			{ObjectID: "obj1", NodeLabel: "TestNode1"},
-			{ObjectID: "obj2", NodeLabel: "TestNode2"},
-			{ObjectID: "obj3", NodeLabel: "TestNode3"},
-			{ObjectID: "obj4", NodeLabel: "TestNode4"},
-		},
 	}
-	err = dbInst.CreateAssetGroupCollection(testCtx, collection, collection.Entries)
-	if err != nil {
-		t.Fatalf("Error creating asset group collection: %v", err)
+	entries := model.AssetGroupCollectionEntries{
+		{ObjectID: "obj1", NodeLabel: "TestNode1"},
+		{ObjectID: "obj2", NodeLabel: "TestNode2"},
+		{ObjectID: "obj3", NodeLabel: "TestNode3"},
+		{ObjectID: "obj4", NodeLabel: "TestNode4"},
 	}
+	err = dbInst.CreateAssetGroupCollection(testCtx, collection, entries)
+	require.Nil(t, err)
 
 	// Test updated member count
-	t.Run("UpdatedMemberCount", func(t *testing.T) {
+	t.Run("GetAssetGroup", func(t *testing.T) {
 		fetchedGroup, err := dbInst.GetAssetGroup(testCtx, assetGroup.ID)
-		if err != nil {
-			t.Fatalf("Error fetching asset group: %v", err)
-		}
-		// each entry in both sys_group and user_group
-		if fetchedGroup.MemberCount != 3 {
-			t.Errorf("Expected member count to be 3, got %d", fetchedGroup.MemberCount)
-		}
+		require.Nil(t, err)
+		require.Equal(t, 4, fetchedGroup.MemberCount)
 	})
 
 	// Test GetAllAssetGroups
 	t.Run("GetAllAssetGroups", func(t *testing.T) {
 		allGroups, err := dbInst.GetAllAssetGroups(testCtx, "", model.SQLFilter{})
-		if err != nil {
-			t.Fatalf("Error fetching all asset groups: %v", err)
-		}
+		require.Nil(t, err)
 		found := false
 		for _, g := range allGroups {
 			if g.ID == assetGroup.ID {
 				found = true
-				if g.MemberCount != 3 {
-					t.Errorf("Expected member count in GetAllAssetGroups to be 3, got %d", g.MemberCount)
-				}
+				require.Equal(t, 4, g.MemberCount)
 				break
 			}
 		}
 		if !found {
 			t.Errorf("Asset group not found in GetAllAssetGroups result")
-		}
-	})
-
-	// Clean up
-	t.Cleanup(func() {
-		err := dbInst.DeleteAssetGroup(testCtx, assetGroup)
-		if err != nil {
-			t.Fatalf("Error deleting asset group: %v", err)
 		}
 	})
 }

--- a/packages/go/errors/error.go
+++ b/packages/go/errors/error.go
@@ -36,6 +36,7 @@ func New(value string) error {
 	return Error(value)
 }
 
+// Deprecated: Use stdlib errors.Is(...) instead.
 // Is reports whether any error in err's chain matches target.
 func Is(err error, target error) bool {
 	return goerrors.Is(err, target)


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Added a new `getAssetGroupMemberCount` helper function that queries the latest asset group collection

## Motivation and Context

Resolves the bug where asset group member counts were incorrectly reported as 0 in API responses and ensures accurate representation of group membership

## How Has This Been Tested?

Manually tested via API Explorer UI

## Screenshots (optional):

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [X] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [X] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [X] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
