### PR TITLE
BED-4460: stop retrying /features request at app entrypoint

### DIFF
--- a/cmd/ui/src/App.tsx
+++ b/cmd/ui/src/App.tsx
@@ -46,7 +46,7 @@ const Inner: React.FC = () => {
     const authState = useAppSelector((state) => state.auth);
     const queryClient = useQueryClient();
     const location = useLocation();
-    const featureFlagsRes = useFeatureFlags();
+    const featureFlagsRes = useFeatureFlags({ retry: false });
 
     const darkMode = useAppSelector((state) => state.global.view.darkMode);
 

--- a/cmd/ui/src/hooks/useFeatureFlags.tsx
+++ b/cmd/ui/src/hooks/useFeatureFlags.tsx
@@ -15,7 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { RequestOptions } from 'js-client-library';
-import { useMutation, useQuery, useQueryClient } from 'react-query';
+import { QueryOptions, UseQueryResult, useMutation, useQuery, useQueryClient } from 'react-query';
 import { apiClient } from 'bh-shared-ui';
 
 export type Flag = {
@@ -39,7 +39,8 @@ export const toggleFeatureFlag = (flagId: string | number, options?: RequestOpti
     return apiClient.toggleFeatureFlag(flagId, options).then((response) => response.data);
 };
 
-export const useFeatureFlags = () => useQuery(featureFlagKeys.all, ({ signal }) => getFeatureFlags({ signal }));
+export const useFeatureFlags = (queryOptions?: QueryOptions): UseQueryResult<Flag[], unknown> =>
+    useQuery(featureFlagKeys.all, ({ signal }) => getFeatureFlags({ signal }), queryOptions);
 
 export const useFeatureFlag = (flagKey: string) =>
     useQuery(featureFlagKeys.all, ({ signal }) => getFeatureFlags({ signal }), {


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description
Stops retying /features request at app entrypoint.

## Motivation and Context

This PR addresses: BED-4660

Prevent loop of logging in and immediately getting logged out

## How Has This Been Tested?
Observing network requests

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
