### PR TITLE
BED-5080 - remove additional integer types from SQL schema

### DIFF
--- a/packages/go/dawgs/drivers/pg/query/sql/schema_up.sql
+++ b/packages/go/dawgs/drivers/pg/query/sql/schema_up.sql
@@ -93,7 +93,7 @@ $$
   begin
     create type nodeComposite as
     (
-      id         integer,
+      id         bigint,
       kind_ids   smallint[8],
       properties jsonb
     );
@@ -133,9 +133,9 @@ $$
   begin
     create type edgeComposite as
     (
-      id         integer,
-      start_id   integer,
-      end_id     integer,
+      id         bigint,
+      start_id   bigint,
+      end_id     bigint,
       kind_id    smallint,
       properties jsonb
     );


### PR DESCRIPTION
## Description

Removing more int32 cruft.

## Motivation and Context

Without this change, type casting using the PgSQL composite types will fail due to the use of `int4` width ID types.

## How Has This Been Tested?

Regression test added.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
