### PR TITLE
BED-4627: global scrollbar styles

### DIFF
--- a/cmd/ui/src/styles/general.scss
+++ b/cmd/ui/src/styles/general.scss
@@ -69,11 +69,6 @@ form {
     /* Non-prefixed version, currently supported by Chrome, Edge, Opera and Firefox */
 }
 
-* {
-    scrollbar-width: thin;
-    scrollbar-color: $lighter-blue #aaa;
-}
-
 svg {
     display: block;
 }
@@ -86,18 +81,4 @@ hr.MuiDivider-middle {
     border-top: thin solid #a9a9a9;
     background: none;
     margin: 0 14px 0 14px;
-}
-
-::-webkit-scrollbar {
-    width: 7px;
-    height: 7px;
-}
-
-::-webkit-scrollbar-track {
-    background: #aaa;
-    box-shadow: inset 0 0 2px #444;
-}
-
-::-webkit-scrollbar-thumb {
-    background: $lighter-blue;
 }

--- a/packages/javascript/bh-shared-ui/src/views/Explore/InfoStyles/Pane.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/Explore/InfoStyles/Pane.tsx
@@ -38,7 +38,6 @@ const usePaneStyles = makeStyles((theme: Theme) => ({
         '& > div.node:nth-child(odd)': {
             background: theme.palette.neutral.tertiary,
         },
-        scrollbarGutter: 'stable',
     },
     breadcrumbs: {
         margin: '6px 10px 6px 10px',


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description
Remove global scroll bar styles and scrollbar gutter

## Motivation and Context

This PR addresses: BED-4627

After reviewing the styles and some conversation in the dark mode channel, we have agreed on removing custom scrollbar styles. Overriding these styles can be inconsistent across different browsers.

## How Has This Been Tested?
visual tests

## Screenshots (optional):
https://github.com/user-attachments/assets/c401f138-6ae9-43ce-97b1-665d4677cbdf

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
