### PR TITLE
BED-4740: replace BloodhoundDB with GetFlagByKeyer

### DIFF
--- a/cmd/api/src/daemons/datapipe/agi.go
+++ b/cmd/api/src/daemons/datapipe/agi.go
@@ -155,10 +155,10 @@ func ParallelTagAzureTierZero(ctx context.Context, db graph.Database) error {
 	return nil
 }
 
-func TagActiveDirectoryTierZero(ctx context.Context, db appcfg.GetFlagByKeyer, graphDB graph.Database) error {
+func TagActiveDirectoryTierZero(ctx context.Context, featureFlagProvider appcfg.GetFlagByKeyer, graphDB graph.Database) error {
 	defer log.Measure(log.LevelInfo, "Finished tagging Active Directory Tier Zero")()
 
-	if autoTagT0ParentObjectsFlag, err := db.GetFlagByKey(ctx, appcfg.FeatureAutoTagT0ParentObjects); err != nil {
+	if autoTagT0ParentObjectsFlag, err := featureFlagProvider.GetFlagByKey(ctx, appcfg.FeatureAutoTagT0ParentObjects); err != nil {
 		return err
 	} else if domains, err := adAnalysis.FetchAllDomains(ctx, graphDB); err != nil {
 		return err

--- a/cmd/api/src/daemons/datapipe/agi.go
+++ b/cmd/api/src/daemons/datapipe/agi.go
@@ -155,7 +155,7 @@ func ParallelTagAzureTierZero(ctx context.Context, db graph.Database) error {
 	return nil
 }
 
-func TagActiveDirectoryTierZero(ctx context.Context, db database.Database, graphDB graph.Database) error {
+func TagActiveDirectoryTierZero(ctx context.Context, db appcfg.GetFlagByKeyer, graphDB graph.Database) error {
 	defer log.Measure(log.LevelInfo, "Finished tagging Active Directory Tier Zero")()
 
 	if autoTagT0ParentObjectsFlag, err := db.GetFlagByKey(ctx, appcfg.FeatureAutoTagT0ParentObjects); err != nil {


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

Swap the db instance with `GetFlagByKeyer` interface .

## Motivation and Context

This PR addresses: BED-4740

We only need the `GetFlagByKeyer` methods from `BloodhoundDB`.

## How Has This Been Tested?

*Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc.*

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)
- Database Migrations

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
