### PR TITLE
BED-5526 removed artifact of event log based NTLM saved query

### DIFF
--- a/packages/javascript/bh-shared-ui/src/commonSearches.ts
+++ b/packages/javascript/bh-shared-ui/src/commonSearches.ts
@@ -396,10 +396,6 @@ export const CommonSearches: CommonSearchType[] = [
                 cypher: 'MATCH p = (n:Base)-[:CoerceAndRelayNTLMToLDAP|CoerceAndRelayNTLMToLDAPS|CoerceAndRelayNTLMToADCS|CoerceAndRelayNTLMToSMB]->(:Base)\nRETURN p LIMIT 500',
             },
             {
-                description: 'All NTLM session-based relay edges',
-                cypher: 'MATCH p = (n:Base)-[:CoerceAndRelayNTLMToLDAP|CoerceAndRelayNTLMToLDAPS|CoerceAndRelayNTLMToADCS|CoerceAndRelayNTLMToSMB]->(:Base)\nRETURN p LIMIT 500',
-            },
-            {
                 description: 'ESC8-vulnerable Enterprise CAs',
                 cypher: 'MATCH (n:EnterpriseCA)\nWHERE n.adcswebenrollmenthttp = True\nOR (n.adcswebenrollmenthttps = True AND n.adcswebenrollmenthttpsepa = False)\nRETURN n',
             },


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Removes a duplicated NTLM saved query

## Motivation and Context

This PR addresses: BED-5526

We had removed event log based NTLM edge processing, this query was left in after the removal but ends up being a duplicate of the `All coerce and NTLM relay edges` query

## How Has This Been Tested?

<img width="1913" alt="image" src="https://github.com/user-attachments/assets/b6b4bd90-0672-47f9-b489-7a98439154fb" />

`All NTLM Session-based Relay Edges` was removed, which is the expected behavior


## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
