### PR TITLE
BED-4931: Add Audit Logging for SAML Authentication Attempts after BED-4767

### DIFF
--- a/cmd/api/src/api/auth.go
+++ b/cmd/api/src/api/auth.go
@@ -93,11 +93,11 @@ func NewAuthenticator(cfg config.Configuration, db database.Database, ctxInitial
 	}
 }
 
-func (s authenticator) auditLogin(requestContext context.Context, commitID uuid.UUID, user model.User, loginRequest LoginRequest, status model.AuditLogEntryStatus, loginError error) {
+func (s authenticator) auditLogin(requestContext context.Context, commitID uuid.UUID, status model.AuditLogEntryStatus, user model.User, fields types.JSONUntypedObject) {
 	bhCtx := ctx.Get(requestContext)
 	auditLog := model.AuditLog{
 		Action:          model.AuditLogActionLoginAttempt,
-		Fields:          types.JSONUntypedObject{"username": loginRequest.Username, "auth_type": loginRequest.LoginMethod},
+		Fields:          fields,
 		RequestID:       bhCtx.RequestID,
 		SourceIpAddress: bhCtx.RequestIP,
 		Status:          status,
@@ -110,11 +110,10 @@ func (s authenticator) auditLogin(requestContext context.Context, commitID uuid.
 		auditLog.ActorEmail = user.EmailAddress.ValueOrZero()
 	}
 
-	if status == model.AuditLogStatusFailure {
-		auditLog.Fields["error"] = loginError
+	err := s.db.CreateAuditLog(requestContext, auditLog)
+	if err != nil {
+		log.Warnf("failed to write login audit log %+v", err)
 	}
-
-	s.db.CreateAuditLog(requestContext, auditLog)
 }
 
 func (s authenticator) validateSecretLogin(ctx context.Context, loginRequest LoginRequest) (model.User, string, error) {
@@ -138,32 +137,25 @@ func (s authenticator) validateSecretLogin(ctx context.Context, loginRequest Log
 }
 
 func (s authenticator) LoginWithSecret(ctx context.Context, loginRequest LoginRequest) (LoginDetails, error) {
-	var (
-		commitID     uuid.UUID
-		err          error
-		sessionToken string
-		user         model.User
-	)
+	auditLogFields := types.JSONUntypedObject{"username": loginRequest.Username, "auth_type": auth.ProviderTypeSecret}
 
-	commitID, err = uuid.NewV4()
-	if err != nil {
+	if commitID, err := uuid.NewV4(); err != nil {
 		log.Errorf("Error generating commit ID for login: %s", err)
 		return LoginDetails{}, err
-	}
-
-	s.auditLogin(ctx, commitID, user, loginRequest, model.AuditLogStatusIntent, err)
-
-	user, sessionToken, err = s.validateSecretLogin(ctx, loginRequest)
-
-	if err != nil {
-		s.auditLogin(ctx, commitID, user, loginRequest, model.AuditLogStatusFailure, err)
-		return LoginDetails{}, err
 	} else {
-		s.auditLogin(ctx, commitID, user, loginRequest, model.AuditLogStatusSuccess, err)
-		return LoginDetails{
-			User:         user,
-			SessionToken: sessionToken,
-		}, nil
+		s.auditLogin(ctx, commitID, model.AuditLogStatusIntent, model.User{}, auditLogFields)
+
+		if user, sessionToken, err := s.validateSecretLogin(ctx, loginRequest); err != nil {
+			auditLogFields["error"] = err
+			s.auditLogin(ctx, commitID, model.AuditLogStatusFailure, user, auditLogFields)
+			return LoginDetails{}, err
+		} else {
+			s.auditLogin(ctx, commitID, model.AuditLogStatusSuccess, user, auditLogFields)
+			return LoginDetails{
+				User:         user,
+				SessionToken: sessionToken,
+			}, nil
+		}
 	}
 }
 
@@ -337,27 +329,26 @@ func SetSecureBrowserCookie(request *http.Request, response http.ResponseWriter,
 	})
 }
 
+// authProvider should be either model.SAMLProvider or model.OIDCProvider
 func (s authenticator) CreateSSOSession(request *http.Request, response http.ResponseWriter, principalNameOrEmail string, authProvider any) {
 	var (
-		hostURL      = *ctx.FromRequest(request).Host
-		requestCtx   = request.Context()
-		commitID     uuid.UUID
-		user         model.User
-		err          error
-		loginRequest = LoginRequest{
-			Username: principalNameOrEmail,
-		}
+		hostURL    = *ctx.FromRequest(request).Host
+		requestCtx = request.Context()
+		err        error
 
-		loginOutcome = model.AuditLogStatusFailure
-		loginError   error
+		user model.User
+
+		commitID        uuid.UUID
+		auditLogFields  = types.JSONUntypedObject{"username": principalNameOrEmail}
+		auditLogOutcome = model.AuditLogStatusFailure
 	)
 
 	// Set LoginAttempt method for audit logs
 	switch authProvider.(type) {
 	case model.SAMLProvider:
-		loginRequest.LoginMethod = auth.ProviderTypeSAML
+		auditLogFields["auth_type"] = auth.ProviderTypeSAML
 	case model.OIDCProvider:
-		loginRequest.LoginMethod = auth.ProviderTypeOIDC
+		auditLogFields["auth_type"] = auth.ProviderTypeOIDC
 	}
 
 	// Generate commit ID for audit logging
@@ -368,63 +359,62 @@ func (s authenticator) CreateSSOSession(request *http.Request, response http.Res
 	}
 
 	// Log the intent to authenticate
-	s.auditLogin(requestCtx, commitID, user, loginRequest, model.AuditLogStatusIntent, nil)
+	s.auditLogin(requestCtx, commitID, model.AuditLogStatusIntent, user, auditLogFields)
 
 	// Log authentication success or failure
 	defer func() {
-		s.auditLogin(requestCtx, commitID, user, loginRequest, loginOutcome, loginError)
+		s.auditLogin(requestCtx, commitID, auditLogOutcome, user, auditLogFields)
 	}()
 
-	if user, err = s.db.LookupUser(requestCtx, principalNameOrEmail); err != nil {
+	if user, err := s.db.LookupUser(requestCtx, principalNameOrEmail); err != nil {
+		auditLogFields["error"] = err
 		if !errors.Is(err, database.ErrNotFound) {
 			HandleDatabaseError(request, response, err)
 		} else {
 			WriteErrorResponse(requestCtx, BuildErrorResponse(http.StatusForbidden, "user is not allowed", request), response)
 		}
-		loginError = err
-		return
-	}
+	} else {
+		switch typedAuthProvider := authProvider.(type) {
+		case model.SAMLProvider:
+			if !user.SAMLProviderID.Valid || typedAuthProvider.ID != user.SAMLProvider.ID {
+				auditLogFields["error"] = ErrorUserNotAuthorizedForProvider
+				WriteErrorResponse(requestCtx, BuildErrorResponse(http.StatusForbidden, "user is not allowed", request), response)
+				return
+			}
 
-	switch typedAuthProvider := authProvider.(type) {
-	case model.SAMLProvider:
-		if !user.SAMLProviderID.Valid || typedAuthProvider.ID != user.SAMLProvider.ID {
-			loginError = ErrorUserNotAuthorizedForProvider
-			WriteErrorResponse(requestCtx, BuildErrorResponse(http.StatusForbidden, "user is not allowed", request), response)
+		case model.OIDCProvider:
+			//todo connect to db provider table
+
+			// Delete pre-auth cookies regardless
+			DeleteBrowserCookie(request, response, AuthPKCECookieName)
+			DeleteBrowserCookie(request, response, AuthStateCookieName)
+
+		default:
+			auditLogFields["error"] = ErrorInvalidAuthProvider
+			WriteErrorResponse(requestCtx, BuildErrorResponse(http.StatusBadRequest, ErrorInvalidAuthProvider.Error(), request), response)
 			return
 		}
 
-	case model.OIDCProvider:
-		//todo connect to db provider table
+		if sessionJWT, err := s.CreateSession(requestCtx, user, authProvider); err != nil {
+			auditLogFields["error"] = err
+			if locationURL := URLJoinPath(hostURL, UserDisabledPath); errors.Is(err, ErrUserDisabled) {
+				response.Header().Add(headers.Location.String(), locationURL.String())
+				response.WriteHeader(http.StatusFound)
+			} else {
+				WriteErrorResponse(requestCtx, BuildErrorResponse(http.StatusInternalServerError, "session creation failure", request), response)
+			}
+		} else {
+			auditLogOutcome = model.AuditLogStatusSuccess
 
-		// Delete pre-auth cookies regardless
-		DeleteBrowserCookie(request, response, AuthPKCECookieName)
-		DeleteBrowserCookie(request, response, AuthStateCookieName)
+			locationURL := URLJoinPath(hostURL, UserInterfacePath)
 
-	default:
-		loginError = ErrorInvalidAuthProvider
-		WriteErrorResponse(requestCtx, BuildErrorResponse(http.StatusBadRequest, "invalid auth provider", request), response)
-		return
-	}
+			// Set the token cookie
+			SetSecureBrowserCookie(request, response, AuthTokenCookieName, sessionJWT, time.Now().UTC().Add(s.cfg.AuthSessionTTL()), false)
 
-	if sessionJWT, err := s.CreateSession(requestCtx, user, authProvider); err != nil {
-		loginError = err
-		if locationURL := URLJoinPath(hostURL, UserDisabledPath); errors.Is(err, ErrUserDisabled) {
+			// Redirect back to the UI landing page
 			response.Header().Add(headers.Location.String(), locationURL.String())
 			response.WriteHeader(http.StatusFound)
-		} else {
-			WriteErrorResponse(requestCtx, BuildErrorResponse(http.StatusInternalServerError, "session creation failure", request), response)
 		}
-	} else {
-		loginOutcome = model.AuditLogStatusSuccess
-
-		locationURL := URLJoinPath(hostURL, UserInterfacePath)
-
-		// Set the token cookie
-		SetSecureBrowserCookie(request, response, AuthTokenCookieName, sessionJWT, time.Now().UTC().Add(s.cfg.AuthSessionTTL()), false)
-
-		// Redirect back to the UI landing page
-		response.Header().Add(headers.Location.String(), locationURL.String())
-		response.WriteHeader(http.StatusFound)
 	}
 }
 
@@ -452,7 +442,7 @@ func (s authenticator) CreateSession(ctx context.Context, user model.User, authP
 		userSession.AuthProviderType = model.SessionAuthProviderOIDC
 		userSession.AuthProviderID = typedAuthProvider.ID
 	default:
-		return "", errors.New("invalid auth provider")
+		return "", ErrorInvalidAuthProvider
 	}
 
 	if newSession, err := s.db.CreateUserSession(ctx, userSession); err != nil {

--- a/cmd/api/src/api/auth.go
+++ b/cmd/api/src/api/auth.go
@@ -49,7 +49,7 @@ const (
 	ErrInvalidAuth                    = errors.Error("invalid authentication")
 	ErrNoUserSecret                   = errors.Error("user does not have a secret auth provider registered")
 	ErrUserDisabled                   = errors.Error("user disabled")
-	ErrorUserNotAuthorizedForProvider = errors.Error("User not authorized for this provider")
+	ErrorUserNotAuthorizedForProvider = errors.Error("user not authorized for this provider")
 	ErrorInvalidAuthProvider          = errors.Error("invalid auth provider")
 )
 

--- a/cmd/api/src/api/auth.go
+++ b/cmd/api/src/api/auth.go
@@ -363,7 +363,7 @@ func (s authenticator) CreateSSOSession(request *http.Request, response http.Res
 	// Generate commit ID for audit logging
 	if commitID, err = uuid.NewV4(); err != nil {
 		log.Errorf("Error generating commit ID for login: %s", err)
-		WriteErrorResponse(requestCtx, BuildErrorResponse(http.StatusInternalServerError, "session creation failure", request), response)
+		WriteErrorResponse(requestCtx, BuildErrorResponse(http.StatusInternalServerError, "audit log creation failure", request), response)
 		return
 	}
 

--- a/cmd/api/src/api/auth_internal_test.go
+++ b/cmd/api/src/api/auth_internal_test.go
@@ -82,7 +82,7 @@ func buildAuditLog(testCtx context.Context, user model.User, loginRequest LoginR
 		Action:          model.AuditLogActionLoginAttempt,
 		ActorName:       user.PrincipalName,
 		ActorEmail:      user.EmailAddress.ValueOrZero(),
-		Fields:          types.JSONUntypedObject{"username": loginRequest.Username},
+		Fields:          types.JSONUntypedObject{"username": loginRequest.Username, "auth_type": loginRequest.LoginMethod},
 		RequestID:       bhCtx.RequestID,
 		SourceIpAddress: bhCtx.RequestIP,
 		Status:          status,

--- a/cmd/api/src/api/saml/saml.go
+++ b/cmd/api/src/api/saml/saml.go
@@ -51,9 +51,7 @@ const (
 )
 
 const (
-	ErrorUserNotFound                 = errors.Error("User not found")
-	ErrorSAMLAssertion                = errors.Error("SAML assertion error")
-	ErrorUserNotAuthorizedForProvider = errors.Error("User not authorized for this provider")
+	ErrorSAMLAssertion = errors.Error("SAML assertion error")
 )
 
 type WriteAPIErrorResponse func(request *http.Request, response http.ResponseWriter, statusCode int, message string)

--- a/cmd/api/src/auth/model.go
+++ b/cmd/api/src/auth/model.go
@@ -35,6 +35,8 @@ import (
 
 const (
 	ProviderTypeSecret = "secret"
+	ProviderTypeSAML   = "saml"
+	ProviderTypeOIDC   = "oidc"
 
 	HMAC_SHA2_256 = "hmac-sha2-256"
 )

--- a/cmd/api/src/config/default.go
+++ b/cmd/api/src/config/default.go
@@ -18,7 +18,6 @@ package config
 
 import (
 	"fmt"
-
 	"github.com/specterops/bloodhound/dawgs/drivers/neo4j"
 
 	"github.com/specterops/bloodhound/src/serde"

--- a/cmd/api/src/database/sso_providers.go
+++ b/cmd/api/src/database/sso_providers.go
@@ -98,7 +98,6 @@ func (s *BloodhoundDB) GetAllSSOProviders(ctx context.Context, order string, sql
 	if sqlFilter.SQLString != "" {
 		query = query.Where(sqlFilter.SQLString, sqlFilter.Params...)
 	}
-
 	// Apply sorting order if provided
 	if order != "" {
 		query = query.Order(order)


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

The bugfix provided from #913 is no longer valid after the refactoring of `createSessionFromAssertion` from the latest changeset in #898. This PR addresses BED-4931, factoring the changes from #898

## Motivation and Context

This PR addresses: BED-4931

## How Has This Been Tested?

- Manually tested via API explorer
- Unit testing in `auth_internal_test.go`
- Unit testing in `saml_internal_test.go`

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [X] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [X] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [X] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
