### PR TITLE
BED-5012 feat: add callback uri to oidc details

### DIFF
--- a/cmd/api/src/database/samlproviders.go
+++ b/cmd/api/src/database/samlproviders.go
@@ -1,3 +1,19 @@
+// Copyright 2024 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package database
 
 import (

--- a/cmd/api/src/model/samlprovider.go
+++ b/cmd/api/src/model/samlprovider.go
@@ -1,3 +1,19 @@
+// Copyright 2024 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package model
 
 import (

--- a/packages/javascript/bh-shared-ui/src/components/SSOProviderInfoPanel/SSOProviderInfoPanel.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/SSOProviderInfoPanel/SSOProviderInfoPanel.tsx
@@ -46,19 +46,26 @@ const SAMLProviderInfoPanel: FC<{
 );
 
 const OIDCProviderInfoPanel: FC<{
-    oidcProviderDetails: OIDCProviderInfo;
-}> = ({ oidcProviderDetails }) => (
-    <FieldsContainer>
-        <Field
-            label={<LabelWithCopy label='Client ID' valueToCopy={oidcProviderDetails.client_id} hoverOnly />}
-            value={oidcProviderDetails.client_id}
-        />
-        <Field
-            label={<LabelWithCopy label='Issuer' valueToCopy={oidcProviderDetails.issuer} hoverOnly />}
-            value={oidcProviderDetails.issuer}
-        />
-    </FieldsContainer>
-);
+    ssoProvider: SSOProvider;
+}> = ({ ssoProvider }) => {
+    const oidcProviderDetails = ssoProvider.details as OIDCProviderInfo;
+    return (
+        <FieldsContainer>
+            <Field
+                label={<LabelWithCopy label='Client ID' valueToCopy={oidcProviderDetails.client_id} hoverOnly />}
+                value={oidcProviderDetails.client_id}
+            />
+            <Field
+                label={<LabelWithCopy label='Issuer' valueToCopy={oidcProviderDetails.issuer} hoverOnly />}
+                value={oidcProviderDetails.issuer}
+            />
+            <Field
+                label={<LabelWithCopy label='Callback URL' valueToCopy={ssoProvider.callback_uri} hoverOnly />}
+                value={ssoProvider.callback_uri}
+            />
+        </FieldsContainer>
+    );
+};
 
 const SSOProviderInfoPanel: FC<{
     ssoProvider: SSOProvider;
@@ -77,7 +84,7 @@ const SSOProviderInfoPanel: FC<{
             infoPanel = <SAMLProviderInfoPanel samlProviderDetails={ssoProvider.details as SAMLProviderInfo} />;
             break;
         case 'oidc':
-            infoPanel = <OIDCProviderInfoPanel oidcProviderDetails={ssoProvider.details as OIDCProviderInfo} />;
+            infoPanel = <OIDCProviderInfoPanel ssoProvider={ssoProvider} />;
             break;
         default:
             infoPanel = null;

--- a/packages/javascript/js-client-library/src/types.ts
+++ b/packages/javascript/js-client-library/src/types.ts
@@ -179,6 +179,8 @@ export interface SSOProvider extends Serial {
     slug: string;
     type: 'OIDC' | 'SAML';
     details: SAMLProviderInfo | OIDCProviderInfo;
+    login_uri: string;
+    callback_uri: string;
 }
 
 export interface ListSSOProvidersResponse {


### PR DESCRIPTION
## Description

Add callback uri info for easy copy pasting when setting up OIDC

## Motivation and Context

This PR addresses: BED-5012

*Why is this change required? What problem does it solve?*

## How Has This Been Tested?

Ran locally

## Types of changes

<!-- Please remove any items that do not apply. -->
- New feature (non-breaking change which adds functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
