### PR TITLE
BP-1303: Replace truncated version with wrapped version number when nav collapsed

### DIFF
--- a/packages/javascript/bh-shared-ui/src/components/Navigation/MainNav.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/Navigation/MainNav.tsx
@@ -103,7 +103,7 @@ const MainNavVersionNumber: FC = () => {
         <div className='relative w-full flex min-h-10 h-10' data-testid='main-nav-version-number'>
             <div
                 className={
-                    'w-9 break-all group-hover:w-full group-hover:whitespace-nowrap flex absolute top-3 left-3 duration-300 ease-in-out text-xs font-medium text-neutral-dark-0 dark:text-neutral-light-1 group-hover:left-16'
+                    'w-9 break-all group-hover:w-auto group-hover:overflow-x-hidden group-hover:whitespace-nowrap flex absolute top-3 left-3 duration-300 ease-in-out text-xs font-medium text-neutral-dark-0 dark:text-neutral-light-1 group-hover:left-16'
                 }>
                 <span className={'opacity-0 hidden duration-300 ease-in-out group-hover:opacity-100 group-hover:block'}>
                     BloodHound:&nbsp;

--- a/packages/javascript/bh-shared-ui/src/components/Navigation/MainNav.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/Navigation/MainNav.tsx
@@ -100,15 +100,15 @@ const MainNavVersionNumber: FC = () => {
 
     return (
         // Note: The min-h allows for the version number to keep its position when the nav is scrollable
-        <div className='relative w-full flex min-h-10 h-10 overflow-x-hidden' data-testid='main-nav-version-number'>
+        <div className='relative w-full flex min-h-10 h-10' data-testid='main-nav-version-number'>
             <div
                 className={
-                    'w-full flex absolute bottom-3 left-3 duration-300 ease-in-out text-xs whitespace-nowrap font-medium text-neutral-dark-0 dark:text-neutral-light-1 group-hover:left-16'
+                    'w-9 break-all group-hover:w-full group-hover:whitespace-nowrap flex absolute top-3 left-3 duration-300 ease-in-out text-xs font-medium text-neutral-dark-0 dark:text-neutral-light-1 group-hover:left-16'
                 }>
                 <span className={'opacity-0 hidden duration-300 ease-in-out group-hover:opacity-100 group-hover:block'}>
                     BloodHound:&nbsp;
                 </span>
-                <span className={cn('group-[:not(:hover)]:max-w-9 overflow-x-hidden')}>{apiVersion}</span>
+                <span className={cn('group-[:not(:hover)]:max-w-9')}>{apiVersion}</span>
             </div>
         </div>
     );


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

The collapsed nav will now show the whole version number and wrap to next line if it exceeds space. When nav is expanded it will be all in one line.

## Motivation and Context

This PR addresses: [BP-1303](https://specterops.atlassian.net/browse/BP-1303)

## How Has This Been Tested?

Manually

## Screenshots (optional):

<img width="1918" alt="Screenshot 2025-01-31 at 2 14 48 PM" src="https://github.com/user-attachments/assets/c0c2c7e4-f5b4-4bef-b06b-3d631ef04ae7" />

<img width="1914" alt="Screenshot 2025-01-31 at 2 22 48 PM" src="https://github.com/user-attachments/assets/0a9fe1b6-9b82-4ab6-b9ba-49e82d333cdb" />


## Types of changes

- Chore (a change that does not modify the application functionality)
- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


[BP-1303]: https://specterops.atlassian.net/browse/BP-1303?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ