### PR TITLE
feat: BED-5159 - cysql support coalesce function

### DIFF
--- a/packages/go/cypher/models/cypher/functions.go
+++ b/packages/go/cypher/models/cypher/functions.go
@@ -33,6 +33,7 @@ const (
 	ToStringFunction           = "tostring"
 	ToIntegerFunction          = "toint"
 	ListSizeFunction           = "size"
+	CoalesceFunction           = "coalesce"
 
 	// ITTC - Instant Type; Temporal Component (https://neo4j.com/docs/cypher-manual/current/functions/temporal/)
 	ITTCYear              = "year"

--- a/packages/go/cypher/models/pgsql/format/format.go
+++ b/packages/go/cypher/models/pgsql/format/format.go
@@ -206,7 +206,7 @@ func formatNode(builder *OutputBuilder, rootExpr pgsql.SyntaxNode) error {
 			exprStack = append(exprStack, *typedNextExpr)
 
 		case pgsql.FunctionCall:
-			if typedNextExpr.CastType != pgsql.UnsetDataType {
+			if typedNextExpr.CastType.IsKnown() {
 				exprStack = append(exprStack, typedNextExpr.CastType, pgsql.FormattingLiteral("::"))
 			}
 

--- a/packages/go/cypher/models/pgsql/pgtypes.go
+++ b/packages/go/cypher/models/pgsql/pgtypes.go
@@ -111,6 +111,16 @@ const (
 	ExpansionTerminalNode DataType = "expansion_terminal_node"
 )
 
+func (s DataType) IsKnown() bool {
+	switch s {
+	case UnsetDataType, UnknownDataType:
+		return false
+
+	default:
+		return true
+	}
+}
+
 // TODO: operator, while unused, is part of a refactor for this function to make it operator aware
 func (s DataType) Compatible(other DataType, operator Operator) (DataType, bool) {
 	if s == other {

--- a/packages/go/cypher/models/pgsql/test/translation_cases/nodes.sql
+++ b/packages/go/cypher/models/pgsql/test/translation_cases/nodes.sql
@@ -561,3 +561,27 @@ with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0
                or @pi1::text = any (jsonb_to_text_array(n0.properties -> 'array')::text[]))
 select s0.n0 as n
 from s0;
+
+-- case: match (n:NodeKind1) where coalesce(n.system_tags, '') contains 'admin_tier_0' return n
+with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0
+            from node n0
+            where n0.kind_ids operator (pg_catalog.&&) array [1]::int2[]
+              and coalesce(n0.properties ->> 'system_tags', '')::text like '%admin_tier_0%')
+select s0.n0 as n
+from s0;
+
+-- case: match (n:NodeKind1) where coalesce(n.a, n.b, 1) = 1 return n
+with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0
+            from node n0
+            where n0.kind_ids operator (pg_catalog.&&) array [1]::int2[]
+              and coalesce((n0.properties -> 'a')::int8, (n0.properties -> 'b')::int8, 1)::int8 = 1)
+select s0.n0 as n
+from s0;
+
+-- case: match (n:NodeKind1) where coalesce(n.a, n.b) = 1 return n
+with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0
+            from node n0
+            where n0.kind_ids operator (pg_catalog.&&) array [1]::int2[]
+              and coalesce(n0.properties -> 'a', n0.properties -> 'b')::int8 = 1)
+select s0.n0 as n
+from s0;

--- a/packages/go/cypher/models/pgsql/translate/translation.go
+++ b/packages/go/cypher/models/pgsql/translate/translation.go
@@ -232,6 +232,60 @@ func (s *Translator) translateDateTimeFunctionCall(cypherFunc *cypher.FunctionIn
 	return nil
 }
 
+func (s *Translator) translateCoalesceFunction(functionInvocation *cypher.FunctionInvocation) error {
+	if numArgs := functionInvocation.NumArguments(); numArgs == 0 {
+		s.SetError(fmt.Errorf("expected at least one argument for cypher function: %s", functionInvocation.Name))
+	} else {
+		var (
+			arguments    = make([]pgsql.Expression, numArgs)
+			expectedType = pgsql.UnsetDataType
+		)
+
+		// This loop is used to pop off the coalesce function arguments in the intended order (since they're
+		// pushed onto the translator stack).
+		for idx := range functionInvocation.Arguments {
+			if argument, err := s.treeTranslator.Pop(); err != nil {
+				return err
+			} else {
+				arguments[numArgs-idx-1] = argument
+			}
+		}
+
+		// Find and validate types of the arguments
+		for _, argument := range arguments {
+			if argumentType, err := InferExpressionType(argument); err != nil {
+				return err
+			} else if argumentType.IsKnown() {
+				// If the expected type isn't known yet then assign the known inferred type to it
+				if !expectedType.IsKnown() {
+					expectedType = argumentType
+				} else if expectedType != argumentType {
+					// All other inferrable argument types must match the first inferred type encountered
+					return fmt.Errorf("types in coalesce function must match %s but got %s", expectedType, argumentType)
+				}
+			}
+		}
+
+		if expectedType.IsKnown() {
+			// Rewrite any property lookup operators now that we have some type information
+			for idx, argument := range arguments {
+				if propertyLookup, isPropertyLookup := asPropertyLookup(argument); isPropertyLookup {
+					arguments[idx] = rewritePropertyLookupOperator(propertyLookup, expectedType)
+				}
+			}
+		}
+
+		// Translate the function call to the expected SQL form
+		s.treeTranslator.Push(pgsql.FunctionCall{
+			Function:   pgsql.FunctionCoalesce,
+			Parameters: arguments,
+			CastType:   expectedType,
+		})
+	}
+
+	return nil
+}
+
 func (s *Translator) translateKindMatcher(kindMatcher *cypher.KindMatcher) error {
 	if variable, isVariable := kindMatcher.Reference.(*cypher.Variable); !isVariable {
 		return fmt.Errorf("expected variable for kind matcher reference but found type: %T", kindMatcher.Reference)

--- a/packages/go/cypher/models/pgsql/translate/translator.go
+++ b/packages/go/cypher/models/pgsql/translate/translator.go
@@ -482,7 +482,9 @@ func (s *Translator) Exit(expression cypher.SyntaxNode) {
 
 		switch formattedName {
 		case cypher.IdentityFunction:
-			if referenceArgument, err := PopFromBuilderAs[pgsql.Identifier](s.treeTranslator); err != nil {
+			if typedExpression.NumArguments() != 1 {
+				s.SetError(fmt.Errorf("expected only one argument for cypher function: %s", typedExpression.Name))
+			} else if referenceArgument, err := PopFromBuilderAs[pgsql.Identifier](s.treeTranslator); err != nil {
 				s.SetError(err)
 			} else {
 				s.treeTranslator.Push(pgsql.CompoundIdentifier{referenceArgument, pgsql.ColumnID})
@@ -509,7 +511,7 @@ func (s *Translator) Exit(expression cypher.SyntaxNode) {
 			}
 
 		case cypher.EdgeTypeFunction:
-			if typedExpression.NumArguments() > 1 {
+			if typedExpression.NumArguments() != 1 {
 				s.SetError(fmt.Errorf("expected only one argument for cypher function: %s", typedExpression.Name))
 			} else if argument, err := s.treeTranslator.Pop(); err != nil {
 				s.SetError(err)
@@ -520,7 +522,7 @@ func (s *Translator) Exit(expression cypher.SyntaxNode) {
 			}
 
 		case cypher.NodeLabelsFunction:
-			if typedExpression.NumArguments() > 1 {
+			if typedExpression.NumArguments() != 1 {
 				s.SetError(fmt.Errorf("expected only one argument for cypher function: %s", typedExpression.Name))
 			} else if argument, err := s.treeTranslator.Pop(); err != nil {
 				s.SetError(err)
@@ -531,7 +533,7 @@ func (s *Translator) Exit(expression cypher.SyntaxNode) {
 			}
 
 		case cypher.CountFunction:
-			if typedExpression.NumArguments() > 1 {
+			if typedExpression.NumArguments() != 1 {
 				s.SetError(fmt.Errorf("expected only one argument for cypher function: %s", typedExpression.Name))
 			} else if argument, err := s.treeTranslator.Pop(); err != nil {
 				s.SetError(err)
@@ -572,7 +574,7 @@ func (s *Translator) Exit(expression cypher.SyntaxNode) {
 			}
 
 		case cypher.ToLowerFunction:
-			if typedExpression.NumArguments() > 1 {
+			if typedExpression.NumArguments() != 1 {
 				s.SetError(fmt.Errorf("expected only one argument for cypher function: %s", typedExpression.Name))
 			} else if argument, err := s.treeTranslator.Pop(); err != nil {
 				s.SetError(err)
@@ -590,7 +592,7 @@ func (s *Translator) Exit(expression cypher.SyntaxNode) {
 			}
 
 		case cypher.ListSizeFunction:
-			if typedExpression.NumArguments() > 1 {
+			if typedExpression.NumArguments() != 1 {
 				s.SetError(fmt.Errorf("expected only one argument for cypher function: %s", typedExpression.Name))
 			} else if argument, err := s.treeTranslator.Pop(); err != nil {
 				s.SetError(err)
@@ -615,7 +617,7 @@ func (s *Translator) Exit(expression cypher.SyntaxNode) {
 			}
 
 		case cypher.ToUpperFunction:
-			if typedExpression.NumArguments() > 1 {
+			if typedExpression.NumArguments() != 1 {
 				s.SetError(fmt.Errorf("expected only one argument for cypher function: %s", typedExpression.Name))
 			} else if argument, err := s.treeTranslator.Pop(); err != nil {
 				s.SetError(err)
@@ -633,7 +635,7 @@ func (s *Translator) Exit(expression cypher.SyntaxNode) {
 			}
 
 		case cypher.ToStringFunction:
-			if typedExpression.NumArguments() > 1 {
+			if typedExpression.NumArguments() != 1 {
 				s.SetError(fmt.Errorf("expected only one argument for cypher function: %s", typedExpression.Name))
 			} else if argument, err := s.treeTranslator.Pop(); err != nil {
 				s.SetError(err)
@@ -642,12 +644,17 @@ func (s *Translator) Exit(expression cypher.SyntaxNode) {
 			}
 
 		case cypher.ToIntegerFunction:
-			if typedExpression.NumArguments() > 1 {
+			if typedExpression.NumArguments() != 1 {
 				s.SetError(fmt.Errorf("expected only one argument for cypher function: %s", typedExpression.Name))
 			} else if argument, err := s.treeTranslator.Pop(); err != nil {
 				s.SetError(err)
 			} else {
 				s.treeTranslator.Push(pgsql.NewTypeCast(argument, pgsql.Int8))
+			}
+
+		case cypher.CoalesceFunction:
+			if err := s.translateCoalesceFunction(typedExpression); err != nil {
+				s.SetError(err)
 			}
 
 		default:


### PR DESCRIPTION
## Description

Changeset contains support for translating Cypher `coalesce` functions correctly.

## Motivation and Context

This function is a vital conditional expression that should be supported.

## How Has This Been Tested?

Additional test cases added to validate the changes.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
