### PR TITLE
BED-5044 - revert edge constraint map checking in API and prefer SQL upsert

### DIFF
--- a/packages/go/dawgs/drivers/pg/query/format.go
+++ b/packages/go/dawgs/drivers/pg/query/format.go
@@ -134,8 +134,7 @@ func FormatRelationshipPartitionUpsert(graphTarget model.Graph, identityProperti
 		"(graph_id, start_id, end_id, kind_id, properties) ",
 		"select $1::int4, unnest($2::int4[]), unnest($3::int4[]), unnest($4::int2[]), unnest($5::jsonb[]) ",
 		formatConflictMatcher(identityProperties, "graph_id, start_id, end_id, kind_id"),
-		"do update set properties = e.properties || excluded.properties ",
-		"returning id;",
+		"do update set properties = e.properties || excluded.properties;",
 	)
 }
 

--- a/packages/go/dawgs/drivers/pg/statements.go
+++ b/packages/go/dawgs/drivers/pg/statements.go
@@ -22,8 +22,13 @@ const (
 	createNodeWithIDBatchStatement    = `insert into node (graph_id, id, kind_ids, properties) select $1, unnest($2::int4[]), unnest($3::text[])::int2[], unnest($4::jsonb[])`
 	deleteNodeWithIDStatement         = `delete from node where node.id = any($1)`
 
-	createEdgeStatement       = `insert into edge (graph_id, start_id, end_id, kind_id, properties) values (@graph_id, @start_id, @end_id, @kind_id, @properties) returning (id, start_id, end_id, kind_id, properties)::edgeComposite;`
-	createEdgeBatchStatement  = `insert into edge (graph_id, start_id, end_id, kind_id, properties) select $1::int4, unnest($2::int4[]), unnest($3::int4[]), unnest($4::int2[]), unnest($5::jsonb[]);`
+	createEdgeStatement = `insert into edge (graph_id, start_id, end_id, kind_id, properties) values (@graph_id, @start_id, @end_id, @kind_id, @properties) returning (id, start_id, end_id, kind_id, properties)::edgeComposite;`
+
+	// TODO: The query below is not a pure creation statement as it contains an `on conflict` clause to dance around
+	//	     Azure post-processing. This was done because Azure post will submit the same creation request hundreds of
+	// 		 times for the same edge. In PostgreSQL this results in a constraint violation. For now this is best-effort
+	//		 until Azure post-processing can be refactored.
+	createEdgeBatchStatement  = `insert into edge as e (graph_id, start_id, end_id, kind_id, properties) select $1::int4, unnest($2::int4[]), unnest($3::int4[]), unnest($4::int2[]), unnest($5::jsonb[]) on conflict (graph_id, start_id, end_id, kind_id) do update set properties = e.properties || excluded.properties;`
 	deleteEdgeWithIDStatement = `delete from edge as e where e.id = any($1)`
 
 	edgePropertySetOnlyStatement      = `update edge set properties = properties || $1::jsonb where edge.id = $2`


### PR DESCRIPTION
## Description

Revert and change for edge creation during post-processing.

## Motivation and Context

* Related to BED-4997
* Fixes BED-5044

The changes authored had a far greater impact on memory than expected. This ticket exists to cover reverting the change and authoring a small update to the SQL used for create to change the edge create statement into an edge upsert statement.

## How Has This Been Tested?

Local test w/ folk on Zoom.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
