### PR TITLE
BED-5353A: Hide version number when nav collapsed

### DIFF
--- a/packages/javascript/bh-shared-ui/src/components/Navigation/MainNav.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/Navigation/MainNav.test.tsx
@@ -135,24 +135,16 @@ describe('MainNav', () => {
 
         expect(testLinkItem.functionHandler).toBeCalled();
     });
-    it('should render only a version number when collapsed', async () => {
-        const versionNumberContainer = await screen.findByTestId('main-nav-version-number');
-        const versionNumberLabel = await within(versionNumberContainer).findByText(/bloodhound/i);
-        const versionNumberDigits = await within(versionNumberContainer).findByText(currentVersionNumber);
-
-        expect(versionNumberDigits).toBeInTheDocument();
-        expect(versionNumberLabel).toHaveClass('hidden');
-    });
     it('should render a label and version number when expanded', async () => {
         const MainNavBar = await screen.findByRole('navigation');
         expect(MainNavBar).toHaveClass('group');
 
         const versionNumberContainer = await within(MainNavBar).findByTestId('main-nav-version-number');
-        const versionNumberDigits = await within(versionNumberContainer).findByText(currentVersionNumber);
-        const versionNumberLabel = await within(versionNumberContainer).findByText(/bloodhound/i);
+        const versionNumberLabel = await within(versionNumberContainer).findByText(
+            `BloodHound: ${currentVersionNumber}`
+        );
 
         // ---- collapsed classes ----
-        expect(versionNumberDigits).toHaveClass('group-[:not(:hover)]:max-w-9');
         expect(versionNumberLabel).toHaveClass('hidden');
         expect(versionNumberLabel).toHaveClass('opacity-0');
         // ---- collapsed classes ----

--- a/packages/javascript/bh-shared-ui/src/components/Navigation/MainNav.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/Navigation/MainNav.tsx
@@ -103,12 +103,11 @@ const MainNavVersionNumber: FC = () => {
         <div className='relative w-full flex min-h-10 h-10' data-testid='main-nav-version-number'>
             <div
                 className={
-                    'w-9 break-all group-hover:w-auto group-hover:overflow-x-hidden group-hover:whitespace-nowrap flex absolute top-3 left-3 duration-300 ease-in-out text-xs font-medium text-neutral-dark-0 dark:text-neutral-light-1 group-hover:left-16'
+                    'w-9 group-hover:w-auto group-hover:overflow-x-hidden group-hover:whitespace-nowrap flex absolute top-3 left-3 duration-300 ease-in-out text-xs font-medium text-neutral-dark-0 dark:text-neutral-light-1 group-hover:left-16'
                 }>
                 <span className={'opacity-0 hidden duration-300 ease-in-out group-hover:opacity-100 group-hover:block'}>
-                    BloodHound:&nbsp;
+                    BloodHound:&nbsp;{apiVersion}
                 </span>
-                <span className={cn('group-[:not(:hover)]:max-w-9')}>{apiVersion}</span>
             </div>
         </div>
     );


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

This hides the version number to only show it when nav is expanded

## Motivation and Context

This PR addresses suggestion and comments from [BED-5353](https://specterops.atlassian.net/browse/BED-5353)

## How Has This Been Tested?

Manually and updated tests

## Screenshots (optional):

<img width="1811" alt="Screenshot 2025-02-03 at 2 58 50 PM" src="https://github.com/user-attachments/assets/4a98c012-763b-40b4-a673-40051b7f850d" />
<img width="1912" alt="Screenshot 2025-02-03 at 2 59 00 PM" src="https://github.com/user-attachments/assets/30353dc9-a17a-4ccd-9211-fbb1e5aa86cc" />
<img width="1908" alt="Screenshot 2025-02-03 at 3 00 25 PM" src="https://github.com/user-attachments/assets/6262f69e-b9cb-49c2-aae4-c518a1cbffd5" />
<img width="1905" alt="Screenshot 2025-02-03 at 3 00 34 PM" src="https://github.com/user-attachments/assets/960e4726-1c66-45b3-98ee-6422352c3e98" />

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


[BED-5353]: https://specterops.atlassian.net/browse/BED-5353?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ