### PR TITLE
fix(bed-4320): Return an error if decoding fails

### DIFF
--- a/cmd/api/src/daemons/datapipe/decoders.go
+++ b/cmd/api/src/daemons/datapipe/decoders.go
@@ -46,13 +46,14 @@ func decodeBasicData[T any](batch graph.Batch, reader io.ReadSeeker, conversionF
 	)
 
 	for decoder.More() {
-		//This variable needs to be initialized here, otherwise the marshaller will cache the map in the struct
+		// This variable needs to be initialized here, otherwise the marshaller will cache the map in the struct
 		var decodeTarget T
 		if err := decoder.Decode(&decodeTarget); err != nil {
 			log.Errorf("Error decoding %T object: %v", decodeTarget, err)
 			if errors.Is(err, io.EOF) {
 				break
 			}
+			return err
 		} else {
 			count++
 			conversionFunc(decodeTarget, &convertedData)


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

*Describe your changes in detail*

## Motivation and Context

This PR addresses: [BED-4320](https://specterops.atlassian.net/browse/BED-4320)

*Why is this change required? What problem does it solve?*

## How Has This Been Tested?

Using one of the test files from https://github.com/SpecterOps/BloodHound/wiki/Example-Data and changing the value from `*_domains.json`,

```json
    {
      "TargetDomainSid": "S-1-5-21-2845847946-3451170323-4261139666",
      "TargetDomainName": "GHOST.CORP",
      "IsTransitive": true,
      "SidFilteringEnabled": false,
      "TrustDirection": "Bidirectional",
      "TrustType": "ParentChild"
    },
```

after 

```json
    {
      "TargetDomainSid": "S-1-5-21-2845847946-3451170323-4261139666",
      "TargetDomainName": "GHOST.CORP",
      "IsTransitive": true,
      "SidFilteringEnabled": false,
      "TrustDirection": 1,
      "TrustType": "ParentChild"
    },
```

We then produce the error on the UI.

<img width="1472" alt="image" src="https://github.com/user-attachments/assets/141ef20c-cf60-4d9f-8646-d12e04a9960a">

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


[BED-4320]: https://specterops.atlassian.net/browse/BED-4320?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ