### PR TITLE
BED-4888: Cleaned up citrix RDP configuration tests

### DIFF
--- a/packages/javascript/bh-shared-ui/src/components/CitrixRDPConfiguration/CitrixRDPConfiguration.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/CitrixRDPConfiguration/CitrixRDPConfiguration.test.tsx
@@ -83,7 +83,7 @@ describe('CitrixRDPConfiguration', () => {
 
             await user.click(panelSwitch);
 
-            const panelDialogTitle = screen.getByText(dialogTitle, { exact: false });
+            const panelDialogTitle = await screen.findByText(dialogTitle, { exact: false });
             const panelDialogDescription = screen.getByText(/analysis has been added with citrix configuration/i);
 
             expect(panelSwitch).toBeInTheDocument();
@@ -95,11 +95,9 @@ describe('CitrixRDPConfiguration', () => {
 
             await user.click(cancelButton);
 
-            await waitFor(() => {
-                expect(panelDialogTitle).not.toBeInTheDocument();
-                expect(panelDialogDescription).not.toBeInTheDocument();
-                expect(panelSwitch).not.toBeChecked();
-            });
+            await waitFor(() => expect(panelDialogTitle).not.toBeInTheDocument());
+            expect(panelDialogDescription).not.toBeInTheDocument();
+            expect(panelSwitch).not.toBeChecked();
         });
 
         it('on clicking switch shows modal and when clicking confirm closes it and switch changes to enabled', async () => {
@@ -108,7 +106,7 @@ describe('CitrixRDPConfiguration', () => {
 
             await user.click(panelSwitch);
 
-            const panelDialogTitle = screen.getByText(dialogTitle, { exact: false });
+            const panelDialogTitle = await screen.findByText(dialogTitle, { exact: false });
             const panelDialogDescription = screen.getByText(/analysis has been added with citrix configuration/i);
 
             expect(panelSwitch).toBeInTheDocument();
@@ -120,11 +118,9 @@ describe('CitrixRDPConfiguration', () => {
 
             await user.click(confirmButton);
 
-            await waitFor(() => {
-                expect(panelDialogTitle).not.toBeInTheDocument();
-                expect(panelDialogDescription).not.toBeInTheDocument();
-                expect(panelSwitch).toBeChecked();
-            });
+            await waitFor(() => expect(panelDialogTitle).not.toBeInTheDocument());
+            expect(panelDialogDescription).not.toBeInTheDocument();
+            expect(panelSwitch).toBeChecked();
         });
     });
     describe('Click on switch to disable', () => {
@@ -139,7 +135,7 @@ describe('CitrixRDPConfiguration', () => {
 
             await user.click(panelSwitch);
 
-            const panelDialogTitle = screen.getByText(dialogTitle, { exact: false });
+            const panelDialogTitle = await screen.findByText(dialogTitle, { exact: false });
             const panelDialogDescription = screen.getByText(/analysis has been removed with citrix configuration/i);
 
             expect(panelSwitch).toBeInTheDocument();
@@ -151,11 +147,9 @@ describe('CitrixRDPConfiguration', () => {
 
             await user.click(cancelButton);
 
-            await waitFor(() => {
-                expect(panelDialogTitle).not.toBeInTheDocument();
-                expect(panelDialogDescription).not.toBeInTheDocument();
-                expect(panelSwitch).toBeChecked();
-            });
+            await waitFor(() => expect(panelDialogTitle).not.toBeInTheDocument());
+            expect(panelDialogDescription).not.toBeInTheDocument();
+            expect(panelSwitch).toBeChecked();
         });
         it('on clicking switch shows modal and when clicking confirm closes it and switch changes to disabled', async () => {
             const panelSwitch = screen.getByRole('switch');
@@ -163,7 +157,7 @@ describe('CitrixRDPConfiguration', () => {
 
             await user.click(panelSwitch);
 
-            const panelDialogTitle = screen.getByText(dialogTitle, { exact: false });
+            const panelDialogTitle = await screen.findByText(dialogTitle, { exact: false });
             const panelDialogDescription = screen.getByText(/analysis has been removed with citrix configuration/i);
 
             expect(panelSwitch).toBeInTheDocument();
@@ -175,11 +169,9 @@ describe('CitrixRDPConfiguration', () => {
 
             await user.click(confirmButton);
 
-            await waitFor(() => {
-                expect(panelDialogTitle).not.toBeInTheDocument();
-                expect(panelDialogDescription).not.toBeInTheDocument();
-                expect(panelSwitch).not.toBeChecked();
-            });
+            await waitFor(() => expect(panelDialogTitle).not.toBeInTheDocument());
+            expect(panelDialogDescription).not.toBeInTheDocument();
+            expect(panelSwitch).not.toBeChecked();
         });
     });
 });


### PR DESCRIPTION
## Description

Cleaned up test to match best practices. Removed multiple assertions in a waitFor method, used findByText in queries where  needed instead of getByText.

## Motivation and Context

This addresses [BED-4888](https://specterops.atlassian.net/browse/BED-4888). Really to keep tests as consistent and with as many known best practices as possible.

## How Has This Been Tested?

Ran the tests locally.

## Screenshots (optional):

## Types of changes

- Chore (a change that does not modify the application functionality)

## Checklist:

- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


[BED-4888]: https://specterops.atlassian.net/browse/BED-4888?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ