### PR TITLE
chore: revert available SharpHound version to v2.4.1

### DIFF
--- a/dockerfiles/bloodhound.Dockerfile
+++ b/dockerfiles/bloodhound.Dockerfile
@@ -17,7 +17,7 @@
 ########
 # Global build args
 ################
-ARG SHARPHOUND_VERSION=v2.5.4
+ARG SHARPHOUND_VERSION=v2.4.1
 ARG AZUREHOUND_VERSION=v2.1.9
 
 ########

--- a/tools/docker-compose/api.Dockerfile
+++ b/tools/docker-compose/api.Dockerfile
@@ -17,7 +17,7 @@
 ########
 # Global build args
 ################
-ARG SHARPHOUND_VERSION=v2.5.4
+ARG SHARPHOUND_VERSION=v2.4.1
 ARG AZUREHOUND_VERSION=v2.1.9
 
 ########


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Reverts the version of SharpHound available for download in BHCE to v2.4.1 from v2.5.4

## Motivation and Context

This PR addresses: BED-4668

## How Has This Been Tested?

*Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc.*

No tests have been updated or added for this revert.

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
