### PR TITLE
BED-4921 fix: missing entity id for saml provider

### DIFF
--- a/cmd/api/src/api/v2/auth/saml.go
+++ b/cmd/api/src/api/v2/auth/saml.go
@@ -56,6 +56,8 @@ func serviceProviderFactory(ctx context.Context, cfg config.Configuration, samlP
 	} else if idpMetadata, err := samlsp.ParseMetadata(samlProvider.MetadataXML); err != nil {
 		return bhsaml.ServiceProvider{}, fmt.Errorf("failed to parse metadata XML for service provider %s: %w", samlProvider.Name, err)
 	} else {
+		// This is required to populate the samlProvider.ServiceProviderIssuerURI
+		samlProvider = bhsaml.FormatSAMLProviderURLs(ctx, samlProvider)[0]
 		return bhsaml.NewServiceProvider(samlProvider, bhsaml.FormatServiceProviderURLs(*bhCtx.Get(ctx).Host, samlProvider.Name), samlsp.Options{
 			EntityID:          samlProvider.ServiceProviderIssuerURI.String(),
 			URL:               samlProvider.ServiceProviderIssuerURI.AsURL(),

--- a/cmd/ui/src/views/Login.tsx
+++ b/cmd/ui/src/views/Login.tsx
@@ -103,7 +103,7 @@ const Login: React.FC = () => {
         );
     }
 
-    if (listSSOProvidersQuery.isError || listSSOProvidersQuery.data?.length === 0) {
+    if (listSSOProvidersQuery.isError || !listSSOProvidersQuery.data) {
         return (
             <LoginPage>
                 <LoginForm onSubmit={handleSubmitLoginForm} loading={authState.loginLoading} />


### PR DESCRIPTION
## Description

- Ensure that the entity id is correctly formatted for SAML provider flow
- Fix handling for no sso-provider on UI 

## Motivation and Context

This PR addresses: BED-4921

*Why is this change required? What problem does it solve?*
Currently fallback to /metadata url breaks existing SAML flow

## How Has This Been Tested?

Live.

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->
- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
