### PR TITLE
chore: expand collapse nav with tw hover and grouping

### DIFF
--- a/packages/javascript/bh-shared-ui/src/components/Navigation/MainNav.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/Navigation/MainNav.test.tsx
@@ -145,41 +145,61 @@ describe('MainNav', () => {
     });
     it('should render a label and version number when expanded', async () => {
         const MainNavBar = await screen.findByRole('navigation');
-        const versionNumberContainer = await screen.findByTestId('main-nav-version-number');
-        const versionNumberLabel = await within(versionNumberContainer).findByText(/bloodhound/i);
+        expect(MainNavBar).toHaveClass('group');
+
+        const versionNumberContainer = await within(MainNavBar).findByTestId('main-nav-version-number');
         const versionNumberDigits = await within(versionNumberContainer).findByText(currentVersionNumber);
+        const versionNumberLabel = await within(versionNumberContainer).findByText(/bloodhound/i);
 
-        await user.hover(MainNavBar);
+        // ---- collapsed classes ----
+        expect(versionNumberDigits).toHaveClass('group-[:not(:hover)]:max-w-9');
+        expect(versionNumberLabel).toHaveClass('hidden');
+        expect(versionNumberLabel).toHaveClass('opacity-0');
+        // ---- collapsed classes ----
 
-        expect(versionNumberDigits).toBeInTheDocument();
-        expect(versionNumberLabel).toBeVisible();
+        // ---- classes displayed on hover ----
+        expect(versionNumberLabel).toHaveClass('group-hover:opacity-100');
+        expect(versionNumberLabel).toHaveClass('group-hover:block');
+        // ---- classes displayed on hover ----
     });
-    it('should only render an icon in list item when collapsed and an icon and label when expanded', async () => {
+    it('should only render an icon in list item when collapsed and the label should be styled to be hidden but appear on group-hover of the nav', async () => {
         const testLinkItem = MainNavPrimaryListData[0];
 
         const MainNavBar = screen.getByRole('navigation');
-        const primaryList = await screen.findByTestId('main-nav-primary-list');
+        expect(MainNavBar).toHaveClass('group');
+
+        const primaryList = await within(MainNavBar).findByTestId('main-nav-primary-list');
         const linkItemIcon = await within(primaryList).findByTestId('main-nav-item-label-icon');
         const linkItemText = await within(primaryList).findByText(testLinkItem.label as string);
 
         expect(linkItemIcon).toBeInTheDocument();
+
+        // ---- collapsed classes ----
         expect(linkItemText).toHaveClass('hidden');
+        expect(linkItemText).toHaveClass('opacity-0');
+        // ---- collapsed classes ----
 
-        await user.hover(MainNavBar);
-
-        expect(linkItemIcon).toBeInTheDocument();
-        expect(linkItemText).toBeVisible();
+        // ---- classes displayed on hover ----
+        expect(linkItemText).toHaveClass('group-hover:opacity-100');
+        expect(linkItemText).toHaveClass('group-hover:flex');
+        // ---- classes displayed on hover ----
     });
-    it('should render a powered by when expanded and image', async () => {
+    it('should style the powered-by to display when nav is expanded', async () => {
         const MainNavBar = screen.getByRole('navigation');
-        const poweredByTextContainer = await screen.findByTestId('main-nav-powered-by');
+        expect(MainNavBar).toHaveClass('group');
+
+        const poweredByTextContainer = await within(MainNavBar).findByTestId('main-nav-powered-by');
         const poweredByText = await within(poweredByTextContainer).findByText(/powered by/i);
-
         expect(poweredByText).toBeInTheDocument();
+
+        // ---- collapsed classes ----
         expect(poweredByText).toHaveClass('hidden');
+        expect(poweredByText).toHaveClass('opacity-0');
+        // ---- collapsed classes ----
 
-        await user.hover(MainNavBar);
-
-        expect(poweredByText).toBeVisible();
+        // ---- classes displayed on hover ----
+        expect(poweredByText).toHaveClass('group-hover:opacity-100');
+        expect(poweredByText).toHaveClass('group-hover:flex');
+        // ---- classes displayed on hover ----
     });
 });

--- a/packages/javascript/bh-shared-ui/src/components/Navigation/MainNav.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/Navigation/MainNav.test.tsx
@@ -152,7 +152,7 @@ describe('MainNav', () => {
         await user.hover(MainNavBar);
 
         expect(versionNumberDigits).toBeInTheDocument();
-        expect(versionNumberLabel).toHaveClass('block');
+        expect(versionNumberLabel).toBeVisible();
     });
     it('should only render an icon in list item when collapsed and an icon and label when expanded', async () => {
         const testLinkItem = MainNavPrimaryListData[0];
@@ -168,7 +168,7 @@ describe('MainNav', () => {
         await user.hover(MainNavBar);
 
         expect(linkItemIcon).toBeInTheDocument();
-        expect(linkItemText).toHaveClass('flex');
+        expect(linkItemText).toBeVisible();
     });
     it('should render a powered by when expanded and image', async () => {
         const MainNavBar = screen.getByRole('navigation');
@@ -180,6 +180,6 @@ describe('MainNav', () => {
 
         await user.hover(MainNavBar);
 
-        expect(poweredByText).toHaveClass('flex');
+        expect(poweredByText).toBeVisible();
     });
 });

--- a/packages/javascript/bh-shared-ui/src/components/Navigation/MainNav.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/Navigation/MainNav.tsx
@@ -14,7 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { FC, ReactNode, useState } from 'react';
+import { FC, ReactNode } from 'react';
 import { Link as RouterLink, useLocation } from 'react-router-dom';
 import { useApiVersion } from '../../hooks';
 import { cn } from '../../utils';
@@ -51,49 +51,32 @@ const MainNavListItem: FC<{ children: ReactNode; route?: string }> = ({ children
     );
 };
 
-const MainNavItemAction: FC<{ onClick: () => void; children: ReactNode; isMenuExpanded: boolean }> = ({
-    onClick,
-    children,
-    isMenuExpanded,
-}) => {
+const MainNavItemAction: FC<{ onClick: () => void; children: ReactNode }> = ({ onClick, children }) => {
     return (
         // Note: The w-full is to avoid the hover area to overflow out of the nav when its collapsed which created a flickering effect just outside the nav
         // Note: had to wrap in div to avoid error of button nesting in a button with the switch
         <div
             role='button'
             onClick={onClick}
-            className={cn('h-10 w-auto absolute left-4 flex items-center gap-x-2 hover:underline', {
-                'w-full': isMenuExpanded,
-            })}>
+            className={'h-10 w-auto absolute left-4 flex items-center gap-x-2 hover:underline group-hover:w-full'}>
             {children}
         </div>
     );
 };
 
-const MainNavItemLink: FC<{ route: string; children: ReactNode; isMenuExpanded: boolean }> = ({
-    route,
-    children,
-    isMenuExpanded,
-    ...rest
-}) => {
+const MainNavItemLink: FC<{ route: string; children: ReactNode }> = ({ route, children, ...rest }) => {
     return (
         // Note: The w-full is to avoid the hover area to overflow out of the nav when its collapsed
         <RouterLink
             to={route as string}
-            className={cn('h-10 w-auto absolute left-4 flex items-center gap-x-2 hover:underline', {
-                'w-full': isMenuExpanded,
-            })}
+            className={'h-10 w-auto absolute left-4 flex items-center gap-x-2 hover:underline group-hover:w-full'}
             {...rest}>
             {children}
         </RouterLink>
     );
 };
 
-const MainNavItemLabel: FC<{ icon: ReactNode; label: ReactNode | string; isMenuExpanded: boolean }> = ({
-    icon,
-    label,
-    isMenuExpanded,
-}) => {
+const MainNavItemLabel: FC<{ icon: ReactNode; label: ReactNode | string }> = ({ icon, label }) => {
     return (
         // Note: The min-h here is to keep spacing between the logo and the list below.
         <>
@@ -102,17 +85,16 @@ const MainNavItemLabel: FC<{ icon: ReactNode; label: ReactNode | string; isMenuE
             </span>
             <span
                 data-testid='main-nav-item-label-text'
-                className={cn(
-                    'whitespace-nowrap min-h-10 font-medium text-xl opacity-0 hidden transition-opacity duration-200 ease-in',
-                    { 'opacity-100 flex items-center gap-x-5': isMenuExpanded }
-                )}>
+                className={
+                    'whitespace-nowrap min-h-10 font-medium text-xl opacity-0 hidden transition-opacity duration-200 ease-in group-hover:opacity-100 group-hover:flex group-hover:items-center group-hover:gap-x-5'
+                }>
                 {label}
             </span>
         </>
     );
 };
 
-const MainNavVersionNumber: FC<{ isMenuExpanded: boolean }> = ({ isMenuExpanded }) => {
+const MainNavVersionNumber: FC = () => {
     const { data: apiVersionResponse, isSuccess } = useApiVersion();
     const apiVersion = isSuccess && apiVersionResponse?.server_version;
 
@@ -120,40 +102,30 @@ const MainNavVersionNumber: FC<{ isMenuExpanded: boolean }> = ({ isMenuExpanded 
         // Note: The min-h allows for the version number to keep its position when the nav is scrollable
         <div className='relative w-full flex min-h-10 h-10 overflow-x-hidden' data-testid='main-nav-version-number'>
             <div
-                className={cn(
-                    'w-full flex absolute bottom-3 left-3 duration-300 ease-in-out text-xs whitespace-nowrap font-medium text-neutral-dark-0 dark:text-neutral-light-1',
-                    { 'left-16': isMenuExpanded }
-                )}>
-                <span
-                    className={cn('opacity-0 hidden duration-300 ease-in-out', {
-                        'opacity-100 block': isMenuExpanded,
-                    })}>
+                className={
+                    'w-full flex absolute bottom-3 left-3 duration-300 ease-in-out text-xs whitespace-nowrap font-medium text-neutral-dark-0 dark:text-neutral-light-1 group-hover:left-16'
+                }>
+                <span className={'opacity-0 hidden duration-300 ease-in-out group-hover:opacity-100 group-hover:block'}>
                     BloodHound:&nbsp;
                 </span>
-                <span
-                    className={cn('', {
-                        'max-w-9 overflow-x-hidden': !isMenuExpanded,
-                    })}>
-                    {apiVersion}
-                </span>
+                <span className={cn('group-[:not(:hover)]:max-w-9 overflow-x-hidden')}>{apiVersion}</span>
             </div>
         </div>
     );
 };
 
-const MainNavPoweredBy: FC<{ isMenuExpanded: boolean; children: ReactNode }> = ({ isMenuExpanded, children }) => {
+const MainNavPoweredBy: FC<{ children: ReactNode }> = ({ children }) => {
     return (
         // Note: The min-h allows for the version number to keep its position when the nav is scrollable
         <div className='relative w-full flex min-h-10 h-10 overflow-x-hidden' data-testid='main-nav-powered-by'>
             <div
-                className={cn(
-                    'w-full flex absolute bottom-3 left-3 duration-300 ease-in-out text-xs whitespace-nowrap font-medium text-neutral-dark-0 dark:text-neutral-light-1',
-                    { 'left-12': isMenuExpanded }
-                )}>
+                className={
+                    'w-full flex absolute bottom-3 left-3 duration-300 ease-in-out text-xs whitespace-nowrap font-medium text-neutral-dark-0 dark:text-neutral-light-1 group-hover:left-12'
+                }>
                 <span
-                    className={cn('opacity-0 hidden duration-300 ease-in-out', {
-                        'opacity-100 flex items-center gap-1': isMenuExpanded,
-                    })}>
+                    className={
+                        'opacity-0 hidden duration-300 ease-in-out group-hover:opacity-100 group-hover:flex group-hover:items-center group-hover:gap-1'
+                    }>
                     powered by&nbsp;
                     {children}
                 </span>
@@ -163,24 +135,15 @@ const MainNavPoweredBy: FC<{ isMenuExpanded: boolean; children: ReactNode }> = (
 };
 
 const MainNav: FC<{ mainNavData: MainNavData }> = ({ mainNavData }) => {
-    const [isMenuExpanded, setIsMenuExpanded] = useState(false);
-
     return (
         <nav
-            className={cn(
-                'z-nav fixed top-0 left-0 h-full w-nav-width duration-300 ease-in flex flex-col items-center pt-4 shadow-sm bg-neutral-light-2 dark:bg-neutral-dark-2 print:hidden',
-                { 'w-nav-width-expanded overflow-y-auto overflow-x-hidden': isMenuExpanded }
-            )}
-            onMouseEnter={() => setIsMenuExpanded(true)}
-            onMouseLeave={() => setIsMenuExpanded(false)}>
-            <MainNavItemLink
-                route={mainNavData.logo.project.route}
-                isMenuExpanded={isMenuExpanded}
-                data-testid='main-nav-logo'>
+            className={
+                'z-nav fixed top-0 left-0 h-full w-nav-width duration-300 ease-in flex flex-col items-center pt-4 shadow-sm bg-neutral-light-2 dark:bg-neutral-dark-2 print:hidden hover:w-nav-width-expanded hover:overflow-y-auto hover:overflow-x-hidden group'
+            }>
+            <MainNavItemLink route={mainNavData.logo.project.route} data-testid='main-nav-logo'>
                 <MainNavItemLabel
                     icon={mainNavData.logo.project.icon}
                     label={<MainNavLogoTextImage mainNavLogoData={mainNavData.logo.project} />}
-                    isMenuExpanded={isMenuExpanded}
                 />
             </MainNavItemLink>
             {/* Note: min height here is to keep the version number in bottom of nav */}
@@ -188,12 +151,8 @@ const MainNav: FC<{ mainNavData: MainNavData }> = ({ mainNavData }) => {
                 <ul className='flex flex-col gap-6 mt-8' data-testid='main-nav-primary-list'>
                     {mainNavData.primaryList.map((listDataItem: MainNavDataListItem, itemIndex: number) => (
                         <MainNavListItem key={itemIndex} route={listDataItem.route as string}>
-                            <MainNavItemLink route={listDataItem.route as string} isMenuExpanded={isMenuExpanded}>
-                                <MainNavItemLabel
-                                    icon={listDataItem.icon}
-                                    label={listDataItem.label}
-                                    isMenuExpanded={isMenuExpanded}
-                                />
+                            <MainNavItemLink route={listDataItem.route as string}>
+                                <MainNavItemLabel icon={listDataItem.icon} label={listDataItem.label} />
                             </MainNavItemLink>
                         </MainNavListItem>
                     ))}
@@ -202,32 +161,22 @@ const MainNav: FC<{ mainNavData: MainNavData }> = ({ mainNavData }) => {
                     {mainNavData.secondaryList.map((listDataItem: MainNavDataListItem, itemIndex: number) =>
                         listDataItem.route ? (
                             <MainNavListItem key={itemIndex} route={listDataItem.route as string}>
-                                <MainNavItemLink route={listDataItem.route as string} isMenuExpanded={isMenuExpanded}>
-                                    <MainNavItemLabel
-                                        icon={listDataItem.icon}
-                                        label={listDataItem.label}
-                                        isMenuExpanded={isMenuExpanded}
-                                    />
+                                <MainNavItemLink route={listDataItem.route as string}>
+                                    <MainNavItemLabel icon={listDataItem.icon} label={listDataItem.label} />
                                 </MainNavItemLink>
                             </MainNavListItem>
                         ) : (
                             <MainNavListItem key={itemIndex}>
-                                <MainNavItemAction
-                                    onClick={(() => listDataItem.functionHandler as () => void)()}
-                                    isMenuExpanded={isMenuExpanded}>
-                                    <MainNavItemLabel
-                                        icon={listDataItem.icon}
-                                        label={listDataItem.label}
-                                        isMenuExpanded={isMenuExpanded}
-                                    />
+                                <MainNavItemAction onClick={(() => listDataItem.functionHandler as () => void)()}>
+                                    <MainNavItemLabel icon={listDataItem.icon} label={listDataItem.label} />
                                 </MainNavItemAction>
                             </MainNavListItem>
                         )
                     )}
                 </ul>
             </div>
-            <MainNavVersionNumber isMenuExpanded={isMenuExpanded} />
-            <MainNavPoweredBy isMenuExpanded={isMenuExpanded}>
+            <MainNavVersionNumber />
+            <MainNavPoweredBy>
                 <MainNavLogoTextImage mainNavLogoData={mainNavData.logo.specterOps} />
             </MainNavPoweredBy>
         </nav>


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

The nav uses css hover state to expand and collapse instead of state and js.

## Motivation and Context

This PR addresses: BED-4810

This pursuit is largely personal as I often navigate pages using the vimium extension. "Clicking" a nav item with vimium would leave the nav open until I used my mouse to enter and exit the nav bar which contradicts the intent of keyboard navigation.

The work cleans the component up a little though.

## How Has This Been Tested?

Tests were updated and the behavior works as desired with the vimium extension.

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
