### PR TITLE
BED-5311 fix: incorrect oidc cookie consumption

### DIFF
--- a/cmd/api/src/api/constant.go
+++ b/cmd/api/src/api/constant.go
@@ -34,14 +34,16 @@ const (
 	AuthorizationSchemeBHESignature = "bhesignature"
 	AuthorizationSchemeBearer       = "bearer"
 
+	// Form parameters
+	FormParameterState = "state"
+	FormParameterCode  = "code"
+
 	// Query parameters
 	QueryParameterSortBy         = "sort_by"
 	QueryParameterHydrateCounts  = "counts"
 	QueryParameterHydrateDomains = "hydrate_domains"
 	QueryParameterHydrateOUs     = "hydrate_ous"
 	QueryParameterScope          = "scope"
-	QueryParameterState          = "state"
-	QueryParameterCode           = "code"
 
 	// URI path parameters
 	URIPathVariableApplicationConfigurationParameter = "parameter"


### PR DESCRIPTION
## Description

- Always delete auth cookies in callback
- Fix incorrect sameSite flag for OIDC cross-site cookies

## Motivation and Context

This PR addresses: BED-5311

*Why is this change required? What problem does it solve?*
One cannot login via OIDC in it's current state

## How Has This Been Tested?
Locally against a self-signed cert to mimic prod as closely as possible

## Types of changes

<!-- Please remove any items that do not apply. -->
- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
