### PR TITLE
BED-4778: Fix Go version in distroless release image

### DIFF
--- a/dockerfiles/bloodhound.Dockerfile
+++ b/dockerfiles/bloodhound.Dockerfile
@@ -23,7 +23,7 @@ ARG AZUREHOUND_VERSION=v2.1.9
 ########
 # Builder init
 ################
-FROM --platform=$BUILDPLATFORM docker.io/library/node:20-alpine AS deps
+FROM --platform=$BUILDPLATFORM docker.io/library/node:20-alpine3.20 AS deps
 ARG version=v999.999.999
 ARG checkout_hash=""
 ENV SB_LOG_LEVEL=debug
@@ -31,7 +31,10 @@ ENV SB_VERSION=${version}
 ENV CHECKOUT_HASH=${checkout_hash}
 WORKDIR /bloodhound
 
-RUN apk add --update --no-cache git go
+RUN apk add --update --no-cache git
+
+COPY --from=golang:1.23-alpine3.20 /usr/local/go/ /usr/local/go/
+ENV PATH="/usr/local/go/bin:${PATH}"
 
 COPY . /bloodhound
 RUN go run github.com/specterops/bloodhound/packages/go/stbernard deps
@@ -51,7 +54,7 @@ RUN go run github.com/specterops/bloodhound/packages/go/stbernard build --os ${T
 ########
 # Package other assets
 ################
-FROM --platform=$BUILDPLATFORM docker.io/library/alpine:3.16 as hound-builder
+FROM --platform=$BUILDPLATFORM docker.io/library/alpine:3.20 as hound-builder
 ARG SHARPHOUND_VERSION
 ARG AZUREHOUND_VERSION
 


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Fixes our Go version when building the distroless release image by copying from the official Go alpine image

## Motivation and Context

This PR addresses: BED-4778

Edge commits (and eventually full release commits) are currently blocked by this issue

## How Has This Been Tested?

Needs to run in CI to be sure it's working properly. Local docker run seemed to indicate this will work fine.

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
