### PR TITLE
BED-4592: Remove unnecessary highlighting from Search Current Nodes

### DIFF
--- a/packages/javascript/bh-shared-ui/src/components/SearchCurrentNodes/SearchCurrentNodes.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/SearchCurrentNodes/SearchCurrentNodes.tsx
@@ -37,35 +37,24 @@ const SearchCurrentNodes: FC<{
     const containerRef = useRef<HTMLDivElement>(null);
     const inputRef = useRef<HTMLInputElement>(null);
 
-    const [flatNodeList, setFlatNodeList] = useState<FlatNode[]>([]);
     const [items, setItems] = useState<FlatNode[]>([]);
     const [selectedNode, setSelectedNode] = useState<FlatNode | null | undefined>(null);
-    const [virtualizationHeight, setVirtualizationHeight] = useState<number>(0);
 
     // Node data is a lot easier to work with in the combobox if we transform to an array of flat objects
-    useEffect(() => {
-        const flatNodeList: FlatNode[] = Object.entries(currentNodes).map(([key, value]) => {
-            return { id: key, ...value };
-        });
-        setFlatNodeList(flatNodeList);
-    }, [currentNodes]);
+    const flatNodeList: FlatNode[] = Object.entries(currentNodes).map(([key, value]) => {
+        return { id: key, ...value };
+    });
 
     useEffect(() => inputRef.current?.focus(), []);
 
-    useEffect(() => {
-        if (selectedNode) onSelect(selectedNode);
-    }, [selectedNode, onSelect]);
+    if (selectedNode) onSelect(selectedNode);
 
     // Since we are using a virtualized results container, we need to calculate the height for shorter
     // lists to avoid whitespace
-    useEffect(() => {
-        const resultsHeight = LIST_ITEM_HEIGHT * items.length;
-        if (resultsHeight > MAX_CONTAINER_HEIGHT) {
-            setVirtualizationHeight(MAX_CONTAINER_HEIGHT - 10);
-        } else {
-            setVirtualizationHeight(resultsHeight);
-        }
-    }, [items]);
+    let virtualizationHeight = LIST_ITEM_HEIGHT * items.length;
+    if (virtualizationHeight > MAX_CONTAINER_HEIGHT) {
+        virtualizationHeight = MAX_CONTAINER_HEIGHT - 10;
+    }
 
     useOnClickOutside(containerRef, () => onClose && onClose());
 
@@ -101,7 +90,6 @@ const SearchCurrentNodes: FC<{
                     item={items[index]}
                     index={index}
                     key={index}
-                    highlightedIndex={0}
                     keyword={inputValue}
                     getItemProps={getItemProps}
                 />


### PR DESCRIPTION
## Description
- Remove a prop passed to the search result component that caused the first result in the list of search results to always appear highlighted
- Removed some unnecessary pieces of state and effects from the component to simplify and avoid rerenders

## Motivation and Context

This PR addresses: [BED-4592]

While reviewing the dark mode changes, we realized the existing highlighting does not really convey any information to the user and could potentially be misleading.

## How Has This Been Tested?
- Manual testing to confirm the highlighting is removed

## Screenshots (optional):
<img width="350" alt="Screenshot 2024-07-24 at 10 07 43 AM" src="https://github.com/user-attachments/assets/be797dc7-8c96-4b74-a377-a00ee5cbcd27">
<img width="350" alt="Screenshot 2024-07-24 at 10 07 56 AM" src="https://github.com/user-attachments/assets/ec711959-4bcc-4e45-be04-3bc71ab68df2">

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


[BED-4592]: https://specterops.atlassian.net/browse/BED-4592?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ