### PR TITLE
BED-4388: Properly handle paths passed to OrphanFileSweeper

### DIFF
--- a/cmd/api/src/daemons/datapipe/cleanup.go
+++ b/cmd/api/src/daemons/datapipe/cleanup.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 
 	"github.com/specterops/bloodhound/log"
@@ -61,7 +62,7 @@ func NewOrphanFileSweeper(fileOps FileOperations, tempDirectoryRootPath string) 
 	return &OrphanFileSweeper{
 		lock:                  &sync.Mutex{},
 		fileOps:               fileOps,
-		tempDirectoryRootPath: tempDirectoryRootPath,
+		tempDirectoryRootPath: strings.TrimSuffix(tempDirectoryRootPath, string(filepath.Separator)),
 	}
 }
 
@@ -78,6 +79,9 @@ func (s *OrphanFileSweeper) Clear(ctx context.Context, expectedFileNames []strin
 	// Release the lock once finished
 	defer s.lock.Unlock()
 
+	log.Infof("Running OrphanFileSweeper for path %s", s.tempDirectoryRootPath)
+	log.Debugf("OrphanFileSweeper expected names %v", expectedFileNames)
+
 	if dirEntries, err := s.fileOps.ReadDir(s.tempDirectoryRootPath); err != nil {
 		log.Errorf("Failed reading work directory %s: %v", s.tempDirectoryRootPath, err)
 	} else {
@@ -85,8 +89,17 @@ func (s *OrphanFileSweeper) Clear(ctx context.Context, expectedFileNames []strin
 
 		// Remove expected files from the deletion list
 		for _, expectedFileName := range expectedFileNames {
+			expectedDir, expectedFN := filepath.Split(expectedFileName)
+			if expectedDir != "" {
+				expectedDir = strings.TrimSuffix(expectedDir, string(filepath.Separator))
+				if expectedDir != s.tempDirectoryRootPath {
+					log.Warnf("directory '%s' for expectedFileName '%s' does not match tempDirectoryRootPath '%s': skipping", expectedDir, expectedFileName, s.tempDirectoryRootPath)
+					continue
+				}
+			}
 			for idx, dirEntry := range dirEntries {
-				if expectedFileName == dirEntry.Name() {
+				if expectedFN == dirEntry.Name() {
+					log.Debugf("skipping expected file %s", expectedFN)
 					dirEntries = append(dirEntries[:idx], dirEntries[idx+1:]...)
 				}
 			}
@@ -98,6 +111,7 @@ func (s *OrphanFileSweeper) Clear(ctx context.Context, expectedFileNames []strin
 				break
 			}
 
+			log.Infof("Removing orphaned file %s", orphanedDirEntry.Name())
 			fullPath := filepath.Join(s.tempDirectoryRootPath, orphanedDirEntry.Name())
 
 			if err := s.fileOps.RemoveAll(fullPath); err != nil {

--- a/cmd/api/src/daemons/datapipe/cleanup_test.go
+++ b/cmd/api/src/daemons/datapipe/cleanup_test.go
@@ -135,6 +135,30 @@ func TestOrphanFileSweeper_Clear(t *testing.T) {
 		sweeper.Clear(context.Background(), []string{"1"})
 	})
 
+	t.Run("Exclude Files With Paths", func(t *testing.T) {
+		var (
+			mockCtrl    = gomock.NewController(t)
+			mockFileOps = mocks.NewMockFileOperations(mockCtrl)
+			sweeper     = datapipe.NewOrphanFileSweeper(mockFileOps, workDir)
+		)
+
+		defer mockCtrl.Finish()
+
+		mockFileOps.EXPECT().ReadDir(workDir).Return([]os.DirEntry{
+			dirEntry{
+				name: "1",
+			},
+			dirEntry{
+				name: "2",
+			},
+		}, nil)
+
+		// This one is a negative assertion. Because we're passing in paths to be excluded the listed dirEntries will be
+		// empty and therefore the sweeper MUST NOT call RemoveAll() on the FileOperations mock. If RemoveAll() is
+		// called then this test MUST fail.
+		sweeper.Clear(context.Background(), []string{"1", workDir + "/2"})
+	})
+
 	t.Run("Exit on Context Cancellation", func(t *testing.T) {
 		var (
 			mockCtrl    = gomock.NewController(t)


### PR DESCRIPTION
## Description

This updates the OrphanFileSweeper to properly preserve intended files when cleaning up ingest files. Previously it did not handle being passed filenames with a path, but would only work for plain filenames. Now it will properly compare filenames with a path to see if they should be preserved.

## Motivation and Context

This PR addresses: BED-4388

If the API was restarted during ingest, multiple valid but not yet processed ingest files would be deleted. This would cause file not found errors when attempting to process those files, as well as requiring another collection to reacquire the deleted ingest data.

## How Has This Been Tested?

I ran AzureHound locally and triggered an on-demand collection. I then monitored the ingest directory during the collection process and restarted the API while there were multiple files yet to be processed. I verified that upon API restart most of the files were preserved, and that there were no missing file errors in the API logs.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
