### PR TITLE
BED-4921 chore: surface cert parsing error

### DIFF
--- a/cmd/api/src/api/v2/auth/auth.go
+++ b/cmd/api/src/api/v2/auth/auth.go
@@ -139,6 +139,9 @@ func (s ManagementResource) GetSAMLProvider(response http.ResponseWriter, reques
 	} else if provider, err := s.db.GetSAMLProvider(request.Context(), int32(providerID)); err != nil {
 		api.HandleDatabaseError(request, response, err)
 	} else {
+		// Format the service provider uri's in response
+		provider = bhsaml.FormatSAMLProviderURLs(request.Context(), provider)[0]
+
 		api.WriteBasicResponse(request.Context(), provider, http.StatusOK, response)
 	}
 }

--- a/cmd/api/src/api/v2/auth/saml.go
+++ b/cmd/api/src/api/v2/auth/saml.go
@@ -83,7 +83,7 @@ func (s ManagementResource) ServeMetadata(response http.ResponseWriter, request 
 	} else if ssoProvider.SAMLProvider == nil {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusNotFound, api.ErrorResponseDetailsResourceNotFound, request), response)
 	} else if serviceProvider, err := serviceProviderFactory(request.Context(), s.config, *ssoProvider.SAMLProvider); err != nil {
-		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusInternalServerError, api.ErrorResponseDetailsInternalServerError, request), response)
+		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusInternalServerError, err.Error(), request), response)
 	} else {
 		if content, err := xml.MarshalIndent(serviceProvider.Metadata(), "", "  "); err != nil {
 			log.Errorf("[SAML] XML marshalling failure during service provider encoding for %s: %v", ssoProvider.SAMLProvider.IssuerURI, err)
@@ -102,7 +102,7 @@ func (s ManagementResource) SAMLLoginHandler(response http.ResponseWriter, reque
 	if ssoProvider.SAMLProvider == nil {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusNotFound, api.ErrorResponseDetailsResourceNotFound, request), response)
 	} else if serviceProvider, err := serviceProviderFactory(request.Context(), s.config, *ssoProvider.SAMLProvider); err != nil {
-		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusInternalServerError, api.ErrorResponseDetailsInternalServerError, request), response)
+		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusInternalServerError, err.Error(), request), response)
 	} else {
 		providerResource := saml2.NewProviderResource(s.db, s.config, serviceProvider, samlWriteAPIErrorResponse)
 		binding, bindingLocation := providerResource.BindingTypeAndLocation()
@@ -149,7 +149,7 @@ func (s ManagementResource) SAMLCallbackHandler(response http.ResponseWriter, re
 	if ssoProvider.SAMLProvider == nil {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusNotFound, api.ErrorResponseDetailsResourceNotFound, request), response)
 	} else if serviceProvider, err := serviceProviderFactory(request.Context(), s.config, *ssoProvider.SAMLProvider); err != nil {
-		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusInternalServerError, api.ErrorResponseDetailsInternalServerError, request), response)
+		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusInternalServerError, err.Error(), request), response)
 	} else {
 		providerResource := saml2.NewProviderResource(s.db, s.config, serviceProvider, samlWriteAPIErrorResponse)
 		if err := request.ParseForm(); err != nil {


### PR DESCRIPTION
## Description

- Surface parsing cert errors
- Fix missing format uri on `/api/v2/saml/providers/{provider_id}`

## Motivation and Context

Addresses: https://github.com/SpecterOps/BloodHound/issues/949
Addresses: BED-4768
Addresses: BED-4767
Addresses: BED-4921

*Why is this change required? What problem does it solve?*

When we refactored the saml login flow, we obfuscated any parsing cert errors under 500, this keeps the 500 but surfaces the specific error now

## How Has This Been Tested?

Locally with bruno

## Screenshots (optional):
Before:
<img width="880" alt="image" src="https://github.com/user-attachments/assets/ffdb977b-8b75-4d46-9aa8-68231359836c">

<img width="888" alt="image" src="https://github.com/user-attachments/assets/6d56c07c-49f5-4242-b41f-a8508a9cecb5">

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
