### PR TITLE
BED-4639:  Update Copy menu palette for dark mode

### DIFF
--- a/cmd/ui/src/views/Explore/ContextMenu/CopyMenuItem.tsx
+++ b/cmd/ui/src/views/Explore/ContextMenu/CopyMenuItem.tsx
@@ -24,8 +24,8 @@ const StyledTooltip = styled(({ className, ...props }: TooltipProps) => (
     <Tooltip {...props} classes={{ popper: className }} />
 ))(({ theme }) => ({
     [`& .${tooltipClasses.tooltip}`]: {
-        color: 'black',
-        backgroundColor: theme.palette.common.white,
+        color: theme.palette.text.primary,
+        backgroundColor: theme.palette.background.paper,
         padding: 0,
         paddingTop: '0.5rem',
         paddingBottom: '0.5rem',


### PR DESCRIPTION
## Description
This change updates the styles for the submenu under "Copy" in the right click context menu on the Explore page to display correctly with dark mode.

## Motivation and Context

This PR addresses: [BED-4639]

This particular component was missed during the initial dark mode implementation.

## How Has This Been Tested?
Visual confirmation that this menu matches the parent context menu in both dark and light mode

## Screenshots (optional):
<img width="350" alt="Screenshot 2024-07-30 at 10 10 45 AM" src="https://github.com/user-attachments/assets/a1dd4cde-53d1-4c24-af16-7f9b04021364">
<img width="350" alt="Screenshot 2024-07-30 at 10 11 12 AM" src="https://github.com/user-attachments/assets/3b10d4d6-900c-4892-8ad4-4733cf2733f4">

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


[BED-4639]: https://specterops.atlassian.net/browse/BED-4639?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ