### PR TITLE
BED-4750 added LoginURL to properties and re-generated files

### DIFF
--- a/packages/cue/bh/azure/azure.cue
+++ b/packages/cue/bh/azure/azure.cue
@@ -276,6 +276,7 @@ Properties: [
 	MFAEnabled,
 	License,
 	Licenses,
+	LoginURL,
 	MFAEnforced,
 	UserPrincipalName,
 	IsAssignableToRole,

--- a/packages/go/graphschema/azure/azure.go
+++ b/packages/go/graphschema/azure/azure.go
@@ -100,7 +100,6 @@ const (
 	AppOwnerOrganizationID  Property = "appownerorganizationid"
 	AppDescription          Property = "appdescription"
 	AppDisplayName          Property = "appdisplayname"
-	LoginURL                Property = "loginurl"
 	ServicePrincipalType    Property = "serviceprincipaltype"
 	UserType                Property = "usertype"
 	TenantID                Property = "tenantid"
@@ -123,6 +122,7 @@ const (
 	MFAEnabled              Property = "mfaenabled"
 	License                 Property = "license"
 	Licenses                Property = "licenses"
+	LoginURL                Property = "loginurl"
 	MFAEnforced             Property = "mfaenforced"
 	UserPrincipalName       Property = "userprincipalname"
 	IsAssignableToRole      Property = "isassignabletorole"
@@ -132,7 +132,7 @@ const (
 )
 
 func AllProperties() []Property {
-	return []Property{AppOwnerOrganizationID, AppDescription, AppDisplayName, LoginURL, ServicePrincipalType, UserType, TenantID, ServicePrincipalID, ServicePrincipalNames, OperatingSystemVersion, TrustType, IsBuiltIn, AppID, AppRoleID, DeviceID, NodeResourceGroupID, OnPremID, OnPremSyncEnabled, SecurityEnabled, SecurityIdentifier, EnableRBACAuthorization, Scope, Offer, MFAEnabled, License, Licenses, MFAEnforced, UserPrincipalName, IsAssignableToRole, PublisherDomain, SignInAudience, RoleTemplateID}
+	return []Property{AppOwnerOrganizationID, AppDescription, AppDisplayName, ServicePrincipalType, UserType, TenantID, ServicePrincipalID, ServicePrincipalNames, OperatingSystemVersion, TrustType, IsBuiltIn, AppID, AppRoleID, DeviceID, NodeResourceGroupID, OnPremID, OnPremSyncEnabled, SecurityEnabled, SecurityIdentifier, EnableRBACAuthorization, Scope, Offer, MFAEnabled, License, Licenses, LoginURL, MFAEnforced, UserPrincipalName, IsAssignableToRole, PublisherDomain, SignInAudience, RoleTemplateID}
 }
 func ParseProperty(source string) (Property, error) {
 	switch source {
@@ -142,8 +142,6 @@ func ParseProperty(source string) (Property, error) {
 		return AppDescription, nil
 	case "appdisplayname":
 		return AppDisplayName, nil
-	case "loginurl":
-		return LoginURL, nil
 	case "serviceprincipaltype":
 		return ServicePrincipalType, nil
 	case "usertype":
@@ -188,6 +186,8 @@ func ParseProperty(source string) (Property, error) {
 		return License, nil
 	case "licenses":
 		return Licenses, nil
+	case "loginurl":
+		return LoginURL, nil
 	case "mfaenforced":
 		return MFAEnforced, nil
 	case "userprincipalname":
@@ -212,8 +212,6 @@ func (s Property) String() string {
 		return string(AppDescription)
 	case AppDisplayName:
 		return string(AppDisplayName)
-	case LoginURL:
-		return string(LoginURL)
 	case ServicePrincipalType:
 		return string(ServicePrincipalType)
 	case UserType:
@@ -258,6 +256,8 @@ func (s Property) String() string {
 		return string(License)
 	case Licenses:
 		return string(Licenses)
+	case LoginURL:
+		return string(LoginURL)
 	case MFAEnforced:
 		return string(MFAEnforced)
 	case UserPrincipalName:
@@ -282,8 +282,6 @@ func (s Property) Name() string {
 		return "App Description"
 	case AppDisplayName:
 		return "App Display Name"
-	case LoginURL:
-		return "Login URL"
 	case ServicePrincipalType:
 		return "Service Principal Type"
 	case UserType:
@@ -328,6 +326,8 @@ func (s Property) Name() string {
 		return "License"
 	case Licenses:
 		return "Licenses"
+	case LoginURL:
+		return "Login URL"
 	case MFAEnforced:
 		return "MFA Enforced"
 	case UserPrincipalName:

--- a/packages/javascript/bh-shared-ui/src/graphSchema.ts
+++ b/packages/javascript/bh-shared-ui/src/graphSchema.ts
@@ -886,7 +886,6 @@ export enum AzureKindProperties {
     AppOwnerOrganizationID = 'appownerorganizationid',
     AppDescription = 'appdescription',
     AppDisplayName = 'appdisplayname',
-    LoginURL = 'loginurl',
     ServicePrincipalType = 'serviceprincipaltype',
     UserType = 'usertype',
     TenantID = 'tenantid',
@@ -909,6 +908,7 @@ export enum AzureKindProperties {
     MFAEnabled = 'mfaenabled',
     License = 'license',
     Licenses = 'licenses',
+    LoginURL = 'loginurl',
     MFAEnforced = 'mfaenforced',
     UserPrincipalName = 'userprincipalname',
     IsAssignableToRole = 'isassignabletorole',
@@ -924,8 +924,6 @@ export function AzureKindPropertiesToDisplay(value: AzureKindProperties): string
             return 'App Description';
         case AzureKindProperties.AppDisplayName:
             return 'App Display Name';
-        case AzureKindProperties.LoginURL:
-            return 'Login URL';
         case AzureKindProperties.ServicePrincipalType:
             return 'Service Principal Type';
         case AzureKindProperties.UserType:
@@ -970,6 +968,8 @@ export function AzureKindPropertiesToDisplay(value: AzureKindProperties): string
             return 'License';
         case AzureKindProperties.Licenses:
             return 'Licenses';
+        case AzureKindProperties.LoginURL:
+            return 'Login URL';
         case AzureKindProperties.MFAEnforced:
             return 'MFA Enforced';
         case AzureKindProperties.UserPrincipalName:


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Add `LoginURL` to `azure.cue` properties

## Motivation and Context

This PR addresses: BED-4750

Running `just generate` off of `main` successfully runs, but it removes `azure.LoginURL` from the codebase. Running a subsequent generate will produce errors saying `azure.LoginURL` does not exist.
Adding `LoginURL` to the properties properly generates the file

## How Has This Been Tested?

Run `just generate` twice to ensure that the files are properly being generated and are not causing errors

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
