### PR TITLE
BED-4641 - Create Ingest Defect Graph Migration

### DIFF
--- a/packages/go/dawgs/drivers/neo4j/cypher.go
+++ b/packages/go/dawgs/drivers/neo4j/cypher.go
@@ -207,6 +207,7 @@ type nodeUpdates struct {
 	identityKind       graph.Kind
 	identityProperties []string
 	nodeKindsToAdd     graph.Kinds
+	nodeKindsToRemove  graph.Kinds
 	properties         []map[string]any
 }
 
@@ -222,6 +223,7 @@ func (s nodeUpdateByMap) add(update graph.NodeUpdate) {
 			identityKind:       update.IdentityKind,
 			identityProperties: update.IdentityProperties,
 			nodeKindsToAdd:     update.Node.Kinds,
+			nodeKindsToRemove:  update.Node.DeletedKinds,
 			properties: []map[string]any{
 				update.Node.Properties.Map,
 			},
@@ -271,6 +273,19 @@ func cypherBuildNodeUpdateQueryBatch(updates []graph.NodeUpdate) ([]string, []ma
 			for _, kindToAdd := range batch.nodeKindsToAdd {
 				output.WriteString(", n:")
 				output.WriteString(kindToAdd.String())
+			}
+		}
+
+		if len(batch.nodeKindsToRemove) > 0 {
+			output.WriteString(" remove ")
+
+			for idx, kindToRemove := range batch.nodeKindsToRemove {
+				if idx > 0 {
+					output.WriteString(",")
+				}
+
+				output.WriteString("n:")
+				output.WriteString(kindToRemove.String())
 			}
 		}
 

--- a/packages/go/dawgs/ops/ops.go
+++ b/packages/go/dawgs/ops/ops.go
@@ -18,9 +18,11 @@ package ops
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"github.com/specterops/bloodhound/dawgs/util/channels"
+	"sync"
 
-	"github.com/RoaringBitmap/roaring/roaring64"
 	"github.com/specterops/bloodhound/dawgs/cardinality"
 	"github.com/specterops/bloodhound/dawgs/graph"
 	"github.com/specterops/bloodhound/dawgs/query"
@@ -406,14 +408,136 @@ func FetchRelationshipNodes(tx graph.Transaction, relationship *graph.Relationsh
 	}
 }
 
-func NodeQueryToIDBitmap(query graph.NodeQuery) (*roaring64.Bitmap, error) {
-	bitmap := roaring64.NewBitmap()
+// FetchLargestNodeID will fetch the current node database identifier ceiling.
+func FetchLargestNodeID(ctx context.Context, db graph.Database) (graph.ID, error) {
+	var (
+		largestNodeID graph.ID
 
-	return bitmap, query.FetchIDs(func(cursor graph.Cursor[graph.ID]) error {
-		for nextID := range cursor.Chan() {
-			bitmap.Add(nextID.Uint64())
+		err = db.ReadTransaction(ctx, func(tx graph.Transaction) error {
+			if node, err := tx.Nodes().OrderBy(query.Order(query.NodeID(), query.Descending())).Limit(1).First(); err != nil {
+				return err
+			} else {
+				largestNodeID = node.ID
+			}
+
+			return nil
+		})
+	)
+
+	return largestNodeID, err
+}
+
+func parallelFetchNodes(ctx context.Context, db graph.Database, maxID graph.ID, criteria graph.Criteria, numWorkers int) (graph.NodeSet, error) {
+	const stride = 20_000
+
+	var (
+		rangeC   = make(chan graph.ID)
+		nodeC    = make(chan *graph.Node)
+		errorC   = make(chan error)
+		nodes    = graph.NodeSet{}
+		workerWG = &sync.WaitGroup{}
+		mergeWG  = &sync.WaitGroup{}
+		errs     []error
+	)
+
+	// Fetch workers
+	for workerID := 0; workerID < numWorkers; workerID++ {
+		workerWG.Add(1)
+
+		go func() {
+			defer workerWG.Done()
+
+			if err := db.ReadTransaction(ctx, func(tx graph.Transaction) error {
+				// Create a slice of criteria to join the node ID range constraints to any passed user criteria
+				var criteriaSlice []graph.Criteria
+
+				if criteria != nil {
+					criteriaSlice = append(criteriaSlice, criteria)
+				}
+
+				// Select the next node ID range floor while honoring context cancellation and channel closure
+				nextRangeFloor, channelOpen := channels.Receive(ctx, rangeC)
+
+				for channelOpen {
+					if err := tx.Nodes().Filter(query.And(
+						append(criteriaSlice,
+							query.GreaterThanOrEquals(query.NodeID(), nextRangeFloor),
+							query.LessThan(query.NodeID(), nextRangeFloor+stride),
+						)...,
+					)).Fetch(func(cursor graph.Cursor[*graph.Node]) error {
+						channels.PipeAll(ctx, cursor.Chan(), nodeC)
+						return cursor.Error()
+					}); err != nil {
+						return err
+					}
+
+					nextRangeFloor, channelOpen = channels.Receive(ctx, rangeC)
+				}
+
+				return nil
+			}); err != nil {
+				channels.Submit(ctx, errorC, err)
+			}
+		}()
+	}
+
+	// Merge goroutine for fetched nodes and collected errors
+	mergeWG.Add(1)
+
+	go func() {
+		defer mergeWG.Done()
+
+		for {
+			select {
+			case <-ctx.Done():
+				// Bail if the context is canceled
+				return
+
+			case nextNode, channelOpen := <-nodeC:
+				if !channelOpen {
+					// Channel closure indicates completion of work and join of the parallel workers
+					return
+				}
+
+				nodes.Add(nextNode)
+
+			case nextErr, channelOpen := <-errorC:
+				if !channelOpen {
+					// Channel closure indicates completion of work and join of the parallel workers
+					return
+				}
+
+				errs = append(errs, nextErr)
+			}
 		}
+	}()
 
-		return cursor.Error()
-	})
+	// Iterate through node ID ranges up to the maximum ID by the stride constant
+	for nextRangeFloor := graph.ID(0); nextRangeFloor <= maxID; nextRangeFloor += stride {
+		channels.Submit(ctx, rangeC, nextRangeFloor)
+	}
+
+	// Stop the fetch workers
+	close(rangeC)
+	workerWG.Wait()
+
+	// Wait for the merge routine to join to ensure that both the nodes instance and the errs instance contain
+	// everything to be collected from the parallel workers
+	close(nodeC)
+	close(errorC)
+	mergeWG.Wait()
+
+	// Return the fetched nodes and joined errors lastly
+	return nodes, errors.Join(errs...)
+}
+
+// ParallelFetchNodes will first look up the largest node database identifier. The function will then spin up to
+// numWorkers parallel read transactions. Each transaction will apply the user passed criteria to this function to a
+// range of node database identifiers to avoid parallel worker collisions.
+func ParallelFetchNodes(ctx context.Context, db graph.Database, criteria graph.Criteria, numWorkers int) (graph.NodeSet, error) {
+	if largestNodeID, err := FetchLargestNodeID(ctx, db); err != nil {
+		return nil, err
+	} else {
+		return parallelFetchNodes(ctx, db, largestNodeID, criteria, numWorkers)
+	}
 }

--- a/packages/go/dawgs/query/model.go
+++ b/packages/go/dawgs/query/model.go
@@ -145,10 +145,10 @@ func DeleteProperties(reference graph.Criteria, propertyNames ...string) *cypher
 	return cypherModel.NewUpdatingClause(removeClause)
 }
 
-func Kind(reference graph.Criteria, kind graph.Kind) *cypherModel.KindMatcher {
+func Kind(reference graph.Criteria, kinds ...graph.Kind) *cypherModel.KindMatcher {
 	return &cypherModel.KindMatcher{
 		Reference: reference,
-		Kinds:     graph.Kinds{kind},
+		Kinds:     kinds,
 	}
 }
 
@@ -526,6 +526,10 @@ func Returning(elements ...graph.Criteria) *cypherModel.Return {
 	return &cypherModel.Return{
 		Projection: projection,
 	}
+}
+
+func Size(expression graph.Criteria) *cypherModel.FunctionInvocation {
+	return cypherModel.NewSimpleFunctionInvocation("size", expression)
 }
 
 func Not(expression graph.Criteria) *cypherModel.Negation {


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

`Version_513_Migration` covers a bug discovered in ingest that would result in nodes containing more than one kind. For example, the following query should return no results: `(n:Base) where (n:User and n:Computer) return n` but, at time of writing, due to the ingest defect several environments will return results for this query.

For instances where nodes are discovered that contain more than one valid kind assignment, the node's kinds are reset to the matching base entity kind such that:

```
node.Kinds = Kinds{ad.Entity, ad.User, ad.Computer} must be reset to:
node.Kinds = Kinds{ad.Entity}
```

## Motivation and Context

This PR addresses: BED-4641

*Why is this change required? What problem does it solve?*

## How Has This Been Tested?

Tested locally with a 1M+ node dataset.

## Types of changes

<!-- Please remove any items that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Database Migrations

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
