### PR TITLE
BED-4534: Saved Cypher Improvements & Description Field

### DIFF
--- a/cmd/api/src/api/v2/saved_queries.go
+++ b/cmd/api/src/api/v2/saved_queries.go
@@ -99,8 +99,9 @@ func (s Resources) ListSavedQueries(response http.ResponseWriter, request *http.
 }
 
 type CreateSavedQueryRequest struct {
-	Query string `json:"query"`
-	Name  string `json:"name"`
+	Query       string `json:"query"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
 }
 
 func (s Resources) CreateSavedQuery(response http.ResponseWriter, request *http.Request) {
@@ -114,7 +115,7 @@ func (s Resources) CreateSavedQuery(response http.ResponseWriter, request *http.
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, err.Error(), request), response)
 	} else if createRequest.Name == "" || createRequest.Query == "" {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, "the name and/or query field is empty", request), response)
-	} else if savedQuery, err := s.DB.CreateSavedQuery(request.Context(), user.ID, createRequest.Name, createRequest.Query); err != nil {
+	} else if savedQuery, err := s.DB.CreateSavedQuery(request.Context(), user.ID, createRequest.Name, createRequest.Query, createRequest.Description); err != nil {
 		if strings.Contains(err.Error(), "duplicate key value violates unique constraint") {
 			api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, "duplicate name for saved query: please choose a different name", request), response)
 		} else {

--- a/cmd/api/src/api/v2/saved_queries.go
+++ b/cmd/api/src/api/v2/saved_queries.go
@@ -101,7 +101,7 @@ func (s Resources) ListSavedQueries(response http.ResponseWriter, request *http.
 type CreateSavedQueryRequest struct {
 	Query       string `json:"query"`
 	Name        string `json:"name"`
-	Description string `json:"description"`
+	Description string `json:"description,omitempty"`
 }
 
 func (s Resources) CreateSavedQuery(response http.ResponseWriter, request *http.Request) {

--- a/cmd/api/src/api/v2/saved_queries_test.go
+++ b/cmd/api/src/api/v2/saved_queries_test.go
@@ -329,7 +329,7 @@ func TestResources_CreateSavedQuery_DuplicateName(t *testing.T) {
 	userId, err := uuid2.NewV4()
 	require.Nil(t, err)
 
-	mockDB.EXPECT().CreateSavedQuery(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(model.SavedQuery{}, fmt.Errorf("duplicate key value violates unique constraint \"idx_saved_queries_composite_index\""))
+	mockDB.EXPECT().CreateSavedQuery(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(model.SavedQuery{}, fmt.Errorf("duplicate key value violates unique constraint \"idx_saved_queries_composite_index\""))
 
 	payload := v2.CreateSavedQueryRequest{
 		Query: "Match(n) return n",
@@ -363,11 +363,12 @@ func TestResources_CreateSavedQuery_CreateFailure(t *testing.T) {
 	require.Nil(t, err)
 
 	payload := v2.CreateSavedQueryRequest{
-		Query: "Match(n) return n",
-		Name:  "myCustomQuery1",
+		Query:       "Match(n) return n",
+		Name:        "myCustomQuery1",
+		Description: "An example description",
 	}
 
-	mockDB.EXPECT().CreateSavedQuery(gomock.Any(), userId, payload.Name, payload.Query).Return(model.SavedQuery{}, fmt.Errorf("foo"))
+	mockDB.EXPECT().CreateSavedQuery(gomock.Any(), userId, payload.Name, payload.Query, payload.Description).Return(model.SavedQuery{}, fmt.Errorf("foo"))
 
 	req, err := http.NewRequestWithContext(createContextWithOwnerId(userId), "POST", endpoint, must.MarshalJSONReader(payload))
 	require.Nil(t, err)
@@ -395,14 +396,16 @@ func TestResources_CreateSavedQuery(t *testing.T) {
 	require.Nil(t, err)
 
 	payload := v2.CreateSavedQueryRequest{
-		Query: "Match(n) return n",
-		Name:  "myCustomQuery1",
+		Query:       "Match(n) return n",
+		Name:        "myCustomQuery1",
+		Description: "An example description",
 	}
 
-	mockDB.EXPECT().CreateSavedQuery(gomock.Any(), userId, payload.Name, payload.Query).Return(model.SavedQuery{
-		UserID: userId.String(),
-		Name:   payload.Name,
-		Query:  payload.Query,
+	mockDB.EXPECT().CreateSavedQuery(gomock.Any(), userId, payload.Name, payload.Query, payload.Description).Return(model.SavedQuery{
+		UserID:      userId.String(),
+		Name:        payload.Name,
+		Query:       payload.Query,
+		Description: "An example description",
 	}, nil)
 
 	req, err := http.NewRequestWithContext(createContextWithOwnerId(userId), "POST", endpoint, must.MarshalJSONReader(payload))

--- a/cmd/api/src/database/db.go
+++ b/cmd/api/src/database/db.go
@@ -153,7 +153,7 @@ type Database interface {
 	fileupload.FileUploadData
 
 	// Saved Queries
-	SavedQueries
+	SavedQueriesData
 
 	// Saved Queries Permissions
 	SavedQueriesPermissionsData

--- a/cmd/api/src/database/db.go
+++ b/cmd/api/src/database/db.go
@@ -44,8 +44,8 @@ const (
 )
 
 var (
-    ErrDuplicateAGName = errors.New("duplicate asset group name")
-    ErrDuplicateAGTag  = errors.New("duplicate asset group tag")
+	ErrDuplicateAGName = errors.New("duplicate asset group name")
+	ErrDuplicateAGTag  = errors.New("duplicate asset group tag")
 )
 
 func IsUnexpectedDatabaseError(err error) bool {
@@ -153,11 +153,10 @@ type Database interface {
 	fileupload.FileUploadData
 
 	// Saved Queries
-	ListSavedQueries(ctx context.Context, userID uuid.UUID, order string, filter model.SQLFilter, skip, limit int) (model.SavedQueries, int, error)
-	CreateSavedQuery(ctx context.Context, userID uuid.UUID, name string, query string) (model.SavedQuery, error)
-	DeleteSavedQuery(ctx context.Context, id int) error
-	SavedQueryBelongsToUser(ctx context.Context, userID uuid.UUID, savedQueryID int) (bool, error)
-	DeleteAssetGroupSelectorsForAssetGroups(ctx context.Context, assetGroupIds []int) error
+	SavedQueries
+
+	// Saved Queries Permissions
+	SavedQueriesPermissionsData
 
 	// Analysis Request
 	AnalysisRequestData

--- a/cmd/api/src/database/db.go
+++ b/cmd/api/src/database/db.go
@@ -81,6 +81,7 @@ type Database interface {
 	GetAssetGroupSelector(ctx context.Context, id int32) (model.AssetGroupSelector, error)
 	DeleteAssetGroupSelector(ctx context.Context, selector model.AssetGroupSelector) error
 	UpdateAssetGroupSelectors(ctx context.Context, assetGroup model.AssetGroup, selectorSpecs []model.AssetGroupSelectorSpec, systemSelector bool) (model.UpdatedAssetGroupSelectors, error)
+	DeleteAssetGroupSelectorsForAssetGroups(ctx context.Context, assetGroupIds []int) error
 
 	Wipe(ctx context.Context) error
 	Migrate(ctx context.Context) error

--- a/cmd/api/src/database/migration/migrations/v5.13.1.sql
+++ b/cmd/api/src/database/migration/migrations/v5.13.1.sql
@@ -1,0 +1,28 @@
+-- Copyright 2024 Specter Ops, Inc.
+--
+-- Licensed under the Apache License, Version 2.0
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- SPDX-License-Identifier: Apache-2.0
+
+ALTER TABLE IF EXISTS saved_queries
+  ADD COLUMN IF NOT EXISTS description TEXT DEFAULT '';
+
+CREATE TABLE IF NOT EXISTS saved_queries_permissions
+(
+  id                BIGSERIAL PRIMARY KEY,
+  shared_to_user_id TEXT REFERENCES users (id),
+  query_id          BIGSERIAL REFERENCES saved_queries (id) NOT NULL,
+  global            BOOL                     DEFAULT FALSE  NOT NULL,
+  created_at        TIMESTAMP WITH TIME ZONE DEFAULT now(),
+  updated_at        TIMESTAMP WITH TIME ZONE DEFAULT now()
+);

--- a/cmd/api/src/database/migration/migrations/v5.13.1.sql
+++ b/cmd/api/src/database/migration/migrations/v5.13.1.sql
@@ -24,5 +24,6 @@ CREATE TABLE IF NOT EXISTS saved_queries_permissions
   query_id          BIGSERIAL REFERENCES saved_queries (id) ON DELETE CASCADE  NOT NULL,
   global            BOOL                                         DEFAULT FALSE NOT NULL,
   created_at        TIMESTAMP WITH TIME ZONE                     DEFAULT now(),
-  updated_at        TIMESTAMP WITH TIME ZONE                     DEFAULT now()
+  updated_at        TIMESTAMP WITH TIME ZONE                     DEFAULT now(),
+  UNIQUE (shared_to_user_id, query_id)
 );

--- a/cmd/api/src/database/migration/migrations/v5.13.1.sql
+++ b/cmd/api/src/database/migration/migrations/v5.13.1.sql
@@ -20,9 +20,9 @@ ALTER TABLE IF EXISTS saved_queries
 CREATE TABLE IF NOT EXISTS saved_queries_permissions
 (
   id                BIGSERIAL PRIMARY KEY,
-  shared_to_user_id TEXT REFERENCES users (id),
-  query_id          BIGSERIAL REFERENCES saved_queries (id) NOT NULL,
-  global            BOOL                     DEFAULT FALSE  NOT NULL,
-  created_at        TIMESTAMP WITH TIME ZONE DEFAULT now(),
-  updated_at        TIMESTAMP WITH TIME ZONE DEFAULT now()
+  shared_to_user_id TEXT REFERENCES users (id) ON DELETE CASCADE DEFAULT NULL,
+  query_id          BIGSERIAL REFERENCES saved_queries (id) ON DELETE CASCADE  NOT NULL,
+  global            BOOL                                         DEFAULT FALSE NOT NULL,
+  created_at        TIMESTAMP WITH TIME ZONE                     DEFAULT now(),
+  updated_at        TIMESTAMP WITH TIME ZONE                     DEFAULT now()
 );

--- a/cmd/api/src/database/migration/migrations/v5.13.1.sql
+++ b/cmd/api/src/database/migration/migrations/v5.13.1.sql
@@ -15,7 +15,7 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 ALTER TABLE IF EXISTS saved_queries
-  ADD COLUMN IF NOT EXISTS description TEXT DEFAULT '';
+  ADD COLUMN IF NOT EXISTS description VARCHAR(500) DEFAULT '';
 
 CREATE TABLE IF NOT EXISTS saved_queries_permissions
 (

--- a/cmd/api/src/database/migration/migrations/v5.13.1.sql
+++ b/cmd/api/src/database/migration/migrations/v5.13.1.sql
@@ -15,7 +15,7 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 ALTER TABLE IF EXISTS saved_queries
-  ADD COLUMN IF NOT EXISTS description VARCHAR(500) DEFAULT '';
+  ADD COLUMN IF NOT EXISTS description TEXT DEFAULT '';
 
 CREATE TABLE IF NOT EXISTS saved_queries_permissions
 (

--- a/cmd/api/src/database/migration/migrations/v5.13.1.sql
+++ b/cmd/api/src/database/migration/migrations/v5.13.1.sql
@@ -22,7 +22,7 @@ CREATE TABLE IF NOT EXISTS saved_queries_permissions
   id                BIGSERIAL PRIMARY KEY,
   shared_to_user_id TEXT REFERENCES users (id) ON DELETE CASCADE DEFAULT NULL,
   query_id          BIGSERIAL REFERENCES saved_queries (id) ON DELETE CASCADE  NOT NULL,
-  global            BOOL                                         DEFAULT FALSE NOT NULL,
+  public            BOOL                                         DEFAULT FALSE NOT NULL,
   created_at        TIMESTAMP WITH TIME ZONE                     DEFAULT now(),
   updated_at        TIMESTAMP WITH TIME ZONE                     DEFAULT now(),
   UNIQUE (shared_to_user_id, query_id)

--- a/cmd/api/src/database/mocks/db.go
+++ b/cmd/api/src/database/mocks/db.go
@@ -317,19 +317,19 @@ func (mr *MockDatabaseMockRecorder) CreateSavedQuery(arg0, arg1, arg2, arg3, arg
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSavedQuery", reflect.TypeOf((*MockDatabase)(nil).CreateSavedQuery), arg0, arg1, arg2, arg3, arg4)
 }
 
-// CreateSavedQueryPermissionToGlobal mocks base method.
-func (m *MockDatabase) CreateSavedQueryPermissionToGlobal(arg0 context.Context, arg1 int64) (model.SavedQueriesPermissions, error) {
+// CreateSavedQueryPermissionToPublic mocks base method.
+func (m *MockDatabase) CreateSavedQueryPermissionToPublic(arg0 context.Context, arg1 int64) (model.SavedQueriesPermissions, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateSavedQueryPermissionToGlobal", arg0, arg1)
+	ret := m.ctrl.Call(m, "CreateSavedQueryPermissionToPublic", arg0, arg1)
 	ret0, _ := ret[0].(model.SavedQueriesPermissions)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// CreateSavedQueryPermissionToGlobal indicates an expected call of CreateSavedQueryPermissionToGlobal.
-func (mr *MockDatabaseMockRecorder) CreateSavedQueryPermissionToGlobal(arg0, arg1 interface{}) *gomock.Call {
+// CreateSavedQueryPermissionToPublic indicates an expected call of CreateSavedQueryPermissionToPublic.
+func (mr *MockDatabaseMockRecorder) CreateSavedQueryPermissionToPublic(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSavedQueryPermissionToGlobal", reflect.TypeOf((*MockDatabase)(nil).CreateSavedQueryPermissionToGlobal), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSavedQueryPermissionToPublic", reflect.TypeOf((*MockDatabase)(nil).CreateSavedQueryPermissionToPublic), arg0, arg1)
 }
 
 // CreateSavedQueryPermissionToUser mocks base method.
@@ -1041,6 +1041,21 @@ func (mr *MockDatabaseMockRecorder) GetPermissionsForSavedQuery(arg0, arg1 inter
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPermissionsForSavedQuery", reflect.TypeOf((*MockDatabase)(nil).GetPermissionsForSavedQuery), arg0, arg1)
 }
 
+// GetPublicSavedQueries mocks base method.
+func (m *MockDatabase) GetPublicSavedQueries(arg0 context.Context) (model.SavedQueries, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetPublicSavedQueries", arg0)
+	ret0, _ := ret[0].(model.SavedQueries)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetPublicSavedQueries indicates an expected call of GetPublicSavedQueries.
+func (mr *MockDatabaseMockRecorder) GetPublicSavedQueries(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPublicSavedQueries", reflect.TypeOf((*MockDatabase)(nil).GetPublicSavedQueries), arg0)
+}
+
 // GetRole mocks base method.
 func (m *MockDatabase) GetRole(arg0 context.Context, arg1 int32) (model.Role, error) {
 	m.ctrl.T.Helper()
@@ -1101,34 +1116,19 @@ func (mr *MockDatabaseMockRecorder) GetSAMLProviderUsers(arg0, arg1 interface{})
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSAMLProviderUsers", reflect.TypeOf((*MockDatabase)(nil).GetSAMLProviderUsers), arg0, arg1)
 }
 
-// GetSavedQueriesSharedGlobally mocks base method.
-func (m *MockDatabase) GetSavedQueriesSharedGlobally(arg0 context.Context) (model.SavedQueries, error) {
+// GetSharedSavedQueries mocks base method.
+func (m *MockDatabase) GetSharedSavedQueries(arg0 context.Context, arg1 int64) (model.SavedQueries, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetSavedQueriesSharedGlobally", arg0)
+	ret := m.ctrl.Call(m, "GetSharedSavedQueries", arg0, arg1)
 	ret0, _ := ret[0].(model.SavedQueries)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetSavedQueriesSharedGlobally indicates an expected call of GetSavedQueriesSharedGlobally.
-func (mr *MockDatabaseMockRecorder) GetSavedQueriesSharedGlobally(arg0 interface{}) *gomock.Call {
+// GetSharedSavedQueries indicates an expected call of GetSharedSavedQueries.
+func (mr *MockDatabaseMockRecorder) GetSharedSavedQueries(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSavedQueriesSharedGlobally", reflect.TypeOf((*MockDatabase)(nil).GetSavedQueriesSharedGlobally), arg0)
-}
-
-// GetSavedQueriesSharedWithUser mocks base method.
-func (m *MockDatabase) GetSavedQueriesSharedWithUser(arg0 context.Context, arg1 int64) (model.SavedQueries, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetSavedQueriesSharedWithUser", arg0, arg1)
-	ret0, _ := ret[0].(model.SavedQueries)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetSavedQueriesSharedWithUser indicates an expected call of GetSavedQueriesSharedWithUser.
-func (mr *MockDatabaseMockRecorder) GetSavedQueriesSharedWithUser(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSavedQueriesSharedWithUser", reflect.TypeOf((*MockDatabase)(nil).GetSavedQueriesSharedWithUser), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSharedSavedQueries", reflect.TypeOf((*MockDatabase)(nil).GetSharedSavedQueries), arg0, arg1)
 }
 
 // GetTimeRangedAssetGroupCollections mocks base method.

--- a/cmd/api/src/database/mocks/db.go
+++ b/cmd/api/src/database/mocks/db.go
@@ -1026,6 +1026,21 @@ func (mr *MockDatabaseMockRecorder) GetPermission(arg0, arg1 interface{}) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPermission", reflect.TypeOf((*MockDatabase)(nil).GetPermission), arg0, arg1)
 }
 
+// GetPermissionsForSavedQuery mocks base method.
+func (m *MockDatabase) GetPermissionsForSavedQuery(arg0 context.Context, arg1 int64) (model.SavedQueriesPermissions, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetPermissionsForSavedQuery", arg0, arg1)
+	ret0, _ := ret[0].(model.SavedQueriesPermissions)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetPermissionsForSavedQuery indicates an expected call of GetPermissionsForSavedQuery.
+func (mr *MockDatabaseMockRecorder) GetPermissionsForSavedQuery(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPermissionsForSavedQuery", reflect.TypeOf((*MockDatabase)(nil).GetPermissionsForSavedQuery), arg0, arg1)
+}
+
 // GetRole mocks base method.
 func (m *MockDatabase) GetRole(arg0 context.Context, arg1 int32) (model.Role, error) {
 	m.ctrl.T.Helper()
@@ -1099,20 +1114,6 @@ func (m *MockDatabase) GetSavedQueriesSharedWithUser(arg0 context.Context, arg1 
 func (mr *MockDatabaseMockRecorder) GetSavedQueriesSharedWithUser(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSavedQueriesSharedWithUser", reflect.TypeOf((*MockDatabase)(nil).GetSavedQueriesSharedWithUser), arg0, arg1)
-}
-
-// GetSavedQueryPermissions mocks base method.
-func (m *MockDatabase) GetSavedQueryPermissions(arg0 context.Context, arg1 int64) model.SavedQueriesPermissions {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetSavedQueryPermissions", arg0, arg1)
-	ret0, _ := ret[0].(model.SavedQueriesPermissions)
-	return ret0
-}
-
-// GetSavedQueryPermissions indicates an expected call of GetSavedQueryPermissions.
-func (mr *MockDatabaseMockRecorder) GetSavedQueryPermissions(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSavedQueryPermissions", reflect.TypeOf((*MockDatabase)(nil).GetSavedQueryPermissions), arg0, arg1)
 }
 
 // GetTimeRangedAssetGroupCollections mocks base method.
@@ -1380,22 +1381,6 @@ func (m *MockDatabase) SavedQueryBelongsToUser(arg0 context.Context, arg1 uuid.U
 func (mr *MockDatabaseMockRecorder) SavedQueryBelongsToUser(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SavedQueryBelongsToUser", reflect.TypeOf((*MockDatabase)(nil).SavedQueryBelongsToUser), arg0, arg1, arg2)
-}
-
-// SearchSavedQueries mocks base method.
-func (m *MockDatabase) SearchSavedQueries(arg0 context.Context, arg1 uuid.UUID, arg2 model.SQLFilter, arg3, arg4 int, arg5, arg6, arg7, arg8 string) (model.SavedQueries, int, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SearchSavedQueries", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
-	ret0, _ := ret[0].(model.SavedQueries)
-	ret1, _ := ret[1].(int)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
-}
-
-// SearchSavedQueries indicates an expected call of SearchSavedQueries.
-func (mr *MockDatabaseMockRecorder) SearchSavedQueries(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SearchSavedQueries", reflect.TypeOf((*MockDatabase)(nil).SearchSavedQueries), arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
 }
 
 // SetConfigurationParameter mocks base method.

--- a/cmd/api/src/database/mocks/db.go
+++ b/cmd/api/src/database/mocks/db.go
@@ -82,6 +82,21 @@ func (mr *MockDatabaseMockRecorder) CancelAllFileUploads(arg0 interface{}) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelAllFileUploads", reflect.TypeOf((*MockDatabase)(nil).CancelAllFileUploads), arg0)
 }
 
+// CheckUserHasPermissionToSavedQuery mocks base method.
+func (m *MockDatabase) CheckUserHasPermissionToSavedQuery(arg0 context.Context, arg1 int64, arg2 uuid.UUID) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CheckUserHasPermissionToSavedQuery", arg0, arg1, arg2)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CheckUserHasPermissionToSavedQuery indicates an expected call of CheckUserHasPermissionToSavedQuery.
+func (mr *MockDatabaseMockRecorder) CheckUserHasPermissionToSavedQuery(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckUserHasPermissionToSavedQuery", reflect.TypeOf((*MockDatabase)(nil).CheckUserHasPermissionToSavedQuery), arg0, arg1, arg2)
+}
+
 // Close mocks base method.
 func (m *MockDatabase) Close(arg0 context.Context) {
 	m.ctrl.T.Helper()
@@ -288,18 +303,48 @@ func (mr *MockDatabaseMockRecorder) CreateSAMLIdentityProvider(arg0, arg1 interf
 }
 
 // CreateSavedQuery mocks base method.
-func (m *MockDatabase) CreateSavedQuery(arg0 context.Context, arg1 uuid.UUID, arg2, arg3 string) (model.SavedQuery, error) {
+func (m *MockDatabase) CreateSavedQuery(arg0 context.Context, arg1 uuid.UUID, arg2, arg3, arg4 string) (model.SavedQuery, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateSavedQuery", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "CreateSavedQuery", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(model.SavedQuery)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateSavedQuery indicates an expected call of CreateSavedQuery.
-func (mr *MockDatabaseMockRecorder) CreateSavedQuery(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockDatabaseMockRecorder) CreateSavedQuery(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSavedQuery", reflect.TypeOf((*MockDatabase)(nil).CreateSavedQuery), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSavedQuery", reflect.TypeOf((*MockDatabase)(nil).CreateSavedQuery), arg0, arg1, arg2, arg3, arg4)
+}
+
+// CreateSavedQueryPermissionToGlobal mocks base method.
+func (m *MockDatabase) CreateSavedQueryPermissionToGlobal(arg0 context.Context, arg1 int64) (model.SavedQueriesPermissions, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateSavedQueryPermissionToGlobal", arg0, arg1)
+	ret0, _ := ret[0].(model.SavedQueriesPermissions)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateSavedQueryPermissionToGlobal indicates an expected call of CreateSavedQueryPermissionToGlobal.
+func (mr *MockDatabaseMockRecorder) CreateSavedQueryPermissionToGlobal(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSavedQueryPermissionToGlobal", reflect.TypeOf((*MockDatabase)(nil).CreateSavedQueryPermissionToGlobal), arg0, arg1)
+}
+
+// CreateSavedQueryPermissionToUser mocks base method.
+func (m *MockDatabase) CreateSavedQueryPermissionToUser(arg0 context.Context, arg1 int64, arg2 uuid.UUID) (model.SavedQueriesPermissions, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateSavedQueryPermissionToUser", arg0, arg1, arg2)
+	ret0, _ := ret[0].(model.SavedQueriesPermissions)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateSavedQueryPermissionToUser indicates an expected call of CreateSavedQueryPermissionToUser.
+func (mr *MockDatabaseMockRecorder) CreateSavedQueryPermissionToUser(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSavedQueryPermissionToUser", reflect.TypeOf((*MockDatabase)(nil).CreateSavedQueryPermissionToUser), arg0, arg1, arg2)
 }
 
 // CreateUser mocks base method.
@@ -1041,6 +1086,35 @@ func (mr *MockDatabaseMockRecorder) GetSAMLProviderUsers(arg0, arg1 interface{})
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSAMLProviderUsers", reflect.TypeOf((*MockDatabase)(nil).GetSAMLProviderUsers), arg0, arg1)
 }
 
+// GetSavedQueriesSharedWithUser mocks base method.
+func (m *MockDatabase) GetSavedQueriesSharedWithUser(arg0 context.Context, arg1 int64) (model.SavedQueries, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSavedQueriesSharedWithUser", arg0, arg1)
+	ret0, _ := ret[0].(model.SavedQueries)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetSavedQueriesSharedWithUser indicates an expected call of GetSavedQueriesSharedWithUser.
+func (mr *MockDatabaseMockRecorder) GetSavedQueriesSharedWithUser(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSavedQueriesSharedWithUser", reflect.TypeOf((*MockDatabase)(nil).GetSavedQueriesSharedWithUser), arg0, arg1)
+}
+
+// GetSavedQueryPermissions mocks base method.
+func (m *MockDatabase) GetSavedQueryPermissions(arg0 context.Context, arg1 int64) model.SavedQueriesPermissions {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSavedQueryPermissions", arg0, arg1)
+	ret0, _ := ret[0].(model.SavedQueriesPermissions)
+	return ret0
+}
+
+// GetSavedQueryPermissions indicates an expected call of GetSavedQueryPermissions.
+func (mr *MockDatabaseMockRecorder) GetSavedQueryPermissions(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSavedQueryPermissions", reflect.TypeOf((*MockDatabase)(nil).GetSavedQueryPermissions), arg0, arg1)
+}
+
 // GetTimeRangedAssetGroupCollections mocks base method.
 func (m *MockDatabase) GetTimeRangedAssetGroupCollections(arg0 context.Context, arg1 int32, arg2, arg3 int64, arg4 string) (model.AssetGroupCollections, error) {
 	m.ctrl.T.Helper()
@@ -1306,6 +1380,22 @@ func (m *MockDatabase) SavedQueryBelongsToUser(arg0 context.Context, arg1 uuid.U
 func (mr *MockDatabaseMockRecorder) SavedQueryBelongsToUser(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SavedQueryBelongsToUser", reflect.TypeOf((*MockDatabase)(nil).SavedQueryBelongsToUser), arg0, arg1, arg2)
+}
+
+// SearchSavedQueries mocks base method.
+func (m *MockDatabase) SearchSavedQueries(arg0 context.Context, arg1 uuid.UUID, arg2 model.SQLFilter, arg3, arg4 int, arg5, arg6, arg7, arg8 string) (model.SavedQueries, int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SearchSavedQueries", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
+	ret0, _ := ret[0].(model.SavedQueries)
+	ret1, _ := ret[1].(int)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// SearchSavedQueries indicates an expected call of SearchSavedQueries.
+func (mr *MockDatabaseMockRecorder) SearchSavedQueries(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SearchSavedQueries", reflect.TypeOf((*MockDatabase)(nil).SearchSavedQueries), arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
 }
 
 // SetConfigurationParameter mocks base method.

--- a/cmd/api/src/database/mocks/db.go
+++ b/cmd/api/src/database/mocks/db.go
@@ -1101,6 +1101,21 @@ func (mr *MockDatabaseMockRecorder) GetSAMLProviderUsers(arg0, arg1 interface{})
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSAMLProviderUsers", reflect.TypeOf((*MockDatabase)(nil).GetSAMLProviderUsers), arg0, arg1)
 }
 
+// GetSavedQueriesSharedGlobally mocks base method.
+func (m *MockDatabase) GetSavedQueriesSharedGlobally(arg0 context.Context) (model.SavedQueries, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSavedQueriesSharedGlobally", arg0)
+	ret0, _ := ret[0].(model.SavedQueries)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetSavedQueriesSharedGlobally indicates an expected call of GetSavedQueriesSharedGlobally.
+func (mr *MockDatabaseMockRecorder) GetSavedQueriesSharedGlobally(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSavedQueriesSharedGlobally", reflect.TypeOf((*MockDatabase)(nil).GetSavedQueriesSharedGlobally), arg0)
+}
+
 // GetSavedQueriesSharedWithUser mocks base method.
 func (m *MockDatabase) GetSavedQueriesSharedWithUser(arg0 context.Context, arg1 int64) (model.SavedQueries, error) {
 	m.ctrl.T.Helper()

--- a/cmd/api/src/database/saved_queries.go
+++ b/cmd/api/src/database/saved_queries.go
@@ -28,7 +28,6 @@ type SavedQueriesData interface {
 	CreateSavedQuery(ctx context.Context, userID uuid.UUID, name string, query string, description string) (model.SavedQuery, error)
 	DeleteSavedQuery(ctx context.Context, id int) error
 	SavedQueryBelongsToUser(ctx context.Context, userID uuid.UUID, savedQueryID int) (bool, error)
-	DeleteAssetGroupSelectorsForAssetGroups(ctx context.Context, assetGroupIds []int) error
 	GetSavedQueriesSharedWithUser(ctx context.Context, userID int64) (model.SavedQueries, error)
 	GetSavedQueriesSharedGlobally(ctx context.Context) (model.SavedQueries, error)
 }

--- a/cmd/api/src/database/saved_queries.go
+++ b/cmd/api/src/database/saved_queries.go
@@ -28,8 +28,8 @@ type SavedQueriesData interface {
 	CreateSavedQuery(ctx context.Context, userID uuid.UUID, name string, query string, description string) (model.SavedQuery, error)
 	DeleteSavedQuery(ctx context.Context, id int) error
 	SavedQueryBelongsToUser(ctx context.Context, userID uuid.UUID, savedQueryID int) (bool, error)
-	GetSavedQueriesSharedWithUser(ctx context.Context, userID int64) (model.SavedQueries, error)
-	GetSavedQueriesSharedGlobally(ctx context.Context) (model.SavedQueries, error)
+	GetSharedSavedQueries(ctx context.Context, userID int64) (model.SavedQueries, error)
+	GetPublicSavedQueries(ctx context.Context) (model.SavedQueries, error)
 }
 
 func (s *BloodhoundDB) ListSavedQueries(ctx context.Context, userID uuid.UUID, order string, filter model.SQLFilter, skip, limit int) (model.SavedQueries, int, error) {
@@ -85,8 +85,8 @@ func (s *BloodhoundDB) SavedQueryBelongsToUser(ctx context.Context, userID uuid.
 	}
 }
 
-// GetSavedQueriesSharedWithUser returns all the saved queries that the given userID has access to, including global queries
-func (s *BloodhoundDB) GetSavedQueriesSharedWithUser(ctx context.Context, userID int64) (model.SavedQueries, error) {
+// GetSharedSavedQueries returns all the saved queries that the given userID has access to, including global queries
+func (s *BloodhoundDB) GetSharedSavedQueries(ctx context.Context, userID int64) (model.SavedQueries, error) {
 	savedQueries := model.SavedQueries{}
 
 	result := s.db.WithContext(ctx).Where("shared_to_user_id = ?", userID).Find(&savedQueries)
@@ -94,10 +94,10 @@ func (s *BloodhoundDB) GetSavedQueriesSharedWithUser(ctx context.Context, userID
 	return savedQueries, CheckError(result)
 }
 
-// GetSavedQueriesSharedGlobally returns all the queries that were shared globally
-func (s *BloodhoundDB) GetSavedQueriesSharedGlobally(ctx context.Context) (model.SavedQueries, error) {
+// GetPublicSavedQueries returns all the queries that were shared publicly
+func (s *BloodhoundDB) GetPublicSavedQueries(ctx context.Context) (model.SavedQueries, error) {
 	savedQueries := model.SavedQueries{}
 
-	result := s.db.WithContext(ctx).Where("global = true").Find(&savedQueries)
+	result := s.db.WithContext(ctx).Where("public = true").Find(&savedQueries)
 	return savedQueries, CheckError(result)
 }

--- a/cmd/api/src/database/saved_queries.go
+++ b/cmd/api/src/database/saved_queries.go
@@ -66,13 +66,7 @@ func (s *BloodhoundDB) CreateSavedQuery(ctx context.Context, userID uuid.UUID, n
 		Description: description,
 	}
 
-	// Create the saved query as well as add the permission for the creator
-	if result := s.db.WithContext(ctx).Create(&savedQuery); result.Error != nil {
-		return model.SavedQuery{}, result.Error
-	} else if _, err := s.CreateSavedQueryPermissionToUser(ctx, savedQuery.ID, userID); err != nil {
-		return savedQuery, err
-	}
-	return savedQuery, nil
+	return savedQuery, CheckError(s.db.WithContext(ctx).Create(&savedQuery))
 }
 
 func (s *BloodhoundDB) DeleteSavedQuery(ctx context.Context, id int) error {

--- a/cmd/api/src/database/saved_queries.go
+++ b/cmd/api/src/database/saved_queries.go
@@ -29,8 +29,6 @@ type SavedQueriesData interface {
 	DeleteSavedQuery(ctx context.Context, id int) error
 	SavedQueryBelongsToUser(ctx context.Context, userID uuid.UUID, savedQueryID int) (bool, error)
 	DeleteAssetGroupSelectorsForAssetGroups(ctx context.Context, assetGroupIds []int) error
-	SearchSavedQueries(ctx context.Context, userID uuid.UUID, filter model.SQLFilter, skip, limit int, order string, name string, query string, description string) (model.SavedQueries, int, error)
-	GetSavedQueryPermissions(ctx context.Context, queryID int64) model.SavedQueriesPermissions
 }
 
 func (s *BloodhoundDB) ListSavedQueries(ctx context.Context, userID uuid.UUID, order string, filter model.SQLFilter, skip, limit int) (model.SavedQueries, int, error) {

--- a/cmd/api/src/database/saved_queries.go
+++ b/cmd/api/src/database/saved_queries.go
@@ -23,7 +23,7 @@ import (
 	"gorm.io/gorm"
 )
 
-type SavedQueries interface {
+type SavedQueriesData interface {
 	ListSavedQueries(ctx context.Context, userID uuid.UUID, order string, filter model.SQLFilter, skip, limit int) (model.SavedQueries, int, error)
 	CreateSavedQuery(ctx context.Context, userID uuid.UUID, name string, query string, description string) (model.SavedQuery, error)
 	DeleteSavedQuery(ctx context.Context, id int) error

--- a/cmd/api/src/database/saved_queries_permissions.go
+++ b/cmd/api/src/database/saved_queries_permissions.go
@@ -28,6 +28,7 @@ type SavedQueriesPermissionsData interface {
 	CreateSavedQueryPermissionToGlobal(ctx context.Context, queryID int64) (model.SavedQueriesPermissions, error)
 	GetSavedQueriesSharedWithUser(ctx context.Context, userID int64) (model.SavedQueries, error)
 	CheckUserHasPermissionToSavedQuery(ctx context.Context, queryID int64, userID uuid.UUID) (bool, error)
+	GetPermissionsForSavedQuery(ctx context.Context, queryID int64) (model.SavedQueriesPermissions, error)
 }
 
 // CreateSavedQueryPermissionToUser creates a new entry to the SavedQueriesPermissions table granting a provided user id to access a provided query
@@ -66,4 +67,11 @@ func (s *BloodhoundDB) CheckUserHasPermissionToSavedQuery(ctx context.Context, q
 	result := s.db.WithContext(ctx).First(&userHasPermission, "user_id = ? AND query_id = ?", userID, queryID)
 
 	return userHasPermission, CheckError(result)
+}
+
+// GetPermissionsForSavedQuery gets all permissions associated with the provided query ID
+func (s *BloodhoundDB) GetPermissionsForSavedQuery(ctx context.Context, queryID int64) (model.SavedQueriesPermissions, error) {
+	queryPermissions := model.SavedQueriesPermissions{QueryID: queryID}
+	result := s.db.WithContext(ctx).Where("query_id = ?", queryID).Find(&queryPermissions)
+	return queryPermissions, CheckError(result)
 }

--- a/cmd/api/src/database/saved_queries_permissions.go
+++ b/cmd/api/src/database/saved_queries_permissions.go
@@ -22,6 +22,7 @@ import (
 	"github.com/specterops/bloodhound/src/model"
 )
 
+// SavedQueriesPermissionsData methods representing the database interactions pertaining to the saved_queries_permissions model
 type SavedQueriesPermissionsData interface {
 	CreateSavedQueryPermissionToUser(ctx context.Context, queryID int64, userID uuid.UUID) (model.SavedQueriesPermissions, error)
 	CreateSavedQueryPermissionToGlobal(ctx context.Context, queryID int64) (model.SavedQueriesPermissions, error)

--- a/cmd/api/src/database/saved_queries_permissions.go
+++ b/cmd/api/src/database/saved_queries_permissions.go
@@ -1,0 +1,68 @@
+// Copyright 2024 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package database
+
+import (
+	"context"
+	"github.com/gofrs/uuid"
+	"github.com/specterops/bloodhound/src/model"
+)
+
+type SavedQueriesPermissionsData interface {
+	CreateSavedQueryPermissionToUser(ctx context.Context, queryID int64, userID uuid.UUID) (model.SavedQueriesPermissions, error)
+	CreateSavedQueryPermissionToGlobal(ctx context.Context, queryID int64) (model.SavedQueriesPermissions, error)
+	GetSavedQueriesSharedWithUser(ctx context.Context, userID int64) (model.SavedQueries, error)
+	CheckUserHasPermissionToSavedQuery(ctx context.Context, queryID int64, userID uuid.UUID) (bool, error)
+}
+
+// CreateSavedQueryPermissionToUser creates a new entry to the SavedQueriesPermissions table granting a provided user id to access a provided query
+func (s *BloodhoundDB) CreateSavedQueryPermissionToUser(ctx context.Context, queryID int64, userID uuid.UUID) (model.SavedQueriesPermissions, error) {
+	permission := model.SavedQueriesPermissions{
+		QueryID:        queryID,
+		SharedToUserID: NullUUID(userID),
+		Global:         false,
+	}
+
+	return permission, CheckError(s.db.WithContext(ctx).Create(&permission))
+}
+
+// CreateSavedQueryPermissionToGlobal creates a new entry to the SavedQueriesPermissions table granting global read permissions to all users
+func (s *BloodhoundDB) CreateSavedQueryPermissionToGlobal(ctx context.Context, queryID int64) (model.SavedQueriesPermissions, error) {
+	permission := model.SavedQueriesPermissions{
+		QueryID: queryID,
+		Global:  true,
+	}
+
+	return permission, CheckError(s.db.WithContext(ctx).Create(&permission))
+}
+
+// GetSavedQueriesSharedWithUser returns all of the saved queries that the given userID has access to, including global queries
+func (s *BloodhoundDB) GetSavedQueriesSharedWithUser(ctx context.Context, userID int64) (model.SavedQueries, error) {
+	savedQueries := model.SavedQueries{}
+
+	result := s.db.WithContext(ctx).Where("shared_to_user_id = ?", userID).Or("global = true").Find(&savedQueries)
+
+	return savedQueries, CheckError(result)
+}
+
+// CheckUserHasPermissionToSavedQuery returns true or false depending on if the given userID has permission to read the given queryID
+func (s *BloodhoundDB) CheckUserHasPermissionToSavedQuery(ctx context.Context, queryID int64, userID uuid.UUID) (bool, error) {
+	userHasPermission := false
+	result := s.db.WithContext(ctx).First(&userHasPermission, "user_id = ? AND query_id = ?", userID, queryID)
+
+	return userHasPermission, CheckError(result)
+}

--- a/cmd/api/src/database/saved_queries_permissions.go
+++ b/cmd/api/src/database/saved_queries_permissions.go
@@ -26,7 +26,6 @@ import (
 type SavedQueriesPermissionsData interface {
 	CreateSavedQueryPermissionToUser(ctx context.Context, queryID int64, userID uuid.UUID) (model.SavedQueriesPermissions, error)
 	CreateSavedQueryPermissionToGlobal(ctx context.Context, queryID int64) (model.SavedQueriesPermissions, error)
-	GetSavedQueriesSharedWithUser(ctx context.Context, userID int64) (model.SavedQueries, error)
 	CheckUserHasPermissionToSavedQuery(ctx context.Context, queryID int64, userID uuid.UUID) (bool, error)
 	GetPermissionsForSavedQuery(ctx context.Context, queryID int64) (model.SavedQueriesPermissions, error)
 }
@@ -50,15 +49,6 @@ func (s *BloodhoundDB) CreateSavedQueryPermissionToGlobal(ctx context.Context, q
 	}
 
 	return permission, CheckError(s.db.WithContext(ctx).Create(&permission))
-}
-
-// GetSavedQueriesSharedWithUser returns all of the saved queries that the given userID has access to, including global queries
-func (s *BloodhoundDB) GetSavedQueriesSharedWithUser(ctx context.Context, userID int64) (model.SavedQueries, error) {
-	savedQueries := model.SavedQueries{}
-
-	result := s.db.WithContext(ctx).Where("shared_to_user_id = ?", userID).Or("global = true").Find(&savedQueries)
-
-	return savedQueries, CheckError(result)
 }
 
 // CheckUserHasPermissionToSavedQuery returns true or false depending on if the given userID has permission to read the given queryID

--- a/cmd/api/src/database/saved_queries_permissions_test.go
+++ b/cmd/api/src/database/saved_queries_permissions_test.go
@@ -1,3 +1,19 @@
+// Copyright 2024 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 // +build integration
 

--- a/cmd/api/src/database/saved_queries_permissions_test.go
+++ b/cmd/api/src/database/saved_queries_permissions_test.go
@@ -52,7 +52,7 @@ func TestSavedQueriesPermissions_SharingToUser(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, database.NullUUID(user2.ID), permissions.SharedToUserID)
-	assert.Equal(t, false, permissions.Global)
+	assert.Equal(t, false, permissions.Public)
 	assert.Equal(t, query.ID, permissions.QueryID)
 }
 
@@ -70,9 +70,9 @@ func TestSavedQueriesPermissions_SharingToGlobal(t *testing.T) {
 	query, err := dbInst.CreateSavedQuery(testCtx, user.ID, "Test Query", "MATCH(n) RETURN n", "An example Query")
 	require.NoError(t, err)
 
-	permissions, err := dbInst.CreateSavedQueryPermissionToGlobal(testCtx, query.ID)
+	permissions, err := dbInst.CreateSavedQueryPermissionToPublic(testCtx, query.ID)
 	require.NoError(t, err)
 
-	assert.Equal(t, true, permissions.Global)
+	assert.Equal(t, true, permissions.Public)
 	assert.Equal(t, query.ID, permissions.QueryID)
 }

--- a/cmd/api/src/database/saved_queries_permissions_test.go
+++ b/cmd/api/src/database/saved_queries_permissions_test.go
@@ -1,0 +1,62 @@
+//go:build integration
+// +build integration
+
+package database_test
+
+import (
+	"context"
+	"github.com/specterops/bloodhound/src/database"
+	"github.com/specterops/bloodhound/src/model"
+	"github.com/specterops/bloodhound/src/test/integration"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestSavedQueriesPermissions_SharingToUser(t *testing.T) {
+	var (
+		testCtx = context.Background()
+		dbInst  = integration.SetupDB(t)
+	)
+
+	user, err := dbInst.CreateUser(testCtx, model.User{
+		PrincipalName: userPrincipal,
+	})
+	require.NoError(t, err)
+
+	user2, err := dbInst.CreateUser(testCtx, model.User{
+		PrincipalName: user2Principal,
+	})
+	require.NoError(t, err)
+
+	query, err := dbInst.CreateSavedQuery(testCtx, user.ID, "Test Query", "MATCH(n) RETURN n", "An example Query")
+	require.NoError(t, err)
+
+	permissions, err := dbInst.CreateSavedQueryPermissionToUser(testCtx, query.ID, user2.ID)
+	require.NoError(t, err)
+
+	assert.Equal(t, database.NullUUID(user2.ID), permissions.SharedToUserID)
+	assert.Equal(t, false, permissions.Global)
+	assert.Equal(t, query.ID, permissions.QueryID)
+}
+
+func TestSavedQueriesPermissions_SharingToGlobal(t *testing.T) {
+	var (
+		testCtx = context.Background()
+		dbInst  = integration.SetupDB(t)
+	)
+
+	user, err := dbInst.CreateUser(testCtx, model.User{
+		PrincipalName: userPrincipal,
+	})
+	require.NoError(t, err)
+
+	query, err := dbInst.CreateSavedQuery(testCtx, user.ID, "Test Query", "MATCH(n) RETURN n", "An example Query")
+	require.NoError(t, err)
+
+	permissions, err := dbInst.CreateSavedQueryPermissionToGlobal(testCtx, query.ID)
+	require.NoError(t, err)
+
+	assert.Equal(t, true, permissions.Global)
+	assert.Equal(t, query.ID, permissions.QueryID)
+}

--- a/cmd/api/src/database/saved_queries_test.go
+++ b/cmd/api/src/database/saved_queries_test.go
@@ -47,7 +47,7 @@ func TestSavedQueries_ListSavedQueries(t *testing.T) {
 	require.Nil(t, err)
 
 	for i := 0; i < 7; i++ {
-		if _, err := dbInst.CreateSavedQuery(testCtx, userUUID, fmt.Sprintf("saved_query_%d", i), ""); err != nil {
+		if _, err := dbInst.CreateSavedQuery(testCtx, userUUID, fmt.Sprintf("saved_query_%d", i), "", ""); err != nil {
 			t.Fatalf("Error creating audit log: %v", err)
 		}
 	}

--- a/cmd/api/src/docs/json/definitions/v2.json
+++ b/cmd/api/src/docs/json/definitions/v2.json
@@ -951,6 +951,9 @@
             },
             "name": {
                 "type": "string"
+            },
+            "description": {
+                "type": "string"
             }
         }
     },

--- a/cmd/api/src/model/saved_queries.go
+++ b/cmd/api/src/model/saved_queries.go
@@ -34,6 +34,7 @@ func (s SavedQueries) IsSortable(column string) bool {
 	case "user_id",
 		"name",
 		"query",
+		"description",
 		"id",
 		"created_at",
 		"updated_at",
@@ -77,7 +78,7 @@ func (s SavedQueries) IsString(column string) bool {
 	switch column {
 	case "name",
 		"query",
-		"descriptions":
+		"description":
 		return true
 	default:
 		return false

--- a/cmd/api/src/model/saved_queries.go
+++ b/cmd/api/src/model/saved_queries.go
@@ -19,9 +19,10 @@ package model
 import "fmt"
 
 type SavedQuery struct {
-	UserID string `json:"user_id" gorm:"index:,unique,composite:compositeIndex"`
-	Name   string `json:"name" gorm:"index:,unique,composite:compositeIndex"`
-	Query  string `json:"query"`
+	UserID      string `json:"user_id" gorm:"index:,unique,composite:compositeIndex"`
+	Name        string `json:"name" gorm:"index:,unique,composite:compositeIndex"`
+	Query       string `json:"query"`
+	Description string `json:"description"`
 
 	BigSerial
 }
@@ -45,9 +46,10 @@ func (s SavedQueries) IsSortable(column string) bool {
 
 func (s SavedQueries) ValidFilters() map[string][]FilterOperator {
 	return map[string][]FilterOperator{
-		"user_id": {Equals, NotEquals},
-		"name":    {Equals, NotEquals},
-		"query":   {Equals, NotEquals},
+		"user_id":     {Equals, NotEquals},
+		"name":        {Equals, NotEquals},
+		"query":       {Equals, NotEquals},
+		"description": {Equals, NotEquals},
 	}
 }
 
@@ -74,7 +76,8 @@ func (s SavedQueries) GetValidFilterPredicatesAsStrings(column string) ([]string
 func (s SavedQueries) IsString(column string) bool {
 	switch column {
 	case "name",
-		"query":
+		"query",
+		"descriptions":
 		return true
 	default:
 		return false

--- a/cmd/api/src/model/saved_queries_permissions.go
+++ b/cmd/api/src/model/saved_queries_permissions.go
@@ -1,0 +1,32 @@
+//
+// Copyright 2024 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package model
+
+import (
+	"github.com/gofrs/uuid"
+)
+
+// SavedQueriesPermissions represents the database model which allows users to share saved cypher queries
+type SavedQueriesPermissions struct {
+	ID             int64         `json:"id"`
+	SharedToUserID uuid.NullUUID `json:"shared_to_user_id"`
+	QueryID        int64         `json:"query_id"`
+	Global         bool          `json:"global"`
+
+	Basic
+}

--- a/cmd/api/src/model/saved_queries_permissions.go
+++ b/cmd/api/src/model/saved_queries_permissions.go
@@ -26,7 +26,7 @@ type SavedQueriesPermissions struct {
 	ID             int64         `json:"id"`
 	SharedToUserID uuid.NullUUID `json:"shared_to_user_id"`
 	QueryID        int64         `json:"query_id"`
-	Global         bool          `json:"global"`
+	Public         bool          `json:"public"`
 
 	Basic
 }

--- a/cmd/api/src/model/saved_queries_test.go
+++ b/cmd/api/src/model/saved_queries_test.go
@@ -35,9 +35,9 @@ func TestSavedQueries_IsSortable(t *testing.T) {
 func TestSavedQueries_ValidFilters(t *testing.T) {
 	savedQueries := model.SavedQueries{}
 	validFilters := savedQueries.ValidFilters()
-	require.Equal(t, 3, len(validFilters))
+	require.Equal(t, 4, len(validFilters))
 
-	for _, column := range []string{"user_id", "name", "query"} {
+	for _, column := range []string{"user_id", "name", "query", "description"} {
 		operators, ok := validFilters[column]
 		require.True(t, ok)
 		require.Equal(t, 2, len(operators))

--- a/packages/go/openapi/src/schemas/model.saved-query.yaml
+++ b/packages/go/openapi/src/schemas/model.saved-query.yaml
@@ -27,3 +27,5 @@ properties:
     type: string
   query:
     type: string
+  description:
+    type: string


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

These changes add a new description field to the `saved_queries` model, which will allow users the ability to add short descriptions on what their cypher query does.
We are also adding a new model called `saved_queries_permissions` which will contain the relationships between users and the queries they have been shared - globally or directly.

## Motivation and Context

This PR addresses: BED-4535

*Why is this change required? What problem does it solve?*
Initial database implementation required for work on API to begin development. Ultimately will enable the ability to search and share cypher queries directly from the UI.

## How Has This Been Tested?

First I ensured that the UI was still able to save queries while sending up the new description field in the body:

![image](https://github.com/user-attachments/assets/d206ca39-88c6-4427-8746-34800472a2e7)


We can see that the migration successfully ran on startup by having the description field exist, and we can see that the query was correctly saved with the `DEFAULT ''` value.


I then tested the API using Bruno to send a request to `/api/v2/saved-queries`
![image](https://github.com/user-attachments/assets/32fde371-31f7-4137-8f80-f36cae25d8ef)


The query was saved with the description that was sent in the request body.

Since these changes were put in place before the API was made to enable sharing, I used DataGrip to test the `saved_queries_permissions` table

After clearing my postgres volume to ensure best testing results, I was able to create a globally shared cypher:
![image](https://github.com/user-attachments/assets/fc622387-ab01-4be6-8695-0591079280e6)


A cypher to a user:
![image](https://github.com/user-attachments/assets/0f9febd3-8713-4258-a7b5-7e28383cb1ac)


And trying to share a cypher to the same user results in a unique constraint violation:
![image](https://github.com/user-attachments/assets/c4ec9f00-ea5b-4baa-96fa-3254355ab9b4)


## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->
- New feature (non-breaking change which adds functionality)
- Database Migrations

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
