### PR TITLE
BED-4778: Fix multiarch builds

### DIFF
--- a/.github/workflows/edge-publish.yml
+++ b/.github/workflows/edge-publish.yml
@@ -18,7 +18,7 @@ name: Publish Edge Build
 
 on:
   push:
-    branches: [main, BED-4778]
+    branches: [main]
 
 env:
   REVISION: v5.0.0-edge

--- a/.github/workflows/edge-publish.yml
+++ b/.github/workflows/edge-publish.yml
@@ -18,7 +18,7 @@ name: Publish Edge Build
 
 on:
   push:
-    branches: [main]
+    branches: [main, BED-4778]
 
 env:
   REVISION: v5.0.0-edge

--- a/dockerfiles/bloodhound.Dockerfile
+++ b/dockerfiles/bloodhound.Dockerfile
@@ -21,6 +21,11 @@ ARG SHARPHOUND_VERSION=v2.4.1
 ARG AZUREHOUND_VERSION=v2.1.9
 
 ########
+# Golang Image
+################
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.23-alpine3.20 AS godeps
+
+########
 # Builder init
 ################
 FROM --platform=$BUILDPLATFORM docker.io/library/node:20-alpine3.20 AS deps
@@ -33,11 +38,8 @@ WORKDIR /bloodhound
 
 RUN apk add --update --no-cache git
 
-COPY --from=golang:1.23-alpine3.20 /usr/local/go/ /usr/local/go/
+COPY --from=godeps /usr/local/go/ /usr/local/go/
 ENV PATH="/usr/local/go/bin:${PATH}"
-
-RUN ls -la /usr/local/go/bin
-RUN tail -c 64 /usr/local/go/bin/go
 
 COPY . /bloodhound
 RUN go run github.com/specterops/bloodhound/packages/go/stbernard deps

--- a/dockerfiles/bloodhound.Dockerfile
+++ b/dockerfiles/bloodhound.Dockerfile
@@ -36,6 +36,9 @@ RUN apk add --update --no-cache git
 COPY --from=golang:1.23-alpine3.20 /usr/local/go/ /usr/local/go/
 ENV PATH="/usr/local/go/bin:${PATH}"
 
+RUN ls -la /usr/local/go/bin
+RUN tail -c 64 /usr/local/go/bin/go
+
 COPY . /bloodhound
 RUN go run github.com/specterops/bloodhound/packages/go/stbernard deps
 


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Fixes multiarch builds so we stop failing for real this time

## Motivation and Context

This PR addresses: BED-4778

Last attempt at a fix broke multiplatform builds since local testing for that case is difficult to set up

## How Has This Been Tested?

Mix of local testing and engaging the edge publish action by adding this branch to it during testing. Artifacts were tested on a Linux x86-64 machine and an Apple Silicon machine to ensure the final results were correct.

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
