### PR TITLE
BED-4591: api-explorer filter input styles

### DIFF
--- a/cmd/ui/src/App.tsx
+++ b/cmd/ui/src/App.tsx
@@ -74,6 +74,17 @@ const Inner: React.FC = () => {
                         `]: {
                         color: theme.palette.color.primary,
                     },
+                    '& .filter-container .operation-filter-input': {
+                        backgroundColor: 'inherit',
+                        border: `1px solid ${theme.palette.grey[700]}`,
+
+                        '&:hover': {
+                            borderColor: theme.palette.color.links,
+                        },
+                        '&:focus': {
+                            outline: `1px solid ${theme.palette.color.links}`,
+                        },
+                    },
                     '& .responses-inner': {
                         [`& h4, & h5`]: {
                             color: theme.palette.color.primary,


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description
Updates api-explorer filter input styles to match other inputs

## Motivation and Context

This PR addresses: BED-4591

Api explorer filter input did not respect dark mode.

## How Has This Been Tested?
visual tests

## Screenshots (optional):

![Screenshot 2024-07-24 at 9 05 47 AM](https://github.com/user-attachments/assets/b07564ee-0b97-4b1e-9230-c6c24a8fcccd)
![Screenshot 2024-07-24 at 9 01 22 AM](https://github.com/user-attachments/assets/a43ce1a4-a41f-4c29-81b1-686ce0b40b7a)
![Screenshot 2024-07-24 at 9 01 15 AM](https://github.com/user-attachments/assets/7791f196-7203-4808-9e32-0240c050014e)

## Types of changes

<!-- Please remove any items that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
