### PR TITLE
BED-4907: Edge type shortcuts

### DIFF
--- a/cmd/api/src/api/tools/analysis_schedule.go
+++ b/cmd/api/src/api/tools/analysis_schedule.go
@@ -1,3 +1,19 @@
+// Copyright 2024 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package tools
 
 import (

--- a/cmd/api/src/api/tools/analysis_schedule_test.go
+++ b/cmd/api/src/api/tools/analysis_schedule_test.go
@@ -1,3 +1,19 @@
+// Copyright 2024 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package tools_test
 
 import (

--- a/packages/cue/bh/ad/ad.cue
+++ b/packages/cue/bh/ad/ad.cue
@@ -1293,6 +1293,11 @@ SyncedToEntraUser: types.#Kind & {
 	schema: "active_directory"
 }
 
+ALL_AD_ATTACKS: types.#Kind & {
+	symbol: "ALL_AD_ATTACKS"
+	schema: "active_directory"
+}
+
 // Relationship Kinds
 RelationshipKinds: [
 	Owns,
@@ -1364,6 +1369,7 @@ RelationshipKinds: [
 	ADCSESC10b,
 	ADCSESC13,
 	SyncedToEntraUser,
+	ALL_AD_ATTACKS
 ]
 
 // ACL Relationships

--- a/packages/cue/bh/ad/ad.cue
+++ b/packages/cue/bh/ad/ad.cue
@@ -1293,12 +1293,6 @@ SyncedToEntraUser: types.#Kind & {
 	schema: "active_directory"
 }
 
-AllADAttacks: types.#Kind & {
-	symbol: "AllADAttacks"
-	schema: "active_directory"
-	representation: "ALL_AD_ATTACKS"
-}
-
 // Relationship Kinds
 RelationshipKinds: [
 	Owns,
@@ -1369,8 +1363,7 @@ RelationshipKinds: [
 	ADCSESC10a,
 	ADCSESC10b,
 	ADCSESC13,
-	SyncedToEntraUser,
-	AllADAttacks
+	SyncedToEntraUser
 ]
 
 // ACL Relationships

--- a/packages/cue/bh/ad/ad.cue
+++ b/packages/cue/bh/ad/ad.cue
@@ -1293,9 +1293,10 @@ SyncedToEntraUser: types.#Kind & {
 	schema: "active_directory"
 }
 
-ALL_AD_ATTACKS: types.#Kind & {
-	symbol: "ALL_AD_ATTACKS"
+AllADAttacks: types.#Kind & {
+	symbol: "AllADAttacks"
 	schema: "active_directory"
+	representation: "ALL_AD_ATTACKS"
 }
 
 // Relationship Kinds
@@ -1369,7 +1370,7 @@ RelationshipKinds: [
 	ADCSESC10b,
 	ADCSESC13,
 	SyncedToEntraUser,
-	ALL_AD_ATTACKS
+	AllADAttacks
 ]
 
 // ACL Relationships

--- a/packages/cue/bh/azure/azure.cue
+++ b/packages/cue/bh/azure/azure.cue
@@ -723,12 +723,6 @@ SyncedToADUser: types.#Kind & {
 	representation:	"SyncedToADUser"
 }
 
-AllAZAttacks: types.#Kind & {
-	symbol: "AllAZAttacks"
-	schema: "azure"
-	representation: "ALL_AZ_ATTACKS"
-}
-
 RelationshipKinds: [
 	AvereContributor,
 	Contains,
@@ -776,8 +770,7 @@ RelationshipKinds: [
 	AZMGAddSecret,
 	AZMGGrantAppRoles,
 	AZMGGrantRole,
-	SyncedToADUser,
-	AllAZAttacks
+	SyncedToADUser
 ]
 
 AppRoleTransitRelationshipKinds: [

--- a/packages/cue/bh/azure/azure.cue
+++ b/packages/cue/bh/azure/azure.cue
@@ -723,6 +723,12 @@ SyncedToADUser: types.#Kind & {
 	representation:	"SyncedToADUser"
 }
 
+AllAZAttacks: types.#Kind & {
+	symbol: "AllAZAttacks"
+	schema: "azure"
+	representation: "ALL_AZ_ATTACKS"
+}
+
 RelationshipKinds: [
 	AvereContributor,
 	Contains,
@@ -771,6 +777,7 @@ RelationshipKinds: [
 	AZMGGrantAppRoles,
 	AZMGGrantRole,
 	SyncedToADUser,
+	AllAZAttacks
 ]
 
 AppRoleTransitRelationshipKinds: [

--- a/packages/cue/bh/common/common.cue
+++ b/packages/cue/bh/common/common.cue
@@ -162,9 +162,23 @@ MigrationData: types.#Kind & {
 	representation: "MigrationData"
 }
 
+AllADAttacks: types.#Kind & {
+	symbol: "AllADAttacks"
+	schema: "active_directory"
+	representation: "ALL_AD_ATTACKS"
+}
+
+AllAZAttacks: types.#Kind & {
+	symbol: "AllAZAttacks"
+	schema: "azure"
+	representation: "ALL_AZ_ATTACKS"
+}
+
 NodeKinds: [
 	MigrationData,
 ]
 
 RelationshipKinds: [
+	AllADAttacks, 
+	AllAZAttacks
 ]

--- a/packages/go/cypher/models/cypher/format/format.go
+++ b/packages/go/cypher/models/cypher/format/format.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/specterops/bloodhound/cypher/models/cypher"
 	"github.com/specterops/bloodhound/graphschema/ad"
+	"github.com/specterops/bloodhound/graphschema/azure"
 
 	"github.com/specterops/bloodhound/dawgs/graph"
 )
@@ -38,18 +39,14 @@ func writeJoinedKinds(output io.Writer, delimiter string, kinds graph.Kinds) err
 			}
 		}
 
-		// expand token to all pathfinding relationships in AD
+		// if kind is a shortcut edge type, further expansion is required
 		if kind == ad.AllADAttacks {
-			for idx, relType := range ad.PathfindingRelationships() {
-				if idx > 0 {
-					if _, err := io.WriteString(output, delimiter); err != nil {
-						return err
-					}
-				}
-
-				if _, err := io.WriteString(output, relType.String()); err != nil {
-					return err
-				}
+			if err := writeJoinedKinds(output, delimiter, ad.PathfindingRelationships()); err != nil {
+				return err
+			}
+		} else if kind == azure.AllAZAttacks {
+			if err := writeJoinedKinds(output, delimiter, azure.PathfindingRelationships()); err != nil {
+				return err
 			}
 		} else {
 			if _, err := io.WriteString(output, kind.String()); err != nil {

--- a/packages/go/cypher/models/cypher/format/format.go
+++ b/packages/go/cypher/models/cypher/format/format.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"github.com/specterops/bloodhound/cypher/models/cypher"
+	"github.com/specterops/bloodhound/graphschema/ad"
 
 	"github.com/specterops/bloodhound/dawgs/graph"
 )
@@ -34,6 +35,14 @@ func writeJoinedKinds(output io.Writer, delimiter string, kinds graph.Kinds) err
 		if idx > 0 {
 			if _, err := io.WriteString(output, delimiter); err != nil {
 				return err
+			}
+		}
+
+		if kind == "ALL_AD_ATTACKS" {
+			for _, relType := range ad.PathfindingRelationships() {
+				if _, err := io.WriteString(output, relType.String()+delimiter); err != nil {
+					return err
+				}
 			}
 		}
 

--- a/packages/go/cypher/models/cypher/format/format.go
+++ b/packages/go/cypher/models/cypher/format/format.go
@@ -38,16 +38,23 @@ func writeJoinedKinds(output io.Writer, delimiter string, kinds graph.Kinds) err
 			}
 		}
 
-		if kind == "ALL_AD_ATTACKS" {
-			for _, relType := range ad.PathfindingRelationships() {
-				if _, err := io.WriteString(output, relType.String()+delimiter); err != nil {
+		// expand token to all pathfinding relationships in AD
+		if kind == ad.AllADAttacks {
+			for idx, relType := range ad.PathfindingRelationships() {
+				if idx > 0 {
+					if _, err := io.WriteString(output, delimiter); err != nil {
+						return err
+					}
+				}
+
+				if _, err := io.WriteString(output, relType.String()); err != nil {
 					return err
 				}
 			}
-		}
-
-		if _, err := io.WriteString(output, kind.String()); err != nil {
-			return err
+		} else {
+			if _, err := io.WriteString(output, kind.String()); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/packages/go/cypher/models/cypher/format/format.go
+++ b/packages/go/cypher/models/cypher/format/format.go
@@ -25,6 +25,7 @@ import (
 	"github.com/specterops/bloodhound/cypher/models/cypher"
 	"github.com/specterops/bloodhound/graphschema/ad"
 	"github.com/specterops/bloodhound/graphschema/azure"
+	"github.com/specterops/bloodhound/graphschema/common"
 
 	"github.com/specterops/bloodhound/dawgs/graph"
 )
@@ -40,11 +41,11 @@ func writeJoinedKinds(output io.Writer, delimiter string, kinds graph.Kinds) err
 		}
 
 		// if kind is a shortcut edge type, further expansion is required
-		if kind == ad.AllADAttacks {
+		if kind == common.AllADAttacks {
 			if err := writeJoinedKinds(output, delimiter, ad.PathfindingRelationships()); err != nil {
 				return err
 			}
-		} else if kind == azure.AllAZAttacks {
+		} else if kind == common.AllAZAttacks {
 			if err := writeJoinedKinds(output, delimiter, azure.PathfindingRelationships()); err != nil {
 				return err
 			}

--- a/packages/go/cypher/models/cypher/format/format_test.go
+++ b/packages/go/cypher/models/cypher/format/format_test.go
@@ -43,7 +43,7 @@ func TestCypherEmitter_StripLiterals(t *testing.T) {
 }
 
 func TestCypherEmitter_HappyPath(t *testing.T) {
-	// test.LoadFixture(t, test.MutationTestCases).Run(t)
+	test.LoadFixture(t, test.MutationTestCases).Run(t)
 	test.LoadFixture(t, test.PositiveTestCases).Run(t)
 }
 

--- a/packages/go/cypher/models/cypher/format/format_test.go
+++ b/packages/go/cypher/models/cypher/format/format_test.go
@@ -43,7 +43,7 @@ func TestCypherEmitter_StripLiterals(t *testing.T) {
 }
 
 func TestCypherEmitter_HappyPath(t *testing.T) {
-	test.LoadFixture(t, test.MutationTestCases).Run(t)
+	// test.LoadFixture(t, test.MutationTestCases).Run(t)
 	test.LoadFixture(t, test.PositiveTestCases).Run(t)
 }
 

--- a/packages/go/cypher/test/cases/positive_tests.json
+++ b/packages/go/cypher/test/cases/positive_tests.json
@@ -1,16 +1,6 @@
 {
     "test_cases": [
         {
-            "name": "ALL_AD_ATTACKS shortcut",
-            "type": "string_match",
-            "details": {
-                "query": "match p = ()-[:ALL_AD_ATTACKS]->() return p",
-                "matcher": "match p = \\(\\)-\\[:Owns|GenericAll|GenericWrite|WriteOwner|WriteDacl|MemberOf|ForceChangePassword|AllExtendedRights|AddMember|HasSession|Contains|GPLink|AllowedToDelegate|TrustedBy|AllowedToAct|AdminTo|CanPSRemote|CanRDP|ExecuteDCOM|HasSIDHistory|AddSelf|DCSync|ReadLAPSPassword|ReadGMSAPassword|DumpSMSAPassword|SQLAdmin|AddAllowedToAct|WriteSPN|AddKeyCredentialLink|SyncLAPSPassword|WriteAccountRestrictions|WriteGPLink|GoldenCert|ADCSESC1|ADCSESC3|ADCSESC4|ADCSESC5|ADCSESC6a|ADCSESC6b|ADCSESC7|ADCSESC9a|ADCSESC9b|ADCSESC10a|ADCSESC10b|ADCSESC13|DCFor|SyncedToEntraUser\\]->\\(\\) return p",
-                "complexity": 3
-            },
-            "targeted": true
-        },
-        {
             "name": "Match all nodes in the graph",
             "type": "string_match",
             "details": {
@@ -921,6 +911,38 @@
             "details": {
                 "query": "match (u:User {dontreqpreauth: true}) return u",
                 "complexity": 1
+            }
+        },
+        {
+            "name": "ALL_AD_ATTACKS edge shortcut",
+            "type": "string_match",
+            "details": {
+                "query": "match p = ()-[:ALL_AD_ATTACKS]->() return p",
+                "matcher": "match\\s+p\\s*=\\s*\\(\\)\\s*-\\[:Owns\\|GenericAll\\|GenericWrite\\|WriteOwner\\|WriteDacl\\|MemberOf\\|ForceChangePassword\\|AllExtendedRights\\|AddMember\\|HasSession\\|Contains\\|GPLink\\|AllowedToDelegate\\|TrustedBy\\|AllowedToAct\\|AdminTo\\|CanPSRemote\\|CanRDP\\|ExecuteDCOM\\|HasSIDHistory\\|AddSelf\\|DCSync\\|ReadLAPSPassword\\|ReadGMSAPassword\\|DumpSMSAPassword\\|SQLAdmin\\|AddAllowedToAct\\|WriteSPN\\|AddKeyCredentialLink\\|SyncLAPSPassword\\|WriteAccountRestrictions\\|WriteGPLink\\|GoldenCert\\|ADCSESC1\\|ADCSESC3\\|ADCSESC4\\|ADCSESC5\\|ADCSESC6a\\|ADCSESC6b\\|ADCSESC7\\|ADCSESC9a\\|ADCSESC9b\\|ADCSESC10a\\|ADCSESC10b\\|ADCSESC13\\|DCFor\\|SyncedToEntraUser\\]->\\(\\)\\s+return\\s+p"
+            }
+        },
+        {
+            "name": "ALL_AZ_ATTACKS edge shortcut",
+            "type": "string_match",
+            "details": {
+                "query": "match p = ()-[:ALL_AZ_ATTACKS]->() return p",
+                "matcher": "match\\s+p\\s*=\\s*\\(\\)\\s*-\\[:AZAvereContributor\\|AZContains\\|AZContributor\\|AZGetCertificates\\|AZGetKeys\\|AZGetSecrets\\|AZHasRole\\|AZMemberOf\\|AZOwner\\|AZRunsAs\\|AZVMContributor\\|AZAutomationContributor\\|AZKeyVaultContributor\\|AZVMAdminLogin\\|AZAddMembers\\|AZAddSecret\\|AZExecuteCommand\\|AZGlobalAdmin\\|AZPrivilegedAuthAdmin\\|AZGrant\\|AZGrantSelf\\|AZPrivilegedRoleAdmin\\|AZResetPassword\\|AZUserAccessAdministrator\\|AZOwns\\|AZCloudAppAdmin\\|AZAppAdmin\\|AZAddOwner\\|AZManagedIdentity\\|AZAKSContributor\\|AZNodeResourceGroup\\|AZWebsiteContributor\\|AZLogicAppContributor\\|AZMGAddMember\\|AZMGAddOwner\\|AZMGAddSecret\\|AZMGGrantAppRoles\\|AZMGGrantRole\\|SyncedToADUser\\]->\\(\\)\\s+return\\s+p"
+            }
+        },
+        {
+            "name": "ALL_AD_ATTACKS edge shortcut with extra edge after",
+            "type": "string_match",
+            "details": {
+                "query": "match p = ()-[:ALL_AD_ATTACKS|ExtraEdge]->() return p",
+                "matcher": "match\\s+p\\s*=\\s*\\(\\)\\s*-\\[:Owns\\|GenericAll\\|GenericWrite\\|WriteOwner\\|WriteDacl\\|MemberOf\\|ForceChangePassword\\|AllExtendedRights\\|AddMember\\|HasSession\\|Contains\\|GPLink\\|AllowedToDelegate\\|TrustedBy\\|AllowedToAct\\|AdminTo\\|CanPSRemote\\|CanRDP\\|ExecuteDCOM\\|HasSIDHistory\\|AddSelf\\|DCSync\\|ReadLAPSPassword\\|ReadGMSAPassword\\|DumpSMSAPassword\\|SQLAdmin\\|AddAllowedToAct\\|WriteSPN\\|AddKeyCredentialLink\\|SyncLAPSPassword\\|WriteAccountRestrictions\\|WriteGPLink\\|GoldenCert\\|ADCSESC1\\|ADCSESC3\\|ADCSESC4\\|ADCSESC5\\|ADCSESC6a\\|ADCSESC6b\\|ADCSESC7\\|ADCSESC9a\\|ADCSESC9b\\|ADCSESC10a\\|ADCSESC10b\\|ADCSESC13\\|DCFor\\|SyncedToEntraUser\\|ExtraEdge\\]->\\(\\)\\s+return\\s+p"
+            }
+        },
+        {
+            "name": "ALL_AD_ATTACKS edge shortcut with extra edge before",
+            "type": "string_match",
+            "details": {
+                "query": "match p = ()-[:ExtraEdge|ALL_AD_ATTACKS]->() return p",
+                "matcher": "match\\s+p\\s*=\\s*\\(\\)\\s*-\\[:ExtraEdge\\|Owns\\|GenericAll\\|GenericWrite\\|WriteOwner\\|WriteDacl\\|MemberOf\\|ForceChangePassword\\|AllExtendedRights\\|AddMember\\|HasSession\\|Contains\\|GPLink\\|AllowedToDelegate\\|TrustedBy\\|AllowedToAct\\|AdminTo\\|CanPSRemote\\|CanRDP\\|ExecuteDCOM\\|HasSIDHistory\\|AddSelf\\|DCSync\\|ReadLAPSPassword\\|ReadGMSAPassword\\|DumpSMSAPassword\\|SQLAdmin\\|AddAllowedToAct\\|WriteSPN\\|AddKeyCredentialLink\\|SyncLAPSPassword\\|WriteAccountRestrictions\\|WriteGPLink\\|GoldenCert\\|ADCSESC1\\|ADCSESC3\\|ADCSESC4\\|ADCSESC5\\|ADCSESC6a\\|ADCSESC6b\\|ADCSESC7\\|ADCSESC9a\\|ADCSESC9b\\|ADCSESC10a\\|ADCSESC10b\\|ADCSESC13\\|DCFor\\|SyncedToEntraUser\\]->\\(\\)\\s+return\\s+p"
             }
         }
     ]

--- a/packages/go/cypher/test/cases/positive_tests.json
+++ b/packages/go/cypher/test/cases/positive_tests.json
@@ -1,6 +1,14 @@
 {
     "test_cases": [
         {
+            "name": "brandon testing",
+            "type": "string_match",
+            "details": {
+                "query": "match p = (a)-[:Mon|Tues|Weds]->(b) return p",
+                "complexity": 3
+            }
+        },
+        {
             "name": "Match all nodes in the graph",
             "type": "string_match",
             "details": {

--- a/packages/go/cypher/test/cases/positive_tests.json
+++ b/packages/go/cypher/test/cases/positive_tests.json
@@ -1,10 +1,11 @@
 {
     "test_cases": [
         {
-            "name": "brandon testing",
+            "name": "ALL_AD_ATTACKS shortcut",
             "type": "string_match",
             "details": {
-                "query": "match p = (a)-[:CanRDP|ALL_AD_ATTACKS]->(b) return p",
+                "query": "match p = ()-[:ALL_AD_ATTACKS]->() return p",
+                "matcher": "match p = \\(\\)-\\[:Owns|GenericAll|GenericWrite|WriteOwner|WriteDacl|MemberOf|ForceChangePassword|AllExtendedRights|AddMember|HasSession|Contains|GPLink|AllowedToDelegate|TrustedBy|AllowedToAct|AdminTo|CanPSRemote|CanRDP|ExecuteDCOM|HasSIDHistory|AddSelf|DCSync|ReadLAPSPassword|ReadGMSAPassword|DumpSMSAPassword|SQLAdmin|AddAllowedToAct|WriteSPN|AddKeyCredentialLink|SyncLAPSPassword|WriteAccountRestrictions|WriteGPLink|GoldenCert|ADCSESC1|ADCSESC3|ADCSESC4|ADCSESC5|ADCSESC6a|ADCSESC6b|ADCSESC7|ADCSESC9a|ADCSESC9b|ADCSESC10a|ADCSESC10b|ADCSESC13|DCFor|SyncedToEntraUser\\]->\\(\\) return p",
                 "complexity": 3
             },
             "targeted": true

--- a/packages/go/cypher/test/cases/positive_tests.json
+++ b/packages/go/cypher/test/cases/positive_tests.json
@@ -4,9 +4,10 @@
             "name": "brandon testing",
             "type": "string_match",
             "details": {
-                "query": "match p = (a)-[:Mon|Tues|Weds]->(b) return p",
+                "query": "match p = (a)-[:CanRDP|ALL_AD_ATTACKS]->(b) return p",
                 "complexity": 3
-            }
+            },
+            "targeted": true
         },
         {
             "name": "Match all nodes in the graph",

--- a/packages/go/graphschema/ad/ad.go
+++ b/packages/go/graphschema/ad/ad.go
@@ -110,7 +110,7 @@ var (
 	ADCSESC10b                      = graph.StringKind("ADCSESC10b")
 	ADCSESC13                       = graph.StringKind("ADCSESC13")
 	SyncedToEntraUser               = graph.StringKind("SyncedToEntraUser")
-	ALL_AD_ATTACKS                  = graph.StringKind("ALL_AD_ATTACKS")
+	AllADAttacks                    = graph.StringKind("ALL_AD_ATTACKS")
 )
 
 type Property string
@@ -858,7 +858,7 @@ func Nodes() []graph.Kind {
 	return []graph.Kind{Entity, User, Computer, Group, GPO, OU, Container, Domain, LocalGroup, LocalUser, AIACA, RootCA, EnterpriseCA, NTAuthStore, CertTemplate, IssuancePolicy}
 }
 func Relationships() []graph.Kind {
-	return []graph.Kind{Owns, GenericAll, GenericWrite, WriteOwner, WriteDACL, MemberOf, ForceChangePassword, AllExtendedRights, AddMember, HasSession, Contains, GPLink, AllowedToDelegate, GetChanges, GetChangesAll, GetChangesInFilteredSet, TrustedBy, AllowedToAct, AdminTo, CanPSRemote, CanRDP, ExecuteDCOM, HasSIDHistory, AddSelf, DCSync, ReadLAPSPassword, ReadGMSAPassword, DumpSMSAPassword, SQLAdmin, AddAllowedToAct, WriteSPN, AddKeyCredentialLink, LocalToComputer, MemberOfLocalGroup, RemoteInteractiveLogonPrivilege, SyncLAPSPassword, WriteAccountRestrictions, WriteGPLink, RootCAFor, DCFor, PublishedTo, ManageCertificates, ManageCA, DelegatedEnrollmentAgent, Enroll, HostsCAService, WritePKIEnrollmentFlag, WritePKINameFlag, NTAuthStoreFor, TrustedForNTAuth, EnterpriseCAFor, IssuedSignedBy, GoldenCert, EnrollOnBehalfOf, OIDGroupLink, ExtendedByPolicy, ADCSESC1, ADCSESC3, ADCSESC4, ADCSESC5, ADCSESC6a, ADCSESC6b, ADCSESC7, ADCSESC9a, ADCSESC9b, ADCSESC10a, ADCSESC10b, ADCSESC13, SyncedToEntraUser, ALL_AD_ATTACKS}
+	return []graph.Kind{Owns, GenericAll, GenericWrite, WriteOwner, WriteDACL, MemberOf, ForceChangePassword, AllExtendedRights, AddMember, HasSession, Contains, GPLink, AllowedToDelegate, GetChanges, GetChangesAll, GetChangesInFilteredSet, TrustedBy, AllowedToAct, AdminTo, CanPSRemote, CanRDP, ExecuteDCOM, HasSIDHistory, AddSelf, DCSync, ReadLAPSPassword, ReadGMSAPassword, DumpSMSAPassword, SQLAdmin, AddAllowedToAct, WriteSPN, AddKeyCredentialLink, LocalToComputer, MemberOfLocalGroup, RemoteInteractiveLogonPrivilege, SyncLAPSPassword, WriteAccountRestrictions, WriteGPLink, RootCAFor, DCFor, PublishedTo, ManageCertificates, ManageCA, DelegatedEnrollmentAgent, Enroll, HostsCAService, WritePKIEnrollmentFlag, WritePKINameFlag, NTAuthStoreFor, TrustedForNTAuth, EnterpriseCAFor, IssuedSignedBy, GoldenCert, EnrollOnBehalfOf, OIDGroupLink, ExtendedByPolicy, ADCSESC1, ADCSESC3, ADCSESC4, ADCSESC5, ADCSESC6a, ADCSESC6b, ADCSESC7, ADCSESC9a, ADCSESC9b, ADCSESC10a, ADCSESC10b, ADCSESC13, SyncedToEntraUser, AllADAttacks}
 }
 func ACLRelationships() []graph.Kind {
 	return []graph.Kind{AllExtendedRights, ForceChangePassword, AddMember, AddAllowedToAct, GenericAll, WriteDACL, WriteOwner, GenericWrite, ReadLAPSPassword, ReadGMSAPassword, Owns, AddSelf, WriteSPN, AddKeyCredentialLink, GetChanges, GetChangesAll, GetChangesInFilteredSet, WriteAccountRestrictions, WriteGPLink, SyncLAPSPassword, DCSync, ManageCertificates, ManageCA, Enroll, WritePKIEnrollmentFlag, WritePKINameFlag}

--- a/packages/go/graphschema/ad/ad.go
+++ b/packages/go/graphschema/ad/ad.go
@@ -21,7 +21,6 @@ package ad
 
 import (
 	"errors"
-
 	graph "github.com/specterops/bloodhound/dawgs/graph"
 )
 
@@ -111,6 +110,7 @@ var (
 	ADCSESC10b                      = graph.StringKind("ADCSESC10b")
 	ADCSESC13                       = graph.StringKind("ADCSESC13")
 	SyncedToEntraUser               = graph.StringKind("SyncedToEntraUser")
+	ALL_AD_ATTACKS                  = graph.StringKind("ALL_AD_ATTACKS")
 )
 
 type Property string
@@ -858,7 +858,7 @@ func Nodes() []graph.Kind {
 	return []graph.Kind{Entity, User, Computer, Group, GPO, OU, Container, Domain, LocalGroup, LocalUser, AIACA, RootCA, EnterpriseCA, NTAuthStore, CertTemplate, IssuancePolicy}
 }
 func Relationships() []graph.Kind {
-	return []graph.Kind{Owns, GenericAll, GenericWrite, WriteOwner, WriteDACL, MemberOf, ForceChangePassword, AllExtendedRights, AddMember, HasSession, Contains, GPLink, AllowedToDelegate, GetChanges, GetChangesAll, GetChangesInFilteredSet, TrustedBy, AllowedToAct, AdminTo, CanPSRemote, CanRDP, ExecuteDCOM, HasSIDHistory, AddSelf, DCSync, ReadLAPSPassword, ReadGMSAPassword, DumpSMSAPassword, SQLAdmin, AddAllowedToAct, WriteSPN, AddKeyCredentialLink, LocalToComputer, MemberOfLocalGroup, RemoteInteractiveLogonPrivilege, SyncLAPSPassword, WriteAccountRestrictions, WriteGPLink, RootCAFor, DCFor, PublishedTo, ManageCertificates, ManageCA, DelegatedEnrollmentAgent, Enroll, HostsCAService, WritePKIEnrollmentFlag, WritePKINameFlag, NTAuthStoreFor, TrustedForNTAuth, EnterpriseCAFor, IssuedSignedBy, GoldenCert, EnrollOnBehalfOf, OIDGroupLink, ExtendedByPolicy, ADCSESC1, ADCSESC3, ADCSESC4, ADCSESC5, ADCSESC6a, ADCSESC6b, ADCSESC7, ADCSESC9a, ADCSESC9b, ADCSESC10a, ADCSESC10b, ADCSESC13, SyncedToEntraUser}
+	return []graph.Kind{Owns, GenericAll, GenericWrite, WriteOwner, WriteDACL, MemberOf, ForceChangePassword, AllExtendedRights, AddMember, HasSession, Contains, GPLink, AllowedToDelegate, GetChanges, GetChangesAll, GetChangesInFilteredSet, TrustedBy, AllowedToAct, AdminTo, CanPSRemote, CanRDP, ExecuteDCOM, HasSIDHistory, AddSelf, DCSync, ReadLAPSPassword, ReadGMSAPassword, DumpSMSAPassword, SQLAdmin, AddAllowedToAct, WriteSPN, AddKeyCredentialLink, LocalToComputer, MemberOfLocalGroup, RemoteInteractiveLogonPrivilege, SyncLAPSPassword, WriteAccountRestrictions, WriteGPLink, RootCAFor, DCFor, PublishedTo, ManageCertificates, ManageCA, DelegatedEnrollmentAgent, Enroll, HostsCAService, WritePKIEnrollmentFlag, WritePKINameFlag, NTAuthStoreFor, TrustedForNTAuth, EnterpriseCAFor, IssuedSignedBy, GoldenCert, EnrollOnBehalfOf, OIDGroupLink, ExtendedByPolicy, ADCSESC1, ADCSESC3, ADCSESC4, ADCSESC5, ADCSESC6a, ADCSESC6b, ADCSESC7, ADCSESC9a, ADCSESC9b, ADCSESC10a, ADCSESC10b, ADCSESC13, SyncedToEntraUser, ALL_AD_ATTACKS}
 }
 func ACLRelationships() []graph.Kind {
 	return []graph.Kind{AllExtendedRights, ForceChangePassword, AddMember, AddAllowedToAct, GenericAll, WriteDACL, WriteOwner, GenericWrite, ReadLAPSPassword, ReadGMSAPassword, Owns, AddSelf, WriteSPN, AddKeyCredentialLink, GetChanges, GetChangesAll, GetChangesInFilteredSet, WriteAccountRestrictions, WriteGPLink, SyncLAPSPassword, DCSync, ManageCertificates, ManageCA, Enroll, WritePKIEnrollmentFlag, WritePKINameFlag}

--- a/packages/go/graphschema/ad/ad.go
+++ b/packages/go/graphschema/ad/ad.go
@@ -110,7 +110,6 @@ var (
 	ADCSESC10b                      = graph.StringKind("ADCSESC10b")
 	ADCSESC13                       = graph.StringKind("ADCSESC13")
 	SyncedToEntraUser               = graph.StringKind("SyncedToEntraUser")
-	AllADAttacks                    = graph.StringKind("ALL_AD_ATTACKS")
 )
 
 type Property string
@@ -858,7 +857,7 @@ func Nodes() []graph.Kind {
 	return []graph.Kind{Entity, User, Computer, Group, GPO, OU, Container, Domain, LocalGroup, LocalUser, AIACA, RootCA, EnterpriseCA, NTAuthStore, CertTemplate, IssuancePolicy}
 }
 func Relationships() []graph.Kind {
-	return []graph.Kind{Owns, GenericAll, GenericWrite, WriteOwner, WriteDACL, MemberOf, ForceChangePassword, AllExtendedRights, AddMember, HasSession, Contains, GPLink, AllowedToDelegate, GetChanges, GetChangesAll, GetChangesInFilteredSet, TrustedBy, AllowedToAct, AdminTo, CanPSRemote, CanRDP, ExecuteDCOM, HasSIDHistory, AddSelf, DCSync, ReadLAPSPassword, ReadGMSAPassword, DumpSMSAPassword, SQLAdmin, AddAllowedToAct, WriteSPN, AddKeyCredentialLink, LocalToComputer, MemberOfLocalGroup, RemoteInteractiveLogonPrivilege, SyncLAPSPassword, WriteAccountRestrictions, WriteGPLink, RootCAFor, DCFor, PublishedTo, ManageCertificates, ManageCA, DelegatedEnrollmentAgent, Enroll, HostsCAService, WritePKIEnrollmentFlag, WritePKINameFlag, NTAuthStoreFor, TrustedForNTAuth, EnterpriseCAFor, IssuedSignedBy, GoldenCert, EnrollOnBehalfOf, OIDGroupLink, ExtendedByPolicy, ADCSESC1, ADCSESC3, ADCSESC4, ADCSESC5, ADCSESC6a, ADCSESC6b, ADCSESC7, ADCSESC9a, ADCSESC9b, ADCSESC10a, ADCSESC10b, ADCSESC13, SyncedToEntraUser, AllADAttacks}
+	return []graph.Kind{Owns, GenericAll, GenericWrite, WriteOwner, WriteDACL, MemberOf, ForceChangePassword, AllExtendedRights, AddMember, HasSession, Contains, GPLink, AllowedToDelegate, GetChanges, GetChangesAll, GetChangesInFilteredSet, TrustedBy, AllowedToAct, AdminTo, CanPSRemote, CanRDP, ExecuteDCOM, HasSIDHistory, AddSelf, DCSync, ReadLAPSPassword, ReadGMSAPassword, DumpSMSAPassword, SQLAdmin, AddAllowedToAct, WriteSPN, AddKeyCredentialLink, LocalToComputer, MemberOfLocalGroup, RemoteInteractiveLogonPrivilege, SyncLAPSPassword, WriteAccountRestrictions, WriteGPLink, RootCAFor, DCFor, PublishedTo, ManageCertificates, ManageCA, DelegatedEnrollmentAgent, Enroll, HostsCAService, WritePKIEnrollmentFlag, WritePKINameFlag, NTAuthStoreFor, TrustedForNTAuth, EnterpriseCAFor, IssuedSignedBy, GoldenCert, EnrollOnBehalfOf, OIDGroupLink, ExtendedByPolicy, ADCSESC1, ADCSESC3, ADCSESC4, ADCSESC5, ADCSESC6a, ADCSESC6b, ADCSESC7, ADCSESC9a, ADCSESC9b, ADCSESC10a, ADCSESC10b, ADCSESC13, SyncedToEntraUser}
 }
 func ACLRelationships() []graph.Kind {
 	return []graph.Kind{AllExtendedRights, ForceChangePassword, AddMember, AddAllowedToAct, GenericAll, WriteDACL, WriteOwner, GenericWrite, ReadLAPSPassword, ReadGMSAPassword, Owns, AddSelf, WriteSPN, AddKeyCredentialLink, GetChanges, GetChangesAll, GetChangesInFilteredSet, WriteAccountRestrictions, WriteGPLink, SyncLAPSPassword, DCSync, ManageCertificates, ManageCA, Enroll, WritePKIEnrollmentFlag, WritePKINameFlag}

--- a/packages/go/graphschema/azure/azure.go
+++ b/packages/go/graphschema/azure/azure.go
@@ -21,7 +21,6 @@ package azure
 
 import (
 	"errors"
-
 	graph "github.com/specterops/bloodhound/dawgs/graph"
 )
 

--- a/packages/go/graphschema/azure/azure.go
+++ b/packages/go/graphschema/azure/azure.go
@@ -92,6 +92,7 @@ var (
 	AZMGGrantAppRoles                    = graph.StringKind("AZMGGrantAppRoles")
 	AZMGGrantRole                        = graph.StringKind("AZMGGrantRole")
 	SyncedToADUser                       = graph.StringKind("SyncedToADUser")
+	AllAZAttacks                         = graph.StringKind("ALL_AZ_ATTACKS")
 )
 
 type Property string
@@ -353,7 +354,7 @@ func (s Property) Is(others ...graph.Kind) bool {
 	return false
 }
 func Relationships() []graph.Kind {
-	return []graph.Kind{AvereContributor, Contains, Contributor, GetCertificates, GetKeys, GetSecrets, HasRole, MemberOf, Owner, RunsAs, VMContributor, AutomationContributor, KeyVaultContributor, VMAdminLogin, AddMembers, AddSecret, ExecuteCommand, GlobalAdmin, PrivilegedAuthAdmin, Grant, GrantSelf, PrivilegedRoleAdmin, ResetPassword, UserAccessAdministrator, Owns, ScopedTo, CloudAppAdmin, AppAdmin, AddOwner, ManagedIdentity, ApplicationReadWriteAll, AppRoleAssignmentReadWriteAll, DirectoryReadWriteAll, GroupReadWriteAll, GroupMemberReadWriteAll, RoleManagementReadWriteDirectory, ServicePrincipalEndpointReadWriteAll, AKSContributor, NodeResourceGroup, WebsiteContributor, LogicAppContributor, AZMGAddMember, AZMGAddOwner, AZMGAddSecret, AZMGGrantAppRoles, AZMGGrantRole, SyncedToADUser}
+	return []graph.Kind{AvereContributor, Contains, Contributor, GetCertificates, GetKeys, GetSecrets, HasRole, MemberOf, Owner, RunsAs, VMContributor, AutomationContributor, KeyVaultContributor, VMAdminLogin, AddMembers, AddSecret, ExecuteCommand, GlobalAdmin, PrivilegedAuthAdmin, Grant, GrantSelf, PrivilegedRoleAdmin, ResetPassword, UserAccessAdministrator, Owns, ScopedTo, CloudAppAdmin, AppAdmin, AddOwner, ManagedIdentity, ApplicationReadWriteAll, AppRoleAssignmentReadWriteAll, DirectoryReadWriteAll, GroupReadWriteAll, GroupMemberReadWriteAll, RoleManagementReadWriteDirectory, ServicePrincipalEndpointReadWriteAll, AKSContributor, NodeResourceGroup, WebsiteContributor, LogicAppContributor, AZMGAddMember, AZMGAddOwner, AZMGAddSecret, AZMGGrantAppRoles, AZMGGrantRole, SyncedToADUser, AllAZAttacks}
 }
 func AppRoleTransitRelationshipKinds() []graph.Kind {
 	return []graph.Kind{AZMGAddMember, AZMGAddOwner, AZMGAddSecret, AZMGGrantAppRoles, AZMGGrantRole}

--- a/packages/go/graphschema/azure/azure.go
+++ b/packages/go/graphschema/azure/azure.go
@@ -92,7 +92,6 @@ var (
 	AZMGGrantAppRoles                    = graph.StringKind("AZMGGrantAppRoles")
 	AZMGGrantRole                        = graph.StringKind("AZMGGrantRole")
 	SyncedToADUser                       = graph.StringKind("SyncedToADUser")
-	AllAZAttacks                         = graph.StringKind("ALL_AZ_ATTACKS")
 )
 
 type Property string
@@ -354,7 +353,7 @@ func (s Property) Is(others ...graph.Kind) bool {
 	return false
 }
 func Relationships() []graph.Kind {
-	return []graph.Kind{AvereContributor, Contains, Contributor, GetCertificates, GetKeys, GetSecrets, HasRole, MemberOf, Owner, RunsAs, VMContributor, AutomationContributor, KeyVaultContributor, VMAdminLogin, AddMembers, AddSecret, ExecuteCommand, GlobalAdmin, PrivilegedAuthAdmin, Grant, GrantSelf, PrivilegedRoleAdmin, ResetPassword, UserAccessAdministrator, Owns, ScopedTo, CloudAppAdmin, AppAdmin, AddOwner, ManagedIdentity, ApplicationReadWriteAll, AppRoleAssignmentReadWriteAll, DirectoryReadWriteAll, GroupReadWriteAll, GroupMemberReadWriteAll, RoleManagementReadWriteDirectory, ServicePrincipalEndpointReadWriteAll, AKSContributor, NodeResourceGroup, WebsiteContributor, LogicAppContributor, AZMGAddMember, AZMGAddOwner, AZMGAddSecret, AZMGGrantAppRoles, AZMGGrantRole, SyncedToADUser, AllAZAttacks}
+	return []graph.Kind{AvereContributor, Contains, Contributor, GetCertificates, GetKeys, GetSecrets, HasRole, MemberOf, Owner, RunsAs, VMContributor, AutomationContributor, KeyVaultContributor, VMAdminLogin, AddMembers, AddSecret, ExecuteCommand, GlobalAdmin, PrivilegedAuthAdmin, Grant, GrantSelf, PrivilegedRoleAdmin, ResetPassword, UserAccessAdministrator, Owns, ScopedTo, CloudAppAdmin, AppAdmin, AddOwner, ManagedIdentity, ApplicationReadWriteAll, AppRoleAssignmentReadWriteAll, DirectoryReadWriteAll, GroupReadWriteAll, GroupMemberReadWriteAll, RoleManagementReadWriteDirectory, ServicePrincipalEndpointReadWriteAll, AKSContributor, NodeResourceGroup, WebsiteContributor, LogicAppContributor, AZMGAddMember, AZMGAddOwner, AZMGAddSecret, AZMGGrantAppRoles, AZMGGrantRole, SyncedToADUser}
 }
 func AppRoleTransitRelationshipKinds() []graph.Kind {
 	return []graph.Kind{AZMGAddMember, AZMGAddOwner, AZMGAddSecret, AZMGGrantAppRoles, AZMGGrantRole}

--- a/packages/go/graphschema/common/common.go
+++ b/packages/go/graphschema/common/common.go
@@ -21,7 +21,6 @@ package common
 
 import (
 	"errors"
-
 	graph "github.com/specterops/bloodhound/dawgs/graph"
 )
 

--- a/packages/go/graphschema/common/common.go
+++ b/packages/go/graphschema/common/common.go
@@ -26,6 +26,8 @@ import (
 
 var (
 	MigrationData = graph.StringKind("MigrationData")
+	AllADAttacks  = graph.StringKind("ALL_AD_ATTACKS")
+	AllAZAttacks  = graph.StringKind("ALL_AZ_ATTACKS")
 )
 
 type Property string
@@ -178,7 +180,7 @@ func Nodes() []graph.Kind {
 	return []graph.Kind{MigrationData}
 }
 func Relationships() []graph.Kind {
-	return []graph.Kind{}
+	return []graph.Kind{AllADAttacks, AllAZAttacks}
 }
 func NodeKinds() []graph.Kind {
 	return []graph.Kind{MigrationData}

--- a/packages/javascript/bh-shared-ui/src/commonSearches.tsx
+++ b/packages/javascript/bh-shared-ui/src/commonSearches.tsx
@@ -14,13 +14,13 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { ActiveDirectoryPathfindingEdges, AzurePathfindingEdges } from './graphSchema';
+import { ActiveDirectoryRelationshipKind, AzureRelationshipKind } from './graphSchema';
 
 const categoryAD = 'Active Directory';
 const categoryAzure = 'Azure';
 
-const azureTransitEdgeTypes = AzurePathfindingEdges().join('|');
-const adTransitEdgeTypes = ActiveDirectoryPathfindingEdges().join('|');
+const adTransitEdgeTypes = ActiveDirectoryRelationshipKind.AllADAttacks;
+const azureTransitEdgeTypes = AzureRelationshipKind.AllAZAttacks;
 
 const highPrivilegedRoleDisplayNameRegex =
     'Global Administrator.*|User Administrator.*|Cloud Application Administrator.*|Authentication Policy Administrator.*|Exchange Administrator.*|Helpdesk Administrator.*|Privileged Authentication Administrator.*';

--- a/packages/javascript/bh-shared-ui/src/commonSearches.tsx
+++ b/packages/javascript/bh-shared-ui/src/commonSearches.tsx
@@ -14,13 +14,13 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { ActiveDirectoryRelationshipKind, AzureRelationshipKind } from './graphSchema';
+import { CommonRelationshipKind } from './graphSchema';
 
 const categoryAD = 'Active Directory';
 const categoryAzure = 'Azure';
 
-const adTransitEdgeTypes = ActiveDirectoryRelationshipKind.AllADAttacks;
-const azureTransitEdgeTypes = AzureRelationshipKind.AllAZAttacks;
+const adTransitEdgeTypes = CommonRelationshipKind.AllADAttacks;
+const azureTransitEdgeTypes = CommonRelationshipKind.AllAZAttacks;
 
 const highPrivilegedRoleDisplayNameRegex =
     'Global Administrator.*|User Administrator.*|Cloud Application Administrator.*|Authentication Policy Administrator.*|Exchange Administrator.*|Helpdesk Administrator.*|Privileged Authentication Administrator.*';

--- a/packages/javascript/bh-shared-ui/src/graphSchema.ts
+++ b/packages/javascript/bh-shared-ui/src/graphSchema.ts
@@ -140,6 +140,7 @@ export enum ActiveDirectoryRelationshipKind {
     ADCSESC10b = 'ADCSESC10b',
     ADCSESC13 = 'ADCSESC13',
     SyncedToEntraUser = 'SyncedToEntraUser',
+    ALL_AD_ATTACKS = 'ALL_AD_ATTACKS',
 }
 export function ActiveDirectoryRelationshipKindToDisplay(value: ActiveDirectoryRelationshipKind): string | undefined {
     switch (value) {
@@ -281,6 +282,8 @@ export function ActiveDirectoryRelationshipKindToDisplay(value: ActiveDirectoryR
             return 'ADCSESC13';
         case ActiveDirectoryRelationshipKind.SyncedToEntraUser:
             return 'SyncedToEntraUser';
+        case ActiveDirectoryRelationshipKind.ALL_AD_ATTACKS:
+            return 'ALL_AD_ATTACKS';
         default:
             return undefined;
     }

--- a/packages/javascript/bh-shared-ui/src/graphSchema.ts
+++ b/packages/javascript/bh-shared-ui/src/graphSchema.ts
@@ -140,7 +140,7 @@ export enum ActiveDirectoryRelationshipKind {
     ADCSESC10b = 'ADCSESC10b',
     ADCSESC13 = 'ADCSESC13',
     SyncedToEntraUser = 'SyncedToEntraUser',
-    ALL_AD_ATTACKS = 'ALL_AD_ATTACKS',
+    AllADAttacks = 'ALL_AD_ATTACKS',
 }
 export function ActiveDirectoryRelationshipKindToDisplay(value: ActiveDirectoryRelationshipKind): string | undefined {
     switch (value) {
@@ -282,8 +282,8 @@ export function ActiveDirectoryRelationshipKindToDisplay(value: ActiveDirectoryR
             return 'ADCSESC13';
         case ActiveDirectoryRelationshipKind.SyncedToEntraUser:
             return 'SyncedToEntraUser';
-        case ActiveDirectoryRelationshipKind.ALL_AD_ATTACKS:
-            return 'ALL_AD_ATTACKS';
+        case ActiveDirectoryRelationshipKind.AllADAttacks:
+            return 'AllADAttacks';
         default:
             return undefined;
     }
@@ -780,6 +780,7 @@ export enum AzureRelationshipKind {
     AZMGGrantAppRoles = 'AZMGGrantAppRoles',
     AZMGGrantRole = 'AZMGGrantRole',
     SyncedToADUser = 'SyncedToADUser',
+    AllAZAttacks = 'ALL_AZ_ATTACKS',
 }
 export function AzureRelationshipKindToDisplay(value: AzureRelationshipKind): string | undefined {
     switch (value) {
@@ -877,6 +878,8 @@ export function AzureRelationshipKindToDisplay(value: AzureRelationshipKind): st
             return 'AZMGGrantRole';
         case AzureRelationshipKind.SyncedToADUser:
             return 'SyncedToADUser';
+        case AzureRelationshipKind.AllAZAttacks:
+            return 'AllAZAttacks';
         default:
             return undefined;
     }

--- a/packages/javascript/bh-shared-ui/src/graphSchema.ts
+++ b/packages/javascript/bh-shared-ui/src/graphSchema.ts
@@ -140,7 +140,6 @@ export enum ActiveDirectoryRelationshipKind {
     ADCSESC10b = 'ADCSESC10b',
     ADCSESC13 = 'ADCSESC13',
     SyncedToEntraUser = 'SyncedToEntraUser',
-    AllADAttacks = 'ALL_AD_ATTACKS',
 }
 export function ActiveDirectoryRelationshipKindToDisplay(value: ActiveDirectoryRelationshipKind): string | undefined {
     switch (value) {
@@ -282,8 +281,6 @@ export function ActiveDirectoryRelationshipKindToDisplay(value: ActiveDirectoryR
             return 'ADCSESC13';
         case ActiveDirectoryRelationshipKind.SyncedToEntraUser:
             return 'SyncedToEntraUser';
-        case ActiveDirectoryRelationshipKind.AllADAttacks:
-            return 'AllADAttacks';
         default:
             return undefined;
     }
@@ -780,7 +777,6 @@ export enum AzureRelationshipKind {
     AZMGGrantAppRoles = 'AZMGGrantAppRoles',
     AZMGGrantRole = 'AZMGGrantRole',
     SyncedToADUser = 'SyncedToADUser',
-    AllAZAttacks = 'ALL_AZ_ATTACKS',
 }
 export function AzureRelationshipKindToDisplay(value: AzureRelationshipKind): string | undefined {
     switch (value) {
@@ -878,8 +874,6 @@ export function AzureRelationshipKindToDisplay(value: AzureRelationshipKind): st
             return 'AZMGGrantRole';
         case AzureRelationshipKind.SyncedToADUser:
             return 'SyncedToADUser';
-        case AzureRelationshipKind.AllAZAttacks:
-            return 'AllAZAttacks';
         default:
             return undefined;
     }
@@ -1039,6 +1033,20 @@ export function CommonNodeKindToDisplay(value: CommonNodeKind): string | undefin
     switch (value) {
         case CommonNodeKind.MigrationData:
             return 'MigrationData';
+        default:
+            return undefined;
+    }
+}
+export enum CommonRelationshipKind {
+    AllADAttacks = 'ALL_AD_ATTACKS',
+    AllAZAttacks = 'ALL_AZ_ATTACKS',
+}
+export function CommonRelationshipKindToDisplay(value: CommonRelationshipKind): string | undefined {
+    switch (value) {
+        case CommonRelationshipKind.AllADAttacks:
+            return 'AllADAttacks';
+        case CommonRelationshipKind.AllAZAttacks:
+            return 'AllAZAttacks';
         default:
             return undefined;
     }


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

*Describe your changes in detail*

i added two new edges to our schema in cue, ALL_AD_ATTACKS and ALL_AZ_ATTACKS. 

this change tweaks the logic of the cypher emitter when it is converting SQL AST->cypher string. when emitting for  a relationship pattern in `formatRelationshipPattern`,  if the provided AST node has the graph.Kind of "ALL_AD_ATTACKS" or "ALL_AZ_ATTACKS", then that graph.Kind is replaced with the full expansion of pathfinding edges defined in cue.  the pre built queries now utilize these two edges.

for example, when a user provides the query:

`match p = ()-[:ALL_AD_ATTACKS]->() return p` 

it gets translated to the following cypher:
  
`match p = ()-[:Owns|GenericAll|GenericWrite|WriteOwner|WriteDacl|MemberOf|ForceChangePassword|AllExtendedRights|AddMember|HasSession|Contains|GPLink|AllowedToDelegate|TrustedBy|AllowedToAct|AdminTo|CanPSRemote|CanRDP|ExecuteDCOM|HasSIDHistory|AddSelf|DCSync|ReadLAPSPassword|ReadGMSAPassword|DumpSMSAPassword|SQLAdmin|AddAllowedToAct|WriteSPN|AddKeyCredentialLink|SyncLAPSPassword|WriteAccountRestrictions|WriteGPLink|GoldenCert|ADCSESC1|ADCSESC3|ADCSESC4|ADCSESC5|ADCSESC6a|ADCSESC6b|ADCSESC7|ADCSESC9a|ADCSESC9b|ADCSESC10a|ADCSESC10b|ADCSESC13|DCFor|SyncedToEntraUser]->() return p`

## Motivation and Context

This PR addresses: [BED-4907]

*Why is this change required? What problem does it solve?*
we want to have edge type shortcuts for common cypher statements that are currently very laborious to craft.

## How Has This Been Tested?

*Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc.*
unit tests have been added to poke different ways that the emitter expands the new edge kinds

## Screenshots (optional):


## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)
- Database Migrations

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [ ] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [ ] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [ ] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


[BED-4907]: https://specterops.atlassian.net/browse/BED-4907?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ