### PR TITLE
CySQL Fix Poor Type Negotiation for []graph.ID Parameters

### DIFF
--- a/packages/go/dawgs/graph/node.go
+++ b/packages/go/dawgs/graph/node.go
@@ -436,11 +436,11 @@ func IDsToUint32Slice(ids []ID) []uint32 {
 	return rawIDs
 }
 
-func IDsToUint64Slice(ids []ID) []uint32 {
-	rawIDs := make([]uint32, len(ids))
+func IDsToUint64Slice(ids []ID) []uint64 {
+	rawIDs := make([]uint64, len(ids))
 
 	for idx, id := range ids {
-		rawIDs[idx] = id.Uint32()
+		rawIDs[idx] = id.Uint64()
 	}
 
 	return rawIDs


### PR DESCRIPTION
## Description

This prevents the possibility of missing nodes causing a panic in caching logic for traversal.

## Motivation and Context

Seeing this happen in two large environments. This also cleans up caching logic that could panic.

## How Has This Been Tested?

Integration test coverage.

## Types of changes

<!-- Please remove any items that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
