### PR TITLE
BED-5410: Fix invalid slog parameters in measure logs

### DIFF
--- a/packages/go/analysis/azure/tenant.go
+++ b/packages/go/analysis/azure/tenant.go
@@ -103,7 +103,7 @@ func FetchTenants(ctx context.Context, db graph.Database) (graph.NodeSet, error)
 
 // TenantRoles returns the NodeSet of roles for a given tenant that match one of the given role template IDs. If no role template ID is provided, then all of the tenant role nodes are returned in the NodeSet.
 func TenantRoles(tx graph.Transaction, tenant *graph.Node, roleTemplateIDs ...string) (graph.NodeSet, error) {
-	defer measure.Measure(slog.LevelInfo, "TenantRoles - Tenant %d", tenant.ID)()
+	defer measure.Measure(slog.LevelInfo, "TenantRoles completed", "tenant", tenant.ID)()
 
 	if !IsTenantNode(tenant) {
 		return nil, fmt.Errorf("cannot fetch tenant roles - node %d must be of kind %s", tenant.ID, azure.Tenant)

--- a/packages/go/analysis/impact/id_aggregator.go
+++ b/packages/go/analysis/impact/id_aggregator.go
@@ -214,7 +214,7 @@ func (s IDA) resolve(targetID uint64) cardinality.Provider[uint64] {
 
 func (s IDA) Cardinality(targets ...uint64) cardinality.Provider[uint64] {
 	slog.Debug(fmt.Sprintf("Calculating pathMembers cardinality for %d targets", len(targets)))
-	defer measure.Measure(slog.LevelDebug, "Calculated pathMembers cardinality for %d targets", len(targets))()
+	defer measure.Measure(slog.LevelDebug, "Calculated pathMembers cardinality", "num_targets", len(targets))()
 
 	impact := s.newCardinalityProvider()
 

--- a/packages/go/dawgs/ops/traversal.go
+++ b/packages/go/dawgs/ops/traversal.go
@@ -144,7 +144,7 @@ type TraversalContext struct {
 }
 
 func Traversal(tx graph.Transaction, plan TraversalPlan, pathVisitor PathVisitor) error {
-	defer measure.Measure(slog.LevelInfo, "Node %d Traversal", plan.Root.ID)()
+	defer measure.Measure(slog.LevelInfo, "Node Traversal", "root_id", plan.Root.ID)()
 
 	var (
 		requireTraversalOrder = plan.Limit > 0 || plan.Skip > 0


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Several of our Measure logs were incorrectly migrated to slog format during our switch to slog

## Motivation and Context

This PR addresses: BED-5410

Several of our Measure logs were incorrectly migrated to slog format during our switch to slog

## How Has This Been Tested?

All existing tests complete and the project builds, there were no logical changes

## Types of changes

<!-- Please remove any items that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
