### PR TITLE
Improve group shortcutting and ADCS logic

### DIFF
--- a/cmd/api/src/analysis/post_integration_test.go
+++ b/cmd/api/src/analysis/post_integration_test.go
@@ -87,8 +87,7 @@ func TestCrossProduct(t *testing.T) {
 		secondSet := []*graph.Node{testContext.Harness.ShortcutHarness.Group2}
 		groupExpansions, err := ad2.ExpandAllRDPLocalGroups(context.Background(), db)
 		require.Nil(t, err)
-		domainsid, _ := harness.ShortcutHarness.Group3.Properties.Get(ad.DomainSID.String()).String()
-		results := ad2.CalculateCrossProductNodeSets(tx, domainsid, groupExpansions, firstSet, secondSet)
+		results := ad2.CalculateCrossProductNodeSets(tx, groupExpansions, firstSet, secondSet)
 		require.Truef(t, results.Contains(harness.ShortcutHarness.Group3.ID.Uint64()), "missing id %d", harness.ShortcutHarness.Group3.ID.Uint64())
 	})
 }
@@ -103,8 +102,7 @@ func TestCrossProductAuthUsers(t *testing.T) {
 		secondSet := []*graph.Node{testContext.Harness.ShortcutHarnessAuthUsers.Group2}
 		groupExpansions, err := ad2.ExpandAllRDPLocalGroups(context.Background(), db)
 		require.Nil(t, err)
-		domainsid, _ := harness.ShortcutHarnessAuthUsers.Group3.Properties.Get(ad.DomainSID.String()).String()
-		results := ad2.CalculateCrossProductNodeSets(tx, domainsid, groupExpansions, firstSet, secondSet)
+		results := ad2.CalculateCrossProductNodeSets(tx, groupExpansions, firstSet, secondSet)
 		require.True(t, results.Contains(harness.ShortcutHarnessAuthUsers.Group2.ID.Uint64()))
 	})
 }
@@ -119,8 +117,7 @@ func TestCrossProductEveryone(t *testing.T) {
 		secondSet := []*graph.Node{testContext.Harness.ShortcutHarnessEveryone.Group2}
 		groupExpansions, err := ad2.ExpandAllRDPLocalGroups(context.Background(), db)
 		require.Nil(t, err)
-		domainsid, _ := harness.ShortcutHarnessEveryone.Group3.Properties.Get(ad.DomainSID.String()).String()
-		results := ad2.CalculateCrossProductNodeSets(tx, domainsid, groupExpansions, firstSet, secondSet)
+		results := ad2.CalculateCrossProductNodeSets(tx, groupExpansions, firstSet, secondSet)
 		require.True(t, results.Contains(harness.ShortcutHarnessEveryone.Group2.ID.Uint64()))
 	})
 }
@@ -135,8 +132,7 @@ func TestCrossProductEveryone2(t *testing.T) {
 		secondSet := []*graph.Node{testContext.Harness.ShortcutHarnessEveryone2.Group2}
 		groupExpansions, err := ad2.ExpandAllRDPLocalGroups(context.Background(), db)
 		require.Nil(t, err)
-		domainsid, _ := harness.ShortcutHarnessEveryone2.Group3.Properties.Get(ad.DomainSID.String()).String()
-		results := ad2.CalculateCrossProductNodeSets(tx, domainsid, groupExpansions, firstSet, secondSet)
+		results := ad2.CalculateCrossProductNodeSets(tx, groupExpansions, firstSet, secondSet)
 		require.True(t, results.Contains(harness.ShortcutHarnessEveryone2.Group1.ID.Uint64()))
 		require.True(t, results.Contains(harness.ShortcutHarnessEveryone2.Group2.ID.Uint64()))
 	})

--- a/packages/go/analysis/ad/ad.go
+++ b/packages/go/analysis/ad/ad.go
@@ -318,7 +318,7 @@ func createOrUpdateWellKnownLink(tx graph.Transaction, startNode *graph.Node, en
 
 // CalculateCrossProductNodeSets finds the intersection of the given sets of nodes.
 // See CalculateCrossProductNodeSetsDoc.md for explaination of the specialGroups (Authenticated Users and Everyone) and why we treat them the way we do
-func CalculateCrossProductNodeSets(tx graph.Transaction, domainsid string, groupExpansions impact.PathAggregator, nodeSlices ...[]*graph.Node) cardinality.Duplex[uint64] {
+func CalculateCrossProductNodeSets(tx graph.Transaction, groupExpansions impact.PathAggregator, nodeSlices ...[]*graph.Node) cardinality.Duplex[uint64] {
 	if len(nodeSlices) < 2 {
 		slog.Error("Cross products require at least 2 nodesets")
 		return cardinality.NewBitmap64()
@@ -341,7 +341,7 @@ func CalculateCrossProductNodeSets(tx graph.Transaction, domainsid string, group
 	)
 
 	// Get the IDs of the Auth. Users and Everyone groups
-	specialGroups, err := FetchAuthUsersAndEveryoneGroups(tx, domainsid)
+	specialGroups, err := FetchAuthUsersAndEveryoneGroups(tx)
 
 	if err != nil {
 		slog.Error(fmt.Sprintf("Could not fetch groups: %s", err.Error()))

--- a/packages/go/analysis/ad/adcscache.go
+++ b/packages/go/analysis/ad/adcscache.go
@@ -86,9 +86,7 @@ func (s *ADCSCache) BuildCache(ctx context.Context, db graph.Database, enterpris
 				s.certTemplateEnrollers[ct.ID] = firstDegreePrincipals.Slice()
 
 				// Check if Auth. Users or Everyone has enroll
-				if domainsid, err := ct.Properties.Get(ad.DomainSID.String()).String(); err != nil {
-					slog.WarnContext(ctx, fmt.Sprintf("Error getting domain SID for certtemplate %d: %v", ct.ID, err))
-				} else if authUsersOrEveryoneHasEnroll, err := containsAuthUsersOrEveryone(tx, firstDegreePrincipals.Slice(), domainsid); err != nil {
+				if authUsersOrEveryoneHasEnroll, err := containsAuthUsersOrEveryone(tx, firstDegreePrincipals.Slice()); err != nil {
 					slog.ErrorContext(ctx, fmt.Sprintf("Error fetching if auth. users or everyone has enroll on certtemplate %d: %v", ct.ID, err))
 				} else {
 					s.certTemplateHasSpecialEnrollers[ct.ID] = authUsersOrEveryoneHasEnroll
@@ -111,9 +109,7 @@ func (s *ADCSCache) BuildCache(ctx context.Context, db graph.Database, enterpris
 				s.enterpriseCAEnrollers[eca.ID] = firstDegreeEnrollers.Slice()
 
 				// Check if Auth. Users or Everyone has enroll
-				if domainsid, err := eca.Properties.Get(ad.DomainSID.String()).String(); err != nil {
-					slog.WarnContext(ctx, fmt.Sprintf("Error getting domain SID for eca %d: %v", eca.ID, err))
-				} else if authUsersOrEveryoneHasEnroll, err := containsAuthUsersOrEveryone(tx, firstDegreeEnrollers.Slice(), domainsid); err != nil {
+				if authUsersOrEveryoneHasEnroll, err := containsAuthUsersOrEveryone(tx, firstDegreeEnrollers.Slice()); err != nil {
 					slog.ErrorContext(ctx, fmt.Sprintf("Error fetching if auth. users or everyone has enroll on enterprise ca %d: %v", eca.ID, err))
 				} else {
 					s.enterpriseCAHasSpecialEnrollers[eca.ID] = authUsersOrEveryoneHasEnroll

--- a/packages/go/analysis/ad/esc9.go
+++ b/packages/go/analysis/ad/esc9.go
@@ -33,12 +33,10 @@ import (
 	"github.com/specterops/bloodhound/graphschema/ad"
 )
 
-func PostADCSESC9a(ctx context.Context, tx graph.Transaction, outC chan<- analysis.CreatePostRelationshipJob, groupExpansions impact.PathAggregator, eca, domain *graph.Node, cache ADCSCache) error {
+func PostADCSESC9a(ctx context.Context, tx graph.Transaction, outC chan<- analysis.CreatePostRelationshipJob, groupExpansions impact.PathAggregator, eca *graph.Node, targetDomains *graph.NodeSet, cache ADCSCache) error {
 	results := cardinality.NewBitmap64()
 
-	if ok := cache.HasWeakCertBindingInForest(domain.ID.Uint64()); !ok {
-		return nil
-	} else if publishedCertTemplates := cache.GetPublishedTemplateCache(eca.ID); len(publishedCertTemplates) == 0 {
+	if publishedCertTemplates := cache.GetPublishedTemplateCache(eca.ID); len(publishedCertTemplates) == 0 {
 		return nil
 	} else if ecaEnrollers := cache.GetEnterpriseCAEnrollers(eca.ID); len(ecaEnrollers) == 0 {
 		return nil
@@ -68,23 +66,26 @@ func PostADCSESC9a(ctx context.Context, tx graph.Transaction, outC chan<- analys
 		}
 
 		results.Each(func(value uint64) bool {
-			return channels.Submit(ctx, outC, analysis.CreatePostRelationshipJob{
-				FromID: graph.ID(value),
-				ToID:   domain.ID,
-				Kind:   ad.ADCSESC9a,
-			})
+			for _, domain := range targetDomains.Slice() {
+				if cache.HasWeakCertBindingInForest(domain.ID.Uint64()) {
+					channels.Submit(ctx, outC, analysis.CreatePostRelationshipJob{
+						FromID: graph.ID(value),
+						ToID:   domain.ID,
+						Kind:   ad.ADCSESC9a,
+					})
+				}
+			}
+			return true
 		})
 
 		return nil
 	}
 }
 
-func PostADCSESC9b(ctx context.Context, tx graph.Transaction, outC chan<- analysis.CreatePostRelationshipJob, groupExpansions impact.PathAggregator, eca, domain *graph.Node, cache ADCSCache) error {
+func PostADCSESC9b(ctx context.Context, tx graph.Transaction, outC chan<- analysis.CreatePostRelationshipJob, groupExpansions impact.PathAggregator, eca *graph.Node, targetDomains *graph.NodeSet, cache ADCSCache) error {
 	results := cardinality.NewBitmap64()
 
-	if ok := cache.HasWeakCertBindingInForest(domain.ID.Uint64()); !ok {
-		return nil
-	} else if publishedCertTemplates := cache.GetPublishedTemplateCache(eca.ID); len(publishedCertTemplates) == 0 {
+	if publishedCertTemplates := cache.GetPublishedTemplateCache(eca.ID); len(publishedCertTemplates) == 0 {
 		return nil
 	} else if ecaEnrollers := cache.GetEnterpriseCAEnrollers(eca.ID); len(ecaEnrollers) == 0 {
 		return nil
@@ -111,12 +112,18 @@ func PostADCSESC9b(ctx context.Context, tx graph.Transaction, outC chan<- analys
 		}
 
 		results.Each(func(value uint64) bool {
-			return channels.Submit(ctx, outC, analysis.CreatePostRelationshipJob{
-				FromID: graph.ID(value),
-				ToID:   domain.ID,
-				Kind:   ad.ADCSESC9b,
-			})
+			for _, domain := range targetDomains.Slice() {
+				if cache.HasWeakCertBindingInForest(domain.ID.Uint64()) {
+					channels.Submit(ctx, outC, analysis.CreatePostRelationshipJob{
+						FromID: graph.ID(value),
+						ToID:   domain.ID,
+						Kind:   ad.ADCSESC9b,
+					})
+				}
+			}
+			return true
 		})
+
 		return nil
 	}
 }

--- a/packages/go/analysis/ad/post.go
+++ b/packages/go/analysis/ad/post.go
@@ -188,15 +188,12 @@ func getLAPSSyncers(tx graph.Transaction, domain *graph.Node, groupExpansions im
 		getChangesFilteredQuery = analysis.FromEntityToEntityWithRelationshipKind(tx, domain, ad.GetChangesInFilteredSet)
 	)
 
-	if domainsid, err := domain.Properties.Get(ad.DomainSID.String()).String(); err != nil {
-		slog.Warn(fmt.Sprintf("Error getting domain SID for domain %d: %v", domain.ID, err))
-		return nil, err
-	} else if getChangesNodes, err := ops.FetchStartNodes(getChangesQuery); err != nil {
+	if getChangesNodes, err := ops.FetchStartNodes(getChangesQuery); err != nil {
 		return nil, err
 	} else if getChangesFilteredNodes, err := ops.FetchStartNodes(getChangesFilteredQuery); err != nil {
 		return nil, err
 	} else {
-		results := CalculateCrossProductNodeSets(tx, domainsid, groupExpansions, getChangesNodes.Slice(), getChangesFilteredNodes.Slice())
+		results := CalculateCrossProductNodeSets(tx, groupExpansions, getChangesNodes.Slice(), getChangesFilteredNodes.Slice())
 
 		return results, nil
 	}
@@ -208,15 +205,12 @@ func getDCSyncers(tx graph.Transaction, domain *graph.Node, groupExpansions impa
 		getChangesAllQuery = analysis.FromEntityToEntityWithRelationshipKind(tx, domain, ad.GetChangesAll)
 	)
 
-	if domainsid, err := domain.Properties.Get(ad.DomainSID.String()).String(); err != nil {
-		slog.Warn(fmt.Sprintf("Error getting domain SID for domain %d: %v", domain.ID, err))
-		return nil, err
-	} else if getChangesNodes, err := ops.FetchStartNodes(getChangesQuery); err != nil {
+	if getChangesNodes, err := ops.FetchStartNodes(getChangesQuery); err != nil {
 		return nil, err
 	} else if getChangesAllNodes, err := ops.FetchStartNodes(getChangesAllQuery); err != nil {
 		return nil, err
 	} else {
-		results := CalculateCrossProductNodeSets(tx, domainsid, groupExpansions, getChangesNodes.Slice(), getChangesAllNodes.Slice())
+		results := CalculateCrossProductNodeSets(tx, groupExpansions, getChangesNodes.Slice(), getChangesAllNodes.Slice())
 
 		return results, nil
 	}

--- a/packages/go/analysis/ad/queries.go
+++ b/packages/go/analysis/ad/queries.go
@@ -1799,11 +1799,10 @@ func FetchCertTemplateCAs(tx graph.Transaction, certTemplate *graph.Node) (graph
 	))
 }
 
-func FetchAuthUsersAndEveryoneGroups(tx graph.Transaction, domainSID string) (graph.NodeSet, error) {
+func FetchAuthUsersAndEveryoneGroups(tx graph.Transaction) (graph.NodeSet, error) {
 	return ops.FetchNodeSet(tx.Nodes().Filterf(func() graph.Criteria {
 		return query.And(
 			query.Kind(query.Node(), ad.Group),
-			query.Equals(query.NodeProperty(ad.DomainSID.String()), domainSID),
 			query.Or(
 				query.StringEndsWith(query.NodeProperty(common.ObjectID.String()), AuthenticatedUsersSuffix),
 				query.StringEndsWith(query.NodeProperty(common.ObjectID.String()), EveryoneSuffix),


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Improve group shortcutting (cross-product node set) logic and optimize ADCS post-processing.

## Motivation and Context

This PR addresses: BED-5473, BED-5474

BED-5473:
Our special group shortcutting (cross-product node set) logic, that ensures we don’t check membership of Authenticated Users and Everyone (special groups) but simply assume all nodes as members, only considers the Authenticated Users and Everyone groups of the current domain. That means the shortcutting does not work when the target node is of a different forest. This change removes the filtering based on the domain SID.

BED-5474:
An enterprise CA can chain up to multiple domains. In that case, we calculate the the same ADCS edges for a given enterprise CA once per domain. With this change, we now iterate enterprise CAs, determine what domains they chain up to, and then calculate the edges only once per enterprise CA.

## How Has This Been Tested?
With the following data: 
[Desktop.zip](https://github.com/user-attachments/files/18871009/Desktop.zip)

## Screenshots (optional):

Before (with test data):
![image](https://github.com/user-attachments/assets/eea93d4e-488e-4239-a826-1e8ade139697)

After:
![image](https://github.com/user-attachments/assets/2286eb9b-1000-40a0-89e5-6f68a028dbdd)

## Types of changes

<!-- Please remove any items that do not apply. -->

- New feature (non-breaking change which adds functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
