### PR TITLE
BED-4655: Add Authentik to docker-compose.dev.yml

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,24 +35,14 @@ BH_POSTGRES_DB=bloodhound
 BH_POSTGRES_VOLUME=bh-postgres-data
 BH_POSTGRES_PORT=127.0.0.1:6543
 
-# BloodHound Authentik SSO IdP
-BH_PG_USER=authentik-bloodhound
-BH_PG_DB=authentik-bloodhound
-BH_PG_PASS=bloodhoundcommunityedition
-BH_ATK_SECRET=bloodhoundcommunityedition
+# Authentik SSO IdP, authentik Worker, authentik Postgres
+# Some env variables are reused in multiple authentik services
+ATK_BH_PG_USER=authentik-bloodhound
+ATK_BH_PG_DB=authentik-bloodhound
+ATK_BH_PG_PASS=bloodhoundcommunityedition
+ATK_BH_SECRET=bloodhoundcommunityedition
 COMPOSE_PORT_HTTP=127.0.0.1:9000
 COMPOSE_PORT_HTTPS=127.0.0.1:9443
-
-# BloodHound Authentik Worker
-BH_PG_USER=authentik-bloodhound
-BH_PG_DB=authentik-bloodhound
-BH_PG_PASS=bloodhoundcommunityedition
-BH_ATK_SECRET=bloodhoundcommunityedition
-
-# BloodHound Authentik Postgres
-BH_PG_PASS=bloodhoundcommunityedition
-BH_PG_USER=authentik-bloodhound
-BH_PG_DB=authentik-bloodhound
 
 # Integration Postgres
 INTEGRATION_POSTGRES_USER=bloodhound

--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,25 @@ BH_POSTGRES_DB=bloodhound
 BH_POSTGRES_VOLUME=bh-postgres-data
 BH_POSTGRES_PORT=127.0.0.1:6543
 
+# BloodHound Authentik SSO IdP
+BH_PG_USER=authentik-bloodhound
+BH_PG_DB=authentik-bloodhound
+BH_PG_PASS=bloodhoundcommunityedition
+BH_ATK_SECRET=bloodhoundcommunityedition
+COMPOSE_PORT_HTTP=127.0.0.1:9000
+COMPOSE_PORT_HTTPS=127.0.0.1:9443
+
+# BloodHound Authentik Worker
+BH_PG_USER=authentik-bloodhound
+BH_PG_DB=authentik-bloodhound
+BH_PG_PASS=bloodhoundcommunityedition
+BH_ATK_SECRET=bloodhoundcommunityedition
+
+# BloodHound Authentik Postgres
+BH_PG_PASS=bloodhoundcommunityedition
+BH_PG_USER=authentik-bloodhound
+BH_PG_DB=authentik-bloodhound
+
 # Integration Postgres
 INTEGRATION_POSTGRES_USER=bloodhound
 INTEGRATION_POSTGRES_PASSWORD=bloodhoundcommunityedition

--- a/.env.example
+++ b/.env.example
@@ -37,8 +37,8 @@ BH_POSTGRES_PORT=127.0.0.1:6543
 
 # Authentik SSO IdP, authentik Worker, authentik Postgres
 # Some env variables are reused in multiple authentik services
-ATK_BH_PG_USER=authentik-bloodhound
-ATK_BH_PG_DB=authentik-bloodhound
+ATK_BH_PG_USER=authentik
+ATK_BH_PG_DB=authentik
 ATK_BH_PG_PASS=bloodhoundcommunityedition
 ATK_BH_SECRET=bloodhoundcommunityedition
 COMPOSE_PORT_HTTP=127.0.0.1:9000

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -115,11 +115,10 @@ services:
       retries: 5
       start_period: 30s
 
-  bh-api:
+  bh-api: &bh-api
     profiles:
       - dev
       - api-only
-      - sso
     build:
       context: tools/docker-compose
       dockerfile: api.Dockerfile
@@ -190,7 +189,14 @@ services:
       graph-db:
         condition: service_healthy
 
-  bh-authentik:
+  bh-api-sso:
+    <<: *bh-api
+    profiles:
+      - sso
+    links:
+      - authentik:authentik.localhost
+
+  authentik:
     profiles:
       - sso
       - sso-only
@@ -198,12 +204,12 @@ services:
     restart: unless-stopped
     command: server
     environment:
-      AUTHENTIK_REDIS__HOST: bh-authentik-valkey
-      AUTHENTIK_POSTGRESQL__HOST: bh-authentik-db
-      AUTHENTIK_POSTGRESQL__USER: ${BH_PG_USER:-authentik-bloodhound}
-      AUTHENTIK_POSTGRESQL__NAME: ${BH_PG_DB:-authentik-bloodhound}
-      AUTHENTIK_POSTGRESQL__PASSWORD: ${BH_PG_PASS:-bloodhoundcommunityedition}
-      AUTHENTIK_SECRET_KEY: ${BH_ATK_SECRET:-bloodhoundcommunityedition}
+      AUTHENTIK_REDIS__HOST: authentik-valkey
+      AUTHENTIK_POSTGRESQL__HOST: authentik-db
+      AUTHENTIK_POSTGRESQL__USER: ${ATK_BH_PG_USER:-authentik}
+      AUTHENTIK_POSTGRESQL__NAME: ${ATK_BH_PG_DB:-authentik}
+      AUTHENTIK_POSTGRESQL__PASSWORD: ${ATK_BH_PG_PASS:-bloodhoundcommunityedition}
+      AUTHENTIK_SECRET_KEY: ${ATK_BH_SECRET:-bloodhoundcommunityedition}
     labels:
       - traefik.enable=true
       - traefik.http.routers.authentik.rule=Host(`${BH_AUTHENTIK_HOSTNAME:-authentik.localhost}`)
@@ -213,10 +219,10 @@ services:
       - "${COMPOSE_PORT_HTTP:-9000}:9000"
       - "${COMPOSE_PORT_HTTPS:-9443}:9443"
     depends_on:
-      - bh-authentik-db
-      - bh-authentik-valkey
+      - authentik-db
+      - authentik-valkey
 
-  bh-authentik-worker:
+  authentik-worker:
     profiles:
       - sso
       - sso-only
@@ -224,17 +230,17 @@ services:
     restart: unless-stopped
     command: worker
     environment:
-      AUTHENTIK_REDIS__HOST: bh-authentik-valkey
-      AUTHENTIK_POSTGRESQL__HOST: bh-authentik-db
-      AUTHENTIK_POSTGRESQL__USER: ${BH_PG_USER:-authentik-bloodhound}
-      AUTHENTIK_POSTGRESQL__NAME: ${BH_PG_DB:-authentik-bloodhound}
-      AUTHENTIK_POSTGRESQL__PASSWORD: ${BH_PG_PASS:-bloodhoundcommunityedition}
-      AUTHENTIK_SECRET_KEY: ${BH_ATK_SECRET:-bloodhoundcommunityedition}
+      AUTHENTIK_REDIS__HOST: authentik-valkey
+      AUTHENTIK_POSTGRESQL__HOST: authentik-db
+      AUTHENTIK_POSTGRESQL__USER: ${ATK_BH_PG_USER:-authentik}
+      AUTHENTIK_POSTGRESQL__NAME: ${ATK_BH_PG_DB:-authentik}
+      AUTHENTIK_POSTGRESQL__PASSWORD: ${ATK_BH_PG_PASS:-bloodhoundcommunityedition}
+      AUTHENTIK_SECRET_KEY: ${ATK_BH_SECRET:-bloodhoundcommunityedition}
     depends_on:
-      - bh-authentik-db
-      - bh-authentik-valkey
+      - authentik-db
+      - authentik-valkey
 
-  bh-authentik-valkey:
+  authentik-valkey:
     profiles:
       - sso
       - sso-only
@@ -242,9 +248,9 @@ services:
     command: --save 60 1 --loglevel warning
     restart: unless-stopped
     volumes:
-      - bh-authentik-valkey:/data
+      - authentik-valkey:/data
 
-  bh-authentik-db:
+  authentik-db:
     profiles:
       - sso
       - sso-only
@@ -257,16 +263,16 @@ services:
       retries: 5
       timeout: 5s
     volumes:
-      - bh-authentik-db:/var/lib/postgresql/data
+      - authentik-db:/var/lib/postgresql/data
     environment:
-      POSTGRES_PASSWORD: ${BH_PG_PASS:-bloodhoundcommunityedition}
-      POSTGRES_USER: ${BH_PG_USER:-authentik-bloodhound}
-      POSTGRES_DB: ${BH_PG_DB:-authentik-bloodhound}
+      POSTGRES_PASSWORD: ${ATK_BH_PG_PASS:-bloodhoundcommunityedition}
+      POSTGRES_USER: ${ATK_BH_PG_USER:-authentik}
+      POSTGRES_DB: ${ATK_BH_PG_DB:-authentik}
 
 volumes:
   neo4j-data:
   postgres-data:
   go-pkg-mod:
   ui-cache:
-  bh-authentik-valkey:
-  bh-authentik-db:
+  authentik-valkey:
+  authentik-db:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -34,6 +34,7 @@ services:
       - ui-only
       - debug-api
       - pg-only
+      - sso
     image: docker.io/library/postgres:16
     environment:
       - PGUSER=${BH_POSTGRES_USER:-bloodhound}
@@ -62,6 +63,7 @@ services:
       - ui-only
       - debug-api
       - pg-only
+      - sso
     build:
       context: tools/docker-compose
       dockerfile: pgadmin.Dockerfile
@@ -86,6 +88,7 @@ services:
       - api-only
       - ui-only
       - debug-api
+      - sso
     build:
       args:
         memconfig: true
@@ -116,6 +119,7 @@ services:
     profiles:
       - dev
       - api-only
+      - sso
     build:
       context: tools/docker-compose
       dockerfile: api.Dockerfile
@@ -143,6 +147,7 @@ services:
       - dev
       - ui-only
       - debug-api
+      - sso
     build:
       context: .
       dockerfile: tools/docker-compose/ui.Dockerfile
@@ -185,8 +190,83 @@ services:
       graph-db:
         condition: service_healthy
 
+  bh-authentik:
+    profiles:
+      - sso
+      - sso-only
+    image: ${AUTHENTIK_IMAGE:-ghcr.io/goauthentik/server}:${AUTHENTIK_TAG:-2023.10.7}
+    restart: unless-stopped
+    command: server
+    environment:
+      AUTHENTIK_REDIS__HOST: bh-authentik-valkey
+      AUTHENTIK_POSTGRESQL__HOST: bh-authentik-db
+      AUTHENTIK_POSTGRESQL__USER: ${BH_PG_USER:-authentik-bloodhound}
+      AUTHENTIK_POSTGRESQL__NAME: ${BH_PG_DB:-authentik-bloodhound}
+      AUTHENTIK_POSTGRESQL__PASSWORD: ${BH_PG_PASS:-bloodhoundcommunityedition}
+      AUTHENTIK_SECRET_KEY: ${BH_ATK_SECRET:-bloodhoundcommunityedition}
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.authentik.rule=Host(`${BH_AUTHENTIK_HOSTNAME:-authentik.localhost}`)
+      - traefik.http.routers.authentik.service=authentik
+      - traefik.http.services.authentik.loadbalancer.server.port=9000
+    ports:
+      - "${COMPOSE_PORT_HTTP:-9000}:9000"
+      - "${COMPOSE_PORT_HTTPS:-9443}:9443"
+    depends_on:
+      - bh-authentik-db
+      - bh-authentik-valkey
+
+  bh-authentik-worker:
+    profiles:
+      - sso
+      - sso-only
+    image: ${AUTHENTIK_IMAGE:-ghcr.io/goauthentik/server}:${AUTHENTIK_TAG:-2023.10.7}
+    restart: unless-stopped
+    command: worker
+    environment:
+      AUTHENTIK_REDIS__HOST: bh-authentik-valkey
+      AUTHENTIK_POSTGRESQL__HOST: bh-authentik-db
+      AUTHENTIK_POSTGRESQL__USER: ${BH_PG_USER:-authentik-bloodhound}
+      AUTHENTIK_POSTGRESQL__NAME: ${BH_PG_DB:-authentik-bloodhound}
+      AUTHENTIK_POSTGRESQL__PASSWORD: ${BH_PG_PASS:-bloodhoundcommunityedition}
+      AUTHENTIK_SECRET_KEY: ${BH_ATK_SECRET:-bloodhoundcommunityedition}
+    depends_on:
+      - bh-authentik-db
+      - bh-authentik-valkey
+
+  bh-authentik-valkey:
+    profiles:
+      - sso
+      - sso-only
+    image: docker.io/valkey/valkey:alpine
+    command: --save 60 1 --loglevel warning
+    restart: unless-stopped
+    volumes:
+      - bh-authentik-valkey:/data
+
+  bh-authentik-db:
+    profiles:
+      - sso
+      - sso-only
+    image: docker.io/library/postgres:13.2-alpine
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -d $${POSTGRES_DB} -U $${POSTGRES_USER}"]
+      start_period: 20s
+      interval: 30s
+      retries: 5
+      timeout: 5s
+    volumes:
+      - bh-authentik-db:/var/lib/postgresql/data
+    environment:
+      POSTGRES_PASSWORD: ${BH_PG_PASS:-bloodhoundcommunityedition}
+      POSTGRES_USER: ${BH_PG_USER:-authentik-bloodhound}
+      POSTGRES_DB: ${BH_PG_DB:-authentik-bloodhound}
+
 volumes:
   neo4j-data:
   postgres-data:
   go-pkg-mod:
   ui-cache:
+  bh-authentik-valkey:
+  bh-authentik-db:

--- a/justfile
+++ b/justfile
@@ -143,6 +143,14 @@ bh-ui-only *ARGS='up':
 pg-only *ARGS='up':
   @docker compose --profile pg-only -f docker-compose.dev.yml {{ARGS}}
 
+# run docker compose commands for the BH dev profile with SSO IDP Authentik (Default: up)
+bh-sso *ARGS='up':
+  @docker compose --profile sso -f docker-compose.dev.yml {{ARGS}}
+
+# run docker compose commands for the SSO IDP Authentik only (Default: up)
+bh-sso-only *ARGS='up':
+  @docker compose --profile sso-only -f docker-compose.dev.yml {{ARGS}}
+
 # run docker compose commands for the BH testing databases (Default: up)
 bh-testing *ARGS='up -d':
   @docker compose --project-name bh-testing -f docker-compose.testing.yml {{ARGS}}


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description
- Add authentik to docker-compose.dev.yml
- Added profiles bh-sso as well as bh-sso-only  for just support to quickly spin up authentik and bhe

## Motivation and Context
- Ticket: BED-4655

*Why is this change required? What problem does it solve?*
- This adds authentik - https://github.com/goauthentik/authentik to the dev stack. It provides us with an IDP that supports a variety of SSO protocols so we can locally test and support OIDC / SAML auth flows.

## How Has This Been Tested?
- Run `just bh-sso` Note you have to go to `http://authentik.localhost/if/flow/initial-setup/` to register an admin password before you can progress further

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->
- New feature (non-breaking change which adds functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
