### PR TITLE
BED-4363 fix: adcs feature flag not in schema.sql

### DIFF
--- a/cmd/api/src/database/migration/migrations/schema.sql
+++ b/cmd/api/src/database/migration/migrations/schema.sql
@@ -656,6 +656,7 @@ INSERT INTO feature_flags (created_at, updated_at, key, name, description, enabl
 INSERT INTO feature_flags (created_at, updated_at, key, name, description, enabled, user_updatable) VALUES (current_timestamp, current_timestamp, 'azure_support', 'Enable Azure Support', 'Enables Azure support.', true, false);
 INSERT INTO feature_flags (created_at, updated_at, key, name, description, enabled, user_updatable) VALUES (current_timestamp, current_timestamp, 'reconciliation', 'Reconciliation', 'Enables Reconciliation', true, false);
 INSERT INTO feature_flags (created_at, updated_at, key, name, description, enabled, user_updatable) VALUES (current_timestamp, current_timestamp, 'entity_panel_cache', 'Enable application level caching', 'Enables the use of application level caching for entity panel queries', true, false);
+INSERT INTO feature_flags (created_at, updated_at, key, name, description, enabled, user_updatable) VALUES (current_timestamp, current_timestamp, 'adcs', 'Enable collection and processing of Active Directory Certificate Services Data', 'Enables the ability to collect, analyze, and explore Active Directory Certificate Services data and previews new attack paths.', false, false );
 
 
 -- Populate parameters table

--- a/cmd/api/src/database/migration/migrations/v5.15.0.sql
+++ b/cmd/api/src/database/migration/migrations/v5.15.0.sql
@@ -27,7 +27,6 @@ ALTER TABLE IF EXISTS permissions
   ADD CONSTRAINT permissions_authority_name_key UNIQUE (authority, name);
 
 -- Feature Flags
-INSERT INTO feature_flags (created_at, updated_at, key, name, description, enabled, user_updatable) VALUES (current_timestamp, current_timestamp, 'adcs', 'Enable collection and processing of Active Directory Certificate Services Data', 'Enables the ability to collect, analyze, and explore Active Directory Certificate Services data and previews new attack paths.', false, true) ON CONFLICT DO NOTHING;
 INSERT INTO feature_flags (created_at, updated_at, key, name, description, enabled, user_updatable) VALUES (current_timestamp, current_timestamp, 'clear_graph_data', 'Clear Graph Data', 'Enables the ability to delete all nodes and edges from the graph database.', true, false) ON CONFLICT DO NOTHING;
 INSERT INTO feature_flags (created_at, updated_at, key, name, description, enabled, user_updatable) VALUES (current_timestamp, current_timestamp, 'risk_exposure_new_calculation', 'Use new tier zero risk exposure calculation', 'Enables the use of new tier zero risk exposure metatree metrics.', false, false) ON CONFLICT DO NOTHING;
 INSERT INTO feature_flags (created_at, updated_at, key, name, description, enabled, user_updatable) VALUES (current_timestamp, current_timestamp, 'fedramp_eula', 'FedRAMP EULA', 'Enables showing the FedRAMP EULA on every login. (Enterprise only)', false, false) ON CONFLICT DO NOTHING;


### PR DESCRIPTION
## Description

- Moved the `adcs` feature flag to `schema.sql` where it should have been from this PR https://github.com/SpecterOps/BloodHound/pull/772
- Also bootstrapped it with updatable to false to be super safe

## Motivation and Context

This PR addresses: BED-4363

Fixes a bug where adcs was updatable in bootstrapped environments due to order of migrations

## How Has This Been Tested?

bootstrapped db to ensure it wasn't updatable 

## Types of changes

- Bug fix (non-breaking change which fixes an issue)
- Database Migrations

## Checklist:

- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
