### PR TITLE
chore: refactored saved query id parameter to always expect int64

### DIFF
--- a/cmd/api/src/api/v2/saved_queries.go
+++ b/cmd/api/src/api/v2/saved_queries.go
@@ -178,7 +178,7 @@ func (s Resources) UpdateSavedQuery(response http.ResponseWriter, request *http.
 	} else if err := api.ReadJSONRequestPayloadLimited(&updateRequest, request); err != nil {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, err.Error(), request), response)
 		return
-	} else if savedQueryID, err := strconv.Atoi(rawSavedQueryID); err != nil {
+	} else if savedQueryID, err := strconv.ParseInt(rawSavedQueryID, 10, 64); err != nil {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, api.ErrorResponseDetailsIDMalformed, request), response)
 		return
 	} else if savedQuery, err = s.DB.GetSavedQuery(request.Context(), savedQueryID); err != nil {
@@ -223,7 +223,7 @@ func (s Resources) DeleteSavedQuery(response http.ResponseWriter, request *http.
 
 	if user, isUser := auth.GetUserFromAuthCtx(ctx2.FromRequest(request).AuthCtx); !isUser {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, "No associated user found", request), response)
-	} else if savedQueryID, err := strconv.Atoi(rawSavedQueryID); err != nil {
+	} else if savedQueryID, err := strconv.ParseInt(rawSavedQueryID, 10, 64); err != nil {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, api.ErrorResponseDetailsIDMalformed, request), response)
 	} else if savedQueryBelongsToUser, err := s.DB.SavedQueryBelongsToUser(request.Context(), user.ID, savedQueryID); errors.Is(err, database.ErrNotFound) {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusNotFound, "query does not exist", request), response)

--- a/cmd/api/src/database/mocks/db.go
+++ b/cmd/api/src/database/mocks/db.go
@@ -532,7 +532,7 @@ func (mr *MockDatabaseMockRecorder) DeleteSAMLProvider(arg0, arg1 interface{}) *
 }
 
 // DeleteSavedQuery mocks base method.
-func (m *MockDatabase) DeleteSavedQuery(arg0 context.Context, arg1 int) error {
+func (m *MockDatabase) DeleteSavedQuery(arg0 context.Context, arg1 int64) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteSavedQuery", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -1117,7 +1117,7 @@ func (mr *MockDatabaseMockRecorder) GetSAMLProviderUsers(arg0, arg1 interface{})
 }
 
 // GetSavedQuery mocks base method.
-func (m *MockDatabase) GetSavedQuery(arg0 context.Context, arg1 int) (model.SavedQuery, error) {
+func (m *MockDatabase) GetSavedQuery(arg0 context.Context, arg1 int64) (model.SavedQuery, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSavedQuery", arg0, arg1)
 	ret0, _ := ret[0].(model.SavedQuery)
@@ -1414,7 +1414,7 @@ func (mr *MockDatabaseMockRecorder) RequiresMigration(arg0 interface{}) *gomock.
 }
 
 // SavedQueryBelongsToUser mocks base method.
-func (m *MockDatabase) SavedQueryBelongsToUser(arg0 context.Context, arg1 uuid.UUID, arg2 int) (bool, error) {
+func (m *MockDatabase) SavedQueryBelongsToUser(arg0 context.Context, arg1 uuid.UUID, arg2 int64) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SavedQueryBelongsToUser", arg0, arg1, arg2)
 	ret0, _ := ret[0].(bool)

--- a/cmd/api/src/database/saved_queries.go
+++ b/cmd/api/src/database/saved_queries.go
@@ -18,26 +18,27 @@ package database
 
 import (
 	"context"
+
 	"github.com/gofrs/uuid"
 	"github.com/specterops/bloodhound/src/model"
 	"gorm.io/gorm"
 )
 
 type SavedQueriesData interface {
-	GetSavedQuery(ctx context.Context, queryID int) (model.SavedQuery, error)
+	GetSavedQuery(ctx context.Context, savedQueryID int64) (model.SavedQuery, error)
 	ListSavedQueries(ctx context.Context, userID uuid.UUID, order string, filter model.SQLFilter, skip, limit int) (model.SavedQueries, int, error)
 	CreateSavedQuery(ctx context.Context, userID uuid.UUID, name string, query string, description string) (model.SavedQuery, error)
 	UpdateSavedQuery(ctx context.Context, savedQuery model.SavedQuery) (model.SavedQuery, error)
-	DeleteSavedQuery(ctx context.Context, id int) error
-	SavedQueryBelongsToUser(ctx context.Context, userID uuid.UUID, savedQueryID int) (bool, error)
+	DeleteSavedQuery(ctx context.Context, savedQueryID int64) error
+	SavedQueryBelongsToUser(ctx context.Context, userID uuid.UUID, savedQueryID int64) (bool, error)
 	GetSharedSavedQueries(ctx context.Context, userID uuid.UUID) (model.SavedQueries, error)
 	GetPublicSavedQueries(ctx context.Context) (model.SavedQueries, error)
 	IsSavedQueryPublic(ctx context.Context, savedQueryID int64) (bool, error)
 }
 
-func (s *BloodhoundDB) GetSavedQuery(ctx context.Context, queryID int) (model.SavedQuery, error) {
+func (s *BloodhoundDB) GetSavedQuery(ctx context.Context, savedQueryID int64) (model.SavedQuery, error) {
 	savedQuery := model.SavedQuery{}
-	result := s.db.WithContext(ctx).First(&savedQuery, queryID)
+	result := s.db.WithContext(ctx).First(&savedQuery, savedQueryID)
 	return savedQuery, CheckError(result)
 }
 
@@ -84,11 +85,11 @@ func (s *BloodhoundDB) UpdateSavedQuery(ctx context.Context, savedQuery model.Sa
 	return savedQuery, CheckError(s.db.WithContext(ctx).Save(&savedQuery))
 }
 
-func (s *BloodhoundDB) DeleteSavedQuery(ctx context.Context, id int) error {
-	return CheckError(s.db.WithContext(ctx).Delete(&model.SavedQuery{}, id))
+func (s *BloodhoundDB) DeleteSavedQuery(ctx context.Context, savedQueryID int64) error {
+	return CheckError(s.db.WithContext(ctx).Delete(&model.SavedQuery{}, savedQueryID))
 }
 
-func (s *BloodhoundDB) SavedQueryBelongsToUser(ctx context.Context, userID uuid.UUID, savedQueryID int) (bool, error) {
+func (s *BloodhoundDB) SavedQueryBelongsToUser(ctx context.Context, userID uuid.UUID, savedQueryID int64) (bool, error) {
 	var savedQuery model.SavedQuery
 	if result := s.db.WithContext(ctx).First(&savedQuery, savedQueryID); result.Error != nil {
 		return false, CheckError(result)


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Updated usage of the `saved_query.id` field to always expect int64. This includes reading the value in from the API handler and passing through to the database functions.

## Motivation and Context

This PR addresses: BED-4698

Light refactoring to make `savedQueryID` usages more consistent overall, including always treating as an int64 and using the same naming conventions everywhere.

## How Has This Been Tested?

Existing tests pass, no functional changes

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
