### PR TITLE
fix: filter node property at ingest and for entity panel display

### DIFF
--- a/cmd/api/src/daemons/datapipe/ingest_test.go
+++ b/cmd/api/src/daemons/datapipe/ingest_test.go
@@ -1,0 +1,48 @@
+// Copyright 2024 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package datapipe_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/specterops/bloodhound/graphschema/ad"
+	"github.com/specterops/bloodhound/graphschema/common"
+	"github.com/specterops/bloodhound/src/daemons/datapipe"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNormalizeEinNodeProperties(t *testing.T) {
+	var (
+		nowUTC     = time.Now().UTC()
+		objectID   = "objectid"
+		properties = map[string]any{
+			datapipe.ReconcileProperty:      false,
+			common.Name.String():            "name",
+			common.OperatingSystem.String(): "temple",
+			ad.DistinguishedName.String():   "distinguished-name",
+		}
+		normalizedProperties = datapipe.NormalizeEinNodeProperties(properties, objectID, nowUTC)
+	)
+
+	assert.Nil(t, normalizedProperties[datapipe.ReconcileProperty])
+	assert.NotNil(t, normalizedProperties[common.LastSeen.String()])
+	assert.Equal(t, "OBJECTID", normalizedProperties[common.ObjectID.String()])
+	assert.Equal(t, "NAME", normalizedProperties[common.Name.String()])
+	assert.Equal(t, "DISTINGUISHED-NAME", normalizedProperties[ad.DistinguishedName.String()])
+	assert.Equal(t, "TEMPLE", normalizedProperties[common.OperatingSystem.String()])
+}

--- a/packages/javascript/bh-shared-ui/src/views/Explore/fragments.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/Explore/fragments.test.tsx
@@ -14,8 +14,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { Field } from './fragments';
 import { render, screen } from '../../test-utils';
+import { EntityField } from '../../utils';
+import { exclusionList, Field, ObjectInfoFields } from './fragments';
 
 describe('Field', () => {
     it('should render a Field when the provided value is false', () => {
@@ -42,5 +43,23 @@ describe('Field', () => {
     it('should not render a Field when the provided value is []', () => {
         const { container } = render(<Field label='Test Field (Array)' value={[]} keyprop='test-field-array' />);
         expect(container.innerHTML).toBe('');
+    });
+});
+
+describe('ObjectInfoFields', () => {
+    it('should filter properties that we do not want to display in the entity panel', () => {
+        const properties: EntityField[] = exclusionList.map((key) => {
+            return { label: key, value: 'test', keyprop: key };
+        });
+        const validProperty: EntityField = { label: 'Object ID', value: 'OBJECT_ID' };
+        properties.push(validProperty);
+
+        render(<ObjectInfoFields fields={properties} />);
+
+        expect(screen.getByText('Object ID')).toBeInTheDocument();
+
+        exclusionList.forEach((property) => {
+            expect(screen.queryByText(property)).not.toBeInTheDocument();
+        });
     });
 });

--- a/packages/javascript/bh-shared-ui/src/views/Explore/fragments.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/Explore/fragments.tsx
@@ -19,7 +19,7 @@ import useCollapsibleSectionStyles from './InfoStyles/CollapsibleSection';
 import React, { PropsWithChildren } from 'react';
 import { EntityField, format } from '../../utils';
 
-const exclusionList = [
+export const exclusionList = [
     'gid',
     'admin_rights_count',
     'admin_rights_risk_percent',
@@ -32,6 +32,7 @@ const exclusionList = [
     'displayname',
     'service_principal_id',
     'highvalue',
+    'reconcile',
 ];
 
 const filterNegatedFields = (fields: EntityField[]): EntityField[] =>


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description
Prevents 'reconcile' from being persisted in node properties upon ingest.
Prevents 'reconcile' from being displayed in the entity panel if already persisted.

## Motivation and Context

This PR addresses: BED-4623

## How Has This Been Tested?
Unit tests have been added.

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
