### PR TITLE
fix: theme graph label colors

### DIFF
--- a/cmd/ui/src/rendering/programs/edge-label.ts
+++ b/cmd/ui/src/rendering/programs/edge-label.ts
@@ -24,11 +24,7 @@
 import { Settings } from 'sigma/settings';
 import { Coordinates, NodeDisplayData, PartialButFor } from 'sigma/types';
 import { bezier } from 'src/rendering/utils/bezier';
-import {
-    HIGHLIGHTED_LABEL_BACKGROUND_COLOR,
-    HIGHLIGHTED_LABEL_FONT_COLOR,
-    calculateLabelOpacity,
-} from 'src/rendering/utils/utils';
+import { calculateLabelOpacity } from 'src/rendering/utils/utils';
 import { getEdgeLabelTextLength, calculateEdgeDistanceForLabel, EdgeDistanceProperties } from 'src/ducks/graph/utils';
 import { Attributes } from 'graphology-types';
 import { getControlPointsFromGroupSize } from './edge.self';
@@ -48,7 +44,7 @@ const drawBackground = (
 ) => {
     const inverseSqrtZoomRatio = edgeData.inverseSqrtZoomRatio || 1;
     if (edgeData.selected) {
-        context.fillStyle = HIGHLIGHTED_LABEL_BACKGROUND_COLOR;
+        context.fillStyle = edgeData.highlightedBackground;
         context.globalAlpha = fadeAlphaFromZoom;
     } else {
         context.fillStyle = edgeData.backgroundColor;
@@ -91,7 +87,7 @@ const drawText = (
 
     // Text should always be completely opaque, before factoring in fade from zoom level
     context.globalAlpha = fadeAlphaFromZoom;
-    context.fillStyle = edgeData.selected ? HIGHLIGHTED_LABEL_FONT_COLOR : edgeData.color;
+    context.fillStyle = edgeData.selected ? edgeData.highlightedText : edgeData.labelColor;
 
     context.fillText(label, -textLength / 2, (edgeData.size / 2) * (edgeData.inverseSqrtZoomRatio || 1));
 };

--- a/cmd/ui/src/rendering/programs/node-hover.ts
+++ b/cmd/ui/src/rendering/programs/node-hover.ts
@@ -17,12 +17,7 @@
 import { Settings } from 'sigma/settings';
 import { NodeDisplayData, PartialButFor } from 'sigma/types';
 import drawLabel from 'src/rendering/programs/node-label';
-import {
-    HIGHLIGHTED_LABEL_BACKGROUND_COLOR,
-    HIGHLIGHTED_LABEL_FONT_COLOR,
-    calculateLabelOpacity,
-    getNodeRadius,
-} from 'src/rendering/utils/utils';
+import { calculateLabelOpacity, getNodeRadius } from 'src/rendering/utils/utils';
 
 export default function drawHover(
     context: CanvasRenderingContext2D,
@@ -36,7 +31,7 @@ export default function drawHover(
     const size = settings.labelSize * inverseSqrtZoomRatio;
 
     context.font = `${weight} ${size}px ${font}`;
-    context.fillStyle = HIGHLIGHTED_LABEL_BACKGROUND_COLOR;
+    context.fillStyle = data.highlightedBackground;
 
     const PADDING = 2;
     const radius = getNodeRadius(true, inverseSqrtZoomRatio, data.size);
@@ -75,7 +70,7 @@ export default function drawHover(
 
     // toggle the default text color before/after this drawLabel call so that the color is only
     // changed for hovered nodes
-    settings.labelColor.color = HIGHLIGHTED_LABEL_FONT_COLOR;
+    settings.labelColor.color = data.highlightedText;
     drawLabel(context, data, settings);
-    settings.labelColor.color = '#000';
+    settings.labelColor.color = data.labelColor;
 }

--- a/cmd/ui/src/rendering/programs/node-label.ts
+++ b/cmd/ui/src/rendering/programs/node-label.ts
@@ -17,14 +17,13 @@
 import { Settings } from 'sigma/settings';
 import { NodeDisplayData, PartialButFor } from 'sigma/types';
 import { calculateLabelOpacity } from '../utils/utils';
-import { HIGHLIGHTED_LABEL_FONT_COLOR } from '../utils/utils';
 
 export default function drawLabel(
     context: CanvasRenderingContext2D,
     data: PartialButFor<NodeDisplayData & { inverseSqrtZoomRatio: number }, 'x' | 'y' | 'size' | 'label' | 'color'>,
     settings: Settings
 ): void {
-    if (!data.label) return;
+    if (!data.label || !settings.labelColor.color) return;
     const inverseSqrtZoomRatio = data.inverseSqrtZoomRatio || 1;
 
     const size = settings.labelSize * inverseSqrtZoomRatio,
@@ -33,7 +32,7 @@ export default function drawLabel(
 
     context.globalAlpha = calculateLabelOpacity(inverseSqrtZoomRatio);
 
-    context.fillStyle = data.highlighted ? HIGHLIGHTED_LABEL_FONT_COLOR : data.labelColor;
+    context.fillStyle = settings.labelColor.color;
     context.font = `${weight} ${size}px ${font}`;
 
     context.fillText(

--- a/cmd/ui/src/rendering/utils/utils.ts
+++ b/cmd/ui/src/rendering/utils/utils.ts
@@ -14,9 +14,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-export const HIGHLIGHTED_LABEL_BACKGROUND_COLOR = '#FF6D66';
-export const HIGHLIGHTED_LABEL_FONT_COLOR = '#FFF';
-
 export const STARTING_ZOOM_FADE_RATIO = 0.5;
 export const ENDING_ZOOM_FADE_RATIO = 0.3;
 

--- a/cmd/ui/src/utils.ts
+++ b/cmd/ui/src/utils.ts
@@ -14,7 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { apiClient } from 'bh-shared-ui';
+import { GlyphIconInfo, apiClient } from 'bh-shared-ui';
 import { FlatGraphResponse, GraphData, GraphResponse, StyledGraphEdge, StyledGraphNode } from 'js-client-library';
 import identity from 'lodash/identity';
 import throttle from 'lodash/throttle';
@@ -92,20 +92,40 @@ export const initializeBHEClient = () => {
     );
 };
 
+type ThemedLabels = {
+    labelColor: string;
+    backgroundColor: string;
+    highlightedBackground: string;
+    highlightedText: string;
+};
+
+type ThemedGlyph = {
+    colors: {
+        backgroundColor: string;
+        color: string;
+    };
+    tierZeroGlyph: GlyphIconInfo;
+};
+
+export type ThemedOptions = {
+    labels: ThemedLabels;
+    nodeBorderColor: string;
+    glyph: ThemedGlyph;
+};
+
 export type NodeParams = {
     x: number;
     y: number;
     size?: number;
     color?: string;
     borderColor?: string;
-    labelColor: string;
     type?: string;
     highlighted?: boolean;
     image?: string;
     label?: string;
     glyphs?: Glyph[];
     forceLabel?: boolean;
-};
+} & ThemedLabels;
 
 export interface Index<T> {
     [id: string]: T;
@@ -122,8 +142,6 @@ export type EdgeParams = {
     size: number;
     type: string;
     label: string;
-    color: string;
-    backgroundColor: string;
     exploreGraphId: string;
     groupPosition?: number;
     groupSize?: number;
@@ -131,7 +149,7 @@ export type EdgeParams = {
     control?: Coordinates;
     controlInViewport?: Coordinates;
     forceLabel?: boolean;
-};
+} & ThemedLabels;
 
 const getLastSeenValue = (object: any): string => {
     if (object.lastSeen) return object.lastSeen;

--- a/cmd/ui/src/views/Explore/GraphView.tsx
+++ b/cmd/ui/src/views/Explore/GraphView.tsx
@@ -20,11 +20,11 @@ import {
     GraphButtonProps,
     GraphProgress,
     NoDataAlert,
+    WebGLDisabledAlert,
+    isWebGLEnabled,
     setEdgeInfoOpen,
     setSelectedEdge,
     useAvailableDomains,
-    isWebGLEnabled,
-    WebGLDisabledAlert,
 } from 'bh-shared-ui';
 import { MultiDirectedGraph } from 'graphology';
 import { random } from 'graphology-layout';
@@ -51,7 +51,7 @@ import EdgeInfoPane from 'src/views/Explore/EdgeInfo/EdgeInfoPane';
 import EntityInfoPanel from 'src/views/Explore/EntityInfo/EntityInfoPanel';
 import ExploreSearch from 'src/views/Explore/ExploreSearch';
 import usePrompt from 'src/views/Explore/NavigationAlert';
-import { initGraphEdges, initGraphNodes } from 'src/views/Explore/utils';
+import { initGraph } from 'src/views/Explore/utils';
 import ContextMenu from './ContextMenu/ContextMenu';
 
 const GraphView: FC = () => {
@@ -79,10 +79,8 @@ const GraphView: FC = () => {
         if (isEmpty(items) || isEmpty(items.nodes)) items = transformFlatGraphResponse(items);
 
         const graph = new MultiDirectedGraph();
-        const nodeSize = 25;
 
-        initGraphNodes(graph, items.nodes, nodeSize, theme, darkMode);
-        initGraphEdges(graph, items.edges, theme);
+        initGraph(graph, items, theme, darkMode);
 
         setCurrentNodes(items.nodes);
 

--- a/packages/javascript/bh-shared-ui/src/utils/icons.ts
+++ b/packages/javascript/bh-shared-ui/src/utils/icons.ts
@@ -59,8 +59,10 @@ export type IconDictionary = {
     [index: string]: IconInfo;
 };
 
+export type GlyphIconInfo = IconInfo & { iconColor: string };
+
 export type GlyphDictionary = {
-    [index: string]: IconInfo & { iconColor: string };
+    [index: string]: GlyphIconInfo;
 };
 
 export enum GlyphKind {


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description
Updates the graph label colors to better reflect the theme

## Motivation and Context

This PR addresses: BED-4596

Fixes hovered/selected styles contrast ratio non conformance
Labels fit theme colors better

## How Has This Been Tested?
See screenshots section

## Screenshots (optional):

![Screenshot 2024-07-24 at 5 54 00 PM](https://github.com/user-attachments/assets/9c078cab-67a3-4424-b004-a94b649cf839)
![Screenshot 2024-07-24 at 5 54 38 PM](https://github.com/user-attachments/assets/ad96707b-a63b-4383-af54-143315543288)



## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)
- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
