### PR TITLE
BED-4932 (extension): Added structure for js-client endpoints for posture page

### DIFF
--- a/packages/javascript/js-client-library/src/client.ts
+++ b/packages/javascript/js-client-library/src/client.ts
@@ -31,6 +31,8 @@ import {
     ListFileTypesForIngestResponse,
     PaginatedResponse,
     PostureResponse,
+    PostureFindingTrendsResponse,
+    PostureHistoryResponse,
     SavedQuery,
     StartFileIngestResponse,
     UpdateConfigurationResponse,
@@ -161,6 +163,7 @@ class BHEAPIClient {
         this.baseClient.get<AssetGroupResponse>('/api/v2/asset-groups', options);
 
     /* analysis */
+
     getComboTreeGraph = (domainId: string, nodeId: string | null = null, options?: types.RequestOptions) =>
         this.baseClient.get(
             `/api/v2/meta-trees/${domainId}`,
@@ -270,6 +273,47 @@ class BHEAPIClient {
             Object.assign(
                 {
                     params: params,
+                },
+                options
+            )
+        );
+    };
+
+    getPostureFindingTrends = (
+        start: Date,
+        end: Date,
+        domainSID: string,
+        sort_by?: string,
+        options?: types.RequestOptions
+    ) => {
+        return this.baseClient.get<PostureFindingTrendsResponse>(
+            `/api/v2/finding-trends/${domainSID}`,
+            Object.assign(
+                {
+                    start: start?.toISOString(),
+                    end: end?.toISOString(),
+                    sort_by,
+                },
+                options
+            )
+        );
+    };
+
+    getPostureHistory = (
+        start: Date,
+        end: Date,
+        domainSID: string,
+        dataType: string,
+        partition_by?: string,
+        options?: types.RequestOptions
+    ) => {
+        return this.baseClient.get<PostureHistoryResponse>(
+            `/api/v2/posture-history/${domainSID}/${dataType}`,
+            Object.assign(
+                {
+                    start: start?.toISOString(),
+                    end: end?.toISOString(),
+                    partition_by,
                 },
                 options
             )

--- a/packages/javascript/js-client-library/src/responses.ts
+++ b/packages/javascript/js-client-library/src/responses.ts
@@ -100,6 +100,25 @@ type PostureStat = TimestampFields & {
 
 export type PostureResponse = PaginatedResponse<PostureStat[]>;
 
+type PostureFindingTrend = {
+    finding: string;
+    start_count: number;
+    end_count: number;
+    severity: string;
+};
+
+export type PostureFindingTrendsResponse = { findings: PostureFindingTrend[]; total_start: number; total_end: number };
+
+type PostureHistoryAggregatedData = {
+    date: string;
+    min: number;
+    max: number;
+    average: number;
+    count: number;
+};
+
+export type PostureHistoryResponse = { aggregation_data: PostureHistoryAggregatedData[] };
+
 type DatapipeStatus = {
     status: 'idle' | 'ingesting' | 'analyzing' | 'purging';
     last_complete_analysis_at: string;


### PR DESCRIPTION
## Description

To setup mock data calls, added structure of finding-trends and posture-history js-client api calls. 

## Motivation and Context

This PR is part of setting up the posture page for subsequent tickets, so in a sense it addresses [BED-4932](https://specterops.atlassian.net/browse/BED-4932) although it wasn't specifically stated in the AC.

It helps build out the components with mock data and being able to setup the actual calls that will be used.

## How Has This Been Tested?

Testes this manually

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)
- New feature (non-breaking change which adds functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
