### PR TITLE
chore: introduce Or method to threadsafekindbitmap

### DIFF
--- a/local-harnesses/build.config.json.template
+++ b/local-harnesses/build.config.json.template
@@ -15,6 +15,7 @@
     "neo4j": {
         "connection": "neo4j://neo4j:bloodhoundcommunityedition@graph-db:7687/"
     },
+    "graph_driver": "pg",
     "default_admin": {
         "principal_name": "admin",
         "password": "SFdzJoW2GT7Fn68aEieKn7S1S2DLdXnw",

--- a/local-harnesses/integration.config.json.template
+++ b/local-harnesses/integration.config.json.template
@@ -12,6 +12,7 @@
     "database": {
         "connection": "user=bloodhound password=bloodhoundcommunityedition dbname=bloodhound host=localhost port=65432"
     },
+    "graph_driver": "pg",
     "default_admin": {
         "principal_name": "admin",
         "password": "admin",

--- a/packages/go/dawgs/graph/types.go
+++ b/packages/go/dawgs/graph/types.go
@@ -177,6 +177,17 @@ func (s ThreadSafeKindBitmap) Get(kinds ...Kind) cardinality.Duplex[uint64] {
 	return bitmap
 }
 
+func (s ThreadSafeKindBitmap) Or(kind Kind, other cardinality.Duplex[uint64]) {
+	s.rwLock.RLock()
+	defer s.rwLock.RUnlock()
+
+	if kindBitmap, hasKind := s.bitmaps[kind.String()]; hasKind {
+		kindBitmap.Or(other)
+	} else {
+		s.bitmaps[kind.String()] = other
+	}
+}
+
 func (s ThreadSafeKindBitmap) Cardinality(kinds ...Kind) uint64 {
 	return s.Get(kinds...).Cardinality()
 }


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description
A union method to the threadsafekindbitmap is added for use upstream.

## Motivation and Context

This PR addresses: BED-5339

This method will be used in concurrent process for safe reading and writing of kind maps.

## How Has This Been Tested?
The new method was used upstream and analysis was run on a test dataset to ensure that there isn't a material change in performance.

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)
- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
