### PR TITLE
Kpom/bed 4907/cypher shortcut helpers

### DIFF
--- a/cmd/api/src/queries/graph.go
+++ b/cmd/api/src/queries/graph.go
@@ -367,7 +367,6 @@ type PreparedQuery struct {
 }
 
 func (s *GraphQuery) PrepareCypherQuery(rawCypher string) (PreparedQuery, error) {
-
 	var (
 		cypherFilters = []frontend.Visitor{
 			&frontend.ExplicitProcedureInvocationFilter{},
@@ -381,8 +380,6 @@ func (s *GraphQuery) PrepareCypherQuery(rawCypher string) (PreparedQuery, error)
 
 	// If cypher mutations are disabled, we want to add the updating clause filter to properly error as unsupported query
 	if !s.EnableCypherMutations {
-		cypherFilters = append(cypherFilters, &frontend.UpdatingNotAllowedClauseFilter{})
-	} else {
 		cypherFilters = append(cypherFilters, &frontend.UpdatingClauseFilter{})
 	}
 

--- a/cmd/api/src/queries/graph.go
+++ b/cmd/api/src/queries/graph.go
@@ -379,7 +379,10 @@ func (s *GraphQuery) PrepareCypherQuery(rawCypher string) (PreparedQuery, error)
 	)
 
 	// If cypher mutations are disabled, we want to add the updating clause filter to properly error as unsupported query
+	// If we are mutating, make sure our expansions aren't included in any sort of update
 	if !s.EnableCypherMutations {
+		cypherFilters = append(cypherFilters, &frontend.UpdatingNotAllowedClauseFilter{})
+	} else {
 		cypherFilters = append(cypherFilters, &frontend.UpdatingClauseFilter{})
 	}
 

--- a/cmd/api/src/queries/graph.go
+++ b/cmd/api/src/queries/graph.go
@@ -367,6 +367,7 @@ type PreparedQuery struct {
 }
 
 func (s *GraphQuery) PrepareCypherQuery(rawCypher string) (PreparedQuery, error) {
+
 	var (
 		cypherFilters = []frontend.Visitor{
 			&frontend.ExplicitProcedureInvocationFilter{},
@@ -380,6 +381,8 @@ func (s *GraphQuery) PrepareCypherQuery(rawCypher string) (PreparedQuery, error)
 
 	// If cypher mutations are disabled, we want to add the updating clause filter to properly error as unsupported query
 	if !s.EnableCypherMutations {
+		cypherFilters = append(cypherFilters, &frontend.UpdatingNotAllowedClauseFilter{})
+	} else {
 		cypherFilters = append(cypherFilters, &frontend.UpdatingClauseFilter{})
 	}
 

--- a/packages/go/cypher/frontend/context.go
+++ b/packages/go/cypher/frontend/context.go
@@ -33,9 +33,10 @@ type descentEntry struct {
 type Context struct {
 	visitorStack []*descentEntry
 	filters      []Visitor
+	Errors       []error
 
-	Errors      []error
-	HasMutation bool
+	HasMutation          bool
+	HasShortcutExpansion bool
 }
 
 func NewContext(filters ...Visitor) *Context {

--- a/packages/go/cypher/frontend/error.go
+++ b/packages/go/cypher/frontend/error.go
@@ -34,6 +34,7 @@ func (s SyntaxError) Error() string {
 
 var (
 	ErrUpdateClauseNotSupported            = errors.New("updating clauses are not supported")
+	ErrUpdateWithExpansionNotSupported     = errors.New("updating clauses with expansions are not supported")
 	ErrUserSpecifiedParametersNotSupported = errors.New("user-specified parameters are not supported")
 	ErrProcedureInvocationNotSupported     = errors.New("procedure invocation is not supported")
 

--- a/packages/go/cypher/frontend/filter.go
+++ b/packages/go/cypher/frontend/filter.go
@@ -25,7 +25,6 @@ import (
 // TODO: Review if relying on a deny model is less secure than explicit allow
 func DefaultCypherContext() *Context {
 	return NewContext(
-		&UpdatingNotAllowedClauseFilter{},
 		&UpdatingClauseFilter{},
 		&ExplicitProcedureInvocationFilter{},
 		&ImplicitProcedureInvocationFilter{},
@@ -57,18 +56,10 @@ func (s *SpecifiedParametersFilter) EnterOC_Parameter(ctx *parser.OC_ParameterCo
 	s.ctx.AddErrors(ErrUserSpecifiedParametersNotSupported)
 }
 
-type UpdatingNotAllowedClauseFilter struct {
-	BaseVisitor
-}
-
-func (s *UpdatingNotAllowedClauseFilter) EnterOC_UpdatingClause(ctx *parser.OC_UpdatingClauseContext) {
-	s.ctx.AddErrors(ErrUpdateClauseNotSupported)
-}
-
 type UpdatingClauseFilter struct {
 	BaseVisitor
 }
 
 func (s *UpdatingClauseFilter) EnterOC_UpdatingClause(ctx *parser.OC_UpdatingClauseContext) {
-	// Do something that marks this as an updating clause to check later (in pattern.go)
+	s.ctx.AddErrors(ErrUpdateClauseNotSupported)
 }

--- a/packages/go/cypher/frontend/filter.go
+++ b/packages/go/cypher/frontend/filter.go
@@ -25,6 +25,7 @@ import (
 // TODO: Review if relying on a deny model is less secure than explicit allow
 func DefaultCypherContext() *Context {
 	return NewContext(
+		&UpdatingNotAllowedClauseFilter{},
 		&UpdatingClauseFilter{},
 		&ExplicitProcedureInvocationFilter{},
 		&ImplicitProcedureInvocationFilter{},
@@ -56,10 +57,18 @@ func (s *SpecifiedParametersFilter) EnterOC_Parameter(ctx *parser.OC_ParameterCo
 	s.ctx.AddErrors(ErrUserSpecifiedParametersNotSupported)
 }
 
+type UpdatingNotAllowedClauseFilter struct {
+	BaseVisitor
+}
+
+func (s *UpdatingNotAllowedClauseFilter) EnterOC_UpdatingClause(ctx *parser.OC_UpdatingClauseContext) {
+	s.ctx.AddErrors(ErrUpdateClauseNotSupported)
+}
+
 type UpdatingClauseFilter struct {
 	BaseVisitor
 }
 
 func (s *UpdatingClauseFilter) EnterOC_UpdatingClause(ctx *parser.OC_UpdatingClauseContext) {
-	s.ctx.AddErrors(ErrUpdateClauseNotSupported)
+	// Do something that marks this as an updating clause to check later (in pattern.go)
 }

--- a/packages/go/cypher/frontend/pattern.go
+++ b/packages/go/cypher/frontend/pattern.go
@@ -91,21 +91,31 @@ func (s *RelationshipPatternVisitor) EnterOC_RelTypeName(ctx *parser.OC_RelTypeN
 }
 
 func (s *RelationshipPatternVisitor) ExitOC_RelTypeName(ctx *parser.OC_RelTypeNameContext) {
-	rel_type := ctx.GetText()
-	if rel_type == "AZ_ATTACK_PATHS" || rel_type == "ALL_ATTACK_PATHS" {
-		for _, kind := range azure.PathfindingRelationships() {
+	relationshipType := ctx.GetText()
+
+	// Helper function to add kinds from relationships
+	addKindsFromRelationships := func(kinds []graph.Kind) {
+		for _, kind := range kinds {
 			s.RelationshipPattern.Kinds = s.RelationshipPattern.Kinds.Add(kind)
 		}
 	}
 
-	if rel_type == "AD_ATTACK_PATHS" || rel_type == "ALL_ATTACK_PATHS" {
-		for _, kind := range ad.PathfindingRelationships() {
-			s.RelationshipPattern.Kinds = s.RelationshipPattern.Kinds.Add(kind)
-		}
-	}
+	// Handle Azure and AD attack paths
+	switch relationshipType {
+	case "ALL_ATTACK_PATHS":
+		addKindsFromRelationships(azure.PathfindingRelationships())
+		addKindsFromRelationships(ad.PathfindingRelationships())
 
-	kind := graph.StringKind(s.ctx.Exit().(*SymbolicNameOrReservedWordVisitor).Name)
-	s.RelationshipPattern.Kinds = append(s.RelationshipPattern.Kinds, kind)
+	case "AZ_ATTACK_PATHS":
+		addKindsFromRelationships(azure.PathfindingRelationships())
+
+	case "AD_ATTACK_PATHS":
+		addKindsFromRelationships(ad.PathfindingRelationships())
+
+	default:
+		kind := graph.StringKind(s.ctx.Exit().(*SymbolicNameOrReservedWordVisitor).Name)
+		addKindsFromRelationships([]graph.Kind{kind})
+	}
 }
 
 func (s *RelationshipPatternVisitor) EnterOC_Variable(ctx *parser.OC_VariableContext) {

--- a/packages/go/cypher/frontend/pattern.go
+++ b/packages/go/cypher/frontend/pattern.go
@@ -103,13 +103,25 @@ func (s *RelationshipPatternVisitor) ExitOC_RelTypeName(ctx *parser.OC_RelTypeNa
 	// Handle Azure and AD attack paths
 	switch relationshipType {
 	case "ALL_ATTACK_PATHS":
+		s.ctx.HasShortcutExpansion = true
+		if s.ctx.HasMutation {
+			s.ctx.AddErrors(ErrUpdateWithExpansionNotSupported)
+		}
 		addKindsFromRelationships(azure.PathfindingRelationships())
 		addKindsFromRelationships(ad.PathfindingRelationships())
 
 	case "AZ_ATTACK_PATHS":
+		s.ctx.HasShortcutExpansion = true
+		if s.ctx.HasMutation {
+			s.ctx.AddErrors(ErrUpdateWithExpansionNotSupported)
+		}
 		addKindsFromRelationships(azure.PathfindingRelationships())
 
 	case "AD_ATTACK_PATHS":
+		s.ctx.HasShortcutExpansion = true
+		if s.ctx.HasMutation {
+			s.ctx.AddErrors(ErrUpdateWithExpansionNotSupported)
+		}
 		addKindsFromRelationships(ad.PathfindingRelationships())
 
 	default:

--- a/packages/go/cypher/frontend/pattern.go
+++ b/packages/go/cypher/frontend/pattern.go
@@ -21,12 +21,12 @@ import (
 	"strconv"
 
 	"github.com/specterops/bloodhound/cypher/models/cypher"
+	"github.com/specterops/bloodhound/graphschema/ad"
+	"github.com/specterops/bloodhound/graphschema/azure"
 
 	"github.com/antlr4-go/antlr/v4"
 	"github.com/specterops/bloodhound/cypher/parser"
 	"github.com/specterops/bloodhound/dawgs/graph"
-	"github.com/specterops/bloodhound/graphschema/ad"
-	"github.com/specterops/bloodhound/graphschema/azure"
 )
 
 type WhereVisitor struct {
@@ -123,11 +123,11 @@ func (s *RelationshipPatternVisitor) ExitOC_RelTypeName(ctx *parser.OC_RelTypeNa
 			s.ctx.AddErrors(ErrUpdateWithExpansionNotSupported)
 		}
 		addKindsFromRelationships(ad.PathfindingRelationships())
-
 	default:
-		kind := graph.StringKind(s.ctx.Exit().(*SymbolicNameOrReservedWordVisitor).Name)
+		kind := graph.StringKind(relationshipType)
 		addKindsFromRelationships([]graph.Kind{kind})
 	}
+	s.ctx.Exit()
 }
 
 func (s *RelationshipPatternVisitor) EnterOC_Variable(ctx *parser.OC_VariableContext) {

--- a/packages/go/cypher/frontend/pattern.go
+++ b/packages/go/cypher/frontend/pattern.go
@@ -25,6 +25,8 @@ import (
 	"github.com/antlr4-go/antlr/v4"
 	"github.com/specterops/bloodhound/cypher/parser"
 	"github.com/specterops/bloodhound/dawgs/graph"
+	"github.com/specterops/bloodhound/graphschema/ad"
+	"github.com/specterops/bloodhound/graphschema/azure"
 )
 
 type WhereVisitor struct {
@@ -89,6 +91,19 @@ func (s *RelationshipPatternVisitor) EnterOC_RelTypeName(ctx *parser.OC_RelTypeN
 }
 
 func (s *RelationshipPatternVisitor) ExitOC_RelTypeName(ctx *parser.OC_RelTypeNameContext) {
+	rel_type := ctx.GetText()
+	if rel_type == "AZ_ATTACK_PATHS" || rel_type == "ALL_ATTACK_PATHS" {
+		for _, kind := range azure.PathfindingRelationships() {
+			s.RelationshipPattern.Kinds = s.RelationshipPattern.Kinds.Add(kind)
+		}
+	}
+
+	if rel_type == "AD_ATTACK_PATHS" || rel_type == "ALL_ATTACK_PATHS" {
+		for _, kind := range ad.PathfindingRelationships() {
+			s.RelationshipPattern.Kinds = s.RelationshipPattern.Kinds.Add(kind)
+		}
+	}
+
 	kind := graph.StringKind(s.ctx.Exit().(*SymbolicNameOrReservedWordVisitor).Name)
 	s.RelationshipPattern.Kinds = append(s.RelationshipPattern.Kinds, kind)
 }

--- a/packages/go/cypher/frontend/query.go
+++ b/packages/go/cypher/frontend/query.go
@@ -485,9 +485,6 @@ func (s *DeleteVisitor) EnterOC_Expression(ctx *parser.OC_ExpressionContext) {
 }
 
 func (s *DeleteVisitor) ExitOC_Expression(ctx *parser.OC_ExpressionContext) {
-	if s.ctx.HasShortcutExpansion {
-		s.ctx.AddErrors(ErrUpdateWithExpansionNotSupported)
-	}
 	s.Delete.Expressions = append(s.Delete.Expressions, s.ctx.Exit().(*ExpressionVisitor).Expression)
 }
 

--- a/packages/go/cypher/frontend/query.go
+++ b/packages/go/cypher/frontend/query.go
@@ -485,7 +485,7 @@ func (s *DeleteVisitor) EnterOC_Expression(ctx *parser.OC_ExpressionContext) {
 }
 
 func (s *DeleteVisitor) ExitOC_Expression(ctx *parser.OC_ExpressionContext) {
-	if s.ctx.HasMutation {
+	if s.ctx.HasShortcutExpansion {
 		s.ctx.AddErrors(ErrUpdateWithExpansionNotSupported)
 	}
 	s.Delete.Expressions = append(s.Delete.Expressions, s.ctx.Exit().(*ExpressionVisitor).Expression)

--- a/packages/go/cypher/frontend/query.go
+++ b/packages/go/cypher/frontend/query.go
@@ -485,6 +485,9 @@ func (s *DeleteVisitor) EnterOC_Expression(ctx *parser.OC_ExpressionContext) {
 }
 
 func (s *DeleteVisitor) ExitOC_Expression(ctx *parser.OC_ExpressionContext) {
+	if s.ctx.HasMutation {
+		s.ctx.AddErrors(ErrUpdateWithExpansionNotSupported)
+	}
 	s.Delete.Expressions = append(s.Delete.Expressions, s.ctx.Exit().(*ExpressionVisitor).Expression)
 }
 


### PR DESCRIPTION
## Description

Add the ability to have "helper" shortcuts that allow a user to specify ALL_ATTACK_PATHS (or by AZ/AD). 

## Motivation and Context

This PR addresses: https://specterops.atlassian.net/browse/BED-4907


## How Has This Been Tested?
curl 'http://bhe.localhost/api/v2/graphs/cypher' --compressed -X POST \
    -H "Authorization: Bearer *************" \
    -H 'Content-Type: application/json' \
    --data-raw '{"query":"MATCH p=shortestPath((n)-[:ALL_ATTACK_PATHS*1..]->(m:Computer))\nWHERE m.unconstraineddelegation = true AND n<>m\nRETURN p\nLIMIT 1000"}' | jq

should return a list of all Attack Edge Types

- New feature (non-breaking change which adds functionality)


<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: This PR addresses: https://specterops.atlassian.net/browse/BED-4907
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
