### PR TITLE
BED-4725: normalize files to UTF8 when extracting zip files for ingest

### DIFF
--- a/cmd/api/src/daemons/datapipe/jobs.go
+++ b/cmd/api/src/daemons/datapipe/jobs.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"os"
 
+	"github.com/specterops/bloodhound/bomenc"
 	"github.com/specterops/bloodhound/dawgs/graph"
 	"github.com/specterops/bloodhound/dawgs/util"
 	"github.com/specterops/bloodhound/log"
@@ -165,7 +166,10 @@ func (s *Daemon) preProcessIngestFile(path string, fileType model.FileType) ([]s
 			} else if srcFile, err := f.Open(); err != nil {
 				errs.Add(fmt.Errorf("error opening file %s in archive %s: %v", f.Name, path, err))
 				failed++
-			} else if _, err := io.Copy(tempFile, srcFile); err != nil {
+			} else if normFile, err := bomenc.NormalizeToUTF8(srcFile); err != nil {
+				errs.Add(fmt.Errorf("error normalizing file %s to UTF8 in archive %s: %v", f.Name, path, err))
+				failed++
+			} else if _, err := io.Copy(tempFile, normFile); err != nil {
 				errs.Add(fmt.Errorf("error extracting file %s in archive %s: %v", f.Name, path, err))
 				failed++
 			} else if err := tempFile.Close(); err != nil {

--- a/cmd/api/src/services/fileupload/file_upload.go
+++ b/cmd/api/src/services/fileupload/file_upload.go
@@ -38,12 +38,6 @@ import (
 
 const jobActivityTimeout = time.Minute * 20
 
-const (
-	UTF8BOM1 = 0xef
-	UTF8BOM2 = 0xbb
-	UTF8BMO3 = 0xbf
-)
-
 var ErrInvalidJSON = errors.New("file is not valid json")
 
 type FileUploadData interface {


### PR DESCRIPTION
## Description

Used `bomenc.NormalizeToUTF8()` to normalize files during extraction while processing zip files for ingest.

## Motivation and Context

BED-4725

Currently JSON files in an uploaded zip file that are encoded with a BOM marker or alternative UTF format fail to ingest.

## How Has This Been Tested?

Uploaded a zip file containing an UTF16LE encoded JSON file to see if it would ingest without errors.

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [ ] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
