### PR TITLE
Add Enroll Edge Type to Path Finding

### DIFF
--- a/packages/javascript/bh-shared-ui/src/views/Explore/ExploreSearch/edgeTypes.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/Explore/ExploreSearch/edgeTypes.tsx
@@ -96,6 +96,7 @@ export const AllEdgeTypes: Category[] = [
             {
                 name: 'Active Directory Certificate Services',
                 edgeTypes: [
+                    ActiveDirectoryRelationshipKind.Enroll,
                     ActiveDirectoryRelationshipKind.GoldenCert,
                     ActiveDirectoryRelationshipKind.ADCSESC1,
                     ActiveDirectoryRelationshipKind.ADCSESC3,


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Added the Enroll type to Edge Types as it was missing from Path Finding

## Motivation and Context

This PR addresses: [[GitHub issue](https://github.com/SpecterOps/BloodHound/issues/799)]

Was not able to path find between node with enrollment rights to a Cert Template

## How Has This Been Tested?

This has not been tested, I am hoping there is not more to fix this issue but hopefully you can confirm.

## Screenshots (optional):

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
