### PR TITLE
BED-5110 added NoDataDialog component

### DIFF
--- a/packages/javascript/bh-shared-ui/src/components/NoDataDialog/NoDataDialog.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/NoDataDialog/NoDataDialog.test.tsx
@@ -16,34 +16,9 @@
 
 import { render, screen } from '../../test-utils';
 import NoDataDialog from '.';
-import { UseQueryResult } from 'react-query';
 
 const gettingStartedLinkText = 'Getting Started guide';
 const fileIngestLinkText = 'start by uploading your data';
-const mockUseAvailableDomainsQuery: UseQueryResult<any, Error> = {
-    data: [],
-    isLoading: false,
-    isError: false,
-    isSuccess: true,
-    isIdle: false,
-    isLoadingError: false,
-    isRefetchError: false,
-    status: 'success',
-    failureCount: 0,
-    dataUpdatedAt: 0,
-    errorUpdatedAt: 0,
-    errorUpdateCount: 0,
-    isFetched: true,
-    isFetchedAfterMount: true,
-    isFetching: false,
-    isPlaceholderData: false,
-    isPreviousData: false,
-    isRefetching: false,
-    isStale: false,
-    error: null,
-    remove: vi.fn(),
-    refetch: vi.fn(),
-};
 
 describe('NoDataDialog', () => {
     it('should render', () => {
@@ -51,12 +26,25 @@ describe('NoDataDialog', () => {
             <NoDataDialog
                 gettingStartedLink={<>{gettingStartedLinkText}</>}
                 fileIngestLink={<>{fileIngestLinkText}</>}
-                useAvailableDomainsQuery={mockUseAvailableDomainsQuery}
+                open={true}
             />
         );
 
         expect(screen.getByText('No Data Available')).toBeInTheDocument();
         expect(screen.getByText(/Getting Started guide/)).toBeInTheDocument();
         expect(screen.getByText(/start by uploading your data/)).toBeInTheDocument();
+    });
+    it('should not render when data is present', () => {
+        render(
+            <NoDataDialog
+                gettingStartedLink={<>{gettingStartedLinkText}</>}
+                fileIngestLink={<>{fileIngestLinkText}</>}
+                open={false}
+            />
+        );
+
+        expect(screen.queryByText('No Data Available')).not.toBeInTheDocument();
+        expect(screen.queryByText(/Getting Started guide/)).not.toBeInTheDocument();
+        expect(screen.queryByText(/start by uploading your data/)).not.toBeInTheDocument();
     });
 });

--- a/packages/javascript/bh-shared-ui/src/components/NoDataDialog/NoDataDialog.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/NoDataDialog/NoDataDialog.test.tsx
@@ -16,9 +16,34 @@
 
 import { render, screen } from '../../test-utils';
 import NoDataDialog from '.';
+import { UseQueryResult } from 'react-query';
 
 const gettingStartedLinkText = 'Getting Started guide';
 const fileIngestLinkText = 'start by uploading your data';
+const mockUseAvailableDomainsQuery: UseQueryResult<any, Error> = {
+    data: [],
+    isLoading: false,
+    isError: false,
+    isSuccess: true,
+    isIdle: false,
+    isLoadingError: false,
+    isRefetchError: false,
+    status: 'success',
+    failureCount: 0,
+    dataUpdatedAt: 0,
+    errorUpdatedAt: 0,
+    errorUpdateCount: 0,
+    isFetched: true,
+    isFetchedAfterMount: true,
+    isFetching: false,
+    isPlaceholderData: false,
+    isPreviousData: false,
+    isRefetching: false,
+    isStale: false,
+    error: null,
+    remove: vi.fn(),
+    refetch: vi.fn(),
+};
 
 describe('NoDataDialog', () => {
     it('should render', () => {
@@ -26,6 +51,7 @@ describe('NoDataDialog', () => {
             <NoDataDialog
                 gettingStartedLink={<>{gettingStartedLinkText}</>}
                 fileIngestLink={<>{fileIngestLinkText}</>}
+                useAvailableDomainsQuery={mockUseAvailableDomainsQuery}
             />
         );
 

--- a/packages/javascript/bh-shared-ui/src/components/NoDataDialog/NoDataDialog.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/NoDataDialog/NoDataDialog.test.tsx
@@ -31,6 +31,6 @@ describe('NoDataDialog', () => {
 
         expect(screen.getByText('No Data Available')).toBeInTheDocument();
         expect(screen.getByText(/Getting Started guide/)).toBeInTheDocument();
-        expect(screen.queryByText(/start by uploading your data/)).toBeNull();
+        expect(screen.getByText(/start by uploading your data/)).toBeInTheDocument();
     });
 });

--- a/packages/javascript/bh-shared-ui/src/components/NoDataDialog/NoDataDialog.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/NoDataDialog/NoDataDialog.test.tsx
@@ -1,0 +1,36 @@
+// Copyright 2023 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { render, screen } from '../../test-utils';
+import NoDataDialog from '.';
+
+const gettingStartedLinkText = 'Getting Started guide';
+const fileIngestLinkText = 'start by uploading your data';
+
+describe('NoDataDialog', () => {
+    it('should render', () => {
+        render(
+            <NoDataDialog
+                gettingStartedLink={<>{gettingStartedLinkText}</>}
+                fileIngestLink={<>{fileIngestLinkText}</>}
+            />
+        );
+
+        expect(screen.getByText('No Data Available')).toBeInTheDocument();
+        expect(screen.getByText(/Getting Started guide/)).toBeInTheDocument();
+        expect(screen.queryByText(/start by uploading your data/)).toBeNull();
+    });
+});

--- a/packages/javascript/bh-shared-ui/src/components/NoDataDialog/NoDataDialog.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/NoDataDialog/NoDataDialog.tsx
@@ -1,0 +1,43 @@
+// Copyright 2023 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { Dialog, DialogContent, DialogDescription, DialogPortal, DialogTitle } from '@bloodhoundenterprise/doodleui';
+
+type NoDataDialogProps = {
+    fileIngestLink?: JSX.Element;
+    gettingStartedLink?: JSX.Element;
+};
+
+export const NoDataDialog: React.FC<NoDataDialogProps> = ({ fileIngestLink, gettingStartedLink }) => {
+    return (
+        <Dialog
+            open={true}
+            onOpenChange={() => {
+                // unblocks the body from being clickable so the user can go to another tab
+                document.body.style.pointerEvents = '';
+            }}>
+            <DialogPortal>
+                <DialogContent className='focus:outline-none' DialogOverlayProps={{ className: 'top-12' }}>
+                    <DialogTitle>No Data Available</DialogTitle>
+                    <DialogDescription>
+                        To explore your environment, {fileIngestLink}, on the file ingest page. Need help? Check out the{' '}
+                        {gettingStartedLink} for instructions.
+                    </DialogDescription>
+                </DialogContent>
+            </DialogPortal>
+        </Dialog>
+    );
+};

--- a/packages/javascript/bh-shared-ui/src/components/NoDataDialog/NoDataDialog.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/NoDataDialog/NoDataDialog.tsx
@@ -15,19 +15,22 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Dialog, DialogContent, DialogDescription, DialogPortal, DialogTitle } from '@bloodhoundenterprise/doodleui';
-import { useAvailableDomains } from '../../hooks';
+import { UseQueryResult } from 'react-query';
 
 type NoDataDialogProps = {
-    fileIngestLink?: JSX.Element;
-    gettingStartedLink?: JSX.Element;
+    fileIngestLink: JSX.Element;
+    gettingStartedLink: JSX.Element;
+    useAvailableDomainsQuery: UseQueryResult;
 };
 
-export const NoDataDialog: React.FC<NoDataDialogProps> = ({ fileIngestLink, gettingStartedLink }) => {
-    const useAvailableDomainsQuery = useAvailableDomains();
-
+export const NoDataDialog: React.FC<NoDataDialogProps> = ({
+    fileIngestLink,
+    gettingStartedLink,
+    useAvailableDomainsQuery,
+}) => {
     return (
         <Dialog
-            open={useAvailableDomainsQuery.data.length === 0}
+            open={Array.isArray(useAvailableDomainsQuery.data) && useAvailableDomainsQuery.data?.length === 0}
             onOpenChange={() => {
                 // unblocks the body from being clickable so the user can go to another tab
                 document.body.style.pointerEvents = '';

--- a/packages/javascript/bh-shared-ui/src/components/NoDataDialog/NoDataDialog.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/NoDataDialog/NoDataDialog.tsx
@@ -15,22 +15,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Dialog, DialogContent, DialogDescription, DialogPortal, DialogTitle } from '@bloodhoundenterprise/doodleui';
-import { UseQueryResult } from 'react-query';
 
 type NoDataDialogProps = {
     fileIngestLink: JSX.Element;
     gettingStartedLink: JSX.Element;
-    useAvailableDomainsQuery: UseQueryResult;
+    open: boolean;
 };
 
-export const NoDataDialog: React.FC<NoDataDialogProps> = ({
-    fileIngestLink,
-    gettingStartedLink,
-    useAvailableDomainsQuery,
-}) => {
+export const NoDataDialog: React.FC<NoDataDialogProps> = ({ fileIngestLink, gettingStartedLink, open }) => {
     return (
         <Dialog
-            open={Array.isArray(useAvailableDomainsQuery.data) && useAvailableDomainsQuery.data?.length === 0}
+            open={open}
             onOpenChange={() => {
                 // unblocks the body from being clickable so the user can go to another tab
                 document.body.style.pointerEvents = '';

--- a/packages/javascript/bh-shared-ui/src/components/NoDataDialog/NoDataDialog.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/NoDataDialog/NoDataDialog.tsx
@@ -15,6 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Dialog, DialogContent, DialogDescription, DialogPortal, DialogTitle } from '@bloodhoundenterprise/doodleui';
+import { useAvailableDomains } from '../../hooks';
 
 type NoDataDialogProps = {
     fileIngestLink?: JSX.Element;
@@ -22,9 +23,11 @@ type NoDataDialogProps = {
 };
 
 export const NoDataDialog: React.FC<NoDataDialogProps> = ({ fileIngestLink, gettingStartedLink }) => {
+    const useAvailableDomainsQuery = useAvailableDomains();
+
     return (
         <Dialog
-            open={true}
+            open={useAvailableDomainsQuery.data.length === 0}
             onOpenChange={() => {
                 // unblocks the body from being clickable so the user can go to another tab
                 document.body.style.pointerEvents = '';

--- a/packages/javascript/bh-shared-ui/src/components/NoDataDialog/index.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/NoDataDialog/index.tsx
@@ -1,0 +1,19 @@
+// Copyright 2023 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { NoDataDialog } from './NoDataDialog';
+
+export default NoDataDialog;

--- a/packages/javascript/bh-shared-ui/src/components/index.ts
+++ b/packages/javascript/bh-shared-ui/src/components/index.ts
@@ -128,6 +128,8 @@ export { default as MenuItem } from './MenuItem';
 
 export { default as NoDataAlert } from './NoDataAlert';
 
+export { default as NoDataDialog } from './NoDataDialog';
+
 export * from './NodeIcon';
 export { default as NodeIcon } from './NodeIcon';
 


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

*Describe your changes in detail*
Added a NoDataDialog component as requested in BED-5110.

## Motivation and Context

This PR addresses: [BED-5110](https://specterops.atlassian.net/browse/BED-5110)

*Why is this change required? What problem does it solve?*

This component addresses the need to have a shared dialog component that we can use across platforms to let the user know that no data is available.

## How Has This Been Tested?

*Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc.*

This has been tested with unit tests to check proper rendering of the dialog component. It was also tested via a local dev environment to ensure proper functionality.

## Screenshots (optional):
<img width="1130" alt="Screenshot 2024-12-30 at 10 20 58 AM" src="https://github.com/user-attachments/assets/dfd24df1-fa4a-40e3-aef2-8e4ae6a4e126" />


## Types of changes

<!-- Please remove any items that do not apply. -->

- New feature (non-breaking change which adds functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


[BED-5110]: https://specterops.atlassian.net/browse/BED-5110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ