### PR TITLE
CySQL Fixes and Updates

### DIFF
--- a/packages/go/cypher/models/pgsql/format/format.go
+++ b/packages/go/cypher/models/pgsql/format/format.go
@@ -429,7 +429,17 @@ func formatNode(builder *OutputBuilder, rootExpr pgsql.SyntaxNode) error {
 			exprStack = append(exprStack, *typedNextExpr)
 
 		case pgsql.TypeCast:
-			switch typedNextExpr.Expression.(type) {
+			switch typedCastedExpr := typedNextExpr.Expression.(type) {
+			case *pgsql.BinaryExpression:
+				if typedCastedExpr.Operator == pgsql.OperatorJSONTextField && typedNextExpr.CastType == pgsql.Text {
+					// Avoid formatting property lookups wrapped in text type casts
+					exprStack = append(exprStack, typedNextExpr.Expression)
+				} else {
+					exprStack = append(exprStack, pgsql.FormattingLiteral(typedNextExpr.CastType), pgsql.FormattingLiteral(")::"))
+					exprStack = append(exprStack, typedNextExpr.Expression)
+					exprStack = append(exprStack, pgsql.FormattingLiteral("("))
+				}
+
 			case pgsql.Parenthetical:
 				// Avoid formatting type-casted parenthetical statements as (('test'))::text - this should instead look like ('test')::text
 				exprStack = append(exprStack, pgsql.FormattingLiteral(typedNextExpr.CastType), pgsql.FormattingLiteral("::"))

--- a/packages/go/cypher/models/pgsql/operators.go
+++ b/packages/go/cypher/models/pgsql/operators.go
@@ -71,6 +71,13 @@ func OperatorIsPropertyLookup(operator Expression) bool {
 	)
 }
 
+func OperatorIsComparator(operator Expression) bool {
+	return OperatorIsIn(operator,
+		OperatorEquals, OperatorNotEquals, OperatorGreaterThan, OperatorGreaterThanOrEqualTo, OperatorLessThan,
+		OperatorLessThanOrEqualTo, OperatorArrayOverlap, OperatorLike, OperatorILike, OperatorPGArrayOverlap,
+		OperatorRegexMatch, OperatorSimilarTo)
+}
+
 const (
 	UnsetOperator                Operator = ""
 	OperatorUnion                Operator = "union"
@@ -107,6 +114,7 @@ const (
 	OperatorCypherStartsWith Operator = "starts with"
 	OperatorCypherContains   Operator = "contains"
 	OperatorCypherEndsWith   Operator = "ends with"
+	OperatorCypherAdd        Operator = "+"
 
 	OperatorPropertyLookup Operator = "property_lookup"
 	OperatorKindAssignment Operator = "kind_assignment"

--- a/packages/go/cypher/models/pgsql/pgtypes.go
+++ b/packages/go/cypher/models/pgsql/pgtypes.go
@@ -194,12 +194,6 @@ func (s DataType) CoerceToSupertype(other DataType) (DataType, bool) {
 
 	case Int2:
 		switch other {
-		case Int, Int8, Int4, Int2:
-			return other, true
-		}
-
-	case Int4:
-		switch other {
 		case Int2:
 			return s, true
 
@@ -207,18 +201,27 @@ func (s DataType) CoerceToSupertype(other DataType) (DataType, bool) {
 			return other, true
 		}
 
-	case Int8:
+	case Int4:
 		switch other {
-		case Int2, Int4:
+		case Int4, Int2:
 			return s, true
 
 		case Int, Int8:
 			return other, true
 		}
 
+	case Int8:
+		switch other {
+		case Int, Int8, Int4, Int2:
+			return s, true
+		}
+
 	case Int:
 		switch other {
-		case Int, Int8:
+		case Int:
+			return s, true
+
+		case Int8:
 			return other, true
 		}
 
@@ -239,7 +242,7 @@ func (s DataType) CoerceToSupertype(other DataType) (DataType, bool) {
 
 	case Numeric:
 		switch other {
-		case Float4, Float8, Int8, Int4, Int2:
+		case Float4, Float8, Int8, Int, Int4, Int2:
 			return s, true
 
 		case Numeric:

--- a/packages/go/cypher/models/pgsql/pgtypes.go
+++ b/packages/go/cypher/models/pgsql/pgtypes.go
@@ -26,7 +26,6 @@ import (
 
 var (
 	ErrNoAvailableArrayDataType = errors.New("data type has no direct array representation")
-	ErrNonArrayDataType         = errors.New("data type is not an array type")
 )
 
 const (
@@ -141,7 +140,7 @@ func (s DataType) IsComparable(other DataType, operator Operator) bool {
 	case OperatorEquals, OperatorNotEquals, OperatorGreaterThan, OperatorGreaterThanOrEqualTo, OperatorLessThan, OperatorLessThanOrEqualTo:
 		switch s {
 		case NodeComposite, EdgeComposite, PathComposite, JSONB, AnyArray, Text, Boolean,
-			IntArray, Int8Array, Int4Array, Int2Array, Float8Array, Float4Array, NumericArray,
+			IntArray, Int8Array, Int4Array, Int2Array, Float8Array, Float4Array, NumericArray, TextArray,
 			Date, TimeWithTimeZone, TimeWithoutTimeZone, Interval, TimestampWithTimeZone, TimestampWithoutTimeZone:
 			return other == s
 
@@ -182,7 +181,17 @@ func (s DataType) IsComparable(other DataType, operator Operator) bool {
 
 // CoerceToSupertype attempts to take the super of the type s and the type other
 func (s DataType) CoerceToSupertype(other DataType) (DataType, bool) {
+	switch other {
+	case UnknownDataType:
+		// If the other data type is unknown then assume this data type as the super type
+		return s, true
+	}
+
 	switch s {
+	case UnknownDataType:
+		// If this data type is unknown then assume the other type presented as the super type
+		return other, true
+
 	case Int2:
 		switch other {
 		case Int, Int8, Int4, Int2:
@@ -238,6 +247,7 @@ func (s DataType) CoerceToSupertype(other DataType) (DataType, bool) {
 		}
 	}
 
+	// Otherwise unable to identify a super type
 	return UnknownDataType, false
 }
 

--- a/packages/go/cypher/models/pgsql/pgtypes.go
+++ b/packages/go/cypher/models/pgsql/pgtypes.go
@@ -67,34 +67,42 @@ func (s DataType) NodeType() string {
 }
 
 const (
-	UnsetDataType            DataType = ""
-	UnknownDataType          DataType = "UNKNOWN"
-	Reference                DataType = "REFERENCE"
-	Null                     DataType = "NULL"
-	NodeComposite            DataType = "nodecomposite"
-	NodeCompositeArray       DataType = "nodecomposite[]"
-	EdgeComposite            DataType = "edgecomposite"
-	EdgeCompositeArray       DataType = "edgecomposite[]"
-	PathComposite            DataType = "pathcomposite"
-	Int                      DataType = "int"
-	IntArray                 DataType = "int[]"
-	Int2                     DataType = "int2"
-	Int2Array                DataType = "int2[]"
-	Int4                     DataType = "int4"
-	Int4Array                DataType = "int4[]"
-	Int8                     DataType = "int8"
-	Int8Array                DataType = "int8[]"
-	Float4                   DataType = "float4"
-	Float4Array              DataType = "float4[]"
-	Float8                   DataType = "float8"
-	Float8Array              DataType = "float8[]"
-	Boolean                  DataType = "bool"
-	Text                     DataType = "text"
-	TextArray                DataType = "text[]"
-	JSONB                    DataType = "jsonb"
-	JSONBArray               DataType = "jsonb[]"
-	Numeric                  DataType = "numeric"
-	NumericArray             DataType = "numeric[]"
+	// UnsetDataType represents a DataType that has not been visited by any logic. It is the default, zero-value for
+	// the DataType type.
+	UnsetDataType DataType = ""
+
+	// UnknownDataType represents a DataType that has been visited by type inference logic but remains unknowable.
+	UnknownDataType DataType = "unknown"
+
+	Null          DataType = "null"
+	Any           DataType = "any"
+	NodeComposite DataType = "nodecomposite"
+	EdgeComposite DataType = "edgecomposite"
+	PathComposite DataType = "pathcomposite"
+	Int           DataType = "int"
+	Int2          DataType = "int2"
+	Int4          DataType = "int4"
+	Int8          DataType = "int8"
+	Float4        DataType = "float4"
+	Float8        DataType = "float8"
+	Boolean       DataType = "bool"
+	Text          DataType = "text"
+	JSONB         DataType = "jsonb"
+	Numeric       DataType = "numeric"
+
+	AnyArray           DataType = "any[]"
+	NodeCompositeArray DataType = "nodecomposite[]"
+	EdgeCompositeArray DataType = "edgecomposite[]"
+	IntArray           DataType = "int[]"
+	Int2Array          DataType = "int2[]"
+	Int4Array          DataType = "int4[]"
+	Int8Array          DataType = "int8[]"
+	Float4Array        DataType = "float4[]"
+	Float8Array        DataType = "float8[]"
+	TextArray          DataType = "text[]"
+	JSONBArray         DataType = "jsonb[]"
+	NumericArray       DataType = "numeric[]"
+
 	Date                     DataType = "date"
 	TimeWithTimeZone         DataType = "time with time zone"
 	TimeWithoutTimeZone      DataType = "time without time zone"
@@ -121,160 +129,168 @@ func (s DataType) IsKnown() bool {
 	}
 }
 
-// TODO: operator, while unused, is part of a refactor for this function to make it operator aware
-func (s DataType) Compatible(other DataType, operator Operator) (DataType, bool) {
-	if s == other {
-		return s, true
-	}
+func (s DataType) IsComparable(other DataType, operator Operator) bool {
+	switch operator {
+	case OperatorPGArrayOverlap, OperatorArrayOverlap:
+		if !s.IsArrayType() || !other.IsArrayType() {
+			return false
+		}
 
-	if other == UnknownDataType {
-		// Assume unknown data types will offload type matching to the DB
-		return s, true
-	}
+		return s == other
 
+	case OperatorEquals, OperatorNotEquals, OperatorGreaterThan, OperatorGreaterThanOrEqualTo, OperatorLessThan, OperatorLessThanOrEqualTo:
+		switch s {
+		case NodeComposite, EdgeComposite, PathComposite, JSONB, AnyArray, Text, Boolean,
+			IntArray, Int8Array, Int4Array, Int2Array, Float8Array, Float4Array, NumericArray,
+			Date, TimeWithTimeZone, TimeWithoutTimeZone, Interval, TimestampWithTimeZone, TimestampWithoutTimeZone:
+			return other == s
+
+		case Int, Int8, Int4, Int2:
+			switch other {
+			case Int, Int8, Int4, Int2, Float8, Float4, Numeric:
+				return true
+
+			default:
+				return false
+			}
+
+		case Float8, Float4, Numeric:
+			switch other {
+			case Int, Int8, Int4, Int2, Float8, Float4, Numeric:
+				return true
+
+			default:
+				return false
+			}
+
+		default:
+			return false
+		}
+
+	case OperatorLike, OperatorILike, OperatorSimilarTo, OperatorRegexMatch:
+		switch s {
+		case Text:
+			return other == s
+		default:
+			return false
+		}
+
+	default:
+		return false
+	}
+}
+
+// CoerceToSupertype attempts to take the super of the type s and the type other
+func (s DataType) CoerceToSupertype(other DataType) (DataType, bool) {
 	switch s {
-	case UnknownDataType:
-		// Assume unknown data types will offload type matching to the DB
-		return other, true
+	case Int2:
+		switch other {
+		case Int, Int8, Int4, Int2:
+			return other, true
+		}
 
-	case Text:
-		return Text, true
+	case Int4:
+		switch other {
+		case Int2:
+			return s, true
+
+		case Int, Int8, Int4:
+			return other, true
+		}
+
+	case Int8:
+		switch other {
+		case Int2, Int4:
+			return s, true
+
+		case Int, Int8:
+			return other, true
+		}
+
+	case Int:
+		switch other {
+		case Int, Int8:
+			return other, true
+		}
 
 	case Float4:
 		switch other {
-		case Float8:
-			return Float8, true
-
-		case Float4Array:
-			return Float4, true
-
-		case Float8Array:
-			return Float8, true
-
-		case Text:
-			return Text, true
+		case Float4, Float8, Numeric:
+			return other, true
 		}
 
 	case Float8:
 		switch other {
 		case Float4:
-			return Float8, true
+			return s, true
 
-		case Float4Array, Float8Array:
-			return Float8, true
-
-		case Text:
-			return Text, true
+		case Float8, Numeric:
+			return other, true
 		}
 
 	case Numeric:
 		switch other {
-		case Float4, Float8, Int2, Int4, Int8:
-			return Numeric, true
+		case Float4, Float8, Int8, Int4, Int2:
+			return s, true
 
-		case Float4Array, Float8Array, NumericArray:
-			return Numeric, true
-
-		case Text:
-			return Text, true
-		}
-
-	case Int2:
-		switch other {
-		case Int2:
-			return Int2, true
-
-		case Int4:
-			return Int4, true
-
-		case Int8:
-			return Int8, true
-
-		case Int2Array:
-			return Int2, true
-
-		case Int4Array:
-			return Int4, true
-
-		case Int8Array:
-			return Int8, true
-
-		case Text:
-			return Text, true
-		}
-
-	case Int4:
-		switch other {
-		case Int2, Int4:
-			return Int4, true
-
-		case Int8:
-			return Int8, true
-
-		case Int2Array, Int4Array:
-			return Int4, true
-
-		case Int8Array:
-			return Int8, true
-
-		case Text:
-			return Text, true
-		}
-
-	case Int8:
-		switch other {
-		case Int2, Int4, Int8:
-			return Int8, true
-
-		case Int2Array, Int4Array, Int8Array:
-			return Int8, true
-
-		case Text:
-			return Text, true
-		}
-
-	case Int:
-		switch other {
-		case Int2, Int4, Int:
-			return Int, true
-
-		case Int8:
-			return Int8, true
-
-		case Text:
-			return Text, true
-		}
-
-	case Int2Array:
-		switch other {
-		case Int2Array, Int4Array, Int8Array:
-			return other, true
-		}
-
-	case Int4Array:
-		switch other {
-		case Int4Array, Int8Array:
-			return other, true
-		}
-
-	case Float4Array:
-		switch other {
-		case Float4Array, Float8Array:
+		case Numeric:
 			return other, true
 		}
 	}
 
-	return UnsetDataType, false
+	return UnknownDataType, false
 }
 
-func (s DataType) TextConvertable() bool {
-	switch s {
-	case TimestampWithoutTimeZone, TimestampWithTimeZone, TimeWithoutTimeZone, TimeWithTimeZone, Date, Text:
-		return true
-
-	default:
-		return false
+func (s DataType) OperatorResultType(other DataType, operator Operator) (DataType, bool) {
+	if OperatorIsComparator(operator) && s.IsComparable(other, operator) {
+		return Boolean, true
 	}
+
+	// Validate all other supported operators for result type inference
+	switch operator {
+	case OperatorAnd, OperatorOr:
+		return Boolean, true
+
+	case OperatorAdd, OperatorSubtract, OperatorMultiply, OperatorDivide:
+		if s == other {
+			return s, true
+		}
+
+		if supertype, validSupertype := s.CoerceToSupertype(other); validSupertype {
+			return supertype, true
+		}
+
+	case OperatorConcatenate:
+		// Array types may only concatenate if their base types match
+		if s.IsArrayType() {
+			return s, s == other || s.ArrayBaseType() == other
+		}
+
+		if other.IsArrayType() {
+			return other, s == other || s == other.ArrayBaseType()
+		}
+
+		switch s {
+		case UnknownDataType:
+			// Overwrite the unknown data type here and assume that it will resolve correctly
+			return other, true
+
+		case Text:
+			switch other {
+			case UnknownDataType:
+				// Overwrite the unknown data type here and assume that it will resolve to text
+				return s, true
+
+			default:
+				return s, s == other
+			}
+
+		default:
+			return UnknownDataType, false
+		}
+	}
+
+	return UnknownDataType, false
 }
 
 func (s DataType) MatchesOneOf(others ...DataType) bool {
@@ -289,22 +305,12 @@ func (s DataType) MatchesOneOf(others ...DataType) bool {
 
 func (s DataType) IsArrayType() bool {
 	switch s {
-	case Int2Array, Int4Array, Int8Array, Float4Array, Float8Array, TextArray, JSONBArray, NodeCompositeArray, EdgeCompositeArray, NumericArray:
+	case Int2Array, Int4Array, Int8Array, IntArray, Float4Array, Float8Array, TextArray, JSONBArray,
+		NodeCompositeArray, EdgeCompositeArray, NumericArray:
 		return true
 	}
 
 	return false
-}
-
-func (s DataType) ToUpdateResultType() (DataType, error) {
-	switch s {
-	case NodeComposite:
-		return s, nil
-	case EdgeComposite:
-		return s, nil
-	default:
-		return UnsetDataType, fmt.Errorf("data type %s has no update result representation", s)
-	}
 }
 
 func (s DataType) ToArrayType() (DataType, error) {
@@ -315,6 +321,16 @@ func (s DataType) ToArrayType() (DataType, error) {
 		return Int4Array, nil
 	case Int8, Int8Array:
 		return Int8Array, nil
+	case Int, IntArray:
+		return IntArray, nil
+	case Any, AnyArray:
+		return AnyArray, nil
+	case JSONB, JSONBArray:
+		return JSONBArray, nil
+	case NodeComposite, NodeCompositeArray:
+		return NodeCompositeArray, nil
+	case EdgeComposite, EdgeCompositeArray:
+		return EdgeCompositeArray, nil
 	case Float4, Float4Array:
 		return Float4Array, nil
 	case Float8, Float8Array:
@@ -328,24 +344,32 @@ func (s DataType) ToArrayType() (DataType, error) {
 	}
 }
 
-func (s DataType) ArrayBaseType() (DataType, error) {
+func (s DataType) ArrayBaseType() DataType {
 	switch s {
 	case Int2Array:
-		return Int2, nil
+		return Int2
 	case Int4Array:
-		return Int4, nil
+		return Int4
 	case Int8Array:
-		return Int8, nil
+		return Int8
 	case Float4Array:
-		return Float4, nil
+		return Float4
 	case Float8Array:
-		return Float8, nil
+		return Float8
 	case TextArray:
-		return Text, nil
+		return Text
 	case NumericArray:
-		return Numeric, nil
+		return Numeric
+	case JSONBArray:
+		return JSONB
+	case AnyArray:
+		return Any
+	case NodeCompositeArray:
+		return NodeComposite
+	case EdgeCompositeArray:
+		return EdgeComposite
 	default:
-		return s, nil
+		return s
 	}
 }
 

--- a/packages/go/cypher/models/pgsql/pytypes_test.go
+++ b/packages/go/cypher/models/pgsql/pytypes_test.go
@@ -24,6 +24,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestDataType_CoerceToSupertype(t *testing.T) {
+
+}
+
 func TestDataType_Comparable(t *testing.T) {
 	testCases := []struct {
 		LeftTypes  []DataType
@@ -114,7 +118,7 @@ func TestDataType_Comparable(t *testing.T) {
 		// Validate text operations
 		{
 			LeftTypes:  []DataType{Text},
-			Operators:  []Operator{OperatorConcatenate, OperatorLike, OperatorILike, OperatorSimilarTo, OperatorRegexMatch},
+			Operators:  []Operator{OperatorLike, OperatorILike, OperatorSimilarTo, OperatorRegexMatch},
 			RightTypes: []DataType{Text},
 			Expected:   true,
 		},
@@ -122,7 +126,7 @@ func TestDataType_Comparable(t *testing.T) {
 		// Text operations on non-text types should fail
 		{
 			LeftTypes:  []DataType{Int},
-			Operators:  []Operator{OperatorConcatenate, OperatorLike, OperatorILike, OperatorSimilarTo, OperatorRegexMatch},
+			Operators:  []Operator{OperatorLike, OperatorILike, OperatorSimilarTo, OperatorRegexMatch},
 			RightTypes: []DataType{Int},
 			Expected:   false,
 		},
@@ -150,12 +154,12 @@ func TestDataType_Comparable(t *testing.T) {
 		},
 	}
 
-	for _, testCase := range testCases {
+	for idx, testCase := range testCases {
 		for _, leftType := range testCase.LeftTypes {
 			for _, operator := range testCase.Operators {
 				for _, rightType := range testCase.RightTypes {
 					result := leftType.IsComparable(rightType, operator)
-					require.Equal(t, testCase.Expected, result)
+					require.Equalf(t, testCase.Expected, result, "failed test case %d: %+v, %+v", idx, testCase.LeftTypes, testCase.RightTypes)
 				}
 			}
 		}

--- a/packages/go/cypher/models/pgsql/pytypes_test.go
+++ b/packages/go/cypher/models/pgsql/pytypes_test.go
@@ -25,7 +25,79 @@ import (
 )
 
 func TestDataType_CoerceToSupertype(t *testing.T) {
+	testCases := []struct {
+		LeftTypes       []DataType
+		RightTypes      []DataType
+		Expected        DataType
+		ExpectRightType bool
+	}{{
+		LeftTypes:  []DataType{UnknownDataType},
+		RightTypes: []DataType{Int},
+		Expected:   Int,
+	}, {
+		LeftTypes:  []DataType{Int},
+		RightTypes: []DataType{UnknownDataType},
+		Expected:   Int,
+	}, {
+		LeftTypes:  []DataType{Int8},
+		RightTypes: []DataType{Int2, Int4, Int, Int8},
+		Expected:   Int8,
+	}, {
+		LeftTypes:  []DataType{Int4},
+		RightTypes: []DataType{Int2, Int4},
+		Expected:   Int4,
+	}, {
+		LeftTypes:  []DataType{Int4},
+		RightTypes: []DataType{Int},
+		Expected:   Int,
+	}, {
+		LeftTypes:  []DataType{Int4},
+		RightTypes: []DataType{Int8},
+		Expected:   Int8,
+	}, {
+		LeftTypes:       []DataType{Int2},
+		RightTypes:      []DataType{Int2, Int4, Int, Int8},
+		ExpectRightType: true,
+	}, {
+		LeftTypes:       []DataType{Int},
+		RightTypes:      []DataType{Int, Int8},
+		ExpectRightType: true,
+	}, {
+		LeftTypes:       []DataType{Float4},
+		RightTypes:      []DataType{Float4, Float8, Numeric},
+		ExpectRightType: true,
+	}, {
+		LeftTypes:  []DataType{Float8},
+		RightTypes: []DataType{Float4},
+		Expected:   Float8,
+	}, {
+		LeftTypes:       []DataType{Float8},
+		RightTypes:      []DataType{Float8, Numeric},
+		ExpectRightType: true,
+	}, {
+		LeftTypes:  []DataType{Numeric},
+		RightTypes: []DataType{Numeric, Float8, Float4, Int8, Int, Int4, Int2},
+		Expected:   Numeric,
+	}}
 
+	for _, testCase := range testCases {
+		for _, leftType := range testCase.LeftTypes {
+			for _, rightType := range testCase.RightTypes {
+				superType, coerced := leftType.CoerceToSupertype(rightType)
+
+				if !coerced {
+					t.Fatalf("coercing left type %s to right type %s failed", leftType, rightType)
+				}
+
+				if testCase.ExpectRightType {
+					require.Equalf(t, rightType, superType, "expected type %s does not match super type %s", rightType, superType)
+				} else {
+					require.Equalf(t, testCase.Expected, superType, "expected type %s does not match super type %s", testCase.Expected, superType)
+				}
+
+			}
+		}
+	}
 }
 
 func TestDataType_Comparable(t *testing.T) {

--- a/packages/go/cypher/models/pgsql/test/translation_cases/nodes.sql
+++ b/packages/go/cypher/models/pgsql/test/translation_cases/nodes.sql
@@ -108,15 +108,15 @@ with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0
      s1 as (select s0.n0 as n0, (n1.id, n1.kind_ids, n1.properties)::nodecomposite as n1
             from s0,
                  node n1
-            where n1.kind_ids operator (pg_catalog.&&) array [2]::int2[] and ((s0.n0).properties -> 'selected')::bool
-               or (s0.n0).properties -> 'tid' = n1.properties -> 'tid' and (n1.properties -> 'enabled')::bool)
+            where n1.kind_ids operator (pg_catalog.&&) array [2]::int2[] and ((s0.n0).properties ->> 'selected')::bool
+               or (s0.n0).properties -> 'tid' = n1.properties -> 'tid' and (n1.properties ->> 'enabled')::bool)
 select s1.n0 as s, s1.n1 as e
 from s1;
 
 -- case: match (s) where s.value + 2 / 3 > 10 return s
 with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0
             from node n0
-            where (n0.properties -> 'value')::int8 + 2 / 3 > 10)
+            where (n0.properties ->> 'value')::int8 + 2 / 3 > 10)
 select s0.n0 as s
 from s0;
 
@@ -127,7 +127,7 @@ with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0
      s1 as (select s0.n0 as n0, (n1.id, n1.kind_ids, n1.properties)::nodecomposite as n1
             from s0,
                  node n1)
-select s1.n0 as s, (s1.n1).properties -> 'name' as othername
+select s1.n0 as s, (s1.n1).properties ->> 'name' as othername
 from s1;
 
 -- case: match (s) where s.name in ['option 1', 'option 2'] return s
@@ -172,7 +172,7 @@ with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0
      s1 as (select s0.n0 as n0, (n1.id, n1.kind_ids, n1.properties)::nodecomposite as n1
             from s0,
                  node n1
-            where (n1.properties -> 'other')::int8 = 1234)
+            where (n1.properties ->> 'other')::int8 = 1234)
 select s1.n0 as s
 from s1;
 
@@ -182,7 +182,7 @@ with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0 from
             from s0,
                  node n1
             where (s0.n0).properties ->> 'name' = '1234'
-               or (n1.properties -> 'other')::int8 = 1234)
+               or (n1.properties ->> 'other')::int8 = 1234)
 select s1.n0 as s
 from s1;
 
@@ -211,7 +211,7 @@ offset 5 limit 10;
 with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0 from node n0)
 select s0.n0 as s
 from s0
-order by (s0.n0).properties -> 'name', (s0.n0).properties -> 'other_prop' desc;
+order by (s0.n0).properties ->> 'name', (s0.n0).properties ->> 'other_prop' desc;
 
 -- case: match (s) where s.created_at = localtime() return s
 with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0
@@ -281,12 +281,12 @@ from s0;
 
 -- case: match (s) return s.value + 1
 with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0 from node n0)
-select ((s0.n0).properties -> 'value')::int8 + 1
+select ((s0.n0).properties ->> 'value')::int8 + 1
 from s0;
 
 -- case: match (s) return (s.value + 1) / 3
 with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0 from node n0)
-select (((s0.n0).properties -> 'value')::int8 + 1) / 3
+select (((s0.n0).properties ->> 'value')::int8 + 1) / 3
 from s0;
 
 -- case: match (s) where id(s) in [1, 2, 3, 4] return s
@@ -503,7 +503,7 @@ from s0;
 with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0
             from node n0
             where n0.kind_ids operator (pg_catalog.&&) array [1]::int2[]
-              and (n0.properties -> 'functionallevel')::text = any
+              and n0.properties ->> 'functionallevel' = any
                   (array ['2008 R2', '2012', '2008', '2003', '2003 Interim', '2000 Mixed/Native']::text[]))
 select s0.n0 as n
 from s0;
@@ -512,7 +512,7 @@ from s0;
 with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0
             from node n0
             where n0.kind_ids operator (pg_catalog.&&) array [1]::int2[]
-              and (n0.properties -> 'value')::int8 = any (array [1, 2, 3, 4]::int8[]))
+              and (n0.properties ->> 'value')::int8 = any (array [1, 2, 3, 4]::int8[]))
 select s0.n0 as n
 from s0;
 
@@ -520,9 +520,9 @@ from s0;
 with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0
             from node n0
             where n0.kind_ids operator (pg_catalog.&&) array [1]::int2[]
-              and (n0.properties -> 'pwdlastset')::numeric <
+              and (n0.properties ->> 'pwdlastset')::numeric <
                   (extract(epoch from now()::timestamp with time zone)::numeric - (365 * 86400))
-              and not (n0.properties -> 'pwdlastset')::float8 = any (array [- 1, 0]::float8[]))
+              and not (n0.properties ->> 'pwdlastset')::float8 = any (array [- 1, 0]::float8[]))
 select s0.n0 as u
 from s0
 limit 100;
@@ -531,9 +531,9 @@ limit 100;
 with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0
             from node n0
             where n0.kind_ids operator (pg_catalog.&&) array [1]::int2[]
-              and (n0.properties -> 'pwdlastset')::numeric <
+              and (n0.properties ->> 'pwdlastset')::numeric <
                   (extract(epoch from now()::timestamp with time zone)::numeric * 1000 - (365 * 86400000))
-              and not (n0.properties -> 'pwdlastset')::float8 = any (array [- 1, 0]::float8[]))
+              and not (n0.properties ->> 'pwdlastset')::float8 = any (array [- 1, 0]::float8[]))
 select s0.n0 as u
 from s0
 limit 100;
@@ -574,7 +574,7 @@ from s0;
 with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0
             from node n0
             where n0.kind_ids operator (pg_catalog.&&) array [1]::int2[]
-              and coalesce((n0.properties -> 'a')::int8, (n0.properties -> 'b')::int8, 1)::int8 = 1)
+              and coalesce((n0.properties ->> 'a')::int8, (n0.properties ->> 'b')::int8, 1)::int8 = 1)
 select s0.n0 as n
 from s0;
 
@@ -582,7 +582,7 @@ from s0;
 with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0
             from node n0
             where n0.kind_ids operator (pg_catalog.&&) array [1]::int2[]
-              and coalesce(n0.properties -> 'a', n0.properties -> 'b')::int8 = 1)
+              and coalesce(n0.properties ->> 'a', n0.properties ->> 'b')::int8 = 1)
 select s0.n0 as n
 from s0;
 
@@ -590,7 +590,7 @@ from s0;
 with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0
             from node n0
             where n0.kind_ids operator (pg_catalog.&&) array [1]::int2[]
-              and 1 = coalesce(n0.properties -> 'a', n0.properties -> 'b')::int8)
+              and 1 = coalesce(n0.properties ->> 'a', n0.properties ->> 'b')::int8)
 select s0.n0 as n
 from s0;
 
@@ -598,11 +598,11 @@ from s0;
 with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0
             from node n0
             where n0.kind_ids operator (pg_catalog.&&) array [1]::int2[]
-              and (n0.properties -> 'hasspn')::bool = true
-              and (n0.properties -> 'enabled')::bool = true
+              and (n0.properties ->> 'hasspn')::bool = true
+              and (n0.properties ->> 'enabled')::bool = true
               and not coalesce(n0.properties ->> 'objectid', '')::text like '%-502'
-              and not coalesce((n0.properties -> 'gmsa')::bool, false)::bool = true
-              and not coalesce((n0.properties -> 'msa')::bool, false)::bool = true)
+              and not coalesce((n0.properties ->> 'gmsa')::bool, false)::bool = true
+              and not coalesce((n0.properties ->> 'msa')::bool, false)::bool = true)
 select s0.n0 as u
 from s0
 limit 10;

--- a/packages/go/cypher/models/pgsql/test/translation_cases/nodes.sql
+++ b/packages/go/cypher/models/pgsql/test/translation_cases/nodes.sql
@@ -593,3 +593,32 @@ with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0
               and 1 = coalesce(n0.properties -> 'a', n0.properties -> 'b')::int8)
 select s0.n0 as n
 from s0;
+
+-- case: match (u:NodeKind1) where u.hasspn = true and u.enabled = true and not u.objectid ends with '-502' and not coalesce(u.gmsa, false) = true and not coalesce(u.msa, false) = true return u limit 10
+with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0
+            from node n0
+            where n0.kind_ids operator (pg_catalog.&&) array [1]::int2[]
+              and (n0.properties -> 'hasspn')::bool = true
+              and (n0.properties -> 'enabled')::bool = true
+              and not coalesce(n0.properties ->> 'objectid', '')::text like '%-502'
+              and not coalesce((n0.properties -> 'gmsa')::bool, false)::bool = true
+              and not coalesce((n0.properties -> 'msa')::bool, false)::bool = true)
+select s0.n0 as u
+from s0
+limit 10;
+
+-- case: match (n:NodeKind1) where coalesce(n.name, '') = coalesce(n.migrated_name, '') return n
+with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0
+            from node n0
+            where n0.kind_ids operator (pg_catalog.&&) array [1]::int2[]
+              and coalesce(n0.properties ->> 'name', '')::text = coalesce(n0.properties ->> 'migrated_name', '')::text)
+select s0.n0 as n
+from s0;
+
+-- case: match (n:NodeKind1) where '1' in n.array_prop + ['1', '2'] return n
+with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0
+            from node n0
+            where n0.kind_ids operator (pg_catalog.&&) array [1]::int2[]
+              and '1' = any (jsonb_to_text_array(n0.properties -> 'array_prop')::text[] || array ['1', '2']::text[]))
+select s0.n0 as n
+from s0;

--- a/packages/go/cypher/models/pgsql/test/translation_cases/nodes.sql
+++ b/packages/go/cypher/models/pgsql/test/translation_cases/nodes.sql
@@ -127,7 +127,7 @@ with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0
      s1 as (select s0.n0 as n0, (n1.id, n1.kind_ids, n1.properties)::nodecomposite as n1
             from s0,
                  node n1)
-select s1.n0 as s, (s1.n1).properties ->> 'name' as othername
+select s1.n0 as s, (s1.n1).properties -> 'name' as othername
 from s1;
 
 -- case: match (s) where s.name in ['option 1', 'option 2'] return s
@@ -211,7 +211,7 @@ offset 5 limit 10;
 with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0 from node n0)
 select s0.n0 as s
 from s0
-order by (s0.n0).properties ->> 'name', (s0.n0).properties ->> 'other_prop' desc;
+order by (s0.n0).properties -> 'name', (s0.n0).properties -> 'other_prop' desc;
 
 -- case: match (s) where s.created_at = localtime() return s
 with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0

--- a/packages/go/cypher/models/pgsql/test/translation_cases/pattern_binding.sql
+++ b/packages/go/cypher/models/pgsql/test/translation_cases/pattern_binding.sql
@@ -90,7 +90,7 @@ with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite           
                    (n2.id, n2.kind_ids, n2.properties)::nodecomposite                        as n2
             from s0,
                  edge e1
-                   join node n2 on (n2.properties -> 'is_target')::bool and n2.id = e1.start_id
+                   join node n2 on (n2.properties ->> 'is_target')::bool and n2.id = e1.start_id
             where (s0.n1).id = e1.end_id)
 select edges_to_path(variadic array [(s1.e0).id, (s1.e1).id]::int8[])::pathcomposite as p
 from s1;

--- a/packages/go/cypher/models/pgsql/test/translation_cases/pattern_binding.sql
+++ b/packages/go/cypher/models/pgsql/test/translation_cases/pattern_binding.sql
@@ -265,4 +265,3 @@ from s1;
 
 -- todo: the case below covers untyped array literals but has not yet been fixed
 -- case: match p = (:NodeKind1)-[:EdgeKind1|EdgeKind2]->(e:NodeKind2)-[:EdgeKind2]->(:NodeKind1) where (e.a = [] or 'a' in e.a) and (e.b = 0 or e.b = 1) return p
-

--- a/packages/go/cypher/models/pgsql/test/translation_cases/stepwise_traversal.sql
+++ b/packages/go/cypher/models/pgsql/test/translation_cases/stepwise_traversal.sql
@@ -335,12 +335,3 @@ with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite           
 select s1.n2 as n
 from s1;
 
--- case: match p = ()-[]->(e) where e.np = 123 return p
-with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite                        as n0,
-                   (e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite as e0,
-                   (n1.id, n1.kind_ids, n1.properties)::nodecomposite                        as n1
-            from edge e0
-                   join node n0 on n0.id = e0.start_id
-                   join node n1 on (n1.properties ->> 'np')::int8 = 123 and n1.id = e0.end_id)
-select edges_to_path(variadic array [(s0.e0).id]::int8[])::pathcomposite as p
-from s0;

--- a/packages/go/cypher/models/pgsql/test/translation_cases/stepwise_traversal.sql
+++ b/packages/go/cypher/models/pgsql/test/translation_cases/stepwise_traversal.sql
@@ -221,7 +221,7 @@ with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite           
                    join node n0 on n0.id = e0.end_id
                    join node n1 on n1.id = e0.start_id
             where e0.kind_id = any (array [3, 4]::int2[]))
-select (s0.n0).properties ->> 'name', (s0.n1).properties ->> 'name'
+select (s0.n0).properties -> 'name', (s0.n1).properties -> 'name'
 from s0;
 
 -- case: match (s)-[:EdgeKind1|EdgeKind2]->(e)-[:EdgeKind1]->() return s.name as s_name, e.name as e_name
@@ -242,7 +242,7 @@ with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite           
                    join node n2 on n2.id = e1.end_id
             where e1.kind_id = any (array [3]::int2[])
               and (s0.n1).id = e1.start_id)
-select (s1.n0).properties ->> 'name' as s_name, (s1.n1).properties ->> 'name' as e_name
+select (s1.n0).properties -> 'name' as s_name, (s1.n1).properties -> 'name' as e_name
 from s1;
 
 -- case: match (s:NodeKind1)-[r:EdgeKind1|EdgeKind2]->(e:NodeKind2) return s.name, e.name
@@ -253,7 +253,7 @@ with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite           
                    join node n0 on n0.kind_ids operator (pg_catalog.&&) array [1]::int2[] and n0.id = e0.start_id
                    join node n1 on n1.kind_ids operator (pg_catalog.&&) array [2]::int2[] and n1.id = e0.end_id
             where e0.kind_id = any (array [3, 4]::int2[]))
-select (s0.n0).properties ->> 'name', (s0.n1).properties ->> 'name'
+select (s0.n0).properties -> 'name', (s0.n1).properties -> 'name'
 from s0;
 
 -- case: match (s)-[r:EdgeKind1]->() where (s)-[r {prop: 'a'}]->() return s

--- a/packages/go/cypher/models/pgsql/test/translation_cases/update.sql
+++ b/packages/go/cypher/models/pgsql/test/translation_cases/update.sql
@@ -172,5 +172,5 @@ with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite           
      s2
        as (update edge e2 set properties = e2.properties ||
                                            jsonb_build_object('visited', true)::jsonb from s1 where (s1.e1).id = e2.id returning s1.e0 as e0, (e2.id, e2.start_id, e2.end_id, e2.kind_id, e2.properties)::edgecomposite as e1, s1.n0 as n0, s1.n1 as n1, s1.n2 as n2)
-select (s2.e1).properties ->> 'name'
+select (s2.e1).properties -> 'name'
 from s2;

--- a/packages/go/cypher/models/pgsql/test/translation_cases/update.sql
+++ b/packages/go/cypher/models/pgsql/test/translation_cases/update.sql
@@ -172,5 +172,5 @@ with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite           
      s2
        as (update edge e2 set properties = e2.properties ||
                                            jsonb_build_object('visited', true)::jsonb from s1 where (s1.e1).id = e2.id returning s1.e0 as e0, (e2.id, e2.start_id, e2.end_id, e2.kind_id, e2.properties)::edgecomposite as e1, s1.n0 as n0, s1.n1 as n1, s1.n2 as n2)
-select (s2.e1).properties -> 'name'
+select (s2.e1).properties ->> 'name'
 from s2;

--- a/packages/go/cypher/models/pgsql/translate/expression.go
+++ b/packages/go/cypher/models/pgsql/translate/expression.go
@@ -18,7 +18,6 @@ package translate
 
 import (
 	"fmt"
-
 	"github.com/specterops/bloodhound/log"
 
 	"github.com/specterops/bloodhound/cypher/models/pgsql"
@@ -139,7 +138,7 @@ func inferBinaryExpressionType(expression *pgsql.BinaryExpression) (pgsql.DataTy
 
 	if isLeftHinted {
 		if isRightHinted {
-			if higherLevelHint, matchesOrConverts := leftHint.Compatible(rightHint, expression.Operator); !matchesOrConverts {
+			if higherLevelHint, matchesOrConverts := leftHint.OperatorResultType(rightHint, expression.Operator); !matchesOrConverts {
 				return pgsql.UnsetDataType, fmt.Errorf("left and right operands for binary expression \"%s\" are not compatible: %s != %s", expression.Operator, leftHint, rightHint)
 			} else {
 				return higherLevelHint, nil
@@ -149,7 +148,7 @@ func inferBinaryExpressionType(expression *pgsql.BinaryExpression) (pgsql.DataTy
 		} else if inferredRightHint == pgsql.UnknownDataType {
 			// Assume the right side is convertable and return the left operand hint
 			return leftHint, nil
-		} else if upcastHint, matchesOrConverts := leftHint.Compatible(inferredRightHint, expression.Operator); !matchesOrConverts {
+		} else if upcastHint, matchesOrConverts := leftHint.OperatorResultType(inferredRightHint, expression.Operator); !matchesOrConverts {
 			return pgsql.UnsetDataType, fmt.Errorf("left and right operands for binary expression \"%s\" are not compatible: %s != %s", expression.Operator, leftHint, inferredRightHint)
 		} else {
 			return upcastHint, nil
@@ -161,7 +160,7 @@ func inferBinaryExpressionType(expression *pgsql.BinaryExpression) (pgsql.DataTy
 		} else if inferredLeftHint == pgsql.UnknownDataType {
 			// Assume the right side is convertable and return the left operand hint
 			return rightHint, nil
-		} else if upcastHint, matchesOrConverts := rightHint.Compatible(inferredLeftHint, expression.Operator); !matchesOrConverts {
+		} else if upcastHint, matchesOrConverts := rightHint.OperatorResultType(inferredLeftHint, expression.Operator); !matchesOrConverts {
 			return pgsql.UnsetDataType, fmt.Errorf("left and right operands for binary expression \"%s\" are not compatible: %s != %s", expression.Operator, rightHint, inferredLeftHint)
 		} else {
 			return upcastHint, nil
@@ -189,7 +188,7 @@ func inferBinaryExpressionType(expression *pgsql.BinaryExpression) (pgsql.DataTy
 				// Unable to infer any type information, this may be resolved elsewhere so this is not explicitly
 				// an error condition
 				return pgsql.UnknownDataType, nil
-			} else if higherLevelHint, matchesOrConverts := inferredLeftHint.Compatible(inferredRightHint, expression.Operator); !matchesOrConverts {
+			} else if higherLevelHint, matchesOrConverts := inferredLeftHint.OperatorResultType(inferredRightHint, expression.Operator); !matchesOrConverts {
 				return pgsql.UnsetDataType, fmt.Errorf("left and right operands for binary expression \"%s\" are not compatible: %s != %s", expression.Operator, inferredLeftHint, inferredRightHint)
 			} else {
 				return higherLevelHint, nil
@@ -201,7 +200,6 @@ func inferBinaryExpressionType(expression *pgsql.BinaryExpression) (pgsql.DataTy
 func InferExpressionType(expression pgsql.Expression) (pgsql.DataType, error) {
 	switch typedExpression := expression.(type) {
 	case pgsql.Identifier, pgsql.CompoundExpression:
-		// TODO: Type inference may be aided by searching the bound scope for a data type
 		return pgsql.UnknownDataType, nil
 
 	case pgsql.CompoundIdentifier:
@@ -232,7 +230,10 @@ func InferExpressionType(expression pgsql.Expression) (pgsql.DataType, error) {
 
 	case *pgsql.BinaryExpression:
 		switch typedExpression.Operator {
-		case pgsql.OperatorPropertyLookup, pgsql.OperatorJSONField, pgsql.OperatorJSONTextField:
+		case pgsql.OperatorJSONTextField:
+			return pgsql.Text, nil
+
+		case pgsql.OperatorPropertyLookup, pgsql.OperatorJSONField:
 			// This is unknown, not unset meaning that it can be re-cast by future inference inspections
 			return pgsql.UnknownDataType, nil
 
@@ -276,11 +277,7 @@ func TypeCastExpression(expression pgsql.Expression, dataType pgsql.DataType) (p
 
 		if lookupRequiresElementType(dataType, propertyLookup.Operator, propertyLookup.ROperand) {
 			// Take the base type of the array type hint: <unit> in <collection>
-			if arrayBaseType, err := dataType.ArrayBaseType(); err != nil {
-				return nil, err
-			} else {
-				lookupTypeHint = arrayBaseType
-			}
+			lookupTypeHint = dataType.ArrayBaseType()
 		}
 
 		return rewritePropertyLookupOperator(propertyLookup, lookupTypeHint), nil
@@ -304,21 +301,13 @@ func rewritePropertyLookupOperands(expression *pgsql.BinaryExpression) error {
 		// This check exists here to prevent from overwriting a property lookup that's part of a <value> in <list>
 		// binary expression. This may want for better ergonomics in the future
 		if anyExpression, isAnyExpression := expression.ROperand.(pgsql.AnyExpression); isAnyExpression {
-			if arrayBaseType, err := anyExpression.CastType.ArrayBaseType(); err != nil {
-				return err
-			} else {
-				expression.LOperand = rewritePropertyLookupOperator(leftPropertyLookup, arrayBaseType)
-			}
+			expression.LOperand = rewritePropertyLookupOperator(leftPropertyLookup, anyExpression.CastType.ArrayBaseType())
 		} else if rOperandTypeHint, err := InferExpressionType(expression.ROperand); err != nil {
 			return err
 		} else {
 			switch expression.Operator {
 			case pgsql.OperatorIn:
-				if arrayBaseType, err := rOperandTypeHint.ArrayBaseType(); err != nil {
-					return err
-				} else {
-					expression.LOperand = rewritePropertyLookupOperator(leftPropertyLookup, arrayBaseType)
-				}
+				expression.LOperand = rewritePropertyLookupOperator(leftPropertyLookup, rOperandTypeHint.ArrayBaseType())
 
 			case pgsql.OperatorCypherStartsWith, pgsql.OperatorCypherEndsWith, pgsql.OperatorCypherContains, pgsql.OperatorRegexMatch:
 				expression.LOperand = rewritePropertyLookupOperator(leftPropertyLookup, pgsql.Text)
@@ -353,29 +342,94 @@ func rewritePropertyLookupOperands(expression *pgsql.BinaryExpression) error {
 	return nil
 }
 
-func applyTypeFunctionCallTypeHints(expression *pgsql.BinaryExpression) error {
+func newFunctionCallComparatorError(functionCall pgsql.FunctionCall, operator pgsql.Operator, comparisonType pgsql.DataType) error {
+	switch functionCall.Function {
+	case pgsql.FunctionCoalesce:
+		// This is a specific error statement for coalesce statements. These statements have ill-defined
+		// type conversion semantics in Cypher. As such, exposing the type specificity of coalesce to the
+		// user as a distinct error will help reduce the surprise of running on a non-Neo4j substrate.
+		return fmt.Errorf("coalesce has type %s but is being compared against type %s - ensure that all arguments in the coalesce function match the type of the other side of the comparison", functionCall.CastType, comparisonType)
+	default:
+		return fmt.Errorf("function call has return signature of type %s but is being compared using operator %s against type %s", functionCall.CastType, operator, comparisonType)
+	}
+}
+
+func applyTypeFunctionLikeTypeHints(expression *pgsql.BinaryExpression) error {
 	switch typedLOperand := expression.LOperand.(type) {
+	case pgsql.AnyExpression:
+		if rOperandTypeHint, err := InferExpressionType(expression.ROperand); err != nil {
+			return err
+		} else {
+			// In an any-expression where the type of the any-expression is unknown, attempt to infer it
+			if !typedLOperand.CastType.IsKnown() {
+				if rOperandArrayTypeHint, err := rOperandTypeHint.ToArrayType(); err != nil {
+					return err
+				} else {
+					typedLOperand.CastType = rOperandArrayTypeHint
+					expression.LOperand = typedLOperand
+				}
+			}
+
+			// Validate against the array base type of the any-expression
+			lOperandBaseType := typedLOperand.CastType.ArrayBaseType()
+
+			if !lOperandBaseType.IsComparable(rOperandTypeHint, expression.Operator) {
+				return fmt.Errorf("function call has return signature of type %s but is being compared using operator %s against type %s", typedLOperand.CastType, expression.Operator, rOperandTypeHint)
+			}
+		}
+
 	case pgsql.FunctionCall:
-		if !typedLOperand.CastType.IsKnown() {
-			if rOperandTypeHint, err := InferExpressionType(expression.ROperand); err != nil {
-				return err
-			} else {
+		if rOperandTypeHint, err := InferExpressionType(expression.ROperand); err != nil {
+			return err
+		} else {
+			if !typedLOperand.CastType.IsKnown() {
 				typedLOperand.CastType = rOperandTypeHint
 				expression.LOperand = typedLOperand
+			}
+
+			if pgsql.OperatorIsComparator(expression.Operator) && !typedLOperand.CastType.IsComparable(rOperandTypeHint, expression.Operator) {
+				return newFunctionCallComparatorError(typedLOperand, expression.Operator, rOperandTypeHint)
 			}
 		}
 	}
 
 	switch typedROperand := expression.ROperand.(type) {
+	case pgsql.AnyExpression:
+		if lOperandTypeHint, err := InferExpressionType(expression.LOperand); err != nil {
+			return err
+		} else {
+			// In an any-expression where the type of the any-expression is unknown, attempt to infer it
+			if !typedROperand.CastType.IsKnown() {
+				if rOperandArrayTypeHint, err := lOperandTypeHint.ToArrayType(); err != nil {
+					return err
+				} else {
+					typedROperand.CastType = rOperandArrayTypeHint
+					expression.LOperand = typedROperand
+				}
+			}
+
+			// Validate against the array base type of the any-expression
+			rOperandBaseType := typedROperand.CastType.ArrayBaseType()
+
+			if !rOperandBaseType.IsComparable(lOperandTypeHint, expression.Operator) {
+				return fmt.Errorf("function call has return signature of type %s but is being compared using operator %s against type %s", typedROperand.CastType, expression.Operator, lOperandTypeHint)
+			}
+		}
+
 	case pgsql.FunctionCall:
-		if !typedROperand.CastType.IsKnown() {
-			if lOperandTypeHint, err := InferExpressionType(expression.LOperand); err != nil {
-				return err
-			} else {
+		if lOperandTypeHint, err := InferExpressionType(expression.LOperand); err != nil {
+			return err
+		} else {
+			if !typedROperand.CastType.IsKnown() {
 				typedROperand.CastType = lOperandTypeHint
 				expression.ROperand = typedROperand
 			}
+
+			if pgsql.OperatorIsComparator(expression.Operator) && !typedROperand.CastType.IsComparable(lOperandTypeHint, expression.Operator) {
+				return newFunctionCallComparatorError(typedROperand, expression.Operator, lOperandTypeHint)
+			}
 		}
+
 	}
 
 	return nil
@@ -393,7 +447,7 @@ func applyBinaryExpressionTypeHints(expression *pgsql.BinaryExpression) error {
 		return err
 	}
 
-	return applyTypeFunctionCallTypeHints(expression)
+	return applyTypeFunctionLikeTypeHints(expression)
 }
 
 type Builder struct {
@@ -683,6 +737,36 @@ func (s *ExpressionTreeTranslator) PopPushBinaryExpression(scope *Scope, operato
 		}
 
 		switch operator {
+		case pgsql.OperatorCypherAdd:
+			isConcatenationOperation := func(lOperandType, rOperandType pgsql.DataType) bool {
+				// Any use of an array type automatically assumes concatenation
+				if lOperandType.IsArrayType() || rOperandType.IsArrayType() {
+					return true
+				}
+
+				switch lOperandType {
+				case pgsql.Text:
+					switch rOperandType {
+					case pgsql.Text:
+						return true
+					}
+				}
+
+				return false
+			}
+
+			// In the case of the use of the cypher `+` operator we must attempt to disambiguate if the intent
+			// is to concatenate or to perform an addition
+			if lOperandType, err := InferExpressionType(newExpression.LOperand); err != nil {
+				return err
+			} else if rOperandType, err := InferExpressionType(newExpression.ROperand); err != nil {
+				return err
+			} else if isConcatenationOperation(lOperandType, rOperandType) {
+				newExpression.Operator = pgsql.OperatorConcatenate
+			}
+
+			s.Push(newExpression)
+
 		case pgsql.OperatorCypherContains:
 			newExpression.Operator = pgsql.OperatorLike
 

--- a/packages/go/cypher/models/pgsql/translate/expression.go
+++ b/packages/go/cypher/models/pgsql/translate/expression.go
@@ -213,6 +213,7 @@ func InferExpressionType(expression pgsql.Expression) (pgsql.DataType, error) {
 
 		// Infer type information for well known column names
 		switch typedExpression[1] {
+// TODO: Graph ID should be int2
 		case pgsql.ColumnGraphID, pgsql.ColumnID, pgsql.ColumnStartID, pgsql.ColumnEndID:
 			return pgsql.Int8, nil
 
@@ -395,8 +396,6 @@ func applyTypeFunctionLikeTypeHints(expression *pgsql.BinaryExpression) error {
 			if !typedLOperand.CastType.IsKnown() {
 				typedLOperand.CastType = rOperandTypeHint
 				expression.LOperand = typedLOperand
-			} else if !rOperandTypeHint.IsKnown() {
-				expression.LOperand = pgsql.NewTypeCast(expression.LOperand, typedLOperand.CastType)
 			}
 
 			if pgsql.OperatorIsComparator(expression.Operator) && !typedLOperand.CastType.IsComparable(rOperandTypeHint, expression.Operator) {
@@ -437,8 +436,6 @@ func applyTypeFunctionLikeTypeHints(expression *pgsql.BinaryExpression) error {
 			if !typedROperand.CastType.IsKnown() {
 				typedROperand.CastType = lOperandTypeHint
 				expression.ROperand = typedROperand
-			} else if !lOperandTypeHint.IsKnown() {
-				expression.LOperand = pgsql.NewTypeCast(expression.LOperand, typedROperand.CastType)
 			}
 
 			if pgsql.OperatorIsComparator(expression.Operator) && !typedROperand.CastType.IsComparable(lOperandTypeHint, expression.Operator) {

--- a/packages/go/cypher/models/pgsql/translate/expression.go
+++ b/packages/go/cypher/models/pgsql/translate/expression.go
@@ -18,6 +18,7 @@ package translate
 
 import (
 	"fmt"
+
 	"github.com/specterops/bloodhound/log"
 
 	"github.com/specterops/bloodhound/cypher/models/pgsql"

--- a/packages/go/cypher/models/pgsql/translate/expression_test.go
+++ b/packages/go/cypher/models/pgsql/translate/expression_test.go
@@ -111,7 +111,7 @@ func TestInferExpressionType(t *testing.T) {
 			),
 		),
 	}, {
-		Exclusive: true,
+		Exclusive:    true,
 		ExpectedType: pgsql.Int4,
 		Expression: pgsql.NewBinaryExpression(
 			pgsql.NewPropertyLookup(

--- a/packages/go/cypher/models/pgsql/translate/expression_test.go
+++ b/packages/go/cypher/models/pgsql/translate/expression_test.go
@@ -111,6 +111,7 @@ func TestInferExpressionType(t *testing.T) {
 			),
 		),
 	}, {
+		Exclusive: true,
 		ExpectedType: pgsql.Int4,
 		Expression: pgsql.NewBinaryExpression(
 			pgsql.NewPropertyLookup(

--- a/packages/go/cypher/models/pgsql/translate/expression_test.go
+++ b/packages/go/cypher/models/pgsql/translate/expression_test.go
@@ -239,7 +239,7 @@ func TestExpressionTreeTranslator(t *testing.T) {
 	treeTranslator.PopPushOperator(scope, pgsql.OperatorAnd)
 
 	// Assign remaining operands as constraints
-	treeTranslator.ConstrainRemainingOperands()
+	treeTranslator.PopRemainingExpressionsAsConstraints()
 
 	// Pull out the 'a' constraint
 	aIdentifier := pgsql.AsIdentifierSet("a")

--- a/packages/go/cypher/models/pgsql/translate/translation.go
+++ b/packages/go/cypher/models/pgsql/translate/translation.go
@@ -252,6 +252,7 @@ func (s *Translator) translateCoalesceFunction(functionInvocation *cypher.Functi
 
 		// Find and validate types of the arguments
 		for _, argument := range arguments {
+			// Properties have no type information and should be skipped
 			if argumentType, err := InferExpressionType(argument); err != nil {
 				return err
 			} else if argumentType.IsKnown() {

--- a/packages/go/cypher/models/pgsql/translate/translation.go
+++ b/packages/go/cypher/models/pgsql/translate/translation.go
@@ -346,9 +346,9 @@ func (s *Translator) translateProjectionItem(scope *Scope, projectionItem *cyphe
 			}
 
 		case *pgsql.BinaryExpression:
-			if typedSelectItem.Operator == pgsql.OperatorPropertyLookup {
-				// TODO: This probably belongs somewhere else
-				typedSelectItem.Operator = pgsql.OperatorJSONField
+			if propertyLookup, isPropertyLookup := asPropertyLookup(typedSelectItem); isPropertyLookup {
+				// Ensure that projections maintain the raw JSONB type of the field
+				propertyLookup.Operator = pgsql.OperatorJSONField
 			}
 		}
 

--- a/packages/go/cypher/models/pgsql/translate/translator.go
+++ b/packages/go/cypher/models/pgsql/translate/translator.go
@@ -746,7 +746,7 @@ func (s *Translator) Exit(expression cypher.SyntaxNode) {
 		s.exitState(StateTranslatingWhere)
 
 		// Assign the last operands as identifier set constraints
-		if err := s.treeTranslator.ConstrainRemainingOperands(); err != nil {
+		if err := s.treeTranslator.PopRemainingExpressionsAsConstraints(); err != nil {
 			s.SetError(err)
 		}
 

--- a/packages/go/cypher/models/pgsql/translate/translator.go
+++ b/packages/go/cypher/models/pgsql/translate/translator.go
@@ -606,7 +606,10 @@ func (s *Translator) Exit(expression cypher.SyntaxNode) {
 			} else {
 				var functionCall pgsql.FunctionCall
 
-				if _, isPropertyLookup := asPropertyLookup(argument); isPropertyLookup {
+				if propertyLookup, isPropertyLookup := asPropertyLookup(argument); isPropertyLookup {
+					// Ensure that the JSONB array length function receives the JSONB type
+					propertyLookup.Operator = pgsql.OperatorJSONField
+
 					functionCall = pgsql.FunctionCall{
 						Function:   pgsql.FunctionJSONBArrayLength,
 						Parameters: []pgsql.Expression{argument},

--- a/packages/go/cypher/models/pgsql/translate/translator.go
+++ b/packages/go/cypher/models/pgsql/translate/translator.go
@@ -446,6 +446,11 @@ func (s *Translator) Exit(expression cypher.SyntaxNode) {
 		} else if err := RewriteExpressionIdentifiers(lookupExpression, s.query.Scope.CurrentFrameBinding().Identifier, s.query.Scope.Visible()); err != nil {
 			s.SetError(err)
 		} else {
+			if propertyLookup, isPropertyLookup := asPropertyLookup(lookupExpression); isPropertyLookup {
+				// If sorting, use the raw type of the JSONB field
+				propertyLookup.Operator = pgsql.OperatorJSONField
+			}
+
 			s.query.CurrentOrderBy().Expression = lookupExpression
 		}
 

--- a/packages/go/cypher/models/pgsql/translate/update.go
+++ b/packages/go/cypher/models/pgsql/translate/update.go
@@ -145,9 +145,15 @@ func (s *Translator) buildUpdates(scope *Scope) error {
 			}
 
 			for _, propertyAssignment := range identifierMutation.PropertyAssignments.Values() {
+				if propertyLookup, isPropertyLookup := asPropertyLookup(propertyAssignment.ValueExpression); isPropertyLookup {
+					// Ensure that property lookups in JSONB build functions use the JSONB field type
+					propertyLookup.Operator = pgsql.OperatorJSONField
+				}
+
 				jsonObjectFunction.Parameters = append(jsonObjectFunction.Parameters,
 					pgsql.NewLiteral(propertyAssignment.Field, pgsql.Text),
-					propertyAssignment.ValueExpression)
+					propertyAssignment.ValueExpression,
+				)
 			}
 
 			propertyAssignments = models.ValueOptional(jsonObjectFunction.AsExpression())


### PR DESCRIPTION
## Description

Latest batch of CySQL changes.

## Motivation and Context

This changeset address the following tickets:
* BED-5201 - Enforce Better Type Checking in CySQL Frontend
* BED-5192 - Enforce Correct JSONB Operators for Type Conversion
* BED-5193 - Ensure Function Return Signature Null Conversion
* BED-5185 - Correctly Coerce Bare Property Lookups as Boolean

## How Has This Been Tested?

Translation tests have been added for all validated cases.

## Types of changes


- Chore (a change that does not modify the application functionality)
- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
