### PR TITLE
BED-4753: Added styling selectors to address sections in api explorer not working in dark/light mode

### DIFF
--- a/cmd/ui/src/App.tsx
+++ b/cmd/ui/src/App.tsx
@@ -74,6 +74,8 @@ export const Inner: React.FC = () => {
                         & .btn-group > button,
                         & textarea,
                         & select,
+                        & .parameter__type,
+                        & .prop-format,
                         `]: {
                         color: theme.palette.color.primary,
                     },
@@ -100,6 +102,9 @@ export const Inner: React.FC = () => {
                         },
                         '& model-box': {
                             backgroundColor: theme.palette.neutral.primary,
+                        },
+                        '& .parameter__name.required::after': {
+                            color: theme.palette.color.error,
                         },
                     },
                     '& .responses-inner': {

--- a/cmd/ui/src/App.tsx
+++ b/cmd/ui/src/App.tsx
@@ -107,7 +107,7 @@ export const Inner: React.FC = () => {
                             color: theme.palette.color.primary,
                         },
                     },
-                    '& svg.arrow': {
+                    '& svg': {
                         fill: theme.palette.color.primary,
                     },
                     '& .opblock-deprecated': {

--- a/cmd/ui/src/App.tsx
+++ b/cmd/ui/src/App.tsx
@@ -72,11 +72,13 @@ export const Inner: React.FC = () => {
                         & .response-col_links,
                         & .opblock-description-wrapper > p,
                         & .btn-group > button,
+                        & textarea,
+                        & select,
                         `]: {
                         color: theme.palette.color.primary,
                     },
-                    '& .filter-container .operation-filter-input': {
-                        backgroundColor: 'inherit',
+                    ['& input, & textarea, & select, & .models, & .filter-container .operation-filter-input']: {
+                        backgroundColor: theme.palette.neutral.primary,
                         border: `1px solid ${theme.palette.grey[700]}`,
 
                         '&:hover': {
@@ -84,6 +86,20 @@ export const Inner: React.FC = () => {
                         },
                         '&:focus': {
                             outline: `1px solid ${theme.palette.color.links}`,
+                        },
+                    },
+                    '& .models': {
+                        '& h4': {
+                            borderBottomColor: theme.palette.grey[700],
+                        },
+                        '& span, & table': {
+                            color: theme.palette.color.primary,
+                        },
+                        '& svg': {
+                            fill: theme.palette.color.primary,
+                        },
+                        '& model-box': {
+                            backgroundColor: theme.palette.neutral.primary,
                         },
                     },
                     '& .responses-inner': {
@@ -96,6 +112,12 @@ export const Inner: React.FC = () => {
                     },
                     '& .opblock-deprecated': {
                         '& .opblock-title_normal': {
+                            color: theme.palette.color.primary,
+                        },
+                    },
+                    '& .opblock-section-header': {
+                        backgroundColor: theme.palette.neutral.primary,
+                        '& h4, & .btn': {
                             color: theme.palette.color.primary,
                         },
                     },

--- a/cmd/ui/src/App.tsx
+++ b/cmd/ui/src/App.tsx
@@ -103,9 +103,9 @@ export const Inner: React.FC = () => {
                         '& model-box': {
                             backgroundColor: theme.palette.neutral.primary,
                         },
-                        '& .parameter__name.required::after': {
-                            color: theme.palette.color.error,
-                        },
+                    },
+                    '& .parameter__name.required::after': {
+                        color: theme.palette.color.error,
                     },
                     '& .responses-inner': {
                         [`& h4, & h5`]: {


### PR DESCRIPTION
## Description

Added selectors to target elements that were not responding to the dark / light mode functionality in API explorer

## Motivation and Context

This addresses ticket [BED-4753](https://specterops.atlassian.net/browse/BED-4753)

## How Has This Been Tested?

Tested manually.

## Screenshots (optional):

https://github.com/user-attachments/assets/783c8e58-2c87-43cb-bc72-69af2900af47

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


[BED-4753]: https://specterops.atlassian.net/browse/BED-4753?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ