### PR TITLE
Add abuse info for generic ACL edges against ADCS nodes

### DIFF
--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/AllExtendedRights/LinuxAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/AllExtendedRights/LinuxAbuse.tsx
@@ -206,7 +206,11 @@ const LinuxAbuse: FC<EdgeInfoProps & { haslaps: boolean }> = ({ sourceName, targ
                 </>
             );
         default:
-            return null;
+            return (
+                <>
+                    <Typography variant='body2'>No abuse information available for this node type.</Typography>
+                </>
+            );
     }
 };
 

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/AllExtendedRights/LinuxAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/AllExtendedRights/LinuxAbuse.tsx
@@ -205,6 +205,30 @@ const LinuxAbuse: FC<EdgeInfoProps & { haslaps: boolean }> = ({ sourceName, targ
                     </Typography>
                 </>
             );
+        case 'CertTemplate':
+            return (
+                <>
+                    <Typography variant='body2'>
+                        The AllExtendedRights permission grants {sourceName} enrollment rights on the certificate
+                        template {targetName}.
+                    </Typography>
+                    <Typography variant='body2'>Certipy can be used to enroll a certificate:</Typography>
+                    <Typography component={'pre'}>
+                        {'certipy req -u USER@CORP.LOCAL -p PWD -ca CA-NAME -target SERVER -template TEMPLATE'}
+                    </Typography>
+                    <Typography variant='body2'>
+                        The following additional requirements must be met for a principal to be able to enroll a
+                        certificate:
+                        <br />
+                        1) The certificate template is published on an enterprise CA
+                        <br />
+                        2) The principal has Enroll permission on the enterprise CA
+                        <br />
+                        3) The principal meets the issuance requirements and the requirements for subject name and
+                        subject alternative name defined by the template
+                    </Typography>
+                </>
+            );
         default:
             return (
                 <>

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/AllExtendedRights/References.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/AllExtendedRights/References.tsx
@@ -56,6 +56,14 @@ const References: FC = () => {
                 href='https://www.thehacker.recipes/ad/movement/credentials/dumping/dcsync'>
                 https://www.thehacker.recipes/ad/movement/credentials/dumping/dcsync
             </Link>
+            <br />
+            <Link target='_blank' rel='noopener' href='https://github.com/ly4k/Certipy'>
+                https://github.com/ly4k/Certipy
+            </Link>
+            <br />
+            <Link target='_blank' rel='noopener' href='https://github.com/GhostPack/Certify'>
+                https://github.com/GhostPack/Certify
+            </Link>
         </Box>
     );
 };

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/AllExtendedRights/WindowsAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/AllExtendedRights/WindowsAbuse.tsx
@@ -258,7 +258,11 @@ const WindowsAbuse: FC<EdgeInfoProps & { haslaps: boolean }> = ({
                 </Typography>
             );
         default:
-            return null;
+            return (
+                <>
+                    <Typography variant='body2'>No abuse information available for this node type.</Typography>
+                </>
+            );
     }
 };
 

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/AllExtendedRights/WindowsAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/AllExtendedRights/WindowsAbuse.tsx
@@ -257,6 +257,30 @@ const WindowsAbuse: FC<EdgeInfoProps & { haslaps: boolean }> = ({
                     from the domain {targetName}. This can be abused using the lsadump::dcsync command in mimikatz.
                 </Typography>
             );
+        case 'CertTemplate':
+            return (
+                <>
+                    <Typography variant='body2'>
+                        The AllExtendedRights permission grants {sourceName} enrollment rights on the certificate
+                        template {targetName}.
+                    </Typography>
+                    <Typography variant='body2'>Certify can be used to enroll a certificate:</Typography>
+                    <Typography component={'pre'}>
+                        {'Certify.exe request /ca:SERVER\\CA-NAME /template:TEMPLATE'}
+                    </Typography>
+                    <Typography variant='body2'>
+                        The following additional requirements must be met for a principal to be able to enroll a
+                        certificate:
+                        <br />
+                        1) The certificate template is published on an enterprise CA
+                        <br />
+                        2) The principal has Enroll permission on the enterprise CA
+                        <br />
+                        3) The principal meets the issuance requirements and the requirements for subject name and
+                        subject alternative name defined by the template
+                    </Typography>
+                </>
+            );
         default:
             return (
                 <>

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/Enroll/LinuxAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/Enroll/LinuxAbuse.tsx
@@ -17,14 +17,27 @@
 import { FC } from 'react';
 import { Typography } from '@mui/material';
 
-const Abuse: FC = () => {
+const LinuxAbuse: FC = () => {
     return (
-        <Typography variant='body2'>
-            This relationship alone is not enough to perform a privilege escalation or impersonation primitive. This
-            relationship may contribute to other relationships and attributes, from which an escalation opportunity may
-            emerge.
-        </Typography>
+        <>
+            <Typography variant='body2'>Certipy can be used to enroll a certificate:</Typography>
+            <Typography component={'pre'}>
+                {'certipy req -u USER@CORP.LOCAL -p PWD -ca CA-NAME -target SERVER -template TEMPLATE'}
+            </Typography>
+            <Typography variant='body2'>
+                The following requirements must be met for a principal to be able to enroll a certificate:
+                <br />
+                1) The principal has enrollment rights on a certificate template
+                <br />
+                2) The certificate template is published on an enterprise CA
+                <br />
+                3) The principal has Enroll permission on the enterprise CA
+                <br />
+                4) The principal meets the issuance requirements and the requirements for subject name and subject
+                alternative name defined by the template
+            </Typography>
+        </>
     );
 };
 
-export default Abuse;
+export default LinuxAbuse;

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/Enroll/References.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/Enroll/References.tsx
@@ -26,6 +26,14 @@ const References: FC = () => {
                 href='https://specterops.io/wp-content/uploads/sites/3/2022/06/Certified_Pre-Owned.pdf'>
                 https://specterops.io/wp-content/uploads/sites/3/2022/06/Certified_Pre-Owned.pdf
             </Link>
+            <br />
+            <Link target='_blank' rel='noopener' href='https://github.com/GhostPack/Certify'>
+                https://github.com/GhostPack/Certify
+            </Link>
+            <br />
+            <Link target='_blank' rel='noopener' href='https://github.com/ly4k/Certipy'>
+                https://github.com/ly4k/Certipy
+            </Link>
         </Box>
     );
 };

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/Enroll/WindowsAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/Enroll/WindowsAbuse.tsx
@@ -19,11 +19,22 @@ import { Typography } from '@mui/material';
 
 const Abuse: FC = () => {
     return (
-        <Typography variant='body2'>
-            This relationship alone is not enough to perform a privilege escalation or impersonation primitive. This
-            relationship may contribute to other relationships and attributes, from which an escalation opportunity may
-            emerge.
-        </Typography>
+        <>
+            <Typography variant='body2'>Certify can be used to enroll a certificate:</Typography>
+            <Typography component={'pre'}>{'Certify.exe request /ca:SERVER\\CA-NAME /template:TEMPLATE'}</Typography>
+            <Typography variant='body2'>
+                The following requirements must be met for a principal to be able to enroll a certificate:
+                <br />
+                1) The principal has enrollment rights on a certificate template
+                <br />
+                2) The certificate template is published on an enterprise CA
+                <br />
+                3) The principal has Enroll permission on the enterprise CA
+                <br />
+                4) The principal meets the issuance requirements and the requirements for subject name and subject
+                alternative name defined by the template
+            </Typography>
+        </>
     );
 };
 

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/GenericAll/LinuxAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/GenericAll/LinuxAbuse.tsx
@@ -563,6 +563,59 @@ const LinuxAbuse: FC<EdgeInfoProps & { targetId: string; haslaps: boolean }> = (
                     </Typography>
                 </>
             );
+        case 'CertTemplate':
+            return (
+                <>
+                    <Typography variant='body2'>
+                        With GenericAll permission over a certificate template, you may be able to perform an ESC4
+                        attack by modifying the template's attributes. BloodHound will in that case create an ADCSESC4
+                        edge from the principal to the forest domain node.
+                    </Typography>
+                </>
+            );
+        case 'EnterpriseCA':
+            return (
+                <>
+                    <Typography variant='body2'>
+                        With GenericAll permission over an enterprise CA, you can publish certificate templates to the
+                        enterprise CA by adding the CN name of the template in the enterprise CA object's
+                        certificateTemplates attribute. This action may enable you to perform an ADCS domain escalation.
+                    </Typography>
+                </>
+            );
+        case 'RootCA':
+            return (
+                <>
+                    <Typography variant='body2'>
+                        With GenericAll permission over a root CA, you can make a rouge certificate trusted as a root CA
+                        in the AD forest by adding the certificate in the root CA object's cACertificate attribute. This
+                        action may enable you to perform an ADCS domain escalation.
+                    </Typography>
+                </>
+            );
+        case 'NTAuthStore':
+            return (
+                <>
+                    <Typography variant='body2'>
+                        With GenericAll permission over a NTAuth store, you can make an enterprise CA certificate
+                        trusted for NT (domain) authentication the AD forest by adding the certificate in the root CA
+                        object's cACertificate attribute. This action may enable you to perform an ADCS domain
+                        escalation. This action may enable you to perform an ADCS domain escalation.
+                    </Typography>
+                </>
+            );
+        case 'IssuancePolicy':
+            return (
+                <>
+                    <Typography variant='body2'>
+                        With GenericAll permission over an issuance policy object, you create a OID group link to a
+                        targeted group by adding the groups distinguishedName in the msDS-OIDToGroupLink attribute of
+                        the issuance policy object. This action may enable you to gain membership of the group through
+                        an ADCS ESC13 attack.
+                    </Typography>
+                </>
+            );
+
         default:
             return (
                 <>

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/GenericAll/LinuxAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/GenericAll/LinuxAbuse.tsx
@@ -563,8 +563,13 @@ const LinuxAbuse: FC<EdgeInfoProps & { targetId: string; haslaps: boolean }> = (
                     </Typography>
                 </>
             );
+        default:
+            return (
+                <>
+                    <Typography variant='body2'>No abuse information available for this node type.</Typography>
+                </>
+            );
     }
-    return <></>;
 };
 
 export default LinuxAbuse;

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/GenericAll/LinuxAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/GenericAll/LinuxAbuse.tsx
@@ -587,7 +587,7 @@ const LinuxAbuse: FC<EdgeInfoProps & { targetId: string; haslaps: boolean }> = (
             return (
                 <>
                     <Typography variant='body2'>
-                        With GenericAll permission over a root CA, you can make a rouge certificate trusted as a root CA
+                        With GenericAll permission over a root CA, you can make a rogue certificate trusted as a root CA
                         in the AD forest by adding the certificate in the root CA object's cACertificate attribute. This
                         action may enable you to perform an ADCS domain escalation.
                     </Typography>
@@ -598,7 +598,7 @@ const LinuxAbuse: FC<EdgeInfoProps & { targetId: string; haslaps: boolean }> = (
                 <>
                     <Typography variant='body2'>
                         With GenericAll permission over a NTAuth store, you can make an enterprise CA certificate
-                        trusted for NT (domain) authentication the AD forest by adding the certificate in the root CA
+                        trusted for NT (domain) authentication in the AD forest by adding the certificate in the root CA
                         object's cACertificate attribute. This action may enable you to perform an ADCS domain
                         escalation. This action may enable you to perform an ADCS domain escalation.
                     </Typography>
@@ -609,7 +609,7 @@ const LinuxAbuse: FC<EdgeInfoProps & { targetId: string; haslaps: boolean }> = (
                 <>
                     <Typography variant='body2'>
                         With GenericAll permission over an issuance policy object, you create a OID group link to a
-                        targeted group by adding the groups distinguishedName in the msDS-OIDToGroupLink attribute of
+                        targeted group by adding the group's distinguishedName in the msDS-OIDToGroupLink attribute of
                         the issuance policy object. This action may enable you to gain membership of the group through
                         an ADCS ESC13 attack.
                     </Typography>

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/GenericAll/LinuxAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/GenericAll/LinuxAbuse.tsx
@@ -600,7 +600,7 @@ const LinuxAbuse: FC<EdgeInfoProps & { targetId: string; haslaps: boolean }> = (
                         With GenericAll permission over a NTAuth store, you can make an enterprise CA certificate
                         trusted for NT (domain) authentication in the AD forest by adding the certificate in the root CA
                         object's cACertificate attribute. This action may enable you to perform an ADCS domain
-                        escalation. This action may enable you to perform an ADCS domain escalation.
+                        escalation.
                     </Typography>
                 </>
             );

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/GenericAll/References.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/GenericAll/References.tsx
@@ -147,6 +147,27 @@ const References: FC = () => {
                 href='https://www.synacktiv.com/publications/ounedpy-exploiting-hidden-organizational-units-acl-attack-vectors-in-active-directory'>
                 https://www.synacktiv.com/publications/ounedpy-exploiting-hidden-organizational-units-acl-attack-vectors-in-active-directory
             </Link>
+            <br />
+            <Link
+                target='_blank'
+                rel='noopener'
+                href='https://specterops.io/wp-content/uploads/sites/3/2022/06/Certified_Pre-Owned.pdf'>
+                https://specterops.io/wp-content/uploads/sites/3/2022/06/Certified_Pre-Owned.pdf
+            </Link>
+            <br />
+            <Link
+                target='_blank'
+                rel='noopener'
+                href='https://decoder.cloud/2023/11/20/a-deep-dive-in-cert-publishers-group/'>
+                https://decoder.cloud/2023/11/20/a-deep-dive-in-cert-publishers-group/
+            </Link>
+            <br />
+            <Link
+                target='_blank'
+                rel='noopener'
+                href='https://posts.specterops.io/adcs-esc13-abuse-technique-fda4272fbd53'>
+                https://posts.specterops.io/adcs-esc13-abuse-technique-fda4272fbd53
+            </Link>
         </Box>
     );
 };

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/GenericAll/WindowsAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/GenericAll/WindowsAbuse.tsx
@@ -699,6 +699,58 @@ const WindowsAbuse: FC<EdgeInfoProps & { targetId: string; haslaps: boolean }> =
                     </Typography>
                 </>
             );
+        case 'CertTemplate':
+            return (
+                <>
+                    <Typography variant='body2'>
+                        With GenericAll permission over a certificate template, you may be able to perform an ESC4
+                        attack by modifying the template's attributes. BloodHound will in that case create an ADCSESC4
+                        edge from the principal to the forest domain node.
+                    </Typography>
+                </>
+            );
+        case 'EnterpriseCA':
+            return (
+                <>
+                    <Typography variant='body2'>
+                        With GenericAll permission over an enterprise CA, you can publish certificate templates to the
+                        enterprise CA by adding the CN name of the template in the enterprise CA object's
+                        certificateTemplates attribute. This action may enable you to perform an ADCS domain escalation.
+                    </Typography>
+                </>
+            );
+        case 'RootCA':
+            return (
+                <>
+                    <Typography variant='body2'>
+                        With GenericAll permission over a root CA, you can make a rouge certificate trusted as a root CA
+                        in the AD forest by adding the certificate in the root CA object's cACertificate attribute. This
+                        action may enable you to perform an ADCS domain escalation.
+                    </Typography>
+                </>
+            );
+        case 'NTAuthStore':
+            return (
+                <>
+                    <Typography variant='body2'>
+                        With GenericAll permission over a NTAuth store, you can make an enterprise CA certificate
+                        trusted for NT (domain) authentication the AD forest by adding the certificate in the root CA
+                        object's cACertificate attribute. This action may enable you to perform an ADCS domain
+                        escalation. This action may enable you to perform an ADCS domain escalation.
+                    </Typography>
+                </>
+            );
+        case 'IssuancePolicy':
+            return (
+                <>
+                    <Typography variant='body2'>
+                        With GenericAll permission over an issuance policy object, you create a OID group link to a
+                        targeted group by adding the groups distinguishedName in the msDS-OIDToGroupLink attribute of
+                        the issuance policy object. This action may enable you to gain membership of the group through
+                        an ADCS ESC13 attack.
+                    </Typography>
+                </>
+            );
         default:
             return (
                 <>

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/GenericAll/WindowsAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/GenericAll/WindowsAbuse.tsx
@@ -736,7 +736,7 @@ const WindowsAbuse: FC<EdgeInfoProps & { targetId: string; haslaps: boolean }> =
                         With GenericAll permission over a NTAuth store, you can make an enterprise CA certificate
                         trusted for NT (domain) authentication in the AD forest by adding the certificate in the root CA
                         object's cACertificate attribute. This action may enable you to perform an ADCS domain
-                        escalation. This action may enable you to perform an ADCS domain escalation.
+                        escalation.
                     </Typography>
                 </>
             );

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/GenericAll/WindowsAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/GenericAll/WindowsAbuse.tsx
@@ -700,7 +700,11 @@ const WindowsAbuse: FC<EdgeInfoProps & { targetId: string; haslaps: boolean }> =
                 </>
             );
         default:
-            return <></>;
+            return (
+                <>
+                    <Typography variant='body2'>No abuse information available for this node type.</Typography>
+                </>
+            );
     }
 };
 

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/GenericAll/WindowsAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/GenericAll/WindowsAbuse.tsx
@@ -723,7 +723,7 @@ const WindowsAbuse: FC<EdgeInfoProps & { targetId: string; haslaps: boolean }> =
             return (
                 <>
                     <Typography variant='body2'>
-                        With GenericAll permission over a root CA, you can make a rouge certificate trusted as a root CA
+                        With GenericAll permission over a root CA, you can make a rogue certificate trusted as a root CA
                         in the AD forest by adding the certificate in the root CA object's cACertificate attribute. This
                         action may enable you to perform an ADCS domain escalation.
                     </Typography>
@@ -734,7 +734,7 @@ const WindowsAbuse: FC<EdgeInfoProps & { targetId: string; haslaps: boolean }> =
                 <>
                     <Typography variant='body2'>
                         With GenericAll permission over a NTAuth store, you can make an enterprise CA certificate
-                        trusted for NT (domain) authentication the AD forest by adding the certificate in the root CA
+                        trusted for NT (domain) authentication in the AD forest by adding the certificate in the root CA
                         object's cACertificate attribute. This action may enable you to perform an ADCS domain
                         escalation. This action may enable you to perform an ADCS domain escalation.
                     </Typography>
@@ -745,7 +745,7 @@ const WindowsAbuse: FC<EdgeInfoProps & { targetId: string; haslaps: boolean }> =
                 <>
                     <Typography variant='body2'>
                         With GenericAll permission over an issuance policy object, you create a OID group link to a
-                        targeted group by adding the groups distinguishedName in the msDS-OIDToGroupLink attribute of
+                        targeted group by adding the group's distinguishedName in the msDS-OIDToGroupLink attribute of
                         the issuance policy object. This action may enable you to gain membership of the group through
                         an ADCS ESC13 attack.
                     </Typography>

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/GenericWrite/LinuxAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/GenericWrite/LinuxAbuse.tsx
@@ -323,7 +323,7 @@ const LinuxAbuse: FC<EdgeInfoProps> = ({ targetType }) => {
                         With GenericWrite permission over a NTAuth store, you can make an enterprise CA certificate
                         trusted for NT (domain) authentication in the AD forest by adding the certificate in the root CA
                         object's cACertificate attribute. This action may enable you to perform an ADCS domain
-                        escalation. This action may enable you to perform an ADCS domain escalation.
+                        escalation.
                     </Typography>
                 </>
             );

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/GenericWrite/LinuxAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/GenericWrite/LinuxAbuse.tsx
@@ -286,6 +286,58 @@ const LinuxAbuse: FC<EdgeInfoProps> = ({ targetType }) => {
                     </Typography>
                 </>
             );
+        case 'CertTemplate':
+            return (
+                <>
+                    <Typography variant='body2'>
+                        With GenericWrite permission over a certificate template, you may be able to perform an ESC4
+                        attack by modifying the template's attributes. BloodHound will in that case create an ADCSESC4
+                        edge from the principal to the forest domain node.
+                    </Typography>
+                </>
+            );
+        case 'EnterpriseCA':
+            return (
+                <>
+                    <Typography variant='body2'>
+                        With GenericWrite permission over an enterprise CA, you can publish certificate templates to the
+                        enterprise CA by adding the CN name of the template in the enterprise CA object's
+                        certificateTemplates attribute. This action may enable you to perform an ADCS domain escalation.
+                    </Typography>
+                </>
+            );
+        case 'RootCA':
+            return (
+                <>
+                    <Typography variant='body2'>
+                        With GenericWrite permission over a root CA, you can make a rouge certificate trusted as a root
+                        CA in the AD forest by adding the certificate in the root CA object's cACertificate attribute.
+                        This action may enable you to perform an ADCS domain escalation.
+                    </Typography>
+                </>
+            );
+        case 'NTAuthStore':
+            return (
+                <>
+                    <Typography variant='body2'>
+                        With GenericWrite permission over a NTAuth store, you can make an enterprise CA certificate
+                        trusted for NT (domain) authentication the AD forest by adding the certificate in the root CA
+                        object's cACertificate attribute. This action may enable you to perform an ADCS domain
+                        escalation. This action may enable you to perform an ADCS domain escalation.
+                    </Typography>
+                </>
+            );
+        case 'IssuancePolicy':
+            return (
+                <>
+                    <Typography variant='body2'>
+                        With GenericWrite permission over an issuance policy object, you create a OID group link to a
+                        targeted group by adding the groups distinguishedName in the msDS-OIDToGroupLink attribute of
+                        the issuance policy object. This action may enable you to gain membership of the group through
+                        an ADCS ESC13 attack.
+                    </Typography>
+                </>
+            );
         default:
             return (
                 <>

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/GenericWrite/LinuxAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/GenericWrite/LinuxAbuse.tsx
@@ -287,7 +287,11 @@ const LinuxAbuse: FC<EdgeInfoProps> = ({ targetType }) => {
                 </>
             );
         default:
-            return null;
+            return (
+                <>
+                    <Typography variant='body2'>No abuse information available for this node type.</Typography>
+                </>
+            );
     }
 };
 

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/GenericWrite/LinuxAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/GenericWrite/LinuxAbuse.tsx
@@ -310,7 +310,7 @@ const LinuxAbuse: FC<EdgeInfoProps> = ({ targetType }) => {
             return (
                 <>
                     <Typography variant='body2'>
-                        With GenericWrite permission over a root CA, you can make a rouge certificate trusted as a root
+                        With GenericWrite permission over a root CA, you can make a rogue certificate trusted as a root
                         CA in the AD forest by adding the certificate in the root CA object's cACertificate attribute.
                         This action may enable you to perform an ADCS domain escalation.
                     </Typography>
@@ -321,7 +321,7 @@ const LinuxAbuse: FC<EdgeInfoProps> = ({ targetType }) => {
                 <>
                     <Typography variant='body2'>
                         With GenericWrite permission over a NTAuth store, you can make an enterprise CA certificate
-                        trusted for NT (domain) authentication the AD forest by adding the certificate in the root CA
+                        trusted for NT (domain) authentication in the AD forest by adding the certificate in the root CA
                         object's cACertificate attribute. This action may enable you to perform an ADCS domain
                         escalation. This action may enable you to perform an ADCS domain escalation.
                     </Typography>
@@ -332,7 +332,7 @@ const LinuxAbuse: FC<EdgeInfoProps> = ({ targetType }) => {
                 <>
                     <Typography variant='body2'>
                         With GenericWrite permission over an issuance policy object, you create a OID group link to a
-                        targeted group by adding the groups distinguishedName in the msDS-OIDToGroupLink attribute of
+                        targeted group by adding the group's distinguishedName in the msDS-OIDToGroupLink attribute of
                         the issuance policy object. This action may enable you to gain membership of the group through
                         an ADCS ESC13 attack.
                     </Typography>

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/GenericWrite/References.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/GenericWrite/References.tsx
@@ -89,6 +89,27 @@ const References: FC = () => {
                 href='https://www.synacktiv.com/publications/ounedpy-exploiting-hidden-organizational-units-acl-attack-vectors-in-active-directory'>
                 https://www.synacktiv.com/publications/ounedpy-exploiting-hidden-organizational-units-acl-attack-vectors-in-active-directory
             </Link>
+            <br />
+            <Link
+                target='_blank'
+                rel='noopener'
+                href='https://specterops.io/wp-content/uploads/sites/3/2022/06/Certified_Pre-Owned.pdf'>
+                https://specterops.io/wp-content/uploads/sites/3/2022/06/Certified_Pre-Owned.pdf
+            </Link>
+            <br />
+            <Link
+                target='_blank'
+                rel='noopener'
+                href='https://decoder.cloud/2023/11/20/a-deep-dive-in-cert-publishers-group/'>
+                https://decoder.cloud/2023/11/20/a-deep-dive-in-cert-publishers-group/
+            </Link>
+            <br />
+            <Link
+                target='_blank'
+                rel='noopener'
+                href='https://posts.specterops.io/adcs-esc13-abuse-technique-fda4272fbd53'>
+                https://posts.specterops.io/adcs-esc13-abuse-technique-fda4272fbd53
+            </Link>
         </Box>
     );
 };

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/GenericWrite/WindowsAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/GenericWrite/WindowsAbuse.tsx
@@ -348,7 +348,11 @@ const WindowsAbuse: FC<EdgeInfoProps> = ({ sourceName, sourceType, targetName, t
                 </>
             );
         default:
-            return null;
+            return (
+                <>
+                    <Typography variant='body2'>No abuse information available for this node type.</Typography>
+                </>
+            );
     }
 };
 

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/GenericWrite/WindowsAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/GenericWrite/WindowsAbuse.tsx
@@ -347,6 +347,58 @@ const WindowsAbuse: FC<EdgeInfoProps> = ({ sourceName, sourceType, targetName, t
                     </Typography>
                 </>
             );
+        case 'CertTemplate':
+            return (
+                <>
+                    <Typography variant='body2'>
+                        With GenericWrite permission over a certificate template, you may be able to perform an ESC4
+                        attack by modifying the template's attributes. BloodHound will in that case create an ADCSESC4
+                        edge from the principal to the forest domain node.
+                    </Typography>
+                </>
+            );
+        case 'EnterpriseCA':
+            return (
+                <>
+                    <Typography variant='body2'>
+                        With GenericWrite permission over an enterprise CA, you can publish certificate templates to the
+                        enterprise CA by adding the CN name of the template in the enterprise CA object's
+                        certificateTemplates attribute. This action may enable you to perform an ADCS domain escalation.
+                    </Typography>
+                </>
+            );
+        case 'RootCA':
+            return (
+                <>
+                    <Typography variant='body2'>
+                        With GenericWrite permission over a root CA, you can make a rouge certificate trusted as a root
+                        CA in the AD forest by adding the certificate in the root CA object's cACertificate attribute.
+                        This action may enable you to perform an ADCS domain escalation.
+                    </Typography>
+                </>
+            );
+        case 'NTAuthStore':
+            return (
+                <>
+                    <Typography variant='body2'>
+                        With GenericWrite permission over a NTAuth store, you can make an enterprise CA certificate
+                        trusted for NT (domain) authentication the AD forest by adding the certificate in the root CA
+                        object's cACertificate attribute. This action may enable you to perform an ADCS domain
+                        escalation. This action may enable you to perform an ADCS domain escalation.
+                    </Typography>
+                </>
+            );
+        case 'IssuancePolicy':
+            return (
+                <>
+                    <Typography variant='body2'>
+                        With GenericWrite permission over an issuance policy object, you create a OID group link to a
+                        targeted group by adding the groups distinguishedName in the msDS-OIDToGroupLink attribute of
+                        the issuance policy object. This action may enable you to gain membership of the group through
+                        an ADCS ESC13 attack.
+                    </Typography>
+                </>
+            );
         default:
             return (
                 <>

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/GenericWrite/WindowsAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/GenericWrite/WindowsAbuse.tsx
@@ -371,7 +371,7 @@ const WindowsAbuse: FC<EdgeInfoProps> = ({ sourceName, sourceType, targetName, t
             return (
                 <>
                     <Typography variant='body2'>
-                        With GenericWrite permission over a root CA, you can make a rouge certificate trusted as a root
+                        With GenericWrite permission over a root CA, you can make a rogue certificate trusted as a root
                         CA in the AD forest by adding the certificate in the root CA object's cACertificate attribute.
                         This action may enable you to perform an ADCS domain escalation.
                     </Typography>
@@ -382,7 +382,7 @@ const WindowsAbuse: FC<EdgeInfoProps> = ({ sourceName, sourceType, targetName, t
                 <>
                     <Typography variant='body2'>
                         With GenericWrite permission over a NTAuth store, you can make an enterprise CA certificate
-                        trusted for NT (domain) authentication the AD forest by adding the certificate in the root CA
+                        trusted for NT (domain) authentication in the AD forest by adding the certificate in the root CA
                         object's cACertificate attribute. This action may enable you to perform an ADCS domain
                         escalation. This action may enable you to perform an ADCS domain escalation.
                     </Typography>
@@ -393,7 +393,7 @@ const WindowsAbuse: FC<EdgeInfoProps> = ({ sourceName, sourceType, targetName, t
                 <>
                     <Typography variant='body2'>
                         With GenericWrite permission over an issuance policy object, you create a OID group link to a
-                        targeted group by adding the groups distinguishedName in the msDS-OIDToGroupLink attribute of
+                        targeted group by adding the group's distinguishedName in the msDS-OIDToGroupLink attribute of
                         the issuance policy object. This action may enable you to gain membership of the group through
                         an ADCS ESC13 attack.
                     </Typography>

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/GenericWrite/WindowsAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/GenericWrite/WindowsAbuse.tsx
@@ -384,7 +384,7 @@ const WindowsAbuse: FC<EdgeInfoProps> = ({ sourceName, sourceType, targetName, t
                         With GenericWrite permission over a NTAuth store, you can make an enterprise CA certificate
                         trusted for NT (domain) authentication in the AD forest by adding the certificate in the root CA
                         object's cACertificate attribute. This action may enable you to perform an ADCS domain
-                        escalation. This action may enable you to perform an ADCS domain escalation.
+                        escalation.
                     </Typography>
                 </>
             );

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/Owns/LinuxAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/Owns/LinuxAbuse.tsx
@@ -704,7 +704,7 @@ const LinuxAbuse: FC<EdgeInfoProps & { targetId: string; haslaps: boolean }> = (
                 <>
                     <Typography variant='body2'>
                         With ownership over a root CA, you can grant yourself GenericAll. With GenericAll, you can make
-                        a rouge certificate trusted as a root CA in the AD forest by adding the certificate in the root
+                        a rogue certificate trusted as a root CA in the AD forest by adding the certificate in the root
                         CA object's cACertificate attribute. This action may enable you to perform an ADCS domain
                         escalation.
                     </Typography>
@@ -715,9 +715,9 @@ const LinuxAbuse: FC<EdgeInfoProps & { targetId: string; haslaps: boolean }> = (
                 <>
                     <Typography variant='body2'>
                         With ownership over a NTAuth store, you can grant yourself GenericAll. With GenericAll, you can
-                        make an enterprise CA certificate trusted for NT (domain) authentication the AD forest by adding
-                        the certificate in the root CA object's cACertificate attribute. This action may enable you to
-                        perform an ADCS domain escalation. This action may enable you to perform an ADCS domain
+                        make an enterprise CA certificate trusted for NT (domain) authentication in the AD forest by
+                        adding the certificate in the root CA object's cACertificate attribute. This action may enable
+                        you to perform an ADCS domain escalation. This action may enable you to perform an ADCS domain
                         escalation.
                     </Typography>
                 </>

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/Owns/LinuxAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/Owns/LinuxAbuse.tsx
@@ -679,7 +679,11 @@ const LinuxAbuse: FC<EdgeInfoProps & { targetId: string; haslaps: boolean }> = (
                 </>
             );
         default:
-            return null;
+            return (
+                <>
+                    <Typography variant='body2'>No abuse information available for this node type.</Typography>
+                </>
+            );
     }
 };
 

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/Owns/LinuxAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/Owns/LinuxAbuse.tsx
@@ -678,6 +678,61 @@ const LinuxAbuse: FC<EdgeInfoProps & { targetId: string; haslaps: boolean }> = (
                     </Typography>
                 </>
             );
+        case 'CertTemplate':
+            return (
+                <>
+                    <Typography variant='body2'>
+                        With ownership over a certificate template, you can grant yourself GenericAll. With GenericAll,
+                        you may be able to perform an ESC4 attack by modifying the template's attributes. BloodHound
+                        will in that case create an ADCSESC4 edge from the principal to the forest domain node.
+                    </Typography>
+                </>
+            );
+        case 'EnterpriseCA':
+            return (
+                <>
+                    <Typography variant='body2'>
+                        With ownership over an enterprise CA, you can grant yourself GenericAll. With GenericAll, you
+                        can publish certificate templates to the enterprise CA by adding the CN name of the template in
+                        the enterprise CA object's certificateTemplates attribute. This action may enable you to perform
+                        an ADCS domain escalation.
+                    </Typography>
+                </>
+            );
+        case 'RootCA':
+            return (
+                <>
+                    <Typography variant='body2'>
+                        With ownership over a root CA, you can grant yourself GenericAll. With GenericAll, you can make
+                        a rouge certificate trusted as a root CA in the AD forest by adding the certificate in the root
+                        CA object's cACertificate attribute. This action may enable you to perform an ADCS domain
+                        escalation.
+                    </Typography>
+                </>
+            );
+        case 'NTAuthStore':
+            return (
+                <>
+                    <Typography variant='body2'>
+                        With ownership over a NTAuth store, you can grant yourself GenericAll. With GenericAll, you can
+                        make an enterprise CA certificate trusted for NT (domain) authentication the AD forest by adding
+                        the certificate in the root CA object's cACertificate attribute. This action may enable you to
+                        perform an ADCS domain escalation. This action may enable you to perform an ADCS domain
+                        escalation.
+                    </Typography>
+                </>
+            );
+        case 'IssuancePolicy':
+            return (
+                <>
+                    <Typography variant='body2'>
+                        With ownership over an issuance policy object, you can grant yourself GenericAll. With
+                        GenericAll, you create a OID group link to a targeted group by adding the groups
+                        distinguishedName in the msDS-OIDToGroupLink attribute of the issuance policy object. This
+                        action may enable you to gain membership of the group through an ADCS ESC13 attack.
+                    </Typography>
+                </>
+            );
         default:
             return (
                 <>

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/Owns/References.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/Owns/References.tsx
@@ -122,6 +122,27 @@ const References: FC = () => {
                 href='https://posts.specterops.io/shadow-credentials-abusing-key-trust-account-mapping-for-takeover-8ee1a53566ab'>
                 https://posts.specterops.io/shadow-credentials-abusing-key-trust-account-mapping-for-takeover-8ee1a53566ab
             </Link>
+            <br />
+            <Link
+                target='_blank'
+                rel='noopener'
+                href='https://specterops.io/wp-content/uploads/sites/3/2022/06/Certified_Pre-Owned.pdf'>
+                https://specterops.io/wp-content/uploads/sites/3/2022/06/Certified_Pre-Owned.pdf
+            </Link>
+            <br />
+            <Link
+                target='_blank'
+                rel='noopener'
+                href='https://decoder.cloud/2023/11/20/a-deep-dive-in-cert-publishers-group/'>
+                https://decoder.cloud/2023/11/20/a-deep-dive-in-cert-publishers-group/
+            </Link>
+            <br />
+            <Link
+                target='_blank'
+                rel='noopener'
+                href='https://posts.specterops.io/adcs-esc13-abuse-technique-fda4272fbd53'>
+                https://posts.specterops.io/adcs-esc13-abuse-technique-fda4272fbd53
+            </Link>
         </Box>
     );
 };

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/Owns/WindowsAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/Owns/WindowsAbuse.tsx
@@ -947,7 +947,7 @@ const WindowsAbuse: FC<EdgeInfoProps & { targetId: string; haslaps: boolean }> =
                 <>
                     <Typography variant='body2'>
                         With ownership over a root CA, you can grant yourself GenericAll. With GenericAll, you can make
-                        a rouge certificate trusted as a root CA in the AD forest by adding the certificate in the root
+                        a rogue certificate trusted as a root CA in the AD forest by adding the certificate in the root
                         CA object's cACertificate attribute. This action may enable you to perform an ADCS domain
                         escalation.
                     </Typography>
@@ -958,9 +958,9 @@ const WindowsAbuse: FC<EdgeInfoProps & { targetId: string; haslaps: boolean }> =
                 <>
                     <Typography variant='body2'>
                         With ownership over a NTAuth store, you can grant yourself GenericAll. With GenericAll, you can
-                        make an enterprise CA certificate trusted for NT (domain) authentication the AD forest by adding
-                        the certificate in the root CA object's cACertificate attribute. This action may enable you to
-                        perform an ADCS domain escalation. This action may enable you to perform an ADCS domain
+                        make an enterprise CA certificate trusted for NT (domain) authentication in the AD forest by
+                        adding the certificate in the root CA object's cACertificate attribute. This action may enable
+                        you to perform an ADCS domain escalation. This action may enable you to perform an ADCS domain
                         escalation.
                     </Typography>
                 </>

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/Owns/WindowsAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/Owns/WindowsAbuse.tsx
@@ -922,7 +922,11 @@ const WindowsAbuse: FC<EdgeInfoProps & { targetId: string; haslaps: boolean }> =
                 </>
             );
         default:
-            return null;
+            return (
+                <>
+                    <Typography variant='body2'>No abuse information available for this node type.</Typography>
+                </>
+            );
     }
 };
 

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/Owns/WindowsAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/Owns/WindowsAbuse.tsx
@@ -921,6 +921,61 @@ const WindowsAbuse: FC<EdgeInfoProps & { targetId: string; haslaps: boolean }> =
                     </Typography>
                 </>
             );
+        case 'CertTemplate':
+            return (
+                <>
+                    <Typography variant='body2'>
+                        With ownership over a certificate template, you can grant yourself GenericAll. With GenericAll,
+                        you may be able to perform an ESC4 attack by modifying the template's attributes. BloodHound
+                        will in that case create an ADCSESC4 edge from the principal to the forest domain node.
+                    </Typography>
+                </>
+            );
+        case 'EnterpriseCA':
+            return (
+                <>
+                    <Typography variant='body2'>
+                        With ownership over an enterprise CA, you can grant yourself GenericAll. With GenericAll, you
+                        can publish certificate templates to the enterprise CA by adding the CN name of the template in
+                        the enterprise CA object's certificateTemplates attribute. This action may enable you to perform
+                        an ADCS domain escalation.
+                    </Typography>
+                </>
+            );
+        case 'RootCA':
+            return (
+                <>
+                    <Typography variant='body2'>
+                        With ownership over a root CA, you can grant yourself GenericAll. With GenericAll, you can make
+                        a rouge certificate trusted as a root CA in the AD forest by adding the certificate in the root
+                        CA object's cACertificate attribute. This action may enable you to perform an ADCS domain
+                        escalation.
+                    </Typography>
+                </>
+            );
+        case 'NTAuthStore':
+            return (
+                <>
+                    <Typography variant='body2'>
+                        With ownership over a NTAuth store, you can grant yourself GenericAll. With GenericAll, you can
+                        make an enterprise CA certificate trusted for NT (domain) authentication the AD forest by adding
+                        the certificate in the root CA object's cACertificate attribute. This action may enable you to
+                        perform an ADCS domain escalation. This action may enable you to perform an ADCS domain
+                        escalation.
+                    </Typography>
+                </>
+            );
+        case 'IssuancePolicy':
+            return (
+                <>
+                    <Typography variant='body2'>
+                        With ownership over an issuance policy object, you can grant yourself GenericAll. With
+                        GenericAll, you create a OID group link to a targeted group by adding the groups
+                        distinguishedName in the msDS-OIDToGroupLink attribute of the issuance policy object. This
+                        action may enable you to gain membership of the group through an ADCS ESC13 attack.
+                    </Typography>
+                </>
+            );
         default:
             return (
                 <>

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/WriteDacl/LinuxAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/WriteDacl/LinuxAbuse.tsx
@@ -700,7 +700,7 @@ const LinuxAbuse: FC<EdgeInfoProps & { targetId: string; haslaps: boolean }> = (
                 <>
                     <Typography variant='body2'>
                         With WriteDacl permission over a root CA, you can grant yourself GenericAll. With GenericAll,
-                        you can make a rouge certificate trusted as a root CA in the AD forest by adding the certificate
+                        you can make a rogue certificate trusted as a root CA in the AD forest by adding the certificate
                         in the root CA object's cACertificate attribute. This action may enable you to perform an ADCS
                         domain escalation.
                     </Typography>
@@ -711,10 +711,10 @@ const LinuxAbuse: FC<EdgeInfoProps & { targetId: string; haslaps: boolean }> = (
                 <>
                     <Typography variant='body2'>
                         With WriteDacl permission over a NTAuth store, you can grant yourself GenericAll. With
-                        GenericAll, you can make an enterprise CA certificate trusted for NT (domain) authentication the
-                        AD forest by adding the certificate in the root CA object's cACertificate attribute. This action
-                        may enable you to perform an ADCS domain escalation. This action may enable you to perform an
-                        ADCS domain escalation.
+                        GenericAll, you can make an enterprise CA certificate trusted for NT (domain) authentication in
+                        the AD forest by adding the certificate in the root CA object's cACertificate attribute. This
+                        action may enable you to perform an ADCS domain escalation. This action may enable you to
+                        perform an ADCS domain escalation.
                     </Typography>
                 </>
             );

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/WriteDacl/LinuxAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/WriteDacl/LinuxAbuse.tsx
@@ -674,7 +674,11 @@ const LinuxAbuse: FC<EdgeInfoProps & { targetId: string; haslaps: boolean }> = (
                 </>
             );
         default:
-            return null;
+            return (
+                <>
+                    <Typography variant='body2'>No abuse information available for this node type.</Typography>
+                </>
+            );
     }
 };
 

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/WriteDacl/LinuxAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/WriteDacl/LinuxAbuse.tsx
@@ -673,6 +673,62 @@ const LinuxAbuse: FC<EdgeInfoProps & { targetId: string; haslaps: boolean }> = (
                     </Typography>
                 </>
             );
+        case 'CertTemplate':
+            return (
+                <>
+                    <Typography variant='body2'>
+                        With WriteDacl permission over a certificate template, you can grant yourself GenericAll. With
+                        GenericAll, you may be able to perform an ESC4 attack by modifying the template's attributes.
+                        BloodHound will in that case create an ADCSESC4 edge from the principal to the forest domain
+                        node.
+                    </Typography>
+                </>
+            );
+        case 'EnterpriseCA':
+            return (
+                <>
+                    <Typography variant='body2'>
+                        With WriteDacl permission over an enterprise CA, you can grant yourself GenericAll. With
+                        GenericAll, you can publish certificate templates to the enterprise CA by adding the CN name of
+                        the template in the enterprise CA object's certificateTemplates attribute. This action may
+                        enable you to perform an ADCS domain escalation.
+                    </Typography>
+                </>
+            );
+        case 'RootCA':
+            return (
+                <>
+                    <Typography variant='body2'>
+                        With WriteDacl permission over a root CA, you can grant yourself GenericAll. With GenericAll,
+                        you can make a rouge certificate trusted as a root CA in the AD forest by adding the certificate
+                        in the root CA object's cACertificate attribute. This action may enable you to perform an ADCS
+                        domain escalation.
+                    </Typography>
+                </>
+            );
+        case 'NTAuthStore':
+            return (
+                <>
+                    <Typography variant='body2'>
+                        With WriteDacl permission over a NTAuth store, you can grant yourself GenericAll. With
+                        GenericAll, you can make an enterprise CA certificate trusted for NT (domain) authentication the
+                        AD forest by adding the certificate in the root CA object's cACertificate attribute. This action
+                        may enable you to perform an ADCS domain escalation. This action may enable you to perform an
+                        ADCS domain escalation.
+                    </Typography>
+                </>
+            );
+        case 'IssuancePolicy':
+            return (
+                <>
+                    <Typography variant='body2'>
+                        With WriteDacl permission over an issuance policy object, you can grant yourself GenericAll.
+                        With GenericAll, you create a OID group link to a targeted group by adding the groups
+                        distinguishedName in the msDS-OIDToGroupLink attribute of the issuance policy object. This
+                        action may enable you to gain membership of the group through an ADCS ESC13 attack.
+                    </Typography>
+                </>
+            );
         default:
             return (
                 <>

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/WriteDacl/References.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/WriteDacl/References.tsx
@@ -133,6 +133,27 @@ const References: FC = () => {
                 href='https://posts.specterops.io/shadow-credentials-abusing-key-trust-account-mapping-for-takeover-8ee1a53566ab'>
                 https://posts.specterops.io/shadow-credentials-abusing-key-trust-account-mapping-for-takeover-8ee1a53566ab
             </Link>
+            <br />
+            <Link
+                target='_blank'
+                rel='noopener'
+                href='https://specterops.io/wp-content/uploads/sites/3/2022/06/Certified_Pre-Owned.pdf'>
+                https://specterops.io/wp-content/uploads/sites/3/2022/06/Certified_Pre-Owned.pdf
+            </Link>
+            <br />
+            <Link
+                target='_blank'
+                rel='noopener'
+                href='https://decoder.cloud/2023/11/20/a-deep-dive-in-cert-publishers-group/'>
+                https://decoder.cloud/2023/11/20/a-deep-dive-in-cert-publishers-group/
+            </Link>
+            <br />
+            <Link
+                target='_blank'
+                rel='noopener'
+                href='https://posts.specterops.io/adcs-esc13-abuse-technique-fda4272fbd53'>
+                https://posts.specterops.io/adcs-esc13-abuse-technique-fda4272fbd53
+            </Link>
         </Box>
     );
 };

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/WriteDacl/WindowsAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/WriteDacl/WindowsAbuse.tsx
@@ -891,7 +891,7 @@ const WindowsAbuse: FC<EdgeInfoProps & { targetId: string; haslaps: boolean }> =
                 <>
                     <Typography variant='body2'>
                         With WriteDacl permission over a root CA, you can grant yourself GenericAll. With GenericAll,
-                        you can make a rouge certificate trusted as a root CA in the AD forest by adding the certificate
+                        you can make a rogue certificate trusted as a root CA in the AD forest by adding the certificate
                         in the root CA object's cACertificate attribute. This action may enable you to perform an ADCS
                         domain escalation.
                     </Typography>
@@ -902,10 +902,10 @@ const WindowsAbuse: FC<EdgeInfoProps & { targetId: string; haslaps: boolean }> =
                 <>
                     <Typography variant='body2'>
                         With WriteDacl permission over a NTAuth store, you can grant yourself GenericAll. With
-                        GenericAll, you can make an enterprise CA certificate trusted for NT (domain) authentication the
-                        AD forest by adding the certificate in the root CA object's cACertificate attribute. This action
-                        may enable you to perform an ADCS domain escalation. This action may enable you to perform an
-                        ADCS domain escalation.
+                        GenericAll, you can make an enterprise CA certificate trusted for NT (domain) authentication in
+                        the AD forest by adding the certificate in the root CA object's cACertificate attribute. This
+                        action may enable you to perform an ADCS domain escalation. This action may enable you to
+                        perform an ADCS domain escalation.
                     </Typography>
                 </>
             );

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/WriteDacl/WindowsAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/WriteDacl/WindowsAbuse.tsx
@@ -864,6 +864,62 @@ const WindowsAbuse: FC<EdgeInfoProps & { targetId: string; haslaps: boolean }> =
                     </Typography>
                 </>
             );
+        case 'CertTemplate':
+            return (
+                <>
+                    <Typography variant='body2'>
+                        With WriteDacl permission over a certificate template, you can grant yourself GenericAll. With
+                        GenericAll, you may be able to perform an ESC4 attack by modifying the template's attributes.
+                        BloodHound will in that case create an ADCSESC4 edge from the principal to the forest domain
+                        node.
+                    </Typography>
+                </>
+            );
+        case 'EnterpriseCA':
+            return (
+                <>
+                    <Typography variant='body2'>
+                        With WriteDacl permission over an enterprise CA, you can grant yourself GenericAll. With
+                        GenericAll, you can publish certificate templates to the enterprise CA by adding the CN name of
+                        the template in the enterprise CA object's certificateTemplates attribute. This action may
+                        enable you to perform an ADCS domain escalation.
+                    </Typography>
+                </>
+            );
+        case 'RootCA':
+            return (
+                <>
+                    <Typography variant='body2'>
+                        With WriteDacl permission over a root CA, you can grant yourself GenericAll. With GenericAll,
+                        you can make a rouge certificate trusted as a root CA in the AD forest by adding the certificate
+                        in the root CA object's cACertificate attribute. This action may enable you to perform an ADCS
+                        domain escalation.
+                    </Typography>
+                </>
+            );
+        case 'NTAuthStore':
+            return (
+                <>
+                    <Typography variant='body2'>
+                        With WriteDacl permission over a NTAuth store, you can grant yourself GenericAll. With
+                        GenericAll, you can make an enterprise CA certificate trusted for NT (domain) authentication the
+                        AD forest by adding the certificate in the root CA object's cACertificate attribute. This action
+                        may enable you to perform an ADCS domain escalation. This action may enable you to perform an
+                        ADCS domain escalation.
+                    </Typography>
+                </>
+            );
+        case 'IssuancePolicy':
+            return (
+                <>
+                    <Typography variant='body2'>
+                        With WriteDacl permission over an issuance policy object, you can grant yourself GenericAll.
+                        With GenericAll, you create a OID group link to a targeted group by adding the groups
+                        distinguishedName in the msDS-OIDToGroupLink attribute of the issuance policy object. This
+                        action may enable you to gain membership of the group through an ADCS ESC13 attack.
+                    </Typography>
+                </>
+            );
         default:
             return (
                 <>

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/WriteDacl/WindowsAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/WriteDacl/WindowsAbuse.tsx
@@ -865,7 +865,11 @@ const WindowsAbuse: FC<EdgeInfoProps & { targetId: string; haslaps: boolean }> =
                 </>
             );
         default:
-            return null;
+            return (
+                <>
+                    <Typography variant='body2'>No abuse information available for this node type.</Typography>
+                </>
+            );
     }
 };
 

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/WriteOwner/LinuxAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/WriteOwner/LinuxAbuse.tsx
@@ -743,6 +743,63 @@ const LinuxAbuse: FC<EdgeInfoProps & { haslaps: boolean }> = ({ sourceName, targ
                     </Typography>
                 </>
             );
+        case 'CertTemplate':
+            return (
+                <>
+                    <Typography variant='body2'>
+                        With WriteOwner permission on a certificate template, you can grant yourself ownership over the
+                        object to then grant yourself GenericAll. With GenericAll, you may be able to perform an ESC4
+                        attack by modifying the template's attributes. BloodHound will in that case create an ADCSESC4
+                        edge from the principal to the forest domain node.
+                    </Typography>
+                </>
+            );
+        case 'EnterpriseCA':
+            return (
+                <>
+                    <Typography variant='body2'>
+                        With WriteOwner permission on an enterprise CA, you can grant yourself ownership over the object
+                        to then grant yourself GenericAll. With GenericAll, you can publish certificate templates to the
+                        enterprise CA by adding the CN name of the template in the enterprise CA object's
+                        certificateTemplates attribute. This action may enable you to perform an ADCS domain escalation.
+                    </Typography>
+                </>
+            );
+        case 'RootCA':
+            return (
+                <>
+                    <Typography variant='body2'>
+                        With WriteOwner permission on a root CA, you can grant yourself ownership over the object to
+                        then grant yourself GenericAll. With GenericAll, you can make a rouge certificate trusted as a
+                        root CA in the AD forest by adding the certificate in the root CA object's cACertificate
+                        attribute. This action may enable you to perform an ADCS domain escalation.
+                    </Typography>
+                </>
+            );
+        case 'NTAuthStore':
+            return (
+                <>
+                    <Typography variant='body2'>
+                        With WriteOwner permission on a NTAuth store, you can grant yourself ownership over the object
+                        to then grant yourself GenericAll. With GenericAll, you can make an enterprise CA certificate
+                        trusted for NT (domain) authentication the AD forest by adding the certificate in the root CA
+                        object's cACertificate attribute. This action may enable you to perform an ADCS domain
+                        escalation. This action may enable you to perform an ADCS domain escalation.
+                    </Typography>
+                </>
+            );
+        case 'IssuancePolicy':
+            return (
+                <>
+                    <Typography variant='body2'>
+                        With WriteOwner permission on an issuance policy object, you can grant yourself ownership over
+                        the object to then grant yourself GenericAll. With GenericAll, you create a OID group link to a
+                        targeted group by adding the groups distinguishedName in the msDS-OIDToGroupLink attribute of
+                        the issuance policy object. This action may enable you to gain membership of the group through
+                        an ADCS ESC13 attack.
+                    </Typography>
+                </>
+            );
         default:
             return (
                 <>

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/WriteOwner/LinuxAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/WriteOwner/LinuxAbuse.tsx
@@ -770,7 +770,7 @@ const LinuxAbuse: FC<EdgeInfoProps & { haslaps: boolean }> = ({ sourceName, targ
                 <>
                     <Typography variant='body2'>
                         With WriteOwner permission on a root CA, you can grant yourself ownership over the object to
-                        then grant yourself GenericAll. With GenericAll, you can make a rouge certificate trusted as a
+                        then grant yourself GenericAll. With GenericAll, you can make a rogue certificate trusted as a
                         root CA in the AD forest by adding the certificate in the root CA object's cACertificate
                         attribute. This action may enable you to perform an ADCS domain escalation.
                     </Typography>
@@ -782,7 +782,7 @@ const LinuxAbuse: FC<EdgeInfoProps & { haslaps: boolean }> = ({ sourceName, targ
                     <Typography variant='body2'>
                         With WriteOwner permission on a NTAuth store, you can grant yourself ownership over the object
                         to then grant yourself GenericAll. With GenericAll, you can make an enterprise CA certificate
-                        trusted for NT (domain) authentication the AD forest by adding the certificate in the root CA
+                        trusted for NT (domain) authentication in the AD forest by adding the certificate in the root CA
                         object's cACertificate attribute. This action may enable you to perform an ADCS domain
                         escalation. This action may enable you to perform an ADCS domain escalation.
                     </Typography>
@@ -794,7 +794,7 @@ const LinuxAbuse: FC<EdgeInfoProps & { haslaps: boolean }> = ({ sourceName, targ
                     <Typography variant='body2'>
                         With WriteOwner permission on an issuance policy object, you can grant yourself ownership over
                         the object to then grant yourself GenericAll. With GenericAll, you create a OID group link to a
-                        targeted group by adding the groups distinguishedName in the msDS-OIDToGroupLink attribute of
+                        targeted group by adding the group's distinguishedName in the msDS-OIDToGroupLink attribute of
                         the issuance policy object. This action may enable you to gain membership of the group through
                         an ADCS ESC13 attack.
                     </Typography>

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/WriteOwner/LinuxAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/WriteOwner/LinuxAbuse.tsx
@@ -784,7 +784,7 @@ const LinuxAbuse: FC<EdgeInfoProps & { haslaps: boolean }> = ({ sourceName, targ
                         to then grant yourself GenericAll. With GenericAll, you can make an enterprise CA certificate
                         trusted for NT (domain) authentication in the AD forest by adding the certificate in the root CA
                         object's cACertificate attribute. This action may enable you to perform an ADCS domain
-                        escalation. This action may enable you to perform an ADCS domain escalation.
+                        escalation.
                     </Typography>
                 </>
             );

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/WriteOwner/LinuxAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/WriteOwner/LinuxAbuse.tsx
@@ -744,7 +744,11 @@ const LinuxAbuse: FC<EdgeInfoProps & { haslaps: boolean }> = ({ sourceName, targ
                 </>
             );
         default:
-            return null;
+            return (
+                <>
+                    <Typography variant='body2'>No abuse information available for this node type.</Typography>
+                </>
+            );
     }
 };
 

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/WriteOwner/References.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/WriteOwner/References.tsx
@@ -78,6 +78,27 @@ const References: FC = () => {
                 href='https://posts.specterops.io/shadow-credentials-abusing-key-trust-account-mapping-for-takeover-8ee1a53566ab'>
                 https://posts.specterops.io/shadow-credentials-abusing-key-trust-account-mapping-for-takeover-8ee1a53566ab
             </Link>
+            <br />
+            <Link
+                target='_blank'
+                rel='noopener'
+                href='https://specterops.io/wp-content/uploads/sites/3/2022/06/Certified_Pre-Owned.pdf'>
+                https://specterops.io/wp-content/uploads/sites/3/2022/06/Certified_Pre-Owned.pdf
+            </Link>
+            <br />
+            <Link
+                target='_blank'
+                rel='noopener'
+                href='https://decoder.cloud/2023/11/20/a-deep-dive-in-cert-publishers-group/'>
+                https://decoder.cloud/2023/11/20/a-deep-dive-in-cert-publishers-group/
+            </Link>
+            <br />
+            <Link
+                target='_blank'
+                rel='noopener'
+                href='https://posts.specterops.io/adcs-esc13-abuse-technique-fda4272fbd53'>
+                https://posts.specterops.io/adcs-esc13-abuse-technique-fda4272fbd53
+            </Link>
         </Box>
     );
 };

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/WriteOwner/WindowsAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/WriteOwner/WindowsAbuse.tsx
@@ -1020,7 +1020,11 @@ const WindowsAbuse: FC<EdgeInfoProps & { targetId: string; haslaps: boolean }> =
                 </>
             );
         default:
-            return null;
+            return (
+                <>
+                    <Typography variant='body2'>No abuse information available for this node type.</Typography>
+                </>
+            );
     }
 };
 

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/WriteOwner/WindowsAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/WriteOwner/WindowsAbuse.tsx
@@ -1046,7 +1046,7 @@ const WindowsAbuse: FC<EdgeInfoProps & { targetId: string; haslaps: boolean }> =
                 <>
                     <Typography variant='body2'>
                         With WriteOwner permission on a root CA, you can grant yourself ownership over the object to
-                        then grant yourself GenericAll. With GenericAll, you can make a rouge certificate trusted as a
+                        then grant yourself GenericAll. With GenericAll, you can make a rogue certificate trusted as a
                         root CA in the AD forest by adding the certificate in the root CA object's cACertificate
                         attribute. This action may enable you to perform an ADCS domain escalation.
                     </Typography>
@@ -1058,7 +1058,7 @@ const WindowsAbuse: FC<EdgeInfoProps & { targetId: string; haslaps: boolean }> =
                     <Typography variant='body2'>
                         With WriteOwner permission on a NTAuth store, you can grant yourself ownership over the object
                         to then grant yourself GenericAll. With GenericAll, you can make an enterprise CA certificate
-                        trusted for NT (domain) authentication the AD forest by adding the certificate in the root CA
+                        trusted for NT (domain) authentication in the AD forest by adding the certificate in the root CA
                         object's cACertificate attribute. This action may enable you to perform an ADCS domain
                         escalation. This action may enable you to perform an ADCS domain escalation.
                     </Typography>
@@ -1070,7 +1070,7 @@ const WindowsAbuse: FC<EdgeInfoProps & { targetId: string; haslaps: boolean }> =
                     <Typography variant='body2'>
                         With WriteOwner permission on an issuance policy object, you can grant yourself ownership over
                         the object to then grant yourself GenericAll. With GenericAll, you create a OID group link to a
-                        targeted group by adding the groups distinguishedName in the msDS-OIDToGroupLink attribute of
+                        targeted group by adding the group's distinguishedName in the msDS-OIDToGroupLink attribute of
                         the issuance policy object. This action may enable you to gain membership of the group through
                         an ADCS ESC13 attack.
                     </Typography>

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/WriteOwner/WindowsAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/WriteOwner/WindowsAbuse.tsx
@@ -1019,6 +1019,63 @@ const WindowsAbuse: FC<EdgeInfoProps & { targetId: string; haslaps: boolean }> =
                     </Typography>
                 </>
             );
+        case 'CertTemplate':
+            return (
+                <>
+                    <Typography variant='body2'>
+                        With WriteOwner permission on a certificate template, you can grant yourself ownership over the
+                        object to then grant yourself GenericAll. With GenericAll, you may be able to perform an ESC4
+                        attack by modifying the template's attributes. BloodHound will in that case create an ADCSESC4
+                        edge from the principal to the forest domain node.
+                    </Typography>
+                </>
+            );
+        case 'EnterpriseCA':
+            return (
+                <>
+                    <Typography variant='body2'>
+                        With WriteOwner permission on an enterprise CA, you can grant yourself ownership over the object
+                        to then grant yourself GenericAll. With GenericAll, you can publish certificate templates to the
+                        enterprise CA by adding the CN name of the template in the enterprise CA object's
+                        certificateTemplates attribute. This action may enable you to perform an ADCS domain escalation.
+                    </Typography>
+                </>
+            );
+        case 'RootCA':
+            return (
+                <>
+                    <Typography variant='body2'>
+                        With WriteOwner permission on a root CA, you can grant yourself ownership over the object to
+                        then grant yourself GenericAll. With GenericAll, you can make a rouge certificate trusted as a
+                        root CA in the AD forest by adding the certificate in the root CA object's cACertificate
+                        attribute. This action may enable you to perform an ADCS domain escalation.
+                    </Typography>
+                </>
+            );
+        case 'NTAuthStore':
+            return (
+                <>
+                    <Typography variant='body2'>
+                        With WriteOwner permission on a NTAuth store, you can grant yourself ownership over the object
+                        to then grant yourself GenericAll. With GenericAll, you can make an enterprise CA certificate
+                        trusted for NT (domain) authentication the AD forest by adding the certificate in the root CA
+                        object's cACertificate attribute. This action may enable you to perform an ADCS domain
+                        escalation. This action may enable you to perform an ADCS domain escalation.
+                    </Typography>
+                </>
+            );
+        case 'IssuancePolicy':
+            return (
+                <>
+                    <Typography variant='body2'>
+                        With WriteOwner permission on an issuance policy object, you can grant yourself ownership over
+                        the object to then grant yourself GenericAll. With GenericAll, you create a OID group link to a
+                        targeted group by adding the groups distinguishedName in the msDS-OIDToGroupLink attribute of
+                        the issuance policy object. This action may enable you to gain membership of the group through
+                        an ADCS ESC13 attack.
+                    </Typography>
+                </>
+            );
         default:
             return (
                 <>

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/WriteOwner/WindowsAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/WriteOwner/WindowsAbuse.tsx
@@ -1060,7 +1060,7 @@ const WindowsAbuse: FC<EdgeInfoProps & { targetId: string; haslaps: boolean }> =
                         to then grant yourself GenericAll. With GenericAll, you can make an enterprise CA certificate
                         trusted for NT (domain) authentication in the AD forest by adding the certificate in the root CA
                         object's cACertificate attribute. This action may enable you to perform an ADCS domain
-                        escalation. This action may enable you to perform an ADCS domain escalation.
+                        escalation.
                     </Typography>
                 </>
             );


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Add abuse info for GenericAll, GenericWrite, WriteOwner, Owns, WriteDacl, and AllExtendedRights against ADCS nodes.

## Motivation and Context

The abuse info was missing for those edges against those nodes.

This PR addresses: BED-3945

## How Has This Been Tested?
With this data: 
[20240731002117_BloodHound.zip](https://github.com/user-attachments/files/16898329/20240731002117_BloodHound.zip)

## Screenshots (optional):
![image](https://github.com/user-attachments/assets/0830ca75-f2b4-4342-8247-f92561fa8135)


## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
