### PR TITLE
Feature/847 openapi codegen limitations

### DIFF
--- a/packages/go/openapi/doc/openapi.json
+++ b/packages/go/openapi/doc/openapi.json
@@ -12174,6 +12174,7 @@
         "parameters": [
           {
             "name": "finding",
+            "x-go-name": "FindingDeprecated",
             "in": "query",
             "schema": {
               "$ref": "#/components/schemas/api.params.predicate.filter.string"
@@ -12190,6 +12191,7 @@
           {
             "name": "FromPrincipal",
             "deprecated": true,
+            "x-go-name": "FromPrincipalDeprecated",
             "in": "query",
             "schema": {
               "$ref": "#/components/schemas/api.params.predicate.filter.string"
@@ -12198,6 +12200,7 @@
           {
             "name": "ToPrincipal",
             "deprecated": true,
+            "x-go-name": "ToPrincipalDeprecated",
             "in": "query",
             "schema": {
               "$ref": "#/components/schemas/api.params.predicate.filter.string"
@@ -12234,6 +12237,7 @@
           {
             "name": "AcceptedUntil",
             "deprecated": true,
+            "x-go-name": "AcceptedUntilDeprecated",
             "in": "query",
             "schema": {
               "$ref": "#/components/schemas/api.params.predicate.filter.time"
@@ -12589,6 +12593,7 @@
           {
             "name": "from",
             "deprecated": true,
+            "x-go-name": "fromDeprecated",
             "description": "Lower bound for created_at; to return posture stats starting at a specific date/time",
             "in": "query",
             "schema": {
@@ -12599,6 +12604,7 @@
           {
             "name": "to",
             "deprecated": true,
+            "x-go-name": "toDeprecated",
             "description": "Upper bound for created_at; to return posture stats upto a specific date/time",
             "in": "query",
             "schema": {

--- a/packages/go/openapi/doc/openapi.json
+++ b/packages/go/openapi/doc/openapi.json
@@ -205,19 +205,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "data": {
-                      "oneOf": [
-                        {
-                          "$ref": "#/components/schemas/model.user"
-                        },
-                        {
-                          "$ref": "#/components/schemas/model.client"
-                        }
-                      ]
-                    }
-                  }
+                  "$ref": "#/components/schemas/api.response.authenticated-requester"
                 }
               }
             }
@@ -9373,32 +9361,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/api.response.pagination"
-                    },
-                    {
-                      "$ref": "#/components/schemas/api.response.time-window"
-                    },
-                    {
-                      "type": "object",
-                      "properties": {
-                        "data": {
-                          "type": "array",
-                          "items": {
-                            "oneOf": [
-                              {
-                                "$ref": "#/components/schemas/model.ad-data-quality-aggregation"
-                              },
-                              {
-                                "$ref": "#/components/schemas/model.azure-data-quality-aggregation"
-                              }
-                            ]
-                          }
-                        }
-                      }
-                    }
-                  ]
+                  "$ref": "#/components/schemas/api.response.data-quality-platform-aggregate"
                 }
               }
             }
@@ -12574,19 +12537,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "data": {
-                      "oneOf": [
-                        {
-                          "$ref": "#/components/schemas/model.list-finding"
-                        },
-                        {
-                          "$ref": "#/components/schemas/model.relationship-finding"
-                        }
-                      ]
-                    }
-                  }
+                  "$ref": "#/components/schemas/api.response.finding"
                 }
               }
             }
@@ -13817,6 +13768,21 @@
           }
         ]
       },
+      "api.response.authenticated-requester": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/model.user"
+              },
+              {
+                "$ref": "#/components/schemas/model.client"
+              }
+            ]
+          }
+        }
+      },
       "model.saml-provider": {
         "allOf": [
           {
@@ -14786,12 +14752,10 @@
             "type": "object",
             "properties": {
               "shared_to_user_id": {
+                "readOnly": true,
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/null.uuid"
-                  },
-                  {
-                    "readOnly": true
                   }
                 ]
               },
@@ -15071,6 +15035,34 @@
               "run_id": {
                 "type": "string",
                 "format": "uuid"
+              }
+            }
+          }
+        ]
+      },
+      "api.response.data-quality-platform-aggregate": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/api.response.pagination"
+          },
+          {
+            "$ref": "#/components/schemas/api.response.time-window"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "data": {
+                "type": "array",
+                "items": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/model.ad-data-quality-aggregation"
+                    },
+                    {
+                      "$ref": "#/components/schemas/model.azure-data-quality-aggregation"
+                    }
+                  ]
+                }
               }
             }
           }
@@ -15476,6 +15468,21 @@
             }
           }
         ]
+      },
+      "api.response.finding": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/model.list-finding"
+              },
+              {
+                "$ref": "#/components/schemas/model.relationship-finding"
+              }
+            ]
+          }
+        }
       },
       "model.risk-posture-stat": {
         "allOf": [

--- a/packages/go/openapi/src/paths/attack-paths.attack-paths.id.acceptance.yaml
+++ b/packages/go/openapi/src/paths/attack-paths.attack-paths.id.acceptance.yaml
@@ -51,12 +51,7 @@ put:
       content:
         application/json:
           schema:
-            type: object
-            properties:
-              data:
-                oneOf:
-                  - $ref: './../schemas/model.list-finding.yaml'
-                  - $ref: './../schemas/model.relationship-finding.yaml'
+            $ref: './../schemas/api.response.finding.yaml'
     400:
       $ref: './../responses/bad-request.yaml'
     401:

--- a/packages/go/openapi/src/paths/attack-paths.domains.id.details.yaml
+++ b/packages/go/openapi/src/paths/attack-paths.domains.id.details.yaml
@@ -31,6 +31,7 @@ get:
     - Enterprise
   parameters:
     - name: finding
+      x-go-name: "FindingDeprecated"
       in: query
       schema:
         $ref: './../schemas/api.params.predicate.filter.string.yaml'
@@ -44,11 +45,13 @@ get:
         $ref: './../schemas/api.params.query.sort-by.yaml'
     - name: FromPrincipal
       deprecated: true
+      x-go-name: "FromPrincipalDeprecated"
       in: query
       schema:
         $ref: './../schemas/api.params.predicate.filter.string.yaml'
     - name: ToPrincipal
       deprecated: true
+      x-go-name: "ToPrincipalDeprecated"
       in: query
       schema:
         $ref: './../schemas/api.params.predicate.filter.string.yaml'
@@ -70,6 +73,7 @@ get:
         $ref: './../schemas/api.params.predicate.filter.string.yaml'
     - name: AcceptedUntil
       deprecated: true
+      x-go-name: "AcceptedUntilDeprecated"
       in: query
       schema:
         $ref: './../schemas/api.params.predicate.filter.time.yaml'

--- a/packages/go/openapi/src/paths/auth.self.yaml
+++ b/packages/go/openapi/src/paths/auth.self.yaml
@@ -33,11 +33,6 @@ get:
       content:
         application/json:
           schema:
-            type: object
-            properties:
-              data:
-                oneOf:
-                  - $ref: './../schemas/model.user.yaml'
-                  - $ref: './../schemas/model.client.yaml'
+            $ref: './../schemas/api.response.authenticated-requester.yaml'
     429:
       $ref: './../responses/too-many-requests.yaml'

--- a/packages/go/openapi/src/paths/data-quality.platform.id.data-quality-stats.yaml
+++ b/packages/go/openapi/src/paths/data-quality.platform.id.data-quality-stats.yaml
@@ -61,17 +61,7 @@ get:
       content:
         application/json:
           schema:
-            allOf:
-              - $ref: './../schemas/api.response.pagination.yaml'
-              - $ref: './../schemas/api.response.time-window.yaml'
-              - type: object
-                properties:
-                  data:
-                    type: array
-                    items:
-                      oneOf:
-                        - $ref: './../schemas/model.ad-data-quality-aggregation.yaml'
-                        - $ref: './../schemas/model.azure-data-quality-aggregation.yaml'
+            $ref: './../schemas/api.response.data-quality-platform-aggregate.yaml'
     400:
       $ref: './../responses/bad-request.yaml'
     401:

--- a/packages/go/openapi/src/paths/risk-posture.posture-stats.yaml
+++ b/packages/go/openapi/src/paths/risk-posture.posture-stats.yaml
@@ -32,6 +32,7 @@ get:
         $ref: './../schemas/api.params.query.sort-by.yaml'
     - name: from
       deprecated: true
+      x-go-name: "fromDeprecated"
       description: Lower bound for created_at; to return posture stats starting at
         a specific date/time
       in: query
@@ -40,6 +41,7 @@ get:
         format: date-time
     - name: to
       deprecated: true
+      x-go-name: "toDeprecated"
       description: Upper bound for created_at; to return posture stats upto a specific
         date/time
       in: query

--- a/packages/go/openapi/src/schemas/api.response.authenticated-requester.yaml
+++ b/packages/go/openapi/src/schemas/api.response.authenticated-requester.yaml
@@ -1,0 +1,6 @@
+type: object
+properties:
+  data:
+    oneOf:
+      - $ref: './../schemas/model.user.yaml'
+      - $ref: './../schemas/model.client.yaml'

--- a/packages/go/openapi/src/schemas/api.response.data-quality-platform-aggregate.yaml
+++ b/packages/go/openapi/src/schemas/api.response.data-quality-platform-aggregate.yaml
@@ -1,0 +1,15 @@
+type: object
+properties:
+  data:
+    allOf:
+      - $ref: './../schemas/api.response.pagination.yaml'
+      - $ref: './../schemas/api.response.time-window.yaml'
+      - type: object
+        properties:
+          data:
+            type: array
+            items:
+              oneOf:
+                - $ref: './../schemas/model.ad-data-quality-aggregation.yaml'
+                - $ref: './../schemas/model.azure-data-quality-aggregation.yaml'
+

--- a/packages/go/openapi/src/schemas/api.response.data-quality-platform-aggregate.yaml
+++ b/packages/go/openapi/src/schemas/api.response.data-quality-platform-aggregate.yaml
@@ -1,15 +1,12 @@
-type: object
-properties:
-  data:
-    allOf:
-      - $ref: './../schemas/api.response.pagination.yaml'
-      - $ref: './../schemas/api.response.time-window.yaml'
-      - type: object
-        properties:
-          data:
-            type: array
-            items:
-              oneOf:
-                - $ref: './../schemas/model.ad-data-quality-aggregation.yaml'
-                - $ref: './../schemas/model.azure-data-quality-aggregation.yaml'
+allOf:
+  - $ref: './../schemas/api.response.pagination.yaml'
+  - $ref: './../schemas/api.response.time-window.yaml'
+  - type: object
+    properties:
+      data:
+        type: array
+        items:
+          oneOf:
+            - $ref: './../schemas/model.ad-data-quality-aggregation.yaml'
+            - $ref: './../schemas/model.azure-data-quality-aggregation.yaml'
 

--- a/packages/go/openapi/src/schemas/api.response.finding.yaml
+++ b/packages/go/openapi/src/schemas/api.response.finding.yaml
@@ -1,0 +1,6 @@
+type: object
+properties:
+  data:
+    oneOf:
+      - $ref: './../schemas/model.list-finding.yaml'
+      - $ref: './../schemas/model.relationship-finding.yaml'

--- a/packages/go/openapi/src/schemas/model.saved-queries-permissions.yaml
+++ b/packages/go/openapi/src/schemas/model.saved-queries-permissions.yaml
@@ -20,9 +20,9 @@ allOf:
   - type: object
     properties:
       shared_to_user_id:
+        readOnly: true
         allOf:
           - $ref: './null.uuid.yaml'
-          - readOnly: true
       query_id:
         type: integer
         format: int64


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Modified openapi specification to address limitations in the oapi-codegen sdk code generator.
Specifically:

1) Several 200 response define the response schema 'in-place'.  In certain circumstances this confuses the code generator.  The problematic response definitions were moved into their own response schema file and referenced using a $ref.
2) There are openapi parameters that have deprecated properties that cause oapi-codegen to generate duplicate field definitions.  This was fixed by adding explicit 'x-go-name' extensions to disambiguate the deprecated names.
3) There was a readOnly definition for a $ref that was incorrect.

## Motivation and Context

This PR addresses: [672](https://github.com/SpecterOps/BloodHound/issues/672)

The openapi spec was causing oapi-codegen to generate incorrect / uncompilable go client sdk code.  These workarounds allow the codegenerator to generate correct go code *and* the modifications to the spec still describe the same response or request json.

## How Has This Been Tested?

The modified apis were tested with a oapi-codegen generated client.

## Types of changes

<!-- Please remove any items that do not apply. -->

- New feature openapi specification modifications

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
