### PR TITLE
feat: BED-5079 - Add Ingest Task Count Function

### DIFF
--- a/cmd/api/src/api/error.go
+++ b/cmd/api/src/api/error.go
@@ -54,7 +54,7 @@ const (
 	ErrorResponseDetailsOTPInvalid                  = "one time password is invalid"
 	ErrorResponseDetailsResourceNotFound            = "resource not found"
 	ErrorResponseDetailsToBeforeFrom                = "to time cannot be before from time"
-	ErrorResponseDetailsTimeRangeInvalid	= "time range provided is invalid"
+	ErrorResponseDetailsTimeRangeInvalid            = "time range provided is invalid"
 	ErrorResponseDetailsToMalformed                 = "to parameter should be formatted as RFC3339 i.e 2021-04-21T07:20:50.52Z"
 	ErrorResponseMultipleCollectionScopesProvided   = "may only scope collection by exactly one of OU, Domain, or All Trusted Domains"
 	ErrorResponsePayloadUnmarshalError              = "error unmarshalling JSON payload"

--- a/cmd/api/src/database/db.go
+++ b/cmd/api/src/database/db.go
@@ -66,6 +66,7 @@ type Database interface {
 	// Ingest
 	ingest.IngestData
 	GetAllIngestTasks(ctx context.Context) (model.IngestTasks, error)
+	CountAllIngestTasks(ctx context.Context) (int64, error)
 	DeleteIngestTask(ctx context.Context, ingestTask model.IngestTask) error
 	GetIngestTasksForJob(ctx context.Context, jobID int64) (model.IngestTasks, error)
 

--- a/cmd/api/src/database/ingest.go
+++ b/cmd/api/src/database/ingest.go
@@ -35,6 +35,16 @@ func (s *BloodhoundDB) GetAllIngestTasks(ctx context.Context) (model.IngestTasks
 	return ingestTasks, CheckError(result)
 }
 
+func (s *BloodhoundDB) CountAllIngestTasks(ctx context.Context) (int64, error) {
+	var (
+		ingestTaskCount  int64
+		ingestTasksModel model.IngestTasks
+	)
+
+	result := s.db.Model(&ingestTasksModel).WithContext(ctx).Count(&ingestTaskCount)
+	return ingestTaskCount, CheckError(result)
+}
+
 func (s *BloodhoundDB) DeleteIngestTask(ctx context.Context, ingestTask model.IngestTask) error {
 	result := s.db.WithContext(ctx).Delete(&ingestTask)
 	return CheckError(result)

--- a/cmd/api/src/database/mocks/db.go
+++ b/cmd/api/src/database/mocks/db.go
@@ -95,6 +95,21 @@ func (mr *MockDatabaseMockRecorder) Close(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockDatabase)(nil).Close), arg0)
 }
 
+// CountAllIngestTasks mocks base method.
+func (m *MockDatabase) CountAllIngestTasks(arg0 context.Context) (int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CountAllIngestTasks", arg0)
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CountAllIngestTasks indicates an expected call of CountAllIngestTasks.
+func (mr *MockDatabaseMockRecorder) CountAllIngestTasks(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CountAllIngestTasks", reflect.TypeOf((*MockDatabase)(nil).CountAllIngestTasks), arg0)
+}
+
 // CreateADDataQualityAggregation mocks base method.
 func (m *MockDatabase) CreateADDataQualityAggregation(arg0 context.Context, arg1 model.ADDataQualityAggregation) (model.ADDataQualityAggregation, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
## Description

This function is part of supporting BED-5079 in lifting some additional metrics for infrastructure to monitor.

## Motivation and Context

Previously, without this count function present, the metric for monitoring ingest queue depth would fetch the entire contents of each row and then use the golang `len(...)` function to acquire a count.

This reduces the necessary work for the DB and drops network bandwidth for this metric significantly.

## How Has This Been Tested?

Local testing. Unsure as to the value of testing this function in unit or integration.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
