### PR TITLE
Remove DnsAdmins from default tier zero

### DIFF
--- a/packages/go/analysis/ad/ad.go
+++ b/packages/go/analysis/ad/ad.go
@@ -56,7 +56,6 @@ const (
 	AuthenticatedUsersSuffix                  = "-S-1-5-11"
 	EveryoneSuffix                            = "-S-1-1-0"
 	AdminSDHolderDNPrefix                     = "CN=ADMINSDHOLDER,CN=SYSTEM,"
-	DnsAdminsDNPrefix                         = "CN=DNSADMINS,"
 )
 
 func TierZeroWellKnownSIDSuffixes() []string {
@@ -97,22 +96,6 @@ func FetchWellKnownTierZeroEntities(ctx context.Context, db graph.Database, doma
 			}); err != nil {
 				return err
 			}
-		}
-
-		// DnsAdmins
-		if err := tx.Nodes().Filterf(func() graph.Criteria {
-			return query.And(
-				query.KindIn(query.Node(), ad.Group),
-				query.StringStartsWith(query.NodeProperty(ad.DistinguishedName.String()), DnsAdminsDNPrefix),
-				query.Equals(query.NodeProperty(ad.DomainSID.String()), domainSID),
-			)
-		}).Fetch(func(cursor graph.Cursor[*graph.Node]) error {
-			for node := range cursor.Chan() {
-				nodes.Add(node)
-			}
-			return cursor.Error()
-		}); err != nil {
-			return err
 		}
 
 		// AdminSDHolder


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Removes DnsAdmins from default Tier Zero.

## Motivation and Context

This PR addresses: BED-5199

We added DnsAmins to default Tier Zero because the group can in a default AD control DNS in AD, which enables relay attacks. However, some organizations do not host DNS on DCs, and in that case we do not know if the group is abusable, but we think it is not. We will therefore remove it from default Tier Zero. 

## How Has This Been Tested?

Locally.

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
