### PR TITLE
chore: BED-4580 - add audit log failures to delete auth token

### DIFF
--- a/cmd/api/src/api/v2/apiclient/auth.go
+++ b/cmd/api/src/api/v2/apiclient/auth.go
@@ -480,7 +480,7 @@ func (s Client) CreateUserToken(userID uuid.UUID, tokenName string) (model.AuthT
 	}
 }
 
-func (s Client) DeleteUserToken(userID, tokenID uuid.UUID) error {
+func (s Client) DeleteUserToken(tokenID uuid.UUID) error {
 	if response, err := s.Request(http.MethodDelete, fmt.Sprintf("api/v2/tokens/%s", tokenID.String()), nil, nil); err != nil {
 		return err
 	} else {

--- a/cmd/api/src/api/v2/auth_integration_test.go
+++ b/cmd/api/src/api/v2/auth_integration_test.go
@@ -27,6 +27,8 @@ import (
 	"github.com/specterops/bloodhound/src/api"
 	"github.com/specterops/bloodhound/src/api/v2/integration"
 	"github.com/specterops/bloodhound/src/auth"
+	"github.com/specterops/bloodhound/src/model"
+	"github.com/specterops/bloodhound/src/utils/test"
 	"github.com/stretchr/testify/require"
 )
 
@@ -194,7 +196,7 @@ func Test_NonAdminFunctionality(t *testing.T) {
 			t.Fail()
 		}
 
-		err = nonAdminClient.DeleteUserToken(nonAdminUser.ID, tokenToDelete.ID)
+		err = nonAdminClient.DeleteUserToken(tokenToDelete.ID)
 		require.Nilf(t, err, "Received unexpected error when deleting token: %s", err)
 
 		// Ensure the token gets cleaned up if there was an error above
@@ -207,8 +209,18 @@ func Test_NonAdminFunctionality(t *testing.T) {
 	t.Run("Deleting tokens for other user as nonadmin should fail", func(t *testing.T) {
 		tokenToDelete := testCtx.CreateAuthToken(newUser.ID, "newUser token to delete")
 
-		err := nonAdminClient.DeleteUserToken(newUser.ID, tokenToDelete.ID)
-		require.Equalf(t, errors.Error("API returned a 404 error"), err, "Expected to receive a 404 error when attempting to delete a token, got: %s", err)
+		err := nonAdminClient.DeleteUserToken(tokenToDelete.ID)
+		errWrapper := api.ErrorWrapper{}
+		if errors.As(err, &errWrapper) {
+			require.Equal(t, errWrapper.HTTPStatus, http.StatusForbidden)
+		} else {
+			t.Logf("Encountered unknown error deleting auth token: %s", err)
+			t.Fail()
+		}
+
+		err = test.AssertAuditLogs(testCtx.GetLatestAuditLogs(), model.AuditLogActionDeleteAuthToken, model.AuditLogStatusFailure, model.AuditData{
+			"target_user_id": newUser.ID.String(), "id": tokenToDelete.ID.String()})
+		require.Nil(t, err)
 
 		// Use the admin session to cleanup the newly created token
 		testCtx.DeleteAuthToken(newUser.ID, tokenToDelete.ID)

--- a/cmd/api/src/api/v2/integration/auth.go
+++ b/cmd/api/src/api/v2/integration/auth.go
@@ -37,7 +37,7 @@ func (s *Context) ListUserTokens(userID uuid.UUID) model.AuthTokens {
 }
 
 func (s *Context) DeleteAuthToken(userID, tokenID uuid.UUID) {
-	err := s.AdminClient().DeleteUserToken(userID, tokenID)
+	err := s.AdminClient().DeleteUserToken(tokenID)
 	require.Nilf(s.TestCtrl, err, "Failed to delete auth token %s for user %s: %v", tokenID.String(), userID.String(), err)
 }
 

--- a/cmd/api/src/database/auth.go
+++ b/cmd/api/src/database/auth.go
@@ -410,14 +410,7 @@ func (s *BloodhoundDB) GetUserToken(ctx context.Context, userId, tokenId uuid.UU
 // DeleteAuthToken deletes the provided AuthToken row
 // DELETE FROM auth_tokens WHERE id = ...
 func (s *BloodhoundDB) DeleteAuthToken(ctx context.Context, authToken model.AuthToken) error {
-	auditEntry := model.AuditEntry{
-		Action: model.AuditLogActionDeleteAuthToken,
-		Model:  &authToken,
-	}
-
-	return s.AuditableTransaction(ctx, auditEntry, func(tx *gorm.DB) error {
-		return CheckError(tx.WithContext(ctx).Where("id = ?", authToken.ID).Delete(&authToken))
-	})
+	return CheckError(s.db.WithContext(ctx).Where("id = ?", authToken.ID).Delete(&authToken))
 }
 
 // CreateAuthSecret creates a new AuthSecret row

--- a/cmd/api/src/database/auth_test.go
+++ b/cmd/api/src/database/auth_test.go
@@ -239,8 +239,6 @@ func TestDatabase_CreateGetDeleteAuthToken(t *testing.T) {
 		t.Fatalf("Expected auth token to have name %s but saw %v", expectedName, newToken.Name.String)
 	} else if err = dbInst.DeleteAuthToken(ctx, newToken); err != nil {
 		t.Fatalf("Failed to delete auth token: %v", err)
-	} else if err = test.VerifyAuditLogs(dbInst, model.AuditLogActionDeleteAuthToken, "id", newToken.ID.String()); err != nil {
-		t.Fatalf("Failed to validate DeleteAuthToken audit logs:\n%v", err)
 	}
 
 	if updatedUser, err := dbInst.GetUser(ctx, user.ID); err != nil {


### PR DESCRIPTION
## Description
Closes BED-4580

Added `target_user_id` to DeleteAuthToken audit log
Updated unauthorized response to 403 (from 404)
Added additional failure cases to audit log such as the unauthorized case

## Motivation and Context

This PR addresses: BED-4580

## How Has This Been Tested?

Updated tests
The audit log logic was elevated to the handler so the db related test had to be updated to remove audit log checks.

## Types of change

- Chore (a change that does not modify the application functionality)

## Checklist:

- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
