### PR TITLE
Update default tier zero

### DIFF
--- a/packages/go/analysis/ad/ad.go
+++ b/packages/go/analysis/ad/ad.go
@@ -53,8 +53,6 @@ const (
 	EnterpriseKeyAdminsGroupSIDSuffix         = "-527"
 	AdministratorsGroupSIDSuffix              = "-544"
 	BackupOperatorsGroupSIDSuffix             = "-551"
-	PerformanceLogUsersSIDSuffix              = "-559"
-	DCOMUsersSIDSuffix                        = "-562"
 	AuthenticatedUsersSuffix                  = "-S-1-5-11"
 	EveryoneSuffix                            = "-S-1-1-0"
 	AdminSDHolderDNPrefix                     = "CN=ADMINSDHOLDER,CN=SYSTEM,"
@@ -73,8 +71,6 @@ func TierZeroWellKnownSIDSuffixes() []string {
 		EnterpriseKeyAdminsGroupSIDSuffix,
 		BackupOperatorsGroupSIDSuffix,
 		AdministratorsGroupSIDSuffix,
-		DCOMUsersSIDSuffix,
-		PerformanceLogUsersSIDSuffix,
 	}
 }
 


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Removes DCOM Users and Performance Log Users from default Tier Zero.

## Motivation and Context

This PR addresses: BED-5183

We added these groups to default Tier Zero as a new attack revealed how they could compromise any user logged into DCs. Microsoft has now patched that (see end note): [Hello: I’m your Domain Admin and I want to authenticate against you](https://decoder.cloud/2024/04/24/hello-im-your-domain-admin-and-i-want-to-authenticate-against-you/)

## How Has This Been Tested?

Locally.

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
