### PR TITLE
fix: include all asset files in static assets embed.FS

### DIFF
--- a/cmd/api/src/api/static/assets.go
+++ b/cmd/api/src/api/static/assets.go
@@ -11,7 +11,7 @@ const (
 	indexAssetPath = "index.html"
 )
 
-//go:embed assets
+//go:embed all:assets
 var assets embed.FS
 
 var AssetHandler = MakeAssetHandler(AssetConfig{


### PR DESCRIPTION
## Description

Include all files in the static assets `embed.FS` for the UI instead of excluding files starting with `.` or `_`.

## Motivation and Context

This PR addresses: https://specterops.atlassian.net/browse/BED-5259

Some JS files starting with `_` were being dropped from the static assets in the built binary.

## How Has This Been Tested?

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
