### PR TITLE
BED-5178 fix: OIDC default scopes

### DIFF
--- a/cmd/api/src/api/v2/auth/oidc.go
+++ b/cmd/api/src/api/v2/auth/oidc.go
@@ -124,7 +124,7 @@ func (s ManagementResource) OIDCLoginHandler(response http.ResponseWriter, reque
 			ClientID:    ssoProvider.OIDCProvider.ClientID,
 			Endpoint:    provider.Endpoint(),
 			RedirectURL: getRedirectURL(request, ssoProvider),
-			Scopes:      []string{"openid", "profile", "email", "email_verified", "name", "given_name", "family_name"},
+			Scopes:      []string{"openid", "profile", "email"},
 		}
 
 		// use PKCE to protect against CSRF attacks


### PR DESCRIPTION
## Description

Remove the invalid scopes from the OIDC login handler

## Motivation and Context
Currently the login handler incorrectly requests claims inside the scopes parameter. This breaks the stricter IDPs such as Microsoft Entra

This PR addresses: BED-5178

*Why is this change required? What problem does it solve?*

## How Has This Been Tested?

Locally

## Types of changes

<!-- Please remove any items that do not apply. -->
- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
