### PR TITLE
BED-4789 switch air from comstrek repo to air-verse

### DIFF
--- a/tools/docker-compose/api.Dockerfile
+++ b/tools/docker-compose/api.Dockerfile
@@ -70,7 +70,7 @@ VOLUME [ "/go/pkg/mod" ]
 
 RUN mkdir -p /bhapi/collectors/azurehound /bhapi/collectors/sharphound /bhapi/work
 RUN go install github.com/go-delve/delve/cmd/dlv@v1.23.0
-RUN go install github.com/cosmtrek/air@v1.44.0
+RUN go install github.com/air-verse/air@v1.52.3
 
 COPY --from=hound-builder /tmp/sharphound/sharphound-$SHARPHOUND_VERSION.zip /bhapi/collectors/sharphound/
 COPY --from=hound-builder /tmp/sharphound/sharphound-$SHARPHOUND_VERSION.zip.sha256 /bhapi/collectors/sharphound/


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description
Point `air` to the new `air-verse` organization

## Motivation and Context

This PR addresses: BED-4789

`air` has moved from github.com/cosmtrek/air to github.com/air-verse/air

## How Has This Been Tested?

Destroy local containers with:
`docker system prune -a`

Recreate the local containers with:
`just bh-dev`

Ensured that the containers all spin up and the `AIR` console output is shown

## Screenshots (optional):
<img width="907" alt="image" src="https://github.com/user-attachments/assets/55cac596-59ee-4e76-b388-fa3151cad8c7">


## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
