### PR TITLE
BED-4128: Fix skip for audit endpoint

### DIFF
--- a/cmd/api/src/api/v2/audit.go
+++ b/cmd/api/src/api/v2/audit.go
@@ -38,6 +38,7 @@ func (s Resources) ListAuditLogs(response http.ResponseWriter, request *http.Req
 		order         []string
 		auditLogs     model.AuditLogs
 		sortByColumns = request.URL.Query()[api.QueryParameterSortBy]
+		skip          int
 	)
 
 	const (
@@ -93,23 +94,34 @@ func (s Resources) ListAuditLogs(response http.ResponseWriter, request *http.Req
 		}
 
 		queryParams := request.URL.Query()
+		if queryParams.Has(model.PaginationQueryParameterSkip) {
+			if skip, err = ParseSkipQueryParameter(queryParams, 0); err != nil {
+				api.WriteErrorResponse(request.Context(), ErrBadQueryParameter(request, model.PaginationQueryParameterSkip, err), response)
+				return
+			}
+		} else if queryParams.Has(offsetQueryParam) {
+			if skip, err = ParseSkipQueryParameterWithKey(queryParams, offsetQueryParam, 0); err != nil {
+				api.WriteErrorResponse(request.Context(), ErrBadQueryParameter(request, offsetQueryParam, err), response)
+				return
+			}
+		} else {
+			skip = 0
+		}
 
 		// ignoring the error here as this would've failed at ParseQueryParameterFilters before getting here
 		if sqlFilter, err := queryFilters.BuildSQLFilter(); err != nil {
 			api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, "error building SQL for filter", request), response)
 			return
-		} else if offset, err := ParseIntQueryParameter(queryParams, offsetQueryParam, 0); err != nil {
-			api.WriteErrorResponse(request.Context(), ErrBadQueryParameter(request, offsetQueryParam, err), response)
 		} else if limit, err := ParseLimitQueryParameter(queryParams, 1000); err != nil {
 			api.WriteErrorResponse(request.Context(), ErrBadQueryParameter(request, limitQueryParam, err), response)
 		} else if getLogsBefore, err := ParseTimeQueryParameter(queryParams, logsBeforeQueryParam, time.Now()); err != nil {
 			api.WriteErrorResponse(request.Context(), ErrBadQueryParameter(request, logsBeforeQueryParam, err), response)
 		} else if getLogsAfter, err := ParseTimeQueryParameter(queryParams, logsAfterQueryParam, getLogsBefore.Add(-time.Hour*24*365)); err != nil {
 			api.WriteErrorResponse(request.Context(), ErrBadQueryParameter(request, logsAfterQueryParam, err), response)
-		} else if logs, count, err := s.DB.ListAuditLogs(request.Context(), getLogsBefore, getLogsAfter, offset, limit, strings.Join(order, ", "), sqlFilter); err != nil {
+		} else if logs, count, err := s.DB.ListAuditLogs(request.Context(), getLogsBefore, getLogsAfter, skip, limit, strings.Join(order, ", "), sqlFilter); err != nil {
 			api.HandleDatabaseError(request, response, err)
 		} else {
-			api.WriteResponseWrapperWithPagination(request.Context(), AuditLogsResponse{Logs: logs}, limit, offset, count, http.StatusOK, response)
+			api.WriteResponseWrapperWithPagination(request.Context(), AuditLogsResponse{Logs: logs}, limit, skip, count, http.StatusOK, response)
 		}
 	}
 }

--- a/cmd/api/src/api/v2/audit.go
+++ b/cmd/api/src/api/v2/audit.go
@@ -94,6 +94,8 @@ func (s Resources) ListAuditLogs(response http.ResponseWriter, request *http.Req
 		}
 
 		queryParams := request.URL.Query()
+
+		// Note: Handling both 'skip' and 'offset' query parameters to maintain backward compatibility
 		if queryParams.Has(model.PaginationQueryParameterSkip) {
 			if skip, err = ParseSkipQueryParameter(queryParams, 0); err != nil {
 				api.WriteErrorResponse(request.Context(), ErrBadQueryParameter(request, model.PaginationQueryParameterSkip, err), response)
@@ -104,8 +106,6 @@ func (s Resources) ListAuditLogs(response http.ResponseWriter, request *http.Req
 				api.WriteErrorResponse(request.Context(), ErrBadQueryParameter(request, offsetQueryParam, err), response)
 				return
 			}
-		} else {
-			skip = 0
 		}
 
 		// ignoring the error here as this would've failed at ParseQueryParameterFilters before getting here

--- a/cmd/api/src/api/v2/audit_test.go
+++ b/cmd/api/src/api/v2/audit_test.go
@@ -241,3 +241,124 @@ func TestResources_ListAuditLogs_Filtered(t *testing.T) {
 		require.Equal(t, http.StatusOK, response.Code)
 	}
 }
+
+func TestResources_ListAuditLogs_SkipAndOffset(t *testing.T) {
+    var (
+        mockCtrl  = gomock.NewController(t)
+        mockDB    = mocks.NewMockDatabase(mockCtrl)
+        resources = v2.Resources{DB: mockDB}
+    )
+    defer mockCtrl.Finish()
+
+    mockDB.EXPECT().ListAuditLogs(gomock.Any(), gomock.Any(), gomock.Any(), 10, gomock.Any(), "", model.SQLFilter{}).Return(model.AuditLogs{}, 1000, nil)
+
+    endpoint := "/api/v2/audit"
+
+    if req, err := http.NewRequest("GET", endpoint, nil); err != nil {
+        t.Fatal(err)
+    } else {
+        q := url.Values{}
+        q.Add("skip", "10")
+        q.Add("offset", "20")
+
+        req.Header.Set(headers.ContentType.String(), mediatypes.ApplicationJson.String())
+        req.URL.RawQuery = q.Encode()
+
+        router := mux.NewRouter()
+        router.HandleFunc(endpoint, resources.ListAuditLogs).Methods("GET")
+
+        response := httptest.NewRecorder()
+        router.ServeHTTP(response, req)
+        require.Equal(t, http.StatusOK, response.Code)
+    }
+}
+
+func TestResources_ListAuditLogs_OnlyOffset(t *testing.T) {
+    var (
+        mockCtrl  = gomock.NewController(t)
+        mockDB    = mocks.NewMockDatabase(mockCtrl)
+        resources = v2.Resources{DB: mockDB}
+    )
+    defer mockCtrl.Finish()
+
+    mockDB.EXPECT().ListAuditLogs(gomock.Any(), gomock.Any(), gomock.Any(), 20, gomock.Any(), "", model.SQLFilter{}).Return(model.AuditLogs{}, 1000, nil)
+
+    endpoint := "/api/v2/audit"
+
+    if req, err := http.NewRequest("GET", endpoint, nil); err != nil {
+        t.Fatal(err)
+    } else {
+        q := url.Values{}
+        q.Add("offset", "20")
+
+        req.Header.Set(headers.ContentType.String(), mediatypes.ApplicationJson.String())
+        req.URL.RawQuery = q.Encode()
+
+        router := mux.NewRouter()
+        router.HandleFunc(endpoint, resources.ListAuditLogs).Methods("GET")
+
+        response := httptest.NewRecorder()
+        router.ServeHTTP(response, req)
+        require.Equal(t, http.StatusOK, response.Code)
+    }
+}
+
+func TestResources_ListAuditLogs_OnlySkip(t *testing.T) {
+    var (
+        mockCtrl  = gomock.NewController(t)
+        mockDB    = mocks.NewMockDatabase(mockCtrl)
+        resources = v2.Resources{DB: mockDB}
+    )
+    defer mockCtrl.Finish()
+
+    // Expect skip to be 5 (from "skip" parameter)
+    mockDB.EXPECT().ListAuditLogs(gomock.Any(), gomock.Any(), gomock.Any(), 5, gomock.Any(), gomock.Any(), gomock.Any()).Return(model.AuditLogs{}, 1000, nil)
+
+    endpoint := "/api/v2/audit"
+
+    if req, err := http.NewRequest("GET", endpoint, nil); err != nil {
+        t.Fatal(err)
+    } else {
+        q := url.Values{}
+        q.Add("skip", "5")
+
+        req.Header.Set(headers.ContentType.String(), mediatypes.ApplicationJson.String())
+        req.URL.RawQuery = q.Encode()
+
+        router := mux.NewRouter()
+        router.HandleFunc(endpoint, resources.ListAuditLogs).Methods("GET")
+
+        response := httptest.NewRecorder()
+        router.ServeHTTP(response, req)
+        require.Equal(t, http.StatusOK, response.Code)
+    }
+}
+
+func TestResources_ListAuditLogs_InvalidSkip(t *testing.T) {
+    var (
+        mockCtrl  = gomock.NewController(t)
+        mockDB    = mocks.NewMockDatabase(mockCtrl)
+        resources = v2.Resources{DB: mockDB}
+    )
+    defer mockCtrl.Finish()
+
+    endpoint := "/api/v2/audit"
+
+    if req, err := http.NewRequest("GET", endpoint, nil); err != nil {
+        t.Fatal(err)
+    } else {
+        q := url.Values{}
+        q.Add("skip", "invalid")
+
+        req.Header.Set(headers.ContentType.String(), mediatypes.ApplicationJson.String())
+        req.URL.RawQuery = q.Encode()
+
+        router := mux.NewRouter()
+        router.HandleFunc(endpoint, resources.ListAuditLogs).Methods("GET")
+
+        response := httptest.NewRecorder()
+        router.ServeHTTP(response, req)
+        require.Equal(t, http.StatusBadRequest, response.Code)
+        require.Contains(t, response.Body.String(), "query parameter \\\"skip\\\" is malformed")
+    }
+}

--- a/cmd/api/src/api/v2/helpers.go
+++ b/cmd/api/src/api/v2/helpers.go
@@ -57,6 +57,18 @@ func ParseSkipQueryParameter(params url.Values, defaultValue int) (int, error) {
 	}
 }
 
+func ParseSkipQueryParameterWithKey(params url.Values, key string, defaultValue int) (int, error) {
+    if param := params.Get(key); param == "" {
+        return defaultValue, nil
+    } else if skip, err := strconv.Atoi(param); err != nil {
+        return 0, fmt.Errorf("error converting %s value %v to int: %v", key, param, err)
+    } else if skip < 0 {
+        return 0, fmt.Errorf(utils.ErrorInvalidSkip, skip)
+    } else {
+        return skip, nil
+    }
+}
+
 func ParseLimitQueryParameter(params url.Values, defaultValue int) (int, error) {
 	if param := params.Get(model.PaginationQueryParameterLimit); param == "" {
 		return defaultValue, nil

--- a/cmd/api/src/model/pagination.go
+++ b/cmd/api/src/model/pagination.go
@@ -31,5 +31,6 @@ func AllPaginationQueryParameters() []string {
 		PaginationQueryParameterLimit,
 		PaginationQueryParameterBefore,
 		PaginationQueryParameterOffset,
+		PaginationQueryParameterSkip,
 		PaginationQueryParameterSortBy}
 }


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

- Fixes an issue where `skip` parameter is not parsed from the `/api/v2/audit` endpoint, resulting in log output not starting at the specified offset

Currently, this endpoint only supports using `offset` to specify skip, as opposed to other endpoints which uses `skip`.  This change enables the endpoint to support both `offset` and `skip` and uses whichever one is populated. If they are both populated, the endpoint uses the `skip` parameter value.

## Motivation and Context

This PR addresses: BED-4128

## How Has This Been Tested?

Unit tests have been updated

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [X] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [X] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [X] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
