### PR TITLE
Ingest GPOLocalGroup data

### DIFF
--- a/cmd/api/src/daemons/datapipe/convertors.go
+++ b/cmd/api/src/daemons/datapipe/convertors.go
@@ -120,6 +120,10 @@ func convertOUData(ou ein.OU, converted *ConvertedData) {
 	if len(ou.ChildObjects) > 0 {
 		converted.RelProps = append(converted.RelProps, ein.ParseChildObjects(ou.ChildObjects, ou.ObjectIdentifier, ad.OU)...)
 	}
+
+	parsedLocalGroupData := ein.ParseGPOChanges(ou.GPOChanges)
+	converted.RelProps = append(converted.RelProps, parsedLocalGroupData.Relationships...)
+	converted.NodeProps = append(converted.NodeProps, parsedLocalGroupData.Nodes...)
 }
 
 func convertSessionData(session ein.Session, converted *ConvertedSessionData) {

--- a/cmd/api/src/test/fixtures/fixtures/expected_ingest.go
+++ b/cmd/api/src/test/fixtures/fixtures/expected_ingest.go
@@ -216,6 +216,12 @@ var (
 			query.Kind(query.Relationship(), ad.GenericAll),
 			query.Kind(query.End(), ad.OU),
 			query.Equals(query.EndProperty(common.ObjectID.String()), "2A374493-816A-4193-BEFD-D2F4132C6DCA")),
+		query.And(
+			query.Kind(query.Start(), ad.User),
+			query.Equals(query.StartProperty(common.ObjectID.String()), "S-1-5-21-3130019616-2776909439-2417379446-2116"),
+			query.Kind(query.Relationship(), ad.AdminTo),
+			query.Kind(query.End(), ad.Computer),
+			query.Equals(query.EndProperty(common.ObjectID.String()), "S-1-5-21-3130019616-2776909439-2417379446-1104")),
 
 		//// USERS
 		query.And(

--- a/cmd/api/src/test/fixtures/fixtures/v6/ingest/ous.json
+++ b/cmd/api/src/test/fixtures/fixtures/v6/ingest/ous.json
@@ -7,6 +7,23 @@
     },
     "data": [
         {
+            "GPOChanges": {
+                "LocalAdmins": [
+                   {
+                        "ObjectIdentifier": "S-1-5-21-3130019616-2776909439-2417379446-2116",
+                        "ObjectType": "User"
+                   }
+                ],
+                "RemoteDesktopUsers": [],
+                "DcomUsers": [],
+                "PSRemoteUsers": [],
+                "AffectedComputers": [
+                    {
+                        "ObjectIdentifier": "S-1-5-21-3130019616-2776909439-2417379446-1104",
+                        "ObjectType": "Computer"
+                    }
+                ]
+            },
             "Properties": {
                 "domain": "TESTLAB.LOCAL",
                 "name": "DOMAIN CONTROLLERS@TESTLAB.LOCAL",

--- a/packages/go/ein/ad.go
+++ b/packages/go/ein/ad.go
@@ -29,6 +29,11 @@ import (
 	"github.com/specterops/bloodhound/slicesext"
 )
 
+type LocalGroup struct {
+	RID     string
+	Members []TypedPrincipal
+}
+
 func ConvertSessionObject(session Session) IngestibleSession {
 	return IngestibleSession{
 		Source:    session.ComputerSID,
@@ -544,6 +549,68 @@ func ParseChildObjects(data []TypedPrincipal, containerId string, containerType 
 
 	return relationships
 }
+
+func ParseGPOChanges(changes GPOChanges) ParsedLocalGroupData {
+	parsedData := ParsedLocalGroupData{}
+
+	groups := []LocalGroup{
+		{"544", changes.LocalAdmins},
+		{"555", changes.RemoteDesktopUsers},
+		{"562", changes.DcomUsers},
+		{"580", changes.PSRemoteUsers},
+	}
+
+	for _, computer := range changes.AffectedComputers {
+		for _, group := range groups {
+			groupID := computer.ObjectIdentifier + "-" + group.RID
+			if len(group.Members) > 0 {
+				parsedData.Nodes = append(parsedData.Nodes, IngestibleNode{
+					ObjectID: groupID,
+					// TODO: look up computer name?
+					PropertyMap: map[string]any{
+						"name": groupID,
+					},
+					Label: ad.LocalGroup,
+				})
+
+				parsedData.Relationships = append(parsedData.Relationships, NewIngestibleRelationship(
+					IngestibleSource{
+						Source:     groupID,
+						SourceType: ad.LocalGroup,
+					},
+					IngestibleTarget{
+						Target:     computer.ObjectIdentifier,
+						TargetType: ad.Computer,
+					},
+					IngestibleRel{
+						RelProps: map[string]any{ad.IsACL.String(): false},
+						RelType:  ad.LocalToComputer,
+					},
+				))
+			}
+
+			for _, member := range group.Members {
+				parsedData.Relationships = append(parsedData.Relationships, NewIngestibleRelationship(
+					IngestibleSource{
+						Source:     member.ObjectIdentifier,
+						SourceType: member.Kind(),
+					},
+					IngestibleTarget{
+						Target:     groupID,
+						TargetType: ad.LocalGroup,
+					},
+					IngestibleRel{
+						RelProps: map[string]any{ad.IsACL.String(): false},
+						RelType:  ad.MemberOfLocalGroup,
+					},
+				))
+			}
+		}
+	}
+
+	return parsedData
+}
+
 func ParseGpLinks(links []GPLink, itemIdentifier string, itemType graph.Kind) []IngestibleRelationship {
 	relationships := make([]IngestibleRelationship, 0, len(links))
 	for _, gpLink := range links {

--- a/packages/go/ein/incoming_models.go
+++ b/packages/go/ein/incoming_models.go
@@ -289,8 +289,17 @@ type Computer struct {
 	UnconstrainedDelegation bool
 }
 
+type GPOChanges struct {
+	LocalAdmins        []TypedPrincipal
+	RemoteDesktopUsers []TypedPrincipal
+	DcomUsers          []TypedPrincipal
+	PSRemoteUsers      []TypedPrincipal
+	AffectedComputers  []TypedPrincipal
+}
+
 type OU struct {
 	IngestBase
 	ChildObjects []TypedPrincipal
 	Links        []GPLink
+	GPOChanges   GPOChanges
 }


### PR DESCRIPTION
## Description

This pull requests ingests the `GPOChanges` JSON object as collected by SharpHound's `GPOLocalGroup` collector and adds the required nodes for the local groups and corresponding edges for the membership relation.

This in turn enables the existing analysis algorithm to create the previously missing `AdminTo`, `CanRDP`, `CanPSRemote` and `ExecuteDCOM` edges for principals assigned to local groups by means of GPOs.

## Motivation and Context

This PR addresses GitHub issues #280 (and #240).

## How Has This Been Tested?

Tested in a local Ludus lab instance.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have met the contributing prerequisites
- [x] I have ensured that related documentation is up-to-date
- [x] I have followed proper test practices
