### PR TITLE
BED-5377: Enable recreating the default admin user with environment variable

### DIFF
--- a/cmd/api/src/config/config.go
+++ b/cmd/api/src/config/config.go
@@ -165,6 +165,7 @@ type Configuration struct {
 	AuthSessionTTLHours          int                       `json:"auth_session_ttl_hours"`
 	FedRAMPEULAText              string                    `json:"fedramp_eula_text"` // Enterprise only
 	EnableTextLogger             bool                      `json:"enable_text_logger"`
+	RecreateDefaultAdmin         bool                      `json:"recreate_default_admin"`
 }
 
 func (s Configuration) AuthSessionTTL() time.Duration {

--- a/cmd/api/src/config/default.go
+++ b/cmd/api/src/config/default.go
@@ -52,6 +52,7 @@ func NewDefaultConfiguration() (Configuration, error) {
 			DisableIngest:                false,
 			DisableMigrations:            false,
 			EnableCypherMutations:        false,
+			RecreateDefaultAdmin:         false,
 			AuthSessionTTLHours:          8,     // Default to a logged in auth session time to live of 8 hours
 			GraphQueryMemoryLimit:        2,     // 2 GiB by default
 			FedRAMPEULAText:              "",    // Enterprise only

--- a/cmd/api/src/services/entrypoint.go
+++ b/cmd/api/src/services/entrypoint.go
@@ -86,6 +86,14 @@ func Entrypoint(ctx context.Context, cfg config.Configuration, connections boots
 		slog.InfoContext(ctx, "Database migrations are disabled per configuration")
 	}
 
+	// Allow recreating the default admin account to help with lockouts/loading database dumps
+	if cfg.RecreateDefaultAdmin {
+		slog.InfoContext(ctx, "Recreating default admin user")
+		if err := bootstrap.CreateDefaultAdmin(ctx, cfg, connections.RDMS); err != nil {
+			return nil, err
+		}
+	}
+
 	// Audit for duplicate email addresses
 	if nonUniqueEmailMap, err := connections.RDMS.GetAllUsersWithNonUniqueEmails(ctx); err != nil {
 		slog.WarnContext(ctx, "Failed to get all non unique email addresses", "error", err)

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -128,6 +128,7 @@ services:
       bhe_enable_cypher_mutations: ${bhe_enable_cypher_mutations:-false}
       bhe_graph_query_memory_limit: ${bhe_graph_query_memory_limit:-2}
       bhe_enable_text_logger: ${bhe_enable_text_logger:-true}
+      bhe_recreate_default_admin: ${bhe_recreate_default_admin:-false}
     ports:
       - ${BH_API_PORT:-127.0.0.1:8080}:8080
       - ${TOOLAPI_PORT:-127.0.0.1:2112}:2112
@@ -176,6 +177,12 @@ services:
       context: tools/docker-compose
       dockerfile: api.Dockerfile
     command: "-c .air.debug.toml ${AIR_FLAGS:-''}"
+    environment:
+      bhe_disable_cypher_complexity_limit: ${bhe_disable_cypher_complexity_limit:-false}
+      bhe_enable_cypher_mutations: ${bhe_enable_cypher_mutations:-false}
+      bhe_graph_query_memory_limit: ${bhe_graph_query_memory_limit:-2}
+      bhe_enable_text_logger: ${bhe_enable_text_logger:-true}
+      bhe_recreate_default_admin: ${bhe_recreate_default_admin:-false}
     ports:
       - ${BH_API_PORT:-127.0.0.1:8080}:8080
       - ${TOOLAPI_PORT:-127.0.0.1:2112}:2112

--- a/examples/docker-compose/docker-compose.yml
+++ b/examples/docker-compose/docker-compose.yml
@@ -68,6 +68,7 @@ services:
       - bhe_graph_query_memory_limit=${bhe_graph_query_memory_limit:-2}
       - bhe_database_connection=user=${POSTGRES_USER:-bloodhound} password=${POSTGRES_PASSWORD:-bloodhoundcommunityedition} dbname=${POSTGRES_DB:-bloodhound} host=app-db
       - bhe_neo4j_connection=neo4j://${NEO4J_USER:-neo4j}:${NEO4J_SECRET:-bloodhoundcommunityedition}@graph-db:7687/
+      - bhe_recreate_default_admin=${bhe_recreate_default_admin:-false}
       ### Add additional environment variables you wish to use here.
       ### For common configuration options that you might want to use environment variables for, see `.env.example`
       ### example: bhe_database_connection=${bhe_database_connection}


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Adds new environment variable to allow recreating the default admin user

## Motivation and Context

This PR addresses: BED-5377

This supports an upstream need, but also means we'll have a supported way for users to reset their admin credentials if they lose access to their account without having to reset the entire database.

## How Has This Been Tested?

Worked through some scenarios locally with a dataset, seems to handle cases where the admin doesn't yet exist, where it already exists, and won't run by default, only if the environment variable gets intentionally set to true

## Types of changes

<!-- Please remove any items that do not apply. -->

- New feature (non-breaking change which adds functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
