### PR TITLE
BED-4589: Graph loading bar contrast in dark mode

### DIFF
--- a/packages/javascript/bh-shared-ui/src/constants.ts
+++ b/packages/javascript/bh-shared-ui/src/constants.ts
@@ -275,9 +275,9 @@ export const components = (theme: Theme): Partial<Theme['components']> => ({
     MuiLinearProgress: {
         styleOverrides: {
             root: {
-                backgroundColor: theme.palette.secondary.light,
+                backgroundColor: addOpacityToHex(theme.palette.primary.main, 40),
                 '& .MuiLinearProgress-barColorPrimary': {
-                    backgroundColor: theme.palette.primary.dark,
+                    backgroundColor: theme.palette.primary.main,
                 },
             }
         }

--- a/packages/javascript/bh-shared-ui/src/constants.ts
+++ b/packages/javascript/bh-shared-ui/src/constants.ts
@@ -210,9 +210,9 @@ export const components = (theme: Theme): Partial<Theme['components']> => ({
     MuiDialogActions: {
         styleOverrides: {
             root: {
-                padding: theme.spacing(2, 3)
-            }
-        }
+                padding: theme.spacing(2, 3),
+            },
+        },
     },
     MuiPopover: {
         styleOverrides: {
@@ -279,7 +279,7 @@ export const components = (theme: Theme): Partial<Theme['components']> => ({
                 '& .MuiLinearProgress-barColorPrimary': {
                     backgroundColor: theme.palette.primary.main,
                 },
-            }
-        }
-    }
+            },
+        },
+    },
 });


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description
Improves contrast of graph progress bar

## Motivation and Context

This PR addresses: BED-4589

The graph loading bar contrast is low in lightmode

## How Has This Been Tested?
Visual tests
<img width="1382" alt="Screenshot 2024-07-23 at 1 34 13 PM" src="https://github.com/user-attachments/assets/ed97924f-e9ac-4d7c-975e-d7de919bba51">
<img width="1396" alt="Screenshot 2024-07-23 at 1 33 48 PM" src="https://github.com/user-attachments/assets/30a07549-1de0-405c-ba68-cbf89b9b58f8">


## Screenshots (optional):


## Types of changes:

- Chore (a change that does not modify the application functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
