### PR TITLE
BED-5048 fix: removing authSecret with SSO assignment

### DIFF
--- a/cmd/api/src/api/v2/auth/auth.go
+++ b/cmd/api/src/api/v2/auth/auth.go
@@ -528,7 +528,7 @@ func (s ManagementResource) UpdateUser(response http.ResponseWriter, request *ht
 		updateUserRequest v2.UpdateUserRequest
 		pathVars          = mux.Vars(request)
 		rawUserID         = pathVars[api.URIPathVariableUserID]
-		context           = *ctx.FromRequest(request)
+		authCtx           = *ctx.FromRequest(request)
 	)
 
 	if userID, err := uuid.FromString(rawUserID); err != nil {
@@ -550,7 +550,7 @@ func (s ManagementResource) UpdateUser(response http.ResponseWriter, request *ht
 		user.IsDisabled = updateUserRequest.IsDisabled
 
 		if user.IsDisabled {
-			if loggedInUser, _ := auth.GetUserFromAuthCtx(context.AuthCtx); user.ID == loggedInUser.ID {
+			if loggedInUser, _ := auth.GetUserFromAuthCtx(authCtx.AuthCtx); user.ID == loggedInUser.ID {
 				api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, api.ErrorResponseUserSelfDisable, request), response)
 				return
 			} else if userSessions, err := s.db.LookupActiveSessionsByUser(request.Context(), user); err != nil {
@@ -576,6 +576,7 @@ func (s ManagementResource) UpdateUser(response http.ResponseWriter, request *ht
 				return
 			} else {
 				// Ensure that the AuthSecret reference is nil and that the SAML provider is set
+				user.AuthSecret = nil // Required or the below updateUser will re-add the authSecret
 				user.SAMLProviderID = null.Int32From(samlProviderID)
 				user.SSOProviderID = provider.SSOProviderID
 			}
@@ -587,6 +588,7 @@ func (s ManagementResource) UpdateUser(response http.ResponseWriter, request *ht
 				api.HandleDatabaseError(request, response, err)
 				return
 			} else {
+				user.AuthSecret = nil // Required or the below updateUser will re-add the authSecret
 				user.SSOProviderID = updateUserRequest.SSOProviderID
 				if ssoProvider.Type == model.SessionAuthProviderSAML {
 					if ssoProvider.SAMLProvider != nil {
@@ -600,6 +602,7 @@ func (s ManagementResource) UpdateUser(response http.ResponseWriter, request *ht
 		} else {
 			// Default SAMLProviderID and SSOProviderID to null if the update request contains no SAMLProviderID and SSOProviderID
 			user.SAMLProvider = nil
+			user.SSOProvider = nil
 			user.SAMLProviderID = null.NewInt32(0, false)
 			user.SSOProviderID = null.NewInt32(0, false)
 		}


### PR DESCRIPTION
## Description

- Fix not removing auth secret on update user to SSO

## Motivation and Context

This PR addresses: BED-5048 

Need to delete auth secret when swapped to SSO

## How Has This Been Tested?

Locally

## Types of changes

<!-- Please remove any items that do not apply. -->


- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
