### PR TITLE
BED-5369:  Added back data-testid attributes 

### DIFF
--- a/cmd/ui/src/components/MainNav/MainNavData.tsx
+++ b/cmd/ui/src/components/MainNav/MainNavData.tsx
@@ -53,11 +53,13 @@ export const MainNavPrimaryListData = [
         label: 'Explore',
         icon: <AppIcon.LineChart size={24} />,
         route: routes.ROUTE_EXPLORE,
+        testId: 'global_nav-explore',
     },
     {
         label: 'Group Management',
         icon: <AppIcon.Diamond size={24} />,
         route: routes.ROUTE_GROUP_MANAGEMENT,
+        testid: 'global_nav-group-management',
     },
 ];
 
@@ -82,21 +84,25 @@ export const useMainNavSecondaryListData = () => {
             label: 'Profile',
             icon: <AppIcon.User size={24} />,
             route: routes.ROUTE_MY_PROFILE,
+            testId: 'global_nav-my-profile',
         },
         {
             label: 'Docs and Support',
             icon: <AppIcon.FileMagnifyingGlass size={24} />,
             functionHandler: handleGoToSupport,
+            testId: 'global_nav-support',
         },
         {
             label: 'Administration',
             icon: <AppIcon.UserCog size={24} />,
             route: routes.ROUTE_ADMINISTRATION_ROOT,
+            testId: 'global_nav-administration',
         },
         {
             label: 'API Explorer',
             icon: <AppIcon.Compass size={24} />,
             route: routes.ROUTE_API_EXPLORER,
+            testId: 'global_nav-api-explorer',
         },
         {
             label: (
@@ -107,11 +113,13 @@ export const useMainNavSecondaryListData = () => {
             ),
             icon: <AppIcon.EclipseCircle size={24} />,
             functionHandler: handleToggleDarkMode,
+            testId: 'global_nav-dark-mode',
         },
         {
             label: 'Log Out',
             icon: <AppIcon.Logout size={24} />,
             functionHandler: handleLogout,
+            testId: 'global_nav-logout',
         },
     ];
 };

--- a/cmd/ui/src/components/MainNav/MainNavData.tsx
+++ b/cmd/ui/src/components/MainNav/MainNavData.tsx
@@ -59,7 +59,7 @@ export const MainNavPrimaryListData = [
         label: 'Group Management',
         icon: <AppIcon.Diamond size={24} />,
         route: routes.ROUTE_GROUP_MANAGEMENT,
-        testid: 'global_nav-group-management',
+        testId: 'global_nav-group-management',
     },
 ];
 

--- a/packages/javascript/bh-shared-ui/src/components/Navigation/MainNav.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/Navigation/MainNav.test.tsx
@@ -48,6 +48,7 @@ const MainNavPrimaryListData: MainNavDataListItem[] = [
         label: 'Link Item',
         icon: <AppIcon.LineChart size={24} />,
         route: '/test',
+        testId: 'global_nav-test-link',
     },
 ];
 
@@ -58,6 +59,7 @@ const MainNavSecondaryListData: MainNavDataListItem[] = [
         label: 'Action Item',
         icon: <AppIcon.LineChart size={24} />,
         functionHandler: handleClick,
+        testId: 'global_nav-test-action',
     },
 ];
 
@@ -100,18 +102,18 @@ describe('MainNav', () => {
     });
     it('should render a nav element with logo, two lists, a version number and a powered by', () => {
         expect(screen.getByRole('navigation')).toBeInTheDocument();
-        expect(screen.getByTestId('main-nav-logo')).toBeInTheDocument();
-        expect(screen.getByTestId('main-nav-primary-list')).toBeInTheDocument();
-        expect(screen.getByTestId('main-nav-secondary-list')).toBeInTheDocument();
-        expect(screen.getByTestId('main-nav-version-number')).toBeInTheDocument();
-        expect(screen.getByTestId('main-nav-powered-by')).toBeInTheDocument();
+        expect(screen.getByTestId('global_nav-home')).toBeInTheDocument();
+        expect(screen.getByTestId('global_nav-primary-list')).toBeInTheDocument();
+        expect(screen.getByTestId('global_nav-secondary-list')).toBeInTheDocument();
+        expect(screen.getByTestId('global_nav-version-number')).toBeInTheDocument();
+        expect(screen.getByTestId('global_nav-powered-by')).toBeInTheDocument();
     });
     it('should render a navigation list item', async () => {
         const testLinkItem = MainNavPrimaryListData[0];
 
-        const primaryList = await screen.findByTestId('main-nav-primary-list');
+        const primaryList = await screen.findByTestId('global_nav-primary-list');
         const linkItem = await within(primaryList).findByRole('link');
-        const linkItemIcon = await within(primaryList).findByTestId('main-nav-item-label-icon');
+        const linkItemIcon = await within(primaryList).findByTestId('global_nav-item-label-icon');
         const linkItemText = await within(primaryList).findByText(testLinkItem.label as string);
 
         expect(linkItem).toBeInTheDocument();
@@ -122,9 +124,9 @@ describe('MainNav', () => {
     it('should render action list item that handles a function', async () => {
         const testLinkItem = MainNavSecondaryListData[0];
 
-        const secondaryList = await screen.findByTestId('main-nav-secondary-list');
+        const secondaryList = await screen.findByTestId('global_nav-secondary-list');
         const actionItem = await within(secondaryList).findByRole('button');
-        const actionItemIcon = await within(secondaryList).findByTestId('main-nav-item-label-icon');
+        const actionItemIcon = await within(secondaryList).findByTestId('global_nav-item-label-icon');
         const actionItemText = await within(secondaryList).findByText(testLinkItem.label as string);
 
         expect(actionItem).toBeInTheDocument();
@@ -136,7 +138,7 @@ describe('MainNav', () => {
         expect(testLinkItem.functionHandler).toBeCalled();
     });
     it('should render only a version number when collapsed', async () => {
-        const versionNumberContainer = await screen.findByTestId('main-nav-version-number');
+        const versionNumberContainer = await screen.findByTestId('global_nav-version-number');
         const versionNumberLabel = await within(versionNumberContainer).findByText(/bloodhound/i);
         const versionNumberDigits = await within(versionNumberContainer).findByText(currentVersionNumber);
 
@@ -147,7 +149,7 @@ describe('MainNav', () => {
         const MainNavBar = await screen.findByRole('navigation');
         expect(MainNavBar).toHaveClass('group');
 
-        const versionNumberContainer = await within(MainNavBar).findByTestId('main-nav-version-number');
+        const versionNumberContainer = await within(MainNavBar).findByTestId('global_nav-version-number');
         const versionNumberDigits = await within(versionNumberContainer).findByText(currentVersionNumber);
         const versionNumberLabel = await within(versionNumberContainer).findByText(/bloodhound/i);
 
@@ -168,8 +170,8 @@ describe('MainNav', () => {
         const MainNavBar = screen.getByRole('navigation');
         expect(MainNavBar).toHaveClass('group');
 
-        const primaryList = await within(MainNavBar).findByTestId('main-nav-primary-list');
-        const linkItemIcon = await within(primaryList).findByTestId('main-nav-item-label-icon');
+        const primaryList = await within(MainNavBar).findByTestId('global_nav-primary-list');
+        const linkItemIcon = await within(primaryList).findByTestId('global_nav-item-label-icon');
         const linkItemText = await within(primaryList).findByText(testLinkItem.label as string);
 
         expect(linkItemIcon).toBeInTheDocument();
@@ -188,7 +190,7 @@ describe('MainNav', () => {
         const MainNavBar = screen.getByRole('navigation');
         expect(MainNavBar).toHaveClass('group');
 
-        const poweredByTextContainer = await within(MainNavBar).findByTestId('main-nav-powered-by');
+        const poweredByTextContainer = await within(MainNavBar).findByTestId('global_nav-powered-by');
         const poweredByText = await within(poweredByTextContainer).findByText(/powered by/i);
         expect(poweredByText).toBeInTheDocument();
 

--- a/packages/javascript/bh-shared-ui/src/components/Navigation/MainNav.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/Navigation/MainNav.test.tsx
@@ -141,7 +141,7 @@ describe('MainNav', () => {
         const MainNavBar = await screen.findByRole('navigation');
         expect(MainNavBar).toHaveClass('group');
 
-        const versionNumberContainer = await within(MainNavBar).findByTestId('main-nav-version-number');
+        const versionNumberContainer = await within(MainNavBar).findByTestId('global_nav-version-number');
         const versionNumberLabel = await within(versionNumberContainer).findByText(
             `BloodHound: ${currentVersionNumber}`
         );

--- a/packages/javascript/bh-shared-ui/src/components/Navigation/MainNav.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/Navigation/MainNav.tsx
@@ -51,14 +51,15 @@ const MainNavListItem: FC<{ children: ReactNode; route?: string }> = ({ children
     );
 };
 
-const MainNavItemAction: FC<{ onClick: () => void; children: ReactNode }> = ({ onClick, children }) => {
+const MainNavItemAction: FC<{ onClick: () => void; children: ReactNode }> = ({ onClick, children, ...rest }) => {
     return (
         // Note: The w-full is to avoid the hover area to overflow out of the nav when its collapsed which created a flickering effect just outside the nav
         // Note: had to wrap in div to avoid error of button nesting in a button with the switch
         <div
             role='button'
             onClick={onClick}
-            className={'h-10 w-auto absolute left-4 flex items-center gap-x-2 hover:underline group-hover:w-full'}>
+            className={'h-10 w-auto absolute left-4 flex items-center gap-x-2 hover:underline group-hover:w-full'}
+            {...rest}>
             {children}
         </div>
     );
@@ -80,11 +81,11 @@ const MainNavItemLabel: FC<{ icon: ReactNode; label: ReactNode | string }> = ({ 
     return (
         // Note: The min-h here is to keep spacing between the logo and the list below.
         <>
-            <span data-testid='main-nav-item-label-icon' className='flex'>
+            <span data-testid='global_nav-item-label-icon' className='flex'>
                 {icon}
             </span>
             <span
-                data-testid='main-nav-item-label-text'
+                data-testid='global_nav-item-label-text'
                 className={
                     'whitespace-nowrap min-h-10 font-medium text-xl opacity-0 hidden transition-opacity duration-200 ease-in group-hover:opacity-100 group-hover:flex group-hover:items-center group-hover:gap-x-5'
                 }>
@@ -100,7 +101,7 @@ const MainNavVersionNumber: FC = () => {
 
     return (
         // Note: The min-h allows for the version number to keep its position when the nav is scrollable
-        <div className='relative w-full flex min-h-10 h-10' data-testid='main-nav-version-number'>
+        <div className='relative w-full flex min-h-10 h-10' data-testid='global_nav-version-number'>
             <div
                 className={
                     'w-9 break-all group-hover:w-auto group-hover:overflow-x-hidden group-hover:whitespace-nowrap flex absolute top-3 left-3 duration-300 ease-in-out text-xs font-medium text-neutral-dark-0 dark:text-neutral-light-1 group-hover:left-16'
@@ -117,7 +118,7 @@ const MainNavVersionNumber: FC = () => {
 const MainNavPoweredBy: FC<{ children: ReactNode }> = ({ children }) => {
     return (
         // Note: The min-h allows for the version number to keep its position when the nav is scrollable
-        <div className='relative w-full flex min-h-10 h-10 overflow-x-hidden' data-testid='main-nav-powered-by'>
+        <div className='relative w-full flex min-h-10 h-10 overflow-x-hidden' data-testid='global_nav-powered-by'>
             <div
                 className={
                     'w-full flex absolute bottom-3 left-3 duration-300 ease-in-out text-xs whitespace-nowrap font-medium text-neutral-dark-0 dark:text-neutral-light-1 group-hover:left-12'
@@ -140,7 +141,7 @@ const MainNav: FC<{ mainNavData: MainNavData }> = ({ mainNavData }) => {
             className={
                 'z-nav fixed top-0 left-0 h-full w-nav-width duration-300 ease-in flex flex-col items-center pt-4 shadow-sm bg-neutral-light-2 dark:bg-neutral-dark-2 print:hidden hover:w-nav-width-expanded hover:overflow-y-auto hover:overflow-x-hidden group'
             }>
-            <MainNavItemLink route={mainNavData.logo.project.route} data-testid='main-nav-logo'>
+            <MainNavItemLink route={mainNavData.logo.project.route} data-testid='global_nav-home'>
                 <MainNavItemLabel
                     icon={mainNavData.logo.project.icon}
                     label={<MainNavLogoTextImage mainNavLogoData={mainNavData.logo.project} />}
@@ -148,26 +149,28 @@ const MainNav: FC<{ mainNavData: MainNavData }> = ({ mainNavData }) => {
             </MainNavItemLink>
             {/* Note: min height here is to keep the version number in bottom of nav */}
             <div className='h-full min-h-[700px] w-full flex flex-col justify-between mt-6'>
-                <ul className='flex flex-col gap-6 mt-8' data-testid='main-nav-primary-list'>
+                <ul className='flex flex-col gap-6 mt-8' data-testid='global_nav-primary-list'>
                     {mainNavData.primaryList.map((listDataItem: MainNavDataListItem, itemIndex: number) => (
                         <MainNavListItem key={itemIndex} route={listDataItem.route as string}>
-                            <MainNavItemLink route={listDataItem.route as string}>
+                            <MainNavItemLink route={listDataItem.route as string} data-testid={listDataItem.testId}>
                                 <MainNavItemLabel icon={listDataItem.icon} label={listDataItem.label} />
                             </MainNavItemLink>
                         </MainNavListItem>
                     ))}
                 </ul>
-                <ul className='flex flex-col gap-4 mt-16' data-testid='main-nav-secondary-list'>
+                <ul className='flex flex-col gap-4 mt-16' data-testid='global_nav-secondary-list'>
                     {mainNavData.secondaryList.map((listDataItem: MainNavDataListItem, itemIndex: number) =>
                         listDataItem.route ? (
                             <MainNavListItem key={itemIndex} route={listDataItem.route as string}>
-                                <MainNavItemLink route={listDataItem.route as string}>
+                                <MainNavItemLink route={listDataItem.route as string} data-testid={listDataItem.testId}>
                                     <MainNavItemLabel icon={listDataItem.icon} label={listDataItem.label} />
                                 </MainNavItemLink>
                             </MainNavListItem>
                         ) : (
                             <MainNavListItem key={itemIndex}>
-                                <MainNavItemAction onClick={(() => listDataItem.functionHandler as () => void)()}>
+                                <MainNavItemAction
+                                    onClick={(() => listDataItem.functionHandler as () => void)()}
+                                    data-testid={listDataItem.testId}>
                                     <MainNavItemLabel icon={listDataItem.icon} label={listDataItem.label} />
                                 </MainNavItemAction>
                             </MainNavListItem>

--- a/packages/javascript/bh-shared-ui/src/components/Navigation/MainNav.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/Navigation/MainNav.tsx
@@ -73,7 +73,7 @@ const MainNavItemAction: FC<{ onClick: () => void; children: ReactNode; hoverAct
             onClick={onClick}
             className={cn('h-10 w-auto absolute left-4 flex items-center gap-x-2 hover:underline cursor-default', {
                 'group-hover:w-full cursor-pointer': hoverActive,
-            })}>
+            })}
             {...rest}>
             {children}
         </div>
@@ -204,7 +204,10 @@ const MainNav: FC<{ mainNavData: MainNavData }> = ({ mainNavData }) => {
                             key={itemIndex}
                             route={listDataItem.route as string}
                             hoverActive={!isMouseDragging}>
-                            <MainNavItemLink route={listDataItem.route as string} hoverActive={!isMouseDragging} data-testid={listDataItem.testId}>
+                            <MainNavItemLink
+                                route={listDataItem.route as string}
+                                hoverActive={!isMouseDragging}
+                                data-testid={listDataItem.testId}>
                                 <MainNavItemLabel
                                     icon={listDataItem.icon}
                                     label={listDataItem.label}
@@ -221,7 +224,10 @@ const MainNav: FC<{ mainNavData: MainNavData }> = ({ mainNavData }) => {
                                 key={itemIndex}
                                 route={listDataItem.route as string}
                                 hoverActive={!isMouseDragging}>
-                                <MainNavItemLink route={listDataItem.route as string} hoverActive={!isMouseDragging} data-testid={listDataItem.testId}>
+                                <MainNavItemLink
+                                    route={listDataItem.route as string}
+                                    hoverActive={!isMouseDragging}
+                                    data-testid={listDataItem.testId}>
                                     <MainNavItemLabel
                                         icon={listDataItem.icon}
                                         label={listDataItem.label}

--- a/packages/javascript/bh-shared-ui/src/components/Navigation/MainNav.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/Navigation/MainNav.tsx
@@ -59,11 +59,11 @@ const MainNavListItem: FC<{ children: ReactNode; route?: string; hoverActive: bo
     );
 };
 
-const MainNavItemAction: FC<{ onClick: () => void; children: ReactNode; hoverActive: boolean }> = ({
+const MainNavItemAction: FC<{ onClick: () => void; children: ReactNode; hoverActive: boolean; testId: string }> = ({
     onClick,
     children,
     hoverActive,
-    ...rest
+    testId,
 }) => {
     return (
         // Note: The w-full is to avoid the hover area to overflow out of the nav when its collapsed which created a flickering effect just outside the nav
@@ -74,17 +74,17 @@ const MainNavItemAction: FC<{ onClick: () => void; children: ReactNode; hoverAct
             className={cn('h-10 w-auto absolute left-4 flex items-center gap-x-2 hover:underline cursor-default', {
                 'group-hover:w-full cursor-pointer': hoverActive,
             })}
-            {...rest}>
+            data-testid={testId}>
             {children}
         </div>
     );
 };
 
-const MainNavItemLink: FC<{ route: string; children: ReactNode; hoverActive: boolean }> = ({
+const MainNavItemLink: FC<{ route: string; children: ReactNode; hoverActive: boolean; testId: string }> = ({
     route,
     children,
     hoverActive,
-    ...rest
+    testId,
 }) => {
     return (
         // Note: The w-full is to avoid the hover area to overflow out of the nav when its collapsed
@@ -93,7 +93,7 @@ const MainNavItemLink: FC<{ route: string; children: ReactNode; hoverActive: boo
             className={cn('h-10 w-auto absolute left-4 flex items-center gap-x-2 hover:underline cursor-default', {
                 'group-hover:w-full cursor-pointer': hoverActive,
             })}
-            {...rest}>
+            data-testid={testId}>
             {children}
         </RouterLink>
     );
@@ -188,7 +188,7 @@ const MainNav: FC<{ mainNavData: MainNavData }> = ({ mainNavData }) => {
             )}>
             <MainNavItemLink
                 route={mainNavData.logo.project.route}
-                data-testid='global_nav-home'
+                testId='global_nav-home'
                 hoverActive={!isMouseDragging}>
                 <MainNavItemLabel
                     icon={mainNavData.logo.project.icon}
@@ -207,7 +207,7 @@ const MainNav: FC<{ mainNavData: MainNavData }> = ({ mainNavData }) => {
                             <MainNavItemLink
                                 route={listDataItem.route as string}
                                 hoverActive={!isMouseDragging}
-                                data-testid={listDataItem.testId}>
+                                testId={listDataItem.testId}>
                                 <MainNavItemLabel
                                     icon={listDataItem.icon}
                                     label={listDataItem.label}
@@ -227,7 +227,7 @@ const MainNav: FC<{ mainNavData: MainNavData }> = ({ mainNavData }) => {
                                 <MainNavItemLink
                                     route={listDataItem.route as string}
                                     hoverActive={!isMouseDragging}
-                                    data-testid={listDataItem.testId}>
+                                    testId={listDataItem.testId}>
                                     <MainNavItemLabel
                                         icon={listDataItem.icon}
                                         label={listDataItem.label}
@@ -240,7 +240,7 @@ const MainNav: FC<{ mainNavData: MainNavData }> = ({ mainNavData }) => {
                                 <MainNavItemAction
                                     onClick={(() => listDataItem.functionHandler as () => void)()}
                                     hoverActive={!isMouseDragging}
-                                    data-testid={listDataItem.testId}>
+                                    testId={listDataItem.testId}>
                                     <MainNavItemLabel
                                         icon={listDataItem.icon}
                                         label={listDataItem.label}

--- a/packages/javascript/bh-shared-ui/src/components/Navigation/types.ts
+++ b/packages/javascript/bh-shared-ui/src/components/Navigation/types.ts
@@ -39,6 +39,7 @@ export type MainNavDataListItem = {
     icon: ReactNode;
     route?: string;
     functionHandler?: () => void;
+    testId: string;
 };
 
 export type MainNavData = {


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Added back the data-testid attributes to the nav bar items to ensure we don't break existing functionality that depends on it.

## Motivation and Context

This PR addresses: [BED-5369](https://specterops.atlassian.net/browse/BED-5369)

## How Has This Been Tested?

Manually and updated FE tests.

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)
- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


[BED-5369]: https://specterops.atlassian.net/browse/BED-5369?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ