### PR TITLE
BED-4747: Disable Failing Tests

### DIFF
--- a/cmd/api/src/analysis/ad/adcs_integration_test.go
+++ b/cmd/api/src/analysis/ad/adcs_integration_test.go
@@ -1200,7 +1200,8 @@ func TestADCSESC4Composition(t *testing.T) {
 	})
 }
 
-func TestADCSESC9a(t *testing.T) {
+func TestADCSESC9a(t *testing.T) { //***
+	t.Skip("1 Disabling test to allow engineers to continue submitting PRs and not have significant errors BED-4747")
 	testContext := integration.NewGraphTestContext(t, graphschema.DefaultGraphSchema())
 
 	testContext.DatabaseTestWithSetup(func(harness *integration.HarnessDetails) error {
@@ -1504,7 +1505,8 @@ func TestADCSESC9a(t *testing.T) {
 
 }
 
-func TestADCSESC9b(t *testing.T) {
+func TestADCSESC9b(t *testing.T) { //***
+	t.Skip("2 Disabling test to allow engineers to continue submitting PRs and not have significant errors BED-4747")
 	testContext := integration.NewGraphTestContext(t, graphschema.DefaultGraphSchema())
 
 	testContext.DatabaseTestWithSetup(func(harness *integration.HarnessDetails) error {
@@ -2261,7 +2263,8 @@ func FetchADCSPrereqs(db graph.Database) (impact.PathAggregator, []*graph.Node, 
 	}
 }
 
-func TestADCSESC10a(t *testing.T) {
+func TestADCSESC10a(t *testing.T) { //***
+	t.Skip("3 Disabling test to allow engineers to continue submitting PRs and not have significant errors BED-4747")
 	testContext := integration.NewGraphTestContext(t, graphschema.DefaultGraphSchema())
 
 	testContext.DatabaseTestWithSetup(func(harness *integration.HarnessDetails) error {
@@ -2518,7 +2521,8 @@ func TestADCSESC10a(t *testing.T) {
 	})
 }
 
-func TestADCSESC13(t *testing.T) {
+func TestADCSESC13(t *testing.T) { //***
+	t.Skip("4 Disabling test to allow engineers to continue submitting PRs and not have significant errors BED-4747")
 	testContext := integration.NewGraphTestContext(t, graphschema.DefaultGraphSchema())
 	testContext.DatabaseTestWithSetup(func(harness *integration.HarnessDetails) error {
 		harness.ESC13Harness1.Setup(testContext)
@@ -2730,7 +2734,8 @@ func TestADCSESC13(t *testing.T) {
 	})
 }
 
-func TestADCSESC10b(t *testing.T) {
+func TestADCSESC10b(t *testing.T) { //***
+	t.Skip("5 Disabling test to allow engineers to continue submitting PRs and not have significant errors BED-4747")
 	testContext := integration.NewGraphTestContext(t, graphschema.DefaultGraphSchema())
 
 	testContext.DatabaseTestWithSetup(func(harness *integration.HarnessDetails) error {

--- a/cmd/api/src/api/v2/file_uploads_integration_test.go
+++ b/cmd/api/src/api/v2/file_uploads_integration_test.go
@@ -154,7 +154,8 @@ func Test_FileUpload(t *testing.T) {
 	})
 }
 
-func Test_FileUploadWorkFlowVersion5(t *testing.T) {
+func Test_FileUploadWorkFlowVersion5(t *testing.T) { //***
+	t.Skip("1 Disabling test to allow engineers to continue submitting PRs and not have significant errors BED-4747")
 	testCtx := integration.NewFOSSContext(t)
 
 	testCtx.SendFileIngest([]string{
@@ -173,7 +174,8 @@ func Test_FileUploadWorkFlowVersion5(t *testing.T) {
 	testCtx.AssertIngest(fixtures.IngestAssertions)
 }
 
-func Test_FileUploadWorkFlowVersion6(t *testing.T) {
+func Test_FileUploadWorkFlowVersion6(t *testing.T) { //***
+	t.Skip("2 Disabling test to allow engineers to continue submitting PRs and not have significant errors BED-4747")
 	testCtx := integration.NewFOSSContext(t)
 
 	testCtx.SendFileIngest([]string{
@@ -194,7 +196,8 @@ func Test_FileUploadWorkFlowVersion6(t *testing.T) {
 	testCtx.AssertIngest(fixtures.PropertyAssertions)
 }
 
-func Test_FileUploadVersion6AllOptionADCS(t *testing.T) {
+func Test_FileUploadVersion6AllOptionADCS(t *testing.T) { //***
+	t.Skip("3 Disabling test to allow engineers to continue submitting PRs and not have significant errors BED-4747")
 	testCtx := integration.NewFOSSContext(t)
 
 	testCtx.SendFileIngest([]string{
@@ -216,7 +219,8 @@ func Test_FileUploadVersion6AllOptionADCS(t *testing.T) {
 	testCtx.AssertIngest(fixtures.IngestADCSAssertions)
 }
 
-func Test_FileUploadVersion6AllOptionADCSZip(t *testing.T) {
+func Test_FileUploadVersion6AllOptionADCSZip(t *testing.T) { //***
+	t.Skip("4 Disabling test to allow engineers to continue submitting PRs and not have significant errors BED-4747")
 	testCtx := integration.NewFOSSContext(t)
 
 	testCtx.SendZipFileIngest("v6/all/adcs.zip")
@@ -224,7 +228,8 @@ func Test_FileUploadVersion6AllOptionADCSZip(t *testing.T) {
 	testCtx.AssertIngest(fixtures.IngestADCSAssertions)
 }
 
-func Test_CompressedFileUploadWorkFlowVersion5(t *testing.T) {
+func Test_CompressedFileUploadWorkFlowVersion5(t *testing.T) { //***
+	t.Skip("5 Disabling test to allow engineers to continue submitting PRs and not have significant errors BED-4747")
 	testCtx := integration.NewFOSSContext(t)
 
 	testCtx.SendCompressedFileIngest([]string{
@@ -244,7 +249,8 @@ func Test_CompressedFileUploadWorkFlowVersion5(t *testing.T) {
 	testCtx.AssertIngest(fixtures.PropertyAssertions)
 }
 
-func Test_CompressedFileUploadWorkFlowVersion6(t *testing.T) {
+func Test_CompressedFileUploadWorkFlowVersion6(t *testing.T) { //***
+	t.Skip("6 Disabling test to allow engineers to continue submitting PRs and not have significant errors BED-4747")
 	testCtx := integration.NewFOSSContext(t)
 
 	testCtx.SendCompressedFileIngest([]string{


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

- Disabled failing integration tests

## Motivation and Context

- Ticket: BED-4747
- Subtask above is from BED-4680

*Why is this change required? What problem does it solve?*
- Disabling the following tests will allow engineers to continue submitting PRs and not have significant errors

## How Has This Been Tested?

- Tested that all the disabled tests above were being skipped

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
