### PR TITLE
Bed-5010 feat: Add ability to download SAML signing certificate

### DIFF
--- a/cmd/api/src/api/registration/v2.go
+++ b/cmd/api/src/api/registration/v2.go
@@ -61,8 +61,9 @@ func registerV2Auth(resources v2.Resources, routerInst *router.Router, permissio
 		routerInst.DELETE(fmt.Sprintf("/api/v2/sso-providers/{%s}", api.URIPathVariableSSOProviderID), managementResource.DeleteSSOProvider).RequirePermissions(permissions.AuthManageProviders),
 		routerInst.PATCH(fmt.Sprintf("/api/v2/sso-providers/{%s}", api.URIPathVariableSSOProviderID), managementResource.UpdateSSOProvider).RequirePermissions(permissions.AuthManageProviders),
 		routerInst.GET(fmt.Sprintf("/api/v2/sso/{%s}/login", api.URIPathVariableSSOProviderSlug), managementResource.SSOLoginHandler),
-		routerInst.GET(fmt.Sprintf("/api/v2/sso/{%s}/metadata", api.URIPathVariableSSOProviderSlug), managementResource.ServeMetadata),
 		routerInst.PathPrefix(fmt.Sprintf("/api/v2/sso/{%s}/callback", api.URIPathVariableSSOProviderSlug), http.HandlerFunc(managementResource.SSOCallbackHandler)),
+		routerInst.GET(fmt.Sprintf("/api/v2/sso/{%s}/metadata", api.URIPathVariableSSOProviderSlug), managementResource.ServeMetadata),
+		routerInst.GET(fmt.Sprintf("/api/v2/sso/{%s}/signing-certificate", api.URIPathVariableSSOProviderSlug), managementResource.ServeSigningCertificate),
 
 		// Permissions
 		routerInst.GET("/api/v2/permissions", managementResource.ListPermissions).RequirePermissions(permissions.AuthManageSelf),

--- a/cmd/api/src/api/registration/v2.go
+++ b/cmd/api/src/api/registration/v2.go
@@ -60,10 +60,11 @@ func registerV2Auth(resources v2.Resources, routerInst *router.Router, permissio
 		routerInst.POST("/api/v2/sso-providers/oidc", managementResource.CreateOIDCProvider).CheckFeatureFlag(resources.DB, appcfg.FeatureOIDCSupport).RequirePermissions(permissions.AuthManageProviders),
 		routerInst.DELETE(fmt.Sprintf("/api/v2/sso-providers/{%s}", api.URIPathVariableSSOProviderID), managementResource.DeleteSSOProvider).RequirePermissions(permissions.AuthManageProviders),
 		routerInst.PATCH(fmt.Sprintf("/api/v2/sso-providers/{%s}", api.URIPathVariableSSOProviderID), managementResource.UpdateSSOProvider).RequirePermissions(permissions.AuthManageProviders),
+		routerInst.GET(fmt.Sprintf("/api/v2/sso-providers/{%s}/signing-certificate", api.URIPathVariableSSOProviderID), managementResource.ServeSigningCertificate).RequirePermissions(permissions.AuthManageProviders),
+
 		routerInst.GET(fmt.Sprintf("/api/v2/sso/{%s}/login", api.URIPathVariableSSOProviderSlug), managementResource.SSOLoginHandler),
 		routerInst.PathPrefix(fmt.Sprintf("/api/v2/sso/{%s}/callback", api.URIPathVariableSSOProviderSlug), http.HandlerFunc(managementResource.SSOCallbackHandler)),
 		routerInst.GET(fmt.Sprintf("/api/v2/sso/{%s}/metadata", api.URIPathVariableSSOProviderSlug), managementResource.ServeMetadata),
-		routerInst.GET(fmt.Sprintf("/api/v2/sso/{%s}/signing-certificate", api.URIPathVariableSSOProviderSlug), managementResource.ServeSigningCertificate),
 
 		// Permissions
 		routerInst.GET("/api/v2/permissions", managementResource.ListPermissions).RequirePermissions(permissions.AuthManageSelf),

--- a/cmd/api/src/api/v2/auth/saml.go
+++ b/cmd/api/src/api/v2/auth/saml.go
@@ -28,6 +28,7 @@ import (
 	"github.com/crewjam/saml"
 	"github.com/crewjam/saml/samlsp"
 	"github.com/gorilla/mux"
+	"github.com/specterops/bloodhound/crypto"
 	"github.com/specterops/bloodhound/headers"
 	"github.com/specterops/bloodhound/log"
 	"github.com/specterops/bloodhound/mediatypes"
@@ -292,7 +293,7 @@ func (s ManagementResource) ServeSigningCertificate(response http.ResponseWriter
 	} else {
 		// Note this is the public cert not necessarily the IDP cert
 		response.Header().Set(headers.ContentDisposition.String(), fmt.Sprintf("attachment; filename=\"%s-signing-certificate.pem\"", ssoProvider.Slug))
-		if _, err := response.Write([]byte(s.config.SAML.ServiceProviderCertificate)); err != nil {
+		if _, err := response.Write([]byte(crypto.FormatCert(s.config.SAML.ServiceProviderCertificate))); err != nil {
 			log.Errorf("[SAML] Failed to write response for serving signing certificate: %v", err)
 		}
 	}

--- a/packages/go/crypto/tls.go
+++ b/packages/go/crypto/tls.go
@@ -74,16 +74,20 @@ func X509ParseCert(cert string) (*x509.Certificate, error) {
 	}
 }
 
+func FormatCert(cert string) string {
+	if !strings.HasPrefix(cert, "-----BEGIN CERTIFICATE-----") {
+		cert = "-----BEGIN CERTIFICATE-----\n" + cert
+	}
+
+	if !strings.HasSuffix(cert, "-----END CERTIFICATE-----") {
+		cert = cert + "\n-----END CERTIFICATE-----"
+	}
+
+	return cert
+}
+
 func X509ParsePair(cert, key string) (*x509.Certificate, *rsa.PrivateKey, error) {
-	formattedCert := cert
-
-	if !strings.HasPrefix("-----BEGIN CERTIFICATE-----", formattedCert) {
-		formattedCert = "-----BEGIN CERTIFICATE-----\n" + formattedCert
-	}
-
-	if !strings.HasSuffix("-----END CERTIFICATE----- ", formattedCert) {
-		formattedCert = formattedCert + "\n-----END CERTIFICATE----- "
-	}
+	formattedCert := FormatCert(cert)
 
 	if certBlock, _ := pem.Decode([]byte(formattedCert)); certBlock == nil {
 		return nil, nil, fmt.Errorf("unable to decode cert")

--- a/packages/go/openapi/doc/openapi.json
+++ b/packages/go/openapi/doc/openapi.json
@@ -801,6 +801,68 @@
         }
       }
     },
+    "/api/v2/sso-providers/{sso_provider_id}/signing-certificate": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/header.prefer"
+        },
+        {
+          "description": "SSO Provider ID for a SAML provider",
+          "name": "sso_provider_id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      ],
+      "get": {
+        "operationId": "GetSSOProviderSAMLSigningCertificate",
+        "summary": "Get SAML Provider Signing Certificate",
+        "description": "Download the SAML Provider Signing Certificate. Only applies to SAML providers.",
+        "tags": [
+          "Auth",
+          "Community",
+          "Enterprise"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "content-disposition": {
+                "schema": {
+                  "type": "string"
+                },
+                "description": "Suggested filename of structure \"{saml-slug}-signing-certificate.pem\""
+              }
+            },
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/not-found"
+          },
+          "429": {
+            "$ref": "#/components/responses/too-many-requests"
+          },
+          "500": {
+            "$ref": "#/components/responses/internal-server-error"
+          }
+        }
+      }
+    },
     "/api/v2/permissions": {
       "parameters": [
         {

--- a/packages/go/openapi/src/openapi.yaml
+++ b/packages/go/openapi/src/openapi.yaml
@@ -224,6 +224,8 @@ paths:
     $ref: './paths/sso.sso-providers.oidc.yaml'
   /api/v2/sso-providers/{sso_provider_id}:
     $ref: './paths/sso.sso-providers.id.yaml'
+  /api/v2/sso-providers/{sso_provider_id}/signing-certificate:
+      $ref: './paths/sso.sso-providers.id.signing-certificate.yaml'
 
   # permissions
   /api/v2/permissions:

--- a/packages/go/openapi/src/paths/sso.sso-providers.id.signing-certificate.yaml
+++ b/packages/go/openapi/src/paths/sso.sso-providers.id.signing-certificate.yaml
@@ -1,0 +1,55 @@
+# Copyright 2024 Specter Ops, Inc.
+#
+# Licensed under the Apache License, Version 2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+parameters:
+  - $ref: './../parameters/header.prefer.yaml'
+  - description: SSO Provider ID for a SAML provider
+    name: sso_provider_id
+    in: path
+    required: true
+    schema:
+      type: integer
+      format: int32
+get:
+  operationId: GetSSOProviderSAMLSigningCertificate
+  summary: Get SAML Provider Signing Certificate
+  description: Download the SAML Provider Signing Certificate. Only applies to SAML providers.
+  tags:
+    - Auth
+    - Community
+    - Enterprise
+  responses:
+    '200':
+      description: OK
+      headers:
+        content-disposition:
+          schema:
+            type: string
+          description: Suggested filename of structure "{saml-slug}-signing-certificate.pem"
+      content:
+        text/plain:
+          schema:
+            type: string
+    '401':
+      $ref: './../responses/unauthorized.yaml'
+    '403':
+      $ref: './../responses/forbidden.yaml'
+    '404':
+      $ref: './../responses/not-found.yaml'
+    '429':
+      $ref: './../responses/too-many-requests.yaml'
+    '500':
+      $ref: './../responses/internal-server-error.yaml'

--- a/packages/javascript/bh-shared-ui/src/components/SSOProviderInfoPanel/SSOProviderInfoPanel.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/SSOProviderInfoPanel/SSOProviderInfoPanel.tsx
@@ -16,9 +16,13 @@
 
 import { Paper, Box, Typography, useTheme } from '@mui/material';
 import { FC } from 'react';
+import fileDownload from 'js-file-download';
 import { OIDCProviderInfo, SAMLProviderInfo, SSOProvider } from 'js-client-library';
+import { Button } from '@bloodhoundenterprise/doodleui';
 import { Field, FieldsContainer, usePaneStyles, useHeaderStyles } from '../../views/Explore';
 import LabelWithCopy from '../LabelWithCopy';
+import { apiClient } from '../../utils';
+import { useNotifications } from '../../providers';
 
 const SAMLProviderInfoPanel: FC<{
     samlProviderDetails: SAMLProviderInfo;
@@ -73,6 +77,7 @@ const SSOProviderInfoPanel: FC<{
     const theme = useTheme();
     const paneStyles = usePaneStyles();
     const headerStyles = useHeaderStyles();
+    const { addNotification } = useNotifications();
 
     if (!ssoProvider.type) {
         return null;
@@ -90,48 +95,83 @@ const SSOProviderInfoPanel: FC<{
             infoPanel = null;
     }
 
+    const downloadSAMLSigningCertificate = () => {
+        if (ssoProvider.type.toLowerCase() == 'oidc') {
+            addNotification('Only SAML providers support signing certificates.', 'errorDownloadSAMLSigningCertificate');
+        } else {
+            apiClient
+                .getSAMLProviderSigningCertificate(ssoProvider.slug)
+                .then((res) => {
+                    const filename =
+                        res.headers['content-disposition']?.match(/^.*filename="(.*)"$/)?.[1] ||
+                        `${ssoProvider.name}-signing-certificate`;
+
+                    fileDownload(res.data, filename);
+                })
+                .catch((err) => {
+                    console.error(err);
+                    addNotification(
+                        'This file could not be downloaded. Please try again.',
+                        'downloadSAMLSigningCertificate'
+                    );
+                });
+        }
+    };
+
     return (
-        <Box className={paneStyles.container} data-testid='sso_provider-info-panel'>
-            <Paper>
-                <Box className={headerStyles.header} sx={{ backgroundColor: theme.palette.neutral.quinary }}>
-                    <Box
-                        sx={{
-                            backgroundColor: theme.palette.primary.main,
-                            width: 10,
-                            height: theme.spacing(7),
-                            mr: theme.spacing(1),
-                        }}
-                    />
-                    <Typography
-                        data-testid='sso_provider-info-panel_header-text'
-                        variant={'h5'}
-                        noWrap
-                        sx={{
-                            color: theme.palette.text.primary,
-                            flexGrow: 1,
-                        }}>
-                        {ssoProvider?.name}
-                    </Typography>
-                </Box>
-                <Paper
-                    elevation={0}
-                    sx={{
-                        backgroundColor: theme.palette.neutral.secondary,
-                        overflowX: 'hidden',
-                        overflowY: 'auto',
-                        padding: theme.spacing(1, 2),
-                        pointerEvents: 'auto',
-                        '& > div.node:nth-of-type(odd)': {
-                            background: theme.palette.neutral.tertiary,
-                        },
-                    }}>
-                    <Box flexShrink={0} flexGrow={1} fontWeight='bold' ml={theme.spacing(1)} fontSize={'small'}>
-                        Provider Information:
+        <>
+            <Box className={paneStyles.container} data-testid='sso_provider-info-panel'>
+                <Paper>
+                    <Box className={headerStyles.header} sx={{ backgroundColor: theme.palette.neutral.quinary }}>
+                        <Box
+                            sx={{
+                                backgroundColor: theme.palette.primary.main,
+                                width: 10,
+                                height: theme.spacing(7),
+                                mr: theme.spacing(1),
+                            }}
+                        />
+                        <Typography
+                            data-testid='sso_provider-info-panel_header-text'
+                            variant={'h5'}
+                            noWrap
+                            sx={{
+                                color: theme.palette.text.primary,
+                                flexGrow: 1,
+                            }}>
+                            {ssoProvider?.name}
+                        </Typography>
                     </Box>
-                    {infoPanel}
+                    <Paper
+                        elevation={0}
+                        sx={{
+                            backgroundColor: theme.palette.neutral.secondary,
+                            overflowX: 'hidden',
+                            overflowY: 'auto',
+                            padding: theme.spacing(1, 2),
+                            pointerEvents: 'auto',
+                            '& > div.node:nth-of-type(odd)': {
+                                background: theme.palette.neutral.tertiary,
+                            },
+                        }}>
+                        <Box flexShrink={0} flexGrow={1} fontWeight='bold' ml={theme.spacing(1)} fontSize={'small'}>
+                            Provider Information:
+                        </Box>
+                        {infoPanel}
+                    </Paper>
                 </Paper>
-            </Paper>
-        </Box>
+            </Box>
+            {ssoProvider.type.toLowerCase() === 'saml' && (
+                <Box mt={theme.spacing(1)} justifyContent='center' display='flex'>
+                    <Button
+                        aria-label={`Download ${ssoProvider.name} SP Certificate`}
+                        variant='secondary'
+                        onClick={downloadSAMLSigningCertificate}>
+                        Download SAML SP Certificate
+                    </Button>
+                </Box>
+            )}
+        </>
     );
 };
 

--- a/packages/javascript/bh-shared-ui/src/components/SSOProviderInfoPanel/SSOProviderInfoPanel.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/SSOProviderInfoPanel/SSOProviderInfoPanel.tsx
@@ -100,7 +100,7 @@ const SSOProviderInfoPanel: FC<{
             addNotification('Only SAML providers support signing certificates.', 'errorDownloadSAMLSigningCertificate');
         } else {
             apiClient
-                .getSAMLProviderSigningCertificate(ssoProvider.slug)
+                .getSAMLProviderSigningCertificate(ssoProvider.id)
                 .then((res) => {
                     const filename =
                         res.headers['content-disposition']?.match(/^.*filename="(.*)"$/)?.[1] ||

--- a/packages/javascript/js-client-library/src/client.ts
+++ b/packages/javascript/js-client-library/src/client.ts
@@ -688,6 +688,9 @@ class BHEAPIClient {
             options
         );
 
+    getSAMLProviderSigningCertificate = (ssoProviderSlug: types.SSOProvider['slug'], options?: types.RequestOptions) =>
+        this.baseClient.get(`/api/v2/sso/${ssoProviderSlug}/signing-certificate`, options);
+
     deleteSSOProvider = (ssoProviderId: types.SSOProvider['id'], options?: types.RequestOptions) =>
         this.baseClient.delete(`/api/v2/sso-providers/${ssoProviderId}`, options);
 

--- a/packages/javascript/js-client-library/src/client.ts
+++ b/packages/javascript/js-client-library/src/client.ts
@@ -688,8 +688,8 @@ class BHEAPIClient {
             options
         );
 
-    getSAMLProviderSigningCertificate = (ssoProviderSlug: types.SSOProvider['slug'], options?: types.RequestOptions) =>
-        this.baseClient.get(`/api/v2/sso/${ssoProviderSlug}/signing-certificate`, options);
+    getSAMLProviderSigningCertificate = (ssoProviderId: types.SSOProvider['id'], options?: types.RequestOptions) =>
+        this.baseClient.get(`/api/v2/sso-providers/${ssoProviderId}/signing-certificate`, options);
 
     deleteSSOProvider = (ssoProviderId: types.SSOProvider['id'], options?: types.RequestOptions) =>
         this.baseClient.delete(`/api/v2/sso-providers/${ssoProviderId}`, options);


### PR DESCRIPTION
## Description

- Added GET `/sso/{sso-provider-slug}/signing-certificate` for SAML providers
- Added download button to UI to download it
- Fixed formatting cert parsing checks

## Motivation and Context

This PR addresses: BED-5010

*Why is this change required? What problem does it solve?*

Currently it's not easy to retrieve the signing certificate for SAML providers. This rectifies that.

## How Has This Been Tested?

Unit tests + locally

## Types of changes

<!-- Please remove any items that do not apply. -->
- New feature (non-breaking change which adds functionality)


## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
