### PR TITLE
BED-4947: Fix Last Analysis Run At Bug

### DIFF
--- a/cmd/api/src/database/datapipestatus_test.go
+++ b/cmd/api/src/database/datapipestatus_test.go
@@ -47,7 +47,7 @@ func TestDatapipeStatus(t *testing.T) {
 
 	// when `SetDatapipeStatus` is called with `true` for the `updateAnalysisTime` parameter, assert that the time is no longer null
 	require.True(t, status.LastCompleteAnalysisAt.IsZero())
-	err = db.SetDatapipeStatus(testCtx, model.DatapipeStatusAnalyzing, true)
+	err = db.SetDatapipeStatus(testCtx, model.DatapipeStatusIdle, true)
 	require.Nil(t, err)
 	status, err = db.GetDatapipeStatus(testCtx)
 	require.Nil(t, err)


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Fixes a logic bug that was causing last_analysis_run_at to run every time the datapipe status changed

## Motivation and Context

This PR addresses: BED-4947

*Why is this change required? What problem does it solve?*

This bug was causing scheduled analysis to never run

## How Has This Been Tested?

- Existing test has been updated to account for the correct, intended behavior

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->
- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
