### PR TITLE
Revert "chore(docker): Upgrade Neo4j base image to version 5.26.1 (#1131)"

### DIFF
--- a/tools/docker-compose/neo4j.Dockerfile
+++ b/tools/docker-compose/neo4j.Dockerfile
@@ -1,20 +1,20 @@
 # Copyright 2023 Specter Ops, Inc.
-#
+# 
 # Licensed under the Apache License, Version 2.0
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#
+# 
 #     http://www.apache.org/licenses/LICENSE-2.0
-#
+# 
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
+# 
 # SPDX-License-Identifier: Apache-2.0
 
-FROM docker.io/library/neo4j:5.26.1 as base
+FROM docker.io/library/neo4j:4.4.32 as base
 
 ARG memconfig
 
@@ -23,6 +23,6 @@ RUN echo "dbms.security.auth_enabled=false" >> /var/lib/neo4j/conf/neo4j.conf &&
     echo "dbms.security.procedures.unrestricted=apoc.periodic.*,*.specterops.*" >> /var/lib/neo4j/conf/neo4j.conf && \
     echo "dbms.security.procedures.allowlist=apoc.periodic.*,*.specterops.*" >> /var/lib/neo4j/conf/neo4j.conf
 
-RUN if [ "$memconfig" = "true" ]; then neo4j-admin server memory-recommendation >> /var/lib/neo4j/conf/neo4j.conf; fi
+RUN if [ "$memconfig" = "true" ]; then neo4j-admin memrec >> /var/lib/neo4j/conf/neo4j.conf; fi
 
-RUN cp /var/lib/neo4j/labs/apoc-5.26.1-core.jar /var/lib/neo4j/plugins/apoc-5.26.1-core.jar
+RUN cp /var/lib/neo4j/labs/apoc-4.4.0.26-core.jar /var/lib/neo4j/plugins/apoc-4.4.0.26-core.jar


### PR DESCRIPTION
## Description

This reverts commit 4790b740d9393023bf3363c31ac98554f29c01e1. Automated tests began failing after PR #1131 was merged. It appears to be caused by calling a procedure (`db.indexes`) that is deprecated in neo4j 5+.

## Motivation and Context

* This is related to the original ticket of BED-4145.
* Fix broken tests so other PRs can be merged.

## How Has This Been Tested?

*Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc.*

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
