### PR TITLE
BED-4676 feat: Add support for prune TTLs and move reconciliation feature flag to parameters

### DIFF
--- a/cmd/api/src/api/v2/app_config.go
+++ b/cmd/api/src/api/v2/app_config.go
@@ -70,7 +70,7 @@ func (s Resources) SetApplicationConfiguration(response http.ResponseWriter, req
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, fmt.Sprintf("Configuration update request not converted to a parameter: %s", parameter.Key), request), response)
 	} else if !parameter.IsValidKey(parameter.Key) {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, fmt.Sprintf("Configuration parameter %s is not valid.", parameter.Key), request), response)
-	} else if errs := parameter.SanitizeAndValidate(); errs != nil {
+	} else if errs := parameter.Validate(); errs != nil {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, errs.Error(), request), response)
 	} else if err = s.DB.SetConfigurationParameter(request.Context(), parameter); err != nil {
 		api.HandleDatabaseError(request, response, err)

--- a/cmd/api/src/api/v2/app_config.go
+++ b/cmd/api/src/api/v2/app_config.go
@@ -45,7 +45,7 @@ func (s Resources) GetApplicationConfigurations(response http.ResponseWriter, re
 	} else if parameterFilter, hasParameterFilter := queryFilters.FirstFilter(queryParameterName); hasParameterFilter {
 		if parameterFilter.Operator != model.Equals {
 			api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, fmt.Sprintf("%s: %s %s", api.ErrorResponseDetailsFilterPredicateNotSupported, parameterFilter.Name, parameterFilter.Operator), request), response)
-		} else if !cfgParameter.IsValid(parameterFilter.Value) {
+		} else if !cfgParameter.IsValidKey(parameterFilter.Value) {
 			api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, fmt.Sprintf("Configuration parameter %s is not valid.", parameterFilter.Value), request), response)
 		} else if cfgParameter, err = s.DB.GetConfigurationParameter(request.Context(), parameterFilter.Value); err != nil {
 			api.HandleDatabaseError(request, response, err)
@@ -68,8 +68,10 @@ func (s Resources) SetApplicationConfiguration(response http.ResponseWriter, req
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, api.ErrorResponsePayloadUnmarshalError, request), response)
 	} else if parameter, err := convertAppConfigUpdateRequestToParameter(appConfig); err != nil {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, fmt.Sprintf("Configuration update request not converted to a parameter: %s", parameter.Key), request), response)
-	} else if !parameter.IsValid(parameter.Key) {
+	} else if !parameter.IsValidKey(parameter.Key) {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, fmt.Sprintf("Configuration parameter %s is not valid.", parameter.Key), request), response)
+	} else if errs := parameter.SanitizeAndValidate(); errs != nil {
+		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, errs.Error(), request), response)
 	} else if err = s.DB.SetConfigurationParameter(request.Context(), parameter); err != nil {
 		api.HandleDatabaseError(request, response, err)
 	} else {

--- a/cmd/api/src/api/v2/app_config_integration_test.go
+++ b/cmd/api/src/api/v2/app_config_integration_test.go
@@ -21,6 +21,7 @@ package v2_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/specterops/bloodhound/dawgs/drivers/neo4j"
 	v2 "github.com/specterops/bloodhound/src/api/v2"
@@ -31,13 +32,22 @@ import (
 
 func Test_GetAppConfigs(t *testing.T) {
 	var (
+		testCtx = integration.NewFOSSContext(t)
+
 		passwordExpirationWindowFound = false
-		neo4jConfigsFound             = false
-		citrixConfigsFound            = false
 		passwordExpirationValue       appcfg.PasswordExpiration
-		neo4jParametersValue          appcfg.Neo4jParameters
-		citrixConfigValue             appcfg.CitrixRDPSupport
-		testCtx                       = integration.NewFOSSContext(t)
+
+		neo4jConfigsFound    = false
+		neo4jParametersValue appcfg.Neo4jParameters
+
+		citrixConfigsFound = false
+		citrixConfigValue  appcfg.CitrixRDPSupport
+
+		pruneFound           = false
+		pruneParametersValue appcfg.PruneTTLParameters
+
+		reconciliationFound           = false
+		reconciliationParametersValue appcfg.ReconciliationParameter
 	)
 
 	config, err := testCtx.AdminClient().GetAppConfigs()
@@ -58,12 +68,23 @@ func Test_GetAppConfigs(t *testing.T) {
 			mapParameter(t, &citrixConfigValue, parameter)
 			require.False(t, citrixConfigValue.Enabled)
 			citrixConfigsFound = true
+		case appcfg.PruneTTL:
+			mapParameter(t, &pruneParametersValue, parameter)
+			require.Equal(t, appcfg.DefaultPruneBaseTTL, pruneParametersValue.BaseTTL)
+			require.Equal(t, appcfg.DefaultPruneHasSessionEdgeTTL, pruneParametersValue.HasSessionEdgeTTL)
+			pruneFound = true
+		case appcfg.ReconciliationKey:
+			mapParameter(t, &reconciliationParametersValue, parameter)
+			require.True(t, reconciliationParametersValue.Enabled)
+			reconciliationFound = true
 		}
 	}
 
 	require.True(t, passwordExpirationWindowFound, "Failed to find Password Expiration Window in response")
 	require.True(t, neo4jConfigsFound, "Failed to find Neo4J Configs in response")
 	require.True(t, citrixConfigsFound, "Failed to find Citrix configs in response")
+	require.True(t, pruneFound, "Failed to find Prune TTL  in response")
+	require.True(t, reconciliationFound, "Failed to find Reconciliation in response")
 }
 
 func Test_GetAppConfigWithParameter(t *testing.T) {
@@ -98,17 +119,21 @@ func Test_PutAppConfig(t *testing.T) {
 	require.Nilf(t, err, "Error while updating app config: %v", err)
 
 	mapParameter(t, &updatedPasswordExpiration, parameter)
-	require.Equal(t, updatedDuration, updatedPasswordExpiration.Duration)
+	require.Equal(t, time.Hour*24*30, updatedPasswordExpiration.Duration)
 
 	// Check that our change really is in the database
 	config, err := testCtx.AdminClient().GetAppConfig(appcfg.PasswordExpirationWindow)
 	require.Nilf(t, err, "Error while getting updated app config: %v", err)
 
 	mapParameter(t, &updatedPasswordExpiration, config[0])
-	require.Equal(t, updatedDuration, updatedPasswordExpiration.Duration)
+	require.Equal(t, time.Hour*24*30, updatedPasswordExpiration.Duration)
 }
 
-func mapParameter[T *appcfg.PasswordExpiration | *appcfg.Neo4jParameters | *appcfg.CitrixRDPSupport](t *testing.T, value T, parameter appcfg.Parameter) {
+func mapParameter[T *appcfg.PasswordExpiration |
+	*appcfg.Neo4jParameters |
+	*appcfg.CitrixRDPSupport |
+	*appcfg.PruneTTLParameters |
+	*appcfg.ReconciliationParameter](t *testing.T, value T, parameter appcfg.Parameter) {
 	err := parameter.Value.Map(&value)
 	require.Nilf(t, err, "Failed to map parameter value to %T type: %v", value, err)
 }

--- a/cmd/api/src/api/v2/app_config_integration_test.go
+++ b/cmd/api/src/api/v2/app_config_integration_test.go
@@ -47,14 +47,10 @@ func Test_GetAppConfigs(t *testing.T) {
 		switch parameter.Key {
 		case appcfg.PasswordExpirationWindow:
 			mapParameter(t, &passwordExpirationValue, parameter)
-			require.Equal(t, appcfg.PasswordExpirationWindowName, parameter.Name)
-			require.Equal(t, appcfg.PasswordExpirationWindowDescription, parameter.Description)
 			require.Equal(t, appcfg.DefaultPasswordExpirationWindow, passwordExpirationValue.Duration)
 			passwordExpirationWindowFound = true
 		case appcfg.Neo4jConfigs:
 			mapParameter(t, &neo4jParametersValue, parameter)
-			require.Equal(t, appcfg.Neo4jConfigsName, parameter.Name)
-			require.Equal(t, appcfg.Neo4jConfigsDescription, parameter.Description)
 			require.Equal(t, neo4j.DefaultBatchWriteSize, neo4jParametersValue.BatchWriteSize)
 			require.Equal(t, neo4j.DefaultWriteFlushSize, neo4jParametersValue.WriteFlushSize)
 			neo4jConfigsFound = true
@@ -81,8 +77,6 @@ func Test_GetAppConfigWithParameter(t *testing.T) {
 	require.True(t, len(config) == 1, "Response contains too many results")
 	require.Equal(t, appcfg.PasswordExpirationWindow, config[0].Key)
 	mapParameter(t, &passwordExpirationValue, config[0])
-	require.Equal(t, appcfg.PasswordExpirationWindowName, config[0].Name)
-	require.Equal(t, appcfg.PasswordExpirationWindowDescription, config[0].Description)
 	require.Equal(t, appcfg.DefaultPasswordExpirationWindow, passwordExpirationValue.Duration)
 }
 

--- a/cmd/api/src/api/v2/app_config_test.go
+++ b/cmd/api/src/api/v2/app_config_test.go
@@ -180,6 +180,12 @@ func Test_SetApplicationConfiguration(t *testing.T) {
 	})
 
 	t.Run("Error from DB", func(t *testing.T) {
+		appConfigRequest = v2.AppConfigUpdateRequest{
+			Key: appcfg.ReconciliationKey,
+			Value: map[string]any{
+				"enabled": true,
+			},
+		}
 		mockDB.EXPECT().
 			SetConfigurationParameter(gomock.Any(), gomock.Any()).
 			Return(fmt.Errorf("database error"))
@@ -198,6 +204,13 @@ func Test_SetApplicationConfiguration(t *testing.T) {
 	})
 
 	t.Run("Success", func(t *testing.T) {
+		appConfigRequest = v2.AppConfigUpdateRequest{
+			Key: appcfg.ReconciliationKey,
+			Value: map[string]any{
+				"enabled": true,
+			},
+		}
+
 		mockDB.EXPECT().
 			SetConfigurationParameter(gomock.Any(), gomock.Any()).
 			Return(nil)

--- a/cmd/api/src/api/v2/auth/auth.go
+++ b/cmd/api/src/api/v2/auth/auth.go
@@ -450,10 +450,9 @@ func (s ManagementResource) CreateUser(response http.ResponseWriter, request *ht
 				log.Errorf("Error while attempting to digest secret for user: %v", err)
 				api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusInternalServerError, api.ErrorResponseDetailsInternalServerError, request), response)
 				return
-			} else if passwordExpiration, err := appcfg.GetPasswordExpiration(request.Context(), s.db); err != nil {
-				log.Errorf("Error while attempting to fetch password expiration window: %v", err)
-				api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusInternalServerError, api.ErrorResponseDetailsInternalServerError, request), response)
 			} else {
+				passwordExpiration := appcfg.GetPasswordExpiration(request.Context(), s.db)
+
 				userTemplate.AuthSecret = &model.AuthSecret{
 					Digest:       secretDigest.String(),
 					DigestMethod: s.secretDigester.Method(),
@@ -662,10 +661,8 @@ func (s ManagementResource) PutUserAuthSecret(response http.ResponseWriter, requ
 			}
 		}
 
-		if passwordExpiration, err := appcfg.GetPasswordExpiration(request.Context(), s.db); err != nil {
-			log.Errorf("Error while attempting to fetch password expiration window: %v", err)
-			api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusInternalServerError, api.ErrorResponseCodeInternalServerError, request), response)
-		} else if secretDigest, err := s.secretDigester.Digest(setUserSecretRequest.Secret); err != nil {
+		passwordExpiration := appcfg.GetPasswordExpiration(request.Context(), s.db)
+		if secretDigest, err := s.secretDigester.Digest(setUserSecretRequest.Secret); err != nil {
 			log.Errorf("Error while attempting to digest secret for user: %v", err)
 			api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusInternalServerError, api.ErrorResponseDetailsInternalServerError, request), response)
 		} else {

--- a/cmd/api/src/api/v2/auth/auth.go
+++ b/cmd/api/src/api/v2/auth/auth.go
@@ -45,7 +45,6 @@ import (
 	"github.com/specterops/bloodhound/src/model"
 	"github.com/specterops/bloodhound/src/model/appcfg"
 	"github.com/specterops/bloodhound/src/serde"
-	"github.com/specterops/bloodhound/src/utils"
 	"github.com/specterops/bloodhound/src/utils/validation"
 )
 
@@ -443,8 +442,7 @@ func (s ManagementResource) CreateUser(response http.ResponseWriter, request *ht
 
 		if createUserRequest.Secret != "" {
 			if errs := validation.Validate(createUserRequest.SetUserSecretRequest); errs != nil {
-				msg := strings.Join(utils.Errors(errs).AsStringSlice(), ", ")
-				api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, msg, request), response)
+				api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, errs.Error(), request), response)
 				return
 			} else if secretDigest, err := s.secretDigester.Digest(createUserRequest.Secret); err != nil {
 				log.Errorf("Error while attempting to digest secret for user: %v", err)
@@ -645,8 +643,7 @@ func (s ManagementResource) PutUserAuthSecret(response http.ResponseWriter, requ
 	} else if err := api.ReadJSONRequestPayloadLimited(&setUserSecretRequest, request); err != nil {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, err.Error(), request), response)
 	} else if errs := validation.Validate(setUserSecretRequest); errs != nil {
-		msg := strings.Join(utils.Errors(errs).AsStringSlice(), ", ")
-		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, msg, request), response)
+		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, errs.Error(), request), response)
 	} else if targetUser, err := s.db.GetUser(request.Context(), targetUserID); err != nil {
 		api.HandleDatabaseError(request, response, err)
 	} else if targetUser.SAMLProviderID.Valid {

--- a/cmd/api/src/bootstrap/server.go
+++ b/cmd/api/src/bootstrap/server.go
@@ -25,7 +25,6 @@ import (
 	"syscall"
 	"time"
 
-	iso8601 "github.com/channelmeter/iso8601duration"
 	"github.com/specterops/bloodhound/dawgs/graph"
 	"github.com/specterops/bloodhound/log"
 	"github.com/specterops/bloodhound/src/auth"
@@ -105,10 +104,8 @@ func MigrateDB(ctx context.Context, cfg config.Configuration, db database.Databa
 
 		if cfg.DefaultAdmin.ExpireNow {
 			authSecret.ExpiresAt = time.Time{}
-		} else if defaultWindow, err := iso8601.FromString(appcfg.DefaultPasswordExpirationWindow); err != nil {
-			return fmt.Errorf("unable to parse default password expiration window: %w", err)
 		} else {
-			authSecret.ExpiresAt = time.Now().Add(defaultWindow.ToDuration())
+			authSecret.ExpiresAt = time.Now().Add(appcfg.GetPasswordExpiration(ctx, db))
 		}
 
 		if _, err := db.InitializeSecretAuth(ctx, adminUser, authSecret); err != nil {

--- a/cmd/api/src/database/featureflags.go
+++ b/cmd/api/src/database/featureflags.go
@@ -1,0 +1,42 @@
+// Copyright 2024 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package database
+
+import (
+	"context"
+
+	"github.com/specterops/bloodhound/src/model/appcfg"
+)
+
+func (s *BloodhoundDB) GetFlag(ctx context.Context, id int32) (appcfg.FeatureFlag, error) {
+	var flag appcfg.FeatureFlag
+	return flag, CheckError(s.db.WithContext(ctx).Find(&flag, id))
+}
+
+func (s *BloodhoundDB) GetFlagByKey(ctx context.Context, key string) (appcfg.FeatureFlag, error) {
+	var flag appcfg.FeatureFlag
+	return flag, CheckError(s.db.WithContext(ctx).Where("key = ?", key).First(&flag))
+}
+
+func (s *BloodhoundDB) GetAllFlags(ctx context.Context) ([]appcfg.FeatureFlag, error) {
+	var flags []appcfg.FeatureFlag
+	return flags, CheckError(s.db.WithContext(ctx).Find(&flags))
+}
+
+func (s *BloodhoundDB) SetFlag(ctx context.Context, flag appcfg.FeatureFlag) error {
+	return CheckError(s.db.WithContext(ctx).Save(&flag))
+}

--- a/cmd/api/src/database/migration/migrations/v5.16.0.sql
+++ b/cmd/api/src/database/migration/migrations/v5.16.0.sql
@@ -14,25 +14,14 @@
 --
 -- SPDX-License-Identifier: Apache-2.0
 
+-- Add Citrix RDP
 INSERT INTO parameters (key, name, description, value, created_at, updated_at) 
 VALUES ('analysis.citrix_rdp_support', 'Citrix RDP Support', 'This configuration parameter toggles Citrix support during post-processing. When enabled, computers identified with a ''Direct Access Users'' local group will assume that Citrix is installed and CanRDP edges will require membership of both ''Direct Access Users'' and ''Remote Desktop Users'' local groups on the computer.', '{"enabled": false}',current_timestamp,current_timestamp) ON CONFLICT DO NOTHING;
--- -- Fix Parameter table missing autoincr
--- CREATE SEQUENCE IF NOT EXISTS parameter_id_seq
---     AS integer
---     START WITH 1
---     INCREMENT BY 1
---     NO MINVALUE
---     NO MAXVALUE
---     CACHE 1
---     OWNED BY parameters.id;
-
-INSERT INTO parameters (id, key, name, description, value, created_at, updated_at)
-VALUES (3, 'analysis.citrix_rdp_support', 'Citrix RDP Support', 'This configuration parameter toggles Citrix support during post-processing. When on, CanRDP edges will come from the `Direct Access Users` group instead of the builtin `Remote Desktop Users` group.', '{"enabled": false}', current_timestamp, current_timestamp) ON CONFLICT DO NOTHING;
 
 -- Add Prune TTLs
-INSERT INTO parameters (id, key, name, description, value, created_at, updated_at) VALUES (4, 'prune.ttl', 'Prune Retention TTL Configuration Parameters', 'This configuration parameter sets the retention TTLs during analysis pruning.', '{"base_ttl": "P7D", "has_session_edge_ttl": "P3D"}', current_timestamp, current_timestamp) ON CONFLICT DO NOTHING;
+INSERT INTO parameters (key, name, description, value, created_at, updated_at) VALUES ('prune.ttl', 'Prune Retention TTL Configuration Parameters', 'This configuration parameter sets the retention TTLs during analysis pruning.', '{"base_ttl": "P7D", "has_session_edge_ttl": "P3D"}', current_timestamp, current_timestamp) ON CONFLICT DO NOTHING;
 
 -- Add Reconciliation to parameters and remove from feature_flags
-INSERT INTO parameters (id, key, name, description, value, created_at, updated_at) VALUES (5, 'analysis.reconciliation', 'Reconciliation', 'This configuration parameter enables / disables reconciliation during analysis.', format('{"enabled": %s}', (SELECT enabled FROM feature_flags WHERE key = 'reconciliation')::text)::json, current_timestamp, current_timestamp) ON CONFLICT DO NOTHING;
+INSERT INTO parameters (key, name, description, value, created_at, updated_at) VALUES ('analysis.reconciliation', 'Reconciliation', 'This configuration parameter enables / disables reconciliation during analysis.', format('{"enabled": %s}', (SELECT COALESCE((SELECT enabled FROM feature_flags WHERE key = 'reconciliation'), TRUE))::text)::json, current_timestamp, current_timestamp) ON CONFLICT DO NOTHING;
 -- must occur after insert to ensure reconciliation flag is set to whatever current value is
 DELETE FROM feature_flags WHERE key = 'reconciliation';

--- a/cmd/api/src/database/migration/migrations/v5.16.0.sql
+++ b/cmd/api/src/database/migration/migrations/v5.16.0.sql
@@ -26,8 +26,13 @@ VALUES ('analysis.citrix_rdp_support', 'Citrix RDP Support', 'This configuration
 --     CACHE 1
 --     OWNED BY parameters.id;
 
-INSERT INTO parameters (id, key, name, description, value, created_at, updated_at) 
+INSERT INTO parameters (id, key, name, description, value, created_at, updated_at)
 VALUES (3, 'analysis.citrix_rdp_support', 'Citrix RDP Support', 'This configuration parameter toggles Citrix support during post-processing. When on, CanRDP edges will come from the `Direct Access Users` group instead of the builtin `Remote Desktop Users` group.', '{"enabled": false}', current_timestamp, current_timestamp) ON CONFLICT DO NOTHING;
 
 -- Add Prune TTLs
-INSERT INTO parameters (id, key, name, description, value, created_at, updated_at) VALUES (3, 'prune.ttl', 'Prune Retention TTL Configuration Parameters', 'This configuration parameter sets the retention TTLs during analysis pruning.', '{"base_ttl": "P7D", "has_session_edge_ttl": "P3D"}', current_timestamp, current_timestamp) ON CONFLICT DO NOTHING;
+INSERT INTO parameters (id, key, name, description, value, created_at, updated_at) VALUES (4, 'prune.ttl', 'Prune Retention TTL Configuration Parameters', 'This configuration parameter sets the retention TTLs during analysis pruning.', '{"base_ttl": "P7D", "has_session_edge_ttl": "P3D"}', current_timestamp, current_timestamp) ON CONFLICT DO NOTHING;
+
+-- Add Reconciliation to parameters and remove from feature_flags
+INSERT INTO parameters (id, key, name, description, value, created_at, updated_at) VALUES (5, 'analysis.reconciliation', 'Reconciliation', 'This configuration parameter enables / disables reconciliation during analysis.', format('{"enabled": %s}', (SELECT enabled FROM feature_flags WHERE key = 'reconciliation')::text)::json, current_timestamp, current_timestamp) ON CONFLICT DO NOTHING;
+-- must occur after insert to ensure reconciliation flag is set to whatever current value is
+DELETE FROM feature_flags WHERE key = 'reconciliation';

--- a/cmd/api/src/database/migration/migrations/v5.16.0.sql
+++ b/cmd/api/src/database/migration/migrations/v5.16.0.sql
@@ -16,3 +16,18 @@
 
 INSERT INTO parameters (key, name, description, value, created_at, updated_at) 
 VALUES ('analysis.citrix_rdp_support', 'Citrix RDP Support', 'This configuration parameter toggles Citrix support during post-processing. When enabled, computers identified with a ''Direct Access Users'' local group will assume that Citrix is installed and CanRDP edges will require membership of both ''Direct Access Users'' and ''Remote Desktop Users'' local groups on the computer.', '{"enabled": false}',current_timestamp,current_timestamp) ON CONFLICT DO NOTHING;
+-- -- Fix Parameter table missing autoincr
+-- CREATE SEQUENCE IF NOT EXISTS parameter_id_seq
+--     AS integer
+--     START WITH 1
+--     INCREMENT BY 1
+--     NO MINVALUE
+--     NO MAXVALUE
+--     CACHE 1
+--     OWNED BY parameters.id;
+
+INSERT INTO parameters (id, key, name, description, value, created_at, updated_at) 
+VALUES (3, 'analysis.citrix_rdp_support', 'Citrix RDP Support', 'This configuration parameter toggles Citrix support during post-processing. When on, CanRDP edges will come from the `Direct Access Users` group instead of the builtin `Remote Desktop Users` group.', '{"enabled": false}', current_timestamp, current_timestamp) ON CONFLICT DO NOTHING;
+
+-- Add Prune TTLs
+INSERT INTO parameters (id, key, name, description, value, created_at, updated_at) VALUES (3, 'prune.ttl', 'Prune Retention TTL Configuration Parameters', 'This configuration parameter sets the retention TTLs during analysis pruning.', '{"base_ttl": "P7D", "has_session_edge_ttl": "P3D"}', current_timestamp, current_timestamp) ON CONFLICT DO NOTHING;

--- a/cmd/api/src/database/parameters.go
+++ b/cmd/api/src/database/parameters.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Specter Ops, Inc.
+// Copyright 2024 Specter Ops, Inc.
 //
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
@@ -24,25 +24,6 @@ import (
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 )
-
-func (s *BloodhoundDB) GetFlag(ctx context.Context, id int32) (appcfg.FeatureFlag, error) {
-	var flag appcfg.FeatureFlag
-	return flag, CheckError(s.db.WithContext(ctx).Find(&flag, id))
-}
-
-func (s *BloodhoundDB) GetFlagByKey(ctx context.Context, key string) (appcfg.FeatureFlag, error) {
-	var flag appcfg.FeatureFlag
-	return flag, CheckError(s.db.WithContext(ctx).Where("key = ?", key).First(&flag))
-}
-
-func (s *BloodhoundDB) GetAllFlags(ctx context.Context) ([]appcfg.FeatureFlag, error) {
-	var flags []appcfg.FeatureFlag
-	return flags, CheckError(s.db.WithContext(ctx).Find(&flags))
-}
-
-func (s *BloodhoundDB) SetFlag(ctx context.Context, flag appcfg.FeatureFlag) error {
-	return CheckError(s.db.WithContext(ctx).Save(&flag))
-}
 
 func (s *BloodhoundDB) GetAllConfigurationParameters(ctx context.Context) (appcfg.Parameters, error) {
 	var appConfig appcfg.Parameters

--- a/cmd/api/src/database/parameters_test.go
+++ b/cmd/api/src/database/parameters_test.go
@@ -1,0 +1,123 @@
+package database_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/specterops/bloodhound/src/database/types"
+	"github.com/specterops/bloodhound/src/model/appcfg"
+	"github.com/specterops/bloodhound/src/test/integration"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParameters_SetConfigurationParameter(t *testing.T) {
+	var (
+		testCtx = context.Background()
+		dbInst  = integration.SetupDB(t)
+	)
+	newVal, err := types.NewJSONBObject(map[string]any{"enabled": false})
+	require.Nil(t, err)
+
+	updatedParameter := appcfg.Parameter{
+		Key:   appcfg.ReconciliationKey,
+		Value: newVal,
+	}
+
+	err = dbInst.SetConfigurationParameter(testCtx, updatedParameter)
+	require.Nil(t, err)
+
+	parameter, err := dbInst.GetConfigurationParameter(testCtx, appcfg.ReconciliationKey)
+	require.Nil(t, err)
+
+	result := appcfg.ReconciliationParameter{}
+	err = parameter.Map(&result)
+	require.Nil(t, err)
+
+	require.Equal(t, updatedParameter.Key, parameter.Key)
+	require.False(t, result.Enabled)
+}
+
+func TestParameters_GetConfigurationParameter(t *testing.T) {
+	var (
+		testCtx = context.Background()
+		dbInst  = integration.SetupDB(t)
+	)
+
+	t.Run("get password expiration parameter", func(t *testing.T) {
+		parameter, err := dbInst.GetConfigurationParameter(testCtx, appcfg.PasswordExpirationWindow)
+		require.Nil(t, err)
+		expected := &appcfg.Parameter{
+			Key:         appcfg.PasswordExpirationWindow,
+			Name:        "Local Auth Password Expiry Window",
+			Description: "This configuration parameter sets the local auth password expiry window for users that have valid auth secrets. Values for this configuration must follow the duration specification of ISO-8601.",
+		}
+		require.Equal(t, expected.Key, parameter.Key)
+		require.Equal(t, expected.Name, parameter.Name)
+		require.Equal(t, expected.Description, parameter.Description)
+	})
+
+	t.Run("get neo4j configs parameter", func(t *testing.T) {
+		parameter, err := dbInst.GetConfigurationParameter(testCtx, appcfg.Neo4jConfigs)
+		require.Nil(t, err)
+		expected := &appcfg.Parameter{
+			Key:         appcfg.Neo4jConfigs,
+			Name:        "Neo4j Configuration Parameters",
+			Description: "This configuration parameter sets the BatchWriteSize and the BatchFlushSize for Neo4J.",
+		}
+		require.Equal(t, expected.Key, parameter.Key)
+		require.Equal(t, expected.Name, parameter.Name)
+		require.Equal(t, expected.Description, parameter.Description)
+	})
+
+	t.Run("get citrix rdp support parameter", func(t *testing.T) {
+		parameter, err := dbInst.GetConfigurationParameter(testCtx, appcfg.CitrixRDPSupportKey)
+		require.Nil(t, err)
+		expected := &appcfg.Parameter{
+			Key:         appcfg.CitrixRDPSupportKey,
+			Name:        "Citrix RDP Support",
+			Description: "This configuration parameter toggles Citrix support during post-processing. When on, CanRDP edges will come from the `Direct Access Users` group instead of the builtin `Remote Desktop Users` group.",
+		}
+		require.Equal(t, expected.Key, parameter.Key)
+		require.Equal(t, expected.Name, parameter.Name)
+		require.Equal(t, expected.Description, parameter.Description)
+	})
+
+	t.Run("get prune ttl parameter", func(t *testing.T) {
+		parameter, err := dbInst.GetConfigurationParameter(testCtx, appcfg.PruneTTL)
+		require.Nil(t, err)
+		expected := &appcfg.Parameter{
+			Key:         appcfg.PruneTTL,
+			Name:        "Prune Retention TTL Configuration Parameters",
+			Description: "This configuration parameter sets the retention TTLs during analysis pruning.",
+		}
+		require.Equal(t, expected.Key, parameter.Key)
+		require.Equal(t, expected.Name, parameter.Name)
+		require.Equal(t, expected.Description, parameter.Description)
+	})
+
+	t.Run("get reconciliation parameter", func(t *testing.T) {
+		parameter, err := dbInst.GetConfigurationParameter(testCtx, appcfg.ReconciliationKey)
+		require.Nil(t, err)
+		expected := &appcfg.Parameter{
+			Key:         appcfg.ReconciliationKey,
+			Name:        "Reconciliation",
+			Description: "This configuration parameter enables / disables reconciliation during analysis.",
+		}
+		require.Equal(t, expected.Key, parameter.Key)
+		require.Equal(t, expected.Name, parameter.Name)
+		require.Equal(t, expected.Description, parameter.Description)
+	})
+}
+
+func TestParameters_GetAllConfigurationParameter(t *testing.T) {
+	var (
+		testCtx = context.Background()
+		dbInst  = integration.SetupDB(t)
+	)
+	parameters, err := dbInst.GetAllConfigurationParameters(testCtx)
+	require.Nil(t, err)
+	require.Len(t, parameters, 5)
+	for _, parameter := range parameters {
+		require.True(t, parameter.IsValidKey(parameter.Key))
+	}
+}

--- a/cmd/api/src/database/parameters_test.go
+++ b/cmd/api/src/database/parameters_test.go
@@ -75,7 +75,7 @@ func TestParameters_GetConfigurationParameter(t *testing.T) {
 		expected := &appcfg.Parameter{
 			Key:         appcfg.CitrixRDPSupportKey,
 			Name:        "Citrix RDP Support",
-			Description: "This configuration parameter toggles Citrix support during post-processing. When on, CanRDP edges will come from the `Direct Access Users` group instead of the builtin `Remote Desktop Users` group.",
+			Description: "This configuration parameter toggles Citrix support during post-processing. When enabled, computers identified with a 'Direct Access Users' local group will assume that Citrix is installed and CanRDP edges will require membership of both 'Direct Access Users' and 'Remote Desktop Users' local groups on the computer.",
 		}
 		require.Equal(t, expected.Key, parameter.Key)
 		require.Equal(t, expected.Name, parameter.Name)

--- a/cmd/api/src/model/appcfg/flag.go
+++ b/cmd/api/src/model/appcfg/flag.go
@@ -28,7 +28,6 @@ const (
 	FeatureEnableSAMLSSO              = "enable_saml_sso"
 	FeatureScopeCollectionByOU        = "scope_collection_by_ou"
 	FeatureAzureSupport               = "azure_support"
-	FeatureReconciliation             = "reconciliation"
 	FeatureEntityPanelCaching         = "entity_panel_cache"
 	FeatureAdcs                       = "adcs"
 	FeaturePGMigrationDualIngest      = "pg_migration_dual_ingest"

--- a/cmd/api/src/model/appcfg/parameter.go
+++ b/cmd/api/src/model/appcfg/parameter.go
@@ -68,6 +68,13 @@ func (s Parameter) IsValid(parameter string) bool {
 	return validKeys[parameter]
 }
 
+func (s *Parameter) AuditData() model.AuditData {
+	return model.AuditData{
+		"key":   s.Key,
+		"value": s.Value,
+	}
+}
+
 // Parameters is a collection of Parameter structs.
 type Parameters []Parameter
 

--- a/cmd/api/src/model/appcfg/parameter.go
+++ b/cmd/api/src/model/appcfg/parameter.go
@@ -135,7 +135,7 @@ func GetNeo4jParameters(ctx context.Context, service ParameterService) Neo4jPara
 
 	if neo4jParametersCfg, err := service.GetConfigurationParameter(ctx, Neo4jConfigs); err != nil {
 		log.Warnf("Failed to fetch neo4j configuration; returning default values")
-	} else if err = neo4jParametersCfg.Map(result); err != nil {
+	} else if err = neo4jParametersCfg.Map(&result); err != nil {
 		log.Warnf("Invalid neo4j configuration supplied; returning default values")
 	}
 

--- a/cmd/api/src/model/appcfg/parameter.go
+++ b/cmd/api/src/model/appcfg/parameter.go
@@ -36,6 +36,7 @@ const (
 	Neo4jConfigs        = "neo4j.configuration"
 	PruneTTL            = "prune.ttl"
 	CitrixRDPSupportKey = "analysis.citrix_rdp_support"
+	ReconciliationKey   = "analysis.reconciliation"
 )
 
 // Parameter is a runtime configuration parameter that can be fetched from the appcfg.ParameterService interface. The
@@ -61,6 +62,7 @@ func (s Parameter) IsValid(parameter string) bool {
 		PasswordExpirationWindow: true,
 		Neo4jConfigs:             true,
 		PruneTTL:                 true,
+		ReconciliationKey:        true,
 	}
 
 	return validKeys[parameter]
@@ -209,4 +211,22 @@ func GetPruneTTLParameters(ctx context.Context, service ParameterService) PruneT
 	}
 
 	return result
+}
+
+// Reconciliation
+
+type ReconciliationParameter struct {
+	Enabled bool `json:"enabled,omitempty"`
+}
+
+func GetReconciliationParameter(ctx context.Context, service ParameterService) bool {
+	result := ReconciliationParameter{Enabled: true}
+
+	if cfg, err := service.GetConfigurationParameter(ctx, ReconciliationKey); err != nil {
+		log.Warnf("Failed to fetch reconciliation configuration; returning default values")
+	} else if err := cfg.Map(&result); err != nil {
+		log.Warnf("Invalid reconciliation configuration supplied, %v. returning default values.", err)
+	}
+
+	return result.Enabled
 }

--- a/cmd/api/src/model/appcfg/parameter.go
+++ b/cmd/api/src/model/appcfg/parameter.go
@@ -33,10 +33,9 @@ const (
 	PasswordExpirationWindow        = "auth.password_expiration_window"
 	DefaultPasswordExpirationWindow = time.Hour * 24 * 90
 
-	Neo4jConfigs = "neo4j.configuration"
-	PruneTTL     = "prune.ttl"
-	CitrixRDPSupportKey         = "analysis.citrix_rdp_support"
-	PruneTTL = "prune.ttl"
+	Neo4jConfigs        = "neo4j.configuration"
+	PruneTTL            = "prune.ttl"
+	CitrixRDPSupportKey = "analysis.citrix_rdp_support"
 )
 
 // Parameter is a runtime configuration parameter that can be fetched from the appcfg.ParameterService interface. The
@@ -144,6 +143,8 @@ func GetNeo4jParameters(ctx context.Context, service ParameterService) Neo4jPara
 	return result
 }
 
+// CitrixRDP
+
 type CitrixRDPSupport struct {
 	Enabled bool `json:"enabled,omitempty"`
 }
@@ -159,6 +160,8 @@ func GetCitrixRDPSupport(ctx context.Context, service ParameterService) bool {
 
 	return result.Enabled
 }
+
+// PruneTTL
 
 type PruneTTLParameters struct {
 	BaseTTL           time.Duration `json:"base_ttl,omitempty"`

--- a/cmd/api/src/model/appcfg/parameter_test.go
+++ b/cmd/api/src/model/appcfg/parameter_test.go
@@ -1,0 +1,113 @@
+package appcfg_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/specterops/bloodhound/dawgs/drivers/neo4j"
+	"github.com/specterops/bloodhound/src/database/types"
+	"github.com/specterops/bloodhound/src/model/appcfg"
+	"github.com/specterops/bloodhound/src/test/integration"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParameters_IsValidKey(t *testing.T) {
+	parameter := appcfg.Parameter{}
+	t.Run("should return false on invalid keys", func(t *testing.T) {
+		require.False(t, parameter.IsValidKey(""))
+	})
+
+	t.Run("should return true on valid keys", func(t *testing.T) {
+		require.True(t, parameter.IsValidKey(appcfg.PruneTTL))
+	})
+}
+
+func TestParameters_Validate(t *testing.T) {
+	t.Run("should error on missing parent value key", func(t *testing.T) {
+		parameter := appcfg.Parameter{}
+		errs := parameter.Validate()
+		require.Len(t, errs, 1)
+		require.Equal(t, "missing or invalid property: value", errs[0].Error())
+	})
+
+	t.Run("should error on additional fields", func(t *testing.T) {
+		val, err := types.NewJSONBObject(map[string]any{"enabled": true, "added_field": true})
+		require.Nil(t, err)
+		parameter := appcfg.Parameter{Value: val, Key: appcfg.ReconciliationKey}
+		errs := parameter.Validate()
+		require.Len(t, errs, 1)
+		require.Equal(t, "value property contains an invalid field", errs[0].Error())
+	})
+
+	t.Run("should error on invalid parameter key", func(t *testing.T) {
+		val, err := types.NewJSONBObject(map[string]any{"enabled": true})
+		require.Nil(t, err)
+		parameter := appcfg.Parameter{Value: val, Key: "invalid key"}
+		errs := parameter.Validate()
+		require.Len(t, errs, 1)
+		require.Equal(t, "invalid key", errs[0].Error())
+	})
+
+	t.Run("should error for missing field", func(t *testing.T) {
+		val, err := types.NewJSONBObject(map[string]any{"base_ttl": "P7D", "added_field": true})
+		require.Nil(t, err)
+		parameter := appcfg.Parameter{Value: val, Key: appcfg.PruneTTL}
+		errs := parameter.Validate()
+		require.Len(t, errs, 1)
+		require.Equal(t, "missing or invalid has_session_edge_ttl", errs[0].Error())
+	})
+
+	t.Run("should error on unmarshal error for incorrect field value", func(t *testing.T) {
+		val, err := types.NewJSONBObject(map[string]any{"base_ttl": true, "has_session_edge_ttl": "P7D"})
+		require.Nil(t, err)
+		parameter := appcfg.Parameter{Value: val, Key: appcfg.PruneTTL}
+		errs := parameter.Validate()
+		require.Len(t, errs, 1)
+		require.Contains(t, errs[0].Error(), "base_ttl of type string")
+	})
+
+	t.Run("should error on invalid field per validation", func(t *testing.T) {
+		val, err := types.NewJSONBObject(map[string]any{"base_ttl": "P7D", "has_session_edge_ttl": "P14D"})
+		require.Nil(t, err)
+		parameter := appcfg.Parameter{Value: val, Key: appcfg.PruneTTL}
+		errs := parameter.Validate()
+		require.Len(t, errs, 1)
+		require.Equal(t, "HasSessionEdgeTTL: must be <= P7D", errs[0].Error())
+	})
+
+	t.Run("should pass validation", func(t *testing.T) {
+		val, err := types.NewJSONBObject(map[string]any{"base_ttl": "P7D", "has_session_edge_ttl": "P7D"})
+		require.Nil(t, err)
+		parameter := appcfg.Parameter{Value: val, Key: appcfg.PruneTTL}
+		errs := parameter.Validate()
+		require.Len(t, errs, 0)
+	})
+}
+
+func TestParameters_GetPasswordExpiration(t *testing.T) {
+	require.Equal(t, appcfg.DefaultPasswordExpirationWindow, appcfg.GetPasswordExpiration(context.Background(), integration.SetupDB(t)))
+}
+
+func TestParameters_GetNeo4jParameters(t *testing.T) {
+	result := appcfg.Neo4jParameters{
+		WriteFlushSize: neo4j.DefaultWriteFlushSize,
+		BatchWriteSize: neo4j.DefaultBatchWriteSize,
+	}
+	require.Equal(t, result, appcfg.GetNeo4jParameters(context.Background(), integration.SetupDB(t)))
+}
+
+func TestParameters_GetCitrixRDPSupport(t *testing.T) {
+	require.False(t, appcfg.GetCitrixRDPSupport(context.Background(), integration.SetupDB(t)))
+}
+
+func TestParameters_GetPruneTTLParameters(t *testing.T) {
+	result := appcfg.PruneTTLParameters{
+		BaseTTL:           appcfg.DefaultPruneBaseTTL,
+		HasSessionEdgeTTL: appcfg.DefaultPruneHasSessionEdgeTTL,
+	}
+	require.Equal(t, result, appcfg.GetPruneTTLParameters(context.Background(), integration.SetupDB(t)))
+}
+
+func TestParameters_GetReconciliationParameter(t *testing.T) {
+	require.True(t, appcfg.GetReconciliationParameter(context.Background(), integration.SetupDB(t)))
+}

--- a/cmd/api/src/model/audit.go
+++ b/cmd/api/src/model/audit.go
@@ -73,6 +73,8 @@ const (
 	AuditLogActionDeleteBloodhoundData AuditLogAction = "DeleteBloodhoundData"
 
 	AuditLogActionMutateGraph AuditLogAction = "MutateGraph"
+
+	AuditLogActionUpdateParameter AuditLogAction = "UpdateParameter"
 )
 
 // TODO embed Basic into this struct instead of declaring the ID and CreatedAt fields. This will require a migration

--- a/cmd/api/src/utils/validation/duration_validator.go
+++ b/cmd/api/src/utils/validation/duration_validator.go
@@ -1,0 +1,82 @@
+package validation
+
+import (
+	"fmt"
+	"time"
+
+	iso8601 "github.com/channelmeter/iso8601duration"
+	"github.com/specterops/bloodhound/log"
+	"github.com/specterops/bloodhound/src/utils"
+)
+
+const (
+	ErrorDuration    = "invalid iso duration provided %v"
+	ErrorDurationMin = "must be >= %s"
+	ErrorDurationMax = "must be <= %s"
+)
+
+type DurationValidator struct {
+	min, max   string // Used for consistent error output
+	minD, maxD time.Duration
+}
+
+func NewDurationValidator(params map[string]string) Validator {
+	validator := DurationValidator{}
+
+	if minD, ok := params["min"]; ok {
+		validator.min = params["min"]
+		if duration, err := iso8601.FromString(minD); err != nil {
+			log.Warnf("NewDurationValidator invalid min limit provided %s", minD)
+		} else {
+			validator.minD = duration.ToDuration()
+		}
+	}
+
+	if maxD, ok := params["max"]; ok {
+		validator.max = params["max"]
+		if duration, err := iso8601.FromString(maxD); err != nil {
+			log.Warnf("NewDurationValidator invalid max limit provided %s", maxD)
+		} else {
+			validator.maxD = duration.ToDuration()
+		}
+	}
+
+	return validator
+}
+
+func (s DurationValidator) okMin(d time.Duration) bool {
+	return d >= s.minD
+}
+
+func (s DurationValidator) okMax(d time.Duration) bool {
+	return d <= s.maxD
+}
+
+func (s DurationValidator) ok(lower, upper time.Duration) bool {
+	return s.okMin(lower) && s.okMax(upper)
+}
+
+func (s DurationValidator) Validate(value any) utils.Errors {
+	var (
+		d    time.Duration
+		ok   bool
+		errs = utils.Errors{}
+	)
+	if d, ok = value.(time.Duration); !ok {
+		return append(errs, fmt.Errorf(ErrorDuration, value))
+	}
+
+	if s.minD > 0 && !s.okMin(d) {
+		errs = append(errs, fmt.Errorf(ErrorDurationMin, s.min))
+	}
+
+	if s.maxD > 0 && !s.okMax(d) {
+		errs = append(errs, fmt.Errorf(ErrorDurationMax, s.max))
+	}
+
+	if len(errs) > 0 {
+		return errs
+	}
+
+	return nil
+}

--- a/cmd/api/src/utils/validation/duration_validator_test.go
+++ b/cmd/api/src/utils/validation/duration_validator_test.go
@@ -1,0 +1,43 @@
+package validation_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/specterops/bloodhound/src/utils"
+	"github.com/specterops/bloodhound/src/utils/validation"
+)
+
+func TestDurationValidator(t *testing.T) {
+
+	type Epic struct {
+		Duration time.Duration `validate:"duration,min=P1D,max=P14D"`
+	}
+
+	fortnight := time.Hour * 24 * 14
+
+	minErr := fmt.Errorf("Duration: "+validation.ErrorDurationMin, "P1D")
+	maxErr := fmt.Errorf("Duration: "+validation.ErrorDurationMax, "P14D")
+
+	var cases = []struct {
+		Input  Epic
+		Errors utils.Errors
+	}{
+		{Epic{time.Hour}, utils.Errors{minErr}},
+		{Epic{fortnight}, nil},
+		{Epic{fortnight + time.Hour}, utils.Errors{maxErr}},
+	}
+
+	for _, tc := range cases {
+		if errs := validation.Validate(tc.Input); errs != nil {
+			if tc.Errors == nil {
+				t.Errorf("For input: %v, expected errs to be nil: errs = %v\n", tc.Input, errs)
+			} else if errs.Error() != tc.Errors.Error() {
+				t.Errorf("For input: %v, got %v, want %v\n", tc.Input, errs, tc.Errors)
+			}
+		} else if tc.Errors != nil {
+			t.Errorf("For input: %v, expected errs to not be nil\n", tc.Input)
+		}
+	}
+}

--- a/cmd/api/src/utils/validation/mocks/validator.go
+++ b/cmd/api/src/utils/validation/mocks/validator.go
@@ -23,6 +23,7 @@ package mocks
 import (
 	reflect "reflect"
 
+	utils "github.com/specterops/bloodhound/src/utils"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -50,10 +51,10 @@ func (m *MockValidator) EXPECT() *MockValidatorMockRecorder {
 }
 
 // Validate mocks base method.
-func (m *MockValidator) Validate(arg0 interface{}) []error {
+func (m *MockValidator) Validate(arg0 interface{}) utils.Errors {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Validate", arg0)
-	ret0, _ := ret[0].([]error)
+	ret0, _ := ret[0].(utils.Errors)
 	return ret0
 }
 

--- a/cmd/api/src/utils/validation/password_validator.go
+++ b/cmd/api/src/utils/validation/password_validator.go
@@ -87,10 +87,15 @@ func (s PasswordValidator) ok(lower, upper, special, numeric int) bool {
 	return s.okLower(lower) && s.okUpper(upper) && s.okSpecial(special) && s.okNumeric(numeric)
 }
 
-func (s PasswordValidator) Validate(value any) []error {
+func (s PasswordValidator) Validate(value any) utils.Errors {
 	var countLower, countUpper, countSpecial, countNumeric int
-	passwd := value.(string)
+	var passwd string
+	var ok bool
+
 	errs := utils.Errors{}
+	if passwd, ok = value.(string); !ok {
+		return append(errs, fmt.Errorf(ErrorPassword, value))
+	}
 
 	for _, char := range passwd {
 		if s.ok(countLower, countUpper, countSpecial, countNumeric) {

--- a/cmd/api/src/utils/validation/password_validator_test.go
+++ b/cmd/api/src/utils/validation/password_validator_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/specterops/bloodhound/src/utils"
 	"github.com/specterops/bloodhound/src/utils/validation"
 )
 
@@ -37,18 +38,18 @@ func TestPasswordValidator(t *testing.T) {
 
 	var cases = []struct {
 		Input  Foo
-		Errors []error
+		Errors utils.Errors
 	}{
-		{Foo{}, []error{lengthErr, lowerErr, upperErr, specialErr, numericErr}[:]},
+		{Foo{}, utils.Errors{lengthErr, lowerErr, upperErr, specialErr, numericErr}},
 		{Foo{"abcDEF***123"}, nil},
-		{Foo{"abcDEF***aaa"}, []error{numericErr}[:]},
+		{Foo{"abcDEF***aaa"}, utils.Errors{numericErr}},
 	}
 
 	for _, tc := range cases {
 		if errs := validation.Validate(tc.Input); errs != nil {
 			if tc.Errors == nil {
 				t.Errorf("For input: %v, expected errs to be nil: errs = %v\n", tc.Input, errs)
-			} else if len(errs) != len(tc.Errors) {
+			} else if errs.Error() != tc.Errors.Error() {
 				t.Errorf("For input: %v, got %v, want %v\n", tc.Input, errs, tc.Errors)
 			}
 		} else if tc.Errors != nil {

--- a/cmd/api/src/utils/validation/registry.go
+++ b/cmd/api/src/utils/validation/registry.go
@@ -49,5 +49,6 @@ func init() {
 	validatorFactory = ValidatorFactory{map[string]ValidatorFactoryFunc{
 		"password": NewPasswordValidator,
 		"required": NewRequiredValidator,
+		"duration": NewDurationValidator,
 	}}
 }

--- a/cmd/api/src/utils/validation/required_validator.go
+++ b/cmd/api/src/utils/validation/required_validator.go
@@ -36,7 +36,7 @@ func NewRequiredError(value any) error {
 
 type RequiredValidator struct{}
 
-func (s RequiredValidator) Validate(value any) []error {
+func (s RequiredValidator) Validate(value any) utils.Errors {
 	errs := utils.Errors{}
 	if reflect.ValueOf(value).IsZero() {
 		errs = append(errs, NewRequiredError(value))
@@ -46,6 +46,6 @@ func (s RequiredValidator) Validate(value any) []error {
 	}
 }
 
-func NewRequiredValidator(params map[string]string) Validator {
+func NewRequiredValidator(_ map[string]string) Validator {
 	return RequiredValidator{}
 }

--- a/cmd/api/src/utils/validation/required_validator_test.go
+++ b/cmd/api/src/utils/validation/required_validator_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/specterops/bloodhound/src/utils"
 	"github.com/specterops/bloodhound/src/utils/validation"
 )
 
@@ -41,18 +42,18 @@ func TestRequiredValidator(t *testing.T) {
 
 	var cases = []struct {
 		Input  Foo
-		Errors []error
+		Errors utils.Errors
 	}{
-		{Foo{}, []error{stringError, intError, pointerError}[:]},
+		{Foo{}, utils.Errors{stringError, intError, pointerError}},
 		{Foo{someString, 1, &someString}, nil},
-		{Foo{someString, 0, &someString}, []error{intError}[:]},
+		{Foo{someString, 0, &someString}, utils.Errors{intError}},
 	}
 
 	for _, tc := range cases {
 		if errs := validation.Validate(tc.Input); errs != nil {
 			if tc.Errors == nil {
 				t.Errorf("For input: %v, expected errs to be nil: errs = %v\n", tc.Input, errs)
-			} else if len(errs) != len(tc.Errors) {
+			} else if errs.Error() != tc.Errors.Error() {
 				t.Errorf("For input: %v, got %v, want %v\n", tc.Input, errs, tc.Errors)
 			}
 		} else if tc.Errors != nil {

--- a/cmd/api/src/utils/validation/validator.go
+++ b/cmd/api/src/utils/validation/validator.go
@@ -21,6 +21,8 @@ package validation
 import (
 	"fmt"
 	"reflect"
+
+	"github.com/specterops/bloodhound/src/utils"
 )
 
 const tagName = "validate"
@@ -31,12 +33,17 @@ const (
 )
 
 type Validator interface {
-	Validate(value any) []error
+	Validate(value any) utils.Errors
 }
 
-func Validate(obj any) []error {
-	value := reflect.ValueOf(obj)
-	errs := []error{}
+func Validate(obj any) utils.Errors {
+	var errs utils.Errors
+	// Indirect protects value from panicing if a pointer is supplied
+	value := reflect.Indirect(reflect.ValueOf(obj))
+	// value.NumField below panics if not supplied a Struct
+	if reflect.TypeOf(value).Kind() != reflect.Struct {
+		return append(errs, fmt.Errorf(ErrorValidation, obj))
+	}
 
 	for i := 0; i < value.NumField(); i++ {
 		validatorTag := value.Type().Field(i).Tag.Get(tagName)


### PR DESCRIPTION
## Description

- Light cleanup of the parameters service
- Added reconciliation prune TTLs to parameters
- Added duration schema validation support
- Moved reconciliation feature flag to parameters while maintaining current flag value
- Fixed incorrect neo4j configuration loading bug

Blocker: BED-4611 should be merged prior to this one

## Motivation and Context

This PR addresses: BED-4676

## How Has This Been Tested?

Added new integration tests
Locally hit api via Bruno
Updated existing tests

## Types of changes

- Chore (a change that does not modify the application functionality)
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Database Migrations

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
