### PR TITLE
BED-5026 Fix LDAP(S) IsDC Usage From String Comparison To Bool Comparison

### DIFF
--- a/cmd/api/src/test/integration/harnesses.go
+++ b/cmd/api/src/test/integration/harnesses.go
@@ -9463,7 +9463,7 @@ func (s *CoerceAndRelayNTLMToLDAP) Setup(graphTestContext *GraphTestContext) {
 
 	s.Computer1 = graphTestContext.NewActiveDirectoryComputer("Computer1", domain1Sid)
 	s.Computer1.Properties.Set(ad.LDAPSigning.String(), false)
-	s.Computer1.Properties.Set(ad.IsDC.String(), domain1Sid)
+	s.Computer1.Properties.Set(ad.IsDC.String(), true)
 	graphTestContext.UpdateNode(s.Computer1)
 
 	s.Computer2 = graphTestContext.NewActiveDirectoryComputer("Computer2", domain1Sid)
@@ -9483,7 +9483,7 @@ func (s *CoerceAndRelayNTLMToLDAP) Setup(graphTestContext *GraphTestContext) {
 	graphTestContext.UpdateNode(s.Computer5)
 
 	s.Computer6 = graphTestContext.NewActiveDirectoryComputer("Computer6", domain2Sid)
-	s.Computer6.Properties.Set(ad.IsDC.String(), domain2Sid)
+	s.Computer6.Properties.Set(ad.IsDC.String(), true)
 	s.Computer6.Properties.Set(ad.LDAPSigning.String(), false)
 	graphTestContext.UpdateNode(s.Computer6)
 
@@ -9494,11 +9494,11 @@ func (s *CoerceAndRelayNTLMToLDAP) Setup(graphTestContext *GraphTestContext) {
 	s.Computer8 = graphTestContext.NewActiveDirectoryComputer("Computer8", domain3Sid)
 	s.Computer8.Properties.Set(ad.LDAPSigning.String(), true)
 	s.Computer8.Properties.Set(ad.LDAPSAvailable.String(), true)
-	s.Computer8.Properties.Set(ad.IsDC.String(), domain3Sid)
+	s.Computer8.Properties.Set(ad.IsDC.String(), true)
 	graphTestContext.UpdateNode(s.Computer8)
 
 	s.Computer9 = graphTestContext.NewActiveDirectoryComputer("Computer9", domain3Sid)
-	s.Computer9.Properties.Set(ad.IsDC.String(), domain3Sid)
+	s.Computer9.Properties.Set(ad.IsDC.String(), true)
 	graphTestContext.UpdateNode(s.Computer9)
 
 	s.Computer10 = graphTestContext.NewActiveDirectoryComputer("Computer10", domain1Sid)
@@ -9578,7 +9578,7 @@ func (s *CoerceAndRelayNTLMToLDAPS) Setup(graphTestContext *GraphTestContext) {
 	domain3Sid := RandomDomainSID()
 
 	s.Computer1 = graphTestContext.NewActiveDirectoryComputer("Computer1", domain1Sid)
-	s.Computer1.Properties.Set(ad.IsDC.String(), domain1Sid)
+	s.Computer1.Properties.Set(ad.IsDC.String(), true)
 	s.Computer1.Properties.Set(ad.LDAPSEPA.String(), false)
 	s.Computer1.Properties.Set(ad.LDAPSAvailable.String(), true)
 	graphTestContext.UpdateNode(s.Computer1)
@@ -9602,7 +9602,7 @@ func (s *CoerceAndRelayNTLMToLDAPS) Setup(graphTestContext *GraphTestContext) {
 	s.Computer6 = graphTestContext.NewActiveDirectoryComputer("Computer6", domain2Sid)
 	s.Computer6.Properties.Set(ad.LDAPSEPA.String(), false)
 	s.Computer6.Properties.Set(ad.LDAPSAvailable.String(), true)
-	s.Computer6.Properties.Set(ad.IsDC.String(), domain2Sid)
+	s.Computer6.Properties.Set(ad.IsDC.String(), true)
 	graphTestContext.UpdateNode(s.Computer6)
 
 	s.Computer7 = graphTestContext.NewActiveDirectoryComputer("Computer7", domain2Sid)
@@ -9611,30 +9611,30 @@ func (s *CoerceAndRelayNTLMToLDAPS) Setup(graphTestContext *GraphTestContext) {
 
 	s.Computer8 = graphTestContext.NewActiveDirectoryComputer("Computer8", domain3Sid)
 	s.Computer8.Properties.Set(ad.LDAPSEPA.String(), false)
-	s.Computer8.Properties.Set(ad.IsDC.String(), domain3Sid)
+	s.Computer8.Properties.Set(ad.IsDC.String(), true)
 	graphTestContext.UpdateNode(s.Computer8)
 
 	s.Computer9 = graphTestContext.NewActiveDirectoryComputer("Computer9", domain3Sid)
 	s.Computer9.Properties.Set(ad.LDAPSEPA.String(), true)
 	s.Computer9.Properties.Set(ad.LDAPSAvailable.String(), true)
-	s.Computer9.Properties.Set(ad.IsDC.String(), domain3Sid)
+	s.Computer9.Properties.Set(ad.IsDC.String(), true)
 	graphTestContext.UpdateNode(s.Computer9)
 
 	s.Computer10 = graphTestContext.NewActiveDirectoryComputer("Computer10", domain3Sid)
 	s.Computer10.Properties.Set(ad.LDAPSEPA.String(), false)
 	s.Computer10.Properties.Set(ad.LDAPSAvailable.String(), false)
-	s.Computer10.Properties.Set(ad.IsDC.String(), domain3Sid)
+	s.Computer10.Properties.Set(ad.IsDC.String(), true)
 	graphTestContext.UpdateNode(s.Computer10)
 
 	s.Computer11 = graphTestContext.NewActiveDirectoryComputer("Computer11", domain3Sid)
 	s.Computer11.Properties.Set(ad.LDAPSEPA.String(), true)
 	s.Computer11.Properties.Set(ad.LDAPSAvailable.String(), false)
-	s.Computer11.Properties.Set(ad.IsDC.String(), domain3Sid)
+	s.Computer11.Properties.Set(ad.IsDC.String(), true)
 	graphTestContext.UpdateNode(s.Computer11)
 
 	s.Computer12 = graphTestContext.NewActiveDirectoryComputer("Computer12", domain3Sid)
 	s.Computer12.Properties.Set(ad.LDAPSAvailable.String(), true)
-	s.Computer12.Properties.Set(ad.IsDC.String(), domain3Sid)
+	s.Computer12.Properties.Set(ad.IsDC.String(), true)
 	graphTestContext.UpdateNode(s.Computer12)
 
 	s.Computer13 = graphTestContext.NewActiveDirectoryComputer("Computer13", domain1Sid)

--- a/packages/go/analysis/ad/ntlm.go
+++ b/packages/go/analysis/ad/ntlm.go
@@ -403,7 +403,7 @@ func FetchLDAPSigningCache(ctx context.Context, db graph.Database) (map[string]L
 						// IsDC is a property for computers that are Domain Controllers for a Domain
 						// This allows us to ensure the computer has a DCFor relationship to the currently iterated domain
 						query.Equals(
-							query.NodeProperty(ad.IsDC.String()), domainSid,
+							query.NodeProperty(ad.IsDC.String()), true,
 						),
 						query.Equals(
 							query.NodeProperty(ad.LDAPSigning.String()), false,
@@ -417,7 +417,7 @@ func FetchLDAPSigningCache(ctx context.Context, db graph.Database) (map[string]L
 							query.NodeProperty(ad.DomainSID.String()), domainSid,
 						),
 						query.Equals(
-							query.NodeProperty(ad.IsDC.String()), domainSid,
+							query.NodeProperty(ad.IsDC.String()), true,
 						),
 						query.Equals(
 							query.NodeProperty(ad.LDAPSAvailable.String()), true,


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

This change correctly checks the `IsDC` property for a `true` value, rather than checking for a `domainsid`

## Motivation and Context

This PR addresses: BED-5026

Fixes a bug in the harness and LDAP(S) edge creation

## How Has This Been Tested?

Integration tests are passing

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)
- Database Migrations

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
