### PR TITLE
Bed-5068 feat: Add PATCH endpoint to update sso providers

### DIFF
--- a/cmd/api/src/api/registration/v2.go
+++ b/cmd/api/src/api/registration/v2.go
@@ -59,6 +59,7 @@ func registerV2Auth(resources v2.Resources, routerInst *router.Router, permissio
 		routerInst.GET("/api/v2/sso-providers", managementResource.ListAuthProviders),
 		routerInst.POST("/api/v2/sso-providers/oidc", managementResource.CreateOIDCProvider).CheckFeatureFlag(resources.DB, appcfg.FeatureOIDCSupport).RequirePermissions(permissions.AuthManageProviders),
 		routerInst.DELETE(fmt.Sprintf("/api/v2/sso-providers/{%s}", api.URIPathVariableSSOProviderID), managementResource.DeleteSSOProvider).RequirePermissions(permissions.AuthManageProviders),
+		routerInst.PUT(fmt.Sprintf("/api/v2/sso-providers/{%s}", api.URIPathVariableSSOProviderID), managementResource.UpdateSSOProvider).RequirePermissions(permissions.AuthManageProviders),
 		routerInst.GET(fmt.Sprintf("/api/v2/sso/{%s}/login", api.URIPathVariableSSOProviderSlug), managementResource.SSOLoginHandler),
 		routerInst.GET(fmt.Sprintf("/api/v2/sso/{%s}/metadata", api.URIPathVariableSSOProviderSlug), managementResource.ServeMetadata),
 		routerInst.PathPrefix(fmt.Sprintf("/api/v2/sso/{%s}/callback", api.URIPathVariableSSOProviderSlug), http.HandlerFunc(managementResource.SSOCallbackHandler)),

--- a/cmd/api/src/api/registration/v2.go
+++ b/cmd/api/src/api/registration/v2.go
@@ -59,7 +59,7 @@ func registerV2Auth(resources v2.Resources, routerInst *router.Router, permissio
 		routerInst.GET("/api/v2/sso-providers", managementResource.ListAuthProviders),
 		routerInst.POST("/api/v2/sso-providers/oidc", managementResource.CreateOIDCProvider).CheckFeatureFlag(resources.DB, appcfg.FeatureOIDCSupport).RequirePermissions(permissions.AuthManageProviders),
 		routerInst.DELETE(fmt.Sprintf("/api/v2/sso-providers/{%s}", api.URIPathVariableSSOProviderID), managementResource.DeleteSSOProvider).RequirePermissions(permissions.AuthManageProviders),
-		routerInst.PUT(fmt.Sprintf("/api/v2/sso-providers/{%s}", api.URIPathVariableSSOProviderID), managementResource.UpdateSSOProvider).RequirePermissions(permissions.AuthManageProviders),
+		routerInst.PATCH(fmt.Sprintf("/api/v2/sso-providers/{%s}", api.URIPathVariableSSOProviderID), managementResource.UpdateSSOProvider).RequirePermissions(permissions.AuthManageProviders),
 		routerInst.GET(fmt.Sprintf("/api/v2/sso/{%s}/login", api.URIPathVariableSSOProviderSlug), managementResource.SSOLoginHandler),
 		routerInst.GET(fmt.Sprintf("/api/v2/sso/{%s}/metadata", api.URIPathVariableSSOProviderSlug), managementResource.ServeMetadata),
 		routerInst.PathPrefix(fmt.Sprintf("/api/v2/sso/{%s}/callback", api.URIPathVariableSSOProviderSlug), http.HandlerFunc(managementResource.SSOCallbackHandler)),

--- a/cmd/api/src/api/v2/auth/oidc_test.go
+++ b/cmd/api/src/api/v2/auth/oidc_test.go
@@ -23,15 +23,13 @@ import (
 
 	"github.com/specterops/bloodhound/src/api/v2/apitest"
 	"github.com/specterops/bloodhound/src/api/v2/auth"
+	"github.com/specterops/bloodhound/src/database"
 	"github.com/specterops/bloodhound/src/model"
 	"github.com/specterops/bloodhound/src/utils/test"
 	"go.uber.org/mock/gomock"
 )
 
 func TestManagementResource_CreateOIDCProvider(t *testing.T) {
-	const (
-		url = "/api/v2/sso/providers/oidc"
-	)
 	var (
 		mockCtrl          = gomock.NewController(t)
 		resources, mockDB = apitest.NewAuthManagementResource(mockCtrl)
@@ -45,8 +43,6 @@ func TestManagementResource_CreateOIDCProvider(t *testing.T) {
 		}, nil)
 
 		test.Request(t).
-			WithMethod(http.MethodPost).
-			WithURL(url).
 			WithBody(auth.UpsertOIDCProviderRequest{
 				Name:     "Bloodhound gang",
 				Issuer:   "https://localhost/auth",
@@ -59,9 +55,6 @@ func TestManagementResource_CreateOIDCProvider(t *testing.T) {
 
 	t.Run("error parsing body request", func(t *testing.T) {
 		test.Request(t).
-			WithMethod(http.MethodPost).
-			WithURL(url).
-			WithBody("").
 			OnHandlerFunc(resources.CreateOIDCProvider).
 			Require().
 			ResponseStatusCode(http.StatusBadRequest)
@@ -69,8 +62,6 @@ func TestManagementResource_CreateOIDCProvider(t *testing.T) {
 
 	t.Run("error validating request field", func(t *testing.T) {
 		test.Request(t).
-			WithMethod(http.MethodPost).
-			WithURL(url).
 			WithBody(auth.UpsertOIDCProviderRequest{
 				Name:     "test",
 				Issuer:   "1234:not:a:url",
@@ -86,8 +77,6 @@ func TestManagementResource_CreateOIDCProvider(t *testing.T) {
 			Issuer: "12345:bloodhound",
 		}
 		test.Request(t).
-			WithMethod(http.MethodPost).
-			WithURL(url).
 			WithBody(request).
 			OnHandlerFunc(resources.CreateOIDCProvider).
 			Require().
@@ -98,14 +87,96 @@ func TestManagementResource_CreateOIDCProvider(t *testing.T) {
 		mockDB.EXPECT().CreateOIDCProvider(gomock.Any(), "test", "https://localhost/auth", "bloodhound").Return(model.OIDCProvider{}, fmt.Errorf("error"))
 
 		test.Request(t).
-			WithMethod(http.MethodPost).
-			WithURL(url).
 			WithBody(auth.UpsertOIDCProviderRequest{
 				Name:     "test",
 				Issuer:   "https://localhost/auth",
 				ClientID: "bloodhound",
 			}).
 			OnHandlerFunc(resources.CreateOIDCProvider).
+			Require().
+			ResponseStatusCode(http.StatusInternalServerError)
+	})
+}
+
+func TestManagementResource_UpdateOIDCProvider(t *testing.T) {
+	var (
+		mockCtrl          = gomock.NewController(t)
+		resources, mockDB = apitest.NewAuthManagementResource(mockCtrl)
+		baseProvider      = model.SSOProvider{
+			Type: model.SessionAuthProviderOIDC,
+			Name: "Gotham Net",
+			OIDCProvider: &model.OIDCProvider{
+				ClientID: "gotham-net",
+				Issuer:   "https://gotham.net",
+			},
+		}
+		urlParams = map[string]string{"sso_provider_id": "1"}
+	)
+	defer mockCtrl.Finish()
+
+	t.Run("successfully update an OIDCProvider", func(t *testing.T) {
+		mockDB.EXPECT().GetSSOProviderById(gomock.Any(), int32(1)).Return(baseProvider, nil)
+		mockDB.EXPECT().UpdateOIDCProvider(gomock.Any(), gomock.Any())
+
+		test.Request(t).
+			WithURLPathVars(urlParams).
+			WithBody(auth.UpsertOIDCProviderRequest{
+				Name:     "Gotham Net 2",
+				Issuer:   "https://gotham-2.net",
+				ClientID: "gotham-net-2",
+			}).
+			OnHandlerFunc(resources.UpdateSSOProvider).
+			Require().
+			ResponseStatusCode(http.StatusOK)
+	})
+
+	t.Run("error not found while updating an unknown OIDCProvider", func(t *testing.T) {
+		mockDB.EXPECT().GetSSOProviderById(gomock.Any(), int32(1)).Return(model.SSOProvider{}, database.ErrNotFound)
+
+		test.Request(t).
+			WithURLPathVars(urlParams).
+			OnHandlerFunc(resources.UpdateSSOProvider).
+			Require().
+			ResponseStatusCode(http.StatusNotFound)
+	})
+
+	t.Run("error parsing body request", func(t *testing.T) {
+		mockDB.EXPECT().GetSSOProviderById(gomock.Any(), int32(1)).Return(baseProvider, nil)
+
+		test.Request(t).
+			WithURLPathVars(urlParams).
+			OnHandlerFunc(resources.UpdateSSOProvider).
+			Require().
+			ResponseStatusCode(http.StatusBadRequest)
+	})
+
+	t.Run("error validating request field", func(t *testing.T) {
+		mockDB.EXPECT().GetSSOProviderById(gomock.Any(), int32(1)).Return(baseProvider, nil)
+
+		test.Request(t).
+			WithURLPathVars(urlParams).
+			WithBody(auth.UpsertOIDCProviderRequest{
+				Name:     "test",
+				Issuer:   "1234:not:a:url",
+				ClientID: "bloodhound",
+			}).
+			OnHandlerFunc(resources.UpdateSSOProvider).
+			Require().
+			ResponseStatusCode(http.StatusBadRequest)
+	})
+
+	t.Run("error creating oidc provider db entry", func(t *testing.T) {
+		mockDB.EXPECT().GetSSOProviderById(gomock.Any(), int32(1)).Return(baseProvider, nil)
+		mockDB.EXPECT().UpdateOIDCProvider(gomock.Any(), gomock.Any()).Return(model.OIDCProvider{}, fmt.Errorf("error"))
+
+		test.Request(t).
+			WithURLPathVars(urlParams).
+			WithBody(auth.UpsertOIDCProviderRequest{
+				Name:     "test",
+				Issuer:   "https://localhost/auth",
+				ClientID: "bloodhound",
+			}).
+			OnHandlerFunc(resources.UpdateSSOProvider).
 			Require().
 			ResponseStatusCode(http.StatusInternalServerError)
 	})

--- a/cmd/api/src/api/v2/auth/oidc_test.go
+++ b/cmd/api/src/api/v2/auth/oidc_test.go
@@ -47,7 +47,7 @@ func TestManagementResource_CreateOIDCProvider(t *testing.T) {
 		test.Request(t).
 			WithMethod(http.MethodPost).
 			WithURL(url).
-			WithBody(auth.CreateOIDCProviderRequest{
+			WithBody(auth.UpsertOIDCProviderRequest{
 				Name:     "Bloodhound gang",
 				Issuer:   "https://localhost/auth",
 				ClientID: "bloodhound",
@@ -71,7 +71,7 @@ func TestManagementResource_CreateOIDCProvider(t *testing.T) {
 		test.Request(t).
 			WithMethod(http.MethodPost).
 			WithURL(url).
-			WithBody(auth.CreateOIDCProviderRequest{
+			WithBody(auth.UpsertOIDCProviderRequest{
 				Name:     "test",
 				Issuer:   "1234:not:a:url",
 				ClientID: "bloodhound",
@@ -82,7 +82,7 @@ func TestManagementResource_CreateOIDCProvider(t *testing.T) {
 	})
 
 	t.Run("error invalid Issuer", func(t *testing.T) {
-		request := auth.CreateOIDCProviderRequest{
+		request := auth.UpsertOIDCProviderRequest{
 			Issuer: "12345:bloodhound",
 		}
 		test.Request(t).
@@ -100,7 +100,7 @@ func TestManagementResource_CreateOIDCProvider(t *testing.T) {
 		test.Request(t).
 			WithMethod(http.MethodPost).
 			WithURL(url).
-			WithBody(auth.CreateOIDCProviderRequest{
+			WithBody(auth.UpsertOIDCProviderRequest{
 				Name:     "test",
 				Issuer:   "https://localhost/auth",
 				ClientID: "bloodhound",

--- a/cmd/api/src/database/auth_test.go
+++ b/cmd/api/src/database/auth_test.go
@@ -300,13 +300,12 @@ func TestDatabase_CreateGetDeleteAuthSecret(t *testing.T) {
 
 func TestDatabase_CreateUpdateDeleteSAMLProvider(t *testing.T) {
 	var (
-		ctx                 = context.Background()
-		dbInst, user        = initAndCreateUser(t)
-		samlProvider        model.SAMLProvider
-		newSAMLProvider     model.SAMLProvider
-		updatedUser         model.User
-		updatedSAMLProvider model.SAMLProvider
-		err                 error
+		ctx             = context.Background()
+		dbInst, user    = initAndCreateUser(t)
+		samlProvider    model.SAMLProvider
+		newSAMLProvider model.SAMLProvider
+		updatedUser     model.User
+		err             error
 	)
 	// Initialize the SAMLProvider without setting SSOProviderID
 	samlProvider = model.SAMLProvider{
@@ -333,18 +332,22 @@ func TestDatabase_CreateUpdateDeleteSAMLProvider(t *testing.T) {
 		} else if updatedUser.SSOProvider.SAMLProvider.IssuerURI != newSAMLProvider.IssuerURI {
 			t.Fatalf("Updated user has SAMLProvider URL %s when %s was expected", updatedUser.SSOProvider.SAMLProvider.IssuerURI, newSAMLProvider.IssuerURI)
 		} else {
-			updatedSAMLProvider = model.SAMLProvider{
-				Serial: model.Serial{
-					ID: newSAMLProvider.ID,
+			updatedSSOProvider := model.SSOProvider{
+				Name: "updated provider",
+				Type: model.SessionAuthProviderSAML,
+				SAMLProvider: &model.SAMLProvider{
+					Serial: model.Serial{
+						ID: newSAMLProvider.ID,
+					},
+					Name:            "updated provider",
+					DisplayName:     newSAMLProvider.DisplayName,
+					IssuerURI:       newSAMLProvider.IssuerURI,
+					SingleSignOnURI: newSAMLProvider.SingleSignOnURI,
+					SSOProviderID:   newSAMLProvider.SSOProviderID,
 				},
-				Name:            "updated provider",
-				DisplayName:     newSAMLProvider.DisplayName,
-				IssuerURI:       newSAMLProvider.IssuerURI,
-				SingleSignOnURI: newSAMLProvider.SingleSignOnURI,
-				SSOProviderID:   newSAMLProvider.SSOProviderID,
 			}
 
-			if err = dbInst.UpdateSAMLIdentityProvider(ctx, updatedSAMLProvider); err != nil {
+			if _, err = dbInst.UpdateSAMLIdentityProvider(ctx, updatedSSOProvider); err != nil {
 				t.Fatalf("Failed to update SAML provider: %v", err)
 			} else if err = test.VerifyAuditLogs(dbInst, model.AuditLogActionUpdateSAMLIdentityProvider, "saml_name", "updated provider"); err != nil {
 				t.Fatalf("Failed to validate UpdateSAMLIdentityProvider audit logs:\n%v", err)

--- a/cmd/api/src/database/mocks/db.go
+++ b/cmd/api/src/database/mocks/db.go
@@ -1593,6 +1593,20 @@ func (mr *MockDatabaseMockRecorder) SweepSessions(arg0 interface{}) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SweepSessions", reflect.TypeOf((*MockDatabase)(nil).SweepSessions), arg0)
 }
 
+// TerminateUserSessionsBySSOProvider mocks base method.
+func (m *MockDatabase) TerminateUserSessionsBySSOProvider(arg0 context.Context, arg1 model.SSOProvider) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "TerminateUserSessionsBySSOProvider", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// TerminateUserSessionsBySSOProvider indicates an expected call of TerminateUserSessionsBySSOProvider.
+func (mr *MockDatabaseMockRecorder) TerminateUserSessionsBySSOProvider(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TerminateUserSessionsBySSOProvider", reflect.TypeOf((*MockDatabase)(nil).TerminateUserSessionsBySSOProvider), arg0, arg1)
+}
+
 // UpdateAssetGroup mocks base method.
 func (m *MockDatabase) UpdateAssetGroup(arg0 context.Context, arg1 model.AssetGroup) error {
 	m.ctrl.T.Helper()
@@ -1664,18 +1678,49 @@ func (mr *MockDatabaseMockRecorder) UpdateFileUploadJob(arg0, arg1 interface{}) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateFileUploadJob", reflect.TypeOf((*MockDatabase)(nil).UpdateFileUploadJob), arg0, arg1)
 }
 
+// UpdateOIDCProvider mocks base method.
+func (m *MockDatabase) UpdateOIDCProvider(arg0 context.Context, arg1 model.SSOProvider) (model.OIDCProvider, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateOIDCProvider", arg0, arg1)
+	ret0, _ := ret[0].(model.OIDCProvider)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateOIDCProvider indicates an expected call of UpdateOIDCProvider.
+func (mr *MockDatabaseMockRecorder) UpdateOIDCProvider(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateOIDCProvider", reflect.TypeOf((*MockDatabase)(nil).UpdateOIDCProvider), arg0, arg1)
+}
+
 // UpdateSAMLIdentityProvider mocks base method.
-func (m *MockDatabase) UpdateSAMLIdentityProvider(arg0 context.Context, arg1 model.SAMLProvider) error {
+func (m *MockDatabase) UpdateSAMLIdentityProvider(arg0 context.Context, arg1 model.SSOProvider) (model.SAMLProvider, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateSAMLIdentityProvider", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(model.SAMLProvider)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // UpdateSAMLIdentityProvider indicates an expected call of UpdateSAMLIdentityProvider.
 func (mr *MockDatabaseMockRecorder) UpdateSAMLIdentityProvider(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSAMLIdentityProvider", reflect.TypeOf((*MockDatabase)(nil).UpdateSAMLIdentityProvider), arg0, arg1)
+}
+
+// UpdateSSOProvider mocks base method.
+func (m *MockDatabase) UpdateSSOProvider(arg0 context.Context, arg1 model.SSOProvider) (model.SSOProvider, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateSSOProvider", arg0, arg1)
+	ret0, _ := ret[0].(model.SSOProvider)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateSSOProvider indicates an expected call of UpdateSSOProvider.
+func (mr *MockDatabaseMockRecorder) UpdateSSOProvider(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSSOProvider", reflect.TypeOf((*MockDatabase)(nil).UpdateSSOProvider), arg0, arg1)
 }
 
 // UpdateSavedQuery mocks base method.

--- a/cmd/api/src/database/samlproviders.go
+++ b/cmd/api/src/database/samlproviders.go
@@ -18,6 +18,8 @@ package database
 
 import (
 	"context"
+	"fmt"
+	"time"
 
 	"github.com/specterops/bloodhound/src/database/types/null"
 	"github.com/specterops/bloodhound/src/model"
@@ -34,7 +36,7 @@ type SAMLProviderData interface {
 	GetAllSAMLProviders(ctx context.Context) (model.SAMLProviders, error)
 	GetSAMLProvider(ctx context.Context, id int32) (model.SAMLProvider, error)
 	GetSAMLProviderUsers(ctx context.Context, id int32) (model.Users, error)
-	UpdateSAMLIdentityProvider(ctx context.Context, samlProvider model.SAMLProvider) error
+	UpdateSAMLIdentityProvider(ctx context.Context, ssoProvider model.SSOProvider) (model.SAMLProvider, error)
 }
 
 // CreateSAMLIdentityProvider creates a new saml_providers row using the data in the input struct
@@ -95,13 +97,23 @@ func (s *BloodhoundDB) GetSAMLProviderUsers(ctx context.Context, id int32) (mode
 
 // CreateSAMLProvider updates a saml_providers row using the data in the input struct
 // UPDATE saml_identity_providers SET (...) VALUES (...) WHERE id = ...
-func (s *BloodhoundDB) UpdateSAMLIdentityProvider(ctx context.Context, provider model.SAMLProvider) error {
+func (s *BloodhoundDB) UpdateSAMLIdentityProvider(ctx context.Context, ssoProvider model.SSOProvider) (model.SAMLProvider, error) {
 	auditEntry := model.AuditEntry{
 		Action: model.AuditLogActionUpdateSAMLIdentityProvider,
-		Model:  &provider, // Pointer is required to ensure success log contains updated fields after transaction
+		Model:  ssoProvider.SAMLProvider, // Pointer is required to ensure success log contains updated fields after transaction
 	}
 
-	return s.AuditableTransaction(ctx, auditEntry, func(tx *gorm.DB) error {
-		return CheckError(tx.WithContext(ctx).Save(&provider))
+	err := s.AuditableTransaction(ctx, auditEntry, func(tx *gorm.DB) error {
+		bhdb := NewBloodhoundDB(tx, s.idResolver)
+
+		if _, err := bhdb.UpdateSSOProvider(ctx, ssoProvider); err != nil {
+			return err
+		} else {
+			return CheckError(tx.WithContext(ctx).Exec(
+				fmt.Sprintf("UPDATE %s SET name = ?, display_name = ?, issuer_uri = ?, single_sign_on_uri = ?, metadata_xml = ?, updated_at = ? WHERE id = ?;", samlProvidersTableName),
+				ssoProvider.SAMLProvider.Name, ssoProvider.SAMLProvider.DisplayName, ssoProvider.SAMLProvider.IssuerURI, ssoProvider.SAMLProvider.SingleSignOnURI, ssoProvider.SAMLProvider.MetadataXML, time.Now().UTC(), ssoProvider.SAMLProvider.ID))
+		}
 	})
+
+	return *ssoProvider.SAMLProvider, err
 }

--- a/cmd/api/src/model/audit.go
+++ b/cmd/api/src/model/audit.go
@@ -64,8 +64,10 @@ const (
 	AuditLogActionUpdateSAMLIdentityProvider AuditLogAction = "UpdateSAMLIdentityProvider"
 
 	AuditLogActionCreateOIDCIdentityProvider AuditLogAction = "CreateOIDCIdentityProvider"
+	AuditLogActionUpdateOIDCIdentityProvider AuditLogAction = "UpdateOIDCIdentityProvider"
 
 	AuditLogActionCreateSSOIdentityProvider AuditLogAction = "CreateSSOIdentityProvider"
+	AuditLogActionUpdateSSOIdentityProvider AuditLogAction = "UpdateSSOIdentityProvider"
 	AuditLogActionDeleteSSOIdentityProvider AuditLogAction = "DeleteSSOIdentityProvider"
 
 	AuditLogActionAcceptRisk   AuditLogAction = "AcceptRisk"

--- a/cmd/api/src/model/samlprovider.go
+++ b/cmd/api/src/model/samlprovider.go
@@ -43,8 +43,13 @@ var (
 type SAMLRootURIVersion int
 
 var (
-	SAMLRootURIVersion1 SAMLRootURIVersion = 1 // "/v2/login/saml/{slug}/"
-	SAMLRootURIVersion2 SAMLRootURIVersion = 2 // "/v2/sso/{slug}/"
+	SAMLRootURIVersion1 SAMLRootURIVersion = 1
+	SAMLRootURIVersion2 SAMLRootURIVersion = 2
+
+	SAMLRootURIVersionMap = map[SAMLRootURIVersion]string {
+		SAMLRootURIVersion1: "/api/v1/login/saml",
+		SAMLRootURIVersion2: "/api/v2/sso",
+	}
 )
 
 type SAMLProvider struct {
@@ -142,14 +147,13 @@ func (s SAMLProvider) GetSAMLUserPrincipalNameFromAssertion(assertion *saml.Asse
 
 func (s *SAMLProvider) FormatSAMLProviderURLs(hostUrl url.URL) {
 	root := hostUrl
+	root.Path =  path.Join(SAMLRootURIVersionMap[s.RootURIVersion], s.Name)
 
 	// To preserve existing IDP configurations, existing saml providers still use the old acs endpoint which redirects to the new callback handler
 	switch s.RootURIVersion {
 	case SAMLRootURIVersion1:
-		root.Path = path.Join("/api/v1/login/saml", s.Name)
 		s.ServiceProviderACSURI = serde.FromURL(*root.JoinPath("acs"))
 	case SAMLRootURIVersion2:
-		root.Path = path.Join("/api/v2/sso", s.Name)
 		s.ServiceProviderACSURI = serde.FromURL(*root.JoinPath("callback"))
 	}
 

--- a/cmd/api/src/utils/validation/url_validator.go
+++ b/cmd/api/src/utils/validation/url_validator.go
@@ -66,7 +66,7 @@ func (s UrlValidator) Validate(value any) utils.Errors {
 		}
 	}
 
-	if err := validUrl(inputUrl); err != nil {
+	if err := ValidUrl(inputUrl); err != nil {
 		errs = append(errs, errors.New(ErrorUrlInvalid))
 	}
 
@@ -77,7 +77,7 @@ func (s UrlValidator) Validate(value any) utils.Errors {
 	return nil
 }
 
-func validUrl(inputUrl string) error {
+func ValidUrl(inputUrl string) error {
 	if _, err := url.ParseRequestURI(inputUrl); err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description

- Added PATCH `/sso-providers/{sso_provider_id}` to update SSO provider info

## Motivation and Context

This PR addresses: BED-5068

*Why is this change required? What problem does it solve?*

Adds support for editing sso provider info without the need to delete it and disassociate the users. It also terminates active sessions.

## How Has This Been Tested?

*Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc.*

Unit tests
Locally through Bruno

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- New feature (non-breaking change which adds functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
