### PR TITLE
BED-4696 feat: add preMigrationDaemons support

### DIFF
--- a/cmd/api/src/bootstrap/initializer.go
+++ b/cmd/api/src/bootstrap/initializer.go
@@ -36,9 +36,9 @@ type DatabaseConstructor[DBType database.Database, GraphType graph.Database] fun
 type InitializerLogic[DBType database.Database, GraphType graph.Database] func(ctx context.Context, cfg config.Configuration, databaseConnections DatabaseConnections[DBType, GraphType]) ([]daemons.Daemon, error)
 
 type Initializer[DBType database.Database, GraphType graph.Database] struct {
-	Configuration config.Configuration
-	PreEntrypoint InitializerLogic[DBType, GraphType]
-	Entrypoint    InitializerLogic[DBType, GraphType]
+	Configuration       config.Configuration
+	PreMigrationDaemons InitializerLogic[DBType, GraphType]
+	Entrypoint          InitializerLogic[DBType, GraphType]
 	DBConnector   DatabaseConstructor[DBType, GraphType]
 }
 
@@ -70,8 +70,8 @@ func (s Initializer[DBType, GraphType]) Launch(parentCtx context.Context, handle
 	defer databaseConnections.Graph.Close(ctx)
 
 	// Daemons that start prior to blocking db migration
-	if s.PreEntrypoint != nil {
-		if daemonInstances, err := s.PreEntrypoint(ctx, s.Configuration, databaseConnections); err != nil {
+	if s.PreMigrationDaemons != nil {
+		if daemonInstances, err := s.PreMigrationDaemons(ctx, s.Configuration, databaseConnections); err != nil {
 			return fmt.Errorf("failed to start services: %w", err)
 		} else {
 			daemonManager.Start(ctx, daemonInstances...)

--- a/cmd/api/src/cmd/bhapi/main.go
+++ b/cmd/api/src/cmd/bhapi/main.go
@@ -66,7 +66,7 @@ func main() {
 		initializer := bootstrap.Initializer[*database.BloodhoundDB, *graph.DatabaseSwitch]{
 			Configuration: cfg,
 			DBConnector:   services.ConnectDatabases,
-			PreEntrypoint: services.PreEntrypoint,
+			PreMigrationDaemons: services.PreMigrationDaemons,
 			Entrypoint:    services.Entrypoint,
 		}
 

--- a/cmd/api/src/cmd/bhapi/main.go
+++ b/cmd/api/src/cmd/bhapi/main.go
@@ -66,6 +66,7 @@ func main() {
 		initializer := bootstrap.Initializer[*database.BloodhoundDB, *graph.DatabaseSwitch]{
 			Configuration: cfg,
 			DBConnector:   services.ConnectDatabases,
+			PreEntrypoint: services.PreEntrypoint,
 			Entrypoint:    services.Entrypoint,
 		}
 

--- a/cmd/api/src/daemons/api/toolapi/api.go
+++ b/cmd/api/src/daemons/api/toolapi/api.go
@@ -76,6 +76,11 @@ func NewDaemon[DBType database.Database](ctx context.Context, connections bootst
 		}
 	})
 
+	// Health endpoint that is online even during migrations
+	router.Get("/health", func(response http.ResponseWriter, _ *http.Request) {
+		response.WriteHeader(http.StatusOK)
+	})
+
 	router.Get("/logging", tools.GetLoggingDetails)
 	router.Put("/logging", tools.PutLoggingDetails)
 

--- a/cmd/api/src/services/entrypoint.go
+++ b/cmd/api/src/services/entrypoint.go
@@ -21,17 +21,15 @@ import (
 	"fmt"
 	"time"
 
-	schema "github.com/specterops/bloodhound/graphschema"
-	"github.com/specterops/bloodhound/log"
-	"github.com/specterops/bloodhound/src/bootstrap"
-	"github.com/specterops/bloodhound/src/queries"
-
 	"github.com/specterops/bloodhound/cache"
 	"github.com/specterops/bloodhound/dawgs/graph"
+	schema "github.com/specterops/bloodhound/graphschema"
+	"github.com/specterops/bloodhound/log"
 	"github.com/specterops/bloodhound/src/api"
 	"github.com/specterops/bloodhound/src/api/registration"
 	"github.com/specterops/bloodhound/src/api/router"
 	"github.com/specterops/bloodhound/src/auth"
+	"github.com/specterops/bloodhound/src/bootstrap"
 	"github.com/specterops/bloodhound/src/config"
 	"github.com/specterops/bloodhound/src/daemons"
 	"github.com/specterops/bloodhound/src/daemons/api/bhapi"
@@ -40,6 +38,7 @@ import (
 	"github.com/specterops/bloodhound/src/daemons/gc"
 	"github.com/specterops/bloodhound/src/database"
 	"github.com/specterops/bloodhound/src/model/appcfg"
+	"github.com/specterops/bloodhound/src/queries"
 )
 
 // ConnectPostgres initializes a connection to PG, and returns errors if any
@@ -65,6 +64,13 @@ func ConnectDatabases(ctx context.Context, cfg config.Configuration) (bootstrap.
 
 		return connections, nil
 	}
+}
+
+// PreEntrypoint Word of caution: These daemons will be launched prior to any migration starting
+func PreEntrypoint(ctx context.Context, cfg config.Configuration, connections bootstrap.DatabaseConnections[*database.BloodhoundDB, *graph.DatabaseSwitch]) ([]daemons.Daemon, error) {
+	return []daemons.Daemon{
+		toolapi.NewDaemon(ctx, connections, cfg, schema.DefaultGraphSchema()),
+	}, nil
 }
 
 func Entrypoint(ctx context.Context, cfg config.Configuration, connections bootstrap.DatabaseConnections[*database.BloodhoundDB, *graph.DatabaseSwitch]) ([]daemons.Daemon, error) {
@@ -111,7 +117,6 @@ func Entrypoint(ctx context.Context, cfg config.Configuration, connections boots
 
 		return []daemons.Daemon{
 			bhapi.NewDaemon(cfg, routerInst.Handler()),
-			toolapi.NewDaemon(ctx, connections, cfg, schema.DefaultGraphSchema()),
 			gc.NewDataPruningDaemon(connections.RDMS),
 			datapipeDaemon,
 		}, nil

--- a/cmd/api/src/services/entrypoint.go
+++ b/cmd/api/src/services/entrypoint.go
@@ -66,8 +66,8 @@ func ConnectDatabases(ctx context.Context, cfg config.Configuration) (bootstrap.
 	}
 }
 
-// PreEntrypoint Word of caution: These daemons will be launched prior to any migration starting
-func PreEntrypoint(ctx context.Context, cfg config.Configuration, connections bootstrap.DatabaseConnections[*database.BloodhoundDB, *graph.DatabaseSwitch]) ([]daemons.Daemon, error) {
+// PreMigrationDaemons Word of caution: These daemons will be launched prior to any migration starting
+func PreMigrationDaemons(ctx context.Context, cfg config.Configuration, connections bootstrap.DatabaseConnections[*database.BloodhoundDB, *graph.DatabaseSwitch]) ([]daemons.Daemon, error) {
 	return []daemons.Daemon{
 		toolapi.NewDaemon(ctx, connections, cfg, schema.DefaultGraphSchema()),
 	}, nil


### PR DESCRIPTION
## Description

- Added a preMigrationDaemons property to initializer struct in order to allow daemons to start before migrations are run
- Moved the tools api daemon to the preMigrationDaemons property to launch the API prior to migrations
- Added a `/health` endpoint for infrastructure & container management

## Motivation and Context

This PR addresses: BED-4696

Long running migrations on large datasets prevent the bh API `/health` endpoint from starting which can trip container management automation tied to the `/health` endpoint. This bh API `/health` endpoint remains unchanged and can be used in conjunction with the above to determine where in the bootstrap the process is.

## How Has This Been Tested?

Force added a couple minutes sleep to the migration check
Hit GET `0.0.0.0:2112/health` after launching before migration sleep finishes.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
