### PR TITLE
BP-881: Update README.md to reflect the docker-compose.yml filename change, which breaks the hyperlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ Docker Compose is the easiest way to get up and running with BloodHound CE. Inst
 Deploying BloodHound CE quickly with the following steps:
 
 1. Install [Docker Desktop](https://www.docker.com/products/docker-desktop/). Docker Desktop includes Docker Compose as part of the installation.
-2. Download the [Docker Compose YAML file](examples/docker-compose/docker-compose.yaml) and save it to a directory where you'd like to run BloodHound. You can do this from a terminal application with `curl -L https://ghst.ly/getbhce`.
+2. Download the [Docker Compose YAML file](examples/docker-compose/docker-compose.yml) and save it to a directory where you'd like to run BloodHound. You can do this from a terminal application with `curl -L https://ghst.ly/getbhce`.
    > On Windows: Execute the command in CMD, or use `curl.exe` instead of `curl` in PowerShell.
-3. Navigate to the folder with the saved `docker-compose.yaml` file and run `docker compose pull && docker compose up`.
+3. Navigate to the folder with the saved `docker-compose.yml` file and run `docker compose pull && docker compose up`.
 4. Locate the randomly generated password in the terminal output of Docker Compose.
 5. In a browser, navigate to `http://localhost:8080/ui/login`. Login with a username of `admin` and the randomly generated password from the logs.
 
@@ -31,7 +31,7 @@ Deploying BloodHound CE quickly with the following steps:
 ### Upgrade BloodHound CE
 Once installed, upgrade BloodHound CE to the latest version with the following steps:
 
-1. Navigate to the folder with the saved `docker-compose.yaml` file and run `docker compose pull && docker compose up`.
+1. Navigate to the folder with the saved `docker-compose.yml` file and run `docker compose pull && docker compose up`.
 2. In a browser, navigate to `http://localhost:8080/ui/login` and log in with your previously configured username and password.
 
 ### Importing sample data


### PR DESCRIPTION
Changed the link for 'examples/docker-compose/docker-compose.yaml'.  The file is now called 'examples/docker-compose/docker-compose.yml'

The original link results in a 404 as the file did not exist, due to the extension change

<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

*Describe your changes in detail*

## Motivation and Context

This PR addresses: BP-881

## How Has This Been Tested?

Documentation update, no testing needed

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)
- Database Migrations

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
