### PR TITLE
feat: BED-4879 enable by default and hide dark mode feature flag

### DIFF
--- a/cmd/api/src/database/migration/migrations/v6.0.0.sql
+++ b/cmd/api/src/database/migration/migrations/v6.0.0.sql
@@ -42,10 +42,10 @@ VALUES (
 )
 ON CONFLICT DO NOTHING;
 
+-- Update existing Edge tables with an additional constraint to support ON CONFLICT upserts
 do
 $$
   begin
-    -- Update existing Edge tables with an additional constraint to support ON CONFLICT upserts
     alter table edge drop constraint if exists edge_graph_id_start_id_end_id_kind_id_key;
     alter table edge add constraint edge_graph_id_start_id_end_id_kind_id_key unique (graph_id, start_id, end_id, kind_id);
   exception
@@ -54,3 +54,6 @@ $$
     when undefined_table then null;
   end
 $$;
+
+-- Set Dark Mode to default to enabled and hide the flag from users in the UI
+UPDATE feature_flags set enabled = true, user_updatable = false where key = 'dark_mode';


### PR DESCRIPTION
## Description

Marks dark mode as default enabled and hides the flag from the BloodHound UI in preparation for removal of the feature flag and related code paths.

## Motivation and Context

Dark mode is ready for primetime. We should enable it for all installs by default.

## How Has This Been Tested?

Local testing with database access.

## Types of changes

- Chore (a change that does not modify the application functionality)
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)
- Database Migrations

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
