### PR TITLE
Revert BED-4662 PR 767

### DIFF
--- a/cmd/api/src/model/filter.go
+++ b/cmd/api/src/model/filter.go
@@ -39,7 +39,6 @@ const (
 	LessThanOrEquals    FilterOperator = "lte"
 	Equals              FilterOperator = "eq"
 	NotEquals           FilterOperator = "neq"
-	Contains            FilterOperator = "in"
 
 	GreaterThanSymbol         string = ">"
 	GreaterThanOrEqualsSymbol string = ">="
@@ -47,7 +46,6 @@ const (
 	LessThanOrEqualsSymbol    string = "<="
 	EqualsSymbol              string = "="
 	NotEqualsSymbol           string = "<>"
-	ContainsSymbol            string = "like"
 
 	TrueString     = "true"
 	FalseString    = "false"
@@ -80,9 +78,6 @@ func ParseFilterOperator(raw string) (FilterOperator, error) {
 
 	case NotEquals:
 		return NotEquals, nil
-
-	case Contains:
-		return Contains, nil
 
 	default:
 		return "", fmt.Errorf("unknown query parameter filter predicate: %s", raw)
@@ -170,25 +165,14 @@ func (s QueryParameterFilterMap) BuildSQLFilter() (SQLFilter, error) {
 				predicate = EqualsSymbol
 			case NotEquals:
 				predicate = NotEqualsSymbol
-			case Contains:
-				predicate = ContainsSymbol
 			default:
 				return SQLFilter{}, fmt.Errorf("invalid filter predicate specified")
 			}
 
-			switch predicate {
-			case ContainsSymbol:
-				result.WriteString(filter.Name)
-				result.WriteString(" ")
-				result.WriteString(predicate)
-				filter.Value = fmt.Sprintf("%%%s%%", filter.Value)
-				result.WriteString(" lower(?)")
-			default:
-				result.WriteString(filter.Name)
-				result.WriteString(" ")
-				result.WriteString(predicate)
-				result.WriteString(" ?")
-			}
+			result.WriteString(filter.Name)
+			result.WriteString(" ")
+			result.WriteString(predicate)
+			result.WriteString(" ?")
 
 			params = append(params, filter.Value)
 			firstFilter = false

--- a/cmd/api/src/model/filter_test.go
+++ b/cmd/api/src/model/filter_test.go
@@ -76,28 +76,19 @@ func TestModel_BuildSQLFilter_Success(t *testing.T) {
 		IsStringData: false,
 	}
 
-	stringContains := model.QueryParameterFilter{
-		Name:         "filtercolumn6",
-		Operator:     model.Contains,
-		Value:        "something",
-		IsStringData: true,
-	}
-
 	expectedResults := map[string]model.SQLFilter{
-		"numericMin":     {SQLString: fmt.Sprintf("%s > ?", numericMin.Name), Params: []any{numericMin.Value}},
-		"numericMax":     {SQLString: fmt.Sprintf("%s < ?", numericMax.Name), Params: []any{numericMax.Value}},
-		"stringValue":    {SQLString: fmt.Sprintf("%s = ?", stringValue.Name), Params: []any{stringValue.Value}},
-		"boolEquals":     {SQLString: fmt.Sprintf("%s = ?", boolEquals.Name), Params: []any{boolEquals.Value}},
-		"boolNotEquals":  {SQLString: fmt.Sprintf("%s <> ?", boolNotEquals.Name), Params: []any{boolNotEquals.Value}},
-		"stringContains": {SQLString: fmt.Sprintf("%s like lower(?)", stringContains.Name), Params: []any{stringContains.Value}},
+		"numericMin":    {SQLString: fmt.Sprintf("%s > ?", numericMin.Name), Params: []any{numericMin.Value}},
+		"numericMax":    {SQLString: fmt.Sprintf("%s < ?", numericMax.Name), Params: []any{numericMax.Value}},
+		"stringValue":   {SQLString: fmt.Sprintf("%s = ?", stringValue.Name), Params: []any{stringValue.Value}},
+		"boolEquals":    {SQLString: fmt.Sprintf("%s = ?", boolEquals.Name), Params: []any{boolEquals.Value}},
+		"boolNotEquals": {SQLString: fmt.Sprintf("%s <> ?", boolNotEquals.Name), Params: []any{boolNotEquals.Value}},
 	}
 
 	queryParameterFilterMap := model.QueryParameterFilterMap{
-		numericMax.Name:     model.QueryParameterFilters{numericMin, numericMax},
-		stringValue.Name:    model.QueryParameterFilters{stringValue},
-		boolEquals.Name:     model.QueryParameterFilters{boolEquals},
-		boolNotEquals.Name:  model.QueryParameterFilters{boolNotEquals},
-		stringContains.Name: model.QueryParameterFilters{stringContains},
+		numericMax.Name:    model.QueryParameterFilters{numericMin, numericMax},
+		stringValue.Name:   model.QueryParameterFilters{stringValue},
+		boolEquals.Name:    model.QueryParameterFilters{boolEquals},
+		boolNotEquals.Name: model.QueryParameterFilters{boolNotEquals},
 	}
 
 	result, err := queryParameterFilterMap.BuildSQLFilter()

--- a/cmd/api/src/model/saved_queries.go
+++ b/cmd/api/src/model/saved_queries.go
@@ -57,7 +57,7 @@ func (s SavedQueries) ValidFilters() map[string][]FilterOperator {
 		"user_id":     {Equals, NotEquals},
 		"name":        {Equals, NotEquals},
 		"query":       {Equals, NotEquals},
-		"description": {Equals, NotEquals, Contains},
+		"description": {Equals, NotEquals},
 	}
 }
 

--- a/cmd/api/src/model/saved_queries_test.go
+++ b/cmd/api/src/model/saved_queries_test.go
@@ -41,12 +41,7 @@ func TestSavedQueries_ValidFilters(t *testing.T) {
 	for _, column := range []string{"user_id", "name", "query", "description"} {
 		operators, ok := validFilters[column]
 		require.True(t, ok)
-		switch column {
-		case "description":
-			require.Equal(t, 3, len(operators))
-		default:
-			require.Equal(t, 2, len(operators))
-		}
+		require.Equal(t, 2, len(operators))
 	}
 }
 


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Revert #767 
We discussed using a new predicate instead of `in:`, but the changes were already staged for release.
This is to revert the implementation of the `in:` predicate in favor of BED-4726

## Motivation and Context

Avoiding API changes from going out so that we may further improve on it before releasing to the public

## How Has This Been Tested?
I tested the `in:` predicate to ensure it returns an error as the predicate is no longer supported
I then tested the supported predicates for the `ListSavedQueries` endpoint to ensure they still worked

## Screenshots (optional):
`in:` no longer working:
<img width="2567" alt="image" src="https://github.com/user-attachments/assets/2c9675c1-68e9-45f5-8514-493f2e5a973e">

`eq:` description working as intended
<img width="2566" alt="image" src="https://github.com/user-attachments/assets/7fca757a-d79f-405a-b40b-46f2b9f7ef4c">

`neq:` description returns nothing
<img width="2554" alt="image" src="https://github.com/user-attachments/assets/aeade4a5-e385-4fdf-a170-884c61ab8fc5">

`neq:` description returns data
<img width="2511" alt="image" src="https://github.com/user-attachments/assets/84fc3dab-18d7-49ec-8f29-37a9ac9c9d53">

`eq:` name returns data
<img width="2541" alt="image" src="https://github.com/user-attachments/assets/2efa782c-7802-499e-99b0-87fdf9ae2b9b">


`neq:` name returns data
<img width="2536" alt="image" src="https://github.com/user-attachments/assets/651d86ac-955e-401b-94d1-d9e1c422dffc">



## Types of changes

<!-- Please remove any items that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
