### PR TITLE
BED-5354:  Prevent vertical nav from expanding while dragging

### DIFF
--- a/cmd/ui/src/routes/index.ts
+++ b/cmd/ui/src/routes/index.ts
@@ -1,3 +1,19 @@
+// Copyright 2025 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import React from 'react';
 import * as routes from 'src/routes/constants';
 

--- a/packages/javascript/bh-shared-ui/src/components/AppIcon/AppIcon.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/AppIcon/AppIcon.tsx
@@ -1,3 +1,19 @@
+// Copyright 2025 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import * as IconOptions from './Icons';
 
 export type AppIconOptions = keyof typeof IconOptions;

--- a/packages/javascript/bh-shared-ui/src/components/AppIcon/Icons/AttackPaths.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/AppIcon/Icons/AttackPaths.tsx
@@ -1,3 +1,19 @@
+// Copyright 2025 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import React from 'react';
 import { BasePath, BaseSVG, BaseSVGProps } from './utils';
 

--- a/packages/javascript/bh-shared-ui/src/components/AppIcon/Icons/BHCELogo.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/AppIcon/Icons/BHCELogo.tsx
@@ -1,3 +1,19 @@
+// Copyright 2025 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import React from 'react';
 import { BasePath, BaseSVG, BaseSVGProps } from './utils';
 

--- a/packages/javascript/bh-shared-ui/src/components/AppIcon/Icons/BHELogo.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/AppIcon/Icons/BHELogo.tsx
@@ -1,3 +1,19 @@
+// Copyright 2025 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import React from 'react';
 import { BaseSVG, BasePath, BaseSVGProps } from './utils';
 

--- a/packages/javascript/bh-shared-ui/src/components/AppIcon/Icons/BarChart.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/AppIcon/Icons/BarChart.tsx
@@ -1,3 +1,19 @@
+// Copyright 2025 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import React from 'react';
 import { BasePath, BaseSVG, BaseSVGProps } from './utils';
 

--- a/packages/javascript/bh-shared-ui/src/components/AppIcon/Icons/CalendarDay.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/AppIcon/Icons/CalendarDay.tsx
@@ -1,3 +1,19 @@
+// Copyright 2025 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import React from 'react';
 import { BasePath, BaseSVG, BaseSVGProps } from './utils';
 

--- a/packages/javascript/bh-shared-ui/src/components/AppIcon/Icons/CaretDown.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/AppIcon/Icons/CaretDown.tsx
@@ -1,3 +1,19 @@
+// Copyright 2025 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import React from 'react';
 import { BasePath, BaseSVG, BaseSVGProps } from './utils';
 

--- a/packages/javascript/bh-shared-ui/src/components/AppIcon/Icons/CaretUp.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/AppIcon/Icons/CaretUp.tsx
@@ -1,3 +1,19 @@
+// Copyright 2025 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import React from 'react';
 import { BasePath, BaseSVG, BaseSVGProps } from './utils';
 

--- a/packages/javascript/bh-shared-ui/src/components/AppIcon/Icons/Compass.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/AppIcon/Icons/Compass.tsx
@@ -1,3 +1,19 @@
+// Copyright 2025 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import React from 'react';
 import { BasePath, BaseSVG, BaseSVGProps } from './utils';
 

--- a/packages/javascript/bh-shared-ui/src/components/AppIcon/Icons/Diamond.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/AppIcon/Icons/Diamond.tsx
@@ -1,3 +1,19 @@
+// Copyright 2025 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import React from 'react';
 import { BasePath, BaseSVG, BaseSVGProps } from './utils';
 

--- a/packages/javascript/bh-shared-ui/src/components/AppIcon/Icons/EclipseCircle.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/AppIcon/Icons/EclipseCircle.tsx
@@ -1,3 +1,19 @@
+// Copyright 2025 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import React from 'react';
 import { BasePath, BaseSVG, BaseSVGProps } from './utils';
 

--- a/packages/javascript/bh-shared-ui/src/components/AppIcon/Icons/Equals.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/AppIcon/Icons/Equals.tsx
@@ -1,3 +1,19 @@
+// Copyright 2025 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import React from 'react';
 import { BasePath, BaseSVG, BaseSVGProps } from './utils';
 

--- a/packages/javascript/bh-shared-ui/src/components/AppIcon/Icons/FileMagnifyingGlass.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/AppIcon/Icons/FileMagnifyingGlass.tsx
@@ -1,3 +1,19 @@
+// Copyright 2025 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import React from 'react';
 import { BasePath, BaseSVG, BaseSVGProps } from './utils';
 

--- a/packages/javascript/bh-shared-ui/src/components/AppIcon/Icons/FilterOutline.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/AppIcon/Icons/FilterOutline.tsx
@@ -1,3 +1,19 @@
+// Copyright 2025 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import React from 'react';
 import { BasePath, BaseSVG, BaseSVGProps } from './utils';
 

--- a/packages/javascript/bh-shared-ui/src/components/AppIcon/Icons/Findings.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/AppIcon/Icons/Findings.tsx
@@ -1,3 +1,19 @@
+// Copyright 2025 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import React from 'react';
 import { BasePath, BaseSVG, BaseSVGProps } from './utils';
 

--- a/packages/javascript/bh-shared-ui/src/components/AppIcon/Icons/LineChart.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/AppIcon/Icons/LineChart.tsx
@@ -1,3 +1,19 @@
+// Copyright 2025 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import React from 'react';
 import { BasePath, BaseSVG, BaseSVGProps } from './utils';
 

--- a/packages/javascript/bh-shared-ui/src/components/AppIcon/Icons/Logout.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/AppIcon/Icons/Logout.tsx
@@ -1,3 +1,19 @@
+// Copyright 2025 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import React from 'react';
 import { BasePath, BaseSVG, BaseSVGProps } from './utils';
 

--- a/packages/javascript/bh-shared-ui/src/components/AppIcon/Icons/MagnifyingGlass.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/AppIcon/Icons/MagnifyingGlass.tsx
@@ -1,3 +1,19 @@
+// Copyright 2025 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import React from 'react';
 import { BasePath, BaseSVG, BaseSVGProps } from './utils';
 

--- a/packages/javascript/bh-shared-ui/src/components/AppIcon/Icons/SortAsc.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/AppIcon/Icons/SortAsc.tsx
@@ -1,3 +1,19 @@
+// Copyright 2025 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import React from 'react';
 import { BasePath, BaseSVG, BaseSVGProps } from './utils';
 

--- a/packages/javascript/bh-shared-ui/src/components/AppIcon/Icons/SortDesc.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/AppIcon/Icons/SortDesc.tsx
@@ -1,3 +1,19 @@
+// Copyright 2025 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import React from 'react';
 import { BasePath, BaseSVG, BaseSVGProps } from './utils';
 

--- a/packages/javascript/bh-shared-ui/src/components/AppIcon/Icons/SortEmpty.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/AppIcon/Icons/SortEmpty.tsx
@@ -1,3 +1,19 @@
+// Copyright 2025 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import React from 'react';
 import { BasePath, BaseSVG, BaseSVGProps } from './utils';
 

--- a/packages/javascript/bh-shared-ui/src/components/AppIcon/Icons/TierZero.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/AppIcon/Icons/TierZero.tsx
@@ -1,3 +1,19 @@
+// Copyright 2025 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import React from 'react';
 import { BasePath, BaseSVG, BaseSVGProps } from './utils';
 

--- a/packages/javascript/bh-shared-ui/src/components/AppIcon/Icons/User.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/AppIcon/Icons/User.tsx
@@ -1,3 +1,19 @@
+// Copyright 2025 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import React from 'react';
 import { BasePath, BaseSVG, BaseSVGProps } from './utils';
 

--- a/packages/javascript/bh-shared-ui/src/components/AppIcon/Icons/UserCog.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/AppIcon/Icons/UserCog.tsx
@@ -1,3 +1,19 @@
+// Copyright 2025 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import React from 'react';
 import { BasePath, BaseSVG, BaseSVGProps } from './utils';
 

--- a/packages/javascript/bh-shared-ui/src/components/AppIcon/Icons/index.ts
+++ b/packages/javascript/bh-shared-ui/src/components/AppIcon/Icons/index.ts
@@ -1,3 +1,19 @@
+// Copyright 2025 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 export * from './AttackPaths';
 export * from './BHCELogo';
 export * from './BHELogo';

--- a/packages/javascript/bh-shared-ui/src/components/AppIcon/Icons/utils.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/AppIcon/Icons/utils.tsx
@@ -1,3 +1,19 @@
+// Copyright 2025 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { VisuallyHidden } from '@bloodhoundenterprise/doodleui';
 import React from 'react';
 

--- a/packages/javascript/bh-shared-ui/src/components/AppIcon/index.ts
+++ b/packages/javascript/bh-shared-ui/src/components/AppIcon/index.ts
@@ -1,1 +1,17 @@
+// Copyright 2025 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 export * from './AppIcon';

--- a/packages/javascript/bh-shared-ui/src/components/Navigation/MainNav.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/Navigation/MainNav.tsx
@@ -34,17 +34,24 @@ const MainNavLogoTextImage: FC<{
     );
 };
 
-const MainNavListItem: FC<{ children: ReactNode; route?: string }> = ({ children, route }) => {
+const MainNavListItem: FC<{ children: ReactNode; route?: string; hoverActive: boolean }> = ({
+    children,
+    route,
+    hoverActive,
+}) => {
     const location = useLocation();
     const isActiveRoute = route ? location.pathname.includes(route.replace(/\*/g, '')) : false;
 
     return (
         <li
             className={cn(
-                'h-10 px-2 mx-2 flex items-center rounded text-neutral-dark-0 dark:text-neutral-light-1 hover:text-secondary dark:hover:text-secondary-variant-2',
+                'h-10 px-2 mx-2 flex items-center rounded text-neutral-dark-0 dark:text-neutral-light-1',
                 {
                     'text-primary dark:text-primary dark:hover:text-primary bg-neutral-light-4 cursor-default':
                         isActiveRoute,
+                },
+                {
+                    'hover:text-secondary dark:hover:text-secondary-variant-2': hoverActive,
                 }
             )}>
             {children}
@@ -193,7 +200,10 @@ const MainNav: FC<{ mainNavData: MainNavData }> = ({ mainNavData }) => {
             <div className='h-full min-h-[700px] w-full flex flex-col justify-between mt-6'>
                 <ul className='flex flex-col gap-6 mt-8' data-testid='main-nav-primary-list'>
                     {mainNavData.primaryList.map((listDataItem: MainNavDataListItem, itemIndex: number) => (
-                        <MainNavListItem key={itemIndex} route={listDataItem.route as string}>
+                        <MainNavListItem
+                            key={itemIndex}
+                            route={listDataItem.route as string}
+                            hoverActive={!isMouseDragging}>
                             <MainNavItemLink route={listDataItem.route as string} hoverActive={!isMouseDragging}>
                                 <MainNavItemLabel
                                     icon={listDataItem.icon}
@@ -207,7 +217,10 @@ const MainNav: FC<{ mainNavData: MainNavData }> = ({ mainNavData }) => {
                 <ul className='flex flex-col gap-4 mt-16' data-testid='main-nav-secondary-list'>
                     {mainNavData.secondaryList.map((listDataItem: MainNavDataListItem, itemIndex: number) =>
                         listDataItem.route ? (
-                            <MainNavListItem key={itemIndex} route={listDataItem.route as string}>
+                            <MainNavListItem
+                                key={itemIndex}
+                                route={listDataItem.route as string}
+                                hoverActive={!isMouseDragging}>
                                 <MainNavItemLink route={listDataItem.route as string} hoverActive={!isMouseDragging}>
                                     <MainNavItemLabel
                                         icon={listDataItem.icon}
@@ -217,7 +230,7 @@ const MainNav: FC<{ mainNavData: MainNavData }> = ({ mainNavData }) => {
                                 </MainNavItemLink>
                             </MainNavListItem>
                         ) : (
-                            <MainNavListItem key={itemIndex}>
+                            <MainNavListItem key={itemIndex} hoverActive={!isMouseDragging}>
                                 <MainNavItemAction
                                     onClick={(() => listDataItem.functionHandler as () => void)()}
                                     hoverActive={!isMouseDragging}>

--- a/packages/javascript/bh-shared-ui/src/components/Navigation/MainNav.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/Navigation/MainNav.tsx
@@ -41,9 +41,10 @@ const MainNavListItem: FC<{ children: ReactNode; route?: string }> = ({ children
     return (
         <li
             className={cn(
-                'h-10 px-2 mx-2 flex items-center cursor-pointer rounded text-neutral-dark-0 dark:text-neutral-light-1 hover:text-secondary dark:hover:text-secondary-variant-2',
+                'h-10 px-2 mx-2 flex items-center rounded text-neutral-dark-0 dark:text-neutral-light-1 hover:text-secondary dark:hover:text-secondary-variant-2',
                 {
-                    'text-primary dark:text-primary dark:hover:text-primary bg-neutral-light-4': isActiveRoute,
+                    'text-primary dark:text-primary dark:hover:text-primary bg-neutral-light-4 cursor-default':
+                        isActiveRoute,
                 }
             )}>
             {children}
@@ -51,30 +52,37 @@ const MainNavListItem: FC<{ children: ReactNode; route?: string }> = ({ children
     );
 };
 
-const MainNavItemAction: FC<{ onClick: () => void; children: ReactNode }> = ({ onClick, children }) => {
-    const { isMouseDragging } = useIsMouseDragging();
+const MainNavItemAction: FC<{ onClick: () => void; children: ReactNode; hoverActive: boolean }> = ({
+    onClick,
+    children,
+    hoverActive,
+}) => {
     return (
         // Note: The w-full is to avoid the hover area to overflow out of the nav when its collapsed which created a flickering effect just outside the nav
         // Note: had to wrap in div to avoid error of button nesting in a button with the switch
         <div
             role='button'
             onClick={onClick}
-            className={cn('h-10 w-auto absolute left-4 flex items-center gap-x-2 hover:underline', {
-                'group-hover:w-full': !isMouseDragging,
+            className={cn('h-10 w-auto absolute left-4 flex items-center gap-x-2 hover:underline cursor-default', {
+                'group-hover:w-full cursor-pointer': hoverActive,
             })}>
             {children}
         </div>
     );
 };
 
-const MainNavItemLink: FC<{ route: string; children: ReactNode }> = ({ route, children, ...rest }) => {
-    const { isMouseDragging } = useIsMouseDragging();
+const MainNavItemLink: FC<{ route: string; children: ReactNode; hoverActive: boolean }> = ({
+    route,
+    children,
+    hoverActive,
+    ...rest
+}) => {
     return (
         // Note: The w-full is to avoid the hover area to overflow out of the nav when its collapsed
         <RouterLink
             to={route as string}
-            className={cn('h-10 w-auto absolute left-4 flex items-center gap-x-2 hover:underline', {
-                'group-hover:w-full': !isMouseDragging,
+            className={cn('h-10 w-auto absolute left-4 flex items-center gap-x-2 hover:underline cursor-default', {
+                'group-hover:w-full cursor-pointer': hoverActive,
             })}
             {...rest}>
             {children}
@@ -82,8 +90,11 @@ const MainNavItemLink: FC<{ route: string; children: ReactNode }> = ({ route, ch
     );
 };
 
-const MainNavItemLabel: FC<{ icon: ReactNode; label: ReactNode | string }> = ({ icon, label }) => {
-    const { isMouseDragging } = useIsMouseDragging();
+const MainNavItemLabel: FC<{ icon: ReactNode; label: ReactNode | string; hoverActive: boolean }> = ({
+    icon,
+    label,
+    hoverActive,
+}) => {
     return (
         // Note: The min-h here is to keep spacing between the logo and the list below.
         <>
@@ -96,7 +107,7 @@ const MainNavItemLabel: FC<{ icon: ReactNode; label: ReactNode | string }> = ({ 
                     'whitespace-nowrap min-h-10 font-medium text-xl opacity-0 hidden transition-opacity duration-200 ease-in',
                     {
                         'group-hover:w-full group-hover:opacity-100 group-hover:flex group-hover:items-center group-hover:gap-x-5':
-                            !isMouseDragging,
+                            hoverActive,
                     }
                 )}>
                 {label}
@@ -105,10 +116,9 @@ const MainNavItemLabel: FC<{ icon: ReactNode; label: ReactNode | string }> = ({ 
     );
 };
 
-const MainNavVersionNumber: FC = () => {
+const MainNavVersionNumber: FC<{ hoverActive: boolean }> = ({ hoverActive }) => {
     const { data: apiVersionResponse, isSuccess } = useApiVersion();
     const apiVersion = isSuccess && apiVersionResponse?.server_version;
-    const { isMouseDragging } = useIsMouseDragging();
 
     return (
         // Note: The min-h allows for the version number to keep its position when the nav is scrollable
@@ -117,16 +127,16 @@ const MainNavVersionNumber: FC = () => {
                 className={cn(
                     'w-full flex absolute bottom-3 left-3 duration-300 ease-in-out text-xs whitespace-nowrap font-medium text-neutral-dark-0 dark:text-neutral-light-1',
                     {
-                        'group-hover:left-16': !isMouseDragging,
+                        'group-hover:left-16': hoverActive,
                     }
                 )}>
                 <span
                     className={cn('opacity-0 hidden duration-300 ease-in-out', {
-                        'group-hover:opacity-100 group-hover:block': !isMouseDragging,
+                        'group-hover:opacity-100 group-hover:block': hoverActive,
                     })}>
                     BloodHound:&nbsp;
                 </span>
-                <span className={cn('group-[:not(:hover)]:max-w-9 overflow-x-hidden', { 'max-w-9': isMouseDragging })}>
+                <span className={cn('group-[:not(:hover)]:max-w-9 overflow-x-hidden', { 'max-w-9': !hoverActive })}>
                     {apiVersion}
                 </span>
             </div>
@@ -134,9 +144,7 @@ const MainNavVersionNumber: FC = () => {
     );
 };
 
-const MainNavPoweredBy: FC<{ children: ReactNode }> = ({ children }) => {
-    const { isMouseDragging } = useIsMouseDragging();
-
+const MainNavPoweredBy: FC<{ children: ReactNode; hoverActive: boolean }> = ({ children, hoverActive }) => {
     return (
         // Note: The min-h allows for the version number to keep its position when the nav is scrollable
         <div className='relative w-full flex min-h-10 h-10 overflow-x-hidden' data-testid='main-nav-powered-by'>
@@ -144,13 +152,13 @@ const MainNavPoweredBy: FC<{ children: ReactNode }> = ({ children }) => {
                 className={cn(
                     'w-full flex absolute bottom-3 left-3 duration-300 ease-in-out text-xs whitespace-nowrap font-medium text-neutral-dark-0 dark:text-neutral-light-1',
                     {
-                        'group-hover:left-12': !isMouseDragging,
+                        'group-hover:left-12': hoverActive,
                     }
                 )}>
                 <span
                     className={cn('opacity-0 hidden duration-300 ease-in-out ', {
                         'group-hover:opacity-100 group-hover:flex group-hover:items-center group-hover:gap-1':
-                            !isMouseDragging,
+                            hoverActive,
                     })}>
                     powered by&nbsp;
                     {children}
@@ -171,10 +179,14 @@ const MainNav: FC<{ mainNavData: MainNavData }> = ({ mainNavData }) => {
                     'hover:w-nav-width-expanded hover:overflow-y-auto hover:overflow-x-hidden': !isMouseDragging,
                 }
             )}>
-            <MainNavItemLink route={mainNavData.logo.project.route} data-testid='main-nav-logo'>
+            <MainNavItemLink
+                route={mainNavData.logo.project.route}
+                data-testid='main-nav-logo'
+                hoverActive={!isMouseDragging}>
                 <MainNavItemLabel
                     icon={mainNavData.logo.project.icon}
                     label={<MainNavLogoTextImage mainNavLogoData={mainNavData.logo.project} />}
+                    hoverActive={!isMouseDragging}
                 />
             </MainNavItemLink>
             {/* Note: min height here is to keep the version number in bottom of nav */}
@@ -182,8 +194,12 @@ const MainNav: FC<{ mainNavData: MainNavData }> = ({ mainNavData }) => {
                 <ul className='flex flex-col gap-6 mt-8' data-testid='main-nav-primary-list'>
                     {mainNavData.primaryList.map((listDataItem: MainNavDataListItem, itemIndex: number) => (
                         <MainNavListItem key={itemIndex} route={listDataItem.route as string}>
-                            <MainNavItemLink route={listDataItem.route as string}>
-                                <MainNavItemLabel icon={listDataItem.icon} label={listDataItem.label} />
+                            <MainNavItemLink route={listDataItem.route as string} hoverActive={!isMouseDragging}>
+                                <MainNavItemLabel
+                                    icon={listDataItem.icon}
+                                    label={listDataItem.label}
+                                    hoverActive={!isMouseDragging}
+                                />
                             </MainNavItemLink>
                         </MainNavListItem>
                     ))}
@@ -192,22 +208,32 @@ const MainNav: FC<{ mainNavData: MainNavData }> = ({ mainNavData }) => {
                     {mainNavData.secondaryList.map((listDataItem: MainNavDataListItem, itemIndex: number) =>
                         listDataItem.route ? (
                             <MainNavListItem key={itemIndex} route={listDataItem.route as string}>
-                                <MainNavItemLink route={listDataItem.route as string}>
-                                    <MainNavItemLabel icon={listDataItem.icon} label={listDataItem.label} />
+                                <MainNavItemLink route={listDataItem.route as string} hoverActive={!isMouseDragging}>
+                                    <MainNavItemLabel
+                                        icon={listDataItem.icon}
+                                        label={listDataItem.label}
+                                        hoverActive={!isMouseDragging}
+                                    />
                                 </MainNavItemLink>
                             </MainNavListItem>
                         ) : (
                             <MainNavListItem key={itemIndex}>
-                                <MainNavItemAction onClick={(() => listDataItem.functionHandler as () => void)()}>
-                                    <MainNavItemLabel icon={listDataItem.icon} label={listDataItem.label} />
+                                <MainNavItemAction
+                                    onClick={(() => listDataItem.functionHandler as () => void)()}
+                                    hoverActive={!isMouseDragging}>
+                                    <MainNavItemLabel
+                                        icon={listDataItem.icon}
+                                        label={listDataItem.label}
+                                        hoverActive={!isMouseDragging}
+                                    />
                                 </MainNavItemAction>
                             </MainNavListItem>
                         )
                     )}
                 </ul>
             </div>
-            <MainNavVersionNumber />
-            <MainNavPoweredBy>
+            <MainNavVersionNumber hoverActive={!isMouseDragging} />
+            <MainNavPoweredBy hoverActive={!isMouseDragging}>
                 <MainNavLogoTextImage mainNavLogoData={mainNavData.logo.specterOps} />
             </MainNavPoweredBy>
         </nav>

--- a/packages/javascript/bh-shared-ui/src/components/Navigation/MainNav.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/Navigation/MainNav.tsx
@@ -16,7 +16,7 @@
 
 import { FC, ReactNode } from 'react';
 import { Link as RouterLink, useLocation } from 'react-router-dom';
-import { useApiVersion } from '../../hooks';
+import { useApiVersion, useIsMouseDragging } from '../../hooks';
 import { cn } from '../../utils';
 import { MainNavData, MainNavDataListItem, MainNavLogoDataObject } from './types';
 
@@ -52,24 +52,30 @@ const MainNavListItem: FC<{ children: ReactNode; route?: string }> = ({ children
 };
 
 const MainNavItemAction: FC<{ onClick: () => void; children: ReactNode }> = ({ onClick, children }) => {
+    const { isMouseDragging } = useIsMouseDragging();
     return (
         // Note: The w-full is to avoid the hover area to overflow out of the nav when its collapsed which created a flickering effect just outside the nav
         // Note: had to wrap in div to avoid error of button nesting in a button with the switch
         <div
             role='button'
             onClick={onClick}
-            className={'h-10 w-auto absolute left-4 flex items-center gap-x-2 hover:underline group-hover:w-full'}>
+            className={cn('h-10 w-auto absolute left-4 flex items-center gap-x-2 hover:underline', {
+                'group-hover:w-full': !isMouseDragging,
+            })}>
             {children}
         </div>
     );
 };
 
 const MainNavItemLink: FC<{ route: string; children: ReactNode }> = ({ route, children, ...rest }) => {
+    const { isMouseDragging } = useIsMouseDragging();
     return (
         // Note: The w-full is to avoid the hover area to overflow out of the nav when its collapsed
         <RouterLink
             to={route as string}
-            className={'h-10 w-auto absolute left-4 flex items-center gap-x-2 hover:underline group-hover:w-full'}
+            className={cn('h-10 w-auto absolute left-4 flex items-center gap-x-2 hover:underline', {
+                'group-hover:w-full': !isMouseDragging,
+            })}
             {...rest}>
             {children}
         </RouterLink>
@@ -77,6 +83,7 @@ const MainNavItemLink: FC<{ route: string; children: ReactNode }> = ({ route, ch
 };
 
 const MainNavItemLabel: FC<{ icon: ReactNode; label: ReactNode | string }> = ({ icon, label }) => {
+    const { isMouseDragging } = useIsMouseDragging();
     return (
         // Note: The min-h here is to keep spacing between the logo and the list below.
         <>
@@ -85,9 +92,13 @@ const MainNavItemLabel: FC<{ icon: ReactNode; label: ReactNode | string }> = ({ 
             </span>
             <span
                 data-testid='main-nav-item-label-text'
-                className={
-                    'whitespace-nowrap min-h-10 font-medium text-xl opacity-0 hidden transition-opacity duration-200 ease-in group-hover:opacity-100 group-hover:flex group-hover:items-center group-hover:gap-x-5'
-                }>
+                className={cn(
+                    'whitespace-nowrap min-h-10 font-medium text-xl opacity-0 hidden transition-opacity duration-200 ease-in',
+                    {
+                        'group-hover:w-full group-hover:opacity-100 group-hover:flex group-hover:items-center group-hover:gap-x-5':
+                            !isMouseDragging,
+                    }
+                )}>
                 {label}
             </span>
         </>
@@ -97,35 +108,50 @@ const MainNavItemLabel: FC<{ icon: ReactNode; label: ReactNode | string }> = ({ 
 const MainNavVersionNumber: FC = () => {
     const { data: apiVersionResponse, isSuccess } = useApiVersion();
     const apiVersion = isSuccess && apiVersionResponse?.server_version;
+    const { isMouseDragging } = useIsMouseDragging();
 
     return (
         // Note: The min-h allows for the version number to keep its position when the nav is scrollable
         <div className='relative w-full flex min-h-10 h-10 overflow-x-hidden' data-testid='main-nav-version-number'>
             <div
-                className={
-                    'w-full flex absolute bottom-3 left-3 duration-300 ease-in-out text-xs whitespace-nowrap font-medium text-neutral-dark-0 dark:text-neutral-light-1 group-hover:left-16'
-                }>
-                <span className={'opacity-0 hidden duration-300 ease-in-out group-hover:opacity-100 group-hover:block'}>
+                className={cn(
+                    'w-full flex absolute bottom-3 left-3 duration-300 ease-in-out text-xs whitespace-nowrap font-medium text-neutral-dark-0 dark:text-neutral-light-1',
+                    {
+                        'group-hover:left-16': !isMouseDragging,
+                    }
+                )}>
+                <span
+                    className={cn('opacity-0 hidden duration-300 ease-in-out', {
+                        'group-hover:opacity-100 group-hover:block': !isMouseDragging,
+                    })}>
                     BloodHound:&nbsp;
                 </span>
-                <span className={cn('group-[:not(:hover)]:max-w-9 overflow-x-hidden')}>{apiVersion}</span>
+                <span className={cn('group-[:not(:hover)]:max-w-9 overflow-x-hidden', { 'max-w-9': isMouseDragging })}>
+                    {apiVersion}
+                </span>
             </div>
         </div>
     );
 };
 
 const MainNavPoweredBy: FC<{ children: ReactNode }> = ({ children }) => {
+    const { isMouseDragging } = useIsMouseDragging();
+
     return (
         // Note: The min-h allows for the version number to keep its position when the nav is scrollable
         <div className='relative w-full flex min-h-10 h-10 overflow-x-hidden' data-testid='main-nav-powered-by'>
             <div
-                className={
-                    'w-full flex absolute bottom-3 left-3 duration-300 ease-in-out text-xs whitespace-nowrap font-medium text-neutral-dark-0 dark:text-neutral-light-1 group-hover:left-12'
-                }>
+                className={cn(
+                    'w-full flex absolute bottom-3 left-3 duration-300 ease-in-out text-xs whitespace-nowrap font-medium text-neutral-dark-0 dark:text-neutral-light-1',
+                    {
+                        'group-hover:left-12': !isMouseDragging,
+                    }
+                )}>
                 <span
-                    className={
-                        'opacity-0 hidden duration-300 ease-in-out group-hover:opacity-100 group-hover:flex group-hover:items-center group-hover:gap-1'
-                    }>
+                    className={cn('opacity-0 hidden duration-300 ease-in-out ', {
+                        'group-hover:opacity-100 group-hover:flex group-hover:items-center group-hover:gap-1':
+                            !isMouseDragging,
+                    })}>
                     powered by&nbsp;
                     {children}
                 </span>
@@ -135,11 +161,16 @@ const MainNavPoweredBy: FC<{ children: ReactNode }> = ({ children }) => {
 };
 
 const MainNav: FC<{ mainNavData: MainNavData }> = ({ mainNavData }) => {
+    const { isMouseDragging } = useIsMouseDragging();
+
     return (
         <nav
-            className={
-                'z-nav fixed top-0 left-0 h-full w-nav-width duration-300 ease-in flex flex-col items-center pt-4 shadow-sm bg-neutral-light-2 dark:bg-neutral-dark-2 print:hidden hover:w-nav-width-expanded hover:overflow-y-auto hover:overflow-x-hidden group'
-            }>
+            className={cn(
+                'z-nav fixed top-0 left-0 h-full w-nav-width duration-300 ease-in flex flex-col items-center pt-4 shadow-sm bg-neutral-light-2 dark:bg-neutral-dark-2 print:hidden group',
+                {
+                    'hover:w-nav-width-expanded hover:overflow-y-auto hover:overflow-x-hidden': !isMouseDragging,
+                }
+            )}>
             <MainNavItemLink route={mainNavData.logo.project.route} data-testid='main-nav-logo'>
                 <MainNavItemLabel
                     icon={mainNavData.logo.project.icon}

--- a/packages/javascript/bh-shared-ui/src/hooks/index.ts
+++ b/packages/javascript/bh-shared-ui/src/hooks/index.ts
@@ -39,3 +39,5 @@ export * from './useSavedQueries';
 export * from './useSearch';
 
 export * from './useShowNavBar';
+
+export * from './useIsMouseDragging';

--- a/packages/javascript/bh-shared-ui/src/hooks/useIsMouseDragging.tsx
+++ b/packages/javascript/bh-shared-ui/src/hooks/useIsMouseDragging.tsx
@@ -1,0 +1,33 @@
+import { useEffect, useRef, useState } from 'react';
+
+export const useIsMouseDragging = () => {
+    const [isMouseDragging, setIsMouseDragging] = useState<boolean>(false);
+    const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    const handlePointerDown = () => {
+        // We are setting a timeout here so that state is not changed unless the user holds down the mouse button for some period of time
+        timeoutRef.current = setTimeout(() => {
+            setIsMouseDragging(true);
+        }, 200);
+    };
+
+    const handlePointerUp = () => {
+        setIsMouseDragging(false);
+
+        if (timeoutRef.current) {
+            clearTimeout(timeoutRef.current);
+        }
+    };
+
+    useEffect(() => {
+        document.addEventListener('mousedown', handlePointerDown);
+        document.addEventListener('mouseup', handlePointerUp);
+
+        return () => {
+            document.removeEventListener('mousedown', handlePointerDown);
+            document.removeEventListener('mouseup', handlePointerUp);
+        };
+    }, []);
+
+    return { isMouseDragging };
+};

--- a/packages/javascript/bh-shared-ui/src/hooks/useIsMouseDragging.tsx
+++ b/packages/javascript/bh-shared-ui/src/hooks/useIsMouseDragging.tsx
@@ -1,3 +1,19 @@
+// Copyright 2025 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { useEffect, useRef, useState } from 'react';
 
 export const useIsMouseDragging = () => {


### PR DESCRIPTION
## Description
- adds a custom hook that watches for mousedown/mouseup events with a delay on mousedown to exclude clicks
- uses this hook on our vertical nav so that users can drag graph items without expanding the nav

## Motivation and Context
- users need to be able to drag against the edge of their screen, particularly on the explore page

This PR addresses: [BED-5354](https://specterops.atlassian.net/browse/BED-5354)

## How Has This Been Tested?
- all existing tests passed

## Screenshots (optional):

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


[BED-5354]: https://specterops.atlassian.net/browse/BED-5354?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ