### PR TITLE
BED-4662 implement new `in` predicate for string filtering on PG

### DIFF
--- a/cmd/api/src/model/filter.go
+++ b/cmd/api/src/model/filter.go
@@ -182,7 +182,8 @@ func (s QueryParameterFilterMap) BuildSQLFilter() (SQLFilter, error) {
 				result.WriteString(filter.Name)
 				result.WriteString(") ")
 				result.WriteString(predicate)
-				result.WriteString(" lower('%?%')")
+				filter.Value = fmt.Sprintf("%%%s%%", filter.Value)
+				result.WriteString(" lower(?)")
 			default:
 				result.WriteString(filter.Name)
 				result.WriteString(" ")

--- a/cmd/api/src/model/filter.go
+++ b/cmd/api/src/model/filter.go
@@ -182,7 +182,7 @@ func (s QueryParameterFilterMap) BuildSQLFilter() (SQLFilter, error) {
 				result.WriteString(filter.Name)
 				result.WriteString(") ")
 				result.WriteString(predicate)
-				result.WriteString(" lower(%?%)")
+				result.WriteString(" lower('%?%')")
 			default:
 				result.WriteString(filter.Name)
 				result.WriteString(" ")

--- a/cmd/api/src/model/filter.go
+++ b/cmd/api/src/model/filter.go
@@ -176,18 +176,20 @@ func (s QueryParameterFilterMap) BuildSQLFilter() (SQLFilter, error) {
 				return SQLFilter{}, fmt.Errorf("invalid filter predicate specified")
 			}
 
-			if predicate == ContainsSymbol {
+			switch predicate {
+			case ContainsSymbol:
 				result.WriteString("lower(")
 				result.WriteString(filter.Name)
 				result.WriteString(") ")
 				result.WriteString(predicate)
-				result.WriteString(" lower('%?%')")
-			} else {
+				result.WriteString(" lower(%?%)")
+			default:
 				result.WriteString(filter.Name)
 				result.WriteString(" ")
 				result.WriteString(predicate)
 				result.WriteString(" ?")
 			}
+
 			params = append(params, filter.Value)
 			firstFilter = false
 		}

--- a/cmd/api/src/model/filter.go
+++ b/cmd/api/src/model/filter.go
@@ -178,9 +178,8 @@ func (s QueryParameterFilterMap) BuildSQLFilter() (SQLFilter, error) {
 
 			switch predicate {
 			case ContainsSymbol:
-				result.WriteString("lower(")
 				result.WriteString(filter.Name)
-				result.WriteString(") ")
+				result.WriteString(" ")
 				result.WriteString(predicate)
 				filter.Value = fmt.Sprintf("%%%s%%", filter.Value)
 				result.WriteString(" lower(?)")

--- a/cmd/api/src/model/filter_test.go
+++ b/cmd/api/src/model/filter_test.go
@@ -76,19 +76,28 @@ func TestModel_BuildSQLFilter_Success(t *testing.T) {
 		IsStringData: false,
 	}
 
+	stringContains := model.QueryParameterFilter{
+		Name:         "filtercolumn6",
+		Operator:     model.Contains,
+		Value:        "something",
+		IsStringData: true,
+	}
+
 	expectedResults := map[string]model.SQLFilter{
-		"numericMin":    {SQLString: fmt.Sprintf("%s > ?", numericMin.Name), Params: []any{numericMin.Value}},
-		"numericMax":    {SQLString: fmt.Sprintf("%s < ?", numericMax.Name), Params: []any{numericMax.Value}},
-		"stringValue":   {SQLString: fmt.Sprintf("%s = ?", stringValue.Name), Params: []any{stringValue.Value}},
-		"boolEquals":    {SQLString: fmt.Sprintf("%s = ?", boolEquals.Name), Params: []any{boolEquals.Value}},
-		"boolNotEquals": {SQLString: fmt.Sprintf("%s <> ?", boolNotEquals.Name), Params: []any{boolNotEquals.Value}},
+		"numericMin":     {SQLString: fmt.Sprintf("%s > ?", numericMin.Name), Params: []any{numericMin.Value}},
+		"numericMax":     {SQLString: fmt.Sprintf("%s < ?", numericMax.Name), Params: []any{numericMax.Value}},
+		"stringValue":    {SQLString: fmt.Sprintf("%s = ?", stringValue.Name), Params: []any{stringValue.Value}},
+		"boolEquals":     {SQLString: fmt.Sprintf("%s = ?", boolEquals.Name), Params: []any{boolEquals.Value}},
+		"boolNotEquals":  {SQLString: fmt.Sprintf("%s <> ?", boolNotEquals.Name), Params: []any{boolNotEquals.Value}},
+		"stringContains": {SQLString: fmt.Sprintf("lower(%s) like lower('%%?%%')", stringContains.Name), Params: []any{stringContains.Value}},
 	}
 
 	queryParameterFilterMap := model.QueryParameterFilterMap{
-		numericMax.Name:    model.QueryParameterFilters{numericMin, numericMax},
-		stringValue.Name:   model.QueryParameterFilters{stringValue},
-		boolEquals.Name:    model.QueryParameterFilters{boolEquals},
-		boolNotEquals.Name: model.QueryParameterFilters{boolNotEquals},
+		numericMax.Name:     model.QueryParameterFilters{numericMin, numericMax},
+		stringValue.Name:    model.QueryParameterFilters{stringValue},
+		boolEquals.Name:     model.QueryParameterFilters{boolEquals},
+		boolNotEquals.Name:  model.QueryParameterFilters{boolNotEquals},
+		stringContains.Name: model.QueryParameterFilters{stringContains},
 	}
 
 	result, err := queryParameterFilterMap.BuildSQLFilter()

--- a/cmd/api/src/model/filter_test.go
+++ b/cmd/api/src/model/filter_test.go
@@ -89,7 +89,7 @@ func TestModel_BuildSQLFilter_Success(t *testing.T) {
 		"stringValue":    {SQLString: fmt.Sprintf("%s = ?", stringValue.Name), Params: []any{stringValue.Value}},
 		"boolEquals":     {SQLString: fmt.Sprintf("%s = ?", boolEquals.Name), Params: []any{boolEquals.Value}},
 		"boolNotEquals":  {SQLString: fmt.Sprintf("%s <> ?", boolNotEquals.Name), Params: []any{boolNotEquals.Value}},
-		"stringContains": {SQLString: fmt.Sprintf("lower(%s) like lower(?)", stringContains.Name), Params: []any{stringContains.Value}},
+		"stringContains": {SQLString: fmt.Sprintf("%s like lower(?)", stringContains.Name), Params: []any{stringContains.Value}},
 	}
 
 	queryParameterFilterMap := model.QueryParameterFilterMap{

--- a/cmd/api/src/model/filter_test.go
+++ b/cmd/api/src/model/filter_test.go
@@ -89,7 +89,7 @@ func TestModel_BuildSQLFilter_Success(t *testing.T) {
 		"stringValue":    {SQLString: fmt.Sprintf("%s = ?", stringValue.Name), Params: []any{stringValue.Value}},
 		"boolEquals":     {SQLString: fmt.Sprintf("%s = ?", boolEquals.Name), Params: []any{boolEquals.Value}},
 		"boolNotEquals":  {SQLString: fmt.Sprintf("%s <> ?", boolNotEquals.Name), Params: []any{boolNotEquals.Value}},
-		"stringContains": {SQLString: fmt.Sprintf("lower(%s) like lower('%%?%%')", stringContains.Name), Params: []any{stringContains.Value}},
+		"stringContains": {SQLString: fmt.Sprintf("lower(%s) like lower(?)", stringContains.Name), Params: []any{stringContains.Value}},
 	}
 
 	queryParameterFilterMap := model.QueryParameterFilterMap{

--- a/cmd/api/src/model/saved_queries.go
+++ b/cmd/api/src/model/saved_queries.go
@@ -16,7 +16,9 @@
 
 package model
 
-import "fmt"
+import (
+	"fmt"
+)
 
 type SavedQuery struct {
 	UserID      string `json:"user_id" gorm:"index:,unique,composite:compositeIndex"`
@@ -50,7 +52,7 @@ func (s SavedQueries) ValidFilters() map[string][]FilterOperator {
 		"user_id":     {Equals, NotEquals},
 		"name":        {Equals, NotEquals},
 		"query":       {Equals, NotEquals},
-		"description": {Equals, NotEquals},
+		"description": {Equals, NotEquals, Contains},
 	}
 }
 

--- a/cmd/api/src/model/saved_queries_test.go
+++ b/cmd/api/src/model/saved_queries_test.go
@@ -41,7 +41,12 @@ func TestSavedQueries_ValidFilters(t *testing.T) {
 	for _, column := range []string{"user_id", "name", "query", "description"} {
 		operators, ok := validFilters[column]
 		require.True(t, ok)
-		require.Equal(t, 2, len(operators))
+		switch column {
+		case "description":
+			require.Equal(t, 3, len(operators))
+		default:
+			require.Equal(t, 2, len(operators))
+		}
 	}
 }
 


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

In order to support querying for saved_queries via description, we need to support a way to query strings with similarity. Currently, we support `eq` and `neq` predicates for string filters which would require the user to enter the enter saved query's description as the filter. This adds support for our already defined `in` predicate, which is used in our GraphDB, in Postgres.

## Motivation and Context

This PR addresses: BED-4662

Allows filtering our PG database based on string likeness rather than exact match

## How Has This Been Tested?

I created 3 queries with the following `description` values:
> This is a test description
> An example description
> Contains test text

I then sent a request to `http://bloodhound.localhost/api/v2/saved-queries?description=in:test`
Note the query parameter `description=in:test`

I then verified that the resulting queries both contained the word `test` in them (TEST 1 and TEST 2)
I then sent a request with the parameter `description=in:example` which I verified returned only TEST 3 and not TEST 1 or TEST 2
See screenshots for example

## Screenshots (optional):
![image](https://github.com/user-attachments/assets/e2ed109d-088e-4fbb-9c4a-13ed3b67cc04)


## Types of changes

<!-- Please remove any items that do not apply. -->
- New feature (non-breaking change which adds functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
