### PR TITLE
fixed incorrect usage of readonly properties with model refs

### DIFF
--- a/packages/go/openapi/doc/openapi.json
+++ b/packages/go/openapi/doc/openapi.json
@@ -13083,12 +13083,10 @@
             "readOnly": true
           },
           "deleted_at": {
+            "readOnly": true,
             "allOf": [
               {
                 "$ref": "#/components/schemas/null.time"
-              },
-              {
-                "readOnly": true
               }
             ]
           }
@@ -13220,22 +13218,18 @@
             "type": "object",
             "properties": {
               "saml_provider_id": {
+                "readOnly": true,
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/null.int32"
-                  },
-                  {
-                    "readOnly": true
                   }
                 ]
               },
               "AuthSecret": {
+                "readOnly": true,
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/model.auth-secret"
-                  },
-                  {
-                    "readOnly": true
                   }
                 ]
               },
@@ -13247,32 +13241,21 @@
                 }
               },
               "first_name": {
+                "readOnly": true,
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/null.string"
-                  },
-                  {
-                    "readOnly": true
                   }
                 ]
               },
               "last_name": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/null.string"
-                  },
-                  {
-                    "readOnly": false
-                  }
-                ]
+                "$ref": "#/components/schemas/null.string"
               },
               "email_address": {
+                "readOnly": true,
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/null.string"
-                  },
-                  {
-                    "readOnly": true
                   }
                 ]
               },
@@ -13383,22 +13366,18 @@
             "type": "object",
             "properties": {
               "user_id": {
+                "readOnly": true,
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/null.uuid"
-                  },
-                  {
-                    "readOnly": true
                   }
                 ]
               },
               "name": {
+                "readOnly": true,
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/null.string"
-                  },
-                  {
-                    "readOnly": true
                   }
                 ]
               },
@@ -13559,22 +13538,18 @@
                 "readOnly": true
               },
               "event_id": {
+                "readOnly": true,
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/null.int32"
-                  },
-                  {
-                    "readOnly": true
                   }
                 ]
               },
               "status": {
+                "readOnly": true,
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/enum.job-status"
-                  },
-                  {
-                    "readOnly": true
                   }
                 ]
               },
@@ -13593,12 +13568,10 @@
                 "readOnly": true
               },
               "log_path": {
+                "readOnly": true,
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/null.string"
-                  },
-                  {
-                    "readOnly": true
                   }
                 ]
               },
@@ -13710,32 +13683,26 @@
                 }
               },
               "token": {
+                "readOnly": true,
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/model.auth-token"
-                  },
-                  {
-                    "readOnly": true
                   }
                 ]
               },
               "current_job_id": {
+                "readOnly": true,
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/null.int64"
-                  },
-                  {
-                    "readOnly": true
                   }
                 ]
               },
               "current_job": {
+                "readOnly": true,
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/model.client-scheduled-job"
-                  },
-                  {
-                    "readOnly": true
                   }
                 ]
               },
@@ -13745,12 +13712,10 @@
                 "readOnly": true
               },
               "domain_controller": {
+                "readOnly": true,
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/null.string"
-                  },
-                  {
-                    "readOnly": true
                   }
                 ]
               },
@@ -13759,22 +13724,18 @@
                 "readOnly": true
               },
               "user_sid": {
+                "readOnly": true,
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/null.string"
-                  },
-                  {
-                    "readOnly": true
                   }
                 ]
               },
               "type": {
+                "readOnly": true,
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/enum.client-type"
-                  },
-                  {
-                    "readOnly": true
                   }
                 ]
               }
@@ -14122,12 +14083,10 @@
                 "readOnly": true
               },
               "status": {
+                "readOnly": true,
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/enum.audit-log-status"
-                  },
-                  {
-                    "readOnly": true
                   }
                 ]
               }

--- a/packages/go/openapi/src/schemas/model.audit-log.yaml
+++ b/packages/go/openapi/src/schemas/model.audit-log.yaml
@@ -52,6 +52,6 @@ allOf:
         format: uuid
         readOnly: true
       status:
+        readOnly: true
         allOf:
           - $ref: './enum.audit-log-status.yaml'
-          - readOnly: true

--- a/packages/go/openapi/src/schemas/model.auth-token.yaml
+++ b/packages/go/openapi/src/schemas/model.auth-token.yaml
@@ -20,13 +20,13 @@ allOf:
   - type: object
     properties:
       user_id:
+        readOnly: true
         allOf:
           - $ref: './null.uuid.yaml'
-          - readOnly: true
       name:
+        readOnly: true
         allOf:
           - $ref: './null.string.yaml'
-          - readOnly: true
       key:
         type: string
         readOnly: true

--- a/packages/go/openapi/src/schemas/model.client-scheduled-job.yaml
+++ b/packages/go/openapi/src/schemas/model.client-scheduled-job.yaml
@@ -27,13 +27,13 @@ allOf:
         type: string
         readOnly: true
       event_id:
+        readOnly: true
         allOf:
           - $ref: './null.int32.yaml'
-          - readOnly: true
       status:
+        readOnly: true
         allOf:
           - $ref: './enum.job-status.yaml'
-          - readOnly: true
       statusMessage:
         type: string
         readOnly: true
@@ -46,9 +46,9 @@ allOf:
         format: date-time
         readOnly: true
       log_path:
+        readOnly: true
         allOf:
           - $ref: './null.string.yaml'
-          - readOnly: true
       session_collection:
         type: boolean
       local_group_collection:

--- a/packages/go/openapi/src/schemas/model.client.yaml
+++ b/packages/go/openapi/src/schemas/model.client.yaml
@@ -43,33 +43,33 @@ allOf:
         items:
           $ref: './model.client-schedule.yaml'
       token:
+        readOnly: true
         allOf:
           - $ref: './model.auth-token.yaml'
-          - readOnly: true
       current_job_id:
+        readOnly: true
         allOf:
           - $ref: './null.int64.yaml'
-          - readOnly: true
       current_job:
+        readOnly: true
         allOf:
           - $ref: './model.client-scheduled-job.yaml'
-          - readOnly: true
       completed_job_count:
         type: integer
         format: int32
         readOnly: true
       domain_controller:
+        readOnly: true
         allOf:
           - $ref: './null.string.yaml'
-          - readOnly: true
       version:
         type: string
         readOnly: true
       user_sid:
+        readOnly: true
         allOf:
           - $ref: './null.string.yaml'
-          - readOnly: true
       type:
+        readOnly: true
         allOf:
           - $ref: './enum.client-type.yaml'
-          - readOnly: true

--- a/packages/go/openapi/src/schemas/model.components.timestamps.yaml
+++ b/packages/go/openapi/src/schemas/model.components.timestamps.yaml
@@ -25,6 +25,6 @@ properties:
     format: date-time
     readOnly: true
   deleted_at:
+    readOnly: true
     allOf:
       - $ref: './null.time.yaml'
-      - readOnly: true

--- a/packages/go/openapi/src/schemas/model.user.yaml
+++ b/packages/go/openapi/src/schemas/model.user.yaml
@@ -20,30 +20,28 @@ allOf:
   - type: object
     properties:
       saml_provider_id:
+        readOnly: true
         allOf:
           - $ref: './null.int32.yaml'
-          - readOnly: true
       AuthSecret:
+        readOnly: true
         allOf:
           - $ref: './model.auth-secret.yaml'
-          - readOnly: true
       roles:
         type: array
         readOnly: true
         items:
           $ref: './model.role.yaml'
       first_name:
+        readOnly: true
         allOf:
           - $ref: './null.string.yaml'
-          - readOnly: true
       last_name:
-        allOf:
-          - $ref: './null.string.yaml'
-          - readOnly: false
+          $ref: './null.string.yaml'
       email_address:
+        readOnly: true
         allOf:
           - $ref: './null.string.yaml'
-          - readOnly: true
       principal_name:
         type: string
         readOnly: true


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Currently we incorrectly apply readOnly to ref properties like this:
```yaml
status:
  allOf:
    - $ref: './enum.audit-log-status.yaml'
    - readOnly: true
    - ```
It should be applied like this:
```yaml
status:
  readOnly: true
  allOf:
    - $ref: './enum.audit-log-status.yaml'
```

## Motivation and Context

This PR addresses: BED-4736

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
