### PR TITLE
Bed 4638:  table root remove bgimage

### DIFF
--- a/packages/javascript/bh-shared-ui/src/constants.ts
+++ b/packages/javascript/bh-shared-ui/src/constants.ts
@@ -281,4 +281,18 @@ export const components = (theme: Theme): Partial<Theme['components']> => ({
             },
         },
     },
+    MuiTableContainer: {
+        styleOverrides: {
+            root: {
+                backgroundImage: 'unset'
+            }
+        }
+    },
+    MuiPaper: {
+        styleOverrides: {
+            root: {
+                backgroundImage: 'unset'
+            }
+        }
+    }
 });


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description
Removes default background image from Table and Paper MUI components

## Motivation and Context

This PR addresses: BED-4638

There are a number of container background colors that were not matching our color elevations because there was a background image also being applied to them.

## How Has This Been Tested?
visual tests

## Screenshots (optional):
Before: 
![Screenshot 2024-07-30 at 10 22 13 AM](https://github.com/user-attachments/assets/83f1128e-a5a7-4d03-aa3f-55bc71dab7cc)

After:
![Screenshot 2024-07-30 at 10 22 08 AM](https://github.com/user-attachments/assets/e55be43c-ce77-4236-9d26-d9eceb693380)

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)
- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
