### PR TITLE
BED-5067 feat: add edit sso provider support to ui

### DIFF
--- a/packages/go/analysis/post_integration_test.go
+++ b/packages/go/analysis/post_integration_test.go
@@ -1,3 +1,19 @@
+// Copyright 2024 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build serial_integration
 // +build serial_integration
 

--- a/packages/go/openapi/doc/openapi.json
+++ b/packages/go/openapi/doc/openapi.json
@@ -605,7 +605,7 @@
                   "type": "object",
                   "properties": {
                     "data": {
-                      "$ref": "#/components/schemas/model.auth-provider"
+                      "$ref": "#/components/schemas/model.oidc-provider"
                     }
                   }
                 }
@@ -646,6 +646,100 @@
           }
         }
       ],
+    "patch": {
+        "operationId": "PatchSSOProvider",
+        "summary": "Update SSO Provider",
+        "description": "Updates an existing SSO provider. Updating saml provider requires a \"multipart/form-data\" body. Updating oidc provider requires \"application/json\" body. Response is respective provider",
+        "tags": [
+            "Auth",
+            "Community",
+            "Enterprise"
+        ],
+        "requestBody": {
+            "required": true,
+            "content": {
+                "multipart/form-data": {
+                    "schema": {
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "description": "Name of the new SAML provider."
+                            },
+                            "metadata": {
+                                "type": "string",
+                                "format": "binary",
+                                "description": "Metadata XML file."
+                            }
+                        }
+                    }
+                },
+                "application/json": {
+                    "schema": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "description": "Name of the OIDC provider"
+                            },
+                            "issuer": {
+                                "type": "string",
+                                "format": "url",
+                                "description": "URL of the OIDC issuer"
+                            },
+                            "client_id": {
+                                "type": "string",
+                                "description": "Client ID for the OIDC provider"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "responses": {
+            "200": {
+                "description": "OK",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "oneOf": [
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/components/schemas/model.saml-provider"
+                                        }
+                                    }
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/components/schemas/model.oidc-provider"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            },
+            "401": {
+                "$ref": "#/components/responses/unauthorized"
+            },
+            "403": {
+                "$ref": "#/components/responses/forbidden"
+            },
+            "404": {
+                "$ref": "#/components/responses/not-found"
+            },
+            "429": {
+                "$ref": "#/components/responses/too-many-requests"
+            },
+            "500": {
+                "$ref": "#/components/responses/internal-server-error"
+            }
+        }
+    },
       "delete": {
         "operationId": "DeleteSSOProvider",
         "summary": "Delete SSO Provider",

--- a/packages/go/openapi/doc/openapi.json
+++ b/packages/go/openapi/doc/openapi.json
@@ -646,100 +646,100 @@
           }
         }
       ],
-    "patch": {
+      "patch": {
         "operationId": "PatchSSOProvider",
         "summary": "Update SSO Provider",
         "description": "Updates an existing SSO provider. Updating saml provider requires a \"multipart/form-data\" body. Updating oidc provider requires \"application/json\" body. Response is respective provider",
         "tags": [
-            "Auth",
-            "Community",
-            "Enterprise"
+          "Auth",
+          "Community",
+          "Enterprise"
         ],
         "requestBody": {
-            "required": true,
-            "content": {
-                "multipart/form-data": {
-                    "schema": {
-                        "properties": {
-                            "name": {
-                                "type": "string",
-                                "description": "Name of the new SAML provider."
-                            },
-                            "metadata": {
-                                "type": "string",
-                                "format": "binary",
-                                "description": "Metadata XML file."
-                            }
-                        }
-                    }
-                },
-                "application/json": {
-                    "schema": {
-                        "type": "object",
-                        "properties": {
-                            "name": {
-                                "type": "string",
-                                "description": "Name of the OIDC provider"
-                            },
-                            "issuer": {
-                                "type": "string",
-                                "format": "url",
-                                "description": "URL of the OIDC issuer"
-                            },
-                            "client_id": {
-                                "type": "string",
-                                "description": "Client ID for the OIDC provider"
-                            }
-                        }
-                    }
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "Name of the new SAML provider."
+                  },
+                  "metadata": {
+                    "type": "string",
+                    "format": "binary",
+                    "description": "Metadata XML file."
+                  }
                 }
+              }
+            },
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "Name of the OIDC provider"
+                  },
+                  "issuer": {
+                    "type": "string",
+                    "format": "url",
+                    "description": "URL of the OIDC issuer"
+                  },
+                  "client_id": {
+                    "type": "string",
+                    "description": "Client ID for the OIDC provider"
+                  }
+                }
+              }
             }
+          }
         },
         "responses": {
-            "200": {
-                "description": "OK",
-                "content": {
-                    "application/json": {
-                        "schema": {
-                            "oneOf": [
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "data": {
-                                            "$ref": "#/components/schemas/model.saml-provider"
-                                        }
-                                    }
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "data": {
-                                            "$ref": "#/components/schemas/model.oidc-provider"
-                                        }
-                                    }
-                                }
-                            ]
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "$ref": "#/components/schemas/model.saml-provider"
                         }
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "$ref": "#/components/schemas/model.oidc-provider"
+                        }
+                      }
                     }
+                  ]
                 }
-            },
-            "401": {
-                "$ref": "#/components/responses/unauthorized"
-            },
-            "403": {
-                "$ref": "#/components/responses/forbidden"
-            },
-            "404": {
-                "$ref": "#/components/responses/not-found"
-            },
-            "429": {
-                "$ref": "#/components/responses/too-many-requests"
-            },
-            "500": {
-                "$ref": "#/components/responses/internal-server-error"
+              }
             }
+          },
+          "401": {
+            "$ref": "#/components/responses/unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/not-found"
+          },
+          "429": {
+            "$ref": "#/components/responses/too-many-requests"
+          },
+          "500": {
+            "$ref": "#/components/responses/internal-server-error"
+          }
         }
-    },
+      },
       "delete": {
         "operationId": "DeleteSSOProvider",
         "summary": "Delete SSO Provider",

--- a/packages/go/openapi/src/paths/sso.sso-providers.id.yaml
+++ b/packages/go/openapi/src/paths/sso.sso-providers.id.yaml
@@ -23,6 +23,66 @@ parameters:
     schema:
       type: integer
       format: int32
+patch:
+  operationId: PatchSSOProvider
+  summary: Update SSO Provider
+  description: Updates an existing SSO provider. Updating saml provider requires a "multipart/form-data" body. Updating oidc provider requires "application/json" body. Response is respective provider
+  tags:
+    - Auth
+    - Community
+    - Enterprise
+  requestBody:
+    required: true
+    content:
+      multipart/form-data:
+        schema:
+          properties:
+            name:
+              type: string
+              description: Name of the new SAML provider.
+            metadata:
+              type: string
+              format: binary
+              description: Metadata XML file.
+      application/json:
+        schema:
+          type: object
+          properties:
+            name:
+              type: string
+              description: Name of the OIDC provider
+            issuer:
+              type: string
+              format: url
+              description: URL of the OIDC issuer
+            client_id:
+              type: string
+              description: Client ID for the OIDC provider
+  responses:
+    '200':
+      description: OK
+      content:
+        application/json:
+          schema:
+            oneOf:
+              - type: object
+                properties:
+                  data:
+                    $ref: './../schemas/model.saml-provider.yaml'
+              - type: object
+                properties:
+                  data:
+                    $ref: './../schemas/model.oidc-provider.yaml'
+    '401':
+      $ref: './../responses/unauthorized.yaml'
+    '403':
+      $ref: './../responses/forbidden.yaml'
+    '404':
+      $ref: './../responses/not-found.yaml'
+    '429':
+      $ref: './../responses/too-many-requests.yaml'
+    '500':
+      $ref: './../responses/internal-server-error.yaml'
 delete:
   operationId: DeleteSSOProvider
   summary: Delete SSO Provider

--- a/packages/go/openapi/src/paths/sso.sso-providers.oidc.yaml
+++ b/packages/go/openapi/src/paths/sso.sso-providers.oidc.yaml
@@ -54,7 +54,7 @@ post:
             type: object
             properties:
               data:
-                $ref: './../schemas/model.auth-provider.yaml'
+                $ref: './../schemas/model.oidc-provider.yaml'
     '400':
       $ref: './../responses/bad-request.yaml'
     '401':

--- a/packages/javascript/bh-shared-ui/src/components/SSOProviderTable/SSOProviderTable.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/SSOProviderTable/SSOProviderTable.tsx
@@ -15,7 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Button } from '@bloodhoundenterprise/doodleui';
-import { faEllipsisVertical, faTrash } from '@fortawesome/free-solid-svg-icons';
+import { faEdit, faEllipsisVertical, faTrash } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
     IconButton,
@@ -61,7 +61,8 @@ const StyledMenu = withStyles({
 
 const SSOProviderTableActionsMenu: FC<{
     onDeleteSSOProvider: () => void;
-}> = ({ onDeleteSSOProvider }) => {
+    onUpdateSSOProvider: () => void;
+}> = ({ onDeleteSSOProvider, onUpdateSSOProvider }) => {
     /* Hooks */
 
     const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
@@ -76,6 +77,11 @@ const SSOProviderTableActionsMenu: FC<{
 
     const onClickDeleteSSOProvider = () => {
         onDeleteSSOProvider();
+        setAnchorEl(null);
+    };
+
+    const onClickUpdateSSOProvider = () => {
+        onUpdateSSOProvider();
         setAnchorEl(null);
     };
 
@@ -97,6 +103,12 @@ const SSOProviderTableActionsMenu: FC<{
                     </ListItemIcon>
                     <ListItemText primary='Delete SSO Provider' />
                 </MenuItem>
+                <MenuItem onClick={onClickUpdateSSOProvider}>
+                    <ListItemIcon>
+                        <FontAwesomeIcon icon={faEdit} />
+                    </ListItemIcon>
+                    <ListItemText primary='Edit SSO Provider' />
+                </MenuItem>
             </StyledMenu>
         </>
     );
@@ -105,11 +117,20 @@ const SSOProviderTableActionsMenu: FC<{
 const SSOProviderTable: FC<{
     ssoProviders: SSOProvider[];
     loading: boolean;
-    onDeleteSSOProvider: (ssoProviderId: SSOProvider['id']) => void;
+    onDeleteSSOProvider: (ssoProvider: SSOProvider) => void;
+    onUpdateSSOProvider: (ssoProvider: SSOProvider) => void;
     onClickSSOProvider: (ssoProviderId: SSOProvider['id']) => void;
     onToggleTypeSortOrder: () => void;
     typeSortOrder?: SortOrder;
-}> = ({ ssoProviders, loading, onDeleteSSOProvider, onClickSSOProvider, typeSortOrder, onToggleTypeSortOrder }) => {
+}> = ({
+    ssoProviders,
+    loading,
+    onDeleteSSOProvider,
+    onUpdateSSOProvider,
+    onClickSSOProvider,
+    onToggleTypeSortOrder,
+    typeSortOrder,
+}) => {
     const theme = useTheme();
     return (
         <Paper>
@@ -178,7 +199,8 @@ const SSOProviderTable: FC<{
                                 <TableRow key={ssoProvider.id}>
                                     <TableCell align='center' padding='checkbox'>
                                         <SSOProviderTableActionsMenu
-                                            onDeleteSSOProvider={() => onDeleteSSOProvider(ssoProvider.id)}
+                                            onDeleteSSOProvider={() => onDeleteSSOProvider(ssoProvider)}
+                                            onUpdateSSOProvider={() => onUpdateSSOProvider(ssoProvider)}
                                         />
                                     </TableCell>
                                     <TableCell onClick={() => onClickSSOProvider(ssoProvider.id)} size='small'>

--- a/packages/javascript/bh-shared-ui/src/components/UpsertOIDCProviderDialog.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/UpsertOIDCProviderDialog.tsx
@@ -18,7 +18,7 @@ import { Dialog, DialogTitle } from '@mui/material';
 import { SSOProvider, UpsertOIDCProviderRequest } from 'js-client-library';
 import UpsertOIDCProviderForm from './UpsertOIDCProviderForm';
 
-const UpsertSAMLProviderDialog: React.FC<{
+const UpsertOIDCProviderDialog: React.FC<{
     open: boolean;
     error?: string;
     oldSSOProvider?: SSOProvider;
@@ -46,4 +46,4 @@ const UpsertSAMLProviderDialog: React.FC<{
     );
 };
 
-export default UpsertSAMLProviderDialog;
+export default UpsertOIDCProviderDialog;

--- a/packages/javascript/bh-shared-ui/src/components/UpsertOIDCProviderDialog.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/UpsertOIDCProviderDialog.tsx
@@ -14,42 +14,17 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { Button } from '@bloodhoundenterprise/doodleui';
-import { Alert, Dialog, DialogTitle, DialogContent, DialogActions, Grid, TextField } from '@mui/material';
-import { FC } from 'react';
-import { Controller, useForm } from 'react-hook-form';
-import { UpsertOIDCProviderRequest } from 'js-client-library';
+import { Dialog, DialogTitle } from '@mui/material';
+import { SSOProvider, UpsertOIDCProviderRequest } from 'js-client-library';
+import UpsertOIDCProviderForm from './UpsertOIDCProviderForm';
 
-const UpsertOIDCProviderDialog: FC<{
+const UpsertSAMLProviderDialog: React.FC<{
     open: boolean;
     error?: string;
-    isUpdate: boolean;
+    oldSSOProvider?: SSOProvider;
     onClose: () => void;
     onSubmit: (data: UpsertOIDCProviderRequest) => void;
-}> = ({ open, error, isUpdate, onClose, onSubmit: _onSubmit }) => {
-    const {
-        control,
-        handleSubmit,
-        reset,
-        formState: { errors },
-    } = useForm<UpsertOIDCProviderRequest>({
-        defaultValues: {
-            name: '',
-            client_id: '',
-            issuer: '',
-        },
-    });
-
-    const onSubmit = (data: UpsertOIDCProviderRequest) => {
-        _onSubmit(data);
-        reset();
-    };
-
-    const handleClose = () => {
-        onClose();
-        reset();
-    };
-
+}> = ({ open, error, oldSSOProvider, onClose, onSubmit }) => {
     return (
         <Dialog
             open={open}
@@ -60,101 +35,15 @@ const UpsertOIDCProviderDialog: FC<{
                 // @ts-ignore
                 'data-testid': 'create-oidc-provider-dialog',
             }}>
-            <DialogTitle>{isUpdate ? 'Edit' : 'Create'} OIDC Provider</DialogTitle>
-            <form onSubmit={handleSubmit(onSubmit)}>
-                <DialogContent>
-                    <Grid container spacing={2}>
-                        <Grid item xs={12}>
-                            <Controller
-                                control={control}
-                                name='name'
-                                rules={{
-                                    required: 'OIDC Provider Name is required',
-                                    pattern: {
-                                        value: /^[A-z0-9 ]+$/,
-                                        message: 'OIDC Provider Name must be alphanumeric.',
-                                    },
-                                }}
-                                render={({ field }) => (
-                                    <TextField
-                                        {...field}
-                                        id={'name'}
-                                        variant='standard'
-                                        fullWidth
-                                        name='name'
-                                        label='OIDC Provider Name'
-                                        error={!!errors.name}
-                                        helperText={
-                                            errors.name?.message || 'Choose a name for your OIDC Provider configuration'
-                                        }
-                                    />
-                                )}
-                            />
-                        </Grid>
-                        <Grid item xs={12}>
-                            <Controller
-                                control={control}
-                                name='client_id'
-                                rules={{
-                                    required: 'Client ID is required',
-                                }}
-                                render={({ field }) => (
-                                    <TextField
-                                        {...field}
-                                        id={'clientId'}
-                                        variant='standard'
-                                        fullWidth
-                                        name='clientId'
-                                        label='Client ID'
-                                        error={!!errors.client_id}
-                                        helperText={errors.client_id?.message || 'OIDC Provider Client ID'}
-                                    />
-                                )}
-                            />
-                        </Grid>
-                        <Grid item xs={12}>
-                            <Controller
-                                control={control}
-                                name='issuer'
-                                rules={{
-                                    required: 'Issuer is required',
-                                }}
-                                render={({ field }) => (
-                                    <TextField
-                                        {...field}
-                                        id={'issuer'}
-                                        variant='standard'
-                                        fullWidth
-                                        name='issuer'
-                                        label='Issuer'
-                                        error={!!errors.issuer}
-                                        helperText={errors.issuer?.message || 'OIDC Issuer'}
-                                    />
-                                )}
-                            />
-                        </Grid>
-                        {error && (
-                            <Grid item xs={12}>
-                                <Alert severity='error'>{error}</Alert>
-                            </Grid>
-                        )}
-                    </Grid>
-                </DialogContent>
-                <DialogActions>
-                    <Button
-                        type='button'
-                        variant='tertiary'
-                        onClick={handleClose}
-                        data-testid='create-oidc-provider-dialog_button-close'>
-                        Cancel
-                    </Button>
-                    <Button data-testid='create-oidc-provider-dialog_button-save' type='submit'>
-                        Submit
-                    </Button>
-                </DialogActions>
-            </form>
+            <DialogTitle>{oldSSOProvider ? 'Edit' : 'Create'} OIDC Provider</DialogTitle>
+            <UpsertOIDCProviderForm
+                error={error}
+                onClose={onClose}
+                oldSSOProvider={oldSSOProvider}
+                onSubmit={onSubmit}
+            />
         </Dialog>
     );
 };
 
-export default UpsertOIDCProviderDialog;
+export default UpsertSAMLProviderDialog;

--- a/packages/javascript/bh-shared-ui/src/components/UpsertOIDCProviderDialog.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/UpsertOIDCProviderDialog.tsx
@@ -18,20 +18,21 @@ import { Button } from '@bloodhoundenterprise/doodleui';
 import { Alert, Dialog, DialogTitle, DialogContent, DialogActions, Grid, TextField } from '@mui/material';
 import { FC } from 'react';
 import { Controller, useForm } from 'react-hook-form';
-import { CreateOIDCProviderRequest } from 'js-client-library';
+import { UpsertOIDCProviderRequest } from 'js-client-library';
 
-const CreateOIDCProviderDialog: FC<{
+const UpsertOIDCProviderDialog: FC<{
     open: boolean;
     error?: string;
+    isUpdate: boolean;
     onClose: () => void;
-    onSubmit: (data: CreateOIDCProviderRequest) => void;
-}> = ({ open, error, onClose, onSubmit: _onSubmit }) => {
+    onSubmit: (data: UpsertOIDCProviderRequest) => void;
+}> = ({ open, error, isUpdate, onClose, onSubmit: _onSubmit }) => {
     const {
         control,
         handleSubmit,
         reset,
         formState: { errors },
-    } = useForm<CreateOIDCProviderRequest>({
+    } = useForm<UpsertOIDCProviderRequest>({
         defaultValues: {
             name: '',
             client_id: '',
@@ -39,7 +40,7 @@ const CreateOIDCProviderDialog: FC<{
         },
     });
 
-    const onSubmit = (data: CreateOIDCProviderRequest) => {
+    const onSubmit = (data: UpsertOIDCProviderRequest) => {
         _onSubmit(data);
         reset();
     };
@@ -59,7 +60,7 @@ const CreateOIDCProviderDialog: FC<{
                 // @ts-ignore
                 'data-testid': 'create-oidc-provider-dialog',
             }}>
-            <DialogTitle>Create OIDC Provider</DialogTitle>
+            <DialogTitle>{isUpdate ? 'Edit' : 'Create'} OIDC Provider</DialogTitle>
             <form onSubmit={handleSubmit(onSubmit)}>
                 <DialogContent>
                     <Grid container spacing={2}>
@@ -156,4 +157,4 @@ const CreateOIDCProviderDialog: FC<{
     );
 };
 
-export default CreateOIDCProviderDialog;
+export default UpsertOIDCProviderDialog;

--- a/packages/javascript/bh-shared-ui/src/components/UpsertOIDCProviderForm.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/UpsertOIDCProviderForm.tsx
@@ -20,7 +20,7 @@ import { FC } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 import { OIDCProviderInfo, SSOProvider, UpsertOIDCProviderRequest } from 'js-client-library';
 
-const UpsertOIDCProviderDialog: FC<{
+const UpsertOIDCProviderForm: FC<{
     error?: string;
     oldSSOProvider?: SSOProvider;
     onClose: () => void;
@@ -53,7 +53,7 @@ const UpsertOIDCProviderDialog: FC<{
                             control={control}
                             name='name'
                             rules={{
-                                required: !oldSSOProvider && 'OIDC Provider Name is required',
+                                required: 'OIDC Provider Name is required',
                                 pattern: {
                                     value: /^[A-z0-9 ]+$/,
                                     message: 'OIDC Provider Name must be alphanumeric.',
@@ -79,9 +79,7 @@ const UpsertOIDCProviderDialog: FC<{
                         <Controller
                             control={control}
                             name='client_id'
-                            rules={{
-                                required: !oldSSOProvider && 'Client ID is required',
-                            }}
+                            rules={{ required: 'Client ID is required' }}
                             render={({ field }) => (
                                 <TextField
                                     {...field}
@@ -100,9 +98,7 @@ const UpsertOIDCProviderDialog: FC<{
                         <Controller
                             control={control}
                             name='issuer'
-                            rules={{
-                                required: !oldSSOProvider && 'Issuer is required',
-                            }}
+                            rules={{ required: 'Issuer is required' }}
                             render={({ field }) => (
                                 <TextField
                                     {...field}
@@ -140,4 +136,4 @@ const UpsertOIDCProviderDialog: FC<{
     );
 };
 
-export default UpsertOIDCProviderDialog;
+export default UpsertOIDCProviderForm;

--- a/packages/javascript/bh-shared-ui/src/components/UpsertOIDCProviderForm.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/UpsertOIDCProviderForm.tsx
@@ -53,7 +53,7 @@ const UpsertOIDCProviderDialog: FC<{
                             control={control}
                             name='name'
                             rules={{
-                                required: 'OIDC Provider Name is required',
+                                required: !oldSSOProvider && 'OIDC Provider Name is required',
                                 pattern: {
                                     value: /^[A-z0-9 ]+$/,
                                     message: 'OIDC Provider Name must be alphanumeric.',
@@ -80,7 +80,7 @@ const UpsertOIDCProviderDialog: FC<{
                             control={control}
                             name='client_id'
                             rules={{
-                                required: 'Client ID is required',
+                                required: !oldSSOProvider && 'Client ID is required',
                             }}
                             render={({ field }) => (
                                 <TextField
@@ -101,7 +101,7 @@ const UpsertOIDCProviderDialog: FC<{
                             control={control}
                             name='issuer'
                             rules={{
-                                required: 'Issuer is required',
+                                required: !oldSSOProvider && 'Issuer is required',
                             }}
                             render={({ field }) => (
                                 <TextField

--- a/packages/javascript/bh-shared-ui/src/components/UpsertOIDCProviderForm.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/UpsertOIDCProviderForm.tsx
@@ -1,0 +1,143 @@
+// Copyright 2024 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { Button } from '@bloodhoundenterprise/doodleui';
+import { Alert, DialogContent, DialogActions, Grid, TextField } from '@mui/material';
+import { FC } from 'react';
+import { Controller, useForm } from 'react-hook-form';
+import { OIDCProviderInfo, SSOProvider, UpsertOIDCProviderRequest } from 'js-client-library';
+
+const UpsertOIDCProviderDialog: FC<{
+    error?: string;
+    oldSSOProvider?: SSOProvider;
+    onClose: () => void;
+    onSubmit: (data: UpsertOIDCProviderRequest) => void;
+}> = ({ error, oldSSOProvider, onClose, onSubmit }) => {
+    const defaultValues = {
+        name: oldSSOProvider?.name ?? '',
+        client_id: (oldSSOProvider?.details as OIDCProviderInfo)?.client_id ?? '',
+        issuer: (oldSSOProvider?.details as OIDCProviderInfo)?.issuer ?? '',
+    };
+
+    const {
+        control,
+        handleSubmit,
+        reset,
+        formState: { errors },
+    } = useForm<UpsertOIDCProviderRequest>({ defaultValues });
+
+    const handleClose = () => {
+        onClose();
+        reset();
+    };
+
+    return (
+        <form autoComplete='off' onSubmit={handleSubmit(onSubmit)}>
+            <DialogContent>
+                <Grid container spacing={2}>
+                    <Grid item xs={12}>
+                        <Controller
+                            control={control}
+                            name='name'
+                            rules={{
+                                required: 'OIDC Provider Name is required',
+                                pattern: {
+                                    value: /^[A-z0-9 ]+$/,
+                                    message: 'OIDC Provider Name must be alphanumeric.',
+                                },
+                            }}
+                            render={({ field }) => (
+                                <TextField
+                                    {...field}
+                                    id={'name'}
+                                    variant='standard'
+                                    fullWidth
+                                    name='name'
+                                    label='OIDC Provider Name'
+                                    error={!!errors.name}
+                                    helperText={
+                                        errors.name?.message || 'Choose a name for your OIDC Provider configuration'
+                                    }
+                                />
+                            )}
+                        />
+                    </Grid>
+                    <Grid item xs={12}>
+                        <Controller
+                            control={control}
+                            name='client_id'
+                            rules={{
+                                required: 'Client ID is required',
+                            }}
+                            render={({ field }) => (
+                                <TextField
+                                    {...field}
+                                    id={'clientId'}
+                                    variant='standard'
+                                    fullWidth
+                                    name='clientId'
+                                    label='Client ID'
+                                    error={!!errors.client_id}
+                                    helperText={errors.client_id?.message || 'OIDC Provider Client ID'}
+                                />
+                            )}
+                        />
+                    </Grid>
+                    <Grid item xs={12}>
+                        <Controller
+                            control={control}
+                            name='issuer'
+                            rules={{
+                                required: 'Issuer is required',
+                            }}
+                            render={({ field }) => (
+                                <TextField
+                                    {...field}
+                                    id={'issuer'}
+                                    variant='standard'
+                                    fullWidth
+                                    name='issuer'
+                                    label='Issuer'
+                                    error={!!errors.issuer}
+                                    helperText={errors.issuer?.message || 'OIDC Issuer'}
+                                />
+                            )}
+                        />
+                    </Grid>
+                    {error && (
+                        <Grid item xs={12}>
+                            <Alert severity='error'>{error}</Alert>
+                        </Grid>
+                    )}
+                </Grid>
+            </DialogContent>
+            <DialogActions>
+                <Button
+                    type='button'
+                    variant='tertiary'
+                    onClick={handleClose}
+                    data-testid='create-oidc-provider-dialog_button-close'>
+                    Cancel
+                </Button>
+                <Button data-testid='create-oidc-provider-dialog_button-save' type='submit'>
+                    {oldSSOProvider ? 'Confirm Edits' : 'Submit'}
+                </Button>
+            </DialogActions>
+        </form>
+    );
+};
+
+export default UpsertOIDCProviderDialog;

--- a/packages/javascript/bh-shared-ui/src/components/UpsertSAMLProviderDialog/UpsertSAMLProviderDialog.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/UpsertSAMLProviderDialog/UpsertSAMLProviderDialog.tsx
@@ -15,16 +15,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Dialog, DialogTitle } from '@mui/material';
-import { UpsertSAMLProviderFormInputs } from 'js-client-library';
+import { SSOProvider, UpsertSAMLProviderFormInputs } from 'js-client-library';
 import UpsertSAMLProviderForm from '../UpsertSAMLProviderForm';
 
 const UpsertSAMLProviderDialog: React.FC<{
     open: boolean;
     error?: string;
-    isUpdate: boolean;
+    oldSSOProvider?: SSOProvider;
     onClose: () => void;
     onSubmit: (data: UpsertSAMLProviderFormInputs) => void;
-}> = ({ open, error, isUpdate, onClose, onSubmit }) => {
+}> = ({ open, error, oldSSOProvider, onClose, onSubmit }) => {
     return (
         <Dialog
             open={open}
@@ -35,8 +35,13 @@ const UpsertSAMLProviderDialog: React.FC<{
                 // @ts-ignore
                 'data-testid': 'create-saml-provider-dialog',
             }}>
-            <DialogTitle>{isUpdate ? 'Edit' : 'Create'} SAML Provider</DialogTitle>
-            <UpsertSAMLProviderForm error={error} onClose={onClose} onSubmit={onSubmit} />
+            <DialogTitle>{oldSSOProvider ? 'Edit' : 'Create'} SAML Provider</DialogTitle>
+            <UpsertSAMLProviderForm
+                error={error}
+                onClose={onClose}
+                oldSSOProvider={oldSSOProvider}
+                onSubmit={onSubmit}
+            />
         </Dialog>
     );
 };

--- a/packages/javascript/bh-shared-ui/src/components/UpsertSAMLProviderDialog/UpsertSAMLProviderDialog.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/UpsertSAMLProviderDialog/UpsertSAMLProviderDialog.tsx
@@ -15,15 +15,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Dialog, DialogTitle } from '@mui/material';
-import CreateSAMLProviderForm from '../CreateSAMLProviderForm';
-import { CreateSAMLProviderFormInputs } from '../CreateSAMLProviderForm/CreateSAMLProviderForm';
+import { UpsertSAMLProviderFormInputs } from 'js-client-library';
+import UpsertSAMLProviderForm from '../UpsertSAMLProviderForm';
 
-const CreateSAMLProviderDialog: React.FC<{
+const UpsertSAMLProviderDialog: React.FC<{
     open: boolean;
     error?: string;
+    isUpdate: boolean;
     onClose: () => void;
-    onSubmit: (data: CreateSAMLProviderFormInputs) => void;
-}> = ({ open, error, onClose, onSubmit }) => {
+    onSubmit: (data: UpsertSAMLProviderFormInputs) => void;
+}> = ({ open, error, isUpdate, onClose, onSubmit }) => {
     return (
         <Dialog
             open={open}
@@ -34,10 +35,10 @@ const CreateSAMLProviderDialog: React.FC<{
                 // @ts-ignore
                 'data-testid': 'create-saml-provider-dialog',
             }}>
-            <DialogTitle>Create SAML Provider</DialogTitle>
-            <CreateSAMLProviderForm error={error} onClose={onClose} onSubmit={onSubmit} />
+            <DialogTitle>{isUpdate ? 'Edit' : 'Create'} SAML Provider</DialogTitle>
+            <UpsertSAMLProviderForm error={error} onClose={onClose} onSubmit={onSubmit} />
         </Dialog>
     );
 };
 
-export default CreateSAMLProviderDialog;
+export default UpsertSAMLProviderDialog;

--- a/packages/javascript/bh-shared-ui/src/components/UpsertSAMLProviderDialog/index.ts
+++ b/packages/javascript/bh-shared-ui/src/components/UpsertSAMLProviderDialog/index.ts
@@ -14,5 +14,5 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-export * from './CreateSAMLProviderDialog';
-export { default } from './CreateSAMLProviderDialog';
+export * from './UpsertSAMLProviderDialog';
+export { default } from './UpsertSAMLProviderDialog';

--- a/packages/javascript/bh-shared-ui/src/components/UpsertSAMLProviderForm/UpsertSAMLProviderForm.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/UpsertSAMLProviderForm/UpsertSAMLProviderForm.test.tsx
@@ -16,13 +16,13 @@
 
 import userEvent from '@testing-library/user-event';
 import { render, screen, waitFor } from '../../test-utils';
-import CreateSAMLProviderForm from './CreateSAMLProviderForm';
+import UpsertSAMLProviderForm from './UpsertSAMLProviderForm';
 
-describe('CreateSAMLProviderForm', () => {
+describe('UpsertSAMLProviderForm', () => {
     it('should render inputs, labels, and action buttons', () => {
         const testOnClose = vi.fn();
         const testOnSubmit = vi.fn();
-        render(<CreateSAMLProviderForm onClose={testOnClose} onSubmit={testOnSubmit} />);
+        render(<UpsertSAMLProviderForm onClose={testOnClose} onSubmit={testOnSubmit} />);
 
         expect(screen.getByLabelText('SAML Provider Name')).toBeInTheDocument();
 
@@ -37,7 +37,7 @@ describe('CreateSAMLProviderForm', () => {
         const user = userEvent.setup();
         const testOnClose = vi.fn();
         const testOnSubmit = vi.fn();
-        render(<CreateSAMLProviderForm onClose={testOnClose} onSubmit={testOnSubmit} />);
+        render(<UpsertSAMLProviderForm onClose={testOnClose} onSubmit={testOnSubmit} />);
 
         await user.click(screen.getByRole('button', { name: 'Cancel' }));
 
@@ -48,7 +48,7 @@ describe('CreateSAMLProviderForm', () => {
         const user = userEvent.setup();
         const testOnClose = vi.fn();
         const testOnSubmit = vi.fn();
-        render(<CreateSAMLProviderForm onClose={testOnClose} onSubmit={testOnSubmit} />);
+        render(<UpsertSAMLProviderForm onClose={testOnClose} onSubmit={testOnSubmit} />);
 
         await user.click(screen.getByRole('button', { name: 'Submit' }));
 
@@ -65,7 +65,7 @@ describe('CreateSAMLProviderForm', () => {
         const testOnSubmit = vi.fn();
         const validProviderName = 'test-provider-name';
         const validMetadata = new File([], 'test-metadata.xml');
-        render(<CreateSAMLProviderForm onClose={testOnClose} onSubmit={testOnSubmit} />);
+        render(<UpsertSAMLProviderForm onClose={testOnClose} onSubmit={testOnSubmit} />);
 
         await user.type(screen.getByLabelText('SAML Provider Name'), validProviderName);
 

--- a/packages/javascript/bh-shared-ui/src/components/UpsertSAMLProviderForm/UpsertSAMLProviderForm.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/UpsertSAMLProviderForm/UpsertSAMLProviderForm.tsx
@@ -28,23 +28,23 @@ import {
 } from '@mui/material';
 import { useState, FC } from 'react';
 import { Controller, useForm } from 'react-hook-form';
-import { UpsertSAMLProviderFormInputs } from 'js-client-library';
+import { SSOProvider, UpsertSAMLProviderFormInputs } from 'js-client-library';
 
 const UpsertSAMLProviderForm: FC<{
     error?: string;
+    oldSSOProvider?: SSOProvider;
     onClose: () => void;
     onSubmit: (data: UpsertSAMLProviderFormInputs) => void;
-}> = ({ error, onClose, onSubmit }) => {
+}> = ({ error, onClose, oldSSOProvider, onSubmit }) => {
     const theme = useTheme();
     const {
         control,
         handleSubmit,
         reset,
-
         formState: { errors },
     } = useForm<UpsertSAMLProviderFormInputs>({
         defaultValues: {
-            name: '',
+            name: oldSSOProvider?.name ?? '',
             metadata: undefined,
         },
     });
@@ -57,7 +57,7 @@ const UpsertSAMLProviderForm: FC<{
     };
 
     return (
-        <form onSubmit={handleSubmit(onSubmit)}>
+        <form autoComplete='off' onSubmit={handleSubmit(onSubmit)}>
             <DialogContent>
                 <Grid container spacing={2}>
                     <Grid item xs={12}>
@@ -144,7 +144,7 @@ const UpsertSAMLProviderForm: FC<{
                     Cancel
                 </Button>
                 <Button data-testid='create-saml-provider-dialog_button-save' type='submit'>
-                    Submit
+                    {oldSSOProvider ? 'Confirm Edits' : 'Submit'}
                 </Button>
             </DialogActions>
         </form>

--- a/packages/javascript/bh-shared-ui/src/components/UpsertSAMLProviderForm/UpsertSAMLProviderForm.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/UpsertSAMLProviderForm/UpsertSAMLProviderForm.tsx
@@ -65,7 +65,7 @@ const UpsertSAMLProviderForm: FC<{
                             control={control}
                             name='name'
                             rules={{
-                                required: 'SAML Provider Name is required',
+                                required: !oldSSOProvider && 'SAML Provider Name is required',
                                 pattern: {
                                     value: /^[a-z0-9]+(?:-[a-z0-9]+)*$/,
                                     message:
@@ -93,7 +93,7 @@ const UpsertSAMLProviderForm: FC<{
                             control={control}
                             name='metadata'
                             rules={{
-                                required: 'Metadata is required',
+                                required: !oldSSOProvider && 'Metadata is required',
                             }}
                             render={({ field }) => (
                                 <Box p={1} borderRadius={4} bgcolor={theme.palette.neutral.tertiary}>

--- a/packages/javascript/bh-shared-ui/src/components/UpsertSAMLProviderForm/UpsertSAMLProviderForm.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/UpsertSAMLProviderForm/UpsertSAMLProviderForm.tsx
@@ -65,7 +65,7 @@ const UpsertSAMLProviderForm: FC<{
                             control={control}
                             name='name'
                             rules={{
-                                required: !oldSSOProvider && 'SAML Provider Name is required',
+                                required: 'SAML Provider Name is required',
                                 pattern: {
                                     value: /^[a-z0-9]+(?:-[a-z0-9]+)*$/,
                                     message:
@@ -92,9 +92,7 @@ const UpsertSAMLProviderForm: FC<{
                         <Controller
                             control={control}
                             name='metadata'
-                            rules={{
-                                required: !oldSSOProvider && 'Metadata is required',
-                            }}
+                            rules={{ required: !oldSSOProvider && 'Metadata is required' }}
                             render={({ field }) => (
                                 <Box p={1} borderRadius={4} bgcolor={theme.palette.neutral.tertiary}>
                                     <Box display='flex' flexDirection='row' alignItems='center'>

--- a/packages/javascript/bh-shared-ui/src/components/UpsertSAMLProviderForm/UpsertSAMLProviderForm.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/UpsertSAMLProviderForm/UpsertSAMLProviderForm.tsx
@@ -28,16 +28,12 @@ import {
 } from '@mui/material';
 import { useState, FC } from 'react';
 import { Controller, useForm } from 'react-hook-form';
+import { UpsertSAMLProviderFormInputs } from 'js-client-library';
 
-export interface CreateSAMLProviderFormInputs {
-    name: string;
-    metadata: FileList;
-}
-
-const CreateSAMLProviderForm: FC<{
+const UpsertSAMLProviderForm: FC<{
     error?: string;
     onClose: () => void;
-    onSubmit: (data: CreateSAMLProviderFormInputs) => void;
+    onSubmit: (data: UpsertSAMLProviderFormInputs) => void;
 }> = ({ error, onClose, onSubmit }) => {
     const theme = useTheme();
     const {
@@ -46,7 +42,7 @@ const CreateSAMLProviderForm: FC<{
         reset,
 
         formState: { errors },
-    } = useForm<CreateSAMLProviderFormInputs>({
+    } = useForm<UpsertSAMLProviderFormInputs>({
         defaultValues: {
             name: '',
             metadata: undefined,
@@ -155,4 +151,4 @@ const CreateSAMLProviderForm: FC<{
     );
 };
 
-export default CreateSAMLProviderForm;
+export default UpsertSAMLProviderForm;

--- a/packages/javascript/bh-shared-ui/src/components/UpsertSAMLProviderForm/index.ts
+++ b/packages/javascript/bh-shared-ui/src/components/UpsertSAMLProviderForm/index.ts
@@ -14,5 +14,5 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-export * from './CreateSAMLProviderForm';
-export { default } from './CreateSAMLProviderForm';
+export * from './UpsertSAMLProviderForm';
+export { default } from './UpsertSAMLProviderForm';

--- a/packages/javascript/bh-shared-ui/src/components/index.ts
+++ b/packages/javascript/bh-shared-ui/src/components/index.ts
@@ -49,12 +49,6 @@ export { default as ConfirmationDialog } from './ConfirmationDialog';
 export * from './CreateMenu';
 export { default as CreateMenu } from './CreateMenu';
 
-export * from './CreateSAMLProviderDialog';
-export { default as CreateSAMLProviderDialog } from './CreateSAMLProviderDialog';
-
-export * from './CreateSAMLProviderForm';
-export { default as CreateSAMLProviderForm } from './CreateSAMLProviderForm';
-
 export * from './CreateUserForm';
 export { default as CreateUserForm } from './CreateUserForm';
 
@@ -175,6 +169,12 @@ export { default as UpdateUserDialog } from './UpdateUserDialog';
 
 export * from './UpdateUserForm';
 export { default as UpdateUserForm } from './UpdateUserForm';
+
+export * from './UpsertSAMLProviderDialog';
+export { default as UpsertSAMLProviderDialog } from './UpsertSAMLProviderDialog';
+
+export * from './UpsertSAMLProviderForm';
+export { default as UpsertSAMLProviderForm } from './UpsertSAMLProviderForm';
 
 export * from './UserTokenManagementDialog';
 export { default as UserTokenManagementDialog } from './UserTokenManagementDialog';

--- a/packages/javascript/bh-shared-ui/src/views/SSOConfiguration/SSOConfiguration.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/SSOConfiguration/SSOConfiguration.tsx
@@ -96,6 +96,10 @@ const SSOConfiguration: FC = () => {
         return listSSOProvidersQuery.data?.find(({ id }) => id === selectedSSOProviderId);
     }, [selectedSSOProviderId, listSSOProvidersQuery.data]);
 
+    const selectedSSOProviderToUpdate = useMemo(() => {
+        return listSSOProvidersQuery.data?.find(({ id }) => id === ssoProviderIdToDeleteOrUpdate);
+    }, [ssoProviderIdToDeleteOrUpdate, listSSOProvidersQuery.data]);
+
     /* Event Handlers */
 
     const openSAMLProviderDialog = () => {
@@ -280,14 +284,14 @@ const SSOConfiguration: FC = () => {
             </PageWithTitle>
             <UpsertSAMLProviderDialog
                 open={dialogOpen === 'SAML'}
-                isUpdate={dialogOpen === 'SAML' && !!ssoProviderIdToDeleteOrUpdate}
+                oldSSOProvider={dialogOpen === 'SAML' ? selectedSSOProviderToUpdate : undefined}
                 error={createProviderError}
                 onClose={closeDialog}
                 onSubmit={upsertSAMLProvider}
             />
             <UpsertOIDCProviderDialog
                 open={dialogOpen === 'OIDC'}
-                isUpdate={dialogOpen === 'OIDC' && !!ssoProviderIdToDeleteOrUpdate}
+                oldSSOProvider={dialogOpen === 'OIDC' ? selectedSSOProviderToUpdate : undefined}
                 error={createProviderError}
                 onClose={closeDialog}
                 onSubmit={upsertOIDCProvider}

--- a/packages/javascript/bh-shared-ui/src/views/SSOConfiguration/SSOConfiguration.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/SSOConfiguration/SSOConfiguration.tsx
@@ -17,7 +17,7 @@
 import { faSearch } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Box, Grid, Paper, TextField, Typography, useTheme } from '@mui/material';
-import { SSOProvider, UpsertSAMLProviderFormInputs, UpsertOIDCProviderRequest } from 'js-client-library';
+import { SSOProvider, UpsertOIDCProviderRequest, UpsertSAMLProviderFormInputs } from 'js-client-library';
 import { ChangeEvent, FC, useMemo, useState } from 'react';
 import { useMutation, useQuery } from 'react-query';
 import {
@@ -117,7 +117,7 @@ const SSOConfiguration: FC = () => {
     const closeDialog = () => {
         setUpsertProviderError('');
         setDialogOpen('');
-        setSSOProviderIdToDeleteOrUpdate(undefined);
+        setTimeout(() => setSSOProviderIdToDeleteOrUpdate(undefined), 500);
     };
 
     const onClickSSOProvider = (ssoProviderId: SSOProvider['id']) => {
@@ -290,14 +290,14 @@ const SSOConfiguration: FC = () => {
             </PageWithTitle>
             <UpsertSAMLProviderDialog
                 open={dialogOpen === 'SAML'}
-                oldSSOProvider={dialogOpen === 'SAML' ? selectedSSOProviderToUpdate : undefined}
+                oldSSOProvider={selectedSSOProviderToUpdate}
                 error={upsertProviderError}
                 onClose={closeDialog}
                 onSubmit={upsertSAMLProvider}
             />
             <UpsertOIDCProviderDialog
                 open={dialogOpen === 'OIDC'}
-                oldSSOProvider={dialogOpen === 'OIDC' ? selectedSSOProviderToUpdate : undefined}
+                oldSSOProvider={selectedSSOProviderToUpdate}
                 error={upsertProviderError}
                 onClose={closeDialog}
                 onSubmit={upsertOIDCProvider}

--- a/packages/javascript/bh-shared-ui/src/views/SSOConfiguration/SSOConfiguration.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/SSOConfiguration/SSOConfiguration.tsx
@@ -44,7 +44,7 @@ const SSOConfiguration: FC = () => {
     const [ssoProviderIdToDeleteOrUpdate, setSSOProviderIdToDeleteOrUpdate] = useState<SSOProvider['id'] | undefined>();
     const [dialogOpen, setDialogOpen] = useState<'SAML' | 'OIDC' | 'DELETE' | ''>('');
     const [nameFilter, setNameFilter] = useState<string>('');
-    const [createProviderError, setCreateProviderError] = useState<string>('');
+    const [upsertProviderError, setUpsertProviderError] = useState<string>('');
     const [typeSortOrder, setTypeSortOrder] = useState<SortOrder>();
 
     const listSSOProvidersQuery = useQuery(['listSSOProviders'], ({ signal }) =>
@@ -115,7 +115,7 @@ const SSOConfiguration: FC = () => {
     };
 
     const closeDialog = () => {
-        setCreateProviderError('');
+        setUpsertProviderError('');
         setDialogOpen('');
         setSSOProviderIdToDeleteOrUpdate(undefined);
     };
@@ -171,7 +171,7 @@ const SSOConfiguration: FC = () => {
     };
 
     const upsertSAMLProvider = async (samlProvider: UpsertSAMLProviderFormInputs) => {
-        setCreateProviderError('');
+        setUpsertProviderError('');
         try {
             const payload = { name: samlProvider.name, metadata: samlProvider.metadata && samlProvider.metadata[0] };
             if (ssoProviderIdToDeleteOrUpdate) {
@@ -185,14 +185,14 @@ const SSOConfiguration: FC = () => {
             closeDialog();
         } catch (error) {
             console.error(error);
-            setCreateProviderError(
+            setUpsertProviderError(
                 `Unable to ${ssoProviderIdToDeleteOrUpdate ? 'update' : 'create new'} SAML Provider configuration. Please try again.`
             );
         }
     };
 
     const upsertOIDCProvider = async (oidcProvider: UpsertOIDCProviderRequest) => {
-        setCreateProviderError('');
+        setUpsertProviderError('');
         try {
             if (ssoProviderIdToDeleteOrUpdate) {
                 await apiClient.updateOIDCProvider(ssoProviderIdToDeleteOrUpdate, oidcProvider);
@@ -209,7 +209,7 @@ const SSOConfiguration: FC = () => {
             closeDialog();
         } catch (error) {
             console.error(error);
-            setCreateProviderError(
+            setUpsertProviderError(
                 `Unable to ${ssoProviderIdToDeleteOrUpdate ? 'update' : 'create new'} OIDC Provider configuration. Please try again.`
             );
         }
@@ -291,14 +291,14 @@ const SSOConfiguration: FC = () => {
             <UpsertSAMLProviderDialog
                 open={dialogOpen === 'SAML'}
                 oldSSOProvider={dialogOpen === 'SAML' ? selectedSSOProviderToUpdate : undefined}
-                error={createProviderError}
+                error={upsertProviderError}
                 onClose={closeDialog}
                 onSubmit={upsertSAMLProvider}
             />
             <UpsertOIDCProviderDialog
                 open={dialogOpen === 'OIDC'}
                 oldSSOProvider={dialogOpen === 'OIDC' ? selectedSSOProviderToUpdate : undefined}
-                error={createProviderError}
+                error={upsertProviderError}
                 onClose={closeDialog}
                 onSubmit={upsertOIDCProvider}
             />

--- a/packages/javascript/bh-shared-ui/src/views/SSOConfiguration/SSOConfiguration.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/SSOConfiguration/SSOConfiguration.tsx
@@ -173,13 +173,13 @@ const SSOConfiguration: FC = () => {
     const upsertSAMLProvider = async (samlProvider: UpsertSAMLProviderFormInputs) => {
         setCreateProviderError('');
         try {
-            const payload = { ...samlProvider, metadata: samlProvider.metadata[0] };
+            const payload = { name: samlProvider.name, metadata: samlProvider.metadata && samlProvider.metadata[0] };
             if (ssoProviderIdToDeleteOrUpdate) {
                 await apiClient.updateSAMLProviderFromFile(ssoProviderIdToDeleteOrUpdate, payload);
             } else {
-                await apiClient.createSAMLProviderFromFile(payload);
-                listSSOProvidersQuery.refetch();
-                closeDialog();
+                if (payload.name && payload.metadata) {
+                    await apiClient.createSAMLProviderFromFile({ name: payload.name, metadata: payload.metadata });
+                }
             }
             listSSOProvidersQuery.refetch();
             closeDialog();
@@ -197,7 +197,13 @@ const SSOConfiguration: FC = () => {
             if (ssoProviderIdToDeleteOrUpdate) {
                 await apiClient.updateOIDCProvider(ssoProviderIdToDeleteOrUpdate, oidcProvider);
             } else {
-                await apiClient.createOIDCProvider(oidcProvider);
+                if (oidcProvider.name && oidcProvider.client_id && oidcProvider.issuer) {
+                    await apiClient.createOIDCProvider({
+                        name: oidcProvider.name,
+                        client_id: oidcProvider.client_id,
+                        issuer: oidcProvider.issuer,
+                    });
+                }
             }
             listSSOProvidersQuery.refetch();
             closeDialog();

--- a/packages/javascript/js-client-library/src/client.ts
+++ b/packages/javascript/js-client-library/src/client.ts
@@ -642,35 +642,22 @@ class BHEAPIClient {
     getSAMLProvider = (samlProviderId: string, options?: types.RequestOptions) =>
         this.baseClient.get(`/api/v2/saml/providers/${samlProviderId}`, options);
 
-    createSAMLProvider = (
-        data: {
-            name: string;
-            displayName: string;
-            signingCertificate: string;
-            issuerUri: string;
-            singleSignOnUri: string;
-            principalAttributeMappings: string[];
-        },
-        options?: types.RequestOptions
-    ) =>
-        this.baseClient.post(
-            `/api/v2/saml`,
-            {
-                name: data.name,
-                display_name: data.displayName,
-                signing_certificate: data.signingCertificate,
-                issuer_uri: data.issuerUri,
-                single_signon_uri: data.singleSignOnUri,
-                principal_attribute_mappings: data.principalAttributeMappings,
-            },
-            options
-        );
-
     createSAMLProviderFromFile = (data: { name: string; metadata: File }, options?: types.RequestOptions) => {
         const formData = new FormData();
         formData.append('name', data.name);
         formData.append('metadata', data.metadata);
         return this.baseClient.post(`/api/v2/saml/providers`, formData, options);
+    };
+
+    updateSAMLProviderFromFile = (
+        ssoProviderId: types.SSOProvider['id'],
+        data: { name: string; metadata: File },
+        options?: types.RequestOptions
+    ) => {
+        const formData = new FormData();
+        formData.append('name', data.name);
+        formData.append('metadata', data.metadata);
+        return this.baseClient.put(`/api/v2/sso-providers/${ssoProviderId}`, formData, options);
     };
 
     validateSAMLProvider = (
@@ -700,8 +687,11 @@ class BHEAPIClient {
     deleteSSOProvider = (ssoProviderId: types.SSOProvider['id'], options?: types.RequestOptions) =>
         this.baseClient.delete(`/api/v2/sso-providers/${ssoProviderId}`, options);
 
-    createOIDCProvider = (oidcProvider: types.CreateOIDCProviderRequest) =>
+    createOIDCProvider = (oidcProvider: types.UpsertOIDCProviderRequest) =>
         this.baseClient.post(`/api/v2/sso-providers/oidc`, oidcProvider);
+
+    updateOIDCProvider = (ssoProviderId: types.SSOProvider['id'], oidcProvider: types.UpsertOIDCProviderRequest) =>
+        this.baseClient.put(`/api/v2/sso-providers/${ssoProviderId}`, oidcProvider);
 
     listSSOProviders = (options?: types.RequestOptions) =>
         this.baseClient.get<types.ListSSOProvidersResponse>(`/api/v2/sso-providers`, options);

--- a/packages/javascript/js-client-library/src/client.ts
+++ b/packages/javascript/js-client-library/src/client.ts
@@ -651,13 +651,17 @@ class BHEAPIClient {
 
     updateSAMLProviderFromFile = (
         ssoProviderId: types.SSOProvider['id'],
-        data: { name: string; metadata: File },
+        data: { name?: string; metadata?: File },
         options?: types.RequestOptions
     ) => {
         const formData = new FormData();
-        formData.append('name', data.name);
-        formData.append('metadata', data.metadata);
-        return this.baseClient.put(`/api/v2/sso-providers/${ssoProviderId}`, formData, options);
+        if (data.name) {
+            formData.append('name', data.name);
+        }
+        if (data.metadata) {
+            formData.append('metadata', data.metadata);
+        }
+        return this.baseClient.patch(`/api/v2/sso-providers/${ssoProviderId}`, formData, options);
     };
 
     validateSAMLProvider = (
@@ -687,11 +691,11 @@ class BHEAPIClient {
     deleteSSOProvider = (ssoProviderId: types.SSOProvider['id'], options?: types.RequestOptions) =>
         this.baseClient.delete(`/api/v2/sso-providers/${ssoProviderId}`, options);
 
-    createOIDCProvider = (oidcProvider: types.UpsertOIDCProviderRequest) =>
+    createOIDCProvider = (oidcProvider: types.CreateOIDCProviderRequest) =>
         this.baseClient.post(`/api/v2/sso-providers/oidc`, oidcProvider);
 
-    updateOIDCProvider = (ssoProviderId: types.SSOProvider['id'], oidcProvider: types.UpsertOIDCProviderRequest) =>
-        this.baseClient.put(`/api/v2/sso-providers/${ssoProviderId}`, oidcProvider);
+    updateOIDCProvider = (ssoProviderId: types.SSOProvider['id'], oidcProvider: types.UpdateOIDCProviderRequest) =>
+        this.baseClient.patch(`/api/v2/sso-providers/${ssoProviderId}`, oidcProvider);
 
     listSSOProviders = (options?: types.RequestOptions) =>
         this.baseClient.get<types.ListSSOProvidersResponse>(`/api/v2/sso-providers`, options);

--- a/packages/javascript/js-client-library/src/types.ts
+++ b/packages/javascript/js-client-library/src/types.ts
@@ -149,16 +149,20 @@ export interface PutUserAuthSecretRequest {
     needsPasswordReset: boolean;
 }
 
-export interface UpsertSAMLProviderFormInputs {
+export interface CreateSAMLProviderFormInputs {
     name: string;
     metadata: FileList;
 }
+export type UpdateSAMLProviderFormInputs = Partial<CreateSAMLProviderFormInputs>;
+export type UpsertSAMLProviderFormInputs = CreateSAMLProviderFormInputs | UpdateSAMLProviderFormInputs;
 
-export interface UpsertOIDCProviderRequest {
+export interface CreateOIDCProviderRequest {
     name: string;
     client_id: string;
     issuer: string;
 }
+export type UpdateOIDCProviderRequest = Partial<CreateOIDCProviderRequest>;
+export type UpsertOIDCProviderRequest = CreateOIDCProviderRequest | UpdateOIDCProviderRequest;
 
 export interface SAMLProviderInfo extends Serial {
     name: string;

--- a/packages/javascript/js-client-library/src/types.ts
+++ b/packages/javascript/js-client-library/src/types.ts
@@ -149,7 +149,12 @@ export interface PutUserAuthSecretRequest {
     needsPasswordReset: boolean;
 }
 
-export interface CreateOIDCProviderRequest {
+export interface UpsertSAMLProviderFormInputs {
+    name: string;
+    metadata: FileList;
+}
+
+export interface UpsertOIDCProviderRequest {
     name: string;
     client_id: string;
     issuer: string;


### PR DESCRIPTION
## Description

- Renamed create provider dialogs to upsert
- Added edit support to provider dropdown

NOTE: https://github.com/SpecterOps/BloodHound/pull/975 should be merged first

## Motivation and Context

This PR addresses: BED-5067

*Why is this change required? What problem does it solve?*
Currently you cannot edit a SSO provider without deleting it first. This adds support for the UI to hit the new PATCH endpoints created by https://github.com/SpecterOps/BloodHound/pull/975

## How Has This Been Tested?
Locally and through unit tests

## Types of changes

<!-- Please remove any items that do not apply. -->
- New feature (non-breaking change which adds functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
