### PR TITLE
BED-5328 added NTLM saved queries

### DIFF
--- a/packages/javascript/bh-shared-ui/src/commonSearches.ts
+++ b/packages/javascript/bh-shared-ui/src/commonSearches.ts
@@ -14,8 +14,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { OWNED_OBJECT_TAG, TIER_ZERO_TAG } from './constants';
-import { ActiveDirectoryPathfindingEdges, AzurePathfindingEdges } from './graphSchema';
+import {OWNED_OBJECT_TAG, TIER_ZERO_TAG} from './constants';
+import {ActiveDirectoryPathfindingEdges, AzurePathfindingEdges} from './graphSchema';
 
 const categoryAD = 'Active Directory';
 const categoryAzure = 'Azure';
@@ -384,6 +384,44 @@ export const CommonSearches: CommonSearchType[] = [
             {
                 description: 'On-Prem Users synced to Entra Users with Entra Group Membership',
                 cypher: `MATCH p = (:User)-[:SyncedToEntraUser]->(:AZUser)-[:AZMemberOf]->(:AZGroup)\nRETURN p\nLIMIT 1000`,
+            },
+        ],
+    },
+    {
+        subheader: 'NTLM Relay Attacks',
+        category: categoryAD,
+        queries: [
+            {
+                description: 'All coerce and NTLM relay edges',
+                cypher: 'MATCH p = (n:Base)-[:CoerceAndRelayNTLMToLDAP|CoerceAndRelayNTLMToLDAPS|CoerceAndRelayNTLMToADCS|CoerceAndRelayNTLMToSMB]->(:Base)\nRETURN p LIMIT 500',
+            },
+            {
+                description: 'All NTLM session-based relay edges',
+                cypher: 'MATCH p = (n:Base)-[:CoerceAndRelayNTLMToLDAP|CoerceAndRelayNTLMToLDAPS|CoerceAndRelayNTLMToADCS|CoerceAndRelayNTLMToSMB]->(:Base)\nRETURN p LIMIT 500',
+            },
+            {
+                description: 'ESC8-vulnerable Enterprise CAs',
+                cypher: 'MATCH (n:EnterpriseCA)\nWHERE n.adcswebenrollmenthttp = True\nOR (n.adcswebenrollmenthttps = True AND n.adcswebenrollmenthttpsepa = False)\nRETURN n',
+            },
+            {
+                description: 'Computers with the outgoing NTLM setting set to _Deny all_',
+                cypher: 'MATCH (c:Computer)\nWHERE c.restrictoutboundntlm = True\nRETURN c LIMIT 1000',
+            },
+            {
+                description: 'Computers with membership in Protected Users',
+                cypher: 'MATCH p = (:Base)-[:MemberOf*1..]->(g:Group)\nWHERE g.objectid ENDS WITH "-525"\nRETURN p LIMIT 1000',
+            },
+            {
+                description: 'DCs vulnerable to NTLM relay to LDAP attacks',
+                cypher: 'MATCH p = (dc:Computer)-[:DCFor]->(:Domain)\nWHERE NOT dc.ldapsigning = True\nOR (dc.ldapsavailable = True AND NOT dc.ldapsepa = True)\nRETURN p',
+            },
+            {
+                description: 'Computers with the WebClient running',
+                cypher: 'MATCH (c:Computer)\nWHERE c.webclientrunning = True\nRETURN c LIMIT 1000',
+            },
+            {
+                description: 'Computers not requiring inbound SMB signing',
+                cypher: 'MATCH (n:Computer)\nWHERE n.smbsigning = False\nRETURN n',
             },
         ],
     },


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

This adds a set of pre-made saved queries, to the pre-built searches list, for NTLM relay attacks in the Active Directory subcategory

## Motivation and Context

This PR addresses: BED-5328

*Why is this change required? What problem does it solve?*
This allows users to select from a list of pre-made saved queries in order to find nodes and relationships for the new NTLM relay attack paths

## How Has This Been Tested?
I loaded the UI, navigated to the Explore page, and browsed the Pre-built Searches list
<img width="2832" alt="image" src="https://github.com/user-attachments/assets/b80287ea-e8d9-4aae-909c-3669b4f0896e" />

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)
- Database Migrations

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
