### PR TITLE
FEAT/CHORE/BUG: Cypher Updates

### DIFF
--- a/cmd/api/src/api/v2/auth/saml.go
+++ b/cmd/api/src/api/v2/auth/saml.go
@@ -1,3 +1,19 @@
+// Copyright 2024 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package auth
 
 import (

--- a/packages/go/graphschema/ad/ad.go
+++ b/packages/go/graphschema/ad/ad.go
@@ -21,7 +21,6 @@ package ad
 
 import (
 	"errors"
-
 	graph "github.com/specterops/bloodhound/dawgs/graph"
 )
 

--- a/packages/go/graphschema/azure/azure.go
+++ b/packages/go/graphschema/azure/azure.go
@@ -21,7 +21,6 @@ package azure
 
 import (
 	"errors"
-
 	graph "github.com/specterops/bloodhound/dawgs/graph"
 )
 

--- a/packages/go/graphschema/common/common.go
+++ b/packages/go/graphschema/common/common.go
@@ -21,7 +21,6 @@ package common
 
 import (
 	"errors"
-
 	graph "github.com/specterops/bloodhound/dawgs/graph"
 )
 

--- a/packages/javascript/bh-shared-ui/src/commonSearches.tsx
+++ b/packages/javascript/bh-shared-ui/src/commonSearches.tsx
@@ -143,7 +143,15 @@ export const CommonSearches: CommonSearchType[] = [
             },
             {
                 description: 'Shortest paths to Domain Admins',
-                cypher: `MATCH p=shortestPath((n)-[:${adTransitEdgeTypes}*1..]->(g:Group))\nWHERE g.objectid ENDS WITH '-512' AND n<>g\nRETURN p\nLIMIT 1000`,
+                cypher: `MATCH p=shortestPath((n:Base)-[:${adTransitEdgeTypes}*1..]->(g:Group))\nWHERE g.objectid ENDS WITH '-512' AND n<>g\nRETURN p\nLIMIT 1000`,
+            },
+            {
+                description: 'Shortest paths from Owned objects to Tier Zero',
+                cypher: `// MANY TO MANY SHORTEST PATH QUERIES USE EXCESSIVE SYSTEM RESOURCES AND TYPICALLY WILL NOT COMPLETE\n// UNCOMMENT THE FOLLOWING LINES BY REMOVING THE DOUBLE FORWARD SLASHES AT YOUR OWN RISK\n// MATCH p=shortestPath((n)-[:${adTransitEdgeTypes}*1..]->(m))\n// WHERE "admin_tier_0" IN split(m.system_tags, ' ') AND n<>m\n// AND "owned" IN split(n.system_tags,' ')\n// RETURN p\n// LIMIT 1000`,
+            },
+            {
+                description: 'Shortest paths from Owned objects',
+                cypher: `MATCH p=shortestPath((n:Base)-[:${adTransitEdgeTypes}*1..]->(g:Base))\nWHERE 'owned' IN split(n.system_tags,' ') AND n<>g\nRETURN p\nLIMIT 1000`,
             },
         ],
     },

--- a/packages/javascript/bh-shared-ui/src/commonSearches.tsx
+++ b/packages/javascript/bh-shared-ui/src/commonSearches.tsx
@@ -109,7 +109,7 @@ export const CommonSearches: CommonSearchType[] = [
             },
             {
                 description: 'Kerberoastable users with most privileges',
-                cypher: `MATCH (u:User)\nOPTIONAL MATCH (u)-[:AdminTo]->(c1:Computer)\nOPTIONAL MATCH (u)-[:MemberOf*1..]->(:Group)-[:AdminTo]->(c2:Computer)\nWITH u,COLLECT(c1) + COLLECT(c2) AS tempVar\nUNWIND tempVar AS comps\nWHERE u.hasspn=true\nAND u.enabled = true\nAND NOT u.objectid ENDS WITH "-502"\nRETURN u\nLIMIT 100`,
+                cypher: `MATCH (u:User)\nOPTIONAL MATCH (u)-[:AdminTo]->(c1:Computer)\nOPTIONAL MATCH (u)-[:MemberOf*1..]->(:Group)-[:AdminTo]->(c2:Computer)\nWHERE u.hasspn=true\nAND u.enabled = true\nAND NOT u.objectid ENDS WITH "-502"\nWITH u,COLLECT(c1) + COLLECT(c2) AS tempVar\nUNWIND tempVar AS comps\nRETURN u\nLIMIT 100`,
             },
             {
                 description: 'AS-REP Roastable users (DontReqPreAuth)',

--- a/packages/javascript/bh-shared-ui/src/commonSearches.tsx
+++ b/packages/javascript/bh-shared-ui/src/commonSearches.tsx
@@ -105,15 +105,15 @@ export const CommonSearches: CommonSearchType[] = [
         queries: [
             {
                 description: 'Kerberoastable members of Tier Zero / High Value groups',
-                cypher: `MATCH p=shortestPath((n:User)-[:MemberOf]->(g:Group))\nWHERE 'admin_tier_0' IN split(g.system_tags, ' ') AND n.hasspn=true\nAND n.enabled = true\nAND NOT n.objectid ENDS WITH "-502"\nRETURN p\nLIMIT 1000`,
+                cypher: `MATCH p=shortestPath((n:User)-[:MemberOf]->(g:Group))\nWHERE 'admin_tier_0' IN split(g.system_tags, ' ') AND n.hasspn=true\nAND n.enabled = true\nAND NOT n.objectid ENDS WITH '-502'\nRETURN p\nLIMIT 1000`,
             },
             {
                 description: 'All Kerberoastable users',
-                cypher: 'MATCH (u:User)\nWHERE u.hasspn=true\nAND u.enabled = true\nAND NOT u.objectid ENDS WITH "-502"\nRETURN u\nLIMIT 100',
+                cypher: `MATCH (u:User)\nWHERE u.hasspn=true\nAND u.enabled = true\nAND NOT u.objectid ENDS WITH '-502'\nRETURN u\nLIMIT 100`,
             },
             {
                 description: 'Kerberoastable users with most privileges',
-                cypher: `MATCH (u:User)\nOPTIONAL MATCH (u)-[:AdminTo]->(c1:Computer)\nOPTIONAL MATCH (u)-[:MemberOf*1..]->(:Group)-[:AdminTo]->(c2:Computer)\nWHERE u.hasspn=true\nAND u.enabled = true\nAND NOT u.objectid ENDS WITH "-502"\nWITH u,COLLECT(c1) + COLLECT(c2) AS tempVar\nUNWIND tempVar AS comps\nRETURN u\nLIMIT 100`,
+                cypher: `MATCH (u:User)\nOPTIONAL MATCH (u)-[:AdminTo]->(c1:Computer)\nOPTIONAL MATCH (u)-[:MemberOf*1..]->(:Group)-[:AdminTo]->(c2:Computer)\nWHERE u.hasspn=true\nAND u.enabled = true\nAND NOT u.objectid ENDS WITH '-502'\nWITH u,COLLECT(c1) + COLLECT(c2) AS tempVar\nUNWIND tempVar AS comps\nRETURN u\nLIMIT 100`,
             },
             {
                 description: 'AS-REP Roastable users (DontReqPreAuth)',
@@ -147,7 +147,7 @@ export const CommonSearches: CommonSearchType[] = [
             },
             {
                 description: 'Shortest paths from Owned objects to Tier Zero',
-                cypher: `// MANY TO MANY SHORTEST PATH QUERIES USE EXCESSIVE SYSTEM RESOURCES AND TYPICALLY WILL NOT COMPLETE\n// UNCOMMENT THE FOLLOWING LINES BY REMOVING THE DOUBLE FORWARD SLASHES AT YOUR OWN RISK\n// MATCH p=shortestPath((n)-[:${adTransitEdgeTypes}*1..]->(m))\n// WHERE "admin_tier_0" IN split(m.system_tags, ' ') AND n<>m\n// AND "owned" IN split(n.system_tags,' ')\n// RETURN p\n// LIMIT 1000`,
+                cypher: `// MANY TO MANY SHORTEST PATH QUERIES USE EXCESSIVE SYSTEM RESOURCES AND TYPICALLY WILL NOT COMPLETE\n// UNCOMMENT THE FOLLOWING LINES BY REMOVING THE DOUBLE FORWARD SLASHES AT YOUR OWN RISK\n// MATCH p=shortestPath((n)-[:${adTransitEdgeTypes}*1..]->(m))\n// WHERE 'admin_tier_0' IN split(m.system_tags, ' ') AND n<>m\n// AND 'owned' IN split(n.system_tags,' ')\n// RETURN p\n// LIMIT 1000`,
             },
             {
                 description: 'Shortest paths from Owned objects',

--- a/packages/javascript/bh-shared-ui/src/commonSearches.tsx
+++ b/packages/javascript/bh-shared-ui/src/commonSearches.tsx
@@ -7,7 +7,7 @@
 //     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an 'AS IS' BASIS,
+// distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.

--- a/packages/javascript/bh-shared-ui/src/commonSearches.tsx
+++ b/packages/javascript/bh-shared-ui/src/commonSearches.tsx
@@ -101,19 +101,19 @@ export const CommonSearches: CommonSearchType[] = [
         queries: [
             {
                 description: 'Kerberoastable members of Tier Zero / High Value groups',
-                cypher: `MATCH p=shortestPath((n:User)-[:MemberOf]->(g:Group))\nWHERE 'admin_tier_0' IN split(g.system_tags, ' ') AND n.hasspn=true\nRETURN p\nLIMIT 1000`,
+                cypher: `MATCH p=shortestPath((n:User)-[:MemberOf]->(g:Group))\nWHERE 'admin_tier_0' IN split(g.system_tags, ' ') AND n.hasspn=true\nAND n.enabled = true\nAND NOT n.objectid ENDS WITH "-502"\nRETURN p\nLIMIT 1000`,
             },
             {
                 description: 'All Kerberoastable users',
-                cypher: 'MATCH (n:User)\nWHERE n.hasspn=true\nRETURN n\nLIMIT 100',
+                cypher: 'MATCH (u:User)\nWHERE u.hasspn=true\nAND u.enabled = true\nAND NOT u.objectid ENDS WITH "-502"\nRETURN u\nLIMIT 100',
             },
             {
                 description: 'Kerberoastable users with most privileges',
-                cypher: `MATCH (u:User {hasspn:true})\nOPTIONAL MATCH (u)-[:AdminTo]->(c1:Computer)\nOPTIONAL MATCH (u)-[:MemberOf*1..]->(:Group)-[:AdminTo]->(c2:Computer)\nWITH u,COLLECT(c1) + COLLECT(c2) AS tempVar\nUNWIND tempVar AS comps\nRETURN u\nLIMIT 100`,
+                cypher: `MATCH (u:User)\nOPTIONAL MATCH (u)-[:AdminTo]->(c1:Computer)\nOPTIONAL MATCH (u)-[:MemberOf*1..]->(:Group)-[:AdminTo]->(c2:Computer)\nWITH u,COLLECT(c1) + COLLECT(c2) AS tempVar\nUNWIND tempVar AS comps\nWHERE u.hasspn=true\nAND u.enabled = true\nAND NOT u.objectid ENDS WITH "-502"\nRETURN u\nLIMIT 100`,
             },
             {
                 description: 'AS-REP Roastable users (DontReqPreAuth)',
-                cypher: `MATCH (u:User)\nWHERE u.dontreqpreauth = true\nRETURN u\nLIMIT 100`,
+                cypher: `MATCH (u:User)\nWHERE u.dontreqpreauth = true\nAND u.enabled = true\nRETURN u\nLIMIT 100`,
             },
         ],
     },

--- a/packages/javascript/bh-shared-ui/src/commonSearches.tsx
+++ b/packages/javascript/bh-shared-ui/src/commonSearches.tsx
@@ -51,6 +51,10 @@ export const CommonSearches: CommonSearchType[] = [
                 description: 'Locations of Tier Zero / High Value objects',
                 cypher: `MATCH p = (:Domain)-[:Contains*1..]->(n:Base)\nWHERE 'admin_tier_0' IN split(n.system_tags, ' ')\nRETURN p\nLIMIT 1000`,
             },
+            {
+                description: 'Map OU structure',
+                cypher: `MATCH p = (:Domain)-[:Contains*1..]->(n:OU)\nRETURN p\nLIMIT 1000`,
+            },
         ],
     },
     {

--- a/packages/javascript/bh-shared-ui/src/commonSearches.tsx
+++ b/packages/javascript/bh-shared-ui/src/commonSearches.tsx
@@ -7,7 +7,7 @@
 //     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
+// distributed under the License is distributed on an 'AS IS' BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
@@ -41,7 +41,7 @@ export const CommonSearches: CommonSearchType[] = [
         queries: [
             {
                 description: 'All Domain Admins',
-                cypher: `MATCH p=(n:Group)<-[:MemberOf*1..]-(m:Base)\nWHERE n.objectid ENDS WITH "-512"\nRETURN p\nLIMIT 1000`,
+                cypher: `MATCH p=(n:Group)<-[:MemberOf*1..]-(m:Base)\nWHERE n.objectid ENDS WITH '-512'\nRETURN p\nLIMIT 1000`,
             },
             {
                 description: 'Map domain trusts',
@@ -49,7 +49,7 @@ export const CommonSearches: CommonSearchType[] = [
             },
             {
                 description: 'Locations of Tier Zero / High Value objects',
-                cypher: `MATCH p = (:Domain)-[:Contains*1..]->(n:Base)\nWHERE "admin_tier_0" IN split(n.system_tags, ' ')\nRETURN p\nLIMIT 1000`,
+                cypher: `MATCH p = (:Domain)-[:Contains*1..]->(n:Base)\nWHERE 'admin_tier_0' IN split(n.system_tags, ' ')\nRETURN p\nLIMIT 1000`,
             },
         ],
     },
@@ -67,27 +67,27 @@ export const CommonSearches: CommonSearchType[] = [
             },
             {
                 description: 'Computers where Domain Users are local administrators',
-                cypher: `MATCH p=(m:Group)-[:AdminTo]->(n:Computer)\nWHERE m.objectid ENDS WITH "-513"\nRETURN p\nLIMIT 1000`,
+                cypher: `MATCH p=(m:Group)-[:AdminTo]->(n:Computer)\nWHERE m.objectid ENDS WITH '-513'\nRETURN p\nLIMIT 1000`,
             },
             {
                 description: 'Computers where Domain Users can read LAPS passwords',
-                cypher: `MATCH p=(m:Group)-[:AllExtendedRights|ReadLAPSPassword]->(n:Computer)\nWHERE m.objectid ENDS WITH "-513"\nRETURN p\nLIMIT 1000`,
+                cypher: `MATCH p=(m:Group)-[:AllExtendedRights|ReadLAPSPassword]->(n:Computer)\nWHERE m.objectid ENDS WITH '-513'\nRETURN p\nLIMIT 1000`,
             },
             {
                 description: 'Paths from Domain Users to Tier Zero / High Value targets',
-                cypher: `MATCH p=shortestPath((m:Group)-[:${adTransitEdgeTypes}*1..]->(n))\nWHERE "admin_tier_0" IN split(n.system_tags, ' ') AND m.objectid ENDS WITH "-513" AND m<>n\nRETURN p\nLIMIT 1000`,
+                cypher: `MATCH p=shortestPath((m:Group)-[:${adTransitEdgeTypes}*1..]->(n))\nWHERE 'admin_tier_0' IN split(n.system_tags, ' ') AND m.objectid ENDS WITH '-513' AND m<>n\nRETURN p\nLIMIT 1000`,
             },
             {
                 description: 'Workstations where Domain Users can RDP',
-                cypher: `MATCH p=(m:Group)-[:CanRDP]->(c:Computer)\nWHERE m.objectid ENDS WITH "-513" AND NOT toUpper(c.operatingsystem) CONTAINS "SERVER"\nRETURN p\nLIMIT 1000`,
+                cypher: `MATCH p=(m:Group)-[:CanRDP]->(c:Computer)\nWHERE m.objectid ENDS WITH '-513' AND NOT toUpper(c.operatingsystem) CONTAINS 'SERVER'\nRETURN p\nLIMIT 1000`,
             },
             {
                 description: 'Servers where Domain Users can RDP',
-                cypher: `MATCH p=(m:Group)-[:CanRDP]->(c:Computer)\nWHERE m.objectid ENDS WITH "-513" AND toUpper(c.operatingsystem) CONTAINS "SERVER"\nRETURN p\nLIMIT 1000`,
+                cypher: `MATCH p=(m:Group)-[:CanRDP]->(c:Computer)\nWHERE m.objectid ENDS WITH '-513' AND toUpper(c.operatingsystem) CONTAINS 'SERVER'\nRETURN p\nLIMIT 1000`,
             },
             {
                 description: 'Dangerous privileges for Domain Users groups',
-                cypher: `MATCH p=(m:Group)-[:${adTransitEdgeTypes}]->(n:Base)\nWHERE m.objectid ENDS WITH "-513"\nRETURN p\nLIMIT 1000`,
+                cypher: `MATCH p=(m:Group)-[:${adTransitEdgeTypes}]->(n:Base)\nWHERE m.objectid ENDS WITH '-513'\nRETURN p\nLIMIT 1000`,
             },
             {
                 description: 'Domain Admins logons to non-Domain Controllers',
@@ -101,7 +101,7 @@ export const CommonSearches: CommonSearchType[] = [
         queries: [
             {
                 description: 'Kerberoastable members of Tier Zero / High Value groups',
-                cypher: `MATCH p=shortestPath((n:User)-[:MemberOf]->(g:Group))\nWHERE "admin_tier_0" IN split(g.system_tags, ' ') AND n.hasspn=true\nRETURN p\nLIMIT 1000`,
+                cypher: `MATCH p=shortestPath((n:User)-[:MemberOf]->(g:Group))\nWHERE 'admin_tier_0' IN split(g.system_tags, ' ') AND n.hasspn=true\nRETURN p\nLIMIT 1000`,
             },
             {
                 description: 'All Kerberoastable users',
@@ -127,19 +127,19 @@ export const CommonSearches: CommonSearchType[] = [
             },
             {
                 description: 'Shortest paths to Domain Admins from Kerberoastable users',
-                cypher: `MATCH p=shortestPath((n:User)-[:${adTransitEdgeTypes}*1..]->(m:Group))\nWHERE n.hasspn = true AND m.objectid ENDS WITH "-512"\nRETURN p\nLIMIT 1000`,
+                cypher: `MATCH p=shortestPath((n:User)-[:${adTransitEdgeTypes}*1..]->(m:Group))\nWHERE n.hasspn = true AND m.objectid ENDS WITH '-512'\nRETURN p\nLIMIT 1000`,
             },
             {
                 description: 'Shortest paths to Tier Zero / High Value targets',
-                cypher: `MATCH p=shortestPath((n)-[:${adTransitEdgeTypes}*1..]->(m))\nWHERE "admin_tier_0" IN split(m.system_tags, ' ') AND n<>m\nRETURN p\nLIMIT 1000`,
+                cypher: `MATCH p=shortestPath((n)-[:${adTransitEdgeTypes}*1..]->(m))\nWHERE 'admin_tier_0' IN split(m.system_tags, ' ') AND n<>m\nRETURN p\nLIMIT 1000`,
             },
             {
                 description: 'Shortest paths from Domain Users to Tier Zero / High Value targets',
-                cypher: `MATCH p=shortestPath((n:Group)-[:${adTransitEdgeTypes}*1..]->(m))\nWHERE "admin_tier_0" IN split(m.system_tags, ' ') AND n.objectid ENDS WITH "-513" AND n<>m\nRETURN p\nLIMIT 1000`,
+                cypher: `MATCH p=shortestPath((n:Group)-[:${adTransitEdgeTypes}*1..]->(m))\nWHERE 'admin_tier_0' IN split(m.system_tags, ' ') AND n.objectid ENDS WITH '-513' AND n<>m\nRETURN p\nLIMIT 1000`,
             },
             {
                 description: 'Shortest paths to Domain Admins',
-                cypher: `MATCH p=shortestPath((n)-[:${adTransitEdgeTypes}*1..]->(g:Group))\nWHERE g.objectid ENDS WITH "-512" AND n<>g\nRETURN p\nLIMIT 1000`,
+                cypher: `MATCH p=shortestPath((n)-[:${adTransitEdgeTypes}*1..]->(g:Group))\nWHERE g.objectid ENDS WITH '-512' AND n<>g\nRETURN p\nLIMIT 1000`,
             },
         ],
     },
@@ -153,7 +153,7 @@ export const CommonSearches: CommonSearchType[] = [
             },
             {
                 description: 'Public Key Services container',
-                cypher: `MATCH p = (c:Container)-[:Contains*..]->(:Base)\nWHERE c.distinguishedname starts with "CN=PUBLIC KEY SERVICES,CN=SERVICES,CN=CONFIGURATION,DC="\nRETURN p\nLIMIT 1000`,
+                cypher: `MATCH p = (c:Container)-[:Contains*..]->(:Base)\nWHERE c.distinguishedname starts with 'CN=PUBLIC KEY SERVICES,CN=SERVICES,CN=CONFIGURATION,DC='\nRETURN p\nLIMIT 1000`,
             },
             {
                 description: 'Enrollment rights on published certificate templates',
@@ -165,11 +165,11 @@ export const CommonSearches: CommonSearchType[] = [
             },
             {
                 description: 'Enrollment rights on published ESC2 certificate templates',
-                cypher: `MATCH p = (:Base)-[:Enroll|GenericAll|AllExtendedRights]->(ct:CertTemplate)-[:PublishedTo]->(:EnterpriseCA)\nWHERE ct.requiresmanagerapproval = False\nAND (ct.effectiveekus = [] OR "2.5.29.37.0" IN ct.effectiveekus)\nAND (ct.authorizedsignatures = 0 OR ct.schemaversion = 1)\nRETURN p\nLIMIT 1000`,
+                cypher: `MATCH p = (:Base)-[:Enroll|GenericAll|AllExtendedRights]->(ct:CertTemplate)-[:PublishedTo]->(:EnterpriseCA)\nWHERE ct.requiresmanagerapproval = False\nAND (ct.effectiveekus = [] OR '2.5.29.37.0' IN ct.effectiveekus)\nAND (ct.authorizedsignatures = 0 OR ct.schemaversion = 1)\nRETURN p\nLIMIT 1000`,
             },
             {
                 description: 'Enrollment rights on published enrollment agent certificate templates',
-                cypher: `MATCH p = (:Base)-[:Enroll|GenericAll|AllExtendedRights]->(ct:CertTemplate)-[:PublishedTo]->(:EnterpriseCA)\nWHERE "1.3.6.1.4.1.311.20.2.1" IN ct.effectiveekus\nOR "2.5.29.37.0" IN ct.effectiveekus\nOR SIZE(ct.effectiveekus) = 0\nRETURN p\nLIMIT 1000`,
+                cypher: `MATCH p = (:Base)-[:Enroll|GenericAll|AllExtendedRights]->(ct:CertTemplate)-[:PublishedTo]->(:EnterpriseCA)\nWHERE '1.3.6.1.4.1.311.20.2.1' IN ct.effectiveekus\nOR '2.5.29.37.0' IN ct.effectiveekus\nOR SIZE(ct.effectiveekus) = 0\nRETURN p\nLIMIT 1000`,
             },
             {
                 description: 'Enrollment rights on published certificate templates with no security extension',
@@ -194,7 +194,7 @@ export const CommonSearches: CommonSearchType[] = [
             },
             {
                 description: 'Non-default permissions on IssuancePolicy nodes',
-                cypher: `MATCH p = (n:Base)-[:GenericAll|GenericWrite|Owns|WriteOwner|WriteDacl]->(:IssuancePolicy)\nWHERE NOT n.objectid ENDS WITH "-512" AND NOT n.objectid ENDS WITH "-519"\nRETURN p\nLIMIT 1000`,
+                cypher: `MATCH p = (n:Base)-[:GenericAll|GenericWrite|Owns|WriteOwner|WriteDacl]->(:IssuancePolicy)\nWHERE NOT n.objectid ENDS WITH '-512' AND NOT n.objectid ENDS WITH '-519'\nRETURN p\nLIMIT 1000`,
             },
             {
                 description: 'Enrollment rights on CertTemplates with OIDGroupLink',
@@ -208,11 +208,11 @@ export const CommonSearches: CommonSearchType[] = [
         queries: [
             {
                 description: 'Enabled Tier Zero / High Value principals inactive for 60 days',
-                cypher: `WITH 60 as inactive_days\nMATCH (n:Base)\nWHERE n.system_tags CONTAINS "admin_tier_0"\nAND n.enabled = true\nAND n.lastlogontimestamp < (datetime().epochseconds - (inactive_days * 86400)) // Replicated value\nAND n.lastlogon < (datetime().epochseconds - (inactive_days * 86400)) // Non-replicated value\nAND n.whencreated < (datetime().epochseconds - (inactive_days * 86400)) // Exclude recently created principals\nAND NOT n.name STARTS WITH "AZUREADKERBEROS." // Removes false positive, Azure KRBTGT\nAND NOT n.objectid ENDS WITH "-500" // Removes false positive, built-in Administrator\nAND NOT n.name STARTS WITH "AZUREADSSOACC." // Removes false positive, Entra Seamless SSO\nRETURN n`,
+                cypher: `WITH 60 as inactive_days\nMATCH (n:Base)\nWHERE n.system_tags CONTAINS 'admin_tier_0'\nAND n.enabled = true\nAND n.lastlogontimestamp < (datetime().epochseconds - (inactive_days * 86400)) // Replicated value\nAND n.lastlogon < (datetime().epochseconds - (inactive_days * 86400)) // Non-replicated value\nAND n.whencreated < (datetime().epochseconds - (inactive_days * 86400)) // Exclude recently created principals\nAND NOT n.name STARTS WITH 'AZUREADKERBEROS.' // Removes false positive, Azure KRBTGT\nAND NOT n.objectid ENDS WITH '-500' // Removes false positive, built-in Administrator\nAND NOT n.name STARTS WITH 'AZUREADSSOACC.' // Removes false positive, Entra Seamless SSO\nRETURN n`,
             },
             {
                 description: 'Tier Zero / High Value enabled users not requiring smart card authentication',
-                cypher: `MATCH (n:User)\nWHERE "admin_tier_0" IN split(n.system_tags, ' ')\nAND n.enabled = true\nAND n.smartcardrequired = false\nAND NOT n.name STARTS WITH "MSOL_" // Removes false positive, Entra sync\nAND NOT n.name STARTS WITH "PROVAGENTGMSA" // Removes false positive, Entra sync\nAND NOT n.name STARTS WITH "ADSYNCMSA_" // Removes false positive, Entra sync\nRETURN n`,
+                cypher: `MATCH (n:User)\nWHERE 'admin_tier_0' IN split(n.system_tags, ' ')\nAND n.enabled = true\nAND n.smartcardrequired = false\nAND NOT n.name STARTS WITH 'MSOL_' // Removes false positive, Entra sync\nAND NOT n.name STARTS WITH 'PROVAGENTGMSA' // Removes false positive, Entra sync\nAND NOT n.name STARTS WITH 'ADSYNCMSA_' // Removes false positive, Entra sync\nRETURN n`,
             },
             {
                 description: 'Domains where any user can join a computer to the domain',
@@ -228,7 +228,7 @@ export const CommonSearches: CommonSearchType[] = [
             },
             {
                 description: 'Computers with unsupported operating systems',
-                cypher: `MATCH (n:Computer)\nWHERE n.operatingsystem =~ "(?i).*Windows.* (2000|2003|2008|2012|xp|vista|7|8|me|nt).*"\nRETURN n\nLIMIT 100`,
+                cypher: `MATCH (n:Computer)\nWHERE n.operatingsystem =~ '(?i).*Windows.* (2000|2003|2008|2012|xp|vista|7|8|me|nt).*'\nRETURN n\nLIMIT 100`,
             },
             {
                 description: 'Users which do not require password to authenticate',
@@ -240,11 +240,11 @@ export const CommonSearches: CommonSearchType[] = [
             },
             {
                 description: 'Nested groups within Tier Zero / High Value',
-                cypher: `MATCH p=(n:Group)-[:MemberOf*..]->(t:Group)\nWHERE coalesce(t.system_tags,"") CONTAINS ('tier_0')\nAND NOT n.objectid ENDS WITH "-512" // Domain Admins\nAND NOT n.objectid ENDS WITH "-519" // Enterprise Admins\nRETURN p\nLIMIT 1000`,
+                cypher: `MATCH p=(n:Group)-[:MemberOf*..]->(t:Group)\nWHERE coalesce(t.system_tags,'') CONTAINS ('tier_0')\nAND NOT n.objectid ENDS WITH '-512' // Domain Admins\nAND NOT n.objectid ENDS WITH '-519' // Enterprise Admins\nRETURN p\nLIMIT 1000`,
             },
             {
                 description: 'Disabled Tier Zero / High Value principals',
-                cypher: `MATCH (n:Base)\nWHERE n.system_tags CONTAINS "admin_tier_0"\nAND n.enabled = false\nAND NOT n.objectid ENDS WITH "-502" // Removes false positive, KRBTGT\nAND NOT n.objectid ENDS WITH "-500" // Removes false positive, built-in Administrator\nRETURN n\nLIMIT 100`,
+                cypher: `MATCH (n:Base)\nWHERE n.system_tags CONTAINS 'admin_tier_0'\nAND n.enabled = false\nAND NOT n.objectid ENDS WITH '-502' // Removes false positive, KRBTGT\nAND NOT n.objectid ENDS WITH '-500' // Removes false positive, built-in Administrator\nRETURN n\nLIMIT 100`,
             },
             {
                 description: 'Principals with passwords stored using reversible encryption',
@@ -260,7 +260,7 @@ export const CommonSearches: CommonSearchType[] = [
             },
             {
                 description: 'Tier Zero / High Value users with non-expiring passwords',
-                cypher: `MATCH (u:User)\nWHERE u.enabled = true\nAND u.pwdneverexpires = true\nand u.system_tags CONTAINS "admin_tier_0"\nRETURN u\nLIMIT 100`,
+                cypher: `MATCH (u:User)\nWHERE u.enabled = true\nAND u.pwdneverexpires = true\nand u.system_tags CONTAINS 'admin_tier_0'\nRETURN u\nLIMIT 100`,
             },
         ],
     },
@@ -284,7 +284,7 @@ export const CommonSearches: CommonSearchType[] = [
         queries: [
             {
                 description: 'Shortest paths from Entra Users to Tier Zero / High Value targets',
-                cypher: `MATCH p=shortestPath((m:AZUser)-[r:${azureTransitEdgeTypes}*1..]->(n:AZBase))\nWHERE "admin_tier_0" IN split(n.system_tags, ' ') AND n.name =~ '(?i)${highPrivilegedRoleDisplayNameRegex}' AND m<>n\nRETURN p\nLIMIT 1000`,
+                cypher: `MATCH p=shortestPath((m:AZUser)-[r:${azureTransitEdgeTypes}*1..]->(n:AZBase))\nWHERE 'admin_tier_0' IN split(n.system_tags, ' ') AND n.name =~ '(?i)${highPrivilegedRoleDisplayNameRegex}' AND m<>n\nRETURN p\nLIMIT 1000`,
             },
             {
                 description: 'Shortest paths to privileged roles',
@@ -292,7 +292,7 @@ export const CommonSearches: CommonSearchType[] = [
             },
             {
                 description: 'Shortest paths from Azure Applications to Tier Zero / High Value targets',
-                cypher: `MATCH p=shortestPath((m:AZApp)-[r:${azureTransitEdgeTypes}*1..]->(n:AZBase))\nWHERE "admin_tier_0" IN split(n.system_tags, ' ') AND m<>n\nRETURN p\nLIMIT 1000`,
+                cypher: `MATCH p=shortestPath((m:AZApp)-[r:${azureTransitEdgeTypes}*1..]->(n:AZBase))\nWHERE 'admin_tier_0' IN split(n.system_tags, ' ') AND m<>n\nRETURN p\nLIMIT 1000`,
             },
             {
                 description: 'Shortest paths to Azure Subscriptions',
@@ -320,11 +320,11 @@ export const CommonSearches: CommonSearchType[] = [
         queries: [
             {
                 description: 'Foreign principals in Tier Zero / High Value targets',
-                cypher: `MATCH (n:AZServicePrincipal)\nWHERE n.system_tags contains 'admin_tier_0'\nAND NOT toUpper(n.appownerorganizationid) = toUpper(n.tenantid)\nAND n.appownerorganizationid CONTAINS "-"\nRETURN n\nLIMIT 100`,
+                cypher: `MATCH (n:AZServicePrincipal)\nWHERE n.system_tags contains 'admin_tier_0'\nAND NOT toUpper(n.appownerorganizationid) = toUpper(n.tenantid)\nAND n.appownerorganizationid CONTAINS '-'\nRETURN n\nLIMIT 100`,
             },
             {
                 description: 'Tier Zero AD principals synchronized with Entra ID',
-                cypher: `MATCH (ENTRA:AZBase)\nMATCH (AD:Base)\nWHERE ENTRA.onpremsyncenabled = true\nAND ENTRA.onpremid = AD.objectid\nAND AD.system_tags CONTAINS "admin_tier_0"\nRETURN ENTRA\n// Replace "RETURN ENTRA" with "RETURN AD" to see the corresponding AD principals\nLIMIT 100`,
+                cypher: `MATCH (ENTRA:AZBase)\nMATCH (AD:Base)\nWHERE ENTRA.onpremsyncenabled = true\nAND ENTRA.onpremid = AD.objectid\nAND AD.system_tags CONTAINS 'admin_tier_0'\nRETURN ENTRA\n// Replace 'RETURN ENTRA' with 'RETURN AD' to see the corresponding AD principals\nLIMIT 100`,
             },
             {
                 description: 'Tier Zero / High Value external Entra ID users',
@@ -332,7 +332,7 @@ export const CommonSearches: CommonSearchType[] = [
             },
             {
                 description: 'Disabled Tier Zero / High Value principals',
-                cypher: `MATCH (n:AZBase)\nWHERE n.system_tags CONTAINS "admin_tier_0"\nAND n.enabled = false\nRETURN n\nLIMIT 100`,
+                cypher: `MATCH (n:AZBase)\nWHERE n.system_tags CONTAINS 'admin_tier_0'\nAND n.enabled = false\nRETURN n\nLIMIT 100`,
             },
             {
                 description: 'Devices with unsupported operating systems',
@@ -346,7 +346,7 @@ export const CommonSearches: CommonSearchType[] = [
         queries: [
             {
                 description: 'Entra Users synced from On-Prem Users added to Domain Admins group',
-                cypher: 'MATCH p = (:AZUser)-[:SyncedToADUser]->(:User)-[:MemberOf]->(g:Group)\nWHERE g.objectid ENDS WITH "-512"\nRETURN p\nLIMIT 1000',
+                cypher: `MATCH p = (:AZUser)-[:SyncedToADUser]->(:User)-[:MemberOf]->(g:Group)\nWHERE g.objectid ENDS WITH '-512'\nRETURN p\nLIMIT 1000`,
             },
             {
                 description: 'On-Prem Users synced to Entra Users with Entra Admin Roles (direct)',


### PR DESCRIPTION
## Description

Multiple updates to pre-saved Cypher queries to add functionality and fix issues. Details in context below.

## Motivation and Context

This PR addresses:
- BED-4973: Kerberoastable queries did not properly include logic for accounts being enabled and excluding the KRBTGT account
- BED-4972: Saved Cypher queries utilized multiple quote styles making consumption via API a non-ideal experience in handling both double and single quotes.
- BED-4974: Re-adds the old "Map OU structure" query
- BED-4975 / #680: Adds two shortest path queries related to Owned objects

## How Has This Been Tested?

Tested locally with test data, validating that queries ran and returned accurate data.

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [X] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [X] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [X] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
