### PR TITLE
PostgreSQL Related Query Path Fixes

### DIFF
--- a/cmd/api/src/migrations/graph.go
+++ b/cmd/api/src/migrations/graph.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/specterops/bloodhound/dawgs/graph"
 	"github.com/specterops/bloodhound/dawgs/query"
-	"github.com/specterops/bloodhound/graphschema"
 	"github.com/specterops/bloodhound/graphschema/common"
 	"github.com/specterops/bloodhound/log"
 	"github.com/specterops/bloodhound/src/version"
@@ -164,10 +163,6 @@ func (s *GraphMigrator) executeMigrations(ctx context.Context, originalVersion v
 }
 
 func (s *GraphMigrator) executeStepwiseMigrations(ctx context.Context) error {
-	if err := s.db.AssertSchema(ctx, graphschema.DefaultGraphSchema()); err != nil {
-		return fmt.Errorf("error asserting current schema: %w", err)
-	}
-
 	if currentMigration, err := GetMigrationData(ctx, s.db); err != nil {
 		if errors.Is(err, ErrNoMigrationData) {
 			currentVersion := version.GetVersion()

--- a/packages/go/cypher/models/cypher/functions.go
+++ b/packages/go/cypher/models/cypher/functions.go
@@ -17,15 +17,16 @@
 package cypher
 
 const (
-	CountFunction         = "count"
-	DateFunction          = "date"
-	TimeFunction          = "time"
-	LocalTimeFunction     = "localtime"
-	DateTimeFunction      = "datetime"
-	LocalDateTimeFunction = "localdatetime"
-	DurationFunction      = "duration"
-	IdentityFunction      = "id"
-	ToLowerFunction       = "tolower"
-	NodeLabelsFunction    = "labels"
-	EdgeTypeFunction      = "type"
+	CountFunction              = "count"
+	DateFunction               = "date"
+	TimeFunction               = "time"
+	LocalTimeFunction          = "localtime"
+	DateTimeFunction           = "datetime"
+	LocalDateTimeFunction      = "localdatetime"
+	DurationFunction           = "duration"
+	IdentityFunction           = "id"
+	ToLowerFunction            = "tolower"
+	NodeLabelsFunction         = "labels"
+	EdgeTypeFunction           = "type"
+	StringSplitToArrayFunction = "split"
 )

--- a/packages/go/cypher/models/pgsql/functions.go
+++ b/packages/go/cypher/models/pgsql/functions.go
@@ -38,5 +38,6 @@ const (
 	FunctionUnnest                 Identifier = "unnest"
 	FunctionJSONBSet               Identifier = "jsonb_set"
 	FunctionCount                  Identifier = "count"
+	FunctionStringToArray          Identifier = "string_to_array"
 	FunctionEdgesToPath            Identifier = "edges_to_path"
 )

--- a/packages/go/cypher/models/pgsql/test/translation_cases/pattern_expansion.sql
+++ b/packages/go/cypher/models/pgsql/test/translation_cases/pattern_expansion.sql
@@ -34,7 +34,8 @@ with s0 as (with recursive ex0(root_id, next_id, depth, satisfied, is_cycle, pat
                                                                                        from ex0
                                                                                               join edge e0 on e0.start_id = ex0.next_id
                                                                                               join node n1 on n1.id = e0.end_id
-                                                                                       where ex0.depth < 5 and not ex0.is_cycle)
+                                                                                       where ex0.depth < 5
+                                                                                         and not ex0.is_cycle)
             select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0,
                    (select array_agg((e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite)
                     from edge e0
@@ -68,7 +69,8 @@ with s0 as (with recursive ex0(root_id, next_id, depth, satisfied, is_cycle, pat
                                                                                        from ex0
                                                                                               join edge e0 on e0.start_id = ex0.next_id
                                                                                               join node n1 on n1.id = e0.end_id
-                                                                                       where ex0.depth < 5 and not ex0.is_cycle)
+                                                                                       where ex0.depth < 5
+                                                                                         and not ex0.is_cycle)
             select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0,
                    (select array_agg((e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite)
                     from edge e0
@@ -105,7 +107,8 @@ with s0 as (with recursive ex0(root_id, next_id, depth, satisfied, is_cycle, pat
                                                                                        from ex0
                                                                                               join edge e0 on e0.start_id = ex0.next_id
                                                                                               join node n1 on n1.id = e0.end_id
-                                                                                       where ex0.depth < 5 and not ex0.is_cycle
+                                                                                       where ex0.depth < 5
+                                                                                         and not ex0.is_cycle
                                                                                          and e0.properties ->> 'prop' = 'a')
             select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0,
                    (select array_agg((e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite)
@@ -141,7 +144,8 @@ with s0 as (with recursive ex0(root_id, next_id, depth, satisfied, is_cycle, pat
                                                                                        from ex0
                                                                                               join edge e0 on e0.start_id = ex0.next_id
                                                                                               join node n1 on n1.id = e0.end_id
-                                                                                       where ex0.depth < 5 and not ex0.is_cycle)
+                                                                                       where ex0.depth < 5
+                                                                                         and not ex0.is_cycle)
             select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0,
                    (select array_agg((e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite)
                     from edge e0
@@ -176,7 +180,8 @@ with s0 as (with recursive ex0(root_id, next_id, depth, satisfied, is_cycle, pat
                                                                                        from ex0
                                                                                               join edge e0 on e0.start_id = ex0.next_id
                                                                                               join node n1 on n1.id = e0.end_id
-                                                                                       where ex0.depth < 5 and not ex0.is_cycle)
+                                                                                       where ex0.depth < 5
+                                                                                         and not ex0.is_cycle)
             select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0,
                    (select array_agg((e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite)
                     from edge e0
@@ -221,7 +226,8 @@ with s0 as (with recursive ex0(root_id, next_id, depth, satisfied, is_cycle, pat
                                                                                        from ex0
                                                                                               join edge e0 on e0.start_id = ex0.next_id
                                                                                               join node n1 on n1.id = e0.end_id
-                                                                                       where ex0.depth < 5 and not ex0.is_cycle)
+                                                                                       where ex0.depth < 5
+                                                                                         and not ex0.is_cycle)
             select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0,
                    (select array_agg((e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite)
                     from edge e0
@@ -263,7 +269,8 @@ with s0 as (with recursive ex0(root_id, next_id, depth, satisfied, is_cycle, pat
                                                                                        from ex1
                                                                                               join edge e2 on e2.start_id = ex1.next_id
                                                                                               join node n3 on n3.id = e2.end_id
-                                                                                       where ex1.depth < 5 and not ex1.is_cycle)
+                                                                                       where ex1.depth < 5
+                                                                                         and not ex1.is_cycle)
             select s1.e0                                              as e0,
                    s1.e1                                              as e1,
                    s1.ep0                                             as ep0,
@@ -282,3 +289,51 @@ with s0 as (with recursive ex0(root_id, next_id, depth, satisfied, is_cycle, pat
                    join node n3 on e2.id = ex1.path[array_length(ex1.path, 1)::int4] and n3.id = e2.end_id)
 select s2.n3 as l
 from s2;
+
+-- case: match p = (:NodeKind1)-[:EdgeKind1*1..]->(n:NodeKind2) where 'admin_tier_0' in split(n.system_tags, ' ') return p limit 1000
+with s0 as (with recursive ex0(root_id, next_id, depth, satisfied, is_cycle, path) as (select e0.start_id,
+                                                                                              e0.end_id,
+                                                                                              1,
+                                                                                              n1.kind_ids operator (pg_catalog.&&)
+                                                                                              array [2]::int2[] and
+                                                                                              'admin_tier_0' = any
+                                                                                              (string_to_array(n1.properties ->> 'system_tags', ' ')::text[]),
+                                                                                              e0.start_id = e0.end_id,
+                                                                                              array [e0.id]
+                                                                                       from edge e0
+                                                                                              join node n0 on
+                                                                                         n0.kind_ids operator (pg_catalog.&&)
+                                                                                         array [1]::int2[] and
+                                                                                         n0.id = e0.start_id
+                                                                                              join node n1 on n1.id = e0.end_id
+                                                                                       where e0.kind_id = any (array [11]::int2[])
+                                                                                       union
+                                                                                       select ex0.root_id,
+                                                                                              e0.end_id,
+                                                                                              ex0.depth + 1,
+                                                                                              n1.kind_ids operator (pg_catalog.&&)
+                                                                                              array [2]::int2[] and
+                                                                                              'admin_tier_0' = any
+                                                                                              (string_to_array(n1.properties ->> 'system_tags', ' ')::text[]),
+                                                                                              e0.id = any (ex0.path),
+                                                                                              ex0.path || e0.id
+                                                                                       from ex0
+                                                                                              join edge e0 on e0.start_id = ex0.next_id
+                                                                                              join node n1 on n1.id = e0.end_id
+                                                                                       where ex0.depth < 5
+                                                                                         and not ex0.is_cycle
+                                                                                         and e0.kind_id = any (array [11]::int2[]))
+            select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0,
+                   (select array_agg((e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite)
+                    from edge e0
+                    where e0.id = any (ex0.path))                     as e0,
+                   ex0.path                                           as ep0,
+                   (n1.id, n1.kind_ids, n1.properties)::nodecomposite as n1
+            from ex0
+                   join edge e0 on e0.id = any (ex0.path)
+                   join node n0 on n0.id = ex0.root_id
+                   join node n1 on e0.id = ex0.path[array_length(ex0.path, 1)::int4] and n1.id = e0.end_id
+            where ex0.satisfied)
+select edges_to_path(variadic ep0)::pathcomposite as p
+from s0
+limit 1000;

--- a/packages/go/dawgs/drivers/pg/query/query.go
+++ b/packages/go/dawgs/drivers/pg/query/query.go
@@ -19,6 +19,7 @@ package query
 import (
 	_ "embed"
 	"fmt"
+	"strings"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/specterops/bloodhound/dawgs/drivers/pg/model"
@@ -283,7 +284,7 @@ func (s Query) SelectTableIndexDefinitions(tableName string) ([]string, error) {
 			return nil, err
 		}
 
-		definitions = append(definitions, definition)
+		definitions = append(definitions, strings.ToLower(definition))
 	}
 
 	return definitions, result.Error()

--- a/packages/go/dawgs/drivers/pg/query/sql/schema_up.sql
+++ b/packages/go/dawgs/drivers/pg/query/sql/schema_up.sql
@@ -337,12 +337,12 @@ $$
 create or replace function public.asp_harness(primer_query text, recursive_query text, max_depth int4)
   -- | Column      | type    | Usage                                                                                  |
   -- |-------------|---------|----------------------------------------------------------------------------------------|
-  -- | `root_id`   | Int4    | Node that the path originated from. Simplifies referencing the root node of each path. |
-  -- | `next_id`   | Int4    | Next node to expand to.                                                                |
-  -- | `depth`     | Int     | Depth of the current traversal.                                                        |
+  -- | `root_id`   | Int8    | Node that the path originated from. Simplifies referencing the root node of each path. |
+  -- | `next_id`   | Int8    | Next node to expand to.                                                                |
+  -- | `depth`     | Int4    | Depth of the current traversal.                                                        |
   -- | `satisfied` | Boolean | True if the expansion is satisfied.                                                    |
   -- | `is_cycle`  | Boolean | True if the expansion is a cycle.                                                      |
-  -- | `path`      | Int4[]  | Array of edges in order of traversal.                                                  |
+  -- | `path`      | Int8[]  | Array of edges in order of traversal.                                                  |
   returns table
           (
             root_id   int8,

--- a/packages/go/dawgs/drivers/pg/types.go
+++ b/packages/go/dawgs/drivers/pg/types.go
@@ -23,9 +23,9 @@ import (
 )
 
 type edgeComposite struct {
-	ID         int32
-	StartID    int32
-	EndID      int32
+	ID         int64
+	StartID    int64
+	EndID      int64
 	KindID     int16
 	Properties map[string]any
 }
@@ -114,7 +114,7 @@ func (s *edgeComposite) ToRelationship(kindMapper KindMapper, relationship *grap
 }
 
 type nodeComposite struct {
-	ID         int32
+	ID         int64
 	KindIDs    []int16
 	Properties map[string]any
 }


### PR DESCRIPTION
## Description

PG query path related work.

Usually not a fan of stacked changed but these are all super small in scope and it's less thrashing against the staging branch.

## Motivation and Context

Below are the fixed tickets:
* BED-4981 - Correctly Sanitize Index and Constraint Input from PostgreSQL
* BED-4980 - Fixup int32 Types in PostgreSQL Query Path
* BED-4982 - Implement Cypher Split Function for PgSQL Translation

## How Has This Been Tested?

* Updated unit and integration tests

## Types of changes

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
