### PR TITLE
Fix healthcheck to not use env variable

### DIFF
--- a/examples/docker-compose/docker-compose.yml
+++ b/examples/docker-compose/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       test:
         [
           "CMD-SHELL",
-          "pg_isready -U ${POSTGRES_USER:-bloodhound} -d ${POSTGRES_DB:-bloodhound} -h 127.0.0.1 -p ${POSTGRES_PORT:-5432}"
+          "pg_isready -U ${POSTGRES_USER:-bloodhound} -d ${POSTGRES_DB:-bloodhound} -h 127.0.0.1 -p 5432"
         ]
       interval: 10s
       timeout: 5s
@@ -52,7 +52,7 @@ services:
       test:
         [
           "CMD-SHELL",
-          "wget -O /dev/null -q http://localhost:${NEO4J_WEB_PORT:-7474} || exit 1"
+          "wget -O /dev/null -q http://localhost:7474 || exit 1"
         ]
       interval: 10s
       timeout: 5s


### PR DESCRIPTION
## Description

Changing the healthcheck in the example docker compose to not use the environment variable which only specifies the exposed port.

## Motivation and Context

This PR addresses: #862 

This makes it possible to change the ports by setting the env variables, without bloodhound breaking.

## How Has This Been Tested?

I have run it to avoid syntax errors by mistyping.

## Screenshots (optional):

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [ ] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [X] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [X] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
