### PR TITLE
BED-4776: Add .github/CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# An approval from a member of the BloodHound Engineering team will be
+# required when someone opens a pull request.
+* @SpecterOps/bloodhound-engineering


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description
This PR addresses: BED-4776

Adds a new CODEOWNERS file to declare members of @SpecterOps/bloodhound-engineering as the code owners for the entire repository.

This change will enable us to require at least 1 approval from a member of the BloodHound Engineering team for all future pull requests.

To learn more about code owners please read the docs kindly provided by GitHub.
https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners

## How Has This Been Tested?
There are no functional code changes present in this PR.

## Types of changes

<!-- Please remove any items that do not apply. -->
- Chore (a change that does not modify the application functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
