### PR TITLE
BED-4666: remove logout on 401 /features

### DIFF
--- a/cmd/ui/src/utils.ts
+++ b/cmd/ui/src/utils.ts
@@ -77,8 +77,9 @@ export const initializeBHEClient = () => {
         (error) => {
             if (error?.response) {
                 if (error?.response?.status === 401) {
-                    if (IGNORE_401_LOGOUT.includes(error?.response?.config.url)) return
-                    throttledLogout();
+                    if (!IGNORE_401_LOGOUT.includes(error?.response?.config.url)) {
+                        throttledLogout();
+                    }
                 } else if (
                     error?.response?.status === 403 &&
                     !error?.response?.config.url.match('/api/v2/bloodhound-users/[a-z0-9-]+/secret')

--- a/cmd/ui/src/utils.ts
+++ b/cmd/ui/src/utils.ts
@@ -77,7 +77,7 @@ export const initializeBHEClient = () => {
         (error) => {
             if (error?.response) {
                 if (error?.response?.status === 401) {
-                    if (!IGNORE_401_LOGOUT.includes(error?.response?.config.url)) {
+                    if (IGNORE_401_LOGOUT.includes(error?.response?.config.url) === false) {
                         throttledLogout();
                     }
                 } else if (

--- a/cmd/ui/src/utils.ts
+++ b/cmd/ui/src/utils.ts
@@ -25,6 +25,8 @@ import { isLink, isNode } from 'src/ducks/graph/utils';
 import { Glyph } from 'src/rendering/programs/node.glyphs';
 import { store } from 'src/store';
 
+const IGNORE_401_LOGOUT = ['/api/v2/login', '/api/v2/logout', '/api/v2/features']
+
 export const getDatesInRange = (startDate: Date, endDate: Date) => {
     const date = new Date(startDate.getTime());
 
@@ -74,11 +76,8 @@ export const initializeBHEClient = () => {
 
         (error) => {
             if (error?.response) {
-                if (
-                    error?.response?.status === 401 &&
-                    error?.response?.config.url !== '/api/v2/login' &&
-                    error?.response?.config.url !== '/api/v2/logout'
-                ) {
+                if (error?.response?.status === 401) {
+                    if (IGNORE_401_LOGOUT.includes(error?.response?.config.url)) return
                     throttledLogout();
                 } else if (
                     error?.response?.status === 403 &&


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description
Block logout attempts after a 401 when the requested url is `/api/v2/features`

## Motivation and Context

This PR addresses: BED-4666

When a user is logging in with MFA, if the page is unfocused and then refocused, the `/features` endpoint will 401 and force the user back to the username/password screen.

## How Has This Been Tested?
manual tests

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [ ] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
