### PR TITLE
BED-5419: Revert mistaken change to make pg the global default driver

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,9 @@ BH_PKG_MOD_VOLUME=bh-go-pkg-mod
 BH_API_PORT=127.0.0.1:8080
 TOOLAPI_PORT=127.0.0.1:2112
 
+# Graph Driver (use neo4j or pg)
+GRAPH_DRIVER=neo4j
+
 # BloodHound PG Admin
 BH_PG_ADMIN_HOSTNAME=pgadmin.localhost
 BH_PG_ADMIN_EMAIL=bloodhound@specterops.io

--- a/.github/config/integration.config.json
+++ b/.github/config/integration.config.json
@@ -9,8 +9,12 @@
     "log_path": "bhapi.log",
     "enable_startup_wait_period": false,
     "datapipe_interval": 1,
+    "graph_driver": "neo4j",
     "database": {
         "connection": "user=bloodhound password=bloodhoundcommunityedition dbname=bloodhound host=localhost port=65432"
+    },
+    "neo4j": {
+        "connection": "neo4j://neo4j:bloodhoundcommunityedition@localhost:37687/"
     },
     "default_admin": {
         "principal_name": "admin",

--- a/cmd/api/src/config/default.go
+++ b/cmd/api/src/config/default.go
@@ -19,8 +19,7 @@ package config
 import (
 	"fmt"
 
-	"github.com/specterops/bloodhound/dawgs/drivers/pg"
-
+	"github.com/specterops/bloodhound/dawgs/drivers/neo4j"
 	"github.com/specterops/bloodhound/src/serde"
 )
 
@@ -58,7 +57,7 @@ func NewDefaultConfiguration() (Configuration, error) {
 			EnableTextLogger:             false, // Default to JSON logging
 			TLS:                          TLSConfiguration{},
 			SAML:                         SAMLConfiguration{},
-			GraphDriver:                  pg.DriverName, // Default to PG as the graph driver
+			GraphDriver:                  neo4j.DriverName, // Default to PG as the graph driver
 			Database: DatabaseConfiguration{
 				MaxConcurrentSessions: 10,
 			},

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -128,6 +128,7 @@ services:
       bhe_enable_cypher_mutations: ${bhe_enable_cypher_mutations:-false}
       bhe_graph_query_memory_limit: ${bhe_graph_query_memory_limit:-2}
       bhe_enable_text_logger: ${bhe_enable_text_logger:-true}
+      bhe_graph_driver: ${bhe_graph_driver:-neo4j}
     ports:
       - ${BH_API_PORT:-127.0.0.1:8080}:8080
       - ${TOOLAPI_PORT:-127.0.0.1:2112}:2112

--- a/dockerfiles/configs/bloodhound.config.json
+++ b/dockerfiles/configs/bloodhound.config.json
@@ -6,6 +6,7 @@
   "work_dir": "/opt/bloodhound/work",
   "log_level": "INFO",
   "log_path": "bloodhound.log",
+  "graph_driver": "neo4j",
   "tls": {
     "cert_file": "",
     "key_file": ""

--- a/examples/docker-compose/.env.example
+++ b/examples/docker-compose/.env.example
@@ -1,6 +1,9 @@
 # Select the image tag to use (latest, edge, or version number)
 BLOODHOUND_TAG=latest
 
+# Graph driver switch (use neo4j or pg)
+GRAPH_DRIVER=neo4j
+
 # Postgres auth configuration
 POSTGRES_USER=bloodhound
 POSTGRES_PASSWORD=bloodhoundcommunityedition

--- a/examples/docker-compose/bloodhound.config.json
+++ b/examples/docker-compose/bloodhound.config.json
@@ -6,6 +6,7 @@
   "work_dir": "/opt/bloodhound/work",
   "log_level": "INFO",
   "log_path": "bloodhound.log",
+  "graph_driver": "neo4j",
   "tls": {
     "cert_file": "",
     "key_file": ""

--- a/examples/docker-compose/docker-compose.yml
+++ b/examples/docker-compose/docker-compose.yml
@@ -68,6 +68,7 @@ services:
       - bhe_graph_query_memory_limit=${bhe_graph_query_memory_limit:-2}
       - bhe_database_connection=user=${POSTGRES_USER:-bloodhound} password=${POSTGRES_PASSWORD:-bloodhoundcommunityedition} dbname=${POSTGRES_DB:-bloodhound} host=app-db
       - bhe_neo4j_connection=neo4j://${NEO4J_USER:-neo4j}:${NEO4J_SECRET:-bloodhoundcommunityedition}@graph-db:7687/
+      - bhe_graph_driver=${GRAPH_DRIVER:-neo4j}
       ### Add additional environment variables you wish to use here.
       ### For common configuration options that you might want to use environment variables for, see `.env.example`
       ### example: bhe_database_connection=${bhe_database_connection}

--- a/examples/helm/values.yaml
+++ b/examples/helm/values.yaml
@@ -107,6 +107,7 @@ bloodhound:
       bhe_disable_cypher_complexity_limit: "false"
       bhe_enable_cypher_mutations: "false"
       bhe_graph_query_memory_limit: "2"
+      bhe_graph_driver: "neo4j"
     ports:
       - containerPort: 8080
       - containerPort: 2112

--- a/local-harnesses/build.config.json.template
+++ b/local-harnesses/build.config.json.template
@@ -9,6 +9,7 @@
     "log_path": "bhapi.log",
     "enable_startup_wait_period": false,
     "datapipe_interval": 1,
+    "graph_driver": "neo4j",
     "database": {
         "connection": "user=bloodhound password=bloodhoundcommunityedition dbname=bloodhound host=app-db port=5432"
     },

--- a/local-harnesses/integration.config.json.template
+++ b/local-harnesses/integration.config.json.template
@@ -9,6 +9,7 @@
     "log_path": "bhapi.log",
     "enable_startup_wait_period": false,
     "datapipe_interval": 1,
+    "graph_driver": neo4j,
     "database": {
         "connection": "user=bloodhound password=bloodhoundcommunityedition dbname=bloodhound host=localhost port=65432"
     },

--- a/local-harnesses/integration.config.json.template
+++ b/local-harnesses/integration.config.json.template
@@ -13,7 +13,9 @@
     "database": {
         "connection": "user=bloodhound password=bloodhoundcommunityedition dbname=bloodhound host=localhost port=65432"
     },
-    "graph_driver": "pg",
+    "neo4j": {
+        "connection": "neo4j://neo4j:bloodhoundcommunityedition@localhost:37687/"
+    },
     "default_admin": {
         "principal_name": "admin",
         "password": "admin",


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

When preparing BHE defaults, we unintentionally turned on pg by default in BHCE. This change reverts the global default, while ensuring the default configuration files also specify neo4j for now to assist in any future migrations.

## Motivation and Context

This PR addresses: BED-5419

Make sure BHCE continues to default to neo4j as the graph database

## How Has This Been Tested?

No functional changes

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
