### PR TITLE
CySQL Fixes and Order Refactor

### DIFF
--- a/packages/go/cypher/models/pgsql/format/format.go
+++ b/packages/go/cypher/models/pgsql/format/format.go
@@ -482,14 +482,8 @@ func formatNode(builder *OutputBuilder, rootExpr pgsql.SyntaxNode) error {
 		case pgsql.Variadic:
 			exprStack = append(exprStack, typedNextExpr.Expression, pgsql.FormattingLiteral("variadic "))
 
-		case pgsql.CompoundExpression:
-			for idx := len(typedNextExpr) - 1; idx >= 0; idx-- {
-				exprStack = append(exprStack, typedNextExpr[idx])
-
-				if idx > 0 {
-					exprStack = append(exprStack, pgsql.FormattingLiteral("."))
-				}
-			}
+		case pgsql.RowColumnReference:
+			exprStack = append(exprStack, typedNextExpr.Column, pgsql.FormattingLiteral(")."), typedNextExpr.Identifier, pgsql.FormattingLiteral("("))
 
 		case pgsql.ExistsExpression:
 			exprStack = append(exprStack, typedNextExpr.Subquery, pgsql.FormattingLiteral("exists "))
@@ -519,6 +513,9 @@ func formatNode(builder *OutputBuilder, rootExpr pgsql.SyntaxNode) error {
 
 		case pgsql.Subquery:
 			exprStack = append(exprStack, pgsql.FormattingLiteral(")"), typedNextExpr.Query, pgsql.FormattingLiteral("("))
+
+		case pgsql.SyntaxNodeFuture:
+			exprStack = append(exprStack, typedNextExpr.Unwrap())
 
 		default:
 			return fmt.Errorf("unable to format pgsql node type: %T", nextExpr)
@@ -1097,7 +1094,9 @@ func Statement(statement pgsql.Statement, builder *OutputBuilder) (string, error
 	return builder.Build(), nil
 }
 
-func SyntaxNode(node pgsql.SyntaxNode, builder *OutputBuilder) (string, error) {
+func SyntaxNode(node pgsql.SyntaxNode) (string, error) {
+	builder := NewOutputBuilder()
+
 	switch typedNode := node.(type) {
 	case pgsql.Statement:
 		return Statement(typedNode, builder)

--- a/packages/go/cypher/models/pgsql/identifiers.go
+++ b/packages/go/cypher/models/pgsql/identifiers.go
@@ -29,7 +29,7 @@ const (
 )
 
 var reservedIdentifiers = []Identifier{
-	EpochIdentifier,
+	EpochIdentifier, WildcardIdentifier,
 }
 
 func IsReservedIdentifier(identifier Identifier) bool {

--- a/packages/go/cypher/models/pgsql/nodes.go
+++ b/packages/go/cypher/models/pgsql/nodes.go
@@ -23,6 +23,21 @@ type SyntaxNode interface {
 	NodeType() string
 }
 
+// WrappedNode is an interface that allows for an expression to be wrapped to allow for side effects like futures.
+type WrappedNode interface {
+	SyntaxNode
+}
+
+// SyntaxNodeFuture is a SyntaxNode that can be satisfied out-of-tree and communicate if it has been satisfied to
+// upstream consumers. This is useful when a SyntaxNode is required to be embedded in a built syntax tree but
+// can not be formally built itself due to ordering or missing dependency information (in the case of an
+// existential subquery).
+type SyntaxNodeFuture interface {
+	SyntaxNode
+	Unwrap() SyntaxNode
+	Satisfied() bool
+}
+
 // Statement is a syntax node that does not evaluate to a value.
 type Statement interface {
 	SyntaxNode

--- a/packages/go/cypher/models/pgsql/pgtypes.go
+++ b/packages/go/cypher/models/pgsql/pgtypes.go
@@ -89,7 +89,7 @@ const (
 	JSONB         DataType = "jsonb"
 	Numeric       DataType = "numeric"
 
-	AnyArray           DataType = "any[]"
+	AnyArray           DataType = "anyarray"
 	NodeCompositeArray DataType = "nodecomposite[]"
 	EdgeCompositeArray DataType = "edgecomposite[]"
 	IntArray           DataType = "int[]"
@@ -110,7 +110,6 @@ const (
 	TimestampWithoutTimeZone DataType = "timestamp without time zone"
 
 	Scope                 DataType = "scope"
-	InlineProjection      DataType = "inline_projection"
 	ParameterIdentifier   DataType = "parameter_identifier"
 	ExpansionPattern      DataType = "expansion_pattern"
 	ExpansionPath         DataType = "expansion_path"

--- a/packages/go/cypher/models/pgsql/test/translation_cases/delete.sql
+++ b/packages/go/cypher/models/pgsql/test/translation_cases/delete.sql
@@ -18,40 +18,36 @@
 with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0
             from node n0
             where n0.kind_ids operator (pg_catalog.&&) array [1]::int2[]),
-     s1
-       as (delete from node n1 using s0 where (s0.n0).id = n1.id returning (n1.id, n1.kind_ids, n1.properties)::nodecomposite as n0)
+     s1 as (delete from node n1 using s0 where (s0.n0).id = n1.id)
 select 1;
 
 -- case: match ()-[r:EdgeKind1]->() delete r
-with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite                        as n0,
-                   (e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite as e0,
+with s0 as (select (e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite as e0,
+                   (n0.id, n0.kind_ids, n0.properties)::nodecomposite                        as n0,
                    (n1.id, n1.kind_ids, n1.properties)::nodecomposite                        as n1
             from edge e0
                    join node n0 on n0.id = e0.start_id
                    join node n1 on n1.id = e0.end_id
             where e0.kind_id = any (array [3]::int2[])),
-     s1
-       as (delete from edge e1 using s0 where (s0.e0).id = e1.id returning (e1.id, e1.start_id, e1.end_id, e1.kind_id, e1.properties)::edgecomposite as e0, s0.n0 as n0, s0.n1 as n1)
+     s1 as (delete from edge e1 using s0 where (s0.e0).id = e1.id)
 select 1;
 
 -- case: match ()-[]->()-[r:EdgeKind1]->() delete r
-with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite                        as n0,
-                   (e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite as e0,
+with s0 as (select (e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite as e0,
+                   (n0.id, n0.kind_ids, n0.properties)::nodecomposite                        as n0,
                    (n1.id, n1.kind_ids, n1.properties)::nodecomposite                        as n1
             from edge e0
                    join node n0 on n0.id = e0.start_id
                    join node n1 on n1.id = e0.end_id),
      s1 as (select s0.e0                                                                     as e0,
+                   (e1.id, e1.start_id, e1.end_id, e1.kind_id, e1.properties)::edgecomposite as e1,
                    s0.n0                                                                     as n0,
                    s0.n1                                                                     as n1,
-                   (e1.id, e1.start_id, e1.end_id, e1.kind_id, e1.properties)::edgecomposite as e1,
                    (n2.id, n2.kind_ids, n2.properties)::nodecomposite                        as n2
             from s0,
                  edge e1
                    join node n2 on n2.id = e1.end_id
             where e1.kind_id = any (array [3]::int2[])
               and (s0.n1).id = e1.start_id),
-     s2
-       as (delete from edge e2 using s1 where (s1.e1).id = e2.id returning s1.e0 as e0, (e2.id, e2.start_id, e2.end_id, e2.kind_id, e2.properties)::edgecomposite as e1, s1.n0 as n0, s1.n1 as n1, s1.n2 as n2)
+     s2 as (delete from edge e2 using s1 where (s1.e1).id = e2.id)
 select 1;
-

--- a/packages/go/cypher/models/pgsql/test/translation_cases/multipart.sql
+++ b/packages/go/cypher/models/pgsql/test/translation_cases/multipart.sql
@@ -27,8 +27,8 @@ from s1;
 -- case: match (n:NodeKind1) where n.value = 1 with n match (b) where id(b) = id(n) return b
 with s0 as (with s1 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0
                         from node n0
-                        where n0.kind_ids operator (pg_catalog.&&) array [1]::int2[]
-                          and (n0.properties ->> 'value')::int8 = 1)
+                        where (n0.properties ->> 'value')::int8 = 1
+                          and n0.kind_ids operator (pg_catalog.&&) array [1]::int2[])
             select s1.n0 as n0
             from s1),
      s2 as (select s0.n0 as n0, (n1.id, n1.kind_ids, n1.properties)::nodecomposite as n1
@@ -41,8 +41,8 @@ from s2;
 -- case: match (n:NodeKind1) where n.value = 1 with n match (f) where f.name = 'me' with f match (b) where id(b) = id(f) return b
 with s0 as (with s1 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0
                         from node n0
-                        where n0.kind_ids operator (pg_catalog.&&) array [1]::int2[]
-                          and (n0.properties ->> 'value')::int8 = 1)
+                        where (n0.properties ->> 'value')::int8 = 1
+                          and n0.kind_ids operator (pg_catalog.&&) array [1]::int2[])
             select s1.n0 as n0
             from s1),
      s2 as (with s3 as (select s0.n0 as n0, (n1.id, n1.kind_ids, n1.properties)::nodecomposite as n1
@@ -58,130 +58,126 @@ select s4.n2 as b
 from s4;
 
 -- case: match (n:NodeKind1)-[:EdgeKind1*1..]->(:NodeKind2)-[:EdgeKind2]->(m:NodeKind1) where (n:NodeKind1 or n:NodeKind2) and n.enabled = true with m, collect(distinct(n)) as p where size(p) >= 10 return m
-with s0 as (with s1 as (with recursive ex0(root_id, next_id, depth, satisfied, is_cycle, path) as (select e0.start_id,
-                                                                                                          e0.end_id,
-                                                                                                          1,
-                                                                                                          n1.kind_ids operator (pg_catalog.&&) array [2]::int2[],
-                                                                                                          e0.start_id = e0.end_id,
-                                                                                                          array [e0.id]
-                                                                                                   from edge e0
-                                                                                                          join node n0
-                                                                                                               on
-                                                                                                                 n0.kind_ids operator (pg_catalog.&&)
-                                                                                                                 array [1]::int2[] and
-                                                                                                                 (n0.kind_ids operator (pg_catalog.&&)
-                                                                                                                  array [1]::int2[] or
-                                                                                                                  n0.kind_ids operator (pg_catalog.&&)
-                                                                                                                  array [2]::int2[]) and
-                                                                                                                 (n0.properties ->> 'enabled')::bool =
-                                                                                                                 true and
-                                                                                                                 n0.id =
-                                                                                                                 e0.start_id
-                                                                                                          join node n1 on n1.id = e0.end_id
-                                                                                                   where e0.kind_id = any (array [3]::int2[])
-                                                                                                   union
-                                                                                                   select ex0.root_id,
-                                                                                                          e0.end_id,
-                                                                                                          ex0.depth + 1,
-                                                                                                          n1.kind_ids operator (pg_catalog.&&) array [2]::int2[],
-                                                                                                          e0.id = any (ex0.path),
-                                                                                                          ex0.path || e0.id
-                                                                                                   from ex0
-                                                                                                          join edge e0 on e0.start_id = ex0.next_id
-                                                                                                          join node n1 on n1.id = e0.end_id
-                                                                                                   where ex0.depth < 10
-                                                                                                     and not ex0.is_cycle
-                                                                                                     and e0.kind_id = any (array [3]::int2[]))
-                        select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0,
-                               (select array_agg((e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite)
+with s0 as (with s1 as (with recursive s2(root_id, next_id, depth, satisfied, is_cycle, path) as (select e0.start_id,
+                                                                                                         e0.end_id,
+                                                                                                         1,
+                                                                                                         n1.kind_ids operator (pg_catalog.&&) array [2]::int2[],
+                                                                                                         e0.start_id = e0.end_id,
+                                                                                                         array [e0.id]
+                                                                                                  from edge e0
+                                                                                                         join node n0 on
+                                                                                                    (n0.kind_ids operator (pg_catalog.&&)
+                                                                                                     array [1]::int2[] or
+                                                                                                     n0.kind_ids operator (pg_catalog.&&)
+                                                                                                     array [2]::int2[]) and
+                                                                                                    (n0.properties ->> 'enabled')::bool =
+                                                                                                    true and
+                                                                                                    n0.kind_ids operator (pg_catalog.&&)
+                                                                                                    array [1]::int2[] and
+                                                                                                    n0.id = e0.start_id
+                                                                                                         join node n1 on n1.id = e0.end_id
+                                                                                                  where e0.kind_id = any (array [3]::int2[])
+                                                                                                  union
+                                                                                                  select s2.root_id,
+                                                                                                         e0.end_id,
+                                                                                                         s2.depth + 1,
+                                                                                                         n1.kind_ids operator (pg_catalog.&&) array [2]::int2[],
+                                                                                                         e0.id = any (s2.path),
+                                                                                                         s2.path || e0.id
+                                                                                                  from s2
+                                                                                                         join edge e0 on e0.start_id = s2.next_id
+                                                                                                         join node n1 on n1.id = e0.end_id
+                                                                                                  where s2.depth < 10
+                                                                                                    and not s2.is_cycle
+                                                                                                    and e0.kind_id = any (array [3]::int2[]))
+                        select (select array_agg((e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite)
                                 from edge e0
-                                where e0.id = any (ex0.path))                     as e0,
-                               ex0.path                                           as ep0,
+                                where e0.id = any (s2.path))                      as e0,
+                               s2.path                                            as ep0,
+                               (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0,
                                (n1.id, n1.kind_ids, n1.properties)::nodecomposite as n1
-                        from ex0
-                               join edge e0 on e0.id = any (ex0.path)
-                               join node n0 on n0.id = ex0.root_id
-                               join node n1 on e0.id = ex0.path[array_length(ex0.path, 1)::int] and n1.id = e0.end_id
-                        where ex0.satisfied),
-                 s2 as (select s1.e0                                                                     as e0,
+                        from s2
+                               join edge e0 on e0.id = any (s2.path)
+                               join node n0 on n0.id = s2.root_id
+                               join node n1 on e0.id = s2.path[array_length(s2.path, 1)::int] and n1.id = e0.end_id
+                        where s2.satisfied),
+                 s3 as (select s1.e0                                                                     as e0,
+                               (e1.id, e1.start_id, e1.end_id, e1.kind_id, e1.properties)::edgecomposite as e1,
                                s1.ep0                                                                    as ep0,
                                s1.n0                                                                     as n0,
                                s1.n1                                                                     as n1,
-                               (e1.id, e1.start_id, e1.end_id, e1.kind_id, e1.properties)::edgecomposite as e1,
                                (n2.id, n2.kind_ids, n2.properties)::nodecomposite                        as n2
                         from s1,
                              edge e1
                                join node n2
                                     on n2.kind_ids operator (pg_catalog.&&) array [1]::int2[] and n2.id = e1.end_id
                         where e1.kind_id = any (array [4]::int2[])
-                          and (s1.n1).id = e1.start_id)
-            select s2.n2 as n2, array_agg(distinct (n0))::nodecomposite[] as i0
-            from s2
+                          and (s1.e0[array_length(s1.e0, 1)::int]).end_id = e1.start_id)
+            select s3.n2 as n2, array_agg(distinct (n0))::nodecomposite[] as i0
+            from s3
             group by n2)
 select s0.n2 as m
 from s0
 where array_length(s0.i0, 1)::int >= 10;
 
 -- case: match (n:NodeKind1)-[:EdgeKind1*1..]->(:NodeKind2)-[:EdgeKind2]->(m:NodeKind1) where (n:NodeKind1 or n:NodeKind2) and n.enabled = true with m, count(distinct(n)) as p where p >= 10 return m
-with s0 as (with s1 as (with recursive ex0(root_id, next_id, depth, satisfied, is_cycle, path) as (select e0.start_id,
-                                                                                                          e0.end_id,
-                                                                                                          1,
-                                                                                                          n1.kind_ids operator (pg_catalog.&&) array [2]::int2[],
-                                                                                                          e0.start_id = e0.end_id,
-                                                                                                          array [e0.id]
-                                                                                                   from edge e0
-                                                                                                          join node n0
-                                                                                                               on
-                                                                                                                 n0.kind_ids operator (pg_catalog.&&)
-                                                                                                                 array [1]::int2[] and
-                                                                                                                 (n0.kind_ids operator (pg_catalog.&&)
-                                                                                                                  array [1]::int2[] or
-                                                                                                                  n0.kind_ids operator (pg_catalog.&&)
-                                                                                                                  array [2]::int2[]) and
-                                                                                                                 (n0.properties ->> 'enabled')::bool =
-                                                                                                                 true and
-                                                                                                                 n0.id =
-                                                                                                                 e0.start_id
-                                                                                                          join node n1 on n1.id = e0.end_id
-                                                                                                   where e0.kind_id = any (array [3]::int2[])
-                                                                                                   union
-                                                                                                   select ex0.root_id,
-                                                                                                          e0.end_id,
-                                                                                                          ex0.depth + 1,
-                                                                                                          n1.kind_ids operator (pg_catalog.&&) array [2]::int2[],
-                                                                                                          e0.id = any (ex0.path),
-                                                                                                          ex0.path || e0.id
-                                                                                                   from ex0
-                                                                                                          join edge e0 on e0.start_id = ex0.next_id
-                                                                                                          join node n1 on n1.id = e0.end_id
-                                                                                                   where ex0.depth < 10
-                                                                                                     and not ex0.is_cycle
-                                                                                                     and e0.kind_id = any (array [3]::int2[]))
-                        select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0,
-                               (select array_agg((e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite)
+with s0 as (with s1 as (with recursive s2(root_id, next_id, depth, satisfied, is_cycle, path) as (select e0.start_id,
+                                                                                                         e0.end_id,
+                                                                                                         1,
+                                                                                                         n1.kind_ids operator (pg_catalog.&&) array [2]::int2[],
+                                                                                                         e0.start_id = e0.end_id,
+                                                                                                         array [e0.id]
+                                                                                                  from edge e0
+                                                                                                         join node n0 on
+                                                                                                    (n0.kind_ids operator (pg_catalog.&&)
+                                                                                                     array [1]::int2[] or
+                                                                                                     n0.kind_ids operator (pg_catalog.&&)
+                                                                                                     array [2]::int2[]) and
+                                                                                                    (n0.properties ->> 'enabled')::bool =
+                                                                                                    true and
+                                                                                                    n0.kind_ids operator (pg_catalog.&&)
+                                                                                                    array [1]::int2[] and
+                                                                                                    n0.id = e0.start_id
+                                                                                                         join node n1 on n1.id = e0.end_id
+                                                                                                  where e0.kind_id = any (array [3]::int2[])
+                                                                                                  union
+                                                                                                  select s2.root_id,
+                                                                                                         e0.end_id,
+                                                                                                         s2.depth + 1,
+                                                                                                         n1.kind_ids operator (pg_catalog.&&) array [2]::int2[],
+                                                                                                         e0.id = any (s2.path),
+                                                                                                         s2.path || e0.id
+                                                                                                  from s2
+                                                                                                         join edge e0 on e0.start_id = s2.next_id
+                                                                                                         join node n1 on n1.id = e0.end_id
+                                                                                                  where s2.depth < 10
+                                                                                                    and not s2.is_cycle
+                                                                                                    and e0.kind_id = any (array [3]::int2[]))
+                        select (select array_agg((e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite)
                                 from edge e0
-                                where e0.id = any (ex0.path))                     as e0,
-                               ex0.path                                           as ep0,
+                                where e0.id = any (s2.path))                      as e0,
+                               s2.path                                            as ep0,
+                               (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0,
                                (n1.id, n1.kind_ids, n1.properties)::nodecomposite as n1
-                        from ex0
-                               join edge e0 on e0.id = any (ex0.path)
-                               join node n0 on n0.id = ex0.root_id
-                               join node n1 on e0.id = ex0.path[array_length(ex0.path, 1)::int] and n1.id = e0.end_id
-                        where ex0.satisfied),
-                 s2 as (select s1.e0                                                                     as e0,
+                        from s2
+                               join edge e0 on e0.id = any (s2.path)
+                               join node n0 on n0.id = s2.root_id
+                               join node n1 on e0.id = s2.path[array_length(s2.path, 1)::int] and n1.id = e0.end_id
+                        where s2.satisfied),
+                 s3 as (select s1.e0                                                                     as e0,
+                               (e1.id, e1.start_id, e1.end_id, e1.kind_id, e1.properties)::edgecomposite as e1,
                                s1.ep0                                                                    as ep0,
                                s1.n0                                                                     as n0,
                                s1.n1                                                                     as n1,
-                               (e1.id, e1.start_id, e1.end_id, e1.kind_id, e1.properties)::edgecomposite as e1,
                                (n2.id, n2.kind_ids, n2.properties)::nodecomposite                        as n2
                         from s1,
                              edge e1
                                join node n2
                                     on n2.kind_ids operator (pg_catalog.&&) array [1]::int2[] and n2.id = e1.end_id
                         where e1.kind_id = any (array [4]::int2[])
-                          and (s1.n1).id = e1.start_id)
-            select s2.n2 as n2, count((n0))::int8 as i0
-            from s2
+                          and (s1.e0[array_length(s1.e0, 1)::int]).end_id = e1.start_id)
+            select s3.n2 as n2, count((n0))::int8 as i0
+            from s3
             group by n2)
 select s0.n2 as m
 from s0
@@ -192,8 +188,8 @@ with s0 as (select 365 as i0),
      s1 as (select s0.i0 as i0, (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0
             from s0,
                  node n0
-            where n0.kind_ids operator (pg_catalog.&&) array [1]::int2[]
-              and not (n0.properties ->> 'pwdlastset')::float8 = any (array [- 1, 0]::float8[])
+            where not (n0.properties ->> 'pwdlastset')::float8 = any (array [- 1, 0]::float8[])
+              and n0.kind_ids operator (pg_catalog.&&) array [1]::int2[]
               and (n0.properties ->> 'pwdlastset')::numeric <
                   (extract(epoch from now()::timestamp with time zone)::numeric - (s0.i0 * 86400)))
 select s1.n0 as n
@@ -203,48 +199,49 @@ limit 100;
 -- case: match (n:NodeKind1) where n.hasspn = true and n.enabled = true and not n.objectid ends with '-502' and not coalesce(n.gmsa, false) = true and not coalesce(n.msa, false) = true match (n)-[:EdgeKind1|EdgeKind2*1..]->(c:NodeKind2) with distinct n, count(c) as adminCount return n order by adminCount desc limit 100
 with s0 as (with s1 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0
                         from node n0
-                        where n0.kind_ids operator (pg_catalog.&&) array [1]::int2[]
-                          and (n0.properties ->> 'hasspn')::bool = true
+                        where (n0.properties ->> 'hasspn')::bool = true
                           and (n0.properties ->> 'enabled')::bool = true
                           and not coalesce(n0.properties ->> 'objectid', '')::text like '%-502'
                           and not coalesce((n0.properties ->> 'gmsa')::bool, false)::bool = true
-                          and not coalesce((n0.properties ->> 'msa')::bool, false)::bool = true),
-                 s2 as (with recursive ex0(root_id, next_id, depth, satisfied, is_cycle, path) as (select e0.start_id,
-                                                                                                          e0.end_id,
-                                                                                                          1,
-                                                                                                          n1.kind_ids operator (pg_catalog.&&) array [2]::int2[],
-                                                                                                          e0.start_id = e0.end_id,
-                                                                                                          array [e0.id]
-                                                                                                   from s1
-                                                                                                          join edge e0 on e0.start_id = (s1.n0).id
-                                                                                                          join node n0 on n0.id = e0.start_id
-                                                                                                          join node n1 on n1.id = e0.end_id
-                                                                                                   where e0.kind_id = any (array [3, 4]::int2[])
-                                                                                                   union
-                                                                                                   select ex0.root_id,
-                                                                                                          e0.end_id,
-                                                                                                          ex0.depth + 1,
-                                                                                                          n1.kind_ids operator (pg_catalog.&&) array [2]::int2[],
-                                                                                                          e0.id = any (ex0.path),
-                                                                                                          ex0.path || e0.id
-                                                                                                   from ex0
-                                                                                                          join edge e0 on e0.start_id = ex0.next_id
-                                                                                                          join node n1 on n1.id = e0.end_id
-                                                                                                   where ex0.depth < 10
-                                                                                                     and not ex0.is_cycle
-                                                                                                     and e0.kind_id = any (array [3, 4]::int2[]))
-                        select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0,
-                               (select array_agg((e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite)
+                          and not coalesce((n0.properties ->> 'msa')::bool, false)::bool = true
+                          and n0.kind_ids operator (pg_catalog.&&) array [1]::int2[]),
+                 s2 as (with recursive s3(root_id, next_id, depth, satisfied, is_cycle, path) as (select e0.start_id,
+                                                                                                         e0.end_id,
+                                                                                                         1,
+                                                                                                         n1.kind_ids operator (pg_catalog.&&) array [2]::int2[],
+                                                                                                         e0.start_id = e0.end_id,
+                                                                                                         array [e0.id]
+                                                                                                  from s1
+                                                                                                         join edge e0 on e0.start_id = (s1.n0).id
+                                                                                                         join node n0 on (s1.n0).id = e0.start_id
+                                                                                                         join node n1 on n1.id = e0.end_id
+                                                                                                  where e0.kind_id = any (array [3, 4]::int2[])
+                                                                                                  union
+                                                                                                  select s3.root_id,
+                                                                                                         e0.end_id,
+                                                                                                         s3.depth + 1,
+                                                                                                         n1.kind_ids operator (pg_catalog.&&) array [2]::int2[],
+                                                                                                         e0.id = any (s3.path),
+                                                                                                         s3.path || e0.id
+                                                                                                  from s3
+                                                                                                         join edge e0 on e0.start_id = s3.next_id
+                                                                                                         join node n1 on n1.id = e0.end_id
+                                                                                                  where s3.depth < 10
+                                                                                                    and not s3.is_cycle
+                                                                                                    and e0.kind_id = any (array [3, 4]::int2[]))
+                        select (select array_agg((e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite)
                                 from edge e0
-                                where e0.id = any (ex0.path))                     as e0,
-                               ex0.path                                           as ep0,
+                                where e0.id = any (s3.path))                      as e0,
+                               s3.path                                            as ep0,
+                               s1.n0                                              as n0,
                                (n1.id, n1.kind_ids, n1.properties)::nodecomposite as n1
-                        from ex0
-                               join edge e0 on e0.id = any (ex0.path)
-                               join node n0 on n0.id = ex0.root_id
-                               join node n1 on e0.id = ex0.path[array_length(ex0.path, 1)::int] and n1.id = e0.end_id
-                        where ex0.satisfied)
-            select s2.n0 as n0, count(n1)::int8 as i0
+                        from s1,
+                             s3
+                               join edge e0 on e0.id = any (s3.path)
+                               join node n0 on n0.id = s3.root_id
+                               join node n1 on e0.id = s3.path[array_length(s3.path, 1)::int] and n1.id = e0.end_id
+                        where s3.satisfied)
+            select s2.n0 as n0, count(s2.n1)::int8 as i0
             from s2
             group by n0)
 select s0.n0 as n
@@ -255,45 +252,168 @@ limit 100;
 -- case: match (n:NodeKind1) where n.objectid = 'S-1-5-21-1260426776-3623580948-1897206385-23225' match p = (n)-[:EdgeKind1|EdgeKind2*1..]->(c:NodeKind2) return p
 with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0
             from node n0
-            where n0.kind_ids operator (pg_catalog.&&) array [1]::int2[]
-              and n0.properties ->> 'objectid' = 'S-1-5-21-1260426776-3623580948-1897206385-23225'),
-     s1 as (with recursive ex0(root_id, next_id, depth, satisfied, is_cycle, path) as (select e0.start_id,
-                                                                                              e0.end_id,
-                                                                                              1,
-                                                                                              n1.kind_ids operator (pg_catalog.&&) array [2]::int2[],
-                                                                                              e0.start_id = e0.end_id,
-                                                                                              array [e0.id]
-                                                                                       from s0
-                                                                                              join edge e0 on e0.start_id = (s0.n0).id
-                                                                                              join node n0 on n0.id = e0.start_id
-                                                                                              join node n1 on n1.id = e0.end_id
-                                                                                       where e0.kind_id = any (array [3, 4]::int2[])
-                                                                                       union
-                                                                                       select ex0.root_id,
-                                                                                              e0.end_id,
-                                                                                              ex0.depth + 1,
-                                                                                              n1.kind_ids operator (pg_catalog.&&) array [2]::int2[],
-                                                                                              e0.id = any (ex0.path),
-                                                                                              ex0.path || e0.id
-                                                                                       from ex0
-                                                                                              join edge e0 on e0.start_id = ex0.next_id
-                                                                                              join node n1 on n1.id = e0.end_id
-                                                                                       where ex0.depth < 10
-                                                                                         and not ex0.is_cycle
-                                                                                         and e0.kind_id = any (array [3, 4]::int2[]))
-            select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0,
-                   (select array_agg((e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite)
+            where n0.properties ->> 'objectid' = 'S-1-5-21-1260426776-3623580948-1897206385-23225'
+              and n0.kind_ids operator (pg_catalog.&&) array [1]::int2[]),
+     s1 as (with recursive s2(root_id, next_id, depth, satisfied, is_cycle, path) as (select e0.start_id,
+                                                                                             e0.end_id,
+                                                                                             1,
+                                                                                             n1.kind_ids operator (pg_catalog.&&) array [2]::int2[],
+                                                                                             e0.start_id = e0.end_id,
+                                                                                             array [e0.id]
+                                                                                      from s0
+                                                                                             join edge e0 on e0.start_id = (s0.n0).id
+                                                                                             join node n0 on (s0.n0).id = e0.start_id
+                                                                                             join node n1 on n1.id = e0.end_id
+                                                                                      where e0.kind_id = any (array [3, 4]::int2[])
+                                                                                      union
+                                                                                      select s2.root_id,
+                                                                                             e0.end_id,
+                                                                                             s2.depth + 1,
+                                                                                             n1.kind_ids operator (pg_catalog.&&) array [2]::int2[],
+                                                                                             e0.id = any (s2.path),
+                                                                                             s2.path || e0.id
+                                                                                      from s2
+                                                                                             join edge e0 on e0.start_id = s2.next_id
+                                                                                             join node n1 on n1.id = e0.end_id
+                                                                                      where s2.depth < 10
+                                                                                        and not s2.is_cycle
+                                                                                        and e0.kind_id = any (array [3, 4]::int2[]))
+            select (select array_agg((e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite)
                     from edge e0
-                    where e0.id = any (ex0.path))                     as e0,
-                   ex0.path                                           as ep0,
+                    where e0.id = any (s2.path))                      as e0,
+                   s2.path                                            as ep0,
+                   s0.n0                                              as n0,
                    (n1.id, n1.kind_ids, n1.properties)::nodecomposite as n1
-            from ex0
-                   join edge e0 on e0.id = any (ex0.path)
-                   join node n0 on n0.id = ex0.root_id
-                   join node n1 on e0.id = ex0.path[array_length(ex0.path, 1)::int] and n1.id = e0.end_id
-            where ex0.satisfied)
+            from s0,
+                 s2
+                   join edge e0 on e0.id = any (s2.path)
+                   join node n0 on n0.id = s2.root_id
+                   join node n1 on e0.id = s2.path[array_length(s2.path, 1)::int] and n1.id = e0.end_id
+            where s2.satisfied)
 select edges_to_path(variadic ep0)::pathcomposite as p
 from s1;
 
--- todo: match (dc)-[r:EdgeKind1*0..]->(g:NodeKind1) where g.objectid ends with '-516' with collect(dc) as exclude match p = (c:NodeKind2)-[n:EdgeKind2]->(u:NodeKind2)-[:EdgeKind2*1..]->(g:NodeKind1) where g.objectid ends with '-512' and not c in exclude return p limit 100
-;
+-- case: match (g1:NodeKind1) where g1.name starts with 'test' with collect (g1.domain) as excludes match (d:NodeKind2) where d.name starts with 'other' and not d.name in excludes return d
+with s0 as (with s1 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0
+                        from node n0
+                        where n0.properties ->> 'name' like 'test%'
+                          and n0.kind_ids operator (pg_catalog.&&) array [1]::int2[])
+            select array_agg((s1.n0).properties ->> 'domain')::anyarray as i0
+            from s1),
+     s2 as (select s0.i0 as i0, (n1.id, n1.kind_ids, n1.properties)::nodecomposite as n1
+            from s0,
+                 node n1
+            where n1.properties ->> 'name' like 'other%'
+              and n1.kind_ids operator (pg_catalog.&&) array [2]::int2[]
+              and not n1.properties ->> 'name' = any (i0))
+select s2.n1 as d
+from s2;
+
+-- case: with 'a' as uname match (o:NodeKind1) where o.name starts with uname and o.domain = ' ' return o
+with s0 as (select 'a' as i0),
+     s1 as (select s0.i0 as i0, (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0
+            from s0,
+                 node n0
+            where n0.properties ->> 'domain' = ' '
+              and n0.kind_ids operator (pg_catalog.&&) array [1]::int2[]
+              and n0.properties ->> 'name' like s0.i0 || '%')
+select s1.n0 as o
+from s1;
+
+-- case: match (dc)-[r:EdgeKind1*0..]->(g:NodeKind1) where g.objectid ends with '-516' with collect(dc) as exclude match p = (c:NodeKind2)-[n:EdgeKind2]->(u:NodeKind2)-[:EdgeKind2*1..]->(g:NodeKind1) where g.objectid ends with '-512' and not c in exclude return p limit 100
+with s0 as (with s1 as (with recursive s2(root_id, next_id, depth, satisfied, is_cycle, path) as (select e0.start_id,
+                                                                                                         e0.end_id,
+                                                                                                         1,
+                                                                                                         n1.properties ->>
+                                                                                                         'objectid' like
+                                                                                                         '%-516' and
+                                                                                                         n1.kind_ids operator (pg_catalog.&&)
+                                                                                                         array [1]::int2[],
+                                                                                                         e0.start_id = e0.end_id,
+                                                                                                         array [e0.id]
+                                                                                                  from edge e0
+                                                                                                         join node n0 on n0.id = e0.start_id
+                                                                                                         join node n1 on n1.id = e0.end_id
+                                                                                                  where e0.kind_id = any (array [3]::int2[])
+                                                                                                  union
+                                                                                                  select s2.root_id,
+                                                                                                         e0.end_id,
+                                                                                                         s2.depth + 1,
+                                                                                                         n1.properties ->>
+                                                                                                         'objectid' like
+                                                                                                         '%-516' and
+                                                                                                         n1.kind_ids operator (pg_catalog.&&)
+                                                                                                         array [1]::int2[],
+                                                                                                         e0.id = any (s2.path),
+                                                                                                         s2.path || e0.id
+                                                                                                  from s2
+                                                                                                         join edge e0 on e0.start_id = s2.next_id
+                                                                                                         join node n1 on n1.id = e0.end_id
+                                                                                                  where s2.depth < 10
+                                                                                                    and not s2.is_cycle
+                                                                                                    and e0.kind_id = any (array [3]::int2[]))
+                        select (select array_agg((e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite)
+                                from edge e0
+                                where e0.id = any (s2.path))                      as e0,
+                               s2.path                                            as ep0,
+                               (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0,
+                               (n1.id, n1.kind_ids, n1.properties)::nodecomposite as n1
+                        from s2
+                               join edge e0 on e0.id = any (s2.path)
+                               join node n0 on n0.id = s2.root_id
+                               join node n1 on e0.id = s2.path[array_length(s2.path, 1)::int] and n1.id = e0.end_id
+                        where s2.satisfied)
+            select array_agg(s1.n0)::nodecomposite[] as i0
+            from s1),
+     s3 as (select (e1.id, e1.start_id, e1.end_id, e1.kind_id, e1.properties)::edgecomposite as e1,
+                   s0.i0                                                                     as i0,
+                   (n2.id, n2.kind_ids, n2.properties)::nodecomposite                        as n2,
+                   (n3.id, n3.kind_ids, n3.properties)::nodecomposite                        as n3
+            from s0,
+                 edge e1
+                   join node n2 on n2.kind_ids operator (pg_catalog.&&) array [2]::int2[] and n2.id = e1.start_id
+                   join node n3 on n3.kind_ids operator (pg_catalog.&&) array [2]::int2[] and n3.id = e1.end_id
+            where e1.kind_id = any (array [4]::int2[])
+              and not n2.id = any (i0.id)),
+     s4 as (with recursive s5(root_id, next_id, depth, satisfied, is_cycle, path) as (select e2.start_id,
+                                                                                             e2.end_id,
+                                                                                             1,
+                                                                                             false,
+                                                                                             e2.start_id = e2.end_id,
+                                                                                             array [e2.id]
+                                                                                      from s3
+                                                                                             join edge e2
+                                                                                                  on e2.kind_id = any (array [4]::int2[]) and (s3.n3).id = e2.start_id
+                                                                                             join node n4 on n4.id = e2.end_id
+                                                                                      union
+                                                                                      select s5.root_id,
+                                                                                             e2.end_id,
+                                                                                             s5.depth + 1,
+                                                                                             n4.properties ->>
+                                                                                             'objectid' like '%-512' and
+                                                                                             n4.kind_ids operator (pg_catalog.&&)
+                                                                                             array [1]::int2[],
+                                                                                             e2.id = any (s5.path),
+                                                                                             s5.path || e2.id
+                                                                                      from s5
+                                                                                             join edge e2 on e2.start_id = s5.next_id
+                                                                                             join node n4 on n4.id = e2.end_id
+                                                                                      where s5.depth < 10
+                                                                                        and not s5.is_cycle)
+            select s3.e1                                              as e1,
+                   (select array_agg((e2.id, e2.start_id, e2.end_id, e2.kind_id, e2.properties)::edgecomposite)
+                    from edge e2
+                    where e2.id = any (s5.path))                      as e2,
+                   s5.path                                            as ep1,
+                   s3.i0                                              as i0,
+                   s3.n2                                              as n2,
+                   s3.n3                                              as n3,
+                   (n4.id, n4.kind_ids, n4.properties)::nodecomposite as n4
+            from s3,
+                 s5
+                   join edge e2 on e2.id = any (s5.path)
+                   join node n3 on n3.id = s5.root_id
+                   join node n4 on e2.id = s5.path[array_length(s5.path, 1)::int] and n4.id = e2.end_id)
+select edges_to_path(variadic array [(s4.e1).id]::int8[] || s4.ep1)::pathcomposite as p
+from s4
+limit 100;

--- a/packages/go/cypher/models/pgsql/test/translation_cases/pattern_binding.sql
+++ b/packages/go/cypher/models/pgsql/test/translation_cases/pattern_binding.sql
@@ -15,8 +15,8 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 -- case: match p = ()-[]->() return p
-with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite                        as n0,
-                   (e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite as e0,
+with s0 as (select (e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite as e0,
+                   (n0.id, n0.kind_ids, n0.properties)::nodecomposite                        as n0,
                    (n1.id, n1.kind_ids, n1.properties)::nodecomposite                        as n1
             from edge e0
                    join node n0 on n0.id = e0.start_id
@@ -24,17 +24,29 @@ with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite           
 select edges_to_path(variadic array [(s0.e0).id]::int8[])::pathcomposite as p
 from s0;
 
+-- case: match p=(:NodeKind1)-[r]->(:NodeKind1) where r.isacl return p limit 100
+with s0 as (select (e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite as e0,
+                   (n0.id, n0.kind_ids, n0.properties)::nodecomposite                        as n0,
+                   (n1.id, n1.kind_ids, n1.properties)::nodecomposite                        as n1
+            from edge e0
+                   join node n0 on n0.kind_ids operator (pg_catalog.&&) array [1]::int2[] and n0.id = e0.start_id
+                   join node n1 on n1.kind_ids operator (pg_catalog.&&) array [1]::int2[] and n1.id = e0.end_id
+            where (e0.properties ->> 'isacl')::bool)
+select edges_to_path(variadic array [(s0.e0).id]::int8[])::pathcomposite as p
+from s0
+limit 100;
+
 -- case: match p = ()-[r1]->()-[r2]->(e) return e
-with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite                        as n0,
-                   (e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite as e0,
+with s0 as (select (e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite as e0,
+                   (n0.id, n0.kind_ids, n0.properties)::nodecomposite                        as n0,
                    (n1.id, n1.kind_ids, n1.properties)::nodecomposite                        as n1
             from edge e0
                    join node n0 on n0.id = e0.start_id
                    join node n1 on n1.id = e0.end_id),
      s1 as (select s0.e0                                                                     as e0,
+                   (e1.id, e1.start_id, e1.end_id, e1.kind_id, e1.properties)::edgecomposite as e1,
                    s0.n0                                                                     as n0,
                    s0.n1                                                                     as n1,
-                   (e1.id, e1.start_id, e1.end_id, e1.kind_id, e1.properties)::edgecomposite as e1,
                    (n2.id, n2.kind_ids, n2.properties)::nodecomposite                        as n2
             from s0,
                  edge e1
@@ -45,17 +57,17 @@ from s1;
 
 
 -- case: match ()-[r1]->()-[r2]->()-[]->() where r1.name = 'a' and r2.name = 'b' return r1
-with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite                        as n0,
-                   (e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite as e0,
+with s0 as (select (e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite as e0,
+                   (n0.id, n0.kind_ids, n0.properties)::nodecomposite                        as n0,
                    (n1.id, n1.kind_ids, n1.properties)::nodecomposite                        as n1
             from edge e0
                    join node n0 on n0.id = e0.start_id
                    join node n1 on n1.id = e0.end_id
             where e0.properties ->> 'name' = 'a'),
      s1 as (select s0.e0                                                                     as e0,
+                   (e1.id, e1.start_id, e1.end_id, e1.kind_id, e1.properties)::edgecomposite as e1,
                    s0.n0                                                                     as n0,
                    s0.n1                                                                     as n1,
-                   (e1.id, e1.start_id, e1.end_id, e1.kind_id, e1.properties)::edgecomposite as e1,
                    (n2.id, n2.kind_ids, n2.properties)::nodecomposite                        as n2
             from s0,
                  edge e1
@@ -64,10 +76,10 @@ with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite           
               and (s0.n1).id = e1.start_id),
      s2 as (select s1.e0                                                                     as e0,
                    s1.e1                                                                     as e1,
+                   (e2.id, e2.start_id, e2.end_id, e2.kind_id, e2.properties)::edgecomposite as e2,
                    s1.n0                                                                     as n0,
                    s1.n1                                                                     as n1,
                    s1.n2                                                                     as n2,
-                   (e2.id, e2.start_id, e2.end_id, e2.kind_id, e2.properties)::edgecomposite as e2,
                    (n3.id, n3.kind_ids, n3.properties)::nodecomposite                        as n3
             from s1,
                  edge e2
@@ -77,16 +89,16 @@ select s2.e0 as r1
 from s2;
 
 -- case: match p = (a)-[]->()<-[]-(f) where a.name = 'value' and f.is_target return p
-with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite                        as n0,
-                   (e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite as e0,
+with s0 as (select (e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite as e0,
+                   (n0.id, n0.kind_ids, n0.properties)::nodecomposite                        as n0,
                    (n1.id, n1.kind_ids, n1.properties)::nodecomposite                        as n1
             from edge e0
                    join node n0 on n0.properties ->> 'name' = 'value' and n0.id = e0.start_id
                    join node n1 on n1.id = e0.end_id),
      s1 as (select s0.e0                                                                     as e0,
+                   (e1.id, e1.start_id, e1.end_id, e1.kind_id, e1.properties)::edgecomposite as e1,
                    s0.n0                                                                     as n0,
                    s0.n1                                                                     as n1,
-                   (e1.id, e1.start_id, e1.end_id, e1.kind_id, e1.properties)::edgecomposite as e1,
                    (n2.id, n2.kind_ids, n2.properties)::nodecomposite                        as n2
             from s0,
                  edge e1
@@ -96,164 +108,163 @@ select edges_to_path(variadic array [(s1.e0).id, (s1.e1).id]::int8[])::pathcompo
 from s1;
 
 -- case: match p = ()-[*..]->() return p limit 1
-with s0 as (with recursive ex0(root_id, next_id, depth, satisfied, is_cycle, path) as (select e0.start_id,
-                                                                                              e0.end_id,
-                                                                                              1,
-                                                                                              false,
-                                                                                              e0.start_id = e0.end_id,
-                                                                                              array [e0.id]
-                                                                                       from edge e0
-                                                                                              join node n0 on n0.id = e0.start_id
-                                                                                              join node n1 on n1.id = e0.end_id
-                                                                                       union
-                                                                                       select ex0.root_id,
-                                                                                              e0.end_id,
-                                                                                              ex0.depth + 1,
-                                                                                              false,
-                                                                                              e0.id = any (ex0.path),
-                                                                                              ex0.path || e0.id
-                                                                                       from ex0
-                                                                                              join edge e0 on e0.start_id = ex0.next_id
-                                                                                              join node n1 on n1.id = e0.end_id
-                                                                                       where ex0.depth < 10
-                                                                                         and not ex0.is_cycle)
-            select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0,
-                   (select array_agg((e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite)
+with s0 as (with recursive s1(root_id, next_id, depth, satisfied, is_cycle, path) as (select e0.start_id,
+                                                                                             e0.end_id,
+                                                                                             1,
+                                                                                             false,
+                                                                                             e0.start_id = e0.end_id,
+                                                                                             array [e0.id]
+                                                                                      from edge e0
+                                                                                             join node n0 on n0.id = e0.start_id
+                                                                                             join node n1 on n1.id = e0.end_id
+                                                                                      union
+                                                                                      select s1.root_id,
+                                                                                             e0.end_id,
+                                                                                             s1.depth + 1,
+                                                                                             false,
+                                                                                             e0.id = any (s1.path),
+                                                                                             s1.path || e0.id
+                                                                                      from s1
+                                                                                             join edge e0 on e0.start_id = s1.next_id
+                                                                                             join node n1 on n1.id = e0.end_id
+                                                                                      where s1.depth < 10
+                                                                                        and not s1.is_cycle)
+            select (select array_agg((e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite)
                     from edge e0
-                    where e0.id = any (ex0.path))                     as e0,
-                   ex0.path                                           as ep0,
+                    where e0.id = any (s1.path))                      as e0,
+                   s1.path                                            as ep0,
+                   (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0,
                    (n1.id, n1.kind_ids, n1.properties)::nodecomposite as n1
-            from ex0
-                   join edge e0 on e0.id = any (ex0.path)
-                   join node n0 on n0.id = ex0.root_id
-                   join node n1 on e0.id = ex0.path[array_length(ex0.path, 1)::int] and n1.id = e0.end_id)
+            from s1
+                   join edge e0 on e0.id = any (s1.path)
+                   join node n0 on n0.id = s1.root_id
+                   join node n1 on e0.id = s1.path[array_length(s1.path, 1)::int] and n1.id = e0.end_id)
 select edges_to_path(variadic ep0)::pathcomposite as p
 from s0
 limit 1;
 
 -- case: match p = (s)-[*..]->(i)-[]->() where id(s) = 1 and i.name = 'n3' return p limit 1
-with s0 as (with recursive ex0(root_id, next_id, depth, satisfied, is_cycle, path) as (select e0.start_id,
-                                                                                              e0.end_id,
-                                                                                              1,
-                                                                                              n1.properties ->> 'name' = 'n3',
-                                                                                              e0.start_id = e0.end_id,
-                                                                                              array [e0.id]
-                                                                                       from edge e0
-                                                                                              join node n0 on n0.id = 1 and n0.id = e0.start_id
-                                                                                              join node n1 on n1.id = e0.end_id
-                                                                                       union
-                                                                                       select ex0.root_id,
-                                                                                              e0.end_id,
-                                                                                              ex0.depth + 1,
-                                                                                              n1.properties ->> 'name' = 'n3',
-                                                                                              e0.id = any (ex0.path),
-                                                                                              ex0.path || e0.id
-                                                                                       from ex0
-                                                                                              join edge e0 on e0.start_id = ex0.next_id
-                                                                                              join node n1 on n1.id = e0.end_id
-                                                                                       where ex0.depth < 10
-                                                                                         and not ex0.is_cycle)
-            select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0,
-                   (select array_agg((e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite)
+with s0 as (with recursive s1(root_id, next_id, depth, satisfied, is_cycle, path) as (select e0.start_id,
+                                                                                             e0.end_id,
+                                                                                             1,
+                                                                                             n1.properties ->> 'name' = 'n3',
+                                                                                             e0.start_id = e0.end_id,
+                                                                                             array [e0.id]
+                                                                                      from edge e0
+                                                                                             join node n0 on n0.id = 1 and n0.id = e0.start_id
+                                                                                             join node n1 on n1.id = e0.end_id
+                                                                                      union
+                                                                                      select s1.root_id,
+                                                                                             e0.end_id,
+                                                                                             s1.depth + 1,
+                                                                                             n1.properties ->> 'name' = 'n3',
+                                                                                             e0.id = any (s1.path),
+                                                                                             s1.path || e0.id
+                                                                                      from s1
+                                                                                             join edge e0 on e0.start_id = s1.next_id
+                                                                                             join node n1 on n1.id = e0.end_id
+                                                                                      where s1.depth < 10
+                                                                                        and not s1.is_cycle)
+            select (select array_agg((e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite)
                     from edge e0
-                    where e0.id = any (ex0.path))                     as e0,
-                   ex0.path                                           as ep0,
+                    where e0.id = any (s1.path))                      as e0,
+                   s1.path                                            as ep0,
+                   (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0,
                    (n1.id, n1.kind_ids, n1.properties)::nodecomposite as n1
-            from ex0
-                   join edge e0 on e0.id = any (ex0.path)
-                   join node n0 on n0.id = ex0.root_id
-                   join node n1 on e0.id = ex0.path[array_length(ex0.path, 1)::int] and n1.id = e0.end_id
-            where ex0.satisfied),
-     s1 as (select s0.e0                                                                     as e0,
+            from s1
+                   join edge e0 on e0.id = any (s1.path)
+                   join node n0 on n0.id = s1.root_id
+                   join node n1 on e0.id = s1.path[array_length(s1.path, 1)::int] and n1.id = e0.end_id
+            where s1.satisfied),
+     s2 as (select s0.e0                                                                     as e0,
+                   (e1.id, e1.start_id, e1.end_id, e1.kind_id, e1.properties)::edgecomposite as e1,
                    s0.ep0                                                                    as ep0,
                    s0.n0                                                                     as n0,
                    s0.n1                                                                     as n1,
-                   (e1.id, e1.start_id, e1.end_id, e1.kind_id, e1.properties)::edgecomposite as e1,
                    (n2.id, n2.kind_ids, n2.properties)::nodecomposite                        as n2
             from s0,
                  edge e1
                    join node n2 on n2.id = e1.end_id
-            where (s0.n1).id = e1.start_id)
-select edges_to_path(variadic array [(s1.e1).id]::int8[] || s1.ep0)::pathcomposite as p
-from s1
+            where (s0.e0[array_length(s0.e0, 1)::int]).end_id = e1.start_id)
+select edges_to_path(variadic array [(s2.e1).id]::int8[] || s2.ep0)::pathcomposite as p
+from s2
 limit 1;
 
 -- case: match p = ()-[e:EdgeKind1]->()-[:EdgeKind1*..]->() return e, p
-with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite                        as n0,
-                   (e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite as e0,
+with s0 as (select (e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite as e0,
+                   (n0.id, n0.kind_ids, n0.properties)::nodecomposite                        as n0,
                    (n1.id, n1.kind_ids, n1.properties)::nodecomposite                        as n1
             from edge e0
                    join node n0 on n0.id = e0.start_id
                    join node n1 on n1.id = e0.end_id
             where e0.kind_id = any (array [3]::int2[])),
-     s1 as (with recursive ex0(root_id, next_id, depth, satisfied, is_cycle, path) as (select e1.start_id,
-                                                                                              e1.end_id,
-                                                                                              1,
-                                                                                              false,
-                                                                                              e1.start_id = e1.end_id,
-                                                                                              array [e1.id]
-                                                                                       from s0
-                                                                                              join edge e1
-                                                                                                   on e1.kind_id = any (array [3]::int2[]) and (s0.n1).id = e1.start_id
-                                                                                              join node n2 on n2.id = e1.end_id
-                                                                                       union
-                                                                                       select ex0.root_id,
-                                                                                              e1.end_id,
-                                                                                              ex0.depth + 1,
-                                                                                              false,
-                                                                                              e1.id = any (ex0.path),
-                                                                                              ex0.path || e1.id
-                                                                                       from ex0
-                                                                                              join edge e1 on e1.start_id = ex0.next_id
-                                                                                              join node n2 on n2.id = e1.end_id
-                                                                                       where ex0.depth < 10
-                                                                                         and not ex0.is_cycle)
+     s1 as (with recursive s2(root_id, next_id, depth, satisfied, is_cycle, path) as (select e1.start_id,
+                                                                                             e1.end_id,
+                                                                                             1,
+                                                                                             false,
+                                                                                             e1.start_id = e1.end_id,
+                                                                                             array [e1.id]
+                                                                                      from s0
+                                                                                             join edge e1
+                                                                                                  on e1.kind_id = any (array [3]::int2[]) and (s0.n1).id = e1.start_id
+                                                                                             join node n2 on n2.id = e1.end_id
+                                                                                      union
+                                                                                      select s2.root_id,
+                                                                                             e1.end_id,
+                                                                                             s2.depth + 1,
+                                                                                             false,
+                                                                                             e1.id = any (s2.path),
+                                                                                             s2.path || e1.id
+                                                                                      from s2
+                                                                                             join edge e1 on e1.start_id = s2.next_id
+                                                                                             join node n2 on n2.id = e1.end_id
+                                                                                      where s2.depth < 10
+                                                                                        and not s2.is_cycle)
             select s0.e0                                              as e0,
-                   s0.n0                                              as n0,
-                   s0.n1                                              as n1,
                    (select array_agg((e1.id, e1.start_id, e1.end_id, e1.kind_id, e1.properties)::edgecomposite)
                     from edge e1
-                    where e1.id = any (ex0.path))                     as e1,
-                   ex0.path                                           as ep0,
+                    where e1.id = any (s2.path))                      as e1,
+                   s2.path                                            as ep0,
+                   s0.n0                                              as n0,
+                   s0.n1                                              as n1,
                    (n2.id, n2.kind_ids, n2.properties)::nodecomposite as n2
             from s0,
-                 ex0
-                   join edge e1 on e1.id = any (ex0.path)
-                   join node n1 on n1.id = ex0.root_id
-                   join node n2 on e1.id = ex0.path[array_length(ex0.path, 1)::int] and n2.id = e1.end_id)
+                 s2
+                   join edge e1 on e1.id = any (s2.path)
+                   join node n1 on n1.id = s2.root_id
+                   join node n2 on e1.id = s2.path[array_length(s2.path, 1)::int] and n2.id = e1.end_id)
 select s1.e0 as e, edges_to_path(variadic array [(s1.e0).id]::int8[] || s1.ep0)::pathcomposite as p
 from s1;
 
 -- case: match p = (m:NodeKind1)-[:EdgeKind1]->(c:NodeKind2) where m.objectid ends with "-513" and not toUpper(c.operatingsystem) contains "SERVER" return p limit 1000
-with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite                        as n0,
-                   (e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite as e0,
+with s0 as (select (e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite as e0,
+                   (n0.id, n0.kind_ids, n0.properties)::nodecomposite                        as n0,
                    (n1.id, n1.kind_ids, n1.properties)::nodecomposite                        as n1
             from edge e0
-                   join node n0 on n0.kind_ids operator (pg_catalog.&&) array [1]::int2[] and
-                                   n0.properties ->> 'objectid' like '%-513' and n0.id = e0.start_id
-                   join node n1 on n1.kind_ids operator (pg_catalog.&&) array [2]::int2[] and
-                                   not upper(n1.properties ->> 'operatingsystem')::text like '%SERVER%' and
-                                   n1.id = e0.end_id
+                   join node n0 on n0.properties ->> 'objectid' like '%-513' and
+                                   n0.kind_ids operator (pg_catalog.&&) array [1]::int2[] and n0.id = e0.start_id
+                   join node n1 on not upper(n1.properties ->> 'operatingsystem')::text like '%SERVER%' and
+                                   n1.kind_ids operator (pg_catalog.&&) array [2]::int2[] and n1.id = e0.end_id
             where e0.kind_id = any (array [3]::int2[]))
 select edges_to_path(variadic array [(s0.e0).id]::int8[])::pathcomposite as p
 from s0
 limit 1000;
 
 -- case: match p = (:NodeKind1)-[:EdgeKind1|EdgeKind2]->(e:NodeKind2)-[:EdgeKind2]->(:NodeKind1) where 'a' in e.values or 'b' in e.values or size(e.values) = 0 return p
-with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite                        as n0,
-                   (e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite as e0,
+with s0 as (select (e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite as e0,
+                   (n0.id, n0.kind_ids, n0.properties)::nodecomposite                        as n0,
                    (n1.id, n1.kind_ids, n1.properties)::nodecomposite                        as n1
             from edge e0
                    join node n0 on n0.kind_ids operator (pg_catalog.&&) array [1]::int2[] and n0.id = e0.start_id
-                   join node n1 on n1.kind_ids operator (pg_catalog.&&) array [2]::int2[] and
-                                   'a' = any (jsonb_to_text_array(n1.properties -> 'values')::text[]) or
+                   join node n1 on 'a' = any (jsonb_to_text_array(n1.properties -> 'values')::text[]) or
                                    'b' = any (jsonb_to_text_array(n1.properties -> 'values')::text[]) or
-                                   jsonb_array_length(n1.properties -> 'values')::int = 0 and n1.id = e0.end_id
+                                   jsonb_array_length(n1.properties -> 'values')::int = 0 and
+                                   n1.kind_ids operator (pg_catalog.&&) array [2]::int2[] and n1.id = e0.end_id
             where e0.kind_id = any (array [3, 4]::int2[])),
      s1 as (select s0.e0                                                                     as e0,
+                   (e1.id, e1.start_id, e1.end_id, e1.kind_id, e1.properties)::edgecomposite as e1,
                    s0.n0                                                                     as n0,
                    s0.n1                                                                     as n1,
-                   (e1.id, e1.start_id, e1.end_id, e1.kind_id, e1.properties)::edgecomposite as e1,
                    (n2.id, n2.kind_ids, n2.properties)::nodecomposite                        as n2
             from s0,
                  edge e1

--- a/packages/go/cypher/models/pgsql/test/translation_cases/pattern_expansion.sql
+++ b/packages/go/cypher/models/pgsql/test/translation_cases/pattern_expansion.sql
@@ -15,584 +15,684 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 -- case: match (n)-[*..]->(e) return n, e
-with s0 as (with recursive ex0(root_id, next_id, depth, satisfied, is_cycle, path) as (select e0.start_id,
-                                                                                              e0.end_id,
-                                                                                              1,
-                                                                                              false,
-                                                                                              e0.start_id = e0.end_id,
-                                                                                              array [e0.id]
-                                                                                       from edge e0
-                                                                                              join node n0 on n0.id = e0.start_id
-                                                                                              join node n1 on n1.id = e0.end_id
-                                                                                       union
-                                                                                       select ex0.root_id,
-                                                                                              e0.end_id,
-                                                                                              ex0.depth + 1,
-                                                                                              false,
-                                                                                              e0.id = any (ex0.path),
-                                                                                              ex0.path || e0.id
-                                                                                       from ex0
-                                                                                              join edge e0 on e0.start_id = ex0.next_id
-                                                                                              join node n1 on n1.id = e0.end_id
-                                                                                       where ex0.depth < 10
-                                                                                         and not ex0.is_cycle)
-            select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0,
-                   (select array_agg((e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite)
+with s0 as (with recursive s1(root_id, next_id, depth, satisfied, is_cycle, path) as (select e0.start_id,
+                                                                                             e0.end_id,
+                                                                                             1,
+                                                                                             false,
+                                                                                             e0.start_id = e0.end_id,
+                                                                                             array [e0.id]
+                                                                                      from edge e0
+                                                                                             join node n0 on n0.id = e0.start_id
+                                                                                             join node n1 on n1.id = e0.end_id
+                                                                                      union
+                                                                                      select s1.root_id,
+                                                                                             e0.end_id,
+                                                                                             s1.depth + 1,
+                                                                                             false,
+                                                                                             e0.id = any (s1.path),
+                                                                                             s1.path || e0.id
+                                                                                      from s1
+                                                                                             join edge e0 on e0.start_id = s1.next_id
+                                                                                             join node n1 on n1.id = e0.end_id
+                                                                                      where s1.depth < 10
+                                                                                        and not s1.is_cycle)
+            select (select array_agg((e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite)
                     from edge e0
-                    where e0.id = any (ex0.path))                     as e0,
-                   ex0.path                                           as ep0,
+                    where e0.id = any (s1.path))                      as e0,
+                   s1.path                                            as ep0,
+                   (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0,
                    (n1.id, n1.kind_ids, n1.properties)::nodecomposite as n1
-            from ex0
-                   join edge e0 on e0.id = any (ex0.path)
-                   join node n0 on n0.id = ex0.root_id
-                   join node n1 on e0.id = ex0.path[array_length(ex0.path, 1)::int] and n1.id = e0.end_id)
+            from s1
+                   join edge e0 on e0.id = any (s1.path)
+                   join node n0 on n0.id = s1.root_id
+                   join node n1 on e0.id = s1.path[array_length(s1.path, 1)::int] and n1.id = e0.end_id)
 select s0.n0 as n, s0.n1 as e
 from s0;
 
 -- case: match (n)-[*..]->(e:NodeKind1) where n.name = 'n1' return e
-with s0 as (with recursive ex0(root_id, next_id, depth, satisfied, is_cycle, path) as (select e0.start_id,
-                                                                                              e0.end_id,
-                                                                                              1,
-                                                                                              n1.kind_ids operator (pg_catalog.&&) array [1]::int2[],
-                                                                                              e0.start_id = e0.end_id,
-                                                                                              array [e0.id]
-                                                                                       from edge e0
-                                                                                              join node n0 on n0.properties ->> 'name' = 'n1' and n0.id = e0.start_id
-                                                                                              join node n1 on n1.id = e0.end_id
-                                                                                       union
-                                                                                       select ex0.root_id,
-                                                                                              e0.end_id,
-                                                                                              ex0.depth + 1,
-                                                                                              n1.kind_ids operator (pg_catalog.&&) array [1]::int2[],
-                                                                                              e0.id = any (ex0.path),
-                                                                                              ex0.path || e0.id
-                                                                                       from ex0
-                                                                                              join edge e0 on e0.start_id = ex0.next_id
-                                                                                              join node n1 on n1.id = e0.end_id
-                                                                                       where ex0.depth < 10
-                                                                                         and not ex0.is_cycle)
-            select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0,
-                   (select array_agg((e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite)
+with s0 as (with recursive s1(root_id, next_id, depth, satisfied, is_cycle, path) as (select e0.start_id,
+                                                                                             e0.end_id,
+                                                                                             1,
+                                                                                             n1.kind_ids operator (pg_catalog.&&) array [1]::int2[],
+                                                                                             e0.start_id = e0.end_id,
+                                                                                             array [e0.id]
+                                                                                      from edge e0
+                                                                                             join node n0 on n0.properties ->> 'name' = 'n1' and n0.id = e0.start_id
+                                                                                             join node n1 on n1.id = e0.end_id
+                                                                                      union
+                                                                                      select s1.root_id,
+                                                                                             e0.end_id,
+                                                                                             s1.depth + 1,
+                                                                                             n1.kind_ids operator (pg_catalog.&&) array [1]::int2[],
+                                                                                             e0.id = any (s1.path),
+                                                                                             s1.path || e0.id
+                                                                                      from s1
+                                                                                             join edge e0 on e0.start_id = s1.next_id
+                                                                                             join node n1 on n1.id = e0.end_id
+                                                                                      where s1.depth < 10
+                                                                                        and not s1.is_cycle)
+            select (select array_agg((e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite)
                     from edge e0
-                    where e0.id = any (ex0.path))                     as e0,
-                   ex0.path                                           as ep0,
+                    where e0.id = any (s1.path))                      as e0,
+                   s1.path                                            as ep0,
+                   (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0,
                    (n1.id, n1.kind_ids, n1.properties)::nodecomposite as n1
-            from ex0
-                   join edge e0 on e0.id = any (ex0.path)
-                   join node n0 on n0.id = ex0.root_id
-                   join node n1 on e0.id = ex0.path[array_length(ex0.path, 1)::int] and n1.id = e0.end_id
-            where ex0.satisfied)
+            from s1
+                   join edge e0 on e0.id = any (s1.path)
+                   join node n0 on n0.id = s1.root_id
+                   join node n1 on e0.id = s1.path[array_length(s1.path, 1)::int] and n1.id = e0.end_id
+            where s1.satisfied)
 select s0.n1 as e
 from s0;
 
 -- todo: cypher expects the right hand binding for `r` to already be a list of relationships which seems strange
 -- case: match (n)-[r*..]->(e:NodeKind1) where n.name = 'n1' and r.prop = 'a' return e
-with s0 as (with recursive ex0(root_id, next_id, depth, satisfied, is_cycle, path) as (select e0.start_id,
-                                                                                              e0.end_id,
-                                                                                              1,
-                                                                                              n1.kind_ids operator (pg_catalog.&&) array [1]::int2[],
-                                                                                              e0.start_id = e0.end_id,
-                                                                                              array [e0.id]
-                                                                                       from edge e0
-                                                                                              join node n0 on n0.properties ->> 'name' = 'n1' and n0.id = e0.start_id
-                                                                                              join node n1 on n1.id = e0.end_id
-                                                                                       where e0.properties ->> 'prop' = 'a'
-                                                                                       union
-                                                                                       select ex0.root_id,
-                                                                                              e0.end_id,
-                                                                                              ex0.depth + 1,
-                                                                                              n1.kind_ids operator (pg_catalog.&&) array [1]::int2[],
-                                                                                              e0.id = any (ex0.path),
-                                                                                              ex0.path || e0.id
-                                                                                       from ex0
-                                                                                              join edge e0 on e0.start_id = ex0.next_id
-                                                                                              join node n1 on n1.id = e0.end_id
-                                                                                       where ex0.depth < 10
-                                                                                         and not ex0.is_cycle
-                                                                                         and e0.properties ->> 'prop' = 'a')
-            select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0,
-                   (select array_agg((e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite)
+with s0 as (with recursive s1(root_id, next_id, depth, satisfied, is_cycle, path) as (select e0.start_id,
+                                                                                             e0.end_id,
+                                                                                             1,
+                                                                                             n1.kind_ids operator (pg_catalog.&&) array [1]::int2[],
+                                                                                             e0.start_id = e0.end_id,
+                                                                                             array [e0.id]
+                                                                                      from edge e0
+                                                                                             join node n0 on n0.properties ->> 'name' = 'n1' and n0.id = e0.start_id
+                                                                                             join node n1 on n1.id = e0.end_id
+                                                                                      where e0.properties ->> 'prop' = 'a'
+                                                                                      union
+                                                                                      select s1.root_id,
+                                                                                             e0.end_id,
+                                                                                             s1.depth + 1,
+                                                                                             n1.kind_ids operator (pg_catalog.&&) array [1]::int2[],
+                                                                                             e0.id = any (s1.path),
+                                                                                             s1.path || e0.id
+                                                                                      from s1
+                                                                                             join edge e0 on e0.start_id = s1.next_id
+                                                                                             join node n1 on n1.id = e0.end_id
+                                                                                      where s1.depth < 10
+                                                                                        and not s1.is_cycle
+                                                                                        and e0.properties ->> 'prop' = 'a')
+            select (select array_agg((e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite)
                     from edge e0
-                    where e0.id = any (ex0.path))                     as e0,
-                   ex0.path                                           as ep0,
+                    where e0.id = any (s1.path))                      as e0,
+                   s1.path                                            as ep0,
+                   (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0,
                    (n1.id, n1.kind_ids, n1.properties)::nodecomposite as n1
-            from ex0
-                   join edge e0 on e0.id = any (ex0.path)
-                   join node n0 on n0.id = ex0.root_id
-                   join node n1 on e0.id = ex0.path[array_length(ex0.path, 1)::int] and n1.id = e0.end_id
-            where ex0.satisfied)
+            from s1
+                   join edge e0 on e0.id = any (s1.path)
+                   join node n0 on n0.id = s1.root_id
+                   join node n1 on e0.id = s1.path[array_length(s1.path, 1)::int] and n1.id = e0.end_id
+            where s1.satisfied)
 select s0.n1 as e
 from s0;
 
 -- case: match (n)-[*..]->(e:NodeKind1) where n.name = 'n2' return n
-with s0 as (with recursive ex0(root_id, next_id, depth, satisfied, is_cycle, path) as (select e0.start_id,
-                                                                                              e0.end_id,
-                                                                                              1,
-                                                                                              n1.kind_ids operator (pg_catalog.&&) array [1]::int2[],
-                                                                                              e0.start_id = e0.end_id,
-                                                                                              array [e0.id]
-                                                                                       from edge e0
-                                                                                              join node n0 on n0.properties ->> 'name' = 'n2' and n0.id = e0.start_id
-                                                                                              join node n1 on n1.id = e0.end_id
-                                                                                       union
-                                                                                       select ex0.root_id,
-                                                                                              e0.end_id,
-                                                                                              ex0.depth + 1,
-                                                                                              n1.kind_ids operator (pg_catalog.&&) array [1]::int2[],
-                                                                                              e0.id = any (ex0.path),
-                                                                                              ex0.path || e0.id
-                                                                                       from ex0
-                                                                                              join edge e0 on e0.start_id = ex0.next_id
-                                                                                              join node n1 on n1.id = e0.end_id
-                                                                                       where ex0.depth < 10
-                                                                                         and not ex0.is_cycle)
-            select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0,
-                   (select array_agg((e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite)
+with s0 as (with recursive s1(root_id, next_id, depth, satisfied, is_cycle, path) as (select e0.start_id,
+                                                                                             e0.end_id,
+                                                                                             1,
+                                                                                             n1.kind_ids operator (pg_catalog.&&) array [1]::int2[],
+                                                                                             e0.start_id = e0.end_id,
+                                                                                             array [e0.id]
+                                                                                      from edge e0
+                                                                                             join node n0 on n0.properties ->> 'name' = 'n2' and n0.id = e0.start_id
+                                                                                             join node n1 on n1.id = e0.end_id
+                                                                                      union
+                                                                                      select s1.root_id,
+                                                                                             e0.end_id,
+                                                                                             s1.depth + 1,
+                                                                                             n1.kind_ids operator (pg_catalog.&&) array [1]::int2[],
+                                                                                             e0.id = any (s1.path),
+                                                                                             s1.path || e0.id
+                                                                                      from s1
+                                                                                             join edge e0 on e0.start_id = s1.next_id
+                                                                                             join node n1 on n1.id = e0.end_id
+                                                                                      where s1.depth < 10
+                                                                                        and not s1.is_cycle)
+            select (select array_agg((e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite)
                     from edge e0
-                    where e0.id = any (ex0.path))                     as e0,
-                   ex0.path                                           as ep0,
+                    where e0.id = any (s1.path))                      as e0,
+                   s1.path                                            as ep0,
+                   (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0,
                    (n1.id, n1.kind_ids, n1.properties)::nodecomposite as n1
-            from ex0
-                   join edge e0 on e0.id = any (ex0.path)
-                   join node n0 on n0.id = ex0.root_id
-                   join node n1 on e0.id = ex0.path[array_length(ex0.path, 1)::int] and n1.id = e0.end_id
-            where ex0.satisfied)
+            from s1
+                   join edge e0 on e0.id = any (s1.path)
+                   join node n0 on n0.id = s1.root_id
+                   join node n1 on e0.id = s1.path[array_length(s1.path, 1)::int] and n1.id = e0.end_id
+            where s1.satisfied)
 select s0.n0 as n
 from s0;
 
 -- case: match (n)-[*..]->(e:NodeKind1)-[]->(l) where n.name = 'n1' return l
-with s0 as (with recursive ex0(root_id, next_id, depth, satisfied, is_cycle, path) as (select e0.start_id,
-                                                                                              e0.end_id,
-                                                                                              1,
-                                                                                              n1.kind_ids operator (pg_catalog.&&) array [1]::int2[],
-                                                                                              e0.start_id = e0.end_id,
-                                                                                              array [e0.id]
-                                                                                       from edge e0
-                                                                                              join node n0 on n0.properties ->> 'name' = 'n1' and n0.id = e0.start_id
-                                                                                              join node n1 on n1.id = e0.end_id
-                                                                                       union
-                                                                                       select ex0.root_id,
-                                                                                              e0.end_id,
-                                                                                              ex0.depth + 1,
-                                                                                              n1.kind_ids operator (pg_catalog.&&) array [1]::int2[],
-                                                                                              e0.id = any (ex0.path),
-                                                                                              ex0.path || e0.id
-                                                                                       from ex0
-                                                                                              join edge e0 on e0.start_id = ex0.next_id
-                                                                                              join node n1 on n1.id = e0.end_id
-                                                                                       where ex0.depth < 10
-                                                                                         and not ex0.is_cycle)
-            select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0,
-                   (select array_agg((e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite)
+with s0 as (with recursive s1(root_id, next_id, depth, satisfied, is_cycle, path) as (select e0.start_id,
+                                                                                             e0.end_id,
+                                                                                             1,
+                                                                                             n1.kind_ids operator (pg_catalog.&&) array [1]::int2[],
+                                                                                             e0.start_id = e0.end_id,
+                                                                                             array [e0.id]
+                                                                                      from edge e0
+                                                                                             join node n0 on n0.properties ->> 'name' = 'n1' and n0.id = e0.start_id
+                                                                                             join node n1 on n1.id = e0.end_id
+                                                                                      union
+                                                                                      select s1.root_id,
+                                                                                             e0.end_id,
+                                                                                             s1.depth + 1,
+                                                                                             n1.kind_ids operator (pg_catalog.&&) array [1]::int2[],
+                                                                                             e0.id = any (s1.path),
+                                                                                             s1.path || e0.id
+                                                                                      from s1
+                                                                                             join edge e0 on e0.start_id = s1.next_id
+                                                                                             join node n1 on n1.id = e0.end_id
+                                                                                      where s1.depth < 10
+                                                                                        and not s1.is_cycle)
+            select (select array_agg((e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite)
                     from edge e0
-                    where e0.id = any (ex0.path))                     as e0,
-                   ex0.path                                           as ep0,
+                    where e0.id = any (s1.path))                      as e0,
+                   s1.path                                            as ep0,
+                   (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0,
                    (n1.id, n1.kind_ids, n1.properties)::nodecomposite as n1
-            from ex0
-                   join edge e0 on e0.id = any (ex0.path)
-                   join node n0 on n0.id = ex0.root_id
-                   join node n1 on e0.id = ex0.path[array_length(ex0.path, 1)::int] and n1.id = e0.end_id
-            where ex0.satisfied),
-     s1 as (select s0.e0                                                                     as e0,
+            from s1
+                   join edge e0 on e0.id = any (s1.path)
+                   join node n0 on n0.id = s1.root_id
+                   join node n1 on e0.id = s1.path[array_length(s1.path, 1)::int] and n1.id = e0.end_id
+            where s1.satisfied),
+     s2 as (select s0.e0                                                                     as e0,
+                   (e1.id, e1.start_id, e1.end_id, e1.kind_id, e1.properties)::edgecomposite as e1,
                    s0.ep0                                                                    as ep0,
                    s0.n0                                                                     as n0,
                    s0.n1                                                                     as n1,
-                   (e1.id, e1.start_id, e1.end_id, e1.kind_id, e1.properties)::edgecomposite as e1,
                    (n2.id, n2.kind_ids, n2.properties)::nodecomposite                        as n2
             from s0,
                  edge e1
                    join node n2 on n2.id = e1.end_id
-            where (s0.n1).id = e1.start_id)
-select s1.n2 as l
-from s1;
+            where (s0.e0[array_length(s0.e0, 1)::int]).end_id = e1.start_id)
+select s2.n2 as l
+from s2;
 
 -- case: match (n)-[*..]->(e)-[:EdgeKind1|EdgeKind2]->()-[*..]->(l) where n.name = 'n1' and e.name = 'n2' return l
-with s0 as (with recursive ex0(root_id, next_id, depth, satisfied, is_cycle, path) as (select e0.start_id,
-                                                                                              e0.end_id,
-                                                                                              1,
-                                                                                              n1.properties ->> 'name' = 'n2',
-                                                                                              e0.start_id = e0.end_id,
-                                                                                              array [e0.id]
-                                                                                       from edge e0
-                                                                                              join node n0 on n0.properties ->> 'name' = 'n1' and n0.id = e0.start_id
-                                                                                              join node n1 on n1.id = e0.end_id
-                                                                                       union
-                                                                                       select ex0.root_id,
-                                                                                              e0.end_id,
-                                                                                              ex0.depth + 1,
-                                                                                              n1.properties ->> 'name' = 'n2',
-                                                                                              e0.id = any (ex0.path),
-                                                                                              ex0.path || e0.id
-                                                                                       from ex0
-                                                                                              join edge e0 on e0.start_id = ex0.next_id
-                                                                                              join node n1 on n1.id = e0.end_id
-                                                                                       where ex0.depth < 10
-                                                                                         and not ex0.is_cycle)
-            select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0,
-                   (select array_agg((e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite)
+with s0 as (with recursive s1(root_id, next_id, depth, satisfied, is_cycle, path) as (select e0.start_id,
+                                                                                             e0.end_id,
+                                                                                             1,
+                                                                                             n1.properties ->> 'name' = 'n2',
+                                                                                             e0.start_id = e0.end_id,
+                                                                                             array [e0.id]
+                                                                                      from edge e0
+                                                                                             join node n0 on n0.properties ->> 'name' = 'n1' and n0.id = e0.start_id
+                                                                                             join node n1 on n1.id = e0.end_id
+                                                                                      union
+                                                                                      select s1.root_id,
+                                                                                             e0.end_id,
+                                                                                             s1.depth + 1,
+                                                                                             n1.properties ->> 'name' = 'n2',
+                                                                                             e0.id = any (s1.path),
+                                                                                             s1.path || e0.id
+                                                                                      from s1
+                                                                                             join edge e0 on e0.start_id = s1.next_id
+                                                                                             join node n1 on n1.id = e0.end_id
+                                                                                      where s1.depth < 10
+                                                                                        and not s1.is_cycle)
+            select (select array_agg((e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite)
                     from edge e0
-                    where e0.id = any (ex0.path))                     as e0,
-                   ex0.path                                           as ep0,
+                    where e0.id = any (s1.path))                      as e0,
+                   s1.path                                            as ep0,
+                   (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0,
                    (n1.id, n1.kind_ids, n1.properties)::nodecomposite as n1
-            from ex0
-                   join edge e0 on e0.id = any (ex0.path)
-                   join node n0 on n0.id = ex0.root_id
-                   join node n1 on e0.id = ex0.path[array_length(ex0.path, 1)::int] and n1.id = e0.end_id
-            where ex0.satisfied),
-     s1 as (select s0.e0                                                                     as e0,
+            from s1
+                   join edge e0 on e0.id = any (s1.path)
+                   join node n0 on n0.id = s1.root_id
+                   join node n1 on e0.id = s1.path[array_length(s1.path, 1)::int] and n1.id = e0.end_id
+            where s1.satisfied),
+     s2 as (select s0.e0                                                                     as e0,
+                   (e1.id, e1.start_id, e1.end_id, e1.kind_id, e1.properties)::edgecomposite as e1,
                    s0.ep0                                                                    as ep0,
                    s0.n0                                                                     as n0,
                    s0.n1                                                                     as n1,
-                   (e1.id, e1.start_id, e1.end_id, e1.kind_id, e1.properties)::edgecomposite as e1,
                    (n2.id, n2.kind_ids, n2.properties)::nodecomposite                        as n2
             from s0,
                  edge e1
                    join node n2 on n2.id = e1.end_id
             where e1.kind_id = any (array [3, 4]::int2[])
-              and (s0.n1).id = e1.start_id),
-     s2 as (with recursive ex1(root_id, next_id, depth, satisfied, is_cycle, path) as (select e2.start_id,
-                                                                                              e2.end_id,
-                                                                                              1,
-                                                                                              false,
-                                                                                              e2.start_id = e2.end_id,
-                                                                                              array [e2.id]
-                                                                                       from s1
-                                                                                              join edge e2 on (s1.n2).id = e2.start_id
-                                                                                              join node n3 on n3.id = e2.end_id
-                                                                                       union
-                                                                                       select ex1.root_id,
-                                                                                              e2.end_id,
-                                                                                              ex1.depth + 1,
-                                                                                              false,
-                                                                                              e2.id = any (ex1.path),
-                                                                                              ex1.path || e2.id
-                                                                                       from ex1
-                                                                                              join edge e2 on e2.start_id = ex1.next_id
-                                                                                              join node n3 on n3.id = e2.end_id
-                                                                                       where ex1.depth < 10
-                                                                                         and not ex1.is_cycle)
-            select s1.e0                                              as e0,
-                   s1.e1                                              as e1,
-                   s1.ep0                                             as ep0,
-                   s1.n0                                              as n0,
-                   s1.n1                                              as n1,
-                   s1.n2                                              as n2,
+              and (s0.e0[array_length(s0.e0, 1)::int]).end_id = e1.start_id),
+     s3 as (with recursive s4(root_id, next_id, depth, satisfied, is_cycle, path) as (select e2.start_id,
+                                                                                             e2.end_id,
+                                                                                             1,
+                                                                                             false,
+                                                                                             e2.start_id = e2.end_id,
+                                                                                             array [e2.id]
+                                                                                      from s2
+                                                                                             join edge e2 on (s2.n2).id = e2.start_id
+                                                                                             join node n3 on n3.id = e2.end_id
+                                                                                      union
+                                                                                      select s4.root_id,
+                                                                                             e2.end_id,
+                                                                                             s4.depth + 1,
+                                                                                             false,
+                                                                                             e2.id = any (s4.path),
+                                                                                             s4.path || e2.id
+                                                                                      from s4
+                                                                                             join edge e2 on e2.start_id = s4.next_id
+                                                                                             join node n3 on n3.id = e2.end_id
+                                                                                      where s4.depth < 10
+                                                                                        and not s4.is_cycle)
+            select s2.e0                                              as e0,
+                   s2.e1                                              as e1,
                    (select array_agg((e2.id, e2.start_id, e2.end_id, e2.kind_id, e2.properties)::edgecomposite)
                     from edge e2
-                    where e2.id = any (ex1.path))                     as e2,
-                   ex1.path                                           as ep1,
+                    where e2.id = any (s4.path))                      as e2,
+                   s2.ep0                                             as ep0,
+                   s4.path                                            as ep1,
+                   s2.n0                                              as n0,
+                   s2.n1                                              as n1,
+                   s2.n2                                              as n2,
                    (n3.id, n3.kind_ids, n3.properties)::nodecomposite as n3
-            from s1,
-                 ex1
-                   join edge e2 on e2.id = any (ex1.path)
-                   join node n2 on n2.id = ex1.root_id
-                   join node n3 on e2.id = ex1.path[array_length(ex1.path, 1)::int] and n3.id = e2.end_id)
-select s2.n3 as l
-from s2;
+            from s2,
+                 s4
+                   join edge e2 on e2.id = any (s4.path)
+                   join node n2 on n2.id = s4.root_id
+                   join node n3 on e2.id = s4.path[array_length(s4.path, 1)::int] and n3.id = e2.end_id)
+select s3.n3 as l
+from s3;
 
 -- case: match p = (:NodeKind1)-[:EdgeKind1*1..]->(n:NodeKind2) where 'admin_tier_0' in split(n.system_tags, ' ') return p limit 1000
-with s0 as (with recursive ex0(root_id, next_id, depth, satisfied, is_cycle, path) as (select e0.start_id,
-                                                                                              e0.end_id,
-                                                                                              1,
-                                                                                              n1.kind_ids operator (pg_catalog.&&)
-                                                                                              array [2]::int2[] and
-                                                                                              'admin_tier_0' = any
-                                                                                              (string_to_array(n1.properties ->> 'system_tags', ' ')::text[]),
-                                                                                              e0.start_id = e0.end_id,
-                                                                                              array [e0.id]
-                                                                                       from edge e0
-                                                                                              join node n0 on
-                                                                                         n0.kind_ids operator (pg_catalog.&&)
-                                                                                         array [1]::int2[] and
-                                                                                         n0.id = e0.start_id
-                                                                                              join node n1 on n1.id = e0.end_id
-                                                                                       where e0.kind_id = any (array [3]::int2[])
-                                                                                       union
-                                                                                       select ex0.root_id,
-                                                                                              e0.end_id,
-                                                                                              ex0.depth + 1,
-                                                                                              n1.kind_ids operator (pg_catalog.&&)
-                                                                                              array [2]::int2[] and
-                                                                                              'admin_tier_0' = any
-                                                                                              (string_to_array(n1.properties ->> 'system_tags', ' ')::text[]),
-                                                                                              e0.id = any (ex0.path),
-                                                                                              ex0.path || e0.id
-                                                                                       from ex0
-                                                                                              join edge e0 on e0.start_id = ex0.next_id
-                                                                                              join node n1 on n1.id = e0.end_id
-                                                                                       where ex0.depth < 10
-                                                                                         and not ex0.is_cycle
-                                                                                         and e0.kind_id = any (array [3]::int2[]))
-            select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0,
-                   (select array_agg((e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite)
+with s0 as (with recursive s1(root_id, next_id, depth, satisfied, is_cycle, path) as (select e0.start_id,
+                                                                                             e0.end_id,
+                                                                                             1,
+                                                                                             'admin_tier_0' = any
+                                                                                             (string_to_array(n1.properties ->> 'system_tags', ' ')::text[]) and
+                                                                                             n1.kind_ids operator (pg_catalog.&&)
+                                                                                             array [2]::int2[],
+                                                                                             e0.start_id = e0.end_id,
+                                                                                             array [e0.id]
+                                                                                      from edge e0
+                                                                                             join node n0
+                                                                                                  on
+                                                                                                    n0.kind_ids operator (pg_catalog.&&)
+                                                                                                    array [1]::int2[] and
+                                                                                                    n0.id =
+                                                                                                    e0.start_id
+                                                                                             join node n1 on n1.id = e0.end_id
+                                                                                      where e0.kind_id = any (array [3]::int2[])
+                                                                                      union
+                                                                                      select s1.root_id,
+                                                                                             e0.end_id,
+                                                                                             s1.depth + 1,
+                                                                                             'admin_tier_0' = any
+                                                                                             (string_to_array(n1.properties ->> 'system_tags', ' ')::text[]) and
+                                                                                             n1.kind_ids operator (pg_catalog.&&)
+                                                                                             array [2]::int2[],
+                                                                                             e0.id = any (s1.path),
+                                                                                             s1.path || e0.id
+                                                                                      from s1
+                                                                                             join edge e0 on e0.start_id = s1.next_id
+                                                                                             join node n1 on n1.id = e0.end_id
+                                                                                      where s1.depth < 10
+                                                                                        and not s1.is_cycle
+                                                                                        and e0.kind_id = any (array [3]::int2[]))
+            select (select array_agg((e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite)
                     from edge e0
-                    where e0.id = any (ex0.path))                     as e0,
-                   ex0.path                                           as ep0,
+                    where e0.id = any (s1.path))                      as e0,
+                   s1.path                                            as ep0,
+                   (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0,
                    (n1.id, n1.kind_ids, n1.properties)::nodecomposite as n1
-            from ex0
-                   join edge e0 on e0.id = any (ex0.path)
-                   join node n0 on n0.id = ex0.root_id
-                   join node n1 on e0.id = ex0.path[array_length(ex0.path, 1)::int] and n1.id = e0.end_id
-            where ex0.satisfied)
+            from s1
+                   join edge e0 on e0.id = any (s1.path)
+                   join node n0 on n0.id = s1.root_id
+                   join node n1 on e0.id = s1.path[array_length(s1.path, 1)::int] and n1.id = e0.end_id
+            where s1.satisfied)
 select edges_to_path(variadic ep0)::pathcomposite as p
 from s0
 limit 1000;
 
 -- case: match p = (s:NodeKind1)-[*..]->(e:NodeKind2) where s <> e return p
-with s0 as (with recursive ex0(root_id, next_id, depth, satisfied, is_cycle, path) as (select e0.start_id,
-                                                                                              e0.end_id,
-                                                                                              1,
-                                                                                              n1.kind_ids operator (pg_catalog.&&) array [2]::int2[],
-                                                                                              e0.start_id = e0.end_id,
-                                                                                              array [e0.id]
-                                                                                       from edge e0
-                                                                                              join node n0 on
-                                                                                         n0.kind_ids operator (pg_catalog.&&)
-                                                                                         array [1]::int2[] and
-                                                                                         n0.id = e0.start_id
-                                                                                              join node n1 on n1.id = e0.end_id
-                                                                                       union
-                                                                                       select ex0.root_id,
-                                                                                              e0.end_id,
-                                                                                              ex0.depth + 1,
-                                                                                              n1.kind_ids operator (pg_catalog.&&) array [2]::int2[],
-                                                                                              e0.id = any (ex0.path),
-                                                                                              ex0.path || e0.id
-                                                                                       from ex0
-                                                                                              join edge e0 on e0.start_id = ex0.next_id
-                                                                                              join node n1 on n1.id = e0.end_id
-                                                                                       where ex0.depth < 10
-                                                                                         and not ex0.is_cycle)
-            select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0,
-                   (select array_agg((e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite)
+with s0 as (with recursive s1(root_id, next_id, depth, satisfied, is_cycle, path) as (select e0.start_id,
+                                                                                             e0.end_id,
+                                                                                             1,
+                                                                                             n1.kind_ids operator (pg_catalog.&&) array [2]::int2[],
+                                                                                             e0.start_id = e0.end_id,
+                                                                                             array [e0.id]
+                                                                                      from edge e0
+                                                                                             join node n0
+                                                                                                  on
+                                                                                                    n0.kind_ids operator (pg_catalog.&&)
+                                                                                                    array [1]::int2[] and
+                                                                                                    n0.id =
+                                                                                                    e0.start_id
+                                                                                             join node n1 on n1.id = e0.end_id
+                                                                                      union
+                                                                                      select s1.root_id,
+                                                                                             e0.end_id,
+                                                                                             s1.depth + 1,
+                                                                                             n1.kind_ids operator (pg_catalog.&&) array [2]::int2[],
+                                                                                             e0.id = any (s1.path),
+                                                                                             s1.path || e0.id
+                                                                                      from s1
+                                                                                             join edge e0 on e0.start_id = s1.next_id
+                                                                                             join node n1 on n1.id = e0.end_id
+                                                                                      where s1.depth < 10
+                                                                                        and not s1.is_cycle)
+            select (select array_agg((e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite)
                     from edge e0
-                    where e0.id = any (ex0.path))                     as e0,
-                   ex0.path                                           as ep0,
+                    where e0.id = any (s1.path))                      as e0,
+                   s1.path                                            as ep0,
+                   (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0,
                    (n1.id, n1.kind_ids, n1.properties)::nodecomposite as n1
-            from ex0
-                   join edge e0 on e0.id = any (ex0.path)
-                   join node n0 on n0.id = ex0.root_id
-                   join node n1 on e0.id = ex0.path[array_length(ex0.path, 1)::int] and n1.id = e0.end_id
-            where ex0.satisfied
+            from s1
+                   join edge e0 on e0.id = any (s1.path)
+                   join node n0 on n0.id = s1.root_id
+                   join node n1 on e0.id = s1.path[array_length(s1.path, 1)::int] and n1.id = e0.end_id
+            where s1.satisfied
               and n0.id <> n1.id)
 select edges_to_path(variadic ep0)::pathcomposite as p
 from s0;
 
 -- case: match p = (g:NodeKind1)-[:EdgeKind1|EdgeKind2*]->(target:NodeKind1) where g.objectid ends with '1234' and target.objectid ends with '4567' return p
-with s0 as (with recursive ex0(root_id, next_id, depth, satisfied, is_cycle, path) as (select e0.start_id,
-                                                                                              e0.end_id,
-                                                                                              1,
-                                                                                              n1.kind_ids operator (pg_catalog.&&)
-                                                                                              array [1]::int2[] and
-                                                                                              n1.properties ->>
-                                                                                              'objectid' like '%4567',
-                                                                                              e0.start_id = e0.end_id,
-                                                                                              array [e0.id]
-                                                                                       from edge e0
-                                                                                              join node n0 on
-                                                                                         n0.kind_ids operator (pg_catalog.&&)
-                                                                                         array [1]::int2[] and
-                                                                                         n0.properties ->>
-                                                                                         'objectid' like '%1234' and
-                                                                                         n0.id = e0.start_id
-                                                                                              join node n1 on n1.id = e0.end_id
-                                                                                       where e0.kind_id = any (array [3, 4]::int2[])
-                                                                                       union
-                                                                                       select ex0.root_id,
-                                                                                              e0.end_id,
-                                                                                              ex0.depth + 1,
-                                                                                              n1.kind_ids operator (pg_catalog.&&)
-                                                                                              array [1]::int2[] and
-                                                                                              n1.properties ->>
-                                                                                              'objectid' like '%4567',
-                                                                                              e0.id = any (ex0.path),
-                                                                                              ex0.path || e0.id
-                                                                                       from ex0
-                                                                                              join edge e0 on e0.start_id = ex0.next_id
-                                                                                              join node n1 on n1.id = e0.end_id
-                                                                                       where ex0.depth < 10
-                                                                                         and not ex0.is_cycle
-                                                                                         and e0.kind_id = any (array [3, 4]::int2[]))
-            select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0,
-                   (select array_agg((e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite)
+with s0 as (with recursive s1(root_id, next_id, depth, satisfied, is_cycle, path) as (select e0.start_id,
+                                                                                             e0.end_id,
+                                                                                             1,
+                                                                                             n1.properties ->>
+                                                                                             'objectid' like '%4567' and
+                                                                                             n1.kind_ids operator (pg_catalog.&&)
+                                                                                             array [1]::int2[],
+                                                                                             e0.start_id = e0.end_id,
+                                                                                             array [e0.id]
+                                                                                      from edge e0
+                                                                                             join node n0
+                                                                                                  on n0.properties ->>
+                                                                                                     'objectid' like
+                                                                                                     '%1234' and
+                                                                                                     n0.kind_ids operator (pg_catalog.&&)
+                                                                                                     array [1]::int2[] and
+                                                                                                     n0.id =
+                                                                                                     e0.start_id
+                                                                                             join node n1 on n1.id = e0.end_id
+                                                                                      where e0.kind_id = any (array [3, 4]::int2[])
+                                                                                      union
+                                                                                      select s1.root_id,
+                                                                                             e0.end_id,
+                                                                                             s1.depth + 1,
+                                                                                             n1.properties ->>
+                                                                                             'objectid' like '%4567' and
+                                                                                             n1.kind_ids operator (pg_catalog.&&)
+                                                                                             array [1]::int2[],
+                                                                                             e0.id = any (s1.path),
+                                                                                             s1.path || e0.id
+                                                                                      from s1
+                                                                                             join edge e0 on e0.start_id = s1.next_id
+                                                                                             join node n1 on n1.id = e0.end_id
+                                                                                      where s1.depth < 10
+                                                                                        and not s1.is_cycle
+                                                                                        and e0.kind_id = any (array [3, 4]::int2[]))
+            select (select array_agg((e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite)
                     from edge e0
-                    where e0.id = any (ex0.path))                     as e0,
-                   ex0.path                                           as ep0,
+                    where e0.id = any (s1.path))                      as e0,
+                   s1.path                                            as ep0,
+                   (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0,
                    (n1.id, n1.kind_ids, n1.properties)::nodecomposite as n1
-            from ex0
-                   join edge e0 on e0.id = any (ex0.path)
-                   join node n0 on n0.id = ex0.root_id
-                   join node n1 on e0.id = ex0.path[array_length(ex0.path, 1)::int] and n1.id = e0.end_id
-            where ex0.satisfied)
+            from s1
+                   join edge e0 on e0.id = any (s1.path)
+                   join node n0 on n0.id = s1.root_id
+                   join node n1 on e0.id = s1.path[array_length(s1.path, 1)::int] and n1.id = e0.end_id
+            where s1.satisfied)
 select edges_to_path(variadic ep0)::pathcomposite as p
 from s0;
 
--- case: match p = (:NodeKind1)<-[:EdgeKind1|EdgeKind2*..]-() return p limit 10
-with s0 as (with recursive ex0(root_id, next_id, depth, satisfied, is_cycle, path) as (select e0.start_id,
-                                                                                              e0.end_id,
-                                                                                              1,
-                                                                                              false,
-                                                                                              e0.start_id = e0.end_id,
-                                                                                              array [e0.id]
-                                                                                       from edge e0
-                                                                                              join node n0 on
-                                                                                         n0.kind_ids operator (pg_catalog.&&)
-                                                                                         array [1]::int2[] and
-                                                                                         n0.id = e0.end_id
-                                                                                              join node n1 on n1.id = e0.start_id
-                                                                                       where e0.kind_id = any (array [3, 4]::int2[])
-                                                                                       union
-                                                                                       select ex0.root_id,
-                                                                                              e0.end_id,
-                                                                                              ex0.depth + 1,
-                                                                                              false,
-                                                                                              e0.id = any (ex0.path),
-                                                                                              ex0.path || e0.id
-                                                                                       from ex0
-                                                                                              join edge e0 on e0.start_id = ex0.next_id
-                                                                                              join node n1 on n1.id = e0.start_id
-                                                                                       where ex0.depth < 10
-                                                                                         and not ex0.is_cycle
-                                                                                         and e0.kind_id = any (array [3, 4]::int2[]))
-            select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0,
-                   (select array_agg((e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite)
+-- case: match p = (m:NodeKind2)-[:EdgeKind1*1..]->(n:NodeKind1) where n.objectid = '1234' return p limit 10
+with s0 as (with recursive s1(root_id, next_id, depth, satisfied, is_cycle, path) as (select e0.start_id,
+                                                                                             e0.end_id,
+                                                                                             1,
+                                                                                             n1.properties ->>
+                                                                                             'objectid' = '1234' and
+                                                                                             n1.kind_ids operator (pg_catalog.&&)
+                                                                                             array [1]::int2[],
+                                                                                             e0.start_id = e0.end_id,
+                                                                                             array [e0.id]
+                                                                                      from edge e0
+                                                                                             join node n0 on
+                                                                                        n0.kind_ids operator (pg_catalog.&&)
+                                                                                        array [2]::int2[] and
+                                                                                        n0.id = e0.start_id
+                                                                                             join node n1 on n1.id = e0.end_id
+                                                                                      where e0.kind_id = any (array [3]::int2[])
+                                                                                      union
+                                                                                      select s1.root_id,
+                                                                                             e0.end_id,
+                                                                                             s1.depth + 1,
+                                                                                             n1.properties ->>
+                                                                                             'objectid' = '1234' and
+                                                                                             n1.kind_ids operator (pg_catalog.&&)
+                                                                                             array [1]::int2[],
+                                                                                             e0.id = any (s1.path),
+                                                                                             s1.path || e0.id
+                                                                                      from s1
+                                                                                             join edge e0 on e0.start_id = s1.next_id
+                                                                                             join node n1 on n1.id = e0.end_id
+                                                                                      where s1.depth < 10
+                                                                                        and not s1.is_cycle
+                                                                                        and e0.kind_id = any (array [3]::int2[]))
+            select (select array_agg((e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite)
                     from edge e0
-                    where e0.id = any (ex0.path))                     as e0,
-                   ex0.path                                           as ep0,
+                    where e0.id = any (s1.path))                      as e0,
+                   s1.path                                            as ep0,
+                   (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0,
                    (n1.id, n1.kind_ids, n1.properties)::nodecomposite as n1
-            from ex0
-                   join edge e0 on e0.id = any (ex0.path)
-                   join node n0 on n0.id = ex0.root_id
-                   join node n1 on e0.id = ex0.path[array_length(ex0.path, 1)::int] and n1.id = e0.start_id)
+            from s1
+                   join edge e0 on e0.id = any (s1.path)
+                   join node n0 on n0.id = s1.root_id
+                   join node n1 on e0.id = s1.path[array_length(s1.path, 1)::int] and n1.id = e0.end_id
+            where s1.satisfied)
 select edges_to_path(variadic ep0)::pathcomposite as p
 from s0
 limit 10;
 
+-- todo: match p = (n:NodeKind1)<-[:EdgeKind1*1..]-(m:NodeKind2) where n.objectid = '1234' return p limit 10
+with s0 as (with recursive s1(root_id, next_id, depth, satisfied, is_cycle, path) as (select e0.start_id,
+                                                                                             e0.end_id,
+                                                                                             1,
+                                                                                             n1.kind_ids operator (pg_catalog.&&) array [2]::int2[],
+                                                                                             e0.start_id = e0.end_id,
+                                                                                             array [e0.id]
+                                                                                      from edge e0
+                                                                                             join node n0 on
+                                                                                        n0.properties ->> 'objectid' =
+                                                                                        '1234' and
+                                                                                        n0.kind_ids operator (pg_catalog.&&)
+                                                                                        array [1]::int2[] and
+                                                                                        n0.id = e0.end_id
+                                                                                             join node n1 on n1.id = e0.start_id
+                                                                                      where e0.kind_id = any (array [3]::int2[])
+                                                                                      union
+                                                                                      select s1.root_id,
+                                                                                             e0.end_id,
+                                                                                             s1.depth + 1,
+                                                                                             n1.kind_ids operator (pg_catalog.&&) array [2]::int2[],
+                                                                                             e0.id = any (s1.path),
+                                                                                             s1.path || e0.id
+                                                                                      from s1
+                                                                                             join edge e0 on e0.start_id = s1.next_id
+                                                                                             join node n1 on n1.id = e0.start_id
+                                                                                      where s1.depth < 10
+                                                                                        and not s1.is_cycle
+                                                                                        and e0.kind_id = any (array [3]::int2[]))
+            select (select array_agg((e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite)
+                    from edge e0
+                    where e0.id = any (s1.path))                      as e0,
+                   s1.path                                            as ep0,
+                   (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0,
+                   (n1.id, n1.kind_ids, n1.properties)::nodecomposite as n1
+            from s1
+                   join edge e0 on e0.id = any (s1.path)
+                   join node n0 on n0.id = s1.root_id
+                   join node n1 on e0.id = s1.path[array_length(s1.path, 1)::int] and n1.id = e0.start_id
+            where s1.satisfied)
+select edges_to_path(variadic ep0)::pathcomposite as p
+from s0
+limit 10;
+
+-- case: match p = (:NodeKind1)<-[:EdgeKind1|EdgeKind2*..]-() return p limit 10
+with s0 as (with recursive s1(root_id, next_id, depth, satisfied, is_cycle, path) as (select e0.start_id,
+                                                                                             e0.end_id,
+                                                                                             1,
+                                                                                             false,
+                                                                                             e0.start_id = e0.end_id,
+                                                                                             array [e0.id]
+                                                                                      from edge e0
+                                                                                             join node n0
+                                                                                                  on
+                                                                                                    n0.kind_ids operator (pg_catalog.&&)
+                                                                                                    array [1]::int2[] and
+                                                                                                    n0.id = e0.end_id
+                                                                                             join node n1 on n1.id = e0.start_id
+                                                                                      where e0.kind_id = any (array [3, 4]::int2[])
+                                                                                      union
+                                                                                      select s1.root_id,
+                                                                                             e0.end_id,
+                                                                                             s1.depth + 1,
+                                                                                             false,
+                                                                                             e0.id = any (s1.path),
+                                                                                             s1.path || e0.id
+                                                                                      from s1
+                                                                                             join edge e0 on e0.start_id = s1.next_id
+                                                                                             join node n1 on n1.id = e0.start_id
+                                                                                      where s1.depth < 10
+                                                                                        and not s1.is_cycle
+                                                                                        and e0.kind_id = any (array [3, 4]::int2[]))
+            select (select array_agg((e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite)
+                    from edge e0
+                    where e0.id = any (s1.path))                      as e0,
+                   s1.path                                            as ep0,
+                   (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0,
+                   (n1.id, n1.kind_ids, n1.properties)::nodecomposite as n1
+            from s1
+                   join edge e0 on e0.id = any (s1.path)
+                   join node n0 on n0.id = s1.root_id
+                   join node n1 on e0.id = s1.path[array_length(s1.path, 1)::int] and n1.id = e0.start_id)
+select edges_to_path(variadic ep0)::pathcomposite as p
+from s0
+limit 10;
 
 -- case: match p = (:NodeKind1)<-[:EdgeKind1|EdgeKind2*..]-(:NodeKind2)<-[:EdgeKind1|EdgeKind2*..]-(:NodeKind1) return p limit 10
-with s0 as (with recursive ex0(root_id, next_id, depth, satisfied, is_cycle, path) as (select e0.start_id,
-                                                                                              e0.end_id,
-                                                                                              1,
-                                                                                              n1.kind_ids operator (pg_catalog.&&) array [2]::int2[],
-                                                                                              e0.start_id = e0.end_id,
-                                                                                              array [e0.id]
-                                                                                       from edge e0
-                                                                                              join node n0 on
-                                                                                         n0.kind_ids operator (pg_catalog.&&)
-                                                                                         array [1]::int2[] and
-                                                                                         n0.id = e0.end_id
-                                                                                              join node n1 on n1.id = e0.start_id
-                                                                                       where e0.kind_id = any (array [3, 4]::int2[])
-                                                                                       union
-                                                                                       select ex0.root_id,
-                                                                                              e0.end_id,
-                                                                                              ex0.depth + 1,
-                                                                                              n1.kind_ids operator (pg_catalog.&&) array [2]::int2[],
-                                                                                              e0.id = any (ex0.path),
-                                                                                              ex0.path || e0.id
-                                                                                       from ex0
-                                                                                              join edge e0 on e0.start_id = ex0.next_id
-                                                                                              join node n1 on n1.id = e0.start_id
-                                                                                       where ex0.depth < 10
-                                                                                         and not ex0.is_cycle
-                                                                                         and e0.kind_id = any (array [3, 4]::int2[]))
-            select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0,
-                   (select array_agg((e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite)
+with s0 as (with recursive s1(root_id, next_id, depth, satisfied, is_cycle, path) as (select e0.start_id,
+                                                                                             e0.end_id,
+                                                                                             1,
+                                                                                             n1.kind_ids operator (pg_catalog.&&) array [2]::int2[],
+                                                                                             e0.start_id = e0.end_id,
+                                                                                             array [e0.id]
+                                                                                      from edge e0
+                                                                                             join node n0
+                                                                                                  on
+                                                                                                    n0.kind_ids operator (pg_catalog.&&)
+                                                                                                    array [1]::int2[] and
+                                                                                                    n0.id = e0.end_id
+                                                                                             join node n1 on n1.id = e0.start_id
+                                                                                      where e0.kind_id = any (array [3, 4]::int2[])
+                                                                                      union
+                                                                                      select s1.root_id,
+                                                                                             e0.end_id,
+                                                                                             s1.depth + 1,
+                                                                                             n1.kind_ids operator (pg_catalog.&&) array [2]::int2[],
+                                                                                             e0.id = any (s1.path),
+                                                                                             s1.path || e0.id
+                                                                                      from s1
+                                                                                             join edge e0 on e0.start_id = s1.next_id
+                                                                                             join node n1 on n1.id = e0.start_id
+                                                                                      where s1.depth < 10
+                                                                                        and not s1.is_cycle
+                                                                                        and e0.kind_id = any (array [3, 4]::int2[]))
+            select (select array_agg((e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite)
                     from edge e0
-                    where e0.id = any (ex0.path))                     as e0,
-                   ex0.path                                           as ep0,
+                    where e0.id = any (s1.path))                      as e0,
+                   s1.path                                            as ep0,
+                   (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0,
                    (n1.id, n1.kind_ids, n1.properties)::nodecomposite as n1
-            from ex0
-                   join edge e0 on e0.id = any (ex0.path)
-                   join node n0 on n0.id = ex0.root_id
-                   join node n1 on e0.id = ex0.path[array_length(ex0.path, 1)::int] and n1.id = e0.start_id
-            where ex0.satisfied),
-     s1 as (with recursive ex1(root_id, next_id, depth, satisfied, is_cycle, path) as (select e1.start_id,
-                                                                                              e1.end_id,
-                                                                                              1,
-                                                                                              false,
-                                                                                              e1.start_id = e1.end_id,
-                                                                                              array [e1.id]
-                                                                                       from s0
-                                                                                              join edge e1 on
-                                                                                         e1.kind_id = any
-                                                                                         (array [3, 4]::int2[]) and
-                                                                                         (s0.n1).id = e1.end_id
-                                                                                              join node n2 on n2.id = e1.start_id
-                                                                                       union
-                                                                                       select ex1.root_id,
-                                                                                              e1.end_id,
-                                                                                              ex1.depth + 1,
-                                                                                              n2.kind_ids operator (pg_catalog.&&) array [1]::int2[],
-                                                                                              e1.id = any (ex1.path),
-                                                                                              ex1.path || e1.id
-                                                                                       from ex1
-                                                                                              join edge e1 on e1.start_id = ex1.next_id
-                                                                                              join node n2 on n2.id = e1.start_id
-                                                                                       where ex1.depth < 10
-                                                                                         and not ex1.is_cycle)
+            from s1
+                   join edge e0 on e0.id = any (s1.path)
+                   join node n0 on n0.id = s1.root_id
+                   join node n1 on e0.id = s1.path[array_length(s1.path, 1)::int] and n1.id = e0.start_id
+            where s1.satisfied),
+     s2 as (with recursive s3(root_id, next_id, depth, satisfied, is_cycle, path) as (select e1.start_id,
+                                                                                             e1.end_id,
+                                                                                             1,
+                                                                                             false,
+                                                                                             e1.start_id = e1.end_id,
+                                                                                             array [e1.id]
+                                                                                      from s0
+                                                                                             join edge e1
+                                                                                                  on e1.kind_id = any
+                                                                                                     (array [3, 4]::int2[]) and
+                                                                                                     (s0.e0).start_id =
+                                                                                                     e1.end_id
+                                                                                             join node n2 on n2.id = e1.start_id
+                                                                                      union
+                                                                                      select s3.root_id,
+                                                                                             e1.end_id,
+                                                                                             s3.depth + 1,
+                                                                                             n2.kind_ids operator (pg_catalog.&&) array [1]::int2[],
+                                                                                             e1.id = any (s3.path),
+                                                                                             s3.path || e1.id
+                                                                                      from s3
+                                                                                             join edge e1 on e1.start_id = s3.next_id
+                                                                                             join node n2 on n2.id = e1.start_id
+                                                                                      where s3.depth < 10
+                                                                                        and not s3.is_cycle)
             select s0.e0                                              as e0,
-                   s0.ep0                                             as ep0,
-                   s0.n0                                              as n0,
-                   s0.n1                                              as n1,
                    (select array_agg((e1.id, e1.start_id, e1.end_id, e1.kind_id, e1.properties)::edgecomposite)
                     from edge e1
-                    where e1.id = any (ex1.path))                     as e1,
-                   ex1.path                                           as ep1,
+                    where e1.id = any (s3.path))                      as e1,
+                   s0.ep0                                             as ep0,
+                   s3.path                                            as ep1,
+                   s0.n0                                              as n0,
+                   s0.n1                                              as n1,
                    (n2.id, n2.kind_ids, n2.properties)::nodecomposite as n2
             from s0,
-                 ex1
-                   join edge e1 on e1.id = any (ex1.path)
-                   join node n1 on n1.id = ex1.root_id
-                   join node n2 on e1.id = ex1.path[array_length(ex1.path, 1)::int] and n2.id = e1.start_id)
-select edges_to_path(variadic s1.ep1 || s1.ep0)::pathcomposite as p
-from s1
+                 s3
+                   join edge e1 on e1.id = any (s3.path)
+                   join node n1 on n1.id = s3.root_id
+                   join node n2 on e1.id = s3.path[array_length(s3.path, 1)::int] and n2.id = e1.start_id)
+select edges_to_path(variadic s2.ep1 || s2.ep0)::pathcomposite as p
+from s2
 limit 10;
 
 -- case: match p = (n:NodeKind1)-[:EdgeKind1|EdgeKind2*1..2]->(r:NodeKind2) where r.name =~ '(?i)Global Administrator.*|User Administrator.*|Cloud Application Administrator.*|Authentication Policy Administrator.*|Exchange Administrator.*|Helpdesk Administrator.*|Privileged Authentication Administrator.*' return p limit 10
-with s0 as (with recursive ex0(root_id, next_id, depth, satisfied, is_cycle, path) as (select e0.start_id,
-                                                                                              e0.end_id,
-                                                                                              1,
-                                                                                              n1.kind_ids operator (pg_catalog.&&)
-                                                                                              array [2]::int2[] and
-                                                                                              n1.properties ->> 'name' ~
-                                                                                              '(?i)Global Administrator.*|User Administrator.*|Cloud Application Administrator.*|Authentication Policy Administrator.*|Exchange Administrator.*|Helpdesk Administrator.*|Privileged Authentication Administrator.*',
-                                                                                              e0.start_id = e0.end_id,
-                                                                                              array [e0.id]
-                                                                                       from edge e0
-                                                                                              join node n0 on
-                                                                                         n0.kind_ids operator (pg_catalog.&&)
-                                                                                         array [1]::int2[] and
-                                                                                         n0.id = e0.start_id
-                                                                                              join node n1 on n1.id = e0.end_id
-                                                                                       where e0.kind_id = any (array [3, 4]::int2[])
-                                                                                       union
-                                                                                       select ex0.root_id,
-                                                                                              e0.end_id,
-                                                                                              ex0.depth + 1,
-                                                                                              n1.kind_ids operator (pg_catalog.&&)
-                                                                                              array [2]::int2[] and
-                                                                                              n1.properties ->> 'name' ~
-                                                                                              '(?i)Global Administrator.*|User Administrator.*|Cloud Application Administrator.*|Authentication Policy Administrator.*|Exchange Administrator.*|Helpdesk Administrator.*|Privileged Authentication Administrator.*',
-                                                                                              e0.id = any (ex0.path),
-                                                                                              ex0.path || e0.id
-                                                                                       from ex0
-                                                                                              join edge e0 on e0.start_id = ex0.next_id
-                                                                                              join node n1 on n1.id = e0.end_id
-                                                                                       where ex0.depth < 10
-                                                                                         and not ex0.is_cycle
-                                                                                         and e0.kind_id = any (array [3, 4]::int2[]))
-            select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0,
-                   (select array_agg((e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite)
+with s0 as (with recursive s1(root_id, next_id, depth, satisfied, is_cycle, path) as (select e0.start_id,
+                                                                                             e0.end_id,
+                                                                                             1,
+                                                                                             n1.properties ->> 'name' ~
+                                                                                             '(?i)Global Administrator.*|User Administrator.*|Cloud Application Administrator.*|Authentication Policy Administrator.*|Exchange Administrator.*|Helpdesk Administrator.*|Privileged Authentication Administrator.*' and
+                                                                                             n1.kind_ids operator (pg_catalog.&&)
+                                                                                             array [2]::int2[],
+                                                                                             e0.start_id = e0.end_id,
+                                                                                             array [e0.id]
+                                                                                      from edge e0
+                                                                                             join node n0 on
+                                                                                        n0.kind_ids operator (pg_catalog.&&)
+                                                                                        array [1]::int2[] and
+                                                                                        n0.id = e0.start_id
+                                                                                             join node n1 on n1.id = e0.end_id
+                                                                                      where e0.kind_id = any (array [3, 4]::int2[])
+                                                                                      union
+                                                                                      select s1.root_id,
+                                                                                             e0.end_id,
+                                                                                             s1.depth + 1,
+                                                                                             n1.properties ->> 'name' ~
+                                                                                             '(?i)Global Administrator.*|User Administrator.*|Cloud Application Administrator.*|Authentication Policy Administrator.*|Exchange Administrator.*|Helpdesk Administrator.*|Privileged Authentication Administrator.*' and
+                                                                                             n1.kind_ids operator (pg_catalog.&&)
+                                                                                             array [2]::int2[],
+                                                                                             e0.id = any (s1.path),
+                                                                                             s1.path || e0.id
+                                                                                      from s1
+                                                                                             join edge e0 on e0.start_id = s1.next_id
+                                                                                             join node n1 on n1.id = e0.end_id
+                                                                                      where s1.depth < 10
+                                                                                        and not s1.is_cycle
+                                                                                        and e0.kind_id = any (array [3, 4]::int2[]))
+            select (select array_agg((e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite)
                     from edge e0
-                    where e0.id = any (ex0.path))                     as e0,
-                   ex0.path                                           as ep0,
+                    where e0.id = any (s1.path))                      as e0,
+                   s1.path                                            as ep0,
+                   (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0,
                    (n1.id, n1.kind_ids, n1.properties)::nodecomposite as n1
-            from ex0
-                   join edge e0 on e0.id = any (ex0.path)
-                   join node n0 on n0.id = ex0.root_id
-                   join node n1 on e0.id = ex0.path[array_length(ex0.path, 1)::int] and n1.id = e0.end_id
-            where ex0.satisfied)
+            from s1
+                   join edge e0 on e0.id = any (s1.path)
+                   join node n0 on n0.id = s1.root_id
+                   join node n1 on e0.id = s1.path[array_length(s1.path, 1)::int] and n1.id = e0.end_id
+            where s1.satisfied)
 select edges_to_path(variadic ep0)::pathcomposite as p
 from s0
 limit 10;

--- a/packages/go/cypher/models/pgsql/test/translation_cases/shortest_paths.sql
+++ b/packages/go/cypher/models/pgsql/test/translation_cases/shortest_paths.sql
@@ -16,76 +16,76 @@
 
 -- case: match p = allShortestPaths((s:NodeKind1)-[*..]->()) return p
 -- cypher_params: {}
--- pgsql_params: {"pi0":"insert into next_pathspace (root_id, next_id, depth, satisfied, is_cycle, path) select e0.start_id, e0.end_id, 1, exists (select 1 from edge e0 where n1.id = e0.start_id), e0.start_id = e0.end_id, array [e0.id] from edge e0 join node n0 on n0.kind_ids operator (pg_catalog.&&) array [1]::int2[] and n0.id = e0.start_id join node n1 on n1.id = e0.end_id;", "pi1":"insert into next_pathspace (root_id, next_id, depth, satisfied, is_cycle, path) select ex0.root_id, e0.end_id, ex0.depth + 1, exists (select 1 from edge e0 where n1.id = e0.start_id), e0.id = any (ex0.path), ex0.path || e0.id from pathspace ex0 join edge e0 on e0.start_id = ex0.next_id join node n1 on n1.id = e0.end_id where ex0.depth < 10 and not ex0.is_cycle;"}
-with s0 as (with ex0(root_id, next_id, depth, satisfied, is_cycle, path)
+-- pgsql_params: {"pi0":"insert into next_pathspace (root_id, next_id, depth, satisfied, is_cycle, path) select e0.start_id, e0.end_id, 1, exists (select 1 from edge e0 where n1.id = e0.start_id), e0.start_id = e0.end_id, array [e0.id] from edge e0 join node n0 on n0.kind_ids operator (pg_catalog.&&) array [1]::int2[] and n0.id = e0.start_id join node n1 on n1.id = e0.end_id;", "pi1":"insert into next_pathspace (root_id, next_id, depth, satisfied, is_cycle, path) select s1.root_id, e0.end_id, s1.depth + 1, exists (select 1 from edge e0 where n1.id = e0.start_id), e0.id = any (s1.path), s1.path || e0.id from pathspace s1 join edge e0 on e0.start_id = s1.next_id join node n1 on n1.id = e0.end_id where s1.depth < 10 and not s1.is_cycle;"}
+with s0 as (with s1(root_id, next_id, depth, satisfied, is_cycle, path)
                    as (select * from asp_harness(@pi0::text, @pi1::text, 10))
-            select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0,
-                   (select array_agg((e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite)
+            select (select array_agg((e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite)
                     from edge e0
-                    where e0.id = any (ex0.path))                     as e0,
-                   ex0.path                                           as ep0,
+                    where e0.id = any (s1.path))                      as e0,
+                   s1.path                                            as ep0,
+                   (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0,
                    (n1.id, n1.kind_ids, n1.properties)::nodecomposite as n1
-            from ex0
-                   join edge e0 on e0.id = any (ex0.path)
-                   join node n0 on n0.id = ex0.root_id
-                   join node n1 on e0.id = ex0.path[array_length(ex0.path, 1)::int] and n1.id = e0.end_id)
+            from s1
+                   join edge e0 on e0.id = any (s1.path)
+                   join node n0 on n0.id = s1.root_id
+                   join node n1 on e0.id = s1.path[array_length(s1.path, 1)::int] and n1.id = e0.end_id)
 select edges_to_path(variadic ep0)::pathcomposite as p
 from s0;
 
 -- case: match p = allShortestPaths((s:NodeKind1)-[*..]->({name: "123"})) return p
 -- cypher_params: {}
--- pgsql_params: {"pi0":"insert into next_pathspace (root_id, next_id, depth, satisfied, is_cycle, path) select e0.start_id, e0.end_id, 1, n1.properties ->> 'name' = '123', e0.start_id = e0.end_id, array [e0.id] from edge e0 join node n0 on n0.kind_ids operator (pg_catalog.&&) array [1]::int2[] and n0.id = e0.start_id join node n1 on n1.id = e0.end_id;", "pi1":"insert into next_pathspace (root_id, next_id, depth, satisfied, is_cycle, path) select ex0.root_id, e0.end_id, ex0.depth + 1, n1.properties ->> 'name' = '123', e0.id = any (ex0.path), ex0.path || e0.id from pathspace ex0 join edge e0 on e0.start_id = ex0.next_id join node n1 on n1.id = e0.end_id where ex0.depth < 10 and not ex0.is_cycle;"}
-with s0 as (with ex0(root_id, next_id, depth, satisfied, is_cycle, path)
+-- pgsql_params: {"pi0":"insert into next_pathspace (root_id, next_id, depth, satisfied, is_cycle, path) select e0.start_id, e0.end_id, 1, n1.properties ->> 'name' = '123', e0.start_id = e0.end_id, array [e0.id] from edge e0 join node n0 on n0.kind_ids operator (pg_catalog.&&) array [1]::int2[] and n0.id = e0.start_id join node n1 on n1.id = e0.end_id;", "pi1":"insert into next_pathspace (root_id, next_id, depth, satisfied, is_cycle, path) select s1.root_id, e0.end_id, s1.depth + 1, n1.properties ->> 'name' = '123', e0.id = any (s1.path), s1.path || e0.id from pathspace s1 join edge e0 on e0.start_id = s1.next_id join node n1 on n1.id = e0.end_id where s1.depth < 10 and not s1.is_cycle;"}
+with s0 as (with s1(root_id, next_id, depth, satisfied, is_cycle, path)
                    as (select * from asp_harness(@pi0::text, @pi1::text, 10))
-            select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0,
-                   (select array_agg((e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite)
+            select (select array_agg((e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite)
                     from edge e0
-                    where e0.id = any (ex0.path))                     as e0,
-                   ex0.path                                           as ep0,
+                    where e0.id = any (s1.path))                      as e0,
+                   s1.path                                            as ep0,
+                   (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0,
                    (n1.id, n1.kind_ids, n1.properties)::nodecomposite as n1
-            from ex0
-                   join edge e0 on e0.id = any (ex0.path)
-                   join node n0 on n0.id = ex0.root_id
-                   join node n1 on e0.id = ex0.path[array_length(ex0.path, 1)::int] and n1.id = e0.end_id
-            where ex0.satisfied)
+            from s1
+                   join edge e0 on e0.id = any (s1.path)
+                   join node n0 on n0.id = s1.root_id
+                   join node n1 on e0.id = s1.path[array_length(s1.path, 1)::int] and n1.id = e0.end_id
+            where s1.satisfied)
 select edges_to_path(variadic ep0)::pathcomposite as p
 from s0;
 
 -- case: match p = allShortestPaths((s:NodeKind1)-[*..]->(e)) where e.name = '123' return p
 -- cypher_params: {}
--- pgsql_params: {"pi0":"insert into next_pathspace (root_id, next_id, depth, satisfied, is_cycle, path) select e0.start_id, e0.end_id, 1, n1.properties ->> 'name' = '123', e0.start_id = e0.end_id, array [e0.id] from edge e0 join node n0 on n0.kind_ids operator (pg_catalog.&&) array [1]::int2[] and n0.id = e0.start_id join node n1 on n1.id = e0.end_id;", "pi1":"insert into next_pathspace (root_id, next_id, depth, satisfied, is_cycle, path) select ex0.root_id, e0.end_id, ex0.depth + 1, n1.properties ->> 'name' = '123', e0.id = any (ex0.path), ex0.path || e0.id from pathspace ex0 join edge e0 on e0.start_id = ex0.next_id join node n1 on n1.id = e0.end_id where ex0.depth < 10 and not ex0.is_cycle;"}
-with s0 as (with ex0(root_id, next_id, depth, satisfied, is_cycle, path)
+-- pgsql_params: {"pi0":"insert into next_pathspace (root_id, next_id, depth, satisfied, is_cycle, path) select e0.start_id, e0.end_id, 1, n1.properties ->> 'name' = '123', e0.start_id = e0.end_id, array [e0.id] from edge e0 join node n0 on n0.kind_ids operator (pg_catalog.&&) array [1]::int2[] and n0.id = e0.start_id join node n1 on n1.id = e0.end_id;", "pi1":"insert into next_pathspace (root_id, next_id, depth, satisfied, is_cycle, path) select s1.root_id, e0.end_id, s1.depth + 1, n1.properties ->> 'name' = '123', e0.id = any (s1.path), s1.path || e0.id from pathspace s1 join edge e0 on e0.start_id = s1.next_id join node n1 on n1.id = e0.end_id where s1.depth < 10 and not s1.is_cycle;"}
+with s0 as (with s1(root_id, next_id, depth, satisfied, is_cycle, path)
                    as (select * from asp_harness(@pi0::text, @pi1::text, 10))
-            select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0,
-                   (select array_agg((e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite)
+            select (select array_agg((e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite)
                     from edge e0
-                    where e0.id = any (ex0.path))                     as e0,
-                   ex0.path                                           as ep0,
+                    where e0.id = any (s1.path))                      as e0,
+                   s1.path                                            as ep0,
+                   (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0,
                    (n1.id, n1.kind_ids, n1.properties)::nodecomposite as n1
-            from ex0
-                   join edge e0 on e0.id = any (ex0.path)
-                   join node n0 on n0.id = ex0.root_id
-                   join node n1 on e0.id = ex0.path[array_length(ex0.path, 1)::int] and n1.id = e0.end_id
-            where ex0.satisfied)
+            from s1
+                   join edge e0 on e0.id = any (s1.path)
+                   join node n0 on n0.id = s1.root_id
+                   join node n1 on e0.id = s1.path[array_length(s1.path, 1)::int] and n1.id = e0.end_id
+            where s1.satisfied)
 select edges_to_path(variadic ep0)::pathcomposite as p
 from s0;
 
 -- case: match p=shortestPath((n:NodeKind1)-[:EdgeKind1*1..]->(m)) where 'admin_tier_0' in split(m.system_tags, ' ') and n.objectid ends with '-513' and n<>m return p limit 1000
 -- cypher_params: {}
--- pgsql_params: {"pi0":"insert into next_pathspace (root_id, next_id, depth, satisfied, is_cycle, path) select e0.start_id, e0.end_id, 1, 'admin_tier_0' = any (string_to_array(n1.properties ->> 'system_tags', ' ')::text[]), e0.start_id = e0.end_id, array [e0.id] from edge e0 join node n0 on n0.kind_ids operator (pg_catalog.&&) array [1]::int2[] and n0.properties ->> 'objectid' like '%-513' and n0.id = e0.start_id join node n1 on n1.id = e0.end_id where e0.kind_id = any (array [3]::int2[]);", "pi1":"insert into next_pathspace (root_id, next_id, depth, satisfied, is_cycle, path) select ex0.root_id, e0.end_id, ex0.depth + 1, 'admin_tier_0' = any (string_to_array(n1.properties ->> 'system_tags', ' ')::text[]), e0.id = any (ex0.path), ex0.path || e0.id from pathspace ex0 join edge e0 on e0.start_id = ex0.next_id join node n1 on n1.id = e0.end_id where ex0.depth < 10 and not ex0.is_cycle and e0.kind_id = any (array [3]::int2[]);"}
-with s0 as (with ex0(root_id, next_id, depth, satisfied, is_cycle, path)
+-- pgsql_params: {"pi0":"insert into next_pathspace (root_id, next_id, depth, satisfied, is_cycle, path) select e0.start_id, e0.end_id, 1, 'admin_tier_0' = any (string_to_array(n1.properties ->> 'system_tags', ' ')::text[]), e0.start_id = e0.end_id, array [e0.id] from edge e0 join node n0 on n0.properties ->> 'objectid' like '%-513' and n0.kind_ids operator (pg_catalog.&&) array [1]::int2[] and n0.id = e0.start_id join node n1 on n1.id = e0.end_id where e0.kind_id = any (array [3]::int2[]);", "pi1":"insert into next_pathspace (root_id, next_id, depth, satisfied, is_cycle, path) select s1.root_id, e0.end_id, s1.depth + 1, 'admin_tier_0' = any (string_to_array(n1.properties ->> 'system_tags', ' ')::text[]), e0.id = any (s1.path), s1.path || e0.id from pathspace s1 join edge e0 on e0.start_id = s1.next_id join node n1 on n1.id = e0.end_id where s1.depth < 10 and not s1.is_cycle and e0.kind_id = any (array [3]::int2[]);"}
+with s0 as (with s1(root_id, next_id, depth, satisfied, is_cycle, path)
                    as (select * from asp_harness(@pi0::text, @pi1::text, 10))
-            select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0,
-                   (select array_agg((e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite)
+            select (select array_agg((e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite)
                     from edge e0
-                    where e0.id = any (ex0.path))                     as e0,
-                   ex0.path                                           as ep0,
+                    where e0.id = any (s1.path))                      as e0,
+                   s1.path                                            as ep0,
+                   (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0,
                    (n1.id, n1.kind_ids, n1.properties)::nodecomposite as n1
-            from ex0
-                   join edge e0 on e0.id = any (ex0.path)
-                   join node n0 on n0.id = ex0.root_id
-                   join node n1 on e0.id = ex0.path[array_length(ex0.path, 1)::int] and n1.id = e0.end_id
-            where ex0.satisfied
+            from s1
+                   join edge e0 on e0.id = any (s1.path)
+                   join node n0 on n0.id = s1.root_id
+                   join node n1 on e0.id = s1.path[array_length(s1.path, 1)::int] and n1.id = e0.end_id
+            where s1.satisfied
               and n0.id <> n1.id)
 select edges_to_path(variadic ep0)::pathcomposite as p
 from s0
@@ -93,20 +93,20 @@ limit 1000;
 
 -- case: match p=shortestPath((n:NodeKind1)-[:EdgeKind1*1..]->(m)) where 'admin_tier_0' in split(m.system_tags, ' ') and n.objectid ends with '-513' and m<>n return p limit 1000
 -- cypher_params: {}
--- pgsql_params: {"pi0":"insert into next_pathspace (root_id, next_id, depth, satisfied, is_cycle, path) select e0.start_id, e0.end_id, 1, 'admin_tier_0' = any (string_to_array(n1.properties ->> 'system_tags', ' ')::text[]), e0.start_id = e0.end_id, array [e0.id] from edge e0 join node n0 on n0.kind_ids operator (pg_catalog.&&) array [1]::int2[] and n0.properties ->> 'objectid' like '%-513' and n0.id = e0.start_id join node n1 on n1.id = e0.end_id where e0.kind_id = any (array [3]::int2[]);", "pi1":"insert into next_pathspace (root_id, next_id, depth, satisfied, is_cycle, path) select ex0.root_id, e0.end_id, ex0.depth + 1, 'admin_tier_0' = any (string_to_array(n1.properties ->> 'system_tags', ' ')::text[]), e0.id = any (ex0.path), ex0.path || e0.id from pathspace ex0 join edge e0 on e0.start_id = ex0.next_id join node n1 on n1.id = e0.end_id where ex0.depth < 10 and not ex0.is_cycle and e0.kind_id = any (array [3]::int2[]);"}
-with s0 as (with ex0(root_id, next_id, depth, satisfied, is_cycle, path)
+-- pgsql_params: {"pi0":"insert into next_pathspace (root_id, next_id, depth, satisfied, is_cycle, path) select e0.start_id, e0.end_id, 1, 'admin_tier_0' = any (string_to_array(n1.properties ->> 'system_tags', ' ')::text[]), e0.start_id = e0.end_id, array [e0.id] from edge e0 join node n0 on n0.properties ->> 'objectid' like '%-513' and n0.kind_ids operator (pg_catalog.&&) array [1]::int2[] and n0.id = e0.start_id join node n1 on n1.id = e0.end_id where e0.kind_id = any (array [3]::int2[]);", "pi1":"insert into next_pathspace (root_id, next_id, depth, satisfied, is_cycle, path) select s1.root_id, e0.end_id, s1.depth + 1, 'admin_tier_0' = any (string_to_array(n1.properties ->> 'system_tags', ' ')::text[]), e0.id = any (s1.path), s1.path || e0.id from pathspace s1 join edge e0 on e0.start_id = s1.next_id join node n1 on n1.id = e0.end_id where s1.depth < 10 and not s1.is_cycle and e0.kind_id = any (array [3]::int2[]);"}
+with s0 as (with s1(root_id, next_id, depth, satisfied, is_cycle, path)
                    as (select * from asp_harness(@pi0::text, @pi1::text, 10))
-            select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0,
-                   (select array_agg((e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite)
+            select (select array_agg((e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite)
                     from edge e0
-                    where e0.id = any (ex0.path))                     as e0,
-                   ex0.path                                           as ep0,
+                    where e0.id = any (s1.path))                      as e0,
+                   s1.path                                            as ep0,
+                   (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0,
                    (n1.id, n1.kind_ids, n1.properties)::nodecomposite as n1
-            from ex0
-                   join edge e0 on e0.id = any (ex0.path)
-                   join node n0 on n0.id = ex0.root_id
-                   join node n1 on e0.id = ex0.path[array_length(ex0.path, 1)::int] and n1.id = e0.end_id
-            where ex0.satisfied
+            from s1
+                   join edge e0 on e0.id = any (s1.path)
+                   join node n0 on n0.id = s1.root_id
+                   join node n1 on e0.id = s1.path[array_length(s1.path, 1)::int] and n1.id = e0.end_id
+            where s1.satisfied
               and n1.id <> n0.id)
 select edges_to_path(variadic ep0)::pathcomposite as p
 from s0

--- a/packages/go/cypher/models/pgsql/test/translation_cases/stepwise_traversal.sql
+++ b/packages/go/cypher/models/pgsql/test/translation_cases/stepwise_traversal.sql
@@ -15,8 +15,8 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 -- case: match ()-[r]->() return r
-with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite                        as n0,
-                   (e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite as e0,
+with s0 as (select (e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite as e0,
+                   (n0.id, n0.kind_ids, n0.properties)::nodecomposite                        as n0,
                    (n1.id, n1.kind_ids, n1.properties)::nodecomposite                        as n1
             from edge e0
                    join node n0 on n0.id = e0.start_id
@@ -26,9 +26,9 @@ from s0;
 
 -- case: match (n), ()-[r]->() return n, r
 with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0 from node n0),
-     s1 as (select s0.n0                                                                     as n0,
+     s1 as (select (e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite as e0,
+                   s0.n0                                                                     as n0,
                    (n1.id, n1.kind_ids, n1.properties)::nodecomposite                        as n1,
-                   (e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite as e0,
                    (n2.id, n2.kind_ids, n2.properties)::nodecomposite                        as n2
             from s0,
                  edge e0
@@ -40,17 +40,17 @@ from s1;
 -- todo: The cypher parser inserts a `r != e` condition to the final projection, as such, with the
 --       basic harness this query in SQL returns 9 results.
 -- case: match ()-[r]->(), ()-[e]->() return r, e
-with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite                        as n0,
-                   (e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite as e0,
+with s0 as (select (e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite as e0,
+                   (n0.id, n0.kind_ids, n0.properties)::nodecomposite                        as n0,
                    (n1.id, n1.kind_ids, n1.properties)::nodecomposite                        as n1
             from edge e0
                    join node n0 on n0.id = e0.start_id
                    join node n1 on n1.id = e0.end_id),
      s1 as (select s0.e0                                                                     as e0,
+                   (e1.id, e1.start_id, e1.end_id, e1.kind_id, e1.properties)::edgecomposite as e1,
                    s0.n0                                                                     as n0,
                    s0.n1                                                                     as n1,
                    (n2.id, n2.kind_ids, n2.properties)::nodecomposite                        as n2,
-                   (e1.id, e1.start_id, e1.end_id, e1.kind_id, e1.properties)::edgecomposite as e1,
                    (n3.id, n3.kind_ids, n3.properties)::nodecomposite                        as n3
             from s0,
                  edge e1
@@ -60,8 +60,8 @@ select s1.e0 as r, s1.e1 as e
 from s1;
 
 -- case: match ()-[r:EdgeKind1]->() return count(r) as the_count
-with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite                        as n0,
-                   (e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite as e0,
+with s0 as (select (e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite as e0,
+                   (n0.id, n0.kind_ids, n0.properties)::nodecomposite                        as n0,
                    (n1.id, n1.kind_ids, n1.properties)::nodecomposite                        as n1
             from edge e0
                    join node n0 on n0.id = e0.start_id
@@ -70,9 +70,18 @@ with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite           
 select count(s0.e0)::int8 as the_count
 from s0;
 
+with s0 as (select (e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite as e0,
+                   (n0.id, n0.kind_ids, n0.properties)::nodecomposite                        as n0,
+                   (n1.id, n1.kind_ids, n1.properties)::nodecomposite                        as n1
+            from edge e0
+                   join node n0 on n0.id = e0.start_id
+                   join node n1 on n1.id = e0.end_id)
+select count(s0.e0)::int8 as the_count
+from s0;
+
 -- case: match ()-[r:EdgeKind1]->({name: "123"}) return count(r) as the_count
-with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite                        as n0,
-                   (e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite as e0,
+with s0 as (select (e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite as e0,
+                   (n0.id, n0.kind_ids, n0.properties)::nodecomposite                        as n0,
                    (n1.id, n1.kind_ids, n1.properties)::nodecomposite                        as n1
             from edge e0
                    join node n0 on n0.id = e0.start_id
@@ -84,21 +93,21 @@ from s0;
 -- cypher_params: {"a": 1, "b": 2, "c": "123", "d": "456"}
 -- pgsql_params: {"pi0": 1, "pi1": 2, "pi2": "123", "pi3": "456"}
 -- case:  match (s)-[r]->(e) where id(e) = $a and not (id(s) = $b) and (r:EdgeKind1 or r:EdgeKind2) and not (s.objectid ends with $c or e.objectid ends with $d) return distinct id(s), id(r), id(e)
-with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite                        as n0,
-                   (e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite as e0,
+with s0 as (select (e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite as e0,
+                   (n0.id, n0.kind_ids, n0.properties)::nodecomposite                        as n0,
                    (n1.id, n1.kind_ids, n1.properties)::nodecomposite                        as n1
             from edge e0
                    join node n0 on not (n0.id = @pi1::float8) and n0.id = e0.start_id
-                   join node n1 on n1.id = @pi0::float8 and n1.id = e0.end_id
-            where not (n0.properties ->> 'objectid' like '%' || @pi2::text or
-                       n1.properties ->> 'objectid' like '%' || @pi3::text)
-              and (e0.kind_id = any (array [3]::int2[]) or e0.kind_id = any (array [4]::int2[])))
+                   join node n1 on not (n0.properties ->> 'objectid' like '%' || @pi2::text or
+                                        n1.properties ->> 'objectid' like '%' || @pi3::text) and
+                                   n1.id = @pi0::float8 and n1.id = e0.end_id
+            where (e0.kind_id = any (array [3]::int2[]) or e0.kind_id = any (array [4]::int2[])))
 select (s0.n0).id, (s0.e0).id, (s0.n1).id
 from s0;
 
 -- case: match (s)-[r]->(e) where s.name = '123' and e:NodeKind1 and not r.property return s, r, e
-with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite                        as n0,
-                   (e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite as e0,
+with s0 as (select (e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite as e0,
+                   (n0.id, n0.kind_ids, n0.properties)::nodecomposite                        as n0,
                    (n1.id, n1.kind_ids, n1.properties)::nodecomposite                        as n1
             from edge e0
                    join node n0 on n0.properties ->> 'name' = '123' and n0.id = e0.start_id
@@ -108,8 +117,8 @@ select s0.n0 as s, s0.e0 as r, s0.n1 as e
 from s0;
 
 -- case: match ()-[r]->() where r.value = 42 return r
-with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite                        as n0,
-                   (e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite as e0,
+with s0 as (select (e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite as e0,
+                   (n0.id, n0.kind_ids, n0.properties)::nodecomposite                        as n0,
                    (n1.id, n1.kind_ids, n1.properties)::nodecomposite                        as n1
             from edge e0
                    join node n0 on n0.id = e0.start_id
@@ -119,8 +128,8 @@ select s0.e0 as r
 from s0;
 
 -- case: match ()-[r]->() where r.bool_prop return r
-with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite                        as n0,
-                   (e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite as e0,
+with s0 as (select (e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite as e0,
+                   (n0.id, n0.kind_ids, n0.properties)::nodecomposite                        as n0,
                    (n1.id, n1.kind_ids, n1.properties)::nodecomposite                        as n1
             from edge e0
                    join node n0 on n0.id = e0.start_id
@@ -129,12 +138,9 @@ with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite           
 select s0.e0 as r
 from s0;
 
--- todo: with 1 as a match (n) where n.name = a with n match (r) where r.tag_id = n.tag return r
-;
-
 -- case: match (n)-[r]->() where n.name = '123' return n, r
-with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite                        as n0,
-                   (e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite as e0,
+with s0 as (select (e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite as e0,
+                   (n0.id, n0.kind_ids, n0.properties)::nodecomposite                        as n0,
                    (n1.id, n1.kind_ids, n1.properties)::nodecomposite                        as n1
             from edge e0
                    join node n0 on n0.properties ->> 'name' = '123' and n0.id = e0.start_id
@@ -143,8 +149,8 @@ select s0.n0 as n, s0.e0 as r
 from s0;
 
 -- case: match (s)-[r]->(e) where s.name = '123' and e.name = '321' return s, r, e
-with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite                        as n0,
-                   (e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite as e0,
+with s0 as (select (e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite as e0,
+                   (n0.id, n0.kind_ids, n0.properties)::nodecomposite                        as n0,
                    (n1.id, n1.kind_ids, n1.properties)::nodecomposite                        as n1
             from edge e0
                    join node n0 on n0.properties ->> 'name' = '123' and n0.id = e0.start_id
@@ -156,9 +162,9 @@ from s0;
 with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0
             from node n0
             where not (n0.properties ->> 'bool_field')::bool),
-     s1 as (select s0.n0                                                                     as n0,
+     s1 as (select (e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite as e0,
+                   s0.n0                                                                     as n0,
                    (n1.id, n1.kind_ids, n1.properties)::nodecomposite                        as n1,
-                   (e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite as e0,
                    (n2.id, n2.kind_ids, n2.properties)::nodecomposite                        as n2
             from s0,
                  edge e0
@@ -168,16 +174,16 @@ select s1.n0 as f, s1.n1 as s, s1.e0 as r, s1.n2 as e
 from s1;
 
 -- case: match ()-[e0]->(n)<-[e1]-() return e0, n, e1
-with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite                        as n0,
-                   (e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite as e0,
+with s0 as (select (e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite as e0,
+                   (n0.id, n0.kind_ids, n0.properties)::nodecomposite                        as n0,
                    (n1.id, n1.kind_ids, n1.properties)::nodecomposite                        as n1
             from edge e0
                    join node n0 on n0.id = e0.start_id
                    join node n1 on n1.id = e0.end_id),
      s1 as (select s0.e0                                                                     as e0,
+                   (e1.id, e1.start_id, e1.end_id, e1.kind_id, e1.properties)::edgecomposite as e1,
                    s0.n0                                                                     as n0,
                    s0.n1                                                                     as n1,
-                   (e1.id, e1.start_id, e1.end_id, e1.kind_id, e1.properties)::edgecomposite as e1,
                    (n2.id, n2.kind_ids, n2.properties)::nodecomposite                        as n2
             from s0,
                  edge e1
@@ -187,16 +193,16 @@ select s1.e0 as e0, s1.n1 as n, s1.e1 as e1
 from s1;
 
 -- case: match ()-[e0]->(n)-[e1]->() return e0, n, e1
-with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite                        as n0,
-                   (e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite as e0,
+with s0 as (select (e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite as e0,
+                   (n0.id, n0.kind_ids, n0.properties)::nodecomposite                        as n0,
                    (n1.id, n1.kind_ids, n1.properties)::nodecomposite                        as n1
             from edge e0
                    join node n0 on n0.id = e0.start_id
                    join node n1 on n1.id = e0.end_id),
      s1 as (select s0.e0                                                                     as e0,
+                   (e1.id, e1.start_id, e1.end_id, e1.kind_id, e1.properties)::edgecomposite as e1,
                    s0.n0                                                                     as n0,
                    s0.n1                                                                     as n1,
-                   (e1.id, e1.start_id, e1.end_id, e1.kind_id, e1.properties)::edgecomposite as e1,
                    (n2.id, n2.kind_ids, n2.properties)::nodecomposite                        as n2
             from s0,
                  edge e1
@@ -206,16 +212,16 @@ select s1.e0 as e0, s1.n1 as n, s1.e1 as e1
 from s1;
 
 -- case: match ()<-[e0]-(n)<-[e1]-() return e0, n, e1
-with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite                        as n0,
-                   (e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite as e0,
+with s0 as (select (e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite as e0,
+                   (n0.id, n0.kind_ids, n0.properties)::nodecomposite                        as n0,
                    (n1.id, n1.kind_ids, n1.properties)::nodecomposite                        as n1
             from edge e0
                    join node n0 on n0.id = e0.end_id
                    join node n1 on n1.id = e0.start_id),
      s1 as (select s0.e0                                                                     as e0,
+                   (e1.id, e1.start_id, e1.end_id, e1.kind_id, e1.properties)::edgecomposite as e1,
                    s0.n0                                                                     as n0,
                    s0.n1                                                                     as n1,
-                   (e1.id, e1.start_id, e1.end_id, e1.kind_id, e1.properties)::edgecomposite as e1,
                    (n2.id, n2.kind_ids, n2.properties)::nodecomposite                        as n2
             from s0,
                  edge e1
@@ -225,8 +231,8 @@ select s1.e0 as e0, s1.n1 as n, s1.e1 as e1
 from s1;
 
 -- case: match (s)<-[r:EdgeKind1|EdgeKind2]-(e) return s.name, e.name
-with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite                        as n0,
-                   (e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite as e0,
+with s0 as (select (e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite as e0,
+                   (n0.id, n0.kind_ids, n0.properties)::nodecomposite                        as n0,
                    (n1.id, n1.kind_ids, n1.properties)::nodecomposite                        as n1
             from edge e0
                    join node n0 on n0.id = e0.end_id
@@ -236,17 +242,17 @@ select (s0.n0).properties -> 'name', (s0.n1).properties -> 'name'
 from s0;
 
 -- case: match (s)-[:EdgeKind1|EdgeKind2]->(e)-[:EdgeKind1]->() return s.name as s_name, e.name as e_name
-with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite                        as n0,
-                   (e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite as e0,
+with s0 as (select (e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite as e0,
+                   (n0.id, n0.kind_ids, n0.properties)::nodecomposite                        as n0,
                    (n1.id, n1.kind_ids, n1.properties)::nodecomposite                        as n1
             from edge e0
                    join node n0 on n0.id = e0.start_id
                    join node n1 on n1.id = e0.end_id
             where e0.kind_id = any (array [3, 4]::int2[])),
      s1 as (select s0.e0                                                                     as e0,
+                   (e1.id, e1.start_id, e1.end_id, e1.kind_id, e1.properties)::edgecomposite as e1,
                    s0.n0                                                                     as n0,
                    s0.n1                                                                     as n1,
-                   (e1.id, e1.start_id, e1.end_id, e1.kind_id, e1.properties)::edgecomposite as e1,
                    (n2.id, n2.kind_ids, n2.properties)::nodecomposite                        as n2
             from s0,
                  edge e1
@@ -257,8 +263,8 @@ select (s1.n0).properties -> 'name' as s_name, (s1.n1).properties -> 'name' as e
 from s1;
 
 -- case: match (s:NodeKind1)-[r:EdgeKind1|EdgeKind2]->(e:NodeKind2) return s.name, e.name
-with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite                        as n0,
-                   (e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite as e0,
+with s0 as (select (e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite as e0,
+                   (n0.id, n0.kind_ids, n0.properties)::nodecomposite                        as n0,
                    (n1.id, n1.kind_ids, n1.properties)::nodecomposite                        as n1
             from edge e0
                    join node n0 on n0.kind_ids operator (pg_catalog.&&) array [1]::int2[] and n0.id = e0.start_id
@@ -268,13 +274,14 @@ select (s0.n0).properties -> 'name', (s0.n1).properties -> 'name'
 from s0;
 
 -- case: match (s)-[r:EdgeKind1]->() where (s)-[r {prop: 'a'}]->() return s
-with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite                        as n0,
-                   (e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite as e0,
+with s0 as (select (e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite as e0,
+                   (n0.id, n0.kind_ids, n0.properties)::nodecomposite                        as n0,
                    (n1.id, n1.kind_ids, n1.properties)::nodecomposite                        as n1
             from edge e0
                    join node n0 on n0.id = e0.start_id
                    join node n1 on n1.id = e0.end_id
-            where e0.kind_id = any (array [3]::int2[]))
+            where e0.properties ->> 'prop' = 'a'
+              and e0.kind_id = any (array [3]::int2[]))
 select s0.n0 as s
 from s0
 where (with s1 as (select s0.e0                                              as e0,
@@ -284,14 +291,13 @@ where (with s1 as (select s0.e0                                              as 
                    from s0,
                         edge e0
                           join node n0 on (s0.n0).id = (s0.e0).start_id
-                          join node n2 on n2.properties ->> 'prop' = 'a' and n2.id = (s0.e0).end_id
-                   where (s0.e0).properties ->> 'prop' = 'a')
+                          join node n2 on n2.id = (s0.e0).end_id)
        select count(*) > 0
        from s1);
 
 -- case: match (s)-[r:EdgeKind1]->(e) where not (s.system_tags contains 'admin_tier_0') and id(e) = 1 return id(s), labels(s), id(r), type(r)
-with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite                        as n0,
-                   (e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite as e0,
+with s0 as (select (e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite as e0,
+                   (n0.id, n0.kind_ids, n0.properties)::nodecomposite                        as n0,
                    (n1.id, n1.kind_ids, n1.properties)::nodecomposite                        as n1
             from edge e0
                    join node n0 on not (coalesce(n0.properties ->> 'system_tags', '')::text like '%admin_tier_0%') and
@@ -302,52 +308,49 @@ select (s0.n0).id, (s0.n0).kind_ids, (s0.e0).id, (s0.e0).kind_id
 from s0;
 
 -- case: match (s)-[r]->(e) where s:NodeKind1 and toLower(s.name) starts with 'test' and r:EdgeKind1 and id(e) in [1, 2] return r limit 1
-with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite                        as n0,
-                   (e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite as e0,
+with s0 as (select (e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite as e0,
+                   (n0.id, n0.kind_ids, n0.properties)::nodecomposite                        as n0,
                    (n1.id, n1.kind_ids, n1.properties)::nodecomposite                        as n1
             from edge e0
                    join node n0 on n0.kind_ids operator (pg_catalog.&&) array [1]::int2[] and
-                                   lower(n0.properties ->> 'name')::text like 'test' and n0.id = e0.start_id
-                   join node n1
-                        on n1.id = any (array [1, 2]::int8[]) and n1.id = e0.end_id
+                                   lower(n0.properties ->> 'name')::text like 'test%' and n0.id = e0.start_id
+                   join node n1 on n1.id = any (array [1, 2]::int8[]) and n1.id = e0.end_id
             where e0.kind_id = any (array [3]::int2[]))
 select s0.e0 as r
 from s0
 limit 1;
 
 -- case: match (n1)-[]->(n2) where n1 <> n2 return n2
-with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite                        as n0,
-                   (e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite as e0,
+with s0 as (select (e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite as e0,
+                   (n0.id, n0.kind_ids, n0.properties)::nodecomposite                        as n0,
                    (n1.id, n1.kind_ids, n1.properties)::nodecomposite                        as n1
             from edge e0
                    join node n0 on n0.id = e0.start_id
-                   join node n1 on n1.id = e0.end_id
-            where n0.id <> n1.id)
+                   join node n1 on n0.id <> n1.id and n1.id = e0.end_id)
 select s0.n1 as n2
 from s0;
 
 -- case: match (n1)-[]->(n2) where n2 <> n1 return n2
-with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite                        as n0,
-                   (e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite as e0,
+with s0 as (select (e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite as e0,
+                   (n0.id, n0.kind_ids, n0.properties)::nodecomposite                        as n0,
                    (n1.id, n1.kind_ids, n1.properties)::nodecomposite                        as n1
             from edge e0
                    join node n0 on n0.id = e0.start_id
-                   join node n1 on n1.id = e0.end_id
-            where n1.id <> n0.id)
+                   join node n1 on n1.id <> n0.id and n1.id = e0.end_id)
 select s0.n1 as n2
 from s0;
 
 -- case: match ()-[r]->()-[e]->(n) where r <> e return n
-with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite                        as n0,
-                   (e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite as e0,
+with s0 as (select (e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite as e0,
+                   (n0.id, n0.kind_ids, n0.properties)::nodecomposite                        as n0,
                    (n1.id, n1.kind_ids, n1.properties)::nodecomposite                        as n1
             from edge e0
                    join node n0 on n0.id = e0.start_id
                    join node n1 on n1.id = e0.end_id),
      s1 as (select s0.e0                                                                     as e0,
+                   (e1.id, e1.start_id, e1.end_id, e1.kind_id, e1.properties)::edgecomposite as e1,
                    s0.n0                                                                     as n0,
                    s0.n1                                                                     as n1,
-                   (e1.id, e1.start_id, e1.end_id, e1.kind_id, e1.properties)::edgecomposite as e1,
                    (n2.id, n2.kind_ids, n2.properties)::nodecomposite                        as n2
             from s0,
                  edge e1
@@ -356,4 +359,3 @@ with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite           
               and (s0.e0).id <> e1.id)
 select s1.n2 as n
 from s1;
-

--- a/packages/go/cypher/models/pgsql/test/translation_cases/update.sql
+++ b/packages/go/cypher/models/pgsql/test/translation_cases/update.sql
@@ -79,8 +79,8 @@ select s3.n0 as n1, s3.n1 as n3
 from s3;
 
 -- case: match ()-[r]->(:NodeKind1) set r.is_special_outbound = true
-with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite                        as n0,
-                   (e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite as e0,
+with s0 as (select (e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite as e0,
+                   (n0.id, n0.kind_ids, n0.properties)::nodecomposite                        as n0,
                    (n1.id, n1.kind_ids, n1.properties)::nodecomposite                        as n1
             from edge e0
                    join node n0 on n0.id = e0.start_id
@@ -90,8 +90,8 @@ with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite           
 select 1;
 
 -- case: match (a)-[r]->(:NodeKind1) set a.name = '123', r.is_special_outbound = true
-with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite                        as n0,
-                   (e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite as e0,
+with s0 as (select (e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite as e0,
+                   (n0.id, n0.kind_ids, n0.properties)::nodecomposite                        as n0,
                    (n1.id, n1.kind_ids, n1.properties)::nodecomposite                        as n1
             from edge e0
                    join node n0 on n0.id = e0.start_id
@@ -140,37 +140,35 @@ with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite as n0
 select 1;
 
 -- case: match (n)-[r:EdgeKind1]->() where n:NodeKind1 set r.visited = true return r
-with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite                        as n0,
-                   (e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite as e0,
+with s0 as (select (e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite as e0,
+                   (n0.id, n0.kind_ids, n0.properties)::nodecomposite                        as n0,
                    (n1.id, n1.kind_ids, n1.properties)::nodecomposite                        as n1
             from edge e0
                    join node n0 on n0.kind_ids operator (pg_catalog.&&) array [1]::int2[] and n0.id = e0.start_id
                    join node n1 on n1.id = e0.end_id
             where e0.kind_id = any (array [3]::int2[])),
-     s1
-       as (update edge e1 set properties = e1.properties ||
-                                           jsonb_build_object('visited', true)::jsonb from s0 where (s0.e0).id = e1.id returning (e1.id, e1.start_id, e1.end_id, e1.kind_id, e1.properties)::edgecomposite as e0, s0.n0 as n0, s0.n1 as n1)
+     s1 as (update edge e1 set properties = e1.properties ||
+                                            jsonb_build_object('visited', true)::jsonb from s0 where (s0.e0).id = e1.id returning (e1.id, e1.start_id, e1.end_id, e1.kind_id, e1.properties)::edgecomposite as e0, s0.n0 as n0, s0.n1 as n1)
 select s1.e0 as r
 from s1;
 
 -- case: match (n)-[]->()-[r]->() where n.name = 'n1' set r.visited = true return r.name
-with s0 as (select (n0.id, n0.kind_ids, n0.properties)::nodecomposite                        as n0,
-                   (e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite as e0,
+with s0 as (select (e0.id, e0.start_id, e0.end_id, e0.kind_id, e0.properties)::edgecomposite as e0,
+                   (n0.id, n0.kind_ids, n0.properties)::nodecomposite                        as n0,
                    (n1.id, n1.kind_ids, n1.properties)::nodecomposite                        as n1
             from edge e0
                    join node n0 on n0.properties ->> 'name' = 'n1' and n0.id = e0.start_id
                    join node n1 on n1.id = e0.end_id),
      s1 as (select s0.e0                                                                     as e0,
+                   (e1.id, e1.start_id, e1.end_id, e1.kind_id, e1.properties)::edgecomposite as e1,
                    s0.n0                                                                     as n0,
                    s0.n1                                                                     as n1,
-                   (e1.id, e1.start_id, e1.end_id, e1.kind_id, e1.properties)::edgecomposite as e1,
                    (n2.id, n2.kind_ids, n2.properties)::nodecomposite                        as n2
             from s0,
                  edge e1
                    join node n2 on n2.id = e1.end_id
             where (s0.n1).id = e1.start_id),
-     s2
-       as (update edge e2 set properties = e2.properties ||
-                                           jsonb_build_object('visited', true)::jsonb from s1 where (s1.e1).id = e2.id returning s1.e0 as e0, (e2.id, e2.start_id, e2.end_id, e2.kind_id, e2.properties)::edgecomposite as e1, s1.n0 as n0, s1.n1 as n1, s1.n2 as n2)
+     s2 as (update edge e2 set properties = e2.properties ||
+                                            jsonb_build_object('visited', true)::jsonb from s1 where (s1.e1).id = e2.id returning s1.e0 as e0, (e2.id, e2.start_id, e2.end_id, e2.kind_id, e2.properties)::edgecomposite as e1, s1.n0 as n0, s1.n1 as n1, s1.n2 as n2)
 select (s2.e1).properties -> 'name'
 from s2;

--- a/packages/go/cypher/models/pgsql/translate/constraints.go
+++ b/packages/go/cypher/models/pgsql/translate/constraints.go
@@ -92,8 +92,8 @@ func rightEdgeConstraint(segment *PatternSegment, terminalEdge pgsql.Identifier,
 		switch direction {
 		case graph.DirectionOutbound:
 			return pgsql.NewBinaryExpression(
-				pgsql.CompoundExpression{
-					&pgsql.ArrayIndex{
+				pgsql.RowColumnReference{
+					Identifier: &pgsql.ArrayIndex{
 						Expression: segment.Edge.Identifier,
 						Indexes: []pgsql.Expression{
 							pgsql.FunctionCall{
@@ -106,7 +106,7 @@ func rightEdgeConstraint(segment *PatternSegment, terminalEdge pgsql.Identifier,
 							},
 						},
 					},
-					pgsql.ColumnEndID,
+					Column: pgsql.ColumnEndID,
 				},
 				pgsql.OperatorEquals,
 				pgsql.CompoundIdentifier{terminalEdge, pgsql.ColumnStartID},
@@ -128,7 +128,7 @@ func rightEdgeConstraint(segment *PatternSegment, terminalEdge pgsql.Identifier,
 	}
 }
 
-func rightNodeConstraint(edgeIdentifier, nodeIdentifier pgsql.Identifier, direction graph.Direction) (pgsql.Expression, error) {
+func terminalNodeConstraint(edgeIdentifier, nodeIdentifier pgsql.Identifier, direction graph.Direction) (pgsql.Expression, error) {
 	switch direction {
 	case graph.DirectionOutbound:
 		return &pgsql.BinaryExpression{
@@ -165,7 +165,7 @@ func rightNodeConstraint(edgeIdentifier, nodeIdentifier pgsql.Identifier, direct
 }
 
 func rightNodeTraversalStepConstraint(traversalStep *PatternSegment) (pgsql.Expression, error) {
-	return rightNodeConstraint(
+	return terminalNodeConstraint(
 		traversalStep.Edge.Identifier,
 		traversalStep.RightNode.Identifier,
 		traversalStep.Direction)

--- a/packages/go/cypher/models/pgsql/translate/expansion.go
+++ b/packages/go/cypher/models/pgsql/translate/expansion.go
@@ -17,122 +17,11 @@
 package translate
 
 import (
-	"fmt"
-
 	"github.com/specterops/bloodhound/cypher/models"
 	"github.com/specterops/bloodhound/cypher/models/pgsql"
 	"github.com/specterops/bloodhound/cypher/models/pgsql/format"
 	"github.com/specterops/bloodhound/dawgs/drivers/pg/model"
-	"github.com/specterops/bloodhound/dawgs/graph"
 )
-
-type expansionRootComponents struct {
-	RightNodeConstraints *Constraint
-	LeftNodeConstraints  *Constraint
-	RecursiveVisible     *pgsql.IdentifierSet
-	PrimerWhereClause    pgsql.Expression
-	RecursiveWhereClause pgsql.Expression
-}
-
-func prepareExpansionRootComponents(part *PatternPart, traversalStep *PatternSegment, treeTranslator *ExpressionTreeTranslator) (expansionRootComponents, error) {
-	expansionComponents := expansionRootComponents{
-		RecursiveVisible: traversalStep.Expansion.Value.Frame.Visible.Copy(),
-	}
-
-	if terminalNode, err := traversalStep.TerminalNode(); err != nil {
-		return expansionComponents, err
-	} else if rootNode, err := traversalStep.RootNode(); err != nil {
-		return expansionComponents, err
-	} else if rootNodeConstraints, err := consumeConstraintsFrom(pgsql.AsIdentifierSet(rootNode.Identifier), treeTranslator.IdentifierConstraints, part.Constraints); err != nil {
-		return expansionComponents, err
-	} else if terminalNodeConstraints, err := consumeConstraintsFrom(pgsql.AsIdentifierSet(terminalNode.Identifier), treeTranslator.IdentifierConstraints, part.Constraints); err != nil {
-		return expansionComponents, err
-	} else {
-		// The exclusion below is done at this step in the process since the recursive descent portion of the query no longer has
-		// a reference to the root node and any dependent interaction between the root and terminal nodes would require an
-		// additional join. By not consuming the remaining constraints for the root and terminal nodes, they become visible up
-		// in the outer select of the recursive CTE.
-		switch traversalStep.Direction {
-		case graph.DirectionInbound:
-			expansionComponents.LeftNodeConstraints = terminalNodeConstraints
-			expansionComponents.RightNodeConstraints = rootNodeConstraints
-
-			expansionComponents.RecursiveVisible.Remove(rootNode.Identifier)
-
-		case graph.DirectionOutbound:
-			expansionComponents.LeftNodeConstraints = rootNodeConstraints
-			expansionComponents.RightNodeConstraints = terminalNodeConstraints
-
-			expansionComponents.RecursiveVisible.Remove(terminalNode.Identifier)
-
-		default:
-			return expansionComponents, fmt.Errorf("graph direction %s not supported", traversalStep.Direction.String())
-		}
-
-		if edgeConstraints, err := consumeConstraintsFrom(expansionComponents.RecursiveVisible, treeTranslator.IdentifierConstraints, part.Constraints); err != nil {
-			return expansionComponents, err
-		} else {
-			// Set the edge constraints in the primer and recursive select where clauses
-			expansionComponents.PrimerWhereClause = edgeConstraints.Expression
-			expansionComponents.RecursiveWhereClause = pgsql.OptionalAnd(edgeConstraints.Expression, expansionConstraints(traversalStep.Expansion.Value.Binding.Identifier))
-		}
-	}
-
-	return expansionComponents, nil
-}
-
-type expansionStepComponents struct {
-	RightNodeConstraints *Constraint
-	EdgeConstraints      *Constraint
-	RecursiveVisible     *pgsql.IdentifierSet
-	RecursiveWhereClause pgsql.Expression
-}
-
-func prepareExpansionStepComponents(part *PatternPart, traversalStep *PatternSegment, treeTranslator *ExpressionTreeTranslator) (expansionStepComponents, error) {
-	expansionComponents := expansionStepComponents{
-		RecursiveVisible: traversalStep.Expansion.Value.Frame.Visible.Copy(),
-	}
-
-	// The exclusion in scope below is done at this step in the process since the recursive descent portion of the query no longer has
-	// a reference to the root and any dependent interaction between the root and terminal nodes would require an additional join.
-	// By not consuming the remaining constraints for the root and terminal nodes, they become visible up in the outer select of the
-	// recursive CTE.
-
-	switch traversalStep.Direction {
-	case graph.DirectionInbound:
-		if rootNode, err := traversalStep.RootNode(); err != nil {
-			return expansionComponents, err
-		} else if rootNodeConstraints, err := consumeConstraintsFrom(pgsql.AsIdentifierSet(rootNode.Identifier), treeTranslator.IdentifierConstraints, part.Constraints); err != nil {
-			return expansionComponents, err
-		} else {
-			expansionComponents.RightNodeConstraints = rootNodeConstraints
-			expansionComponents.RecursiveVisible.Remove(rootNode.Identifier)
-		}
-
-	case graph.DirectionOutbound:
-		if terminalNode, err := traversalStep.TerminalNode(); err != nil {
-			return expansionComponents, err
-		} else if terminalNodeConstraints, err := consumeConstraintsFrom(pgsql.AsIdentifierSet(terminalNode.Identifier), treeTranslator.IdentifierConstraints, part.Constraints); err != nil {
-			return expansionComponents, err
-		} else {
-			expansionComponents.RightNodeConstraints = terminalNodeConstraints
-			expansionComponents.RecursiveVisible.Remove(terminalNode.Identifier)
-		}
-
-	default:
-		return expansionComponents, fmt.Errorf("graph direction %s not supported", traversalStep.Direction.String())
-	}
-
-	if edgeConstraints, err := consumeConstraintsFrom(expansionComponents.RecursiveVisible, treeTranslator.IdentifierConstraints, part.Constraints); err != nil {
-		return expansionComponents, err
-	} else {
-		// Set the edge constraints in the primer and recursive select where clauses
-		expansionComponents.EdgeConstraints = edgeConstraints
-		expansionComponents.RecursiveWhereClause = expansionConstraints(traversalStep.Expansion.Value.Binding.Identifier)
-	}
-
-	return expansionComponents, nil
-}
 
 const translateDefaultMaxTraversalDepth = 10
 
@@ -214,249 +103,150 @@ func (s *Translator) buildAllShortestPathsExpansionRoot(part *PatternPart, trave
 			},
 
 			RecursiveStatement: pgsql.Select{
-				Where: expansionConstraints(traversalStep.Expansion.Value.Binding.Identifier),
+				Where: expansionConstraints(traversalStep.Expansion.Value.Frame.Binding.Identifier),
 			},
 		}
 	)
 
 	expansion.ProjectionStatement.Projection = traversalStep.Expansion.Value.Projection
 
-	if terminalNode, err := traversalStep.TerminalNode(); err != nil {
-		return pgsql.Query{}, err
-	} else if rootNode, err := traversalStep.RootNode(); err != nil {
-		return pgsql.Query{}, err
-	} else if rootNodeConstraints, err := consumeConstraintsFrom(pgsql.AsIdentifierSet(rootNode.Identifier), s.treeTranslator.IdentifierConstraints, part.Constraints); err != nil {
-		return pgsql.Query{}, err
-	} else if terminalNodeConstraints, err := consumeConstraintsFrom(pgsql.AsIdentifierSet(terminalNode.Identifier), s.treeTranslator.IdentifierConstraints, part.Constraints); err != nil {
+	expansion.PrimerStatement.Where = traversalStep.Expansion.Value.PrimerConstraints
+	expansion.RecursiveStatement.Where = traversalStep.Expansion.Value.RecursiveConstraints
+
+	expansion.PrimerStatement.From = append(expansion.PrimerStatement.From, pgsql.FromClause{
+		Source: pgsql.TableReference{
+			Name:    pgsql.CompoundIdentifier{pgsql.TableEdge},
+			Binding: models.ValueOptional(traversalStep.Edge.Identifier),
+		},
+		Joins: []pgsql.Join{{
+			Table: pgsql.TableReference{
+				Name:    pgsql.CompoundIdentifier{pgsql.TableNode},
+				Binding: models.ValueOptional(traversalStep.LeftNode.Identifier),
+			},
+			JoinOperator: pgsql.JoinOperator{
+				JoinType:   pgsql.JoinTypeInner,
+				Constraint: traversalStep.Expansion.Value.PrimerRootNodeConstraints,
+			},
+		}, {
+			Table: pgsql.TableReference{
+				Name:    pgsql.CompoundIdentifier{pgsql.TableNode},
+				Binding: models.ValueOptional(traversalStep.RightNode.Identifier),
+			},
+			JoinOperator: pgsql.JoinOperator{
+				JoinType:   pgsql.JoinTypeInner,
+				Constraint: traversalStep.Expansion.Value.ExpansionNodeConstraints,
+			},
+		}},
+	})
+
+	// Make sure the recursive query has the expansion bound
+	expansion.RecursiveStatement.From = append(expansion.RecursiveStatement.From, pgsql.FromClause{
+		Source: pgsql.TableReference{
+			Name:    pgsql.CompoundIdentifier{"pathspace"},
+			Binding: models.ValueOptional(traversalStep.Expansion.Value.Frame.Binding.Identifier),
+		},
+		Joins: []pgsql.Join{{
+			Table: pgsql.TableReference{
+				Name:    pgsql.CompoundIdentifier{pgsql.TableEdge},
+				Binding: models.ValueOptional(traversalStep.Edge.Identifier),
+			},
+			JoinOperator: pgsql.JoinOperator{
+				JoinType: pgsql.JoinTypeInner,
+				Constraint: pgsql.NewBinaryExpression(
+					// TODO: Directional
+					pgsql.CompoundIdentifier{traversalStep.Edge.Identifier, pgsql.ColumnStartID},
+					pgsql.OperatorEquals,
+					pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Frame.Binding.Identifier, pgsql.ColumnNextID},
+				),
+			},
+		}, {
+			Table: pgsql.TableReference{
+				Name:    pgsql.CompoundIdentifier{pgsql.TableNode},
+				Binding: models.ValueOptional(traversalStep.RightNode.Identifier),
+			},
+			JoinOperator: pgsql.JoinOperator{
+				JoinType:   pgsql.JoinTypeInner,
+				Constraint: traversalStep.Expansion.Value.ExpansionNodeConstraints,
+			},
+		}},
+	})
+
+	if wrappedSelectJoinConstraint, err := ConjoinExpressions([]pgsql.Expression{
+		pgsql.NewBinaryExpression(
+			pgsql.CompoundIdentifier{traversalStep.Edge.Identifier, pgsql.ColumnID},
+			pgsql.OperatorEquals,
+			&pgsql.ArrayIndex{
+				Expression: pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Frame.Binding.Identifier, expansionPath},
+				Indexes: []pgsql.Expression{
+					pgsql.FunctionCall{
+						Function: pgsql.FunctionArrayLength,
+						Parameters: []pgsql.Expression{
+							pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Frame.Binding.Identifier, expansionPath},
+							pgsql.NewLiteral(1, pgsql.Int8),
+						},
+						CastType: pgsql.Int,
+					},
+				},
+			},
+		),
+		traversalStep.Expansion.Value.ExpansionNodeConstraints}); err != nil {
 		return pgsql.Query{}, err
 	} else {
-		// The exclusion below is done at this step in the process since the recursive descent portion of the query no longer has
-		// a reference to `n0` and any dependent interaction between `n0` and `n1` would require an additional join. By not
-		// consuming the remaining constraints for `n0` and `n1`, they become visible up in the outer select of the recursive CTE.
-		recursiveVisible := traversalStep.Expansion.Value.Frame.Visible.Copy()
-		recursiveVisible.Remove(rootNode.Identifier)
-
-		if edgeConstraints, err := consumeConstraintsFrom(recursiveVisible, s.treeTranslator.IdentifierConstraints, part.Constraints); err != nil {
-			return pgsql.Query{}, err
-		} else {
-			// Set the edge constraints in the primer and recursive select where clauses
-			expansion.PrimerStatement.Where = edgeConstraints.Expression
-			expansion.RecursiveStatement.Where = pgsql.OptionalAnd(edgeConstraints.Expression, expansion.RecursiveStatement.Where)
-		}
-
-		if leftNodeJoinConstraint, err := leftNodeTraversalStepConstraint(traversalStep); err != nil {
-			return pgsql.Query{}, err
-		} else if leftNodeJoinCondition, err := ConjoinExpressions([]pgsql.Expression{rootNodeConstraints.Expression, leftNodeJoinConstraint}); err != nil {
-			return pgsql.Query{}, err
-		} else if rightNodeJoinCondition, err := rightNodeTraversalStepConstraint(traversalStep); err != nil {
-			return pgsql.Query{}, err
-		} else {
-			expansion.PrimerStatement.From = append(expansion.PrimerStatement.From, pgsql.FromClause{
-				Source: pgsql.TableReference{
+		// Select the expansion components for the projection statement
+		expansion.ProjectionStatement.From = append(expansion.ProjectionStatement.From, pgsql.FromClause{
+			Source: pgsql.TableReference{
+				Name:    pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Frame.Binding.Identifier},
+				Binding: models.EmptyOptional[pgsql.Identifier](),
+			},
+			Joins: []pgsql.Join{{
+				Table: pgsql.TableReference{
 					Name:    pgsql.CompoundIdentifier{pgsql.TableEdge},
 					Binding: models.ValueOptional(traversalStep.Edge.Identifier),
 				},
-				Joins: []pgsql.Join{{
-					Table: pgsql.TableReference{
-						Name:    pgsql.CompoundIdentifier{pgsql.TableNode},
-						Binding: models.ValueOptional(traversalStep.LeftNode.Identifier),
-					},
-					JoinOperator: pgsql.JoinOperator{
-						JoinType:   pgsql.JoinTypeInner,
-						Constraint: leftNodeJoinCondition,
-					},
-				}, {
-					Table: pgsql.TableReference{
-						Name:    pgsql.CompoundIdentifier{pgsql.TableNode},
-						Binding: models.ValueOptional(traversalStep.RightNode.Identifier),
-					},
-					JoinOperator: pgsql.JoinOperator{
-						JoinType:   pgsql.JoinTypeInner,
-						Constraint: rightNodeJoinCondition,
-					},
-				}},
-			})
-
-			// Make sure the recursive query has the expansion bound
-			expansion.RecursiveStatement.From = append(expansion.RecursiveStatement.From, pgsql.FromClause{
-				Source: pgsql.TableReference{
-					Name:    pgsql.CompoundIdentifier{"pathspace"},
-					Binding: models.ValueOptional(traversalStep.Expansion.Value.Binding.Identifier),
+				JoinOperator: pgsql.JoinOperator{
+					JoinType: pgsql.JoinTypeInner,
+					Constraint: pgsql.NewBinaryExpression(
+						pgsql.CompoundIdentifier{traversalStep.Edge.Identifier, pgsql.ColumnID},
+						pgsql.OperatorEquals,
+						pgsql.NewAnyExpression(pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Frame.Binding.Identifier, expansionPath}),
+					),
 				},
-				Joins: []pgsql.Join{{
-					Table: pgsql.TableReference{
-						Name:    pgsql.CompoundIdentifier{pgsql.TableEdge},
-						Binding: models.ValueOptional(traversalStep.Edge.Identifier),
-					},
-					JoinOperator: pgsql.JoinOperator{
-						JoinType: pgsql.JoinTypeInner,
-						Constraint: pgsql.NewBinaryExpression(
-							// TODO: Directional
-							pgsql.CompoundIdentifier{traversalStep.Edge.Identifier, pgsql.ColumnStartID},
-							pgsql.OperatorEquals,
-							pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Binding.Identifier, pgsql.ColumnNextID},
-						),
-					},
-				}, {
-					Table: pgsql.TableReference{
-						Name:    pgsql.CompoundIdentifier{pgsql.TableNode},
-						Binding: models.ValueOptional(traversalStep.RightNode.Identifier),
-					},
-					JoinOperator: pgsql.JoinOperator{
-						JoinType:   pgsql.JoinTypeInner,
-						Constraint: rightNodeJoinCondition,
-					},
-				}},
-			})
-
-			if wrappedSelectJoinConstraint, err := ConjoinExpressions([]pgsql.Expression{
-				pgsql.NewBinaryExpression(
-					pgsql.CompoundIdentifier{traversalStep.Edge.Identifier, pgsql.ColumnID},
-					pgsql.OperatorEquals,
-					&pgsql.ArrayIndex{
-						Expression: pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Binding.Identifier, expansionPath},
-						Indexes: []pgsql.Expression{
-							pgsql.FunctionCall{
-								Function: pgsql.FunctionArrayLength,
-								Parameters: []pgsql.Expression{
-									pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Binding.Identifier, expansionPath},
-									pgsql.NewLiteral(1, pgsql.Int8),
-								},
-								CastType: pgsql.Int,
-							},
-						},
-					},
-				),
-				rightNodeJoinCondition}); err != nil {
-				return pgsql.Query{}, err
-			} else {
-				// Select the expansion components for the projection statement
-				expansion.ProjectionStatement.From = append(expansion.ProjectionStatement.From, pgsql.FromClause{
-					Source: pgsql.TableReference{
-						Name:    pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Binding.Identifier},
-						Binding: models.EmptyOptional[pgsql.Identifier](),
-					},
-					Joins: []pgsql.Join{{
-						Table: pgsql.TableReference{
-							Name:    pgsql.CompoundIdentifier{pgsql.TableEdge},
-							Binding: models.ValueOptional(traversalStep.Edge.Identifier),
-						},
-						JoinOperator: pgsql.JoinOperator{
-							JoinType: pgsql.JoinTypeInner,
-							Constraint: pgsql.NewBinaryExpression(
-								pgsql.CompoundIdentifier{traversalStep.Edge.Identifier, pgsql.ColumnID},
-								pgsql.OperatorEquals,
-								pgsql.NewAnyExpression(pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Binding.Identifier, expansionPath}),
-							),
-						},
-					}, {
-						Table: pgsql.TableReference{
-							Name:    pgsql.CompoundIdentifier{pgsql.TableNode},
-							Binding: models.ValueOptional(traversalStep.LeftNode.Identifier),
-						},
-						JoinOperator: pgsql.JoinOperator{
-							JoinType: pgsql.JoinTypeInner,
-							Constraint: pgsql.NewBinaryExpression(
-								pgsql.CompoundIdentifier{traversalStep.LeftNode.Identifier, pgsql.ColumnID},
-								pgsql.OperatorEquals,
-								pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Binding.Identifier, expansionRootID},
-							),
-						},
-					}, {
-						Table: pgsql.TableReference{
-							Name:    pgsql.CompoundIdentifier{pgsql.TableNode},
-							Binding: models.ValueOptional(traversalStep.RightNode.Identifier),
-						},
-						JoinOperator: pgsql.JoinOperator{
-							JoinType:   pgsql.JoinTypeInner,
-							Constraint: wrappedSelectJoinConstraint,
-						},
-					}},
-				})
-			}
-		}
-
-		// If there are terminal constraints, project them as part of the projections
-		if terminalNodeConstraints.Expression != nil {
-			if terminalCriteriaProjection, err := pgsql.As[pgsql.SelectItem](terminalNodeConstraints.Expression); err != nil {
-				return pgsql.Query{}, err
-			} else {
-				expansion.PrimerStatement.Projection = []pgsql.SelectItem{
-					pgsql.CompoundIdentifier{traversalStep.Edge.Identifier, pgsql.ColumnStartID},
-					pgsql.CompoundIdentifier{traversalStep.Edge.Identifier, pgsql.ColumnEndID},
-					pgsql.NewLiteral(1, pgsql.Int),
-					terminalCriteriaProjection,
-					pgsql.NewBinaryExpression(
-						pgsql.CompoundIdentifier{traversalStep.Edge.Identifier, pgsql.ColumnStartID},
+			}, {
+				Table: pgsql.TableReference{
+					Name:    pgsql.CompoundIdentifier{pgsql.TableNode},
+					Binding: models.ValueOptional(traversalStep.LeftNode.Identifier),
+				},
+				JoinOperator: pgsql.JoinOperator{
+					JoinType: pgsql.JoinTypeInner,
+					Constraint: pgsql.NewBinaryExpression(
+						pgsql.CompoundIdentifier{traversalStep.LeftNode.Identifier, pgsql.ColumnID},
 						pgsql.OperatorEquals,
-						pgsql.CompoundIdentifier{traversalStep.Edge.Identifier, pgsql.ColumnEndID},
+						pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Frame.Binding.Identifier, expansionRootID},
 					),
-					pgsql.ArrayLiteral{
-						Values: []pgsql.Expression{
-							pgsql.CompoundIdentifier{traversalStep.Edge.Identifier, pgsql.ColumnID},
-						},
-					},
-				}
+				},
+			}, {
+				Table: pgsql.TableReference{
+					Name:    pgsql.CompoundIdentifier{pgsql.TableNode},
+					Binding: models.ValueOptional(traversalStep.RightNode.Identifier),
+				},
+				JoinOperator: pgsql.JoinOperator{
+					JoinType:   pgsql.JoinTypeInner,
+					Constraint: wrappedSelectJoinConstraint,
+				},
+			}},
+		})
+	}
 
-				expansion.RecursiveStatement.Projection = []pgsql.SelectItem{
-					pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Binding.Identifier, expansionRootID},
-					pgsql.CompoundIdentifier{traversalStep.Edge.Identifier, pgsql.ColumnEndID},
-					pgsql.NewBinaryExpression(
-						pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Binding.Identifier, expansionDepth},
-						pgsql.OperatorAdd,
-						pgsql.NewLiteral(1, pgsql.Int),
-					),
-					terminalCriteriaProjection,
-					pgsql.NewBinaryExpression(
-						pgsql.CompoundIdentifier{traversalStep.Edge.Identifier, pgsql.ColumnID},
-						pgsql.OperatorEquals,
-						pgsql.NewAnyExpression(pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Binding.Identifier, expansionPath}),
-					),
-					pgsql.NewBinaryExpression(
-						pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Binding.Identifier, expansionPath},
-						pgsql.OperatorConcatenate,
-						pgsql.CompoundIdentifier{traversalStep.Edge.Identifier, pgsql.ColumnID},
-					),
-				}
-
-				// Constraints that target the terminal node may crop up here where it's finally in scope. Additionally,
-				// only accept paths that are marked satisfied from the recursive descent CTE
-				if constraints, err := consumeConstraintsFrom(traversalStep.Expansion.Value.Frame.Visible, s.treeTranslator.IdentifierConstraints); err != nil {
-					return pgsql.Query{}, err
-				} else if projectionConstraints, err := ConjoinExpressions([]pgsql.Expression{pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Binding.Identifier, expansionSatisfied}, constraints.Expression}); err != nil {
-					return pgsql.Query{}, err
-				} else {
-					expansion.ProjectionStatement.Where = projectionConstraints
-				}
-			}
+	// If there are terminal constraints, project them as part of the projections
+	if traversalStep.Expansion.Value.TerminalNodeConstraints != nil {
+		if terminalCriteriaProjection, err := pgsql.As[pgsql.SelectItem](traversalStep.Expansion.Value.TerminalNodeConstraints); err != nil {
+			return pgsql.Query{}, err
 		} else {
 			expansion.PrimerStatement.Projection = []pgsql.SelectItem{
 				pgsql.CompoundIdentifier{traversalStep.Edge.Identifier, pgsql.ColumnStartID},
 				pgsql.CompoundIdentifier{traversalStep.Edge.Identifier, pgsql.ColumnEndID},
 				pgsql.NewLiteral(1, pgsql.Int),
-				pgsql.ExistsExpression{
-					Subquery: pgsql.Subquery{
-						Query: pgsql.Query{
-							Body: pgsql.Select{
-								Projection: []pgsql.SelectItem{
-									pgsql.NewLiteral(1, pgsql.Int),
-								},
-								From: []pgsql.FromClause{{
-									Source: pgsql.TableReference{
-										Name:    pgsql.CompoundIdentifier{model.EdgeTable},
-										Binding: models.ValueOptional(traversalStep.Edge.Identifier),
-									},
-								}},
-								Where: pgsql.NewBinaryExpression(
-									pgsql.CompoundIdentifier{traversalStep.RightNode.Identifier, pgsql.ColumnID},
-									pgsql.OperatorEquals,
-									pgsql.CompoundIdentifier{traversalStep.Edge.Identifier, pgsql.ColumnStartID},
-								),
-							},
-						},
-					},
-					Negated: false,
-				},
+				terminalCriteriaProjection,
 				pgsql.NewBinaryExpression(
 					pgsql.CompoundIdentifier{traversalStep.Edge.Identifier, pgsql.ColumnStartID},
 					pgsql.OperatorEquals,
@@ -470,47 +260,117 @@ func (s *Translator) buildAllShortestPathsExpansionRoot(part *PatternPart, trave
 			}
 
 			expansion.RecursiveStatement.Projection = []pgsql.SelectItem{
-				pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Binding.Identifier, expansionRootID},
+				pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Frame.Binding.Identifier, expansionRootID},
 				pgsql.CompoundIdentifier{traversalStep.Edge.Identifier, pgsql.ColumnEndID},
 				pgsql.NewBinaryExpression(
-					pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Binding.Identifier, expansionDepth},
+					pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Frame.Binding.Identifier, expansionDepth},
 					pgsql.OperatorAdd,
 					pgsql.NewLiteral(1, pgsql.Int),
 				),
-				pgsql.ExistsExpression{
-					Subquery: pgsql.Subquery{
-						Query: pgsql.Query{
-							Body: pgsql.Select{
-								Projection: []pgsql.SelectItem{
-									pgsql.NewLiteral(1, pgsql.Int),
-								},
-								From: []pgsql.FromClause{{
-									Source: pgsql.TableReference{
-										Name:    pgsql.CompoundIdentifier{model.EdgeTable},
-										Binding: models.ValueOptional(traversalStep.Edge.Identifier),
-									},
-								}},
-								Where: pgsql.NewBinaryExpression(
-									pgsql.CompoundIdentifier{traversalStep.RightNode.Identifier, pgsql.ColumnID},
-									pgsql.OperatorEquals,
-									pgsql.CompoundIdentifier{traversalStep.Edge.Identifier, pgsql.ColumnStartID},
-								),
-							},
-						},
-					},
-					Negated: false,
-				},
+				terminalCriteriaProjection,
 				pgsql.NewBinaryExpression(
 					pgsql.CompoundIdentifier{traversalStep.Edge.Identifier, pgsql.ColumnID},
 					pgsql.OperatorEquals,
-					pgsql.NewAnyExpression(pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Binding.Identifier, expansionPath}),
+					pgsql.NewAnyExpression(pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Frame.Binding.Identifier, expansionPath}),
 				),
 				pgsql.NewBinaryExpression(
-					pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Binding.Identifier, expansionPath},
+					pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Frame.Binding.Identifier, expansionPath},
 					pgsql.OperatorConcatenate,
 					pgsql.CompoundIdentifier{traversalStep.Edge.Identifier, pgsql.ColumnID},
 				),
 			}
+
+			// Constraints that target the terminal node may crop up here where it's finally in scope. Additionally,
+			// only accept paths that are marked satisfied from the recursive descent CTE
+			if constraints, err := consumeConstraintsFrom(traversalStep.Expansion.Value.Frame.Visible, s.treeTranslator.IdentifierConstraints); err != nil {
+				return pgsql.Query{}, err
+			} else if projectionConstraints, err := ConjoinExpressions([]pgsql.Expression{pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Frame.Binding.Identifier, expansionSatisfied}, constraints.Expression}); err != nil {
+				return pgsql.Query{}, err
+			} else {
+				expansion.ProjectionStatement.Where = projectionConstraints
+			}
+		}
+	} else {
+		expansion.PrimerStatement.Projection = []pgsql.SelectItem{
+			pgsql.CompoundIdentifier{traversalStep.Edge.Identifier, pgsql.ColumnStartID},
+			pgsql.CompoundIdentifier{traversalStep.Edge.Identifier, pgsql.ColumnEndID},
+			pgsql.NewLiteral(1, pgsql.Int),
+			pgsql.ExistsExpression{
+				Subquery: pgsql.Subquery{
+					Query: pgsql.Query{
+						Body: pgsql.Select{
+							Projection: []pgsql.SelectItem{
+								pgsql.NewLiteral(1, pgsql.Int),
+							},
+							From: []pgsql.FromClause{{
+								Source: pgsql.TableReference{
+									Name:    pgsql.CompoundIdentifier{model.EdgeTable},
+									Binding: models.ValueOptional(traversalStep.Edge.Identifier),
+								},
+							}},
+							Where: pgsql.NewBinaryExpression(
+								pgsql.CompoundIdentifier{traversalStep.RightNode.Identifier, pgsql.ColumnID},
+								pgsql.OperatorEquals,
+								pgsql.CompoundIdentifier{traversalStep.Edge.Identifier, pgsql.ColumnStartID},
+							),
+						},
+					},
+				},
+				Negated: false,
+			},
+			pgsql.NewBinaryExpression(
+				pgsql.CompoundIdentifier{traversalStep.Edge.Identifier, pgsql.ColumnStartID},
+				pgsql.OperatorEquals,
+				pgsql.CompoundIdentifier{traversalStep.Edge.Identifier, pgsql.ColumnEndID},
+			),
+			pgsql.ArrayLiteral{
+				Values: []pgsql.Expression{
+					pgsql.CompoundIdentifier{traversalStep.Edge.Identifier, pgsql.ColumnID},
+				},
+			},
+		}
+
+		expansion.RecursiveStatement.Projection = []pgsql.SelectItem{
+			pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Frame.Binding.Identifier, expansionRootID},
+			pgsql.CompoundIdentifier{traversalStep.Edge.Identifier, pgsql.ColumnEndID},
+			pgsql.NewBinaryExpression(
+				pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Frame.Binding.Identifier, expansionDepth},
+				pgsql.OperatorAdd,
+				pgsql.NewLiteral(1, pgsql.Int),
+			),
+			pgsql.ExistsExpression{
+				Subquery: pgsql.Subquery{
+					Query: pgsql.Query{
+						Body: pgsql.Select{
+							Projection: []pgsql.SelectItem{
+								pgsql.NewLiteral(1, pgsql.Int),
+							},
+							From: []pgsql.FromClause{{
+								Source: pgsql.TableReference{
+									Name:    pgsql.CompoundIdentifier{model.EdgeTable},
+									Binding: models.ValueOptional(traversalStep.Edge.Identifier),
+								},
+							}},
+							Where: pgsql.NewBinaryExpression(
+								pgsql.CompoundIdentifier{traversalStep.RightNode.Identifier, pgsql.ColumnID},
+								pgsql.OperatorEquals,
+								pgsql.CompoundIdentifier{traversalStep.Edge.Identifier, pgsql.ColumnStartID},
+							),
+						},
+					},
+				},
+				Negated: false,
+			},
+			pgsql.NewBinaryExpression(
+				pgsql.CompoundIdentifier{traversalStep.Edge.Identifier, pgsql.ColumnID},
+				pgsql.OperatorEquals,
+				pgsql.NewAnyExpression(pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Frame.Binding.Identifier, expansionPath}),
+			),
+			pgsql.NewBinaryExpression(
+				pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Frame.Binding.Identifier, expansionPath},
+				pgsql.OperatorConcatenate,
+				pgsql.CompoundIdentifier{traversalStep.Edge.Identifier, pgsql.ColumnID},
+			),
 		}
 	}
 
@@ -560,7 +420,7 @@ func (s *Translator) buildAllShortestPathsExpansionRoot(part *PatternPart, trave
 		s.translation.Parameters[recursiveParameterBinding.Identifier.String()] = recursiveValue
 		recursiveParameterBinding.Parameter = models.ValueOptional(recursiveParameter)
 
-		return expansion.BuildAllShortestPaths(primerParameter, recursiveParameter, traversalStep.Expansion.Value.Binding.Identifier, translateDefaultMaxTraversalDepth), nil
+		return expansion.BuildAllShortestPaths(primerParameter, recursiveParameter, traversalStep.Expansion.Value.Frame.Binding.Identifier, translateDefaultMaxTraversalDepth), nil
 	}
 }
 
@@ -583,246 +443,196 @@ func (s *Translator) buildExpansionPatternRoot(part *PatternPart, traversalStep 
 
 	expansion.ProjectionStatement.Projection = traversalStep.Expansion.Value.Projection
 
-	if expansionComponents, err := prepareExpansionRootComponents(part, traversalStep, s.treeTranslator); err != nil {
-		return pgsql.Query{}, err
-	} else {
-		expansion.PrimerStatement.Where = expansionComponents.PrimerWhereClause
-		expansion.RecursiveStatement.Where = expansionComponents.RecursiveWhereClause
+	expansion.PrimerStatement.Where = traversalStep.Expansion.Value.PrimerConstraints
+	expansion.RecursiveStatement.Where = traversalStep.Expansion.Value.RecursiveConstraints
 
-		if leftNodeJoinConstraint, err := leftNodeTraversalStepConstraint(traversalStep); err != nil {
-			return pgsql.Query{}, err
-		} else if leftNodeJoinCondition, err := ConjoinExpressions([]pgsql.Expression{expansionComponents.LeftNodeConstraints.Expression, leftNodeJoinConstraint}); err != nil {
-			return pgsql.Query{}, err
-		} else if rightNodeJoinCondition, err := rightNodeTraversalStepConstraint(traversalStep); err != nil {
-			return pgsql.Query{}, err
-		} else {
-			// If the left node was already bound at time of translation connect this expansion to the
-			// previously materialized node
-			if traversalStep.LeftNodeBound {
-				expansion.PrimerStatement.From = append(expansion.PrimerStatement.From, pgsql.FromClause{
-					Source: pgsql.TableReference{
-						Name: pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Frame.Previous.Binding.Identifier},
-					},
-					Joins: []pgsql.Join{{
-						Table: pgsql.TableReference{
-							Name:    pgsql.CompoundIdentifier{pgsql.TableEdge},
-							Binding: models.ValueOptional(traversalStep.Edge.Identifier),
-						},
-						JoinOperator: pgsql.JoinOperator{
-							JoinType: pgsql.JoinTypeInner,
-							Constraint: pgsql.NewBinaryExpression(
-								pgsql.CompoundIdentifier{traversalStep.Edge.Identifier, pgsql.ColumnStartID},
-								pgsql.OperatorEquals,
-								rewriteCompositeTypeFieldReference(
-									traversalStep.Expansion.Value.Frame.Previous.Binding.Identifier,
-									pgsql.CompoundIdentifier{traversalStep.LeftNode.Identifier, pgsql.ColumnID},
-								)),
-						},
-					}, {
-						Table: pgsql.TableReference{
-							Name:    pgsql.CompoundIdentifier{pgsql.TableNode},
-							Binding: models.ValueOptional(traversalStep.LeftNode.Identifier),
-						},
-						JoinOperator: pgsql.JoinOperator{
-							JoinType:   pgsql.JoinTypeInner,
-							Constraint: leftNodeJoinCondition,
-						},
-					}, {
-						Table: pgsql.TableReference{
-							Name:    pgsql.CompoundIdentifier{pgsql.TableNode},
-							Binding: models.ValueOptional(traversalStep.RightNode.Identifier),
-						},
-						JoinOperator: pgsql.JoinOperator{
-							JoinType:   pgsql.JoinTypeInner,
-							Constraint: rightNodeJoinCondition,
-						},
-					}},
-				})
-			} else {
-				expansion.PrimerStatement.From = append(expansion.PrimerStatement.From, pgsql.FromClause{
-					Source: pgsql.TableReference{
-						Name:    pgsql.CompoundIdentifier{pgsql.TableEdge},
-						Binding: models.ValueOptional(traversalStep.Edge.Identifier),
-					},
-					Joins: []pgsql.Join{{
-						Table: pgsql.TableReference{
-							Name:    pgsql.CompoundIdentifier{pgsql.TableNode},
-							Binding: models.ValueOptional(traversalStep.LeftNode.Identifier),
-						},
-						JoinOperator: pgsql.JoinOperator{
-							JoinType:   pgsql.JoinTypeInner,
-							Constraint: leftNodeJoinCondition,
-						},
-					}, {
-						Table: pgsql.TableReference{
-							Name:    pgsql.CompoundIdentifier{pgsql.TableNode},
-							Binding: models.ValueOptional(traversalStep.RightNode.Identifier),
-						},
-						JoinOperator: pgsql.JoinOperator{
-							JoinType:   pgsql.JoinTypeInner,
-							Constraint: rightNodeJoinCondition,
-						},
-					}},
-				})
-			}
-
-			// Make sure the recursive query has the expansion bound
-			expansion.RecursiveStatement.From = append(expansion.RecursiveStatement.From, pgsql.FromClause{
-				Source: pgsql.TableReference{
-					Name: pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Binding.Identifier},
+	// If the left node was already bound at time of translation connect this expansion to the
+	// previously materialized node
+	if traversalStep.LeftNodeBound {
+		expansion.PrimerStatement.From = append(expansion.PrimerStatement.From, pgsql.FromClause{
+			Source: pgsql.TableReference{
+				Name: pgsql.CompoundIdentifier{traversalStep.Frame.Previous.Binding.Identifier},
+			},
+			Joins: []pgsql.Join{{
+				Table: pgsql.TableReference{
+					Name:    pgsql.CompoundIdentifier{pgsql.TableEdge},
+					Binding: models.ValueOptional(traversalStep.Edge.Identifier),
 				},
-				Joins: []pgsql.Join{{
-					Table: pgsql.TableReference{
-						Name:    pgsql.CompoundIdentifier{pgsql.TableEdge},
-						Binding: models.ValueOptional(traversalStep.Edge.Identifier),
-					},
-					JoinOperator: pgsql.JoinOperator{
-						JoinType: pgsql.JoinTypeInner,
-						Constraint: pgsql.NewBinaryExpression(
-							// TODO: Directional
-							pgsql.CompoundIdentifier{traversalStep.Edge.Identifier, pgsql.ColumnStartID},
-							pgsql.OperatorEquals,
-							pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Binding.Identifier, pgsql.ColumnNextID},
-						),
-					},
-				}, {
-					Table: pgsql.TableReference{
-						Name:    pgsql.CompoundIdentifier{pgsql.TableNode},
-						Binding: models.ValueOptional(traversalStep.RightNode.Identifier),
-					},
-					JoinOperator: pgsql.JoinOperator{
-						JoinType:   pgsql.JoinTypeInner,
-						Constraint: rightNodeJoinCondition,
-					},
-				}},
-			})
-
-			if wrappedSelectJoinConstraint, err := ConjoinExpressions([]pgsql.Expression{
-				pgsql.NewBinaryExpression(
-					pgsql.CompoundIdentifier{traversalStep.Edge.Identifier, pgsql.ColumnID},
-					pgsql.OperatorEquals,
-					&pgsql.ArrayIndex{
-						Expression: pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Binding.Identifier, expansionPath},
-						Indexes: []pgsql.Expression{
-							pgsql.FunctionCall{
-								Function: pgsql.FunctionArrayLength,
-								Parameters: []pgsql.Expression{
-									pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Binding.Identifier, expansionPath},
-									pgsql.NewLiteral(1, pgsql.Int8),
-								},
-								CastType: pgsql.Int,
-							},
-						},
-					},
-				),
-				rightNodeJoinCondition}); err != nil {
-				return pgsql.Query{}, err
-			} else {
-				// Select the expansion components for the projection statement
-				expansion.ProjectionStatement.From = append(expansion.ProjectionStatement.From, pgsql.FromClause{
-					Source: pgsql.TableReference{
-						Name:    pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Binding.Identifier},
-						Binding: models.EmptyOptional[pgsql.Identifier](),
-					},
-					Joins: []pgsql.Join{{
-						Table: pgsql.TableReference{
-							Name:    pgsql.CompoundIdentifier{pgsql.TableEdge},
-							Binding: models.ValueOptional(traversalStep.Edge.Identifier),
-						},
-						JoinOperator: pgsql.JoinOperator{
-							JoinType: pgsql.JoinTypeInner,
-							Constraint: pgsql.NewBinaryExpression(
-								pgsql.CompoundIdentifier{traversalStep.Edge.Identifier, pgsql.ColumnID},
-								pgsql.OperatorEquals,
-								pgsql.NewAnyExpression(pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Binding.Identifier, expansionPath}),
-							),
-						},
-					}, {
-						Table: pgsql.TableReference{
-							Name:    pgsql.CompoundIdentifier{pgsql.TableNode},
-							Binding: models.ValueOptional(traversalStep.LeftNode.Identifier),
-						},
-						JoinOperator: pgsql.JoinOperator{
-							JoinType: pgsql.JoinTypeInner,
-							Constraint: pgsql.NewBinaryExpression(
-								pgsql.CompoundIdentifier{traversalStep.LeftNode.Identifier, pgsql.ColumnID},
-								pgsql.OperatorEquals,
-								pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Binding.Identifier, expansionRootID},
-							),
-						},
-					}, {
-						Table: pgsql.TableReference{
-							Name:    pgsql.CompoundIdentifier{pgsql.TableNode},
-							Binding: models.ValueOptional(traversalStep.RightNode.Identifier),
-						},
-						JoinOperator: pgsql.JoinOperator{
-							JoinType:   pgsql.JoinTypeInner,
-							Constraint: wrappedSelectJoinConstraint,
-						},
-					}},
-				})
-			}
-		}
-
-		// If there are right node constraints, project them as part of the primer statement's projection
-		if expansionComponents.RightNodeConstraints.Expression != nil {
-			if terminalCriteriaProjection, err := pgsql.As[pgsql.SelectItem](expansionComponents.RightNodeConstraints.Expression); err != nil {
-				return pgsql.Query{}, err
-			} else {
-				expansion.PrimerStatement.Projection = []pgsql.SelectItem{
-					pgsql.CompoundIdentifier{traversalStep.Edge.Identifier, pgsql.ColumnStartID},
-					pgsql.CompoundIdentifier{traversalStep.Edge.Identifier, pgsql.ColumnEndID},
-					pgsql.NewLiteral(1, pgsql.Int),
-					terminalCriteriaProjection,
-					pgsql.NewBinaryExpression(
+				JoinOperator: pgsql.JoinOperator{
+					JoinType: pgsql.JoinTypeInner,
+					Constraint: pgsql.NewBinaryExpression(
 						pgsql.CompoundIdentifier{traversalStep.Edge.Identifier, pgsql.ColumnStartID},
 						pgsql.OperatorEquals,
-						pgsql.CompoundIdentifier{traversalStep.Edge.Identifier, pgsql.ColumnEndID},
-					),
-					pgsql.ArrayLiteral{
-						Values: []pgsql.Expression{
-							pgsql.CompoundIdentifier{traversalStep.Edge.Identifier, pgsql.ColumnID},
-						},
-					},
-				}
+						rewriteCompositeTypeFieldReference(
+							traversalStep.Frame.Previous.Binding.Identifier,
+							pgsql.CompoundIdentifier{traversalStep.LeftNode.Identifier, pgsql.ColumnID},
+						)),
+				},
+			}, {
+				Table: pgsql.TableReference{
+					Name:    pgsql.CompoundIdentifier{pgsql.TableNode},
+					Binding: models.ValueOptional(traversalStep.LeftNode.Identifier),
+				},
+				JoinOperator: pgsql.JoinOperator{
+					JoinType:   pgsql.JoinTypeInner,
+					Constraint: traversalStep.Expansion.Value.PrimerRootNodeConstraints,
+				},
+			}, {
+				Table: pgsql.TableReference{
+					Name:    pgsql.CompoundIdentifier{pgsql.TableNode},
+					Binding: models.ValueOptional(traversalStep.RightNode.Identifier),
+				},
+				JoinOperator: pgsql.JoinOperator{
+					JoinType:   pgsql.JoinTypeInner,
+					Constraint: traversalStep.Expansion.Value.ExpansionNodeConstraints,
+				},
+			}},
+		})
+	} else {
+		expansion.PrimerStatement.From = append(expansion.PrimerStatement.From, pgsql.FromClause{
+			Source: pgsql.TableReference{
+				Name:    pgsql.CompoundIdentifier{pgsql.TableEdge},
+				Binding: models.ValueOptional(traversalStep.Edge.Identifier),
+			},
+			Joins: []pgsql.Join{{
+				Table: pgsql.TableReference{
+					Name:    pgsql.CompoundIdentifier{pgsql.TableNode},
+					Binding: models.ValueOptional(traversalStep.LeftNode.Identifier),
+				},
+				JoinOperator: pgsql.JoinOperator{
+					JoinType:   pgsql.JoinTypeInner,
+					Constraint: traversalStep.Expansion.Value.PrimerRootNodeConstraints,
+				},
+			}, {
+				Table: pgsql.TableReference{
+					Name:    pgsql.CompoundIdentifier{pgsql.TableNode},
+					Binding: models.ValueOptional(traversalStep.RightNode.Identifier),
+				},
+				JoinOperator: pgsql.JoinOperator{
+					JoinType:   pgsql.JoinTypeInner,
+					Constraint: traversalStep.Expansion.Value.ExpansionNodeConstraints,
+				},
+			}},
+		})
+	}
 
-				expansion.RecursiveStatement.Projection = []pgsql.SelectItem{
-					pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Binding.Identifier, expansionRootID},
-					pgsql.CompoundIdentifier{traversalStep.Edge.Identifier, pgsql.ColumnEndID},
-					pgsql.NewBinaryExpression(
-						pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Binding.Identifier, expansionDepth},
-						pgsql.OperatorAdd,
-						pgsql.NewLiteral(1, pgsql.Int),
-					),
-					terminalCriteriaProjection,
-					pgsql.NewBinaryExpression(
+	// Make sure the recursive query has the expansion bound
+	expansion.RecursiveStatement.From = append(expansion.RecursiveStatement.From, pgsql.FromClause{
+		Source: pgsql.TableReference{
+			Name: pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Frame.Binding.Identifier},
+		},
+		Joins: []pgsql.Join{{
+			Table: pgsql.TableReference{
+				Name:    pgsql.CompoundIdentifier{pgsql.TableEdge},
+				Binding: models.ValueOptional(traversalStep.Edge.Identifier),
+			},
+			JoinOperator: pgsql.JoinOperator{
+				JoinType: pgsql.JoinTypeInner,
+				Constraint: pgsql.NewBinaryExpression(
+					// TODO: Directional
+					pgsql.CompoundIdentifier{traversalStep.Edge.Identifier, pgsql.ColumnStartID},
+					pgsql.OperatorEquals,
+					pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Frame.Binding.Identifier, pgsql.ColumnNextID},
+				),
+			},
+		}, {
+			Table: pgsql.TableReference{
+				Name:    pgsql.CompoundIdentifier{pgsql.TableNode},
+				Binding: models.ValueOptional(traversalStep.RightNode.Identifier),
+			},
+			JoinOperator: pgsql.JoinOperator{
+				JoinType:   pgsql.JoinTypeInner,
+				Constraint: traversalStep.Expansion.Value.ExpansionNodeConstraints,
+			},
+		}},
+	})
+
+	if wrappedSelectJoinConstraint, err := ConjoinExpressions([]pgsql.Expression{
+		pgsql.NewBinaryExpression(
+			pgsql.CompoundIdentifier{traversalStep.Edge.Identifier, pgsql.ColumnID},
+			pgsql.OperatorEquals,
+			&pgsql.ArrayIndex{
+				Expression: pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Frame.Binding.Identifier, expansionPath},
+				Indexes: []pgsql.Expression{
+					pgsql.FunctionCall{
+						Function: pgsql.FunctionArrayLength,
+						Parameters: []pgsql.Expression{
+							pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Frame.Binding.Identifier, expansionPath},
+							pgsql.NewLiteral(1, pgsql.Int8),
+						},
+						CastType: pgsql.Int,
+					},
+				},
+			},
+		),
+		traversalStep.Expansion.Value.ExpansionNodeConstraints}); err != nil {
+		return pgsql.Query{}, err
+	} else {
+		// The current query part may not have a frame associated with it if is a single part query component
+		if traversalStep.Frame.Previous != nil && (s.query.CurrentPart().Frame == nil || traversalStep.Frame.Previous.Binding.Identifier != s.query.CurrentPart().Frame.Binding.Identifier) {
+			expansion.ProjectionStatement.From = append(expansion.ProjectionStatement.From, pgsql.FromClause{
+				Source: pgsql.TableReference{
+					Name:    pgsql.CompoundIdentifier{traversalStep.Frame.Previous.Binding.Identifier},
+					Binding: models.EmptyOptional[pgsql.Identifier](),
+				},
+			})
+		}
+
+		// Select the expansion components for the projection statement
+		expansion.ProjectionStatement.From = append(expansion.ProjectionStatement.From, pgsql.FromClause{
+			Source: pgsql.TableReference{
+				Name:    pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Frame.Binding.Identifier},
+				Binding: models.EmptyOptional[pgsql.Identifier](),
+			},
+			Joins: []pgsql.Join{{
+				Table: pgsql.TableReference{
+					Name:    pgsql.CompoundIdentifier{pgsql.TableEdge},
+					Binding: models.ValueOptional(traversalStep.Edge.Identifier),
+				},
+				JoinOperator: pgsql.JoinOperator{
+					JoinType: pgsql.JoinTypeInner,
+					Constraint: pgsql.NewBinaryExpression(
 						pgsql.CompoundIdentifier{traversalStep.Edge.Identifier, pgsql.ColumnID},
 						pgsql.OperatorEquals,
-						pgsql.NewAnyExpression(pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Binding.Identifier, expansionPath}),
+						pgsql.NewAnyExpression(pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Frame.Binding.Identifier, expansionPath}),
 					),
-					pgsql.NewBinaryExpression(
-						pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Binding.Identifier, expansionPath},
-						pgsql.OperatorConcatenate,
-						pgsql.CompoundIdentifier{traversalStep.Edge.Identifier, pgsql.ColumnID},
+				},
+			}, {
+				Table: pgsql.TableReference{
+					Name:    pgsql.CompoundIdentifier{pgsql.TableNode},
+					Binding: models.ValueOptional(traversalStep.LeftNode.Identifier),
+				},
+				JoinOperator: pgsql.JoinOperator{
+					JoinType: pgsql.JoinTypeInner,
+					Constraint: pgsql.NewBinaryExpression(
+						pgsql.CompoundIdentifier{traversalStep.LeftNode.Identifier, pgsql.ColumnID},
+						pgsql.OperatorEquals,
+						pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Frame.Binding.Identifier, expansionRootID},
 					),
-				}
+				},
+			}, {
+				Table: pgsql.TableReference{
+					Name:    pgsql.CompoundIdentifier{pgsql.TableNode},
+					Binding: models.ValueOptional(traversalStep.RightNode.Identifier),
+				},
+				JoinOperator: pgsql.JoinOperator{
+					JoinType:   pgsql.JoinTypeInner,
+					Constraint: wrappedSelectJoinConstraint,
+				},
+			}},
+		})
+	}
 
-				// Constraints that target the terminal node may crop up here where it's finally in scope. Additionally,
-				// only accept paths that are marked satisfied from the recursive descent CTE
-				if constraints, err := consumeConstraintsFrom(traversalStep.Expansion.Value.Frame.Visible, s.treeTranslator.IdentifierConstraints); err != nil {
-					return pgsql.Query{}, err
-				} else if projectionConstraints, err := ConjoinExpressions([]pgsql.Expression{pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Binding.Identifier, expansionSatisfied}, constraints.Expression}); err != nil {
-					return pgsql.Query{}, err
-				} else {
-					expansion.ProjectionStatement.Where = projectionConstraints
-				}
-			}
+	// If there are right node constraints, project them as part of the primer statement's projection
+	if traversalStep.Expansion.Value.TerminalNodeConstraints != nil {
+		if terminalCriteriaProjection, err := pgsql.As[pgsql.SelectItem](traversalStep.Expansion.Value.TerminalNodeConstraints); err != nil {
+			return pgsql.Query{}, err
 		} else {
 			expansion.PrimerStatement.Projection = []pgsql.SelectItem{
 				pgsql.CompoundIdentifier{traversalStep.Edge.Identifier, pgsql.ColumnStartID},
 				pgsql.CompoundIdentifier{traversalStep.Edge.Identifier, pgsql.ColumnEndID},
 				pgsql.NewLiteral(1, pgsql.Int),
-				pgsql.NewLiteral(false, pgsql.Boolean),
+				terminalCriteriaProjection,
 				pgsql.NewBinaryExpression(
 					pgsql.CompoundIdentifier{traversalStep.Edge.Identifier, pgsql.ColumnStartID},
 					pgsql.OperatorEquals,
@@ -836,29 +646,77 @@ func (s *Translator) buildExpansionPatternRoot(part *PatternPart, traversalStep 
 			}
 
 			expansion.RecursiveStatement.Projection = []pgsql.SelectItem{
-				pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Binding.Identifier, expansionRootID},
+				pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Frame.Binding.Identifier, expansionRootID},
 				pgsql.CompoundIdentifier{traversalStep.Edge.Identifier, pgsql.ColumnEndID},
 				pgsql.NewBinaryExpression(
-					pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Binding.Identifier, expansionDepth},
+					pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Frame.Binding.Identifier, expansionDepth},
 					pgsql.OperatorAdd,
 					pgsql.NewLiteral(1, pgsql.Int),
 				),
-				pgsql.NewLiteral(false, pgsql.Boolean),
+				terminalCriteriaProjection,
 				pgsql.NewBinaryExpression(
 					pgsql.CompoundIdentifier{traversalStep.Edge.Identifier, pgsql.ColumnID},
 					pgsql.OperatorEquals,
-					pgsql.NewAnyExpression(pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Binding.Identifier, expansionPath}),
+					pgsql.NewAnyExpression(pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Frame.Binding.Identifier, expansionPath}),
 				),
 				pgsql.NewBinaryExpression(
-					pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Binding.Identifier, expansionPath},
+					pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Frame.Binding.Identifier, expansionPath},
 					pgsql.OperatorConcatenate,
 					pgsql.CompoundIdentifier{traversalStep.Edge.Identifier, pgsql.ColumnID},
 				),
 			}
+
+			// Constraints that target the terminal node may crop up here where it's finally in scope. Additionally,
+			// only accept paths that are marked satisfied from the recursive descent CTE
+			if constraints, err := consumeConstraintsFrom(traversalStep.Expansion.Value.Frame.Visible, s.treeTranslator.IdentifierConstraints); err != nil {
+				return pgsql.Query{}, err
+			} else if projectionConstraints, err := ConjoinExpressions([]pgsql.Expression{pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Frame.Binding.Identifier, expansionSatisfied}, constraints.Expression}); err != nil {
+				return pgsql.Query{}, err
+			} else {
+				expansion.ProjectionStatement.Where = projectionConstraints
+			}
+		}
+	} else {
+		expansion.PrimerStatement.Projection = []pgsql.SelectItem{
+			pgsql.CompoundIdentifier{traversalStep.Edge.Identifier, pgsql.ColumnStartID},
+			pgsql.CompoundIdentifier{traversalStep.Edge.Identifier, pgsql.ColumnEndID},
+			pgsql.NewLiteral(1, pgsql.Int),
+			pgsql.NewLiteral(false, pgsql.Boolean),
+			pgsql.NewBinaryExpression(
+				pgsql.CompoundIdentifier{traversalStep.Edge.Identifier, pgsql.ColumnStartID},
+				pgsql.OperatorEquals,
+				pgsql.CompoundIdentifier{traversalStep.Edge.Identifier, pgsql.ColumnEndID},
+			),
+			pgsql.ArrayLiteral{
+				Values: []pgsql.Expression{
+					pgsql.CompoundIdentifier{traversalStep.Edge.Identifier, pgsql.ColumnID},
+				},
+			},
+		}
+
+		expansion.RecursiveStatement.Projection = []pgsql.SelectItem{
+			pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Frame.Binding.Identifier, expansionRootID},
+			pgsql.CompoundIdentifier{traversalStep.Edge.Identifier, pgsql.ColumnEndID},
+			pgsql.NewBinaryExpression(
+				pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Frame.Binding.Identifier, expansionDepth},
+				pgsql.OperatorAdd,
+				pgsql.NewLiteral(1, pgsql.Int),
+			),
+			pgsql.NewLiteral(false, pgsql.Boolean),
+			pgsql.NewBinaryExpression(
+				pgsql.CompoundIdentifier{traversalStep.Edge.Identifier, pgsql.ColumnID},
+				pgsql.OperatorEquals,
+				pgsql.NewAnyExpression(pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Frame.Binding.Identifier, expansionPath}),
+			),
+			pgsql.NewBinaryExpression(
+				pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Frame.Binding.Identifier, expansionPath},
+				pgsql.OperatorConcatenate,
+				pgsql.CompoundIdentifier{traversalStep.Edge.Identifier, pgsql.ColumnID},
+			),
 		}
 	}
 
-	return expansion.Build(traversalStep.Expansion.Value.Binding.Identifier), nil
+	return expansion.Build(traversalStep.Expansion.Value.Frame.Binding.Identifier), nil
 }
 
 func (s *Translator) buildExpansionPatternStep(part *PatternPart, traversalStep *PatternSegment) (pgsql.Query, error) {
@@ -891,10 +749,10 @@ func (s *Translator) buildExpansionPatternStep(part *PatternPart, traversalStep 
 
 			RecursiveStatement: pgsql.Select{
 				Projection: []pgsql.SelectItem{
-					pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Binding.Identifier, expansionRootID},
+					pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Frame.Binding.Identifier, expansionRootID},
 					pgsql.CompoundIdentifier{traversalStep.Edge.Identifier, pgsql.ColumnEndID},
 					pgsql.NewBinaryExpression(
-						pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Binding.Identifier, expansionDepth},
+						pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Frame.Binding.Identifier, expansionDepth},
 						pgsql.OperatorAdd,
 						pgsql.NewLiteral(1, pgsql.Int),
 					),
@@ -902,10 +760,10 @@ func (s *Translator) buildExpansionPatternStep(part *PatternPart, traversalStep 
 					pgsql.NewBinaryExpression(
 						pgsql.CompoundIdentifier{traversalStep.Edge.Identifier, pgsql.ColumnID},
 						pgsql.OperatorEquals,
-						pgsql.NewAnyExpression(pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Binding.Identifier, pgsql.ColumnPath}),
+						pgsql.NewAnyExpression(pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Frame.Binding.Identifier, pgsql.ColumnPath}),
 					),
 					pgsql.NewBinaryExpression(
-						pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Binding.Identifier, pgsql.ColumnPath},
+						pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Frame.Binding.Identifier, pgsql.ColumnPath},
 						pgsql.OperatorConcatenate,
 						pgsql.CompoundIdentifier{traversalStep.Edge.Identifier, pgsql.ColumnID},
 					),
@@ -916,178 +774,167 @@ func (s *Translator) buildExpansionPatternStep(part *PatternPart, traversalStep 
 
 	expansion.ProjectionStatement.Projection = traversalStep.Expansion.Value.Projection
 
-	if expansionComponents, err := prepareExpansionStepComponents(part, traversalStep, s.treeTranslator); err != nil {
+	expansion.PrimerStatement.Where = traversalStep.Expansion.Value.PrimerConstraints
+	expansion.RecursiveStatement.Where = traversalStep.Expansion.Value.RecursiveConstraints
+
+	expansion.PrimerStatement.From = append(expansion.PrimerStatement.From, pgsql.FromClause{
+		Source: pgsql.TableReference{
+			Name: pgsql.CompoundIdentifier{traversalStep.Frame.Previous.Binding.Identifier},
+		},
+		Joins: []pgsql.Join{{
+			Table: pgsql.TableReference{
+				Name:    pgsql.CompoundIdentifier{pgsql.TableEdge},
+				Binding: models.ValueOptional(traversalStep.Edge.Identifier),
+			},
+			JoinOperator: pgsql.JoinOperator{
+				JoinType:   pgsql.JoinTypeInner,
+				Constraint: traversalStep.Expansion.Value.ExpansionEdgeConstraints,
+			},
+		}, {
+			Table: pgsql.TableReference{
+				Name:    pgsql.CompoundIdentifier{pgsql.TableNode},
+				Binding: models.ValueOptional(traversalStep.RightNode.Identifier),
+			},
+			JoinOperator: pgsql.JoinOperator{
+				JoinType:   pgsql.JoinTypeInner,
+				Constraint: traversalStep.Expansion.Value.ExpansionNodeConstraints,
+			},
+		}},
+	})
+
+	// Make sure the recursive query has the expansion bound
+	expansion.RecursiveStatement.From = append(expansion.RecursiveStatement.From, pgsql.FromClause{
+		Source: pgsql.TableReference{
+			Name: pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Frame.Binding.Identifier},
+		},
+		Joins: []pgsql.Join{{
+			Table: pgsql.TableReference{
+				Name:    pgsql.CompoundIdentifier{pgsql.TableEdge},
+				Binding: models.ValueOptional(traversalStep.Edge.Identifier),
+			},
+			JoinOperator: pgsql.JoinOperator{
+				JoinType: pgsql.JoinTypeInner,
+				Constraint: pgsql.NewBinaryExpression(
+					// TODO: Directional
+					pgsql.CompoundIdentifier{traversalStep.Edge.Identifier, pgsql.ColumnStartID},
+					pgsql.OperatorEquals,
+					pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Frame.Binding.Identifier, pgsql.ColumnNextID},
+				),
+			},
+		}, {
+			Table: pgsql.TableReference{
+				Name:    pgsql.CompoundIdentifier{pgsql.TableNode},
+				Binding: models.ValueOptional(traversalStep.RightNode.Identifier),
+			},
+			JoinOperator: pgsql.JoinOperator{
+				JoinType:   pgsql.JoinTypeInner,
+				Constraint: traversalStep.Expansion.Value.ExpansionNodeConstraints,
+			},
+		}},
+	})
+
+	if wrappedSelectJoinConstraint, err := ConjoinExpressions([]pgsql.Expression{
+		pgsql.NewBinaryExpression(
+			pgsql.CompoundIdentifier{traversalStep.Edge.Identifier, pgsql.ColumnID},
+			pgsql.OperatorEquals,
+			&pgsql.ArrayIndex{
+				Expression: pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Frame.Binding.Identifier, expansionPath},
+				Indexes: []pgsql.Expression{
+					pgsql.FunctionCall{
+						Function: pgsql.FunctionArrayLength,
+						Parameters: []pgsql.Expression{
+							pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Frame.Binding.Identifier, expansionPath},
+							pgsql.NewLiteral(1, pgsql.Int8),
+						},
+						CastType: pgsql.Int,
+					},
+				},
+			},
+		),
+		traversalStep.Expansion.Value.ExpansionNodeConstraints}); err != nil {
 		return pgsql.Query{}, err
 	} else {
-		expansion.RecursiveStatement.Where = expansionComponents.RecursiveWhereClause
+		// Select the expansion components for the projection statement
+		expansion.ProjectionStatement.From = append(expansion.ProjectionStatement.From, pgsql.FromClause{
+			Source: pgsql.TableReference{
+				Name:    pgsql.CompoundIdentifier{traversalStep.Frame.Previous.Binding.Identifier},
+				Binding: models.EmptyOptional[pgsql.Identifier](),
+			},
+		})
 
-		if rightNodeJoinCondition, err := rightNodeTraversalStepConstraint(traversalStep); err != nil {
+		expansion.ProjectionStatement.From = append(expansion.ProjectionStatement.From, pgsql.FromClause{
+			Source: pgsql.TableReference{
+				Name:    pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Frame.Binding.Identifier},
+				Binding: models.EmptyOptional[pgsql.Identifier](),
+			},
+			Joins: []pgsql.Join{{
+				Table: pgsql.TableReference{
+					Name:    pgsql.CompoundIdentifier{pgsql.TableEdge},
+					Binding: models.ValueOptional(traversalStep.Edge.Identifier),
+				},
+				JoinOperator: pgsql.JoinOperator{
+					JoinType: pgsql.JoinTypeInner,
+					Constraint: pgsql.NewBinaryExpression(
+						pgsql.CompoundIdentifier{traversalStep.Edge.Identifier, pgsql.ColumnID},
+						pgsql.OperatorEquals,
+						pgsql.NewAnyExpression(pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Frame.Binding.Identifier, expansionPath}),
+					),
+				},
+			}, {
+				Table: pgsql.TableReference{
+					Name:    pgsql.CompoundIdentifier{pgsql.TableNode},
+					Binding: models.ValueOptional(traversalStep.LeftNode.Identifier),
+				},
+				JoinOperator: pgsql.JoinOperator{
+					JoinType: pgsql.JoinTypeInner,
+					Constraint: pgsql.NewBinaryExpression(
+						pgsql.CompoundIdentifier{traversalStep.LeftNode.Identifier, pgsql.ColumnID},
+						pgsql.OperatorEquals,
+						pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Frame.Binding.Identifier, expansionRootID},
+					),
+				},
+			}, {
+				Table: pgsql.TableReference{
+					Name:    pgsql.CompoundIdentifier{pgsql.TableNode},
+					Binding: models.ValueOptional(traversalStep.RightNode.Identifier),
+				},
+				JoinOperator: pgsql.JoinOperator{
+					JoinType:   pgsql.JoinTypeInner,
+					Constraint: wrappedSelectJoinConstraint,
+				},
+			}},
+		})
+	}
+
+	// If there are terminal constraints, project them as part of the recursive lookup
+	if traversalStep.Expansion.Value.TerminalNodeConstraints != nil {
+		if terminalCriteriaProjection, err := pgsql.As[pgsql.SelectItem](traversalStep.Expansion.Value.TerminalNodeConstraints); err != nil {
 			return pgsql.Query{}, err
 		} else {
-			if err := rewriteIdentifierReferences(traversalStep.Expansion.Value.Frame, []pgsql.Expression{expansionComponents.EdgeConstraints.Expression, rightNodeJoinCondition}); err != nil {
-				return pgsql.Query{}, err
-			}
-
-			expansion.PrimerStatement.From = append(expansion.PrimerStatement.From, pgsql.FromClause{
-				Source: pgsql.TableReference{
-					Name: pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Frame.Previous.Binding.Identifier},
-				},
-				Joins: []pgsql.Join{{
-					Table: pgsql.TableReference{
-						Name:    pgsql.CompoundIdentifier{pgsql.TableEdge},
-						Binding: models.ValueOptional(traversalStep.Edge.Identifier),
-					},
-					JoinOperator: pgsql.JoinOperator{
-						JoinType:   pgsql.JoinTypeInner,
-						Constraint: expansionComponents.EdgeConstraints.Expression,
-					},
-				}, {
-					Table: pgsql.TableReference{
-						Name:    pgsql.CompoundIdentifier{pgsql.TableNode},
-						Binding: models.ValueOptional(traversalStep.RightNode.Identifier),
-					},
-					JoinOperator: pgsql.JoinOperator{
-						JoinType:   pgsql.JoinTypeInner,
-						Constraint: rightNodeJoinCondition,
-					},
-				}},
-			})
-
-			// Make sure the recursive query has the expansion bound
-			expansion.RecursiveStatement.From = append(expansion.RecursiveStatement.From, pgsql.FromClause{
-				Source: pgsql.TableReference{
-					Name: pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Binding.Identifier},
-				},
-				Joins: []pgsql.Join{{
-					Table: pgsql.TableReference{
-						Name:    pgsql.CompoundIdentifier{pgsql.TableEdge},
-						Binding: models.ValueOptional(traversalStep.Edge.Identifier),
-					},
-					JoinOperator: pgsql.JoinOperator{
-						JoinType: pgsql.JoinTypeInner,
-						Constraint: pgsql.NewBinaryExpression(
-							// TODO: Directional
-							pgsql.CompoundIdentifier{traversalStep.Edge.Identifier, pgsql.ColumnStartID},
-							pgsql.OperatorEquals,
-							pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Binding.Identifier, pgsql.ColumnNextID},
-						),
-					},
-				}, {
-					Table: pgsql.TableReference{
-						Name:    pgsql.CompoundIdentifier{pgsql.TableNode},
-						Binding: models.ValueOptional(traversalStep.RightNode.Identifier),
-					},
-					JoinOperator: pgsql.JoinOperator{
-						JoinType:   pgsql.JoinTypeInner,
-						Constraint: rightNodeJoinCondition,
-					},
-				}},
-			})
-
-			if wrappedSelectJoinConstraint, err := ConjoinExpressions([]pgsql.Expression{
+			expansion.RecursiveStatement.Projection = []pgsql.SelectItem{
+				pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Frame.Binding.Identifier, expansionRootID},
+				pgsql.CompoundIdentifier{traversalStep.Edge.Identifier, pgsql.ColumnEndID},
+				pgsql.NewBinaryExpression(
+					pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Frame.Binding.Identifier, expansionDepth},
+					pgsql.OperatorAdd,
+					pgsql.NewLiteral(1, pgsql.Int),
+				),
+				terminalCriteriaProjection,
 				pgsql.NewBinaryExpression(
 					pgsql.CompoundIdentifier{traversalStep.Edge.Identifier, pgsql.ColumnID},
 					pgsql.OperatorEquals,
-					&pgsql.ArrayIndex{
-						Expression: pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Binding.Identifier, expansionPath},
-						Indexes: []pgsql.Expression{
-							pgsql.FunctionCall{
-								Function: pgsql.FunctionArrayLength,
-								Parameters: []pgsql.Expression{
-									pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Binding.Identifier, expansionPath},
-									pgsql.NewLiteral(1, pgsql.Int8),
-								},
-								CastType: pgsql.Int,
-							},
-						},
-					},
+					pgsql.NewAnyExpression(pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Frame.Binding.Identifier, expansionPath}),
 				),
-				rightNodeJoinCondition}); err != nil {
-				return pgsql.Query{}, err
-			} else {
-				// Select the expansion components for the projection statement
-				expansion.ProjectionStatement.From = append(expansion.ProjectionStatement.From, pgsql.FromClause{
-					Source: pgsql.TableReference{
-						Name:    pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Frame.Previous.Binding.Identifier},
-						Binding: models.EmptyOptional[pgsql.Identifier](),
-					},
-				})
-
-				expansion.ProjectionStatement.From = append(expansion.ProjectionStatement.From, pgsql.FromClause{
-					Source: pgsql.TableReference{
-						Name:    pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Binding.Identifier},
-						Binding: models.EmptyOptional[pgsql.Identifier](),
-					},
-					Joins: []pgsql.Join{{
-						Table: pgsql.TableReference{
-							Name:    pgsql.CompoundIdentifier{pgsql.TableEdge},
-							Binding: models.ValueOptional(traversalStep.Edge.Identifier),
-						},
-						JoinOperator: pgsql.JoinOperator{
-							JoinType: pgsql.JoinTypeInner,
-							Constraint: pgsql.NewBinaryExpression(
-								pgsql.CompoundIdentifier{traversalStep.Edge.Identifier, pgsql.ColumnID},
-								pgsql.OperatorEquals,
-								pgsql.NewAnyExpression(pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Binding.Identifier, expansionPath}),
-							),
-						},
-					}, {
-						Table: pgsql.TableReference{
-							Name:    pgsql.CompoundIdentifier{pgsql.TableNode},
-							Binding: models.ValueOptional(traversalStep.LeftNode.Identifier),
-						},
-						JoinOperator: pgsql.JoinOperator{
-							JoinType: pgsql.JoinTypeInner,
-							Constraint: pgsql.NewBinaryExpression(
-								pgsql.CompoundIdentifier{traversalStep.LeftNode.Identifier, pgsql.ColumnID},
-								pgsql.OperatorEquals,
-								pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Binding.Identifier, expansionRootID},
-							),
-						},
-					}, {
-						Table: pgsql.TableReference{
-							Name:    pgsql.CompoundIdentifier{pgsql.TableNode},
-							Binding: models.ValueOptional(traversalStep.RightNode.Identifier),
-						},
-						JoinOperator: pgsql.JoinOperator{
-							JoinType:   pgsql.JoinTypeInner,
-							Constraint: wrappedSelectJoinConstraint,
-						},
-					}},
-				})
-			}
-		}
-
-		// If there are terminal constraints, project them as part of the recursive lookup
-		if expansionComponents.RightNodeConstraints.Expression != nil {
-			if terminalCriteriaProjection, err := pgsql.As[pgsql.SelectItem](expansionComponents.RightNodeConstraints.Expression); err != nil {
-				return pgsql.Query{}, err
-			} else {
-				expansion.RecursiveStatement.Projection = []pgsql.SelectItem{
-					pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Binding.Identifier, expansionRootID},
-					pgsql.CompoundIdentifier{traversalStep.Edge.Identifier, pgsql.ColumnEndID},
-					pgsql.NewBinaryExpression(
-						pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Binding.Identifier, expansionDepth},
-						pgsql.OperatorAdd,
-						pgsql.NewLiteral(1, pgsql.Int),
-					),
-					terminalCriteriaProjection,
-					pgsql.NewBinaryExpression(
-						pgsql.CompoundIdentifier{traversalStep.Edge.Identifier, pgsql.ColumnID},
-						pgsql.OperatorEquals,
-						pgsql.NewAnyExpression(pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Binding.Identifier, expansionPath}),
-					),
-					pgsql.NewBinaryExpression(
-						pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Binding.Identifier, expansionPath},
-						pgsql.OperatorConcatenate,
-						pgsql.CompoundIdentifier{traversalStep.Edge.Identifier, pgsql.ColumnID},
-					),
-				}
+				pgsql.NewBinaryExpression(
+					pgsql.CompoundIdentifier{traversalStep.Expansion.Value.Frame.Binding.Identifier, expansionPath},
+					pgsql.OperatorConcatenate,
+					pgsql.CompoundIdentifier{traversalStep.Edge.Identifier, pgsql.ColumnID},
+				),
 			}
 		}
 	}
 
 	return pgsql.Query{
-		Body: expansion.Build(traversalStep.Expansion.Value.Binding.Identifier),
+		Body: expansion.Build(traversalStep.Expansion.Value.Frame.Binding.Identifier),
 	}, nil
 }

--- a/packages/go/cypher/models/pgsql/translate/function.go
+++ b/packages/go/cypher/models/pgsql/translate/function.go
@@ -226,8 +226,16 @@ func (s *Translator) translateFunction(typedExpression *cypher.FunctionInvocatio
 					})
 				}
 
+			case *pgsql.BinaryExpression:
+				s.treeTranslator.Push(pgsql.FunctionCall{
+					Function:   pgsql.FunctionArrayAggregate,
+					Parameters: []pgsql.Expression{argument},
+					Distinct:   typedExpression.Distinct,
+					CastType:   pgsql.AnyArray,
+				})
+
 			default:
-				s.SetError(fmt.Errorf("expected identifier for cypher function: %s", typedExpression.Name))
+				s.SetError(fmt.Errorf("unexpected argument type %T for cypher function: %s", typedArgument, typedExpression.Name))
 			}
 		}
 

--- a/packages/go/cypher/models/pgsql/translate/pattern.go
+++ b/packages/go/cypher/models/pgsql/translate/pattern.go
@@ -49,9 +49,9 @@ func (s *Translator) bindPatternExpression(cypherExpression cypher.Expression, d
 	}
 }
 
-func (s *Translator) translatePatternPart(scope *Scope, patternPart *cypher.PatternPart) error {
+func (s *Translator) translatePatternPart(patternPart *cypher.PatternPart) error {
 	// We expect this to be a node select if there aren't enough pattern elements for a traversal
-	newPatternPart := s.query.CurrentPart().pattern.NewPart()
+	newPatternPart := s.query.CurrentPart().currentPattern.NewPart()
 	newPatternPart.IsTraversal = len(patternPart.PatternElements) > 1
 	newPatternPart.ShortestPath = patternPart.ShortestPathPattern
 	newPatternPart.AllShortestPaths = patternPart.AllShortestPathsPattern
@@ -59,11 +59,11 @@ func (s *Translator) translatePatternPart(scope *Scope, patternPart *cypher.Patt
 	if cypherBinding, hasCypherSymbol, err := extractIdentifierFromCypherExpression(patternPart); err != nil {
 		return err
 	} else if hasCypherSymbol {
-		if pathBinding, err := scope.DefineNew(pgsql.PathComposite); err != nil {
+		if pathBinding, err := s.query.Scope.DefineNew(pgsql.PathComposite); err != nil {
 			return err
 		} else {
 			// Generate an alias for this binding
-			scope.Alias(cypherBinding, pathBinding)
+			s.query.Scope.Alias(cypherBinding, pathBinding)
 
 			// Record the new binding in the traversal pattern being built
 			newPatternPart.PatternBinding = models.ValueOptional(pathBinding)
@@ -75,40 +75,40 @@ func (s *Translator) translatePatternPart(scope *Scope, patternPart *cypher.Patt
 
 func (s *Translator) buildPatternPart(part *PatternPart) error {
 	if part.IsTraversal {
-		return s.buildPattern(part)
+		return s.buildTraversalPattern(part)
 	} else {
 		return s.buildNodePattern(part)
 	}
 }
 
-func (s *Translator) buildPattern(part *PatternPart) error {
+func (s *Translator) buildTraversalPattern(part *PatternPart) error {
 	for idx, traversalStep := range part.TraversalSteps {
 		if traversalStep.Expansion.Set {
-			if idx > 0 {
-				if traversalStepQuery, err := s.buildExpansionPatternStep(part, traversalStep); err != nil {
-					return err
-				} else {
-					s.query.CurrentPart().Model.AddCTE(pgsql.CommonTableExpression{
-						Alias: pgsql.TableAlias{
-							Name: traversalStep.Expansion.Value.Frame.Binding.Identifier,
-						},
-						Query: traversalStepQuery,
-					})
-				}
-			} else {
+			if idx == 0 {
 				if traversalStepQuery, err := s.buildExpansionPatternRoot(part, traversalStep); err != nil {
 					return err
 				} else {
 					s.query.CurrentPart().Model.AddCTE(pgsql.CommonTableExpression{
 						Alias: pgsql.TableAlias{
-							Name: traversalStep.Expansion.Value.Frame.Binding.Identifier,
+							Name: traversalStep.Frame.Binding.Identifier,
+						},
+						Query: traversalStepQuery,
+					})
+				}
+			} else {
+				if traversalStepQuery, err := s.buildExpansionPatternStep(part, traversalStep); err != nil {
+					return err
+				} else {
+					s.query.CurrentPart().Model.AddCTE(pgsql.CommonTableExpression{
+						Alias: pgsql.TableAlias{
+							Name: traversalStep.Frame.Binding.Identifier,
 						},
 						Query: traversalStepQuery,
 					})
 				}
 			}
 		} else if idx > 0 {
-			if traversalStepQuery, err := s.buildTraversalPatternStep(part, traversalStep); err != nil {
+			if traversalStepQuery, err := s.buildTraversalPatternStep(traversalStep.Frame, part, traversalStep); err != nil {
 				return err
 			} else {
 				s.query.CurrentPart().Model.AddCTE(pgsql.CommonTableExpression{
@@ -119,7 +119,7 @@ func (s *Translator) buildPattern(part *PatternPart) error {
 				})
 			}
 		} else {
-			if traversalStepQuery, err := s.buildTraversalPatternRoot(part, traversalStep); err != nil {
+			if traversalStepQuery, err := s.buildTraversalPatternRoot(traversalStep.Frame, part, traversalStep); err != nil {
 				return err
 			} else {
 				s.query.CurrentPart().Model.AddCTE(pgsql.CommonTableExpression{

--- a/packages/go/cypher/models/pgsql/translate/predicate.go
+++ b/packages/go/cypher/models/pgsql/translate/predicate.go
@@ -24,18 +24,20 @@ import (
 	"github.com/specterops/bloodhound/dawgs/graph"
 )
 
-func (s *Translator) translatePatternPredicate(scope *Scope) error {
-	// Set the pattern frame
-	s.query.CurrentPart().pattern.Frame = scope.CurrentFrame()
+func (s *Translator) preparePatternPredicate() error {
+	currentQueryPart := s.query.CurrentPart()
+
+	// Stash the match pattern
+	currentQueryPart.StashCurrentPattern()
 
 	// All pattern predicates must be relationship patterns
-	newPatternPart := s.query.CurrentPart().pattern.NewPart()
+	newPatternPart := currentQueryPart.currentPattern.NewPart()
 	newPatternPart.IsTraversal = true
 
 	return nil
 }
 
-func (s *Translator) buildOptimizedRelationshipExistPredicate(part *PatternPart, traversalStep *PatternSegment) error {
+func (s *Translator) buildOptimizedRelationshipExistPredicate(part *PatternPart, traversalStep *PatternSegment) (pgsql.Expression, error) {
 	whereClause := pgsql.NewBinaryExpression(
 		pgsql.NewBinaryExpression(
 			pgsql.CompoundIdentifier{traversalStep.Edge.Identifier, pgsql.ColumnStartID},
@@ -48,12 +50,12 @@ func (s *Translator) buildOptimizedRelationshipExistPredicate(part *PatternPart,
 			pgsql.CompoundIdentifier{traversalStep.LeftNode.Identifier, pgsql.ColumnID}),
 	)
 
-	if err := rewriteIdentifierReferences(traversalStep.Frame, []pgsql.Expression{whereClause}); err != nil {
-		return err
+	if err := RewriteFrameBindings(s.query.Scope, whereClause); err != nil {
+		return nil, err
 	}
 
 	// explain analyze select * from node n0 where not exists(select 1 from edge e0 where e0.start_id = n0.id or e0.end_id = n0.id);
-	s.treeTranslator.Push(pgsql.ExistsExpression{
+	return pgsql.ExistsExpression{
 		Subquery: pgsql.Subquery{
 			Query: pgsql.Query{
 				Body: pgsql.Select{
@@ -70,103 +72,128 @@ func (s *Translator) buildOptimizedRelationshipExistPredicate(part *PatternPart,
 				},
 			},
 		},
-	})
-
-	return nil
+	}, nil
 }
 
-func (s *Translator) buildPatternPredicate() error {
-	if numPatternParts := len(s.query.CurrentPart().pattern.Parts); numPatternParts < 1 || numPatternParts > 1 {
+func (s *Translator) translatePatternPredicate() error {
+	var (
+		currentQueryPart = s.query.CurrentPart()
+		patternPredicate = currentQueryPart.ConsumeCurrentPattern()
+		predicateFuture  = pgsql.NewFuture[*Pattern](patternPredicate, pgsql.Boolean)
+	)
+
+	// Restore the previous match pattern as the current match pattern
+	currentQueryPart.RestoreStashedPattern()
+
+	if numPatternParts := len(patternPredicate.Parts); numPatternParts < 1 || numPatternParts > 1 {
 		return fmt.Errorf("expected exactly one pattern part for pattern predicate but found: %d", numPatternParts)
 	}
 
-	var (
-		lastFrame *Frame
+	// Push this as an expression for rendering constraints
+	s.treeTranslator.Push(predicateFuture)
 
-		patternPart = s.query.CurrentPart().pattern.Parts[0]
-		subQuery    = pgsql.Query{
-			CommonTableExpressions: &pgsql.With{},
-		}
-	)
+	// Track this as a predicate to revisit while rendering the patterns
+	currentQueryPart.AddPatternPredicateFuture(predicateFuture)
+	return nil
+}
 
-	if len(patternPart.TraversalSteps) == 1 {
+func (s *Translator) buildPatternPredicates() error {
+	for _, predicateFuture := range s.query.CurrentPart().patternPredicates {
 		var (
-			traversalStep        = patternPart.TraversalSteps[0]
-			hasGlobalConstraints = s.treeTranslator.IdentifierConstraints.HasConstraints(
-				pgsql.AsIdentifierSet(
-					traversalStep.LeftNode.Identifier,
-					traversalStep.Edge.Identifier,
-					traversalStep.RightNode.Identifier,
-				),
-			)
-			hasPredicateConstraints = patternPart.Constraints.HasConstraints(
-				pgsql.AsIdentifierSet(
-					traversalStep.LeftNode.Identifier,
-					traversalStep.Edge.Identifier,
-					traversalStep.RightNode.Identifier,
-				),
-			)
+			lastFrame *Frame
+
+			patternPart = predicateFuture.Data.Parts[0]
+			subQuery    = pgsql.Query{
+				CommonTableExpressions: &pgsql.With{},
+			}
 		)
 
-		if traversalStep.Direction == graph.DirectionBoth && !hasPredicateConstraints && !hasGlobalConstraints {
-			return s.buildOptimizedRelationshipExistPredicate(patternPart, traversalStep)
-		}
-	}
+		if len(patternPart.TraversalSteps) == 1 {
+			var (
+				traversalStep            = patternPart.TraversalSteps[0]
+				traversalStepIdentifiers = pgsql.AsIdentifierSet(
+					traversalStep.LeftNode.Identifier,
+					traversalStep.Edge.Identifier,
+					traversalStep.RightNode.Identifier,
+				)
+			)
 
-	for idx, traversalStep := range patternPart.TraversalSteps {
-		if traversalStep.Expansion.Set {
-			return fmt.Errorf("expansion in pattern predicate not supported")
-		}
+			if traversalStep.Direction == graph.DirectionBoth {
+				if hasGlobalConstraints, err := s.treeTranslator.IdentifierConstraints.HasConstraints(traversalStepIdentifiers); err != nil {
+					return err
+				} else if hasPredicateConstraints, err := patternPart.Constraints.HasConstraints(traversalStepIdentifiers); err != nil {
+					return err
+				} else if !hasPredicateConstraints && !hasGlobalConstraints {
+					if predicateExpression, err := s.buildOptimizedRelationshipExistPredicate(patternPart, traversalStep); err != nil {
+						return err
+					} else {
+						predicateFuture.SyntaxNode = predicateExpression
+					}
 
-		if idx > 0 {
-			if traversalStepQuery, err := s.buildTraversalPatternStep(patternPart, traversalStep); err != nil {
-				return err
-			} else {
-				subQuery.AddCTE(pgsql.CommonTableExpression{
-					Alias: pgsql.TableAlias{
-						Name: traversalStep.Frame.Binding.Identifier,
-					},
-					Query: traversalStepQuery,
-				})
-			}
-		} else {
-			if traversalStepQuery, err := s.buildTraversalPatternRoot(patternPart, traversalStep); err != nil {
-				return err
-			} else {
-				subQuery.AddCTE(pgsql.CommonTableExpression{
-					Alias: pgsql.TableAlias{
-						Name: traversalStep.Frame.Binding.Identifier,
-					},
-					Query: traversalStepQuery,
-				})
+					return nil
+				}
 			}
 		}
 
-		lastFrame = traversalStep.Frame
-	}
+		if err := s.translateTraversalPatternPart(patternPart, true); err != nil {
+			return err
+		}
 
-	subQuery.Body = pgsql.Select{
-		Projection: pgsql.Projection{
-			pgsql.NewBinaryExpression(
-				pgsql.FunctionCall{
-					Function:   pgsql.FunctionCount,
-					Parameters: []pgsql.Expression{pgsql.WildcardIdentifier},
-				},
-				pgsql.OperatorGreaterThan,
-				pgsql.NewLiteral(0, pgsql.Int),
-			),
-		},
+		for idx, traversalStep := range patternPart.TraversalSteps {
+			if traversalStep.Expansion.Set {
+				return fmt.Errorf("expansion in pattern predicate not supported")
+			}
 
-		From: []pgsql.FromClause{{
-			Source: pgsql.TableReference{
-				Name: pgsql.CompoundIdentifier{lastFrame.Binding.Identifier},
+			if idx > 0 {
+				if traversalStepQuery, err := s.buildTraversalPatternStep(traversalStep.Frame, patternPart, traversalStep); err != nil {
+					return err
+				} else {
+					subQuery.AddCTE(pgsql.CommonTableExpression{
+						Alias: pgsql.TableAlias{
+							Name: traversalStep.Frame.Binding.Identifier,
+						},
+						Query: traversalStepQuery,
+					})
+				}
+			} else {
+				if traversalStepQuery, err := s.buildTraversalPatternRoot(traversalStep.Frame, patternPart, traversalStep); err != nil {
+					return err
+				} else {
+					subQuery.AddCTE(pgsql.CommonTableExpression{
+						Alias: pgsql.TableAlias{
+							Name: traversalStep.Frame.Binding.Identifier,
+						},
+						Query: traversalStepQuery,
+					})
+				}
+			}
+
+			lastFrame = traversalStep.Frame
+		}
+
+		subQuery.Body = pgsql.Select{
+			Projection: pgsql.Projection{
+				pgsql.NewBinaryExpression(
+					pgsql.FunctionCall{
+						Function:   pgsql.FunctionCount,
+						Parameters: []pgsql.Expression{pgsql.WildcardIdentifier},
+					},
+					pgsql.OperatorGreaterThan,
+					pgsql.NewLiteral(0, pgsql.Int),
+				),
 			},
-		}},
-	}
 
-	s.treeTranslator.Push(pgsql.Subquery{
-		Query: subQuery,
-	})
+			From: []pgsql.FromClause{{
+				Source: pgsql.TableReference{
+					Name: pgsql.CompoundIdentifier{lastFrame.Binding.Identifier},
+				},
+			}},
+		}
+
+		predicateFuture.SyntaxNode = pgsql.Subquery{
+			Query: subQuery,
+		}
+	}
 
 	return nil
 }

--- a/packages/go/cypher/models/pgsql/translate/renamer_test.go
+++ b/packages/go/cypher/models/pgsql/translate/renamer_test.go
@@ -1,0 +1,97 @@
+// Copyright 2025 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package translate_test
+
+import (
+	"testing"
+
+	"github.com/specterops/bloodhound/cypher/models/pgsql"
+	"github.com/specterops/bloodhound/cypher/models/pgsql/format"
+	"github.com/specterops/bloodhound/cypher/models/pgsql/translate"
+	"github.com/specterops/bloodhound/src/test"
+	"github.com/stretchr/testify/require"
+)
+
+func mustDefineNew(t *testing.T, scope *translate.Scope, dataType pgsql.DataType) *translate.BoundIdentifier {
+	binding, err := scope.DefineNew(dataType)
+	require.Nil(t, err)
+
+	return binding
+}
+
+func mustPushFrame(t *testing.T, scope *translate.Scope) *translate.Frame {
+	frame, err := scope.PushFrame()
+	require.Nil(t, err)
+
+	return frame
+}
+
+func TestRewriteFrameBindings(t *testing.T) {
+	type testCase struct {
+		Case     pgsql.Expression
+		Expected pgsql.Expression
+	}
+
+	var (
+		scope = translate.NewScope()
+		frame = mustPushFrame(t, scope)
+		a     = mustDefineNew(t, scope, pgsql.Int)
+	)
+
+	frame.Reveal(a.Identifier)
+	frame.Export(a.Identifier)
+
+	a.LastProjection = frame
+
+	// Cases
+	testCases := []testCase{{
+		Case: &pgsql.Parenthetical{
+			Expression: a.Identifier,
+		},
+		Expected: &pgsql.Parenthetical{
+			Expression: pgsql.CompoundIdentifier{frame.Binding.Identifier, a.Identifier},
+		},
+	}, {
+		Case:     pgsql.NewBinaryExpression(a.Identifier, pgsql.OperatorEquals, a.Identifier),
+		Expected: pgsql.NewBinaryExpression(pgsql.CompoundIdentifier{frame.Binding.Identifier, a.Identifier}, pgsql.OperatorEquals, pgsql.CompoundIdentifier{frame.Binding.Identifier, a.Identifier}),
+	}, {
+		Case: &pgsql.AliasedExpression{
+			Expression: a.Identifier,
+			Alias:      pgsql.AsOptionalIdentifier("name"),
+		},
+		Expected: &pgsql.AliasedExpression{
+			Expression: pgsql.CompoundIdentifier{frame.Binding.Identifier, a.Identifier},
+			Alias:      pgsql.AsOptionalIdentifier("name"),
+		},
+	}}
+
+	for _, nextTestCase := range testCases {
+		t.Run("", func(t *testing.T) {
+			test.RequireNilErr(t, translate.RewriteFrameBindings(scope, nextTestCase.Case))
+
+			var (
+				formattedCase, formattedCaseErr         = format.SyntaxNode(nextTestCase.Case)
+				formattedExpected, formattedExpectedErr = format.SyntaxNode(nextTestCase.Expected)
+			)
+
+			test.RequireNilErr(t, formattedCaseErr)
+			test.RequireNilErr(t, formattedExpectedErr)
+
+			require.Equal(t, formattedExpected, formattedCase)
+		})
+	}
+}

--- a/packages/go/cypher/models/pgsql/translate/translator_test.go
+++ b/packages/go/cypher/models/pgsql/translate/translator_test.go
@@ -18,6 +18,7 @@ package translate_test
 
 import (
 	"fmt"
+	"runtime/debug"
 	"testing"
 
 	"github.com/specterops/bloodhound/dawgs/drivers/pg/pgutil"
@@ -57,6 +58,13 @@ func TestTranslate(t *testing.T) {
 	} else {
 		for _, testCase := range testCases {
 			t.Run(testCase.Name, func(t *testing.T) {
+				defer func() {
+					if err := recover(); err != nil {
+						debug.PrintStack()
+						t.Error(err)
+					}
+				}()
+
 				testCase.Assert(t, testCase.PgSQL, kindMapper)
 			})
 

--- a/packages/go/cypher/models/pgsql/translate/traversal.go
+++ b/packages/go/cypher/models/pgsql/translate/traversal.go
@@ -24,139 +24,72 @@ import (
 	"github.com/specterops/bloodhound/dawgs/graph"
 )
 
-func (s *Translator) buildDirectionalTraversalPatternRoot(leftNodeConstraints, edgeConstraints, rightNodeConstraints *Constraint, traversalStep *PatternSegment, direction graph.Direction) (pgsql.Select, error) {
+func (s *Translator) buildDirectionalTraversalPatternRoot(leftNodeConstraints, edgeConstraints, rightNodeConstraints pgsql.Expression, traversalStep *PatternSegment, direction graph.Direction) (pgsql.Select, error) {
+	nextSelect := pgsql.Select{
+		Projection: traversalStep.Projection,
+	}
+	nextSelect.Where = edgeConstraints
+	nextSelect.From = append(nextSelect.From, pgsql.FromClause{
+		Source: pgsql.TableReference{
+			Name:    pgsql.CompoundIdentifier{pgsql.TableEdge},
+			Binding: models.ValueOptional(traversalStep.Edge.Identifier),
+		},
+		Joins: []pgsql.Join{{
+			Table: pgsql.TableReference{
+				Name:    pgsql.CompoundIdentifier{pgsql.TableNode},
+				Binding: models.ValueOptional(traversalStep.LeftNode.Identifier),
+			},
+			JoinOperator: pgsql.JoinOperator{
+				JoinType:   pgsql.JoinTypeInner,
+				Constraint: leftNodeConstraints,
+			},
+		}, {
+			Table: pgsql.TableReference{
+				Name:    pgsql.CompoundIdentifier{pgsql.TableNode},
+				Binding: models.ValueOptional(traversalStep.RightNode.Identifier),
+			},
+			JoinOperator: pgsql.JoinOperator{
+				JoinType:   pgsql.JoinTypeInner,
+				Constraint: rightNodeConstraints,
+			},
+		}},
+	})
+	return nextSelect, nil
+}
+
+func (s *Translator) buildDirectionlessTraversalPatternRoot(part *PatternPart, traversalStep *PatternSegment) (pgsql.Query, error) {
 	directionalSelect := pgsql.Select{
 		Projection: traversalStep.Projection,
 	}
 
-	var (
-		leftNodeJoinConstraint  *pgsql.BinaryExpression
-		rightNodeJoinConstraint *pgsql.BinaryExpression
-	)
-
-	switch direction {
-	case graph.DirectionOutbound:
-		leftNodeJoinConstraint = &pgsql.BinaryExpression{
-			Operator: pgsql.OperatorEquals,
-			ROperand: pgsql.CompoundIdentifier{traversalStep.Edge.Identifier, pgsql.ColumnStartID},
-			LOperand: pgsql.CompoundIdentifier{traversalStep.LeftNode.Identifier, pgsql.ColumnID},
-		}
-
-		rightNodeJoinConstraint = &pgsql.BinaryExpression{
-			Operator: pgsql.OperatorEquals,
-			ROperand: pgsql.CompoundIdentifier{traversalStep.Edge.Identifier, pgsql.ColumnEndID},
-			LOperand: pgsql.CompoundIdentifier{traversalStep.RightNode.Identifier, pgsql.ColumnID},
-		}
-
-	case graph.DirectionInbound:
-		leftNodeJoinConstraint = &pgsql.BinaryExpression{
-			Operator: pgsql.OperatorEquals,
-			ROperand: pgsql.CompoundIdentifier{traversalStep.Edge.Identifier, pgsql.ColumnEndID},
-			LOperand: pgsql.CompoundIdentifier{traversalStep.LeftNode.Identifier, pgsql.ColumnID},
-		}
-
-		rightNodeJoinConstraint = &pgsql.BinaryExpression{
-			Operator: pgsql.OperatorEquals,
-			ROperand: pgsql.CompoundIdentifier{traversalStep.Edge.Identifier, pgsql.ColumnStartID},
-			LOperand: pgsql.CompoundIdentifier{traversalStep.RightNode.Identifier, pgsql.ColumnID},
-		}
-
-	default:
-		return directionalSelect, fmt.Errorf("direction must be set for directional traversal")
-	}
-
-	if leftNodeJoinCondition, err := ConjoinExpressions([]pgsql.Expression{leftNodeConstraints.Expression, leftNodeJoinConstraint}); err != nil {
-		return directionalSelect, err
-	} else if rightNodeJoinCondition, err := ConjoinExpressions([]pgsql.Expression{rightNodeConstraints.Expression, rightNodeJoinConstraint}); err != nil {
-		return directionalSelect, err
-	} else {
-		if err := rewriteIdentifierReferences(traversalStep.Frame, []pgsql.Expression{leftNodeJoinCondition, edgeConstraints.Expression, rightNodeJoinCondition}); err != nil {
-			return directionalSelect, err
-		}
-
-		directionalSelect.Where = edgeConstraints.Expression
+	if traversalStep.Frame.Previous != nil {
 		directionalSelect.From = append(directionalSelect.From, pgsql.FromClause{
 			Source: pgsql.TableReference{
-				Name:    pgsql.CompoundIdentifier{pgsql.TableEdge},
-				Binding: models.ValueOptional(traversalStep.Edge.Identifier),
+				Name: pgsql.CompoundIdentifier{traversalStep.Frame.Previous.Binding.Identifier},
 			},
-			Joins: []pgsql.Join{{
-				Table: pgsql.TableReference{
-					Name:    pgsql.CompoundIdentifier{pgsql.TableNode},
-					Binding: models.ValueOptional(traversalStep.LeftNode.Identifier),
-				},
-				JoinOperator: pgsql.JoinOperator{
-					JoinType:   pgsql.JoinTypeInner,
-					Constraint: leftNodeJoinCondition,
-				},
-			}, {
-				Table: pgsql.TableReference{
-					Name:    pgsql.CompoundIdentifier{pgsql.TableNode},
-					Binding: models.ValueOptional(traversalStep.RightNode.Identifier),
-				},
-				JoinOperator: pgsql.JoinOperator{
-					JoinType:   pgsql.JoinTypeInner,
-					Constraint: rightNodeJoinCondition,
-				},
-			}},
 		})
 	}
 
-	return directionalSelect, nil
-}
+	switch traversalStep.Direction {
+	case graph.DirectionInbound, graph.DirectionOutbound:
+		nextSelect, err := s.buildDirectionalTraversalPatternRoot(traversalStep.LeftNodeJoinCondition, traversalStep.EdgeConstraint.Expression, traversalStep.RightNodeJoinCondition, traversalStep, traversalStep.Direction)
 
-func (s *Translator) buildDirectionlessTraversalPatternRoot(part *PatternPart, traversalStep *PatternSegment) (pgsql.Query, error) {
-	if leftNodeConstraints, err := consumeConstraintsFrom(pgsql.AsIdentifierSet(traversalStep.LeftNode.Identifier), s.treeTranslator.IdentifierConstraints, part.Constraints); err != nil {
-		return pgsql.Query{}, err
-	} else if rightNodeConstraints, err := consumeConstraintsFrom(pgsql.AsIdentifierSet(traversalStep.RightNode.Identifier), s.treeTranslator.IdentifierConstraints, part.Constraints); err != nil {
-		return pgsql.Query{}, err
-	} else if edgeConstraints, err := consumeConstraintsFrom(traversalStep.Frame.Visible, s.treeTranslator.IdentifierConstraints, part.Constraints); err != nil {
-		return pgsql.Query{}, err
-	} else {
-		directionalSelect := pgsql.Select{
-			Projection: traversalStep.Projection,
-		}
+		return pgsql.Query{
+			Body: nextSelect,
+		}, err
 
-		if traversalStep.Frame.Previous != nil {
-			directionalSelect.From = append(directionalSelect.From, pgsql.FromClause{
-				Source: pgsql.TableReference{
-					Name: pgsql.CompoundIdentifier{traversalStep.Frame.Previous.Binding.Identifier},
-				},
-			})
-		}
+	case graph.DirectionBoth:
+		nextSelect, err := s.buildDirectionalTraversalPatternRoot(traversalStep.LeftNodeJoinCondition, traversalStep.EdgeConstraint.Expression, traversalStep.RightNodeJoinCondition, traversalStep, graph.DirectionOutbound)
 
-		switch traversalStep.Direction {
-		case graph.DirectionInbound, graph.DirectionOutbound:
-			nextSelect, err := s.buildDirectionalTraversalPatternRoot(leftNodeConstraints, edgeConstraints, rightNodeConstraints, traversalStep, traversalStep.Direction)
-
-			return pgsql.Query{
-				Body: nextSelect,
-			}, err
-
-		case graph.DirectionBoth:
-			if inboundSelect, err := s.buildDirectionalTraversalPatternRoot(leftNodeConstraints, edgeConstraints, rightNodeConstraints, traversalStep, graph.DirectionInbound); err != nil {
-				return pgsql.Query{}, err
-			} else if outboundSelect, err := s.buildDirectionalTraversalPatternRoot(leftNodeConstraints, edgeConstraints, rightNodeConstraints, traversalStep, graph.DirectionOutbound); err != nil {
-				return pgsql.Query{}, err
-			} else {
-				return pgsql.Query{
-					Body: pgsql.SetOperation{
-						Distinct: true,
-						LOperand: inboundSelect,
-						ROperand: outboundSelect,
-						Operator: pgsql.OperatorUnion,
-					},
-				}, nil
-
-			}
-
-		}
+		return pgsql.Query{
+			Body: nextSelect,
+		}, err
 	}
 
 	return pgsql.Query{}, fmt.Errorf("unsupported")
 }
 
-func (s *Translator) buildTraversalPatternRoot(part *PatternPart, traversalStep *PatternSegment) (pgsql.Query, error) {
+func (s *Translator) buildTraversalPatternRoot(partFrame *Frame, part *PatternPart, traversalStep *PatternSegment) (pgsql.Query, error) {
 	if traversalStep.Direction == graph.DirectionBoth {
 		return s.buildDirectionlessTraversalPatternRoot(part, traversalStep)
 	}
@@ -165,116 +98,82 @@ func (s *Translator) buildTraversalPatternRoot(part *PatternPart, traversalStep 
 		Projection: traversalStep.Projection,
 	}
 
-	if leftNodeConstraints, err := consumeConstraintsFrom(pgsql.AsIdentifierSet(traversalStep.LeftNode.Identifier), s.treeTranslator.IdentifierConstraints, part.Constraints); err != nil {
-		return pgsql.Query{}, err
-	} else if rightNodeConstraints, err := consumeConstraintsFrom(pgsql.AsIdentifierSet(traversalStep.RightNode.Identifier), s.treeTranslator.IdentifierConstraints, part.Constraints); err != nil {
-		return pgsql.Query{}, err
-	} else if edgeConstraints, err := consumeConstraintsFrom(traversalStep.Frame.Visible, s.treeTranslator.IdentifierConstraints, part.Constraints); err != nil {
-		return pgsql.Query{}, err
-	} else {
-		if traversalStep.Frame.Previous != nil {
-			nextSelect.From = append(nextSelect.From, pgsql.FromClause{
-				Source: pgsql.TableReference{
-					Name: pgsql.CompoundIdentifier{traversalStep.Frame.Previous.Binding.Identifier},
-				},
-			})
-		}
-
-		if leftNodeJoinConstraint, err := leftNodeTraversalStepConstraint(traversalStep); err != nil {
-			return pgsql.Query{}, err
-		} else if leftNodeJoinCondition, err := ConjoinExpressions([]pgsql.Expression{leftNodeConstraints.Expression, leftNodeJoinConstraint}); err != nil {
-			return pgsql.Query{}, err
-		} else if rightNodeJoinConstraint, err := rightNodeTraversalStepConstraint(traversalStep); err != nil {
-			return pgsql.Query{}, err
-		} else if rightNodeJoinCondition, err := ConjoinExpressions([]pgsql.Expression{rightNodeConstraints.Expression, rightNodeJoinConstraint}); err != nil {
-			return pgsql.Query{}, err
-		} else {
-			if err := rewriteIdentifierReferences(traversalStep.Frame, []pgsql.Expression{leftNodeJoinCondition, edgeConstraints.Expression, rightNodeJoinCondition}); err != nil {
-				return pgsql.Query{}, err
-			}
-
-			nextSelect.Where = edgeConstraints.Expression
-			nextSelect.From = append(nextSelect.From, pgsql.FromClause{
-				Source: pgsql.TableReference{
-					Name:    pgsql.CompoundIdentifier{pgsql.TableEdge},
-					Binding: models.ValueOptional(traversalStep.Edge.Identifier),
-				},
-				Joins: []pgsql.Join{{
-					Table: pgsql.TableReference{
-						Name:    pgsql.CompoundIdentifier{pgsql.TableNode},
-						Binding: models.ValueOptional(traversalStep.LeftNode.Identifier),
-					},
-					JoinOperator: pgsql.JoinOperator{
-						JoinType:   pgsql.JoinTypeInner,
-						Constraint: leftNodeJoinCondition,
-					},
-				}, {
-					Table: pgsql.TableReference{
-						Name:    pgsql.CompoundIdentifier{pgsql.TableNode},
-						Binding: models.ValueOptional(traversalStep.RightNode.Identifier),
-					},
-					JoinOperator: pgsql.JoinOperator{
-						JoinType:   pgsql.JoinTypeInner,
-						Constraint: rightNodeJoinCondition,
-					},
-				}},
-			})
-		}
+	if partFrame.Previous != nil {
+		nextSelect.From = append(nextSelect.From, pgsql.FromClause{
+			Source: pgsql.TableReference{
+				Name: pgsql.CompoundIdentifier{partFrame.Previous.Binding.Identifier},
+			},
+		})
 	}
+
+	if traversalStep.EdgeConstraint != nil {
+		nextSelect.Where = traversalStep.EdgeConstraint.Expression
+	}
+
+	nextSelect.From = append(nextSelect.From, pgsql.FromClause{
+		Source: pgsql.TableReference{
+			Name:    pgsql.CompoundIdentifier{pgsql.TableEdge},
+			Binding: models.ValueOptional(traversalStep.Edge.Identifier),
+		},
+		Joins: []pgsql.Join{{
+			Table: pgsql.TableReference{
+				Name:    pgsql.CompoundIdentifier{pgsql.TableNode},
+				Binding: models.ValueOptional(traversalStep.LeftNode.Identifier),
+			},
+			JoinOperator: pgsql.JoinOperator{
+				JoinType:   pgsql.JoinTypeInner,
+				Constraint: traversalStep.LeftNodeJoinCondition,
+			},
+		}, {
+			Table: pgsql.TableReference{
+				Name:    pgsql.CompoundIdentifier{pgsql.TableNode},
+				Binding: models.ValueOptional(traversalStep.RightNode.Identifier),
+			},
+			JoinOperator: pgsql.JoinOperator{
+				JoinType:   pgsql.JoinTypeInner,
+				Constraint: traversalStep.RightNodeJoinCondition,
+			},
+		}},
+	})
 
 	return pgsql.Query{
 		Body: nextSelect,
 	}, nil
 }
 
-func (s *Translator) buildTraversalPatternStep(part *PatternPart, traversalStep *PatternSegment) (pgsql.Query, error) {
+func (s *Translator) buildTraversalPatternStep(partFrame *Frame, part *PatternPart, traversalStep *PatternSegment) (pgsql.Query, error) {
 	nextSelect := pgsql.Select{
 		Projection: traversalStep.Projection,
 	}
 
-	if rightNodeConstraints, err := consumeConstraintsFrom(pgsql.AsIdentifierSet(traversalStep.RightNode.Identifier), s.treeTranslator.IdentifierConstraints, part.Constraints); err != nil {
-		return pgsql.Query{}, err
-	} else if edgeConstraints, err := consumeConstraintsFrom(traversalStep.Frame.Visible, s.treeTranslator.IdentifierConstraints, part.Constraints); err != nil {
-		return pgsql.Query{}, err
-	} else if rightNodeJoinConstraint, err := rightNodeTraversalStepConstraint(traversalStep); err != nil {
-		return pgsql.Query{}, err
-	} else if rightNodeJoinCondition, err := ConjoinExpressions([]pgsql.Expression{rightNodeConstraints.Expression, rightNodeJoinConstraint}); err != nil {
-		return pgsql.Query{}, err
-	} else {
-		if err := rewriteIdentifierReferences(traversalStep.Frame, []pgsql.Expression{edgeConstraints.Expression, rightNodeJoinCondition}); err != nil {
-			return pgsql.Query{}, err
-		}
-
-		nextSelect.Where = edgeConstraints.Expression
-
-		if traversalStep.Frame.Previous != nil {
-			nextSelect.From = append(nextSelect.From, pgsql.FromClause{
-				Source: pgsql.TableReference{
-					Name: pgsql.CompoundIdentifier{traversalStep.Frame.Previous.Binding.Identifier},
-				},
-			})
-		}
-		nextSelect.From = []pgsql.FromClause{{
-			Source: pgsql.TableReference{
-				Name: pgsql.CompoundIdentifier{traversalStep.Frame.Previous.Binding.Identifier},
-			},
-		}, {
-			Source: pgsql.TableReference{
-				Name:    pgsql.CompoundIdentifier{pgsql.TableEdge},
-				Binding: models.ValueOptional(traversalStep.Edge.Identifier),
-			},
-			Joins: []pgsql.Join{{
-				Table: pgsql.TableReference{
-					Name:    pgsql.CompoundIdentifier{pgsql.TableNode},
-					Binding: models.ValueOptional(traversalStep.RightNode.Identifier),
-				},
-				JoinOperator: pgsql.JoinOperator{
-					JoinType:   pgsql.JoinTypeInner,
-					Constraint: rightNodeJoinCondition,
-				},
-			}},
-		}}
+	if traversalStep.EdgeConstraint.Expression != nil {
+		nextSelect.Where = traversalStep.EdgeConstraint.Expression
 	}
+
+	if partFrame.Previous != nil {
+		nextSelect.From = append(nextSelect.From, pgsql.FromClause{
+			Source: pgsql.TableReference{
+				Name: pgsql.CompoundIdentifier{partFrame.Previous.Binding.Identifier},
+			},
+		})
+	}
+
+	nextSelect.From = append(nextSelect.From, pgsql.FromClause{
+		Source: pgsql.TableReference{
+			Name:    pgsql.CompoundIdentifier{pgsql.TableEdge},
+			Binding: models.ValueOptional(traversalStep.Edge.Identifier),
+		},
+		Joins: []pgsql.Join{{
+			Table: pgsql.TableReference{
+				Name:    pgsql.CompoundIdentifier{pgsql.TableNode},
+				Binding: models.ValueOptional(traversalStep.RightNode.Identifier),
+			},
+			JoinOperator: pgsql.JoinOperator{
+				JoinType:   pgsql.JoinTypeInner,
+				Constraint: traversalStep.RightNodeJoinCondition,
+			},
+		}},
+	})
 
 	return pgsql.Query{
 		Body: nextSelect,

--- a/packages/go/cypher/models/pgsql/visualization/visualizer.go
+++ b/packages/go/cypher/models/pgsql/visualization/visualizer.go
@@ -85,7 +85,7 @@ func SQLToDigraph(node pgsql.SyntaxNode) (Graph, error) {
 		HierarchicalVisitor: walk.NewComposableHierarchicalVisitor[pgsql.SyntaxNode](),
 	}
 
-	if title, err := format.SyntaxNode(node, format.NewOutputBuilder()); err != nil {
+	if title, err := format.SyntaxNode(node); err != nil {
 		return Graph{}, err
 	} else {
 		visualizer.Graph.Title = title

--- a/packages/go/dawgs/drivers/pg/manager.go
+++ b/packages/go/dawgs/drivers/pg/manager.go
@@ -37,6 +37,15 @@ type KindMapper interface {
 	AssertKinds(ctx context.Context, kinds graph.Kinds) ([]int16, error)
 }
 
+func KindMapperFromGraphDatabase(graphDB graph.Database) (KindMapper, error) {
+	switch typedGraphDB := graphDB.(type) {
+	case *Driver:
+		return typedGraphDB.schemaManager, nil
+	default:
+		return nil, fmt.Errorf("unsupported graph database type: %T", typedGraphDB)
+	}
+}
+
 type SchemaManager struct {
 	defaultGraph    model.Graph
 	database        graph.Database

--- a/packages/go/dawgs/drivers/pg/query/sql/schema_up.sql
+++ b/packages/go/dawgs/drivers/pg/query/sql/schema_up.sql
@@ -325,9 +325,15 @@ create or replace function public.jsonb_to_text_array(target jsonb)
   returns text[]
 as
 $$
-select array(select jsonb_array_elements_text(target));
+begin
+  if target != 'null'::jsonb then
+    return array(select jsonb_array_elements_text(target));
+  else
+    return null;
+  end if;
+end
 $$
-  language sql
+  language plpgsql
   immutable
   parallel safe
   strict;

--- a/packages/go/dawgs/graph/mapper.go
+++ b/packages/go/dawgs/graph/mapper.go
@@ -404,6 +404,10 @@ func NewValueMapper(values []any, mappers ...MapFunc) ValueMapper {
 	}
 }
 
+func (s *valueMapper) Count() int {
+	return len(s.values)
+}
+
 func (s *valueMapper) Next() (any, error) {
 	if s.idx >= len(s.values) {
 		return nil, fmt.Errorf("attempting to get more values than returned - saw %d but wanted %d", len(s.values), s.idx+1)

--- a/packages/go/dawgs/graph/mocks/query.go
+++ b/packages/go/dawgs/graph/mocks/query.go
@@ -50,6 +50,20 @@ func (m *MockValueMapper) EXPECT() *MockValueMapperMockRecorder {
 	return m.recorder
 }
 
+// Count mocks base method.
+func (m *MockValueMapper) Count() int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Count")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+// Count indicates an expected call of Count.
+func (mr *MockValueMapperMockRecorder) Count() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Count", reflect.TypeOf((*MockValueMapper)(nil).Count))
+}
+
 // Map mocks base method.
 func (m *MockValueMapper) Map(target any) error {
 	m.ctrl.T.Helper()

--- a/packages/go/dawgs/graph/query.go
+++ b/packages/go/dawgs/graph/query.go
@@ -23,6 +23,7 @@ type ValueMapper interface {
 	Map(target any) error
 	MapOptions(target ...any) (any, error)
 	Scan(targets ...any) error
+	Count() int
 }
 
 type Scanner interface {

--- a/packages/javascript/bh-shared-ui/src/commonSearches.ts
+++ b/packages/javascript/bh-shared-ui/src/commonSearches.ts
@@ -42,11 +42,11 @@ export const CommonSearches: CommonSearchType[] = [
         queries: [
             {
                 description: 'All Domain Admins',
-                cypher: `MATCH p=(t:Group)<-[:MemberOf*1..]-(:Base)\nWHERE t.objectid ENDS WITH '-512'\nRETURN p\nLIMIT 1000`,
+                cypher: `MATCH p = (a)-[:MemberOf*1..]->(t:Group)\nWHERE (a:User or a:Computer) and t.objectid ENDS WITH '-512'\nRETURN p\nLIMIT 1000`,
             },
             {
                 description: 'Map domain trusts',
-                cypher: `MATCH p=(:Domain)-[:TrustedBy]->(:Domain)\nRETURN p\nLIMIT 1000`,
+                cypher: `MATCH p = (:Domain)-[:TrustedBy]->(:Domain)\nRETURN p\nLIMIT 1000`,
             },
             {
                 description: 'Locations of Tier Zero / High Value objects',
@@ -162,7 +162,7 @@ export const CommonSearches: CommonSearchType[] = [
         queries: [
             {
                 description: 'PKI hierarchy',
-                cypher: `MATCH p=(:Domain)<-[:HostsCAService|IssuedSignedBy|EnterpriseCAFor|RootCAFor|TrustedForNTAuth|NTAuthStoreFor*..]-()\nRETURN p\nLIMIT 1000`,
+                cypher: `MATCH p=()-[:HostsCAService|IssuedSignedBy|EnterpriseCAFor|RootCAFor|TrustedForNTAuth|NTAuthStoreFor*..]->(:Domain)\nRETURN p\nLIMIT 1000`,
             },
             {
                 description: 'Public Key Services container',
@@ -237,7 +237,7 @@ export const CommonSearches: CommonSearchType[] = [
             },
             {
                 description: 'Two-way forest trusts enabled for delegation',
-                cypher: `MATCH p=(n:Domain)-[r:TrustedBy]->(m:Domain)\nWHERE (n)<-[:TrustedBy]-(m)\nAND r.trusttype = 'Forest'\nAND r.tgtdelegationenabled = true\nRETURN p`,
+                cypher: `MATCH p=(n:Domain)-[r:TrustedBy]->(m:Domain)\nWHERE (m)-[:TrustedBy]->(n)\nAND r.trusttype = 'Forest'\nAND r.tgtdelegationenabled = true\nRETURN p`,
             },
             {
                 description: 'Computers with unsupported operating systems',
@@ -269,7 +269,7 @@ export const CommonSearches: CommonSearchType[] = [
             },
             {
                 description: 'Principals with weak supported Kerberos encryption types',
-                cypher: `MATCH (n:Base)\nWHERE ANY(keyword IN n.supportedencryptiontypes WHERE keyword IN ['DES-CBC-CRC', 'DES-CBC-MD5', 'RC4-HMAC-MD5'])\nRETURN n`,
+                cypher: `MATCH (u:Base)\nWHERE 'DES-CBC-CRC' IN u.supportedencryptiontypes\nOR 'DES-CBC-MD5' IN u.supportedencryptiontypes\nOR 'RC4-HMAC-MD5' IN u.supportedencryptiontypes\nRETURN u`,
             },
             {
                 description: 'Tier Zero / High Value users with non-expiring passwords',


### PR DESCRIPTION
## Description

This changeset covers a refactor to force symbol scope creation to happen in Cypher lexical order instead of out-of-order. The refactor addresses significant technical debt in managing which scope variable a symbol is bound to and clears the way for more complicated syntax translations.

This changeset also addresses the following JIRA tickets: BED-5331, BED-5332, BED-5411, and BED-5412.

## Motivation and Context

This pulls up compatibility with the default common searches and addresses several non-functional translations.

## How Has This Been Tested?

* Additional test cases added for each case 
* Test cases adjusted for refactor and review

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)
- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
