### PR TITLE
BED-4663: Fix Hybrid Paths Failure When Node Exists But Not As AD User

### DIFF
--- a/cmd/api/src/analysis/hybrid/hybrid_integration_test.go
+++ b/cmd/api/src/analysis/hybrid/hybrid_integration_test.go
@@ -43,7 +43,7 @@ func TestHybridAttackPaths(t *testing.T) {
 		func(harness *integration.HarnessDetails) error {
 			adUserObjectID := integration.RandomObjectID(t)
 			azUserOnPremID := adUserObjectID
-			harness.HybridAttackPaths.Setup(testContext, adUserObjectID, azUserOnPremID, true, true)
+			harness.HybridAttackPaths.Setup(testContext, adUserObjectID, azUserOnPremID, true, true, false)
 			return nil
 		},
 		func(harness integration.HarnessDetails, db graph.Database) {
@@ -64,7 +64,7 @@ func TestHybridAttackPaths(t *testing.T) {
 		func(harness *integration.HarnessDetails) error {
 			adUserObjectID := integration.RandomObjectID(t)
 			azUserOnPremID := ""
-			harness.HybridAttackPaths.Setup(testContext, adUserObjectID, azUserOnPremID, false, true)
+			harness.HybridAttackPaths.Setup(testContext, adUserObjectID, azUserOnPremID, false, true, false)
 			return nil
 		},
 		func(harness integration.HarnessDetails, db graph.Database) {
@@ -85,7 +85,7 @@ func TestHybridAttackPaths(t *testing.T) {
 		func(harness *integration.HarnessDetails) error {
 			adUserObjectID := integration.RandomObjectID(t)
 			azUserOnPremID := adUserObjectID
-			harness.HybridAttackPaths.Setup(testContext, adUserObjectID, azUserOnPremID, false, true)
+			harness.HybridAttackPaths.Setup(testContext, adUserObjectID, azUserOnPremID, false, true, false)
 			return nil
 		},
 		func(harness integration.HarnessDetails, db graph.Database) {
@@ -106,7 +106,30 @@ func TestHybridAttackPaths(t *testing.T) {
 		func(harness *integration.HarnessDetails) error {
 			adUserObjectID := ""
 			azUserOnPremID := integration.RandomObjectID(t)
-			harness.HybridAttackPaths.Setup(testContext, adUserObjectID, azUserOnPremID, true, false)
+			harness.HybridAttackPaths.Setup(testContext, adUserObjectID, azUserOnPremID, true, false, false)
+			return nil
+		},
+		func(harness integration.HarnessDetails, db graph.Database) {
+			operation := analysis.NewPostRelationshipOperation(context.Background(), db, "Hybrid Attack Path Post Process Test")
+
+			if _, err := hybrid.PostHybrid(context.Background(), db); err != nil {
+				t.Fatalf("failed post processing for hybrid attack paths: %v", err)
+			}
+			operation.Done()
+
+			verifyHybridPaths(t, db, harness, true)
+		},
+	)
+
+	// ADUser does not exist, but the objectid from a selected AZUser exists in the graph. Selected AZUser has OnPremID and
+	// OnPremSyncEnabled=true
+	// The existing node should be upgraded to a user node and used for the path. SyncedToADUser and SyncedToEntraUser
+	// edges should be created and linked to new ADUser node.
+	testContext.DatabaseTestWithSetup(
+		func(harness *integration.HarnessDetails) error {
+			adUserObjectID := ""
+			azUserOnPremID := integration.RandomObjectID(t)
+			harness.HybridAttackPaths.Setup(testContext, adUserObjectID, azUserOnPremID, true, false, true)
 			return nil
 		},
 		func(harness integration.HarnessDetails, db graph.Database) {
@@ -127,7 +150,7 @@ func TestHybridAttackPaths(t *testing.T) {
 		func(harness *integration.HarnessDetails) error {
 			adUserObjectID := integration.RandomObjectID(t)
 			azUserOnPremID := integration.RandomObjectID(t)
-			harness.HybridAttackPaths.Setup(testContext, adUserObjectID, azUserOnPremID, true, true)
+			harness.HybridAttackPaths.Setup(testContext, adUserObjectID, azUserOnPremID, true, true, false)
 			return nil
 		},
 		func(harness integration.HarnessDetails, db graph.Database) {

--- a/cmd/api/src/test/integration/harnesses.go
+++ b/cmd/api/src/test/integration/harnesses.go
@@ -6830,9 +6830,10 @@ type HybridAttackPaths struct {
 	ADUserObjectID string
 	AZUser         *graph.Node
 	AZUserObjectID string
+	UnknownNode    *graph.Node
 }
 
-func (s *HybridAttackPaths) Setup(graphTestContext *GraphTestContext, adUserObjectID string, azUserOnPremID string, onPremSyncEnabled bool, createADUser bool) {
+func (s *HybridAttackPaths) Setup(graphTestContext *GraphTestContext, adUserObjectID string, azUserOnPremID string, onPremSyncEnabled bool, createADUser bool, createUnknownNode bool) {
 	s.ADUserObjectID = adUserObjectID
 	tenantID := RandomObjectID(graphTestContext.testCtx)
 	domainSid := RandomDomainSID()
@@ -6860,6 +6861,12 @@ func (s *HybridAttackPaths) Setup(graphTestContext *GraphTestContext, adUserObje
 		})
 
 		s.ADUser = graphTestContext.NewCustomActiveDirectoryUser(adUserProperties)
+	} else if createUnknownNode {
+		unknownNodeProperties := graph.AsProperties(graph.PropertyMap{
+			common.ObjectID: azUserOnPremID,
+		})
+
+		s.UnknownNode = graphTestContext.NewNode(unknownNodeProperties, ad.Entity)
 	}
 }
 

--- a/packages/go/analysis/hybrid/hybrid.go
+++ b/packages/go/analysis/hybrid/hybrid.go
@@ -175,8 +175,19 @@ func createMissingADUser(ctx context.Context, db graph.Database, objectID string
 	})
 
 	err = db.WriteTransaction(ctx, func(tx graph.Transaction) error {
+		newNode, err = analysis.FetchNodeByObjectID(tx, objectID)
+		if !errors.Is(err, graph.ErrNoResultsFound) {
+			return fmt.Errorf("create missing ad user precheck: %w", err)
+		} else if err == nil {
+			return nil
+		}
+
 		newNode, err = tx.CreateNode(properties, adSchema.Entity, adSchema.User)
-		return err
+		if err != nil {
+			return fmt.Errorf("create missing ad user: %w", err)
+		} else {
+			return nil
+		}
 	})
 
 	return newNode, err


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Fixes an edge case where a node can exist with a given `objectid` but may not have a `User` label due to not being directly collected or some other case where the label is missing. This includes checking each node we think we need to create for existence, and if it does already exist, adding the `User` label to that node.

## Motivation and Context

This PR addresses: BED-4663

Fixes an important edge case we found in v5.13.0. This is being staged for hotfix v5.13.1

## How Has This Been Tested?

Used a debugger to pause on the first objectid that needed to be created because it wasn't found in our list of AD Users. During that pause, I did a `MERGE` for that objectid and ensured that the node had only `:Base`, no `:User`. I then resumed the debugger until the next item and checked Neo4j for the previous node. When not adding on the label, I saw the correct node show up as expected with only the `Base` label. When adding the additional logic to add the `User` label, I saw that it correctly identified the existing node and added the `User` label.

An integration test has also been added for this edge case, and was validated in a similar manual debugging effort while the test ran to validate replication of the edge case and correct outcome.

## Screenshots (optional):
![image](https://github.com/user-attachments/assets/bc925986-fdc0-49b9-987d-2353a9981dab)
Proof that we could properly work with existing nodes that lacked an AD User label, prior to ensuring that label is readded

## Types of changes

<!-- Please remove any items that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
