### PR TITLE
BED-4839 - PG Ingest Fixes

### DIFF
--- a/cmd/api/src/database/migration/migrations/v5.16.0.sql
+++ b/cmd/api/src/database/migration/migrations/v5.16.0.sql
@@ -26,6 +26,18 @@ INSERT INTO parameters (key, name, description, value, created_at, updated_at) V
 -- must occur after insert to ensure reconciliation flag is set to whatever current value is
 DELETE FROM feature_flags WHERE key = 'reconciliation';
 
-
 -- Grant the Read-Only user SavedQueriesRead permissions
 INSERT INTO roles_permissions (role_id, permission_id) VALUES ((SELECT id FROM roles WHERE roles.name  = 'Read-Only'), (SELECT id FROM permissions WHERE permissions.authority  = 'saved_queries'  and permissions.name = 'Read')) ON CONFLICT DO NOTHING;
+
+do
+$$
+  begin
+    -- Update existing Edge tables with an additional constraint to support ON CONFLICT upserts
+    alter table edge drop constraint if exists edge_graph_id_start_id_end_id_kind_id_key;
+    alter table edge add constraint edge_graph_id_start_id_end_id_kind_id_key unique (graph_id, start_id, end_id, kind_id);
+  exception
+    -- This guards against the possibility that the edge table doesn't exist, in which case there's no constraint to
+    -- migrate
+    when undefined_table then null;
+  end
+$$;

--- a/packages/go/cypher/models/pgsql/format/format_test.go
+++ b/packages/go/cypher/models/pgsql/format/format_test.go
@@ -79,7 +79,9 @@ func TestFormat_Update(t *testing.T) {
 
 func TestFormat_Insert(t *testing.T) {
 	formattedQuery, err := format.Statement(pgsql.Insert{
-		Table: pgsql.CompoundIdentifier{"table"},
+		Table: pgsql.TableReference{
+			Name: pgsql.CompoundIdentifier{"table"},
+		},
 		Shape: pgsql.RecordShape{
 			Columns: []pgsql.Identifier{"col1", "col2", "col3"},
 		},
@@ -94,7 +96,9 @@ func TestFormat_Insert(t *testing.T) {
 	require.Equal(t, "insert into table (col1, col2, col3) values ('1', 1, false);", formattedQuery)
 
 	formattedQuery, err = format.Statement(pgsql.Insert{
-		Table: pgsql.CompoundIdentifier{"table"},
+		Table: pgsql.TableReference{
+			Name: pgsql.CompoundIdentifier{"table"},
+		},
 		Shape: pgsql.RecordShape{
 			Columns: []pgsql.Identifier{"col1", "col2", "col3"},
 		},
@@ -121,7 +125,9 @@ func TestFormat_Insert(t *testing.T) {
 	require.Equal(t, "insert into table (col1, col2, col3) select * from other where other.col1 = '1234';", formattedQuery)
 
 	formattedQuery, err = format.Statement(pgsql.Insert{
-		Table: pgsql.CompoundIdentifier{"table"},
+		Table: pgsql.TableReference{
+			Name: pgsql.CompoundIdentifier{"table"},
+		},
 		Shape: pgsql.RecordShape{
 			Columns: []pgsql.Identifier{"col1", "col2", "col3"},
 		},
@@ -151,7 +157,9 @@ func TestFormat_Insert(t *testing.T) {
 	require.Equal(t, "insert into table (col1, col2, col3) select * from other where other.col1 = '1234' returning id;", formattedQuery)
 
 	formattedQuery, err = format.Statement(pgsql.Insert{
-		Table: pgsql.CompoundIdentifier{"table"},
+		Table: pgsql.TableReference{
+			Name: pgsql.CompoundIdentifier{"table"},
+		},
 		Shape: pgsql.RecordShape{
 			Columns: []pgsql.Identifier{"col1", "col2", "col3"},
 		},
@@ -200,7 +208,9 @@ func TestFormat_Insert(t *testing.T) {
 	require.Equal(t, "insert into table (col1, col2, col3) select * from other where other.col1 = '1234' on conflict on constraint other.hash_constraint do update set hit_count = hit_count + 1 where hit_count < 9999 returning id, hit_count;", formattedQuery)
 
 	formattedQuery, err = format.Statement(pgsql.Insert{
-		Table: pgsql.CompoundIdentifier{"table"},
+		Table: pgsql.TableReference{
+			Name: pgsql.CompoundIdentifier{"table"},
+		},
 		Shape: pgsql.RecordShape{
 			Columns: []pgsql.Identifier{"col1", "col2", "col3"},
 		},
@@ -223,7 +233,7 @@ func TestFormat_Insert(t *testing.T) {
 		},
 		OnConflict: &pgsql.OnConflict{
 			Target: &pgsql.ConflictTarget{
-				Columns: pgsql.CompoundIdentifier{"hash"},
+				Columns: []pgsql.Expression{pgsql.CompoundIdentifier{"hash"}},
 			},
 			Action: pgsql.DoUpdate{
 				Assignments: []pgsql.Assignment{pgsql.BinaryExpression{

--- a/packages/go/cypher/models/pgsql/functions.go
+++ b/packages/go/cypher/models/pgsql/functions.go
@@ -35,6 +35,7 @@ const (
 	FunctionNow                    Identifier = "now"
 	FunctionToLower                Identifier = "lower"
 	FunctionCoalesce               Identifier = "coalesce"
+	FunctionUnnest                 Identifier = "unnest"
 	FunctionJSONBSet               Identifier = "jsonb_set"
 	FunctionCount                  Identifier = "count"
 	FunctionEdgesToPath            Identifier = "edges_to_path"

--- a/packages/go/cypher/models/pgsql/pgtypes.go
+++ b/packages/go/cypher/models/pgsql/pgtypes.go
@@ -92,6 +92,7 @@ const (
 	Text                     DataType = "text"
 	TextArray                DataType = "text[]"
 	JSONB                    DataType = "jsonb"
+	JSONBArray               DataType = "jsonb[]"
 	Date                     DataType = "date"
 	TimeWithTimeZone         DataType = "time with time zone"
 	TimeWithoutTimeZone      DataType = "time without time zone"

--- a/packages/go/cypher/models/pgsql/translate/expansion.go
+++ b/packages/go/cypher/models/pgsql/translate/expansion.go
@@ -380,7 +380,9 @@ func (s *Translator) buildAllShortestPathsExpansionRoot(part *PatternPart, trave
 
 	var (
 		primerInsert = pgsql.Insert{
-			Table: pgsql.CompoundIdentifier{"next_pathspace"},
+			Table: pgsql.TableReference{
+				Name: pgsql.CompoundIdentifier{"next_pathspace"},
+			},
 			Shape: expansionColumns(),
 			Source: &pgsql.Query{
 				Body: expansion.PrimerStatement,
@@ -388,7 +390,9 @@ func (s *Translator) buildAllShortestPathsExpansionRoot(part *PatternPart, trave
 		}
 
 		recursiveInsert = pgsql.Insert{
-			Table: pgsql.CompoundIdentifier{"next_pathspace"},
+			Table: pgsql.TableReference{
+				Name: pgsql.CompoundIdentifier{"next_pathspace"},
+			},
 			Shape: expansionColumns(),
 			Source: &pgsql.Query{
 				Body: expansion.RecursiveStatement,

--- a/packages/go/dawgs/drivers/pg/batch.go
+++ b/packages/go/dawgs/drivers/pg/batch.go
@@ -380,7 +380,7 @@ func (s *batch) flushRelationshipUpdateByBuffer(updates *sql.RelationshipUpdateB
 	if graphTarget, err := s.innerTransaction.getTargetGraph(); err != nil {
 		return err
 	} else {
-		query := sql.FormatRelationshipPartitionUpsert(graphTarget)
+		query := sql.FormatRelationshipPartitionUpsert(graphTarget, updates.IdentityProperties)
 
 		if _, err := s.innerTransaction.tx.Exec(s.ctx, query, parameters.Format(graphTarget)...); err != nil {
 			return err

--- a/packages/go/dawgs/drivers/pg/query/sql/schema_up.sql
+++ b/packages/go/dawgs/drivers/pg/query/sql/schema_up.sql
@@ -155,7 +155,9 @@ create table if not exists edge
   properties jsonb    not null,
 
   primary key (id, graph_id),
-  foreign key (graph_id) references graph (id) on delete cascade
+  foreign key (graph_id) references graph (id) on delete cascade,
+
+  unique (graph_id, start_id, end_id, kind_id)
 ) partition by list (graph_id);
 
 -- delete_node_edges is a trigger and associated plpgsql function to cascade delete edges when attached nodes are

--- a/packages/go/log/log.go
+++ b/packages/go/log/log.go
@@ -243,8 +243,7 @@ func LogAndMeasure(level Level, format string, args ...any) func() {
 		then    = time.Now()
 	)
 
-	// Only output the message header on debug
-	WithLevel(LevelDebug).Uint64(FieldMeasurementID, pairID).Msg(message)
+	WithLevel(level).Uint64(FieldMeasurementID, pairID).Msg(message)
 
 	return func() {
 		if elapsed := time.Since(then); elapsed >= measureThreshold {


### PR DESCRIPTION
## Description

This change remove MERGE in favor of an edge composite constraint and INSERT with ON CONFLICT.

## Motivation and Context

This PR addresses: BED-4839

The MERGE keyword comes with come caveats that require a full linear table scan for each insert, trashing performance of ingest in PG. Instead, we should move to a composite constraint and an INSERT w/ ON CONFLICT statement.

## How Has This Been Tested?

Local and integration testing.

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)
- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
