### PR TITLE
fix: BED-4869 clean up logging for TenantRoles

### DIFF
--- a/packages/go/analysis/azure/tenant.go
+++ b/packages/go/analysis/azure/tenant.go
@@ -102,7 +102,7 @@ func FetchTenants(ctx context.Context, db graph.Database) (graph.NodeSet, error)
 
 // TenantRoles returns the NodeSet of roles for a given tenant that match one of the given role template IDs. If no role template ID is provided, then all of the tenant role nodes are returned in the NodeSet.
 func TenantRoles(tx graph.Transaction, tenant *graph.Node, roleTemplateIDs ...string) (graph.NodeSet, error) {
-	defer log.LogAndMeasure(log.LevelInfo, "Tenant %d TenantRoles", tenant.ID)()
+	defer log.Measure(log.LevelInfo, "TenantRoles - Tenant %d", tenant.ID)()
 
 	if !IsTenantNode(tenant) {
 		return nil, fmt.Errorf("cannot fetch tenant roles - node %d must be of kind %s", tenant.ID, azure.Tenant)


### PR DESCRIPTION
## Description

It would be better to use Measure instead of LogAndMeasure for this call. Measure intentionally does not log unless the measured call exceeds a wall time of 1 second. The intent of this call appears to be identifying potential slow calls so the refactor feels right.

## Motivation and Context

Log is too noisy otherwise.

## How Has This Been Tested?

Local testing

## Types of changes

- Chore (a change that does not modify the application functionality)
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)
- Database Migrations

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
