### PR TITLE
BED-4930 fixed color shift in panel lists

### DIFF
--- a/packages/javascript/bh-shared-ui/src/components/InfiniteScrollingTable/InfiniteScrollingTable.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/InfiniteScrollingTable/InfiniteScrollingTable.tsx
@@ -67,9 +67,10 @@ const createItemData = memoize((items, onClick) => ({
 }));
 
 const Row = memo(function Row({ data, index, style }: ListChildComponentProps) {
+    const tableStyle = useStyles();
+
     const { items, onClick } = data;
     const item = items[index];
-    const tableStyle = useStyles();
     const itemClass = index % 2 ? tableStyle.oddItem : tableStyle.evenItem;
 
     if (item === undefined) {

--- a/packages/javascript/bh-shared-ui/src/components/InfiniteScrollingTable/InfiniteScrollingTable.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/InfiniteScrollingTable/InfiniteScrollingTable.tsx
@@ -25,20 +25,16 @@ import makeStyles from '@mui/styles/makeStyles';
 const ITEM_SIZE = 32;
 
 const useStyles = makeStyles((theme) => ({
-    table: {
-        '& ul': {
-            '& > :nth-child(odd)': {
-                backgroundColor: theme.palette.neutral.tertiary,
-                '&:hover': {
-                    backgroundColor: theme.palette.neutral.quaternary,
-                },
-            },
-            '& > :nth-child(even)': {
-                backgroundColor: theme.palette.neutral.secondary,
-                '&:hover': {
-                    backgroundColor: theme.palette.neutral.quaternary,
-                },
-            },
+    evenItem: {
+        backgroundColor: theme.palette.neutral.secondary,
+        '&:hover': {
+            backgroundColor: theme.palette.neutral.quaternary,
+        },
+    },
+    oddItem: {
+        backgroundColor: theme.palette.neutral.tertiary,
+        '&:hover': {
+            backgroundColor: theme.palette.neutral.quaternary,
         },
     },
 }));
@@ -73,7 +69,8 @@ const createItemData = memoize((items, onClick) => ({
 const Row = memo(function Row({ data, index, style }: ListChildComponentProps) {
     const { items, onClick } = data;
     const item = items[index];
-    const itemClass = index % 2 ? 'odd-item' : 'even-item';
+    const tableStyle = useStyles();
+    const itemClass = index % 2 ? tableStyle.oddItem : tableStyle.evenItem;
 
     if (item === undefined) {
         return (
@@ -123,7 +120,6 @@ const InfiniteScrollingTable: React.FC<InfiniteScrollingTableProps> = ({
     const [items, setItems] = useState<Record<number, any>>({});
     const itemData = createItemData(items, onClick);
     const isItemLoaded = (index: number) => !!items[index];
-    const style = useStyles();
 
     const loadMoreItems = async (startIndex: number, stopIndex: number) => {
         if (isFetching) return;
@@ -161,7 +157,6 @@ const InfiniteScrollingTable: React.FC<InfiniteScrollingTableProps> = ({
                     ref={ref}
                     width={'100%'}
                     initialScrollOffset={0}
-                    className={style.table}
                     style={{ borderRadius: 4 }}>
                     {Row}
                 </FixedSizeList>


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

This change moves the style definition from the FixedSizeList/InfiniteLoader to the Row element

## Motivation and Context

This PR addresses: BED-4930

By moving the style definition from the InfiniteLoader to the Row, we are able to accurately determine the index of the row that is being mapped.
What was happening is that the InfiniteLoader adds and removes elements from the DOM when they come in and out of view. This causes the `nth-child(odd)` and `nth-child(even)` bindings to change with each scroll.

## How Has This Been Tested?
I ran Bloodhound Enterprise and navigated to a panel that utilized the InfiniteLoader element and verified that the colors were no longer shifting while scrolling
![Kapture 2024-11-14 at 10 52 42](https://github.com/user-attachments/assets/0b5fe4ee-82d8-4b74-9b74-0fab8a884cb5)


## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)


## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
