### PR TITLE
BED-4675: Update publish workflows to set a relevant run-name

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 name: Publish
+run-name: Publish ${{ github.ref_name }}
 
 on:
   push:
@@ -82,4 +83,3 @@ jobs:
             checkout_hash=$GITHUB_SHA
           provenance: false
           push: true
-

--- a/.github/workflows/rc-publish.yml
+++ b/.github/workflows/rc-publish.yml
@@ -15,6 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 name: Publish Release Candidate
+run-name: Publish ${{ github.ref_name }}
 
 on:
   push:


### PR DESCRIPTION
## Description

Sets a run-name (title) for the publish workflow runs.

## Motivation and Context

BED-4675

Currently the GitHub workflows for publishing builds use the default title for each workflow run. The default doesn't give any indication of which release the build is for. This sets it to use the triggering ref name, which should be the relevant tag.

## How Has This Been Tested?

N/A

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
