### PR TITLE
BED-5288 - Graph Assertion Ordering and Versioned Migration Checks

### DIFF
--- a/cmd/api/src/migrations/graph.go
+++ b/cmd/api/src/migrations/graph.go
@@ -155,6 +155,10 @@ func (s *GraphMigrator) executeMigrations(ctx context.Context, originalVersion v
 		}
 	}
 
+	if releaseVersion := version.GetVersion(); releaseVersion.GreaterThan(mostRecentVersion) {
+		mostRecentVersion = releaseVersion
+	}
+
 	if mostRecentVersion.GreaterThan(originalVersion) {
 		return UpdateMigrationData(ctx, s.db, mostRecentVersion)
 	}

--- a/cmd/api/src/migrations/manifest.go
+++ b/cmd/api/src/migrations/manifest.go
@@ -43,7 +43,7 @@ func RequiresMigration(ctx context.Context, db graph.Database) (bool, error) {
 			return false, fmt.Errorf("unable to get graph db migration data: %w", err)
 		}
 	} else {
-		return LatestGraphMigrationVersion().GreaterThan(currentMigration), nil
+		return version.GetVersion().GreaterThan(currentMigration), nil
 	}
 }
 

--- a/packages/go/dawgs/drivers/pg/pg.go
+++ b/packages/go/dawgs/drivers/pg/pg.go
@@ -107,8 +107,6 @@ func init() {
 			return nil, fmt.Errorf("expected string for configuration type but got %T", cfg)
 		} else if graphDB, err := newDatabase(connectionString); err != nil {
 			return nil, err
-		} else if err := graphDB.AssertSchema(ctx, graph.Schema{}); err != nil {
-			return nil, err
 		} else {
 			return graphDB, nil
 		}


### PR DESCRIPTION
## Description

Minor changes to the ordering of graph schema assertions as well as graph schema migration checking.

## Motivation and Context

Graph assertions in driver spinup for the pg dawgs driver are causing deadlocks during HA hand-off in production. While these deadlocks quickly resolve, they’re thrashing for no reason. The solution proposed is to change, slightly, how graph migration works.

First is to remove the assertion of graph schema from the `dawgs` driver init. Next, instead of checking only for bespoke migrations for versions listed in the graph migration manifest, the version check now references the application version as the latest available migration.

Stepwise graph migrations still function as expected with one exception tacked on the end. After assertions are made, which in the case of an empty DB would end with creation of the graph DB schema, the graph’s migration version is set to the application’s version.

This allows migration to cover CUE file schema changes such as the addition of new graph Kinds.

## How Has This Been Tested?

Integration testing and local HA testing.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
