### PR TITLE
fix: BED-4954 - Include SyncedToADUser and SyncedToEntraUser in Delet…

### DIFF
--- a/cmd/api/src/analysis/ad/post.go
+++ b/cmd/api/src/analysis/ad/post.go
@@ -18,6 +18,7 @@ package ad
 
 import (
 	"context"
+	"github.com/specterops/bloodhound/graphschema/azure"
 
 	"github.com/specterops/bloodhound/analysis"
 	adAnalysis "github.com/specterops/bloodhound/analysis/ad"
@@ -27,7 +28,7 @@ import (
 
 func Post(ctx context.Context, db graph.Database, adcsEnabled bool, citrixEnabled bool) (*analysis.AtomicPostProcessingStats, error) {
 	aggregateStats := analysis.NewAtomicPostProcessingStats()
-	if stats, err := analysis.DeleteTransitEdges(ctx, db, ad.Entity, ad.Entity, adAnalysis.PostProcessedRelationships()...); err != nil {
+	if stats, err := analysis.DeleteTransitEdges(ctx, db, graph.Kinds{ad.Entity, azure.Entity}, adAnalysis.PostProcessedRelationships()...); err != nil {
 		return &aggregateStats, err
 	} else if groupExpansions, err := adAnalysis.ExpandAllRDPLocalGroups(ctx, db); err != nil {
 		return &aggregateStats, err

--- a/cmd/api/src/analysis/azure/post.go
+++ b/cmd/api/src/analysis/azure/post.go
@@ -18,6 +18,7 @@ package azure
 
 import (
 	"context"
+	"github.com/specterops/bloodhound/graphschema/ad"
 
 	"github.com/specterops/bloodhound/analysis"
 	azureAnalysis "github.com/specterops/bloodhound/analysis/azure"
@@ -28,7 +29,7 @@ import (
 
 func Post(ctx context.Context, db graph.Database) (*analysis.AtomicPostProcessingStats, error) {
 	aggregateStats := analysis.NewAtomicPostProcessingStats()
-	if stats, err := analysis.DeleteTransitEdges(ctx, db, azure.Entity, azure.Entity, azureAnalysis.AzurePostProcessedRelationships()...); err != nil {
+	if stats, err := analysis.DeleteTransitEdges(ctx, db, graph.Kinds{ad.Entity, azure.Entity}, azureAnalysis.AzurePostProcessedRelationships()...); err != nil {
 		return &aggregateStats, err
 	} else if userRoleStats, err := azureAnalysis.UserRoleAssignments(ctx, db); err != nil {
 		return &aggregateStats, err

--- a/packages/go/analysis/ad/post.go
+++ b/packages/go/analysis/ad/post.go
@@ -58,6 +58,7 @@ func PostProcessedRelationships() []graph.Kind {
 		ad.ADCSESC9a,
 		ad.ADCSESC13,
 		ad.EnrollOnBehalfOf,
+		ad.SyncedToEntraUser,
 	}
 }
 

--- a/packages/go/analysis/azure/post.go
+++ b/packages/go/analysis/azure/post.go
@@ -131,6 +131,7 @@ func AzurePostProcessedRelationships() []graph.Kind {
 		azure.AZMGAddSecret,
 		azure.AZMGGrantAppRoles,
 		azure.AZMGGrantRole,
+		azure.SyncedToADUser,
 	}
 }
 

--- a/packages/go/analysis/post.go
+++ b/packages/go/analysis/post.go
@@ -120,7 +120,7 @@ type DeleteRelationshipJob struct {
 	ID   graph.ID
 }
 
-func DeleteTransitEdges(ctx context.Context, db graph.Database, fromKind, toKind graph.Kind, targetRelationships ...graph.Kind) (*AtomicPostProcessingStats, error) {
+func DeleteTransitEdges(ctx context.Context, db graph.Database, baseKinds graph.Kinds, targetRelationships ...graph.Kind) (*AtomicPostProcessingStats, error) {
 	defer log.Measure(log.LevelInfo, "Finished deleting transit edges")()
 
 	var (
@@ -134,9 +134,9 @@ func DeleteTransitEdges(ctx context.Context, db graph.Database, fromKind, toKind
 		if err := db.ReadTransaction(ctx, func(tx graph.Transaction) error {
 			fetchedRelationshipIDs, err := ops.FetchRelationshipIDs(tx.Relationships().Filterf(func() graph.Criteria {
 				return query.And(
-					query.Kind(query.Start(), fromKind),
+					query.KindIn(query.Start(), baseKinds...),
 					query.Kind(query.Relationship(), closureKindCopy),
-					query.Kind(query.End(), toKind),
+					query.KindIn(query.End(), baseKinds...),
 				)
 			}))
 


### PR DESCRIPTION
## Description

Azure Post is missing SyncedToADUser: https://github.com/SpecterOps/BloodHound/blob/c347ed2bfa2d524494657269ab23828674f74376/packages/go/analysis/azure/post.go#L120

ActiveDirectory Post is missing SyncedToEntraUser: https://github.com/SpecterOps/BloodHound/blob/c347ed2bfa2d524494657269ab23828674f74376/packages/go/analysis/ad/post.go#L37

Lastly, as written the resulting query from DeleteTransitEdges(...) narrows the start and end node kinds to just one base type: (:Base)-[:SyncedToEntraUser]->(:Base). This presents a problem since AD/Entra Hybrid Paths, by definition, must cross boundaries: (:Base)-[:SyncedToEntraUser]->(:AZBase). As such, the DeleteTransitEdges(...) function must be rewritten to match on multiple start and end node kinds.

## Motivation and Context

This PR addresses: BED-4954

Calls to [DeleteTransitEdges(…)](https://github.com/SpecterOps/BloodHound/blob/c347ed2bfa2d524494657269ab23828674f74376/packages/go/analysis/post.go#L123) do not include the most recent AD/Entra Hybrid Path edges. Additionally, due to the way that the function is written, cross-domain edges will never be deleted.

## How Has This Been Tested?

Integration testing.

## Screenshots (optional):

## Types of changes

- Chore (a change that does not modify the application functionality)
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)
- Database Migrations

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [ ] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [ ] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [ ] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
