### PR TITLE
BED-4746: button alignment on early access page

### DIFF
--- a/cmd/ui/src/views/EarlyAccessFeatures/EarlyAccessFeatures.tsx
+++ b/cmd/ui/src/views/EarlyAccessFeatures/EarlyAccessFeatures.tsx
@@ -54,10 +54,13 @@ export const EarlyAccessFeatureToggle: React.FC<{
                     <Typography variant='body1'>{flag.description}</Typography>
                 </Box>
                 <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-                    <Button disabled={disabled} onClick={handleOnClick}>
+                    {/* TODO: replace style prop with TW classes once TW is added */}
+                    <Button disabled={disabled} onClick={handleOnClick} style={{ width: '132px' }}>
                         <Box display={'flex'} alignItems={'center'}>
-                            {flag.enabled ? <FontAwesomeIcon icon={faCheckCircle} fixedWidth /> : null}
-                            <Typography ml='8px'>{flag.enabled ? 'Enabled' : 'Disabled'}</Typography>
+                            {flag.enabled ? (
+                                <FontAwesomeIcon style={{ marginRight: '8px' }} icon={faCheckCircle} fixedWidth />
+                            ) : null}
+                            <Typography>{flag.enabled ? 'Enabled' : 'Disabled'}</Typography>
                         </Box>
                     </Button>
                 </Box>

--- a/cmd/ui/src/views/EarlyAccessFeatures/EarlyAccessFeatures.tsx
+++ b/cmd/ui/src/views/EarlyAccessFeatures/EarlyAccessFeatures.tsx
@@ -48,12 +48,12 @@ export const EarlyAccessFeatureToggle: React.FC<{
 
     return (
         <Paper>
-            <Box p={2} display='flex' justifyContent='space-between' flexWrap='wrap' style={{ rowGap: '1rem' }}>
+            <Box sx={{ p: 2, display: 'flex', justifyContent: 'space-between', gap: '1rem' }}>
                 <Box overflow='hidden'>
                     <Typography variant='h6'>{flag.name}</Typography>
                     <Typography variant='body1'>{flag.description}</Typography>
                 </Box>
-                <Box>
+                <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
                     <Button disabled={disabled} onClick={handleOnClick}>
                         <Box display={'flex'} alignItems={'center'}>
                             {flag.enabled ? <FontAwesomeIcon icon={faCheckCircle} fixedWidth /> : null}


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description
Fixes button alignment on Early Access page when the feature flag description extends the full width of the FF card.

## Motivation and Context

This PR addresses: BED-4746

The description of the recent `Automatically add parent OUs` feature flag caused the enable/disable button to wrap to the next line. The expectation is that the button stays aligned to the right of the card and centered vertically.

## How Has This Been Tested?
visual tests

## Screenshots (optional):
Previous:
<img width="1109" alt="Screenshot 2024-08-30 at 2 32 11 PM" src="https://github.com/user-attachments/assets/139290d9-0b78-49ec-b05e-7914e9a38d63">

Updated:
<img width="1106" alt="Screenshot 2024-08-30 at 2 32 01 PM" src="https://github.com/user-attachments/assets/85259c50-dfc3-4e24-96d0-d416cc1cb482">

## Types of changes

<!-- Please remove any items that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
