### PR TITLE
BED-4663: Testing ergonomics fix

### DIFF
--- a/cmd/api/src/analysis/hybrid/hybrid_integration_test.go
+++ b/cmd/api/src/analysis/hybrid/hybrid_integration_test.go
@@ -54,7 +54,7 @@ func TestHybridAttackPaths(t *testing.T) {
 			}
 			operation.Done()
 
-			verifyHybridPaths(t, db, harness, true)
+			verifyHybridPaths(t, db, harness, true, true)
 		},
 	)
 
@@ -75,7 +75,7 @@ func TestHybridAttackPaths(t *testing.T) {
 			}
 			operation.Done()
 
-			verifyHybridPaths(t, db, harness, false)
+			verifyHybridPaths(t, db, harness, false, true)
 		},
 	)
 
@@ -96,7 +96,7 @@ func TestHybridAttackPaths(t *testing.T) {
 			}
 			operation.Done()
 
-			verifyHybridPaths(t, db, harness, false)
+			verifyHybridPaths(t, db, harness, false, true)
 		},
 	)
 
@@ -117,7 +117,7 @@ func TestHybridAttackPaths(t *testing.T) {
 			}
 			operation.Done()
 
-			verifyHybridPaths(t, db, harness, true)
+			verifyHybridPaths(t, db, harness, true, true)
 		},
 	)
 
@@ -139,7 +139,7 @@ func TestHybridAttackPaths(t *testing.T) {
 			}
 			operation.Done()
 
-			verifyHybridPaths(t, db, harness, true)
+			verifyHybridPaths(t, db, harness, true, false)
 		},
 	)
 
@@ -160,12 +160,12 @@ func TestHybridAttackPaths(t *testing.T) {
 			}
 			operation.Done()
 
-			verifyHybridPaths(t, db, harness, true)
+			verifyHybridPaths(t, db, harness, true, true)
 		},
 	)
 }
 
-func verifyHybridPaths(t *testing.T, db graph.Database, harness integration.HarnessDetails, shouldHaveEdges bool) {
+func verifyHybridPaths(t *testing.T, db graph.Database, harness integration.HarnessDetails, shouldHaveEdges bool, shouldHaveUserNode bool) {
 	expectedEdgeCount := 1
 	if !shouldHaveEdges {
 		expectedEdgeCount = 0
@@ -200,8 +200,12 @@ func verifyHybridPaths(t *testing.T, db graph.Database, harness integration.Harn
 			assert.Nil(t, err)
 
 			// Ensure we got the correct node types
+			if shouldHaveUserNode {
+				assert.True(t, end.Kinds.ContainsOneOf(ad.User))
+			} else {
+				assert.True(t, end.Kinds.ContainsOneOf(ad.Entity))
+			}
 			assert.True(t, start.Kinds.ContainsOneOf(azure.User))
-			assert.True(t, end.Kinds.ContainsOneOf(ad.User, ad.Entity))
 
 			// Verify the AZUser is the first node
 			assert.Equal(t, harness.HybridAttackPaths.AZUserObjectID, startObjectID)
@@ -248,7 +252,11 @@ func verifyHybridPaths(t *testing.T, db graph.Database, harness integration.Harn
 			assert.Nil(t, err)
 
 			// Ensure we got the correct node types
-			assert.True(t, start.Kinds.ContainsOneOf(ad.User, ad.Entity))
+			if shouldHaveUserNode {
+				assert.True(t, start.Kinds.ContainsOneOf(ad.User))
+			} else {
+				assert.True(t, start.Kinds.ContainsOneOf(ad.Entity))
+			}
 			assert.True(t, end.Kinds.ContainsOneOf(azure.User))
 
 			// Verify the ADUser, but we have to handle the case where the ADUser node is created by the post-processing logic

--- a/dockerfiles/bloodhound.Dockerfile
+++ b/dockerfiles/bloodhound.Dockerfile
@@ -17,7 +17,7 @@
 ########
 # Global build args
 ################
-ARG SHARPHOUND_VERSION=v2.5.4
+ARG SHARPHOUND_VERSION=v2.4.1
 ARG AZUREHOUND_VERSION=v2.1.9
 
 ########

--- a/tools/docker-compose/api.Dockerfile
+++ b/tools/docker-compose/api.Dockerfile
@@ -17,7 +17,7 @@
 ########
 # Global build args
 ################
-ARG SHARPHOUND_VERSION=v2.5.4
+ARG SHARPHOUND_VERSION=v2.4.1
 ARG AZUREHOUND_VERSION=v2.1.9
 
 ########


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

This is a final followup to our hotfix issue BED-4663. The goal was to clean up some testing cases to ensure that places where we expect the nodes to be users are covered appropriately while allowing for the unknown edge case to only rely on `ad.Entity`.

## Motivation and Context

This PR addresses: BED-4663

Testing cleanup identified while reviewing BED-4663 for the hotfix. This work will not be part of the hotfix, but was important to finish tying down for mainline.

## How Has This Been Tested?

Test updated and ran without any issues

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
