### PR TITLE
BED-4781: Add Parca Config for ToolAPI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,7 +9,8 @@ BH_CONFIG_FILE=build.config.json
 # BloodHound API
 BH_HOSTNAME=bloodhound.localhost
 BH_PKG_MOD_VOLUME=bh-go-pkg-mod
-BH_API_PORT=127.0.0.1:8008
+BH_API_PORT=127.0.0.1:8080
+TOOLAPI_PORT=127.0.0.1:2112
 
 # BloodHound PG Admin
 BH_PG_ADMIN_HOSTNAME=pgadmin.localhost

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -41,7 +41,7 @@ services:
       test:
         [
           "CMD-SHELL",
-          "pg_isready -U ${BH_POSTGRES_USER:-bloodhound} -d 'dbname=${BH_POSTGRES_DB:-bloodhound}' -h 127.0.0.1 -p 5432"
+          "pg_isready -U ${BH_POSTGRES_USER:-bloodhound} -d 'dbname=${BH_POSTGRES_DB:-bloodhound}' -h 127.0.0.1 -p 5432",
         ]
       interval: 10s
       timeout: 5s
@@ -88,10 +88,7 @@ services:
       - traefik.http.services.neo4jbrowser.loadbalancer.server.port=7474
     healthcheck:
       test:
-        [
-          "CMD-SHELL",
-          "wget -O /dev/null -q http://localhost:7474 || exit 1"
-        ]
+        ["CMD-SHELL", "wget -O /dev/null -q http://localhost:7474 || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -107,6 +104,7 @@ services:
     command: "-c .air.toml ${AIR_FLAGS:-''}"
     ports:
       - ${BH_API_PORT:-127.0.0.1:8080}:8080
+      - ${TOOLAPI_PORT:-127.0.0.1:2112}:2112
     labels:
       - traefik.enable=true
       - traefik.http.routers.bhapi.rule=Host(`${BH_HOSTNAME:-bloodhound.localhost}`) && PathPrefix(`/api`)
@@ -153,6 +151,7 @@ services:
     command: "-c .air.debug.toml ${AIR_FLAGS:-''}"
     ports:
       - ${BH_API_PORT:-127.0.0.1:8080}:8080
+      - ${TOOLAPI_PORT:-127.0.0.1:2112}:2112
       - ${DEBUG_PORT:-127.0.0.1:3456}:2345
     labels:
       - traefik.enable=true

--- a/local-harnesses/build.config.json.template
+++ b/local-harnesses/build.config.json.template
@@ -1,7 +1,7 @@
 {
     "version": 1,
     "bind_addr": "0.0.0.0:8080",
-    "metrics_port": "localhost:2112",
+    "metrics_port": "0.0.0.0:2112",
     "root_url": "http://0.0.0.0:8080/",
     "work_dir": "/bhapi/work",
     "collectors_base_path": "/bhapi/collectors",

--- a/parca.yaml
+++ b/parca.yaml
@@ -1,0 +1,45 @@
+object_storage:
+  bucket:
+    type: "FILESYSTEM"
+    config:
+      directory: "./data"
+
+# Optionally configure targets to be scraped. It is recommended to start
+# with just Parca Agent CPU profiling and add scraping where valuable.
+# Scraping tends to produce a lot more data than Parca Agent CPU which
+# results in memory usage by the server.
+#
+scrape_configs:
+  - job_name: "pprof"
+    scrape_interval: "1s"
+    static_configs:
+      - targets: ["127.0.0.1:2112"]
+# Nested under the job config:
+#
+# Only keep a certain type of profile from a scrape. For example the Go
+# runtime memory profiles contain memory inuse-space bytes and objects as
+# well as allocated space and objects. Often times inuse-space bytes is
+# the one that is most interest to extract from the Go runtime.
+#
+# profiling_config:
+#   pprof_config:
+#     memory:
+#       keep_sample_type:
+#       - type: inuse_space
+#         unit: bytes
+#
+
+# Nested under the job config:
+#
+# Custom scrape endpoints can be added like just like the example below.
+# The profile name will be `fgprof`, and it will be scraped from the given
+# path and since it is a delta profile, a query parameter
+# ?seconds=<scrape-interval> will be added.
+#
+# profiling_config:
+#   pprof_config:
+#     fgprof:
+#       enabled: true
+#       path: /debug/pprof/fgprof
+#       delta: true
+#

--- a/tools/docker-compose/api.Dockerfile
+++ b/tools/docker-compose/api.Dockerfile
@@ -69,7 +69,7 @@ WORKDIR /bloodhound
 VOLUME [ "/go/pkg/mod" ]
 
 RUN mkdir -p /bhapi/collectors/azurehound /bhapi/collectors/sharphound /bhapi/work
-RUN go install github.com/go-delve/delve/cmd/dlv@v1.21.0
+RUN go install github.com/go-delve/delve/cmd/dlv@v1.23.0
 RUN go install github.com/cosmtrek/air@v1.44.0
 
 COPY --from=hound-builder /tmp/sharphound/sharphound-$SHARPHOUND_VERSION.zip /bhapi/collectors/sharphound/


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

- Adds a valid parca config for scraping pprof data from the toolapi in development modes
    - This allows devs to instrument their dev versions of BHCE to see what function calls are using the most resources, as well as monitor CPU, memory, and goroutine usage
    - Requires installing parca locally, but otherwise you just run it in the project root and everything "Just Works"
- Fixes default configuration for the toolapi to make it properly accessible/configurable
- Fixes an issue with dlv version after the upgrade to Go 1.23

## Motivation and Context

This PR addresses: BED-4781

We need to use parca internally for some instrumentation when evaluating features and it makes sense to standardize our config, making it easier for anyone wanting to work on BloodHound to run the instrumentation.

## How Has This Been Tested?

Locally tested across all common dev workflows

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
