### PR TITLE
BED-4663: Followup

### DIFF
--- a/cmd/api/src/analysis/hybrid/hybrid_integration_test.go
+++ b/cmd/api/src/analysis/hybrid/hybrid_integration_test.go
@@ -123,8 +123,7 @@ func TestHybridAttackPaths(t *testing.T) {
 
 	// ADUser does not exist, but the objectid from a selected AZUser exists in the graph. Selected AZUser has OnPremID and
 	// OnPremSyncEnabled=true
-	// The existing node should be upgraded to a user node and used for the path. SyncedToADUser and SyncedToEntraUser
-	// edges should be created and linked to new ADUser node.
+	// The existing node should be used to create SyncedToADUser and SyncedToEntraUser edges.
 	testContext.DatabaseTestWithSetup(
 		func(harness *integration.HarnessDetails) error {
 			adUserObjectID := ""
@@ -202,7 +201,7 @@ func verifyHybridPaths(t *testing.T, db graph.Database, harness integration.Harn
 
 			// Ensure we got the correct node types
 			assert.True(t, start.Kinds.ContainsOneOf(azure.User))
-			assert.True(t, end.Kinds.ContainsOneOf(ad.User))
+			assert.True(t, end.Kinds.ContainsOneOf(ad.User, ad.Entity))
 
 			// Verify the AZUser is the first node
 			assert.Equal(t, harness.HybridAttackPaths.AZUserObjectID, startObjectID)
@@ -249,7 +248,7 @@ func verifyHybridPaths(t *testing.T, db graph.Database, harness integration.Harn
 			assert.Nil(t, err)
 
 			// Ensure we got the correct node types
-			assert.True(t, start.Kinds.ContainsOneOf(ad.User))
+			assert.True(t, start.Kinds.ContainsOneOf(ad.User, ad.Entity))
 			assert.True(t, end.Kinds.ContainsOneOf(azure.User))
 
 			// Verify the ADUser, but we have to handle the case where the ADUser node is created by the post-processing logic

--- a/packages/go/analysis/hybrid/hybrid.go
+++ b/packages/go/analysis/hybrid/hybrid.go
@@ -174,28 +174,17 @@ func createMissingADUser(ctx context.Context, db graph.Database, objectID string
 		common.ObjectID.String(): objectID,
 	})
 
-	// Using a switch to make the complex error handling logic more clear
 	err = db.WriteTransaction(ctx, func(tx graph.Transaction) error {
-		newNode, err = analysis.FetchNodeByObjectID(tx, objectID)
-		switch {
-		// No node found, so it's safe to create a new AD User
-		case errors.Is(err, graph.ErrNoResultsFound):
+		if newNode, err = analysis.FetchNodeByObjectID(tx, objectID); errors.Is(err, graph.ErrNoResultsFound) {
 			if newNode, err = tx.CreateNode(properties, adSchema.Entity, adSchema.User); err != nil {
 				return fmt.Errorf("create missing ad user: %w", err)
 			} else {
 				return nil
 			}
-		// Node was found, so we need to update it to an AD User
-		case err == nil:
-			newNode.AddKinds(adSchema.User)
-			if err := tx.UpdateNode(newNode); err != nil {
-				return fmt.Errorf("update missing ad user label: %w", err)
-			} else {
-				return nil
-			}
-		// Database error while checking for node
-		default:
+		} else if err != nil {
 			return fmt.Errorf("create missing ad user precheck: %w", err)
+		} else {
+			return nil
 		}
 	})
 


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Removes the logic to convert unknown AD nodes into AD User nodes when making hybrid edges

## Motivation and Context

This PR addresses: BED-4663

We don't want to alter unknown nodes for consistency, so the logic was removed. Some test parameters needed to be adjusted to cover the change properly.

## How Has This Been Tested?

Tests were altered to handle the correct logic and are passing

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
