### PR TITLE
refactor: old saml urls redirect to new sso url

### DIFF
--- a/cmd/api/src/api/auth.go
+++ b/cmd/api/src/api/auth.go
@@ -385,14 +385,12 @@ func (s authenticator) CreateSSOSession(request *http.Request, response http.Res
 				WriteErrorResponse(requestCtx, BuildErrorResponse(http.StatusForbidden, "user is not allowed", request), response)
 				return
 			}
-
 		case model.OIDCProvider:
 			//todo connect to db provider table
 
 			// Delete pre-auth cookies regardless
 			DeleteBrowserCookie(request, response, AuthPKCECookieName)
 			DeleteBrowserCookie(request, response, AuthStateCookieName)
-
 		default:
 			auditLogFields["error"] = ErrorInvalidAuthProvider
 			WriteErrorResponse(requestCtx, BuildErrorResponse(http.StatusBadRequest, ErrorInvalidAuthProvider.Error(), request), response)

--- a/cmd/api/src/api/saml/saml_internal_test.go
+++ b/cmd/api/src/api/saml/saml_internal_test.go
@@ -104,7 +104,7 @@ func TestAuth_CreateSSOSession(t *testing.T) {
 		mockDB.EXPECT().LookupUser(gomock.Any(), username).Return(user, nil)
 		mockDB.EXPECT().CreateUserSession(gomock.Any(), gomock.Any()).Return(model.UserSession{}, nil)
 
-		principalName, err := resource.getSAMLUserPrincipalNameFromAssertion(testAssertion)
+		principalName, err := resource.GetSAMLUserPrincipalNameFromAssertion(testAssertion)
 		require.Nil(t, err)
 
 		testAuthenticator.CreateSSOSession(httpRequest, response, principalName, resource.serviceProvider.Config)
@@ -126,7 +126,7 @@ func TestAuth_CreateSSOSession(t *testing.T) {
 				require.Equal(t, database.ErrNotFound, log.Fields["error"])
 			}
 		})
-		principalName, err := resource.getSAMLUserPrincipalNameFromAssertion(testAssertion)
+		principalName, err := resource.GetSAMLUserPrincipalNameFromAssertion(testAssertion)
 		require.Nil(t, err)
 
 		testAuthenticator.CreateSSOSession(httpRequest, response, principalName, resource.serviceProvider.Config)
@@ -148,7 +148,7 @@ func TestAuth_CreateSSOSession(t *testing.T) {
 
 		mockDB.EXPECT().LookupUser(gomock.Any(), username).Return(model.User{}, nil)
 
-		principalName, err := resource.getSAMLUserPrincipalNameFromAssertion(testAssertion)
+		principalName, err := resource.GetSAMLUserPrincipalNameFromAssertion(testAssertion)
 		require.Nil(t, err)
 
 		testAuthenticator.CreateSSOSession(httpRequest, response, principalName, resource.serviceProvider.Config)
@@ -176,7 +176,7 @@ func TestAuth_CreateSSOSession(t *testing.T) {
 			},
 		}, nil)
 
-		principalName, err := resource.getSAMLUserPrincipalNameFromAssertion(testAssertion)
+		principalName, err := resource.GetSAMLUserPrincipalNameFromAssertion(testAssertion)
 		require.Nil(t, err)
 
 		testAuthenticator.CreateSSOSession(httpRequest, response, principalName, resource.serviceProvider.Config)
@@ -187,7 +187,7 @@ func TestAuth_CreateSSOSession(t *testing.T) {
 	t.Run("Correctly fails with SAML assertion error if assertion is invalid", func(t *testing.T) {
 		testAssertion.AttributeStatements[0].Attributes[0].Values = nil
 
-		_, err := resource.getSAMLUserPrincipalNameFromAssertion(testAssertion)
+		_, err := resource.GetSAMLUserPrincipalNameFromAssertion(testAssertion)
 		require.ErrorIs(t, err, ErrorSAMLAssertion)
 	})
 }

--- a/cmd/api/src/api/v2/auth/auth.go
+++ b/cmd/api/src/api/v2/auth/auth.go
@@ -75,6 +75,30 @@ func NewManagementResource(authConfig config.Configuration, db database.Database
 	}
 }
 
+func (s ManagementResource) SAMLLoginRedirect(response http.ResponseWriter, request *http.Request) {
+	ssoProviderSlug := mux.Vars(request)[api.URIPathVariableServiceProviderName]
+
+	if ssoProvider, err := s.db.GetSSOProviderBySlug(request.Context(), ssoProviderSlug); err != nil {
+		api.HandleDatabaseError(request, response, err)
+	} else {
+		bheCtx := ctx.FromRequest(request)
+		redirectURL := api.URLJoinPath(*bheCtx.Host, fmt.Sprintf("/api/v2/sso/%s/login", ssoProvider.Slug))
+		http.Redirect(response, request, redirectURL.String(), http.StatusFound)
+	}
+}
+
+func (s ManagementResource) SAMLCallbackRedirect(response http.ResponseWriter, request *http.Request) {
+	ssoProviderSlug := mux.Vars(request)[api.URIPathVariableServiceProviderName]
+
+	if ssoProvider, err := s.db.GetSSOProviderBySlug(request.Context(), ssoProviderSlug); err != nil {
+		api.HandleDatabaseError(request, response, err)
+	} else {
+		bheCtx := ctx.FromRequest(request)
+		redirectURL := api.URLJoinPath(*bheCtx.Host, fmt.Sprintf("/api/v2/sso/%s/callback", ssoProvider.Slug))
+		http.Redirect(response, request, redirectURL.String(), http.StatusTemporaryRedirect)
+	}
+}
+
 func (s ManagementResource) ListSAMLSignOnEndpoints(response http.ResponseWriter, request *http.Request) {
 	if samlProviders, err := bhsaml.GetAllSAMLProviders(s.db, request.Context()); err != nil {
 		api.HandleDatabaseError(request, response, err)

--- a/cmd/api/src/api/v2/auth/saml.go
+++ b/cmd/api/src/api/v2/auth/saml.go
@@ -1,0 +1,158 @@
+package auth
+
+import (
+	"context"
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/crewjam/saml"
+	"github.com/crewjam/saml/samlsp"
+	"github.com/gorilla/mux"
+	"github.com/specterops/bloodhound/crypto"
+	"github.com/specterops/bloodhound/headers"
+	"github.com/specterops/bloodhound/log"
+	"github.com/specterops/bloodhound/mediatypes"
+	"github.com/specterops/bloodhound/src/api"
+	saml2 "github.com/specterops/bloodhound/src/api/saml"
+	"github.com/specterops/bloodhound/src/auth/bhsaml"
+	"github.com/specterops/bloodhound/src/config"
+	bhCtx "github.com/specterops/bloodhound/src/ctx"
+	"github.com/specterops/bloodhound/src/model"
+)
+
+const (
+	// TODO: This might be better if generated at run-time. These values were taken from the crewjam SAML provider package
+	defaultContentSecurityPolicy    = "default-src; script-src 'sha256-AjPdJSbZmeWHnEc5ykvJFay8FTWeTeRbs9dutfZ0HqE='; reflected-xss block; referrer no-referrer;"
+	authInitiationContentBodyFormat = `<!DOCTYPE html>
+<html>
+<body>
+%s
+</body>
+</html>
+`
+)
+
+func serviceProviderFactory(ctx context.Context, cfg config.Configuration, samlProvider model.SAMLProvider) (bhsaml.ServiceProvider, error) {
+	if spCert, spKey, err := crypto.X509ParsePair(cfg.SAML.ServiceProviderCertificate, cfg.SAML.ServiceProviderKey); err != nil {
+		return bhsaml.ServiceProvider{}, fmt.Errorf("failed to parse service provider %s's cert pair: %w", samlProvider.Name, err)
+	} else if idpMetadata, err := samlsp.ParseMetadata(samlProvider.MetadataXML); err != nil {
+		return bhsaml.ServiceProvider{}, fmt.Errorf("failed to parse metadata XML for service provider %s: %w", samlProvider.Name, err)
+	} else {
+		return bhsaml.NewServiceProvider(samlProvider, bhsaml.FormatServiceProviderURLs(*bhCtx.Get(ctx).Host, samlProvider.Name), samlsp.Options{
+			EntityID:          samlProvider.ServiceProviderIssuerURI.String(),
+			URL:               samlProvider.ServiceProviderIssuerURI.AsURL(),
+			Key:               spKey,
+			Certificate:       spCert,
+			AllowIDPInitiated: true,
+			SignRequest:       true,
+			IDPMetadata:       idpMetadata,
+		}), nil
+	}
+}
+
+func samlWriteAPIErrorResponse(request *http.Request, response http.ResponseWriter, statusCode int, message string) {
+	api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(statusCode, message, request), response)
+}
+
+// Preserve old metadata endpoint
+func (s ManagementResource) ServeMetadata(response http.ResponseWriter, request *http.Request) {
+	ssoProviderSlug := mux.Vars(request)[api.URIPathVariableServiceProviderName]
+
+	if ssoProvider, err := s.db.GetSSOProviderBySlug(request.Context(), ssoProviderSlug); err != nil {
+		api.HandleDatabaseError(request, response, err)
+	} else if ssoProvider.SAMLProvider == nil {
+		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusNotFound, api.ErrorResponseDetailsResourceNotFound, request), response)
+	} else if serviceProvider, err := serviceProviderFactory(request.Context(), s.config, *ssoProvider.SAMLProvider); err != nil {
+		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusInternalServerError, api.ErrorResponseDetailsInternalServerError, request), response)
+	} else {
+		if content, err := xml.MarshalIndent(serviceProvider.Metadata(), "", "  "); err != nil {
+			log.Errorf("[SAML] XML marshalling failure during service provider encoding for %s: %v", ssoProvider.SAMLProvider.IssuerURI, err)
+			api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusInternalServerError, api.ErrorResponseDetailsInternalServerError, request), response)
+		} else {
+			response.Header().Set(headers.ContentType.String(), mediatypes.ApplicationSamlmetadataXml.String())
+			if _, err := response.Write(content); err != nil {
+				log.Errorf("[SAML] Failed to write response for serving metadata: %v", err)
+			}
+		}
+	}
+}
+
+// HandleStartAuthFlow is called to start the SAML authentication process.
+func (s ManagementResource) SAMLLoginHandler(response http.ResponseWriter, request *http.Request, ssoProvider model.SSOProvider) {
+	if ssoProvider.SAMLProvider == nil {
+		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusNotFound, api.ErrorResponseDetailsResourceNotFound, request), response)
+	} else if serviceProvider, err := serviceProviderFactory(request.Context(), s.config, *ssoProvider.SAMLProvider); err != nil {
+		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusInternalServerError, api.ErrorResponseDetailsInternalServerError, request), response)
+	} else {
+		providerResource := saml2.NewProviderResource(s.db, s.config, serviceProvider, samlWriteAPIErrorResponse)
+		binding, bindingLocation := providerResource.BindingTypeAndLocation()
+		// relayState is limited to 80 bytes but also must be integrity protected.
+		// this means that we cannot use a JWT because it is way too long. Instead,
+		// we set a signed cookie that encodes the original URL which we'll check
+		// against the SAML response when we get it.
+		if authReq, err := serviceProvider.MakeAuthenticationRequest(bindingLocation, binding, providerResource.ResponseBindingType); err != nil {
+			log.Errorf("[SAML] Failed creating SAML authentication request: %v", err)
+			api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusInternalServerError, api.ErrorResponseDetailsInternalServerError, request), response)
+		} else if relayState, err := providerResource.RequestTracker.TrackRequest(response, request, authReq.ID); err != nil {
+			log.Errorf("[SAML] Failed to create a valid relay state token for SAML provider %s: %v", serviceProvider.EntityID, err)
+			http.Error(response, err.Error(), http.StatusInternalServerError)
+		} else {
+			switch binding {
+			case saml.HTTPRedirectBinding:
+				if redirectURL, err := authReq.Redirect(relayState, &serviceProvider.ServiceProvider); err != nil {
+					log.Errorf("[SAML] Failed to format a redirect for SAML provider %s: %v", serviceProvider.EntityID, err)
+					api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusInternalServerError, api.ErrorResponseDetailsInternalServerError, request), response)
+				} else {
+					response.Header().Add(headers.Location.String(), redirectURL.String())
+					response.WriteHeader(http.StatusFound)
+				}
+
+			case saml.HTTPPostBinding:
+				response.Header().Add(headers.ContentSecurityPolicy.String(), defaultContentSecurityPolicy)
+				response.Header().Add(headers.ContentType.String(), mediatypes.TextHtml.String())
+				response.WriteHeader(http.StatusOK)
+
+				if _, err := response.Write([]byte(fmt.Sprintf(authInitiationContentBodyFormat, authReq.Post(relayState)))); err != nil {
+					log.Errorf("[SAML] Failed to write response with HTTP POST binding: %v", err)
+				}
+
+			default:
+				log.Errorf("[SAML] Unhandled binding type %s", binding)
+				api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusInternalServerError, api.ErrorResponseDetailsInternalServerError, request), response)
+			}
+		}
+	}
+}
+
+// HandleStartAuthFlow is called to start the SAML authentication process.
+func (s ManagementResource) SAMLCallbackHandler(response http.ResponseWriter, request *http.Request, ssoProvider model.SSOProvider) {
+	if ssoProvider.SAMLProvider == nil {
+		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusNotFound, api.ErrorResponseDetailsResourceNotFound, request), response)
+	} else if serviceProvider, err := serviceProviderFactory(request.Context(), s.config, *ssoProvider.SAMLProvider); err != nil {
+		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusInternalServerError, api.ErrorResponseDetailsInternalServerError, request), response)
+	} else {
+		providerResource := saml2.NewProviderResource(s.db, s.config, serviceProvider, samlWriteAPIErrorResponse)
+		if err := request.ParseForm(); err != nil {
+			log.Errorf("[SAML] Failed to parse form POST: %v", err)
+			api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, "form POST is malformed", request), response)
+		} else {
+			if assertion, err := serviceProvider.ParseResponse(request, nil); err != nil {
+				var typedErr *saml.InvalidResponseError
+				switch {
+				case errors.As(err, &typedErr):
+					log.Errorf("[SAML] Failed to parse ACS response for provider %s: %v - %s", serviceProvider.URLs.ServiceProviderRoot.String(), typedErr.PrivateErr, typedErr.Response)
+				default:
+					log.Errorf("[SAML] Failed to parse ACS response for provider %s: %v", serviceProvider.URLs.ServiceProviderRoot.String(), err)
+				}
+				api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusUnauthorized, api.ErrorResponseDetailsAuthenticationInvalid, request), response)
+			} else if principalName, err := providerResource.GetSAMLUserPrincipalNameFromAssertion(assertion); err != nil {
+				log.Errorf("[SAML] Failed to lookup user for SAML provider %s: %v", serviceProvider.Config.Name, err)
+				api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, "session assertion does not meet the requirements for user lookup", request), response)
+			} else {
+				s.authenticator.CreateSSOSession(request, response, principalName, *ssoProvider.SAMLProvider)
+			}
+		}
+	}
+}

--- a/cmd/api/src/api/v2/auth/sso.go
+++ b/cmd/api/src/api/v2/auth/sso.go
@@ -165,14 +165,9 @@ func (s ManagementResource) SSOLoginHandler(response http.ResponseWriter, reques
 	} else {
 		switch ssoProvider.Type {
 		case model.SessionAuthProviderSAML:
-			//todo handle saml login
-			api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusNotImplemented, api.ErrorResponseDetailsNotImplemented, request), response)
+			s.SAMLLoginHandler(response, request, ssoProvider)
 		case model.SessionAuthProviderOIDC:
-			if ssoProvider.OIDCProvider == nil {
-				api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusNotFound, api.ErrorResponseDetailsResourceNotFound, request), response)
-			} else {
-				s.OIDCLoginHandler(response, request, ssoProvider, *ssoProvider.OIDCProvider)
-			}
+			s.OIDCLoginHandler(response, request, ssoProvider)
 		default:
 			api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusNotImplemented, api.ErrorResponseDetailsNotImplemented, request), response)
 		}
@@ -187,14 +182,9 @@ func (s ManagementResource) SSOCallbackHandler(response http.ResponseWriter, req
 	} else {
 		switch ssoProvider.Type {
 		case model.SessionAuthProviderSAML:
-			//todo handle saml callback
-			api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusNotImplemented, api.ErrorResponseDetailsNotImplemented, request), response)
+			s.SAMLCallbackHandler(response, request, ssoProvider)
 		case model.SessionAuthProviderOIDC:
-			if ssoProvider.OIDCProvider == nil {
-				api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusNotFound, api.ErrorResponseDetailsResourceNotFound, request), response)
-			} else {
-				s.OIDCCallbackHandler(response, request, ssoProvider, *ssoProvider.OIDCProvider)
-			}
+			s.OIDCCallbackHandler(response, request, ssoProvider)
 		default:
 			api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusNotImplemented, api.ErrorResponseDetailsNotImplemented, request), response)
 		}


### PR DESCRIPTION
## Description

- Setup redirects for old saml urls
- Dynamically generated the saml providers inside handlers

## Motivation and Context

This PR addresses: BED-4921

Allows old saml urls to continue to function by redirecting to the new generic sso login flow 

## How Has This Been Tested?

Locally

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
