### PR TITLE
BED-4835 Add SavedQueriesRead Permission To ReadOnly Role

### DIFF
--- a/cmd/api/src/auth/role.go
+++ b/cmd/api/src/auth/role.go
@@ -48,6 +48,7 @@ func Roles() map[string]RoleTemplate {
 				permissions.AuthCreateToken,
 				permissions.AuthManageSelf,
 				permissions.GraphDBRead,
+				permissions.SavedQueriesRead,
 			},
 		},
 		RoleUploadOnly: {

--- a/cmd/api/src/database/migration/migrations/v5.16.0.sql
+++ b/cmd/api/src/database/migration/migrations/v5.16.0.sql
@@ -14,5 +14,8 @@
 --
 -- SPDX-License-Identifier: Apache-2.0
 
-INSERT INTO parameters (key, name, description, value, created_at, updated_at) 
+INSERT INTO parameters (key, name, description, value, created_at, updated_at)
 VALUES ('analysis.citrix_rdp_support', 'Citrix RDP Support', 'This configuration parameter toggles Citrix support during post-processing. When enabled, computers identified with a ''Direct Access Users'' local group will assume that Citrix is installed and CanRDP edges will require membership of both ''Direct Access Users'' and ''Remote Desktop Users'' local groups on the computer.', '{"enabled": false}',current_timestamp,current_timestamp) ON CONFLICT DO NOTHING;
+
+-- Grant the ReadOnly user SavedQueriesRead permissions
+INSERT INTO roles_permissions (role_id, permission_id) VALUES (3, 15)

--- a/cmd/api/src/database/migration/migrations/v5.16.0.sql
+++ b/cmd/api/src/database/migration/migrations/v5.16.0.sql
@@ -17,5 +17,5 @@
 INSERT INTO parameters (key, name, description, value, created_at, updated_at)
 VALUES ('analysis.citrix_rdp_support', 'Citrix RDP Support', 'This configuration parameter toggles Citrix support during post-processing. When enabled, computers identified with a ''Direct Access Users'' local group will assume that Citrix is installed and CanRDP edges will require membership of both ''Direct Access Users'' and ''Remote Desktop Users'' local groups on the computer.', '{"enabled": false}',current_timestamp,current_timestamp) ON CONFLICT DO NOTHING;
 
--- Grant the ReadOnly user SavedQueriesRead permissions
-INSERT INTO roles_permissions (role_id, permission_id) VALUES (3, 15)
+-- Grant the Read-Only user SavedQueriesRead permissions
+INSERT INTO roles_permissions (role_id, permission_id) VALUES ((SELECT id FROM roles WHERE roles.name  = 'Read-Only'), (SELECT id FROM permissions WHERE permissions.authority  = 'saved_queries'  and permissions.name = 'Read')) ON CONFLICT DO NOTHING;


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Added a migration to add ReadOnly role the SavedQueriesRead permission and updated the role template accordingly 

## Motivation and Context

This PR addresses: BED-4835

Fixes issue where ReadOnly users are not able to access saved queries

## How Has This Been Tested?

Spin up BH `just bhce-dev`
Create or use an existing User with the ReadOnly role
Send a request to
`GET /api/v2/saved-queries?scope=owned` as the ReadOnly user
And expect a 200 response back

<img width="849" alt="image" src="https://github.com/user-attachments/assets/cfdeb3b5-d5e5-43c2-b57e-50aff387880d">


## Screenshots (optional):

Screenshot of the bug running in `main`:
<img width="829" alt="image" src="https://github.com/user-attachments/assets/7aff1e21-1b20-4a33-b662-75adb0588a5a">


## Types of changes

<!-- Please remove any items that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)
- Database Migrations

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
