### PR TITLE
Create a new permission to limit the scope for RoleUploadOnly

### DIFF
--- a/cmd/api/src/api/registration/v2.go
+++ b/cmd/api/src/api/registration/v2.go
@@ -110,9 +110,9 @@ func NewV2API(cfg config.Configuration, resources v2.Resources, routerInst *rout
 	// Collection File Upload API
 	routerInst.GET("/api/v2/file-upload", resources.ListFileUploadJobs).RequireAuth()
 	routerInst.GET("/api/v2/file-upload/accepted-types", resources.ListAcceptedFileUploadTypes).RequireAuth()
-	routerInst.POST("/api/v2/file-upload/start", resources.StartFileUploadJob).RequirePermissions(permissions.GraphDBWrite)
-	routerInst.POST(fmt.Sprintf("/api/v2/file-upload/{%s}", v2.FileUploadJobIdPathParameterName), resources.ProcessFileUpload).RequirePermissions(permissions.GraphDBWrite)
-	routerInst.POST(fmt.Sprintf("/api/v2/file-upload/{%s}/end", v2.FileUploadJobIdPathParameterName), resources.EndFileUploadJob).RequirePermissions(permissions.GraphDBWrite)
+	routerInst.POST("/api/v2/file-upload/start", resources.StartFileUploadJob).RequirePermissions(permissions.GraphDBIngest)
+	routerInst.POST(fmt.Sprintf("/api/v2/file-upload/{%s}", v2.FileUploadJobIdPathParameterName), resources.ProcessFileUpload).RequirePermissions(permissions.GraphDBIngest)
+	routerInst.POST(fmt.Sprintf("/api/v2/file-upload/{%s}/end", v2.FileUploadJobIdPathParameterName), resources.EndFileUploadJob).RequirePermissions(permissions.GraphDBIngest)
 
 	router.With(middleware.DefaultRateLimitMiddleware,
 		// Version API

--- a/cmd/api/src/auth/permission.go
+++ b/cmd/api/src/auth/permission.go
@@ -40,6 +40,7 @@ type PermissionSet struct {
 
 	CollectionManageJobs model.Permission
 
+	GraphDBIngest model.Permission
 	GraphDBMutate model.Permission
 	GraphDBRead   model.Permission
 	GraphDBWrite  model.Permission
@@ -65,6 +66,7 @@ func (s PermissionSet) All() model.Permissions {
 		s.ClientsRead,
 		s.ClientsTasking,
 		s.CollectionManageJobs,
+		s.GraphDBIngest,
 		s.GraphDBMutate,
 		s.GraphDBRead,
 		s.GraphDBWrite,
@@ -96,6 +98,7 @@ func Permissions() PermissionSet {
 
 		CollectionManageJobs: model.NewPermission("collection", "ManageJobs"),
 
+		GraphDBIngest: model.NewPermission("graphdb", "Ingest"),
 		GraphDBMutate: model.NewPermission("graphdb", "Mutate"),
 		GraphDBRead:   model.NewPermission("graphdb", "Read"),
 		GraphDBWrite:  model.NewPermission("graphdb", "Write"),

--- a/cmd/api/src/auth/role.go
+++ b/cmd/api/src/auth/role.go
@@ -56,7 +56,7 @@ func Roles() map[string]RoleTemplate {
 			Description: "Used for data collection clients, can post data but cannot read data",
 			Permissions: model.Permissions{
 				permissions.ClientsTasking,
-				permissions.GraphDBWrite,
+				permissions.GraphDBIngest,
 			},
 		},
 		RoleUser: {
@@ -87,6 +87,7 @@ func Roles() map[string]RoleTemplate {
 				permissions.ClientsRead,
 				permissions.ClientsTasking,
 				permissions.CollectionManageJobs,
+				permissions.GraphDBIngest,
 				permissions.GraphDBWrite,
 				permissions.GraphDBRead,
 				permissions.SavedQueriesRead,

--- a/cmd/api/src/auth/role_test.go
+++ b/cmd/api/src/auth/role_test.go
@@ -189,7 +189,7 @@ func testRoleAccess(t *testing.T, roleName string) {
 			userClient, ok := lab.Unpack(harness, userClientFixture)
 			assert.True(ok)
 
-			_, err := userClient.CreateAssetGroup(v2.AssetGroupCreateRequest{Name: "test"})
+			_, err := userClient.CreateAssetGroup(v2.CreateAssetGroupRequest{Name: "test"})
 			if role.Permissions.Has(auth.Permissions().GraphDBWrite) {
 				assert.Nil(err)
 			} else {

--- a/cmd/api/src/auth/role_test.go
+++ b/cmd/api/src/auth/role_test.go
@@ -185,12 +185,12 @@ func testRoleAccess(t *testing.T, roleName string) {
 			}
 		}),
 
-		lab.TestCase(fmt.Sprintf("%s be able to access GraphDBWrite endpoints", testCondition(role, auth.Permissions().GraphDBWrite)), func(assert *require.Assertions, harness *lab.Harness) {
+		lab.TestCase(fmt.Sprintf("%s be able to access GraphDBIngest endpoints", testCondition(role, auth.Permissions().GraphDBIngest)), func(assert *require.Assertions, harness *lab.Harness) {
 			userClient, ok := lab.Unpack(harness, userClientFixture)
 			assert.True(ok)
 
 			_, err := userClient.CreateFileUploadTask()
-			if role.Permissions.Has(auth.Permissions().GraphDBWrite) {
+			if role.Permissions.Has(auth.Permissions().GraphDBIngest) {
 				assert.Nil(err)
 			} else {
 				requireForbidden(assert, err)

--- a/cmd/api/src/auth/role_test.go
+++ b/cmd/api/src/auth/role_test.go
@@ -189,7 +189,7 @@ func testRoleAccess(t *testing.T, roleName string) {
 			userClient, ok := lab.Unpack(harness, userClientFixture)
 			assert.True(ok)
 
-			err := userClient.RequestAnalysis()
+			_, err := userClient.CreateAssetGroup(v2.AssetGroupCreateRequest{Name: "test"})
 			if role.Permissions.Has(auth.Permissions().GraphDBWrite) {
 				assert.Nil(err)
 			} else {

--- a/cmd/api/src/auth/role_test.go
+++ b/cmd/api/src/auth/role_test.go
@@ -185,6 +185,18 @@ func testRoleAccess(t *testing.T, roleName string) {
 			}
 		}),
 
+		lab.TestCase(fmt.Sprintf("%s be able to access GraphDBWrite endpoints", testCondition(role, auth.Permissions().GraphDBWrite)), func(assert *require.Assertions, harness *lab.Harness) {
+			userClient, ok := lab.Unpack(harness, userClientFixture)
+			assert.True(ok)
+
+			_, err := userClient.RequestAnalysis()
+			if role.Permissions.Has(auth.Permissions().GraphDBWrite) {
+				assert.Nil(err)
+			} else {
+				requireForbidden(assert, err)
+			}
+		}),
+
 		lab.TestCase(fmt.Sprintf("%s be able to access GraphDBIngest endpoints", testCondition(role, auth.Permissions().GraphDBIngest)), func(assert *require.Assertions, harness *lab.Harness) {
 			userClient, ok := lab.Unpack(harness, userClientFixture)
 			assert.True(ok)

--- a/cmd/api/src/auth/role_test.go
+++ b/cmd/api/src/auth/role_test.go
@@ -189,7 +189,7 @@ func testRoleAccess(t *testing.T, roleName string) {
 			userClient, ok := lab.Unpack(harness, userClientFixture)
 			assert.True(ok)
 
-			_, err := userClient.CreateAssetGroup(v2.CreateAssetGroupRequest{Name: "test"})
+			_, err := userClient.CreateAssetGroup(v2.CreateAssetGroupRequest{Name: "test", Tag: "test"})
 			if role.Permissions.Has(auth.Permissions().GraphDBWrite) {
 				assert.Nil(err)
 			} else {

--- a/cmd/api/src/auth/role_test.go
+++ b/cmd/api/src/auth/role_test.go
@@ -189,7 +189,7 @@ func testRoleAccess(t *testing.T, roleName string) {
 			userClient, ok := lab.Unpack(harness, userClientFixture)
 			assert.True(ok)
 
-			_, err := userClient.RequestAnalysis()
+			err := userClient.RequestAnalysis()
 			if role.Permissions.Has(auth.Permissions().GraphDBWrite) {
 				assert.Nil(err)
 			} else {

--- a/cmd/api/src/database/analysisrequest.go
+++ b/cmd/api/src/database/analysisrequest.go
@@ -86,7 +86,7 @@ func (s *BloodhoundDB) setAnalysisRequest(ctx context.Context, requestType model
 	} else {
 		// Analysis request existed, we only want to overwrite if request is for a deletion request, otherwise ignore additional requests
 		if analReq.RequestType == model.AnalysisRequestAnalysis && requestType == model.AnalysisRequestDeletion {
-			updateSql := `update analysis_request_switch set requested_by = ?, request_type = ?, requested_at = ? limit 1;`
+			updateSql := `update analysis_request_switch set requested_by = ?, request_type = ?, requested_at = ?;`
 			tx := s.db.WithContext(ctx).Exec(updateSql, requestedBy, requestType, time.Now().UTC())
 			return tx.Error
 		}

--- a/cmd/api/src/database/migration/migrations/v6.2.0.sql
+++ b/cmd/api/src/database/migration/migrations/v6.2.0.sql
@@ -24,3 +24,5 @@ VALUES (current_timestamp,
         false,
         false)
 ON CONFLICT DO NOTHING;
+
+INSERT INTO permissions (authority, name, created_at, updated_at) VALUES ('graphdb', 'Ingest', current_timestamp, current_timestamp) ON CONFLICT DO NOTHING;

--- a/cmd/api/src/database/migration/migrations/v6.2.0.sql
+++ b/cmd/api/src/database/migration/migrations/v6.2.0.sql
@@ -26,3 +26,27 @@ VALUES (current_timestamp,
 ON CONFLICT DO NOTHING;
 
 INSERT INTO permissions (authority, name, created_at, updated_at) VALUES ('graphdb', 'Ingest', current_timestamp, current_timestamp) ON CONFLICT DO NOTHING;
+
+-- Grant the Upload-Only user GraphDBIngest permissions
+INSERT INTO roles_permissions (role_id, permission_id)
+VALUES ((SELECT id FROM roles WHERE roles.name = 'Upload-Only'),
+        (SELECT id FROM permissions WHERE permissions.authority = 'graphdb' and permissions.name = 'Ingest'))
+ON CONFLICT DO NOTHING;
+
+-- Grant the Power User user GraphDBIngest permissions
+INSERT INTO roles_permissions (role_id, permission_id)
+VALUES ((SELECT id FROM roles WHERE roles.name = 'Power User'),
+        (SELECT id FROM permissions WHERE permissions.authority = 'graphdb' and permissions.name = 'Ingest'))
+ON CONFLICT DO NOTHING;
+
+-- Grant the Admininstrator user GraphDBIngest permissions
+INSERT INTO roles_permissions (role_id, permission_id)
+VALUES ((SELECT id FROM roles WHERE roles.name = 'Administrator'),
+        (SELECT id FROM permissions WHERE permissions.authority = 'graphdb' and permissions.name = 'Ingest'))
+ON CONFLICT DO NOTHING;
+
+-- Remove the GraphDBWrite permission from the Upload-Only role for 
+DELETE FROM roles_permissions 
+WHERE role_id = (SELECT id FROM roles WHERE roles.name = 'Upload-Only')
+AND permission_id = (SELECT id FROM permissions WHERE permissions.authority = 'graphdb' AND permissions.name = 'Write')
+ON CONFLICT DO NOTHING;;

--- a/cmd/api/src/database/migration/migrations/v6.2.0.sql
+++ b/cmd/api/src/database/migration/migrations/v6.2.0.sql
@@ -45,7 +45,7 @@ VALUES ((SELECT id FROM roles WHERE roles.name = 'Administrator'),
         (SELECT id FROM permissions WHERE permissions.authority = 'graphdb' and permissions.name = 'Ingest'))
 ON CONFLICT DO NOTHING;
 
--- Remove the GraphDBWrite permission from the Upload-Only role for 
+-- Remove the GraphDBWrite permission from the Upload-Only role
 DELETE FROM roles_permissions 
 WHERE role_id = (SELECT id FROM roles WHERE roles.name = 'Upload-Only')
 AND permission_id = (SELECT id FROM permissions WHERE permissions.authority = 'graphdb' AND permissions.name = 'Write');

--- a/cmd/api/src/database/migration/migrations/v6.2.0.sql
+++ b/cmd/api/src/database/migration/migrations/v6.2.0.sql
@@ -48,5 +48,4 @@ ON CONFLICT DO NOTHING;
 -- Remove the GraphDBWrite permission from the Upload-Only role for 
 DELETE FROM roles_permissions 
 WHERE role_id = (SELECT id FROM roles WHERE roles.name = 'Upload-Only')
-AND permission_id = (SELECT id FROM permissions WHERE permissions.authority = 'graphdb' AND permissions.name = 'Write')
-ON CONFLICT DO NOTHING;;
+AND permission_id = (SELECT id FROM permissions WHERE permissions.authority = 'graphdb' AND permissions.name = 'Write');


### PR DESCRIPTION
…

<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description
Create a new permission that controls the ingestion/file upload routes, and add that permission to the roles that currently have GraphDBWrite (and remove that permission where necessary)

## Motivation and Context

This PR addresses: BED-4903 and BED-4950

The permission intended to control upload rights for clients should only be allowed to perform uploads. The GraphDBWrite permission also includes to modify access groups and trigger manual analysis runs.

## How Has This Been Tested?

*Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc.*

## Types of changes

- Bug fix (non-breaking change which fixes an issue)
- Database Migrations

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [ ] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
