### PR TITLE
BED-4645: Update support link to point directly to docs

### DIFF
--- a/cmd/ui/src/components/SettingsMenu.tsx
+++ b/cmd/ui/src/components/SettingsMenu.tsx
@@ -126,7 +126,7 @@ const SettingsMenu: React.FC<Props> = ({ anchorEl, handleClose }) => {
                 <MenuItem
                     onClick={() => handleClose()}
                     component='a'
-                    href='https://support.bloodhoundenterprise.io'
+                    href='https://support.bloodhoundenterprise.io/hc'
                     target='_blank'
                     rel='noreferrer'
                     data-testid='global_header_settings-menu_nav-support'>


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Updates the support link to point directly to the help center.

## Motivation and Context

This PR addresses: BED-4645

When TAMs or SEs demonstrate browsing to the documentation to customers, there is a risk that they get redirected to the authenticated ticket view, exposing customer information. This change points the link directly to the help center to avoid that redirect.

## How Has This Been Tested?

Validated locally

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [X] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [X] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [X] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
