### PR TITLE
Update go.work for go version

### DIFF
--- a/go.work
+++ b/go.work
@@ -14,7 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-go 1.23
+go 1.23.0
 
 use (
 	./cmd/api/src


### PR DESCRIPTION
A potential fix for
```
go: downloading go1.23 (linux/amd64)
go: download go1.23 for linux/amd64: toolchain not available
```
When building bh-dev.

## Description

Building of development version on my machine fails with toolchain not available. This changes to go1.23.0 which is enough for me to get it over the line. 

## Motivation and Context
This probably isn't the correct fix for something environmental or user error, but even as PR is closed it might save someone some time when searching issues for the error. Also pinning to .0 is probably bad.

Intent is to raise this and close it as invalid, but at least the information can be found.

## How Has This Been Tested?
I tested that build then completed only.

## Types of changes
- Chore

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [ ] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [X] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [ ] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
