### PR TITLE
BED-4664 fix: remove fatal return on init analysis

### DIFF
--- a/cmd/api/src/services/entrypoint.go
+++ b/cmd/api/src/services/entrypoint.go
@@ -106,7 +106,7 @@ func Entrypoint(ctx context.Context, cfg config.Configuration, connections boots
 
 		// Trigger analysis on first start
 		if err := connections.RDMS.RequestAnalysis(ctx, "init"); err != nil {
-			return nil, fmt.Errorf("failed to request analysis: %w", err)
+			log.Warnf("failed to request init analysis: %v", err)
 		}
 
 		return []daemons.Daemon{


### PR DESCRIPTION
## Description

Remove fatality from api initialization based off init analysis request

## Motivation and Context

This PR addresses: BED-4664

Request analysis failures shouldn't cause api fatalities

## How Has This Been Tested?

Locally

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
