### PR TITLE
Docker Compose Edits for BloodHound CLI

### DIFF
--- a/examples/docker-compose/docker-compose.yml
+++ b/examples/docker-compose/docker-compose.yml
@@ -17,6 +17,8 @@
 services:
   app-db:
     image: docker.io/library/postgres:16
+    labels:
+      name: "bhce_postgres"
     environment:
       - PGUSER=${POSTGRES_USER:-bloodhound}
       - POSTGRES_USER=${POSTGRES_USER:-bloodhound}
@@ -40,6 +42,8 @@ services:
 
   graph-db:
     image: docker.io/library/neo4j:4.4
+    labels:
+      name: "bhce_neo4j"
     environment:
       - NEO4J_AUTH=${NEO4J_USER:-neo4j}/${NEO4J_SECRET:-bloodhoundcommunityedition}
       - NEO4J_dbms_allow__upgrade=${NEO4J_ALLOW_UPGRADE:-true}
@@ -62,6 +66,8 @@ services:
 
   bloodhound:
     image: docker.io/specterops/bloodhound:${BLOODHOUND_TAG:-latest}
+    labels:
+      name: bhce_bloodhound
     environment:
       - bhe_disable_cypher_complexity_limit=${bhe_disable_cypher_complexity_limit:-false}
       - bhe_enable_cypher_mutations=${bhe_enable_cypher_mutations:-false}
@@ -77,9 +83,8 @@ services:
       ### Default to localhost to prevent accidental publishing of the service to your outer networks
       ### These can be modified by your .env file or by setting the environment variables in your Docker host OS
       - ${BLOODHOUND_HOST:-127.0.0.1}:${BLOODHOUND_PORT:-8080}:8080
-    ### Uncomment to use your own bloodhound.config.json to configure the application
-    # volumes:
-    #   - ./bloodhound.config.json:/bloodhound.config.json:ro
+    volumes:
+      - ./bloodhound.config.json:/bloodhound.config.json:ro
     depends_on:
       app-db:
         condition: service_healthy


### PR DESCRIPTION
## Description

This PR adds a `name` label to the containers and uncomments the _bloodhound.config.json_ volume mounting by default. These changes enable some of the functionality built into the upcoming BloodHound CLI.

The most significant change here is using _bloodhound.config.json_ by default. The CLI ensures the file is present, but someone could run into issues if they do not use the CLI. We have been discussing switching the _getbhce_ link to pull down pre-built binaries so new users would download the CLI and run `./bloodhound-cli install` to get started. I am unaware of any decision or movement on that. For now, I think this change will need some consideration.

## Motivation and Context

The `name` labels allow human-identifiable names to be displayed alongside container information when BloodHound CLI's `running` command is used. It also makes it easier for someone to pull logs from a container (e.g., `./bloodhound-cli logs postgres`).

## How Has This Been Tested?

I have been testing the changes with the `main` branch and the current version of BloodHound CLI with Stephen Hinck and others. The changes do not impact the containers.

## Screenshots (optional):

Example of the `name` labels in output:

```
$ ./bloodhound-cli running        
[+] Checking the status of Docker and the Compose plugin...
[+] Collecting list of running BloodHound containers...
[+] Found 3 running BloodHound containers

 Name            Container ID                                                     Image                                  Status               Ports
 ––––––––––––    ––––––––––––                                                     ––––––––––––                           ––––––––––––         ––––––––––––
 bhce_bloodhound d08a11f9cd5ce7a15a21d632601b979e65121bac1dd7055c10a77ac21a8f4fb7 docker.io/specterops/bloodhound:latest Up 5 hours           127.0.0.1:8080:8080 » 8080/tcp
 bhce_neo4j      30f4e3de52b5c719e195bd8ee880a96e927bafe824432be833682570f9f666e5 docker.io/library/neo4j:4.4            Up 5 hours (healthy) 127.0.0.1:7474:7474 » 7474/tcp, 127.0.0.1:7687:7687 » 7687/tcp, 7473/tcp
 bhce_postgres   17b18be3b847f19696d5f6336be738eb781a45b654e10480881b0ad25a1c6304 docker.io/library/postgres:16          Up 5 hours (healthy) 5432/tcp
```

## Types of changes

- Chore (a change that does not modify the application functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [X] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [X] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [X] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
