### PR TITLE
BED 4628:  Error alert text contrast

### DIFF
--- a/packages/javascript/bh-shared-ui/src/constants.ts
+++ b/packages/javascript/bh-shared-ui/src/constants.ts
@@ -259,7 +259,7 @@ export const components = (theme: Theme): Partial<Theme['components']> => ({
     MuiAlert: {
         styleOverrides: {
             root: {
-                '&.MuiAlert-standardWarning, &.MuiAlert-standardInfo': {
+                '&.MuiAlert-standardWarning': {
                     backgroundColor: addOpacityToHex(theme.palette.warning.main, 20),
                 },
                 '&.MuiAlert-standardInfo': {

--- a/packages/javascript/bh-shared-ui/src/constants.ts
+++ b/packages/javascript/bh-shared-ui/src/constants.ts
@@ -259,14 +259,13 @@ export const components = (theme: Theme): Partial<Theme['components']> => ({
     MuiAlert: {
         styleOverrides: {
             root: {
-                '&.MuiAlert-standardWarning': {
+                '&.MuiAlert-standardWarning, &.MuiAlert-standardInfo': {
                     backgroundColor: addOpacityToHex(theme.palette.warning.main, 20),
                 },
                 '&.MuiAlert-standardInfo': {
                     backgroundColor: addOpacityToHex(theme.palette.info.main, 20),
                 },
                 '&.MuiAlert-standardError': {
-                    color: theme.palette.error.contrastText,
                     backgroundColor: addOpacityToHex(theme.palette.error.main, 20),
                 },
             },


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Fix text contrast for MUI error alert in light mode

## Motivation and Context

This PR addresses: BED-4628

The contrast between the text and background color of error alerts was too low in light mode.

## How Has This Been Tested?

## Screenshots (optional):

Uploading Screen Recording 2024-07-24 at 3.28.43 PM.mov…


## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)
- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
