### PR TITLE
BED-5103 fix: users in bad auth state

### DIFF
--- a/cmd/api/src/database/migration/migrations/v6.3.0.sql
+++ b/cmd/api/src/database/migration/migrations/v6.3.0.sql
@@ -32,4 +32,4 @@ ALTER TABLE ONLY saml_providers
 UPDATE feature_flags SET enabled = true WHERE key = 'updated_posture_page';
 
 -- Fix users in bad state due to sso bug
-DELETE FROM auth_secrets WHERE id IN (SELECT auth_secrets.id FROM auth_secrets INNER JOIN users ON users.id = auth_secrets.user_id WHERE users.sso_provider_id IS NOT NULL);
+DELETE FROM auth_secrets WHERE id IN (SELECT auth_secrets.id FROM auth_secrets JOIN users ON users.id = auth_secrets.user_id WHERE users.sso_provider_id IS NOT NULL);

--- a/cmd/api/src/database/migration/migrations/v6.3.0.sql
+++ b/cmd/api/src/database/migration/migrations/v6.3.0.sql
@@ -30,3 +30,6 @@ ALTER TABLE ONLY saml_providers
 
 -- Set the `updated_posture_page` feature flag to true
 UPDATE feature_flags SET enabled = true WHERE key = 'updated_posture_page';
+
+-- Fix users in bad state due to sso bug
+DELETE FROM auth_secrets WHERE id IN (SELECT auth_secrets.id FROM auth_secrets INNER JOIN users ON users.id = auth_secrets.user_id WHERE users.sso_provider_id IS NOT NULL);


### PR DESCRIPTION
## Description

Added migration to delete leftover auth_secret from users that were designated SSO

## Motivation and Context

This PR addresses: BED-5103

*Why is this change required? What problem does it solve?*
A bug was introduced that was recently patched but didn't address any existing users in a bad state. This should address those users.

## How Has This Been Tested?

Locally

## Types of changes

- Bug fix (non-breaking change which fixes an issue)
- Database Migrations

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
