### PR TITLE
BED-5072 fix local dev infinite loop

### DIFF
--- a/cmd/ui/src/main.tsx
+++ b/cmd/ui/src/main.tsx
@@ -84,7 +84,7 @@ const main = async () => {
     const rootContainer = document.getElementById('root');
     const root = createRoot(rootContainer!);
 
-    if (import.meta.env.DEV) {
+    if (import.meta.env.DEV && location.pathname.startsWith('/ui/')) {
         const { worker } = await import('./mocks/browser');
         await worker.start({
             serviceWorker: {


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

This change fixes the infinite loop caused by the mock service workers in local dev.

## Motivation and Context

This PR addresses: [BED-5072]

The issue causes the local dev environment to randomly go into an infinite loop when first starting a server.

## How Has This Been Tested?

This was tested manually to ensure the infinite loop was no longer happening.


## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


[BED-5072]: https://specterops.atlassian.net/browse/BED-5072?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ