### PR TITLE
fix: filters active button styles

### DIFF
--- a/packages/javascript/bh-shared-ui/src/components/AssetGroupFilters/AssetGroupFilters.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/AssetGroupFilters/AssetGroupFilters.test.tsx
@@ -62,17 +62,17 @@ describe('AssetGroupEdit', () => {
     it('indicates that filters are active', async () => {
         const { screen } = await setup({ filterParams, memberCounts });
 
-        const filtersContainer = screen.getByTestId('asset-group-filters-container');
+        const activeFiltersDot = screen.getByTestId('active-filters-dot');
 
-        expect(filtersContainer.className.includes('activeFilters')).toBeTruthy();
+        expect(activeFiltersDot).toHaveStyle({ visibility: 'visible' });
     });
 
     it('indicates that filters are inactive', async () => {
         const { screen } = await setup();
 
-        const filtersContainer = screen.getByTestId('asset-group-filters-container');
+        const activeFiltersDot = screen.getByTestId('active-filters-dot');
 
-        expect(filtersContainer.className.includes('activeFilters')).toBeFalsy();
+        expect(activeFiltersDot).not.toHaveStyle({ visibility: 'visible' });
     });
 
     describe('Node Type dropdown filter', () => {

--- a/packages/javascript/bh-shared-ui/src/components/AssetGroupFilters/AssetGroupFilters.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/AssetGroupFilters/AssetGroupFilters.tsx
@@ -26,9 +26,10 @@ import {
     MenuItem,
     Paper,
     Select,
+    Typography,
+    useTheme,
 } from '@mui/material';
-import { Theme, useTheme } from '@mui/material/styles';
-import makeStyles from '@mui/styles/makeStyles';
+import clsx from 'clsx';
 import { AssetGroupMemberCounts } from 'js-client-library';
 import { AssetGroupMemberParams } from 'js-client-library/dist/types';
 import { FC, useState } from 'react';
@@ -39,28 +40,6 @@ export const FILTERABLE_PARAMS: Array<keyof Pick<AssetGroupMemberParams, 'primar
     'custom_member',
 ];
 
-const useStyles = makeStyles((theme: Theme) => ({
-    formControl: {
-        display: 'block',
-    },
-    activeFilters: {
-        '& button.expand-filters': {
-            fontWeight: 'bolder',
-            '& span': {
-                visibility: 'visible',
-            },
-        },
-    },
-    activeFiltersDot: {
-        width: '6px',
-        height: '6px',
-        borderRadius: '100%',
-        backgroundColor: theme.palette.primary.main,
-        alignSelf: 'baseline',
-        visibility: 'hidden',
-    },
-}));
-
 interface Props {
     filterParams: AssetGroupMemberParams;
     handleFilterChange: (key: (typeof FILTERABLE_PARAMS)[number], value: string) => void;
@@ -69,9 +48,7 @@ interface Props {
 
 const AssetGroupFilters: FC<Props> = ({ filterParams, handleFilterChange, memberCounts = { counts: {} } }) => {
     const [displayFilters, setDisplayFilters] = useState(false);
-
     const theme = useTheme();
-    const classes = useStyles();
 
     const handleClearFilters = () => {
         for (const filter of FILTERABLE_PARAMS) {
@@ -80,28 +57,38 @@ const AssetGroupFilters: FC<Props> = ({ filterParams, handleFilterChange, member
     };
 
     const active = !!filterParams.primary_kind || !!filterParams.custom_member;
-    const activeStyles = active ? classes.activeFilters : '';
 
     return (
         <Box
             p={1}
-            className={activeStyles}
-            bgcolor={theme.palette.neutral.secondary}
             component={Paper}
+            bgcolor={theme.palette.neutral.secondary}
             elevation={0}
             marginBottom={1}
             data-testid='asset-group-filters-container'>
             <Button
                 onClick={() => setDisplayFilters((prev) => !prev)}
                 data-testid='display-filters-button'
-                style={{ width: '100%', marginBottom: '12px' }}>
+                className={clsx('w-full', active && 'font-bold')}>
                 FILTERS
-                <span className={classes.activeFiltersDot} />
+                <Typography
+                    component={'span'}
+                    data-testid={'active-filters-dot'}
+                    style={active ? { visibility: 'visible' } : {}}
+                    sx={{
+                        width: '6px',
+                        height: '6px',
+                        borderRadius: '100%',
+                        backgroundColor: 'white',
+                        alignSelf: 'baseline',
+                        visibility: 'hidden',
+                    }}
+                />
             </Button>
-            <Collapse in={displayFilters} data-testid='asset-group-filter-collapsible-section'>
+            <Collapse in={displayFilters} data-testid='asset-group-filter-collapsible-section' sx={{ mt: '12px' }}>
                 <Grid container spacing={2}>
                     <Grid item xs={12}>
-                        <FormControl className={classes.formControl}>
+                        <FormControl sx={{ display: 'block' }}>
                             <InputLabel id='nodeTypeFilter-label'>Node Type</InputLabel>
                             <Select
                                 id='nodeType'


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description
This will return the active styles to the FILTERS button in the group management page.

## Motivation and Context

This PR addresses: BED-4606
There was a regression in the active styles applied.

## How Has This Been Tested?
Unit test was updated.

## Screenshots (optional):

![image](https://github.com/user-attachments/assets/1b034a3d-fd3c-421e-a49e-bc52c1be8224)

![image](https://github.com/user-attachments/assets/8b37e6d5-6048-473c-b7e0-3ad8191a016f)

![image](https://github.com/user-attachments/assets/4a634d51-32f7-47f6-b227-4359b1a73600)


## Types of changes

<!-- Please remove any items that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
