### PR TITLE
refactor: adcs cache with RWMutex

### DIFF
--- a/cmd/api/src/analysis/ad/adcs_integration_test.go
+++ b/cmd/api/src/analysis/ad/adcs_integration_test.go
@@ -21,6 +21,7 @@ package ad_test
 
 import (
 	"context"
+	"testing"
 
 	"github.com/specterops/bloodhound/analysis"
 	ad2 "github.com/specterops/bloodhound/analysis/ad"
@@ -29,8 +30,6 @@ import (
 
 	"github.com/specterops/bloodhound/dawgs/ops"
 	"github.com/specterops/bloodhound/dawgs/query"
-
-	"testing"
 
 	"github.com/specterops/bloodhound/dawgs/graph"
 	"github.com/specterops/bloodhound/graphschema/ad"
@@ -61,7 +60,7 @@ func TestADCSESC1(t *testing.T) {
 
 				if cache.DoesCAChainProperlyToDomain(innerEnterpriseCA, innerDomain) {
 					operation.Operation.SubmitReader(func(ctx context.Context, tx graph.Transaction, outC chan<- analysis.CreatePostRelationshipJob) error {
-						if err := ad2.PostADCSESC1(ctx, tx, outC, groupExpansions, innerEnterpriseCA, innerDomain, cache); err != nil {
+						if err := ad2.PostADCSESC1(ctx, outC, groupExpansions, innerEnterpriseCA, innerDomain, cache); err != nil {
 							t.Logf("failed post processing for %s: %v", ad.ADCSESC1.String(), err)
 						}
 						return nil

--- a/packages/go/analysis/ad/adcs.go
+++ b/packages/go/analysis/ad/adcs.go
@@ -118,7 +118,7 @@ func processEnterpriseCAWithValidCertChainToDomain(enterpriseCA, domain *graph.N
 	})
 
 	operation.Operation.SubmitReader(func(ctx context.Context, tx graph.Transaction, outC chan<- analysis.CreatePostRelationshipJob) error {
-		if err := PostADCSESC1(ctx, tx, outC, groupExpansions, enterpriseCA, domain, cache); err != nil {
+		if err := PostADCSESC1(ctx, outC, groupExpansions, enterpriseCA, domain, cache); err != nil {
 			log.Errorf("Failed post processing for %s: %v", ad.ADCSESC1.String(), err)
 		}
 		return nil

--- a/packages/go/analysis/ad/adcscache.go
+++ b/packages/go/analysis/ad/adcscache.go
@@ -189,26 +189,21 @@ func (s *ADCSCache) GetPublishedTemplateCache(id graph.ID) []*graph.Node {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	published := s.publishedTemplateCache[id]
-	return published
+	return s.publishedTemplateCache[id]
 }
 
 func (s *ADCSCache) HasUPNCertMappingInForest(id uint32) bool {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	hasUPNCertMappingInForest := s.hasUPNCertMappingInForest.Contains(id)
-
-	return hasUPNCertMappingInForest
+	return s.hasUPNCertMappingInForest.Contains(id)
 }
 
 func (s *ADCSCache) HasWeakCertBindingInForest(id uint32) bool {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	hasWeakCertBindingInForest := s.hasWeakCertBindingInForest.Contains(id)
-
-	return hasWeakCertBindingInForest
+	return s.hasWeakCertBindingInForest.Contains(id)
 }
 
 func hasUPNCertMappingInForest(tx graph.Transaction, domain *graph.Node) (bool, error) {

--- a/packages/go/analysis/ad/adcscache.go
+++ b/packages/go/analysis/ad/adcscache.go
@@ -146,7 +146,11 @@ func (s *ADCSCache) GetExpandedCertTemplateControllers(id graph.ID) cardinality.
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	return s.expandedCertTemplateControllers[id]
+	if expandedCertTemplateControllers, ok := s.expandedCertTemplateControllers[id]; !ok {
+		return cardinality.NewBitmap32()
+	} else {
+		return expandedCertTemplateControllers
+	}
 }
 
 func (s *ADCSCache) SetExpandedCertTemplateControllers(certId graph.ID, principalId uint32) {
@@ -185,7 +189,8 @@ func (s *ADCSCache) GetPublishedTemplateCache(id graph.ID) []*graph.Node {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	return s.publishedTemplateCache[id]
+	published := s.publishedTemplateCache[id]
+	return published
 }
 
 func (s *ADCSCache) HasUPNCertMappingInForest(id uint32) bool {

--- a/packages/go/analysis/ad/adcscache.go
+++ b/packages/go/analysis/ad/adcscache.go
@@ -18,6 +18,7 @@ package ad
 
 import (
 	"context"
+	"sync"
 
 	"github.com/specterops/bloodhound/dawgs/cardinality"
 	"github.com/specterops/bloodhound/dawgs/graph"
@@ -27,46 +28,52 @@ import (
 )
 
 type ADCSCache struct {
-	AuthStoreForChainValid          map[graph.ID]cardinality.Duplex[uint32]
-	RootCAForChainValid             map[graph.ID]cardinality.Duplex[uint32]
-	ExpandedCertTemplateControllers map[graph.ID][]uint32
-	CertTemplateEnrollers           map[graph.ID][]*graph.Node // principals that have enrollment on a cert template via `enroll`, `generic all`, `all extended rights` edges
-	CertTemplateControllers         map[graph.ID][]*graph.Node // principals that have privileges on a cert template via `owner`, `generic all`, `write dacl`, `write owner` edges
-	EnterpriseCAEnrollers           map[graph.ID][]*graph.Node // principals that have enrollment rights on an enterprise ca via `enroll` edge
-	PublishedTemplateCache          map[graph.ID][]*graph.Node // cert templates that are published to an enterprise ca
-	HasUPNCertMappingInForest       map[graph.ID]struct{}      // domains where at least one DC in the forest has Schannel UPN cert mapping enabled
-	HasWeakCertBindingInForest      map[graph.ID]struct{}      // domains where at least one DC in the forest has Kerberos weak cert binding enabled
+	sync.RWMutex
+
+	// To discourage direct access without getting a read lock, these are private
+	authStoreForChainValid          map[graph.ID]cardinality.Duplex[uint32]
+	rootCAForChainValid             map[graph.ID]cardinality.Duplex[uint32]
+	expandedCertTemplateControllers map[graph.ID]cardinality.Duplex[uint32]
+	certTemplateEnrollers           map[graph.ID][]*graph.Node // principals that have enrollment on a cert template via `enroll`, `generic all`, `all extended rights` edges
+	certTemplateControllers         map[graph.ID][]*graph.Node // principals that have privileges on a cert template via `owner`, `generic all`, `write dacl`, `write owner` edges
+	enterpriseCAEnrollers           map[graph.ID][]*graph.Node // principals that have enrollment rights on an enterprise ca via `enroll` edge
+	publishedTemplateCache          map[graph.ID][]*graph.Node // cert templates that are published to an enterprise ca
+	hasUPNCertMappingInForest       cardinality.Duplex[uint32] // domains where at least one DC in the forest has Schannel UPN cert mapping enabled
+	hasWeakCertBindingInForest      cardinality.Duplex[uint32] // domains where at least one DC in the forest has Kerberos weak cert binding enabled
 }
 
 func NewADCSCache() ADCSCache {
 	return ADCSCache{
-		AuthStoreForChainValid:          make(map[graph.ID]cardinality.Duplex[uint32]),
-		RootCAForChainValid:             make(map[graph.ID]cardinality.Duplex[uint32]),
-		ExpandedCertTemplateControllers: make(map[graph.ID][]uint32),
-		CertTemplateEnrollers:           make(map[graph.ID][]*graph.Node),
-		CertTemplateControllers:         make(map[graph.ID][]*graph.Node),
-		EnterpriseCAEnrollers:           make(map[graph.ID][]*graph.Node),
-		PublishedTemplateCache:          make(map[graph.ID][]*graph.Node),
-		HasUPNCertMappingInForest:       make(map[graph.ID]struct{}),
-		HasWeakCertBindingInForest:      make(map[graph.ID]struct{}),
+		authStoreForChainValid:          make(map[graph.ID]cardinality.Duplex[uint32]),
+		rootCAForChainValid:             make(map[graph.ID]cardinality.Duplex[uint32]),
+		expandedCertTemplateControllers: make(map[graph.ID]cardinality.Duplex[uint32]),
+		certTemplateEnrollers:           make(map[graph.ID][]*graph.Node),
+		certTemplateControllers:         make(map[graph.ID][]*graph.Node),
+		enterpriseCAEnrollers:           make(map[graph.ID][]*graph.Node),
+		publishedTemplateCache:          make(map[graph.ID][]*graph.Node),
+		hasUPNCertMappingInForest:       cardinality.NewBitmap32(),
+		hasWeakCertBindingInForest:      cardinality.NewBitmap32(),
 	}
 }
 
-func (s ADCSCache) BuildCache(ctx context.Context, db graph.Database, enterpriseCAs, certTemplates, domains []*graph.Node) {
-	db.ReadTransaction(ctx, func(tx graph.Transaction) error {
+func (s *ADCSCache) BuildCache(ctx context.Context, db graph.Database, enterpriseCAs, certTemplates, domains []*graph.Node) {
+	s.Lock()
+	defer s.Unlock()
+
+	err := db.ReadTransaction(ctx, func(tx graph.Transaction) error {
 		for _, ct := range certTemplates {
 			// cert template enrollers
 			if firstDegreePrincipals, err := fetchFirstDegreeNodes(tx, ct, ad.Enroll, ad.GenericAll, ad.AllExtendedRights); err != nil {
 				log.Errorf("Error fetching enrollers for cert template %d: %v", ct.ID, err)
 			} else {
-				s.CertTemplateEnrollers[ct.ID] = firstDegreePrincipals.Slice()
+				s.certTemplateEnrollers[ct.ID] = firstDegreePrincipals.Slice()
 			}
 
 			// cert template controllers
 			if firstDegreePrincipals, err := fetchFirstDegreeNodes(tx, ct, ad.Owns, ad.GenericAll, ad.WriteDACL, ad.WriteOwner); err != nil {
 				log.Errorf("Error fetching controllers for cert template %d: %v", ct.ID, err)
 			} else {
-				s.CertTemplateControllers[ct.ID] = firstDegreePrincipals.Slice()
+				s.certTemplateControllers[ct.ID] = firstDegreePrincipals.Slice()
 			}
 
 		}
@@ -75,13 +82,13 @@ func (s ADCSCache) BuildCache(ctx context.Context, db graph.Database, enterprise
 			if firstDegreeEnrollers, err := fetchFirstDegreeNodes(tx, eca, ad.Enroll); err != nil {
 				log.Errorf("Error fetching enrollers for enterprise ca %d: %v", eca.ID, err)
 			} else {
-				s.EnterpriseCAEnrollers[eca.ID] = firstDegreeEnrollers.Slice()
+				s.enterpriseCAEnrollers[eca.ID] = firstDegreeEnrollers.Slice()
 			}
 
 			if publishedTemplates, err := FetchCertTemplatesPublishedToCA(tx, eca); err != nil {
 				log.Errorf("Error fetching published cert templates for enterprise ca %d: %v", eca.ID, err)
 			} else {
-				s.PublishedTemplateCache[eca.ID] = publishedTemplates.Slice()
+				s.publishedTemplateCache[eca.ID] = publishedTemplates.Slice()
 			}
 		}
 
@@ -91,51 +98,132 @@ func (s ADCSCache) BuildCache(ctx context.Context, db graph.Database, enterprise
 			} else if authStoreForNodes, err := FetchEnterpriseCAsTrustedForNTAuthToDomain(tx, domain); err != nil {
 				log.Errorf("Error getting cas via authstorefor for domain %d: %v", domain.ID, err)
 			} else {
-				s.AuthStoreForChainValid[domain.ID] = cardinality.NodeSetToDuplex(authStoreForNodes)
-				s.RootCAForChainValid[domain.ID] = cardinality.NodeSetToDuplex(rootCaForNodes)
+				s.authStoreForChainValid[domain.ID] = cardinality.NodeSetToDuplex(authStoreForNodes)
+				s.rootCAForChainValid[domain.ID] = cardinality.NodeSetToDuplex(rootCaForNodes)
 			}
 
 			// Check for weak cert config on DCs
-			if upnMapping, err := HasUPNCertMappingInForest(tx, domain); err != nil {
-				log.Warnf("Error checking HasUPNCertMappingInForest for domain %d: %v", domain.ID, err)
+			if upnMapping, err := hasUPNCertMappingInForest(tx, domain); err != nil {
+				log.Warnf("Error checking hasUPNCertMappingInForest for domain %d: %v", domain.ID, err)
 				return nil
 			} else if upnMapping {
-				s.HasUPNCertMappingInForest[domain.ID] = struct{}{}
+				s.hasUPNCertMappingInForest.Add(domain.ID.Uint32())
 			}
-			if weakCertBinding, err := HasWeakCertBindingInForest(tx, domain); err != nil {
-				log.Warnf("Error checking HasWeakCertBindingInForest for domain %d: %v", domain.ID, err)
+			if weakCertBinding, err := hasWeakCertBindingInForest(tx, domain); err != nil {
+				log.Warnf("Error checking hasWeakCertBindingInForest for domain %d: %v", domain.ID, err)
 				return nil
 			} else if weakCertBinding {
-				s.HasWeakCertBindingInForest[domain.ID] = struct{}{}
+				s.hasWeakCertBindingInForest.Add(domain.ID.Uint32())
 			}
 		}
 
 		return nil
 	})
+	if err != nil {
+		log.Errorf("Error building adcs cache %v", err)
+	}
 
 	log.Infof("Finished building adcs cache")
 }
 
-func (s ADCSCache) DoesCAChainProperlyToDomain(enterpriseCA, domain *graph.Node) bool {
+func (s *ADCSCache) DoesCAChainProperlyToDomain(enterpriseCA, domain *graph.Node) bool {
 	var domainID = domain.ID
 	var caID = enterpriseCA.ID.Uint32()
 
-	if _, ok := s.RootCAForChainValid[domainID]; !ok {
+	s.RLock()
+	defer s.RUnlock()
+	if _, ok := s.rootCAForChainValid[domainID]; !ok {
 		return false
-	} else if _, ok := s.AuthStoreForChainValid[domainID]; !ok {
+	} else if _, ok := s.authStoreForChainValid[domainID]; !ok {
 		return false
 	} else {
-		return s.RootCAForChainValid[domainID].Contains(caID) && s.AuthStoreForChainValid[domainID].Contains(caID)
+		return s.rootCAForChainValid[domainID].Contains(caID) && s.authStoreForChainValid[domainID].Contains(caID)
 	}
 }
 
-func HasUPNCertMappingInForest(tx graph.Transaction, domain *graph.Node) (bool, error) {
+func (s *ADCSCache) GetExpandedCertTemplateControllers(id graph.ID) (cardinality.Duplex[uint32], bool) {
+	s.RLock()
+	defer s.RUnlock()
+
+	expandedCertTemplateControllers, ok := s.expandedCertTemplateControllers[id]
+
+	return expandedCertTemplateControllers, ok
+}
+
+func (s *ADCSCache) SetExpandedCertTemplateControllers(certId graph.ID, principalId uint32)  {
+	s.Lock()
+	defer s.Unlock()
+
+	if _, ok := s.expandedCertTemplateControllers[certId]; !ok {
+		s.expandedCertTemplateControllers[certId] = cardinality.NewBitmap32With(principalId)
+	} else {
+		s.expandedCertTemplateControllers[certId].Add(principalId)
+	}
+
+	return
+}
+
+func (s *ADCSCache) GetCertTemplateEnrollers(id graph.ID) ([]*graph.Node, bool) {
+	s.RLock()
+	defer s.RUnlock()
+
+	certTemplateEnrollers, ok := s.certTemplateEnrollers[id]
+
+	return certTemplateEnrollers, ok
+}
+
+func (s *ADCSCache) GetCertTemplateControllers(id graph.ID) ([]*graph.Node, bool) {
+	s.RLock()
+	defer s.RUnlock()
+
+	certTemplateControllers, ok := s.certTemplateControllers[id]
+
+	return certTemplateControllers, ok
+}
+
+func (s *ADCSCache) GetEnterpriseCAEnrollers(id graph.ID) ([]*graph.Node, bool) {
+	s.RLock()
+	defer s.RUnlock()
+
+	enterpriseCAEnrollers, ok := s.enterpriseCAEnrollers[id]
+
+	return enterpriseCAEnrollers, ok
+}
+
+func (s *ADCSCache) GetPublishedTemplateCache(id graph.ID) ([]*graph.Node, bool) {
+	s.RLock()
+	defer s.RUnlock()
+
+	publishedTemplateCache, ok := s.publishedTemplateCache[id]
+
+	return publishedTemplateCache, ok
+}
+
+func (s *ADCSCache) HasUPNCertMappingInForest(id uint32) bool {
+	s.RLock()
+	defer s.RUnlock()
+
+	hasUPNCertMappingInForest := s.hasUPNCertMappingInForest.Contains(id)
+
+	return hasUPNCertMappingInForest
+}
+
+func (s *ADCSCache) HasWeakCertBindingInForest(id uint32) bool {
+	s.RLock()
+	defer s.RUnlock()
+
+	hasWeakCertBindingInForest := s.hasWeakCertBindingInForest.Contains(id)
+
+	return hasWeakCertBindingInForest
+}
+
+func hasUPNCertMappingInForest(tx graph.Transaction, domain *graph.Node) (bool, error) {
 	if trustedByNodes, err := FetchNodesWithTrustedByParentChildRelationship(tx, domain); err != nil {
 		return false, err
 	} else {
 		for _, trustedByDomain := range trustedByNodes {
 			if dcForNodes, err := FetchNodesWithDCForEdge(tx, trustedByDomain); err != nil {
-				log.Warnf("unable to fetch DCFor nodes in HasUPNCertMappingInForest: %v", err)
+				log.Warnf("unable to fetch DCFor nodes in hasUPNCertMappingInForest: %v", err)
 				continue
 			} else {
 				for _, dcForNode := range dcForNodes {
@@ -154,13 +242,13 @@ func HasUPNCertMappingInForest(tx graph.Transaction, domain *graph.Node) (bool, 
 	return false, nil
 }
 
-func HasWeakCertBindingInForest(tx graph.Transaction, domain *graph.Node) (bool, error) {
+func hasWeakCertBindingInForest(tx graph.Transaction, domain *graph.Node) (bool, error) {
 	if trustedByNodes, err := FetchNodesWithTrustedByParentChildRelationship(tx, domain); err != nil {
 		return false, err
 	} else {
 		for _, trustedByDomain := range trustedByNodes {
 			if dcForNodes, err := FetchNodesWithDCForEdge(tx, trustedByDomain); err != nil {
-				log.Warnf("unable to fetch DCFor nodes in HasWeakCertBindingInForest: %v", err)
+				log.Warnf("unable to fetch DCFor nodes in hasWeakCertBindingInForest: %v", err)
 				continue
 			} else {
 				for _, dcForNode := range dcForNodes {

--- a/packages/go/analysis/ad/esc1.go
+++ b/packages/go/analysis/ad/esc1.go
@@ -32,11 +32,12 @@ import (
 	"github.com/specterops/bloodhound/log"
 )
 
-func PostADCSESC1(ctx context.Context, tx graph.Transaction, outC chan<- analysis.CreatePostRelationshipJob, expandedGroups impact.PathAggregator, enterpriseCA, domain *graph.Node, cache ADCSCache) error {
+func PostADCSESC1(ctx context.Context, outC chan<- analysis.CreatePostRelationshipJob, expandedGroups impact.PathAggregator, enterpriseCA, domain *graph.Node, cache ADCSCache) error {
 	results := cardinality.NewBitmap32()
-	if publishedCertTemplates, ok := cache.GetPublishedTemplateCache(enterpriseCA.ID); !ok {
+	if publishedCertTemplates := cache.GetPublishedTemplateCache(enterpriseCA.ID); len(publishedCertTemplates) == 0 {
 		return nil
 	} else {
+		ecaEnrollers := cache.GetEnterpriseCAEnrollers(enterpriseCA.ID)
 		for _, certTemplate := range publishedCertTemplates {
 			if valid, err := isCertTemplateValidForEsc1(certTemplate); err != nil {
 				log.Warnf("Error validating cert template %d: %v", certTemplate.ID, err)
@@ -44,11 +45,7 @@ func PostADCSESC1(ctx context.Context, tx graph.Transaction, outC chan<- analysi
 			} else if !valid {
 				continue
 			} else {
-				var (
-					enterpriseCAEnrollers, _ = cache.GetEnterpriseCAEnrollers(enterpriseCA.ID)
-					certTemplateEnrollers, _ = cache.GetCertTemplateEnrollers(certTemplate.ID)
-				)
-				results.Or(CalculateCrossProductNodeSets(expandedGroups, certTemplateEnrollers, enterpriseCAEnrollers))
+				results.Or(CalculateCrossProductNodeSets(expandedGroups, cache.GetCertTemplateEnrollers(certTemplate.ID), ecaEnrollers))
 			}
 		}
 	}

--- a/packages/go/analysis/ad/esc1.go
+++ b/packages/go/analysis/ad/esc1.go
@@ -34,7 +34,7 @@ import (
 
 func PostADCSESC1(ctx context.Context, tx graph.Transaction, outC chan<- analysis.CreatePostRelationshipJob, expandedGroups impact.PathAggregator, enterpriseCA, domain *graph.Node, cache ADCSCache) error {
 	results := cardinality.NewBitmap32()
-	if publishedCertTemplates, ok := cache.PublishedTemplateCache[enterpriseCA.ID]; !ok {
+	if publishedCertTemplates, ok := cache.GetPublishedTemplateCache(enterpriseCA.ID); !ok {
 		return nil
 	} else {
 		for _, certTemplate := range publishedCertTemplates {
@@ -44,7 +44,11 @@ func PostADCSESC1(ctx context.Context, tx graph.Transaction, outC chan<- analysi
 			} else if !valid {
 				continue
 			} else {
-				results.Or(CalculateCrossProductNodeSets(expandedGroups, cache.CertTemplateEnrollers[certTemplate.ID], cache.EnterpriseCAEnrollers[enterpriseCA.ID]))
+				var (
+					enterpriseCAEnrollers, _ = cache.GetEnterpriseCAEnrollers(enterpriseCA.ID)
+					certTemplateEnrollers, _ = cache.GetCertTemplateEnrollers(certTemplate.ID)
+				)
+				results.Or(CalculateCrossProductNodeSets(expandedGroups, certTemplateEnrollers, enterpriseCAEnrollers))
 			}
 		}
 	}

--- a/packages/go/analysis/ad/esc10.go
+++ b/packages/go/analysis/ad/esc10.go
@@ -34,11 +34,11 @@ import (
 )
 
 func PostADCSESC10a(ctx context.Context, tx graph.Transaction, outC chan<- analysis.CreatePostRelationshipJob, groupExpansions impact.PathAggregator, eca, domain *graph.Node, cache ADCSCache) error {
-	if _, ok := cache.HasUPNCertMappingInForest[domain.ID]; !ok {
+	if ok := cache.HasUPNCertMappingInForest(domain.ID.Uint32()); !ok {
 		return nil
-	} else if publishedCertTemplates, ok := cache.PublishedTemplateCache[eca.ID]; !ok {
+	} else if publishedCertTemplates, ok := cache.GetPublishedTemplateCache(eca.ID); !ok {
 		return nil
-	} else if ecaControllers, ok := cache.EnterpriseCAEnrollers[eca.ID]; !ok {
+	} else if ecaControllers, ok := cache.GetEnterpriseCAEnrollers(eca.ID); !ok {
 		return nil
 	} else {
 		results := cardinality.NewBitmap32()
@@ -49,7 +49,7 @@ func PostADCSESC10a(ctx context.Context, tx graph.Transaction, outC chan<- analy
 				continue
 			} else if !valid {
 				continue
-			} else if certTemplateEnrollers, ok := cache.CertTemplateEnrollers[template.ID]; !ok {
+			} else if certTemplateEnrollers, ok := cache.GetCertTemplateEnrollers(template.ID); !ok {
 				log.Debugf("Failed to retrieve enrollers for cert template %d from cache", template.ID)
 				continue
 			} else {
@@ -80,11 +80,11 @@ func PostADCSESC10a(ctx context.Context, tx graph.Transaction, outC chan<- analy
 }
 
 func PostADCSESC10b(ctx context.Context, tx graph.Transaction, outC chan<- analysis.CreatePostRelationshipJob, groupExpansions impact.PathAggregator, enterpriseCA, domain *graph.Node, cache ADCSCache) error {
-	if _, ok := cache.HasUPNCertMappingInForest[domain.ID]; !ok {
+	if ok := cache.HasUPNCertMappingInForest(domain.ID.Uint32()); !ok {
 		return nil
-	} else if publishedCertTemplates, ok := cache.PublishedTemplateCache[enterpriseCA.ID]; !ok {
+	} else if publishedCertTemplates, ok := cache.GetPublishedTemplateCache(enterpriseCA.ID); !ok {
 		return nil
-	} else if ecaControllers, ok := cache.EnterpriseCAEnrollers[enterpriseCA.ID]; !ok {
+	} else if ecaEnrollers, ok := cache.GetEnterpriseCAEnrollers(enterpriseCA.ID); !ok {
 		return nil
 	} else {
 		results := cardinality.NewBitmap32()
@@ -95,11 +95,11 @@ func PostADCSESC10b(ctx context.Context, tx graph.Transaction, outC chan<- analy
 				continue
 			} else if !valid {
 				continue
-			} else if certTemplateEnrollers, ok := cache.CertTemplateEnrollers[template.ID]; !ok {
+			} else if certTemplateEnrollers, ok := cache.GetCertTemplateEnrollers(template.ID); !ok {
 				log.Debugf("Failed to retrieve enrollers for cert template %d from cache", template.ID)
 				continue
 			} else {
-				victimBitmap := getVictimBitmap(groupExpansions, certTemplateEnrollers, ecaControllers)
+				victimBitmap := getVictimBitmap(groupExpansions, certTemplateEnrollers, ecaEnrollers)
 
 				if attackers, err := FetchAttackersForEscalations9and10(tx, victimBitmap, true); err != nil {
 					log.Warnf("Error getting start nodes for esc10b attacker nodes: %v", err)

--- a/packages/go/analysis/ad/esc10.go
+++ b/packages/go/analysis/ad/esc10.go
@@ -36,9 +36,9 @@ import (
 func PostADCSESC10a(ctx context.Context, tx graph.Transaction, outC chan<- analysis.CreatePostRelationshipJob, groupExpansions impact.PathAggregator, eca, domain *graph.Node, cache ADCSCache) error {
 	if ok := cache.HasUPNCertMappingInForest(domain.ID.Uint32()); !ok {
 		return nil
-	} else if publishedCertTemplates, ok := cache.GetPublishedTemplateCache(eca.ID); !ok {
+	} else if publishedCertTemplates := cache.GetPublishedTemplateCache(eca.ID); len(publishedCertTemplates) == 0 {
 		return nil
-	} else if ecaControllers, ok := cache.GetEnterpriseCAEnrollers(eca.ID); !ok {
+	} else if ecaControllers := cache.GetEnterpriseCAEnrollers(eca.ID); len(ecaControllers) == 0 {
 		return nil
 	} else {
 		results := cardinality.NewBitmap32()
@@ -49,7 +49,7 @@ func PostADCSESC10a(ctx context.Context, tx graph.Transaction, outC chan<- analy
 				continue
 			} else if !valid {
 				continue
-			} else if certTemplateEnrollers, ok := cache.GetCertTemplateEnrollers(template.ID); !ok {
+			} else if certTemplateEnrollers := cache.GetCertTemplateEnrollers(template.ID); len(certTemplateEnrollers) == 0 {
 				log.Debugf("Failed to retrieve enrollers for cert template %d from cache", template.ID)
 				continue
 			} else {
@@ -82,9 +82,9 @@ func PostADCSESC10a(ctx context.Context, tx graph.Transaction, outC chan<- analy
 func PostADCSESC10b(ctx context.Context, tx graph.Transaction, outC chan<- analysis.CreatePostRelationshipJob, groupExpansions impact.PathAggregator, enterpriseCA, domain *graph.Node, cache ADCSCache) error {
 	if ok := cache.HasUPNCertMappingInForest(domain.ID.Uint32()); !ok {
 		return nil
-	} else if publishedCertTemplates, ok := cache.GetPublishedTemplateCache(enterpriseCA.ID); !ok {
+	} else if publishedCertTemplates := cache.GetPublishedTemplateCache(enterpriseCA.ID); len(publishedCertTemplates) == 0 {
 		return nil
-	} else if ecaEnrollers, ok := cache.GetEnterpriseCAEnrollers(enterpriseCA.ID); !ok {
+	} else if ecaEnrollers := cache.GetEnterpriseCAEnrollers(enterpriseCA.ID); len(ecaEnrollers) == 0 {
 		return nil
 	} else {
 		results := cardinality.NewBitmap32()
@@ -95,7 +95,7 @@ func PostADCSESC10b(ctx context.Context, tx graph.Transaction, outC chan<- analy
 				continue
 			} else if !valid {
 				continue
-			} else if certTemplateEnrollers, ok := cache.GetCertTemplateEnrollers(template.ID); !ok {
+			} else if certTemplateEnrollers := cache.GetCertTemplateEnrollers(template.ID); len(certTemplateEnrollers) == 0 {
 				log.Debugf("Failed to retrieve enrollers for cert template %d from cache", template.ID)
 				continue
 			} else {

--- a/packages/go/analysis/ad/esc13.go
+++ b/packages/go/analysis/ad/esc13.go
@@ -34,7 +34,7 @@ import (
 )
 
 func PostADCSESC13(ctx context.Context, tx graph.Transaction, outC chan<- analysis.CreatePostRelationshipJob, groupExpansions impact.PathAggregator, eca, domain *graph.Node, cache ADCSCache) error {
-	if publishedCertTemplates, ok := cache.PublishedTemplateCache[eca.ID]; !ok {
+	if publishedCertTemplates, ok := cache.GetPublishedTemplateCache(eca.ID); !ok {
 		return nil
 	} else {
 		for _, template := range publishedCertTemplates {
@@ -47,7 +47,11 @@ func PostADCSESC13(ctx context.Context, tx graph.Transaction, outC chan<- analys
 			} else if len(groupNodes) == 0 {
 				continue
 			} else {
-				controlBitmap := CalculateCrossProductNodeSets(groupExpansions, cache.CertTemplateEnrollers[template.ID], cache.EnterpriseCAEnrollers[eca.ID])
+				var (
+					certTemplateEnrollers, _ = cache.GetCertTemplateEnrollers(template.ID)
+					ecaEnrollers, _ = cache.GetEnterpriseCAEnrollers(eca.ID)
+				)
+				controlBitmap := CalculateCrossProductNodeSets(groupExpansions, certTemplateEnrollers, ecaEnrollers)
 				if filtered, err := filterUserDNSResults(tx, controlBitmap, template); err != nil {
 					log.Warnf("Error filtering users from victims for esc13: %v", err)
 					continue

--- a/packages/go/analysis/ad/esc13.go
+++ b/packages/go/analysis/ad/esc13.go
@@ -34,9 +34,10 @@ import (
 )
 
 func PostADCSESC13(ctx context.Context, tx graph.Transaction, outC chan<- analysis.CreatePostRelationshipJob, groupExpansions impact.PathAggregator, eca, domain *graph.Node, cache ADCSCache) error {
-	if publishedCertTemplates, ok := cache.GetPublishedTemplateCache(eca.ID); !ok {
+	if publishedCertTemplates := cache.GetPublishedTemplateCache(eca.ID); len(publishedCertTemplates) == 0 {
 		return nil
 	} else {
+		ecaEnrollers := cache.GetEnterpriseCAEnrollers(eca.ID)
 		for _, template := range publishedCertTemplates {
 			if isValid, err := isCertTemplateValidForESC13(template); err != nil {
 				log.Errorf("Error checking esc13 cert template: %v", err)
@@ -47,11 +48,7 @@ func PostADCSESC13(ctx context.Context, tx graph.Transaction, outC chan<- analys
 			} else if len(groupNodes) == 0 {
 				continue
 			} else {
-				var (
-					certTemplateEnrollers, _ = cache.GetCertTemplateEnrollers(template.ID)
-					ecaEnrollers, _ = cache.GetEnterpriseCAEnrollers(eca.ID)
-				)
-				controlBitmap := CalculateCrossProductNodeSets(groupExpansions, certTemplateEnrollers, ecaEnrollers)
+				controlBitmap := CalculateCrossProductNodeSets(groupExpansions, ecaEnrollers, cache.GetCertTemplateEnrollers(template.ID))
 				if filtered, err := filterUserDNSResults(tx, controlBitmap, template); err != nil {
 					log.Warnf("Error filtering users from victims for esc13: %v", err)
 					continue

--- a/packages/go/analysis/ad/esc3.go
+++ b/packages/go/analysis/ad/esc3.go
@@ -37,7 +37,7 @@ import (
 func PostADCSESC3(ctx context.Context, tx graph.Transaction, outC chan<- analysis.CreatePostRelationshipJob, groupExpansions impact.PathAggregator, eca2, domain *graph.Node, cache ADCSCache) error {
 	results := cardinality.NewBitmap32()
 
-	if publishedCertTemplates, ok := cache.GetPublishedTemplateCache(eca2.ID); !ok {
+	if publishedCertTemplates := cache.GetPublishedTemplateCache(eca2.ID); len(publishedCertTemplates) == 0 {
 		return nil
 	} else if collected, err := eca2.Properties.Get(ad.EnrollmentAgentRestrictionsCollected.String()).Bool(); err != nil {
 		return fmt.Errorf("error getting enrollmentagentcollected for eca2 %d: %w", eca2.ID, err)
@@ -74,9 +74,9 @@ func PostADCSESC3(ctx context.Context, tx graph.Transaction, outC chan<- analysi
 					}
 
 					var (
-						ecaEnrollersTwo, _          = cache.GetEnterpriseCAEnrollers(eca2.ID)
-						certTemplateEnrollersOne, _ = cache.GetCertTemplateEnrollers(certTemplateOne.ID)
-						certTemplateEnrollersTwo, _ = cache.GetCertTemplateEnrollers(certTemplateTwo.ID)
+						ecaEnrollersTwo          = cache.GetEnterpriseCAEnrollers(eca2.ID)
+						certTemplateEnrollersOne = cache.GetCertTemplateEnrollers(certTemplateOne.ID)
+						certTemplateEnrollersTwo = cache.GetCertTemplateEnrollers(certTemplateTwo.ID)
 					)
 
 					if publishedECAs, err := FetchCertTemplateCAs(tx, certTemplateOne); err != nil {
@@ -88,11 +88,10 @@ func PostADCSESC3(ctx context.Context, tx graph.Transaction, outC chan<- analysi
 							log.Errorf("Error getting delegated agents for cert template %d: %v", certTemplateTwo.ID, err)
 						} else {
 							for _, eca1 := range publishedECAs {
-								ecaEnrollersOne, _ := cache.GetEnterpriseCAEnrollers(eca1.ID)
 								tempResults := CalculateCrossProductNodeSets(groupExpansions,
 									certTemplateEnrollersOne,
 									certTemplateEnrollersTwo,
-									ecaEnrollersOne,
+									cache.GetEnterpriseCAEnrollers(eca1.ID),
 									ecaEnrollersTwo,
 									delegatedAgents.Slice())
 
@@ -106,11 +105,10 @@ func PostADCSESC3(ctx context.Context, tx graph.Transaction, outC chan<- analysi
 						}
 					} else {
 						for _, eca1 := range publishedECAs {
-							ecaEnrollersOne, _ := cache.GetEnterpriseCAEnrollers(eca1.ID)
 							tempResults := CalculateCrossProductNodeSets(groupExpansions,
 								certTemplateEnrollersOne,
 								certTemplateEnrollersTwo,
-								ecaEnrollersOne,
+								cache.GetEnterpriseCAEnrollers(eca1.ID),
 								ecaEnrollersTwo)
 
 							if filteredResults, err := filterUserDNSResults(tx, tempResults, certTemplateOne); err != nil {

--- a/packages/go/analysis/ad/esc4.go
+++ b/packages/go/analysis/ad/esc4.go
@@ -35,7 +35,7 @@ import (
 func PostADCSESC4(ctx context.Context, tx graph.Transaction, outC chan<- analysis.CreatePostRelationshipJob, groupExpansions impact.PathAggregator, enterpriseCA, domain *graph.Node, cache ADCSCache) error {
 	// 1.
 	principals := cardinality.NewBitmap32()
-	publishedTemplates, _ := cache.GetPublishedTemplateCache(enterpriseCA.ID)
+	publishedTemplates := cache.GetPublishedTemplateCache(enterpriseCA.ID)
 	// 2. iterate certtemplates that have an outbound `PublishedTo` edge to eca
 	for _, certTemplate := range publishedTemplates {
 		if principalsWithGenericWrite, err := FetchPrincipalsWithGenericWriteOnCertTemplate(tx, certTemplate); err != nil {
@@ -53,8 +53,8 @@ func PostADCSESC4(ctx context.Context, tx graph.Transaction, outC chan<- analysi
 		} else {
 
 			var (
-				enterpriseCAEnrollers, _ = cache.GetEnterpriseCAEnrollers(enterpriseCA.ID)
-				certTemplateControllers, _ = cache.GetCertTemplateControllers(certTemplate.ID)
+				enterpriseCAEnrollers = cache.GetEnterpriseCAEnrollers(enterpriseCA.ID)
+				certTemplateControllers = cache.GetCertTemplateControllers(certTemplate.ID)
 			)
 
 			// 2a. principals that control the cert template

--- a/packages/go/analysis/ad/esc9.go
+++ b/packages/go/analysis/ad/esc9.go
@@ -35,11 +35,11 @@ import (
 func PostADCSESC9a(ctx context.Context, tx graph.Transaction, outC chan<- analysis.CreatePostRelationshipJob, groupExpansions impact.PathAggregator, eca, domain *graph.Node, cache ADCSCache) error {
 	results := cardinality.NewBitmap32()
 
-	if _, ok := cache.HasWeakCertBindingInForest[domain.ID]; !ok {
+	if ok := cache.HasWeakCertBindingInForest(domain.ID.Uint32()); !ok {
 		return nil
-	} else if publishedCertTemplates, ok := cache.PublishedTemplateCache[eca.ID]; !ok {
+	} else if publishedCertTemplates, ok := cache.GetPublishedTemplateCache(eca.ID); !ok {
 		return nil
-	} else if ecaControllers, ok := cache.EnterpriseCAEnrollers[eca.ID]; !ok {
+	} else if ecaEnrollers, ok := cache.GetEnterpriseCAEnrollers(eca.ID); !ok {
 		return nil
 	} else {
 		for _, template := range publishedCertTemplates {
@@ -48,11 +48,11 @@ func PostADCSESC9a(ctx context.Context, tx graph.Transaction, outC chan<- analys
 				continue
 			} else if !valid {
 				continue
-			} else if certTemplateEnrollers, ok := cache.CertTemplateEnrollers[template.ID]; !ok {
+			} else if certTemplateEnrollers, ok := cache.GetCertTemplateEnrollers(template.ID); !ok {
 				log.Debugf("Failed to retrieve enrollers for cert template %d from cache", template.ID)
 				continue
 			} else {
-				victimBitmap := getVictimBitmap(groupExpansions, certTemplateEnrollers, ecaControllers)
+				victimBitmap := getVictimBitmap(groupExpansions, certTemplateEnrollers, ecaEnrollers)
 
 				if filteredVictims, err := filterUserDNSResults(tx, victimBitmap, template); err != nil {
 					log.Warnf("Error filtering users from victims for esc9a: %v", err)
@@ -81,11 +81,11 @@ func PostADCSESC9a(ctx context.Context, tx graph.Transaction, outC chan<- analys
 func PostADCSESC9b(ctx context.Context, tx graph.Transaction, outC chan<- analysis.CreatePostRelationshipJob, groupExpansions impact.PathAggregator, eca, domain *graph.Node, cache ADCSCache) error {
 	results := cardinality.NewBitmap32()
 
-	if _, ok := cache.HasWeakCertBindingInForest[domain.ID]; !ok {
+	if ok := cache.HasWeakCertBindingInForest(domain.ID.Uint32()); !ok {
 		return nil
-	} else if publishedCertTemplates, ok := cache.PublishedTemplateCache[eca.ID]; !ok {
+	} else if publishedCertTemplates, ok := cache.GetPublishedTemplateCache(eca.ID); !ok {
 		return nil
-	} else if ecaControllers, ok := cache.EnterpriseCAEnrollers[eca.ID]; !ok {
+	} else if ecaEnrollers, ok := cache.GetEnterpriseCAEnrollers(eca.ID); !ok {
 		return nil
 	} else {
 		for _, template := range publishedCertTemplates {
@@ -94,11 +94,11 @@ func PostADCSESC9b(ctx context.Context, tx graph.Transaction, outC chan<- analys
 				continue
 			} else if !valid {
 				continue
-			} else if certTemplateEnrollers, ok := cache.CertTemplateEnrollers[template.ID]; !ok {
+			} else if certTemplateEnrollers, ok := cache.GetCertTemplateEnrollers(template.ID); !ok {
 				log.Debugf("Failed to retrieve enrollers for cert template %d from cache", template.ID)
 				continue
 			} else {
-				victimBitmap := getVictimBitmap(groupExpansions, certTemplateEnrollers, ecaControllers)
+				victimBitmap := getVictimBitmap(groupExpansions, certTemplateEnrollers, ecaEnrollers)
 
 				if attackers, err := FetchAttackersForEscalations9and10(tx, victimBitmap, true); err != nil {
 					log.Warnf("Error getting start nodes for esc9a attacker nodes: %v", err)

--- a/packages/go/analysis/ad/esc9.go
+++ b/packages/go/analysis/ad/esc9.go
@@ -37,9 +37,9 @@ func PostADCSESC9a(ctx context.Context, tx graph.Transaction, outC chan<- analys
 
 	if ok := cache.HasWeakCertBindingInForest(domain.ID.Uint32()); !ok {
 		return nil
-	} else if publishedCertTemplates, ok := cache.GetPublishedTemplateCache(eca.ID); !ok {
+	} else if publishedCertTemplates := cache.GetPublishedTemplateCache(eca.ID); len(publishedCertTemplates) == 0 {
 		return nil
-	} else if ecaEnrollers, ok := cache.GetEnterpriseCAEnrollers(eca.ID); !ok {
+	} else if ecaEnrollers := cache.GetEnterpriseCAEnrollers(eca.ID); len(ecaEnrollers) == 0 {
 		return nil
 	} else {
 		for _, template := range publishedCertTemplates {
@@ -48,7 +48,7 @@ func PostADCSESC9a(ctx context.Context, tx graph.Transaction, outC chan<- analys
 				continue
 			} else if !valid {
 				continue
-			} else if certTemplateEnrollers, ok := cache.GetCertTemplateEnrollers(template.ID); !ok {
+			} else if certTemplateEnrollers := cache.GetCertTemplateEnrollers(template.ID); len(certTemplateEnrollers) == 0 {
 				log.Debugf("Failed to retrieve enrollers for cert template %d from cache", template.ID)
 				continue
 			} else {
@@ -83,9 +83,9 @@ func PostADCSESC9b(ctx context.Context, tx graph.Transaction, outC chan<- analys
 
 	if ok := cache.HasWeakCertBindingInForest(domain.ID.Uint32()); !ok {
 		return nil
-	} else if publishedCertTemplates, ok := cache.GetPublishedTemplateCache(eca.ID); !ok {
+	} else if publishedCertTemplates := cache.GetPublishedTemplateCache(eca.ID); len(publishedCertTemplates) == 0 {
 		return nil
-	} else if ecaEnrollers, ok := cache.GetEnterpriseCAEnrollers(eca.ID); !ok {
+	} else if ecaEnrollers := cache.GetEnterpriseCAEnrollers(eca.ID); len(ecaEnrollers) == 0 {
 		return nil
 	} else {
 		for _, template := range publishedCertTemplates {
@@ -94,7 +94,7 @@ func PostADCSESC9b(ctx context.Context, tx graph.Transaction, outC chan<- analys
 				continue
 			} else if !valid {
 				continue
-			} else if certTemplateEnrollers, ok := cache.GetCertTemplateEnrollers(template.ID); !ok {
+			} else if certTemplateEnrollers := cache.GetCertTemplateEnrollers(template.ID); len(certTemplateEnrollers) == 0 {
 				log.Debugf("Failed to retrieve enrollers for cert template %d from cache", template.ID)
 				continue
 			} else {


### PR DESCRIPTION
## Description

Added RWMutex to the adcs cache
Swapped to a getter / setter approach to help protect concurrent access to the inner properties with correct locking

## Motivation and Context

This PR addresses: BED-4796

Analysis was reporting concurrent writes to maps across goroutines./

## How Has This Been Tested?

Relied on testing but should be rigorously tested in larger environments

## Screenshots (optional):

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
