### PR TITLE
BED-4934: Posture page feature flag

### DIFF
--- a/cmd/api/src/database/migration/migrations/v6.1.0.sql
+++ b/cmd/api/src/database/migration/migrations/v6.1.0.sql
@@ -95,3 +95,25 @@ SET sso_provider_id = (SELECT sso.id
                        WHERE u.saml_provider_id = saml.id)
 WHERE sso_provider_id IS NULL
   AND saml_provider_id IS NOT NULL;
+
+-- Add updated posture page feature flag
+INSERT INTO
+    feature_flags (
+        created_at,
+        updated_at,
+        key,
+        name,
+        description,
+        enabled,
+        user_updatable
+    )
+VALUES
+    (
+        current_timestamp,
+        current_timestamp,
+        'updated_posture_page',
+        'Updated Posture Page',
+        'Enables the updated version of the posture page in the UI application',
+        false,
+        false
+    ) ON CONFLICT DO NOTHING;

--- a/cmd/api/src/database/migration/migrations/v6.1.0.sql
+++ b/cmd/api/src/database/migration/migrations/v6.1.0.sql
@@ -95,14 +95,3 @@ SET sso_provider_id = (SELECT sso.id
                        WHERE u.saml_provider_id = saml.id)
 WHERE sso_provider_id IS NULL
   AND saml_provider_id IS NOT NULL;
-
--- Add updated posture page feature flag
-INSERT INTO feature_flags (created_at, updated_at, key, name, description, enabled, user_updatable)
-VALUES (current_timestamp,
-        current_timestamp,
-        'updated_posture_page',
-        'Updated Posture Page',
-        'Enables the updated version of the posture page in the UI application',
-        false,
-        false)
-ON CONFLICT DO NOTHING;

--- a/cmd/api/src/database/migration/migrations/v6.1.0.sql
+++ b/cmd/api/src/database/migration/migrations/v6.1.0.sql
@@ -97,23 +97,12 @@ WHERE sso_provider_id IS NULL
   AND saml_provider_id IS NOT NULL;
 
 -- Add updated posture page feature flag
-INSERT INTO
-    feature_flags (
-        created_at,
-        updated_at,
-        key,
-        name,
-        description,
-        enabled,
-        user_updatable
-    )
-VALUES
-    (
-        current_timestamp,
+INSERT INTO feature_flags (created_at, updated_at, key, name, description, enabled, user_updatable)
+VALUES (current_timestamp,
         current_timestamp,
         'updated_posture_page',
         'Updated Posture Page',
         'Enables the updated version of the posture page in the UI application',
         false,
-        false
-    ) ON CONFLICT DO NOTHING;
+        false)
+ON CONFLICT DO NOTHING;

--- a/cmd/api/src/database/migration/migrations/v6.2.0.sql
+++ b/cmd/api/src/database/migration/migrations/v6.2.0.sql
@@ -1,0 +1,26 @@
+-- Copyright 2024 Specter Ops, Inc.
+--
+-- Licensed under the Apache License, Version 2.0
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- SPDX-License-Identifier: Apache-2.0
+
+-- Add updated posture page feature flag
+INSERT INTO feature_flags (created_at, updated_at, key, name, description, enabled, user_updatable)
+VALUES (current_timestamp,
+        current_timestamp,
+        'updated_posture_page',
+        'Updated Posture Page',
+        'Enables the updated version of the posture page in the UI application',
+        false,
+        false)
+ON CONFLICT DO NOTHING;

--- a/cmd/api/src/model/appcfg/flag.go
+++ b/cmd/api/src/model/appcfg/flag.go
@@ -37,6 +37,7 @@ const (
 	FeatureDarkMode                   = "dark_mode"
 	FeatureAutoTagT0ParentObjects     = "auto_tag_t0_parent_objects"
 	FeatureOIDCSupport                = "oidc_support"
+	FeatureUpdatedPosturePage         = "updated_posture_page"
 )
 
 // FeatureFlag defines the most basic details of what a feature flag must contain to be actionable. Feature flags should be


### PR DESCRIPTION
## Description
Adds a new feature flag to the current migration file with the key `updated_posture_page`. The flag should initially be set to false and should be non user-updatable.

## Motivation and Context
This feature flag will be used for toggling to the new posture page during development.

This PR addresses: [BED-4934]

## How Has This Been Tested?
Confirmed migration runs on startup and creates the new flag with the expected settings and initial value.

## Screenshots (optional):

## Types of changes
- Chore (a change that does not modify the application functionality)
- Database Migrations

## Checklist:
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


[BED-4934]: https://specterops.atlassian.net/browse/BED-4934?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ