### PR TITLE
BED-4479 - ensure update key uniqueness by removing sort

### DIFF
--- a/packages/go/dawgs/drivers/neo4j/cypher.go
+++ b/packages/go/dawgs/drivers/neo4j/cypher.go
@@ -27,7 +27,7 @@ import (
 	"github.com/specterops/bloodhound/log"
 )
 
-func updateKey(identityKind graph.Kind, identityProperties []string, updateKinds graph.Kinds) string {
+func newUpdateKey(identityKind graph.Kind, identityProperties []string, updateKinds graph.Kinds) string {
 	keys := []string{
 		identityKind.String(),
 	}
@@ -42,12 +42,10 @@ func updateKey(identityKind graph.Kind, identityProperties []string, updateKinds
 
 func relUpdateKey(update graph.RelationshipUpdate) string {
 	keys := []string{
-		updateKey(update.Relationship.Kind, update.IdentityProperties, nil),
-		updateKey(update.StartIdentityKind, update.StartIdentityProperties, update.Start.Kinds),
-		updateKey(update.EndIdentityKind, update.EndIdentityProperties, update.End.Kinds),
+		newUpdateKey(update.StartIdentityKind, update.StartIdentityProperties, update.Start.Kinds),
+		newUpdateKey(update.Relationship.Kind, update.IdentityProperties, nil),
+		newUpdateKey(update.EndIdentityKind, update.EndIdentityProperties, update.End.Kinds),
 	}
-
-	sort.Strings(keys)
 
 	return strings.Join(keys, "")
 }
@@ -213,7 +211,7 @@ type nodeUpdates struct {
 type nodeUpdateByMap map[string]*nodeUpdates
 
 func (s nodeUpdateByMap) add(update graph.NodeUpdate) {
-	updateKey := updateKey(update.IdentityKind, update.IdentityProperties, update.Node.Kinds)
+	updateKey := newUpdateKey(update.IdentityKind, update.IdentityProperties, update.Node.Kinds)
 
 	if updates, hasUpdates := s[updateKey]; hasUpdates {
 		updates.properties = append(updates.properties, update.Node.Properties.Map)

--- a/packages/go/dawgs/drivers/neo4j/cypher_internal_test.go
+++ b/packages/go/dawgs/drivers/neo4j/cypher_internal_test.go
@@ -17,11 +17,80 @@
 package neo4j
 
 import (
+	"github.com/specterops/bloodhound/dawgs/graph"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
+
+func Test_relUpdateKey(t *testing.T) {
+	updateKey := relUpdateKey(graph.RelationshipUpdate{
+		Relationship: &graph.Relationship{
+			ID:         1,
+			StartID:    1,
+			EndID:      2,
+			Kind:       graph.StringKind("MemberOf"),
+			Properties: graph.NewProperties(),
+		},
+		Start: &graph.Node{
+			ID:    1,
+			Kinds: graph.Kinds{graph.StringKind("User")},
+			Properties: graph.AsProperties(map[string]any{
+				"objectid": "OID-1",
+			}),
+		},
+		StartIdentityKind:       graph.StringKind("Base"),
+		StartIdentityProperties: []string{"objectid"},
+		End: &graph.Node{
+			ID:    2,
+			Kinds: graph.Kinds{graph.StringKind("Group")},
+			Properties: graph.AsProperties(map[string]any{
+				"objectid": "OID-2",
+			}),
+		},
+		EndIdentityKind:       graph.StringKind("Base"),
+		EndIdentityProperties: []string{"objectid"},
+	})
+
+	// Order must be preserved to make each key unique. This is required as the batch insert is authored as an unwound
+	// merge statement. The update key groups like updates so that the generated query can address an entire batch of
+	// upsert entries at-once:
+	//
+	// unwind $p as p merge (s:Base {objectid: p.s.objectid}) merge (e:Base {objectid: p.e.objectid}) merge (s)-[r:MemberOf]->(e) set s += p.s, e += p.e, r += p.r, s:User, e:Group
+	require.Equal(t, "BaseUserobjectidMemberOfBaseGroupobjectid", updateKey)
+
+	updateKey = relUpdateKey(graph.RelationshipUpdate{
+		Relationship: &graph.Relationship{
+			ID:         1,
+			StartID:    1,
+			EndID:      2,
+			Kind:       graph.StringKind("GenericAll"),
+			Properties: graph.NewProperties(),
+		},
+		Start: &graph.Node{
+			ID:    1,
+			Kinds: graph.Kinds{graph.StringKind("User")},
+			Properties: graph.AsProperties(map[string]any{
+				"objectid": "OID-1",
+			}),
+		},
+		StartIdentityKind:       graph.StringKind("Base"),
+		StartIdentityProperties: []string{"objectid"},
+		End: &graph.Node{
+			ID:    2,
+			Kinds: graph.Kinds{graph.StringKind("Group")},
+			Properties: graph.AsProperties(map[string]any{
+				"objectid": "OID-2",
+			}),
+		},
+		EndIdentityKind:       graph.StringKind("Base"),
+		EndIdentityProperties: []string{"objectid"},
+	})
+
+	// unwind $p as p merge (s:Base {objectid: p.s.objectid}) merge (e:Base {objectid: p.e.objectid}) merge (s)-[r:GenericAll]->(e) set s += p.s, e += p.e, r += p.r, s:User, e:Group
+	require.Equal(t, "BaseUserobjectidGenericAllBaseGroupobjectid", updateKey)
+}
 
 func Test_StripCypher(t *testing.T) {
 	var (


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Batch updates are bucketed by a unique key that matches the generated openCypher query statement. This sort appears to damage the uniqueness of these buckets, resulting in mismatched kinds being applied to nodes during upsert.

This would manifest as nodes having more than one valid kind such as: `match (n) where n:Base and n:Group and n:User return n`

## Motivation and Context

This damages the validity of data stored in the graph as nodes are being incorrectly labeled.

## How Has This Been Tested?

Integration tests pass. Added an additional unit test with some explanation for the assertions.

## Types of changes

<!-- Please remove any items that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)
- Database Migrations

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
