### PR TITLE
Issue #945: Adjust text of the edge AZAddSecret to consider App Instance Property Lock

### DIFF
--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/AZAddSecret/General.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/AZAddSecret/General.tsx
@@ -27,9 +27,11 @@ const General: FC = () => {
             </Typography>
             <Typography variant='body2'>
                 When a principal has been granted "Cloud App Admin" or "App Admin" against the tenant, that principal
-                gains the ability to add new secrets to all Service Principals and App Registrations. Additionally, a
+                gains the ability to add new secrets to all Service Principals* and App Registrations. Additionally, a
                 principal that has been granted "Cloud App Admin" or "App Admin" against, or explicit ownership of a
-                Service Principal or App Registration gains the ability to add secrets to that particular object.
+                Service Principal* or App Registration gains the ability to add secrets to that particular object.
+
+                * Secrets can only be added to the Service Principal if it is not protected by the "App instance property lock" configuration in the corresponding App Registration.
             </Typography>
         </>
     );

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/AZAddSecret/References.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/AZAddSecret/References.tsx
@@ -37,6 +37,12 @@ const References: FC = () => {
                 href='https://docs.microsoft.com/en-us/azure/active-directory/roles/assign-roles-different-scopes'>
                 Assign Azure AD roles at different scopes
             </Link>
+            <Link
+                target='_blank'
+                rel='noopener'
+                href='https://learn.microsoft.com/en-us/entra/identity-platform/howto-configure-app-instance-property-locks'>
+                Protect Service Principals using App Instance Property Lock
+            </Link>
         </Box>
     );
 };


### PR DESCRIPTION
## Description
Adjust text of the edge _AZAddSecret_ to consider _App Instance Property Lock_

## Motivation and Context

This PR partially addresses: Issue https://github.com/SpecterOps/BloodHound/issues/945

Since March 2024 all new App registrations have the app instance property lock enabled by default.
This will lead to more and more false positives with the edge _AZAddSecret_, since it is not possible anymore to add secrets to the Enterprise Application.

This small text adjustment should warn BloodHound users that it is only possible to add new Secrets to an Enterprise Application if it is not protected by the _App Instance Property Lock_ configuration in the corresponding App Registration.


## How Has This Been Tested?
Ran locally

## Types of changes
- Chore (a change that does not modify the application functionality)
- Text adjustment


## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/945
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
