### PR TITLE
fix: update t0 label const name to disambiguate from high value

### DIFF
--- a/cmd/ui/src/views/GroupManagement/GroupManagement.tsx
+++ b/cmd/ui/src/views/GroupManagement/GroupManagement.tsx
@@ -19,10 +19,10 @@ import {
     DropdownOption,
     EntityKinds,
     GroupManagementContent,
+    HIGH_VALUE_LABEL,
     Permission,
-    searchbarActions,
-    TIER_ZERO_LABEL,
     TIER_ZERO_TAG,
+    searchbarActions,
     usePermissions,
 } from 'bh-shared-ui';
 import { AssetGroup, AssetGroupMember } from 'js-client-library';
@@ -74,7 +74,7 @@ const GroupManagement = () => {
             const isTierZero = assetGroup.tag === TIER_ZERO_TAG;
             return {
                 key: assetGroup.id,
-                value: isTierZero ? TIER_ZERO_LABEL : assetGroup.name,
+                value: isTierZero ? HIGH_VALUE_LABEL : assetGroup.name,
                 icon: isTierZero ? faGem : undefined,
             };
         });
@@ -84,7 +84,7 @@ const GroupManagement = () => {
         <GroupManagementContent
             globalDomain={globalDomain}
             showExplorePageLink={!!openNode}
-            tierZeroLabel={TIER_ZERO_LABEL}
+            tierZeroLabel={HIGH_VALUE_LABEL}
             tierZeroTag={TIER_ZERO_TAG}
             // Both these components should eventually be moved into the shared UI library
             entityPanelComponent={<EntityInfoPanel selectedNode={openNode} />}

--- a/packages/javascript/bh-shared-ui/src/constants.ts
+++ b/packages/javascript/bh-shared-ui/src/constants.ts
@@ -21,9 +21,13 @@ export const NODE_GRAPH_RENDER_LIMIT = 1000;
 
 export const ZERO_VALUE_API_DATE = '0001-01-01T00:00:00Z';
 
-export const TIER_ZERO_TAG = 'admin_tier_0';
-export const TIER_ZERO_LABEL = 'High Value';
+// These tags are values associated with the `system_tags` property of a node
 export const OWNED_OBJECT_TAG = 'owned';
+export const TIER_ZERO_TAG = 'admin_tier_0';
+
+// These labels are used as display values
+export const TIER_ZERO_LABEL = 'Admin Tier Zero';
+export const HIGH_VALUE_LABEL = 'High Value';
 
 export const lightPalette = {
     primary: {


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Two different constants are created for disambiguation purposes: `TIER_ZERO_LABEL` and `HIGH_VALUE_LABEL`.

## Motivation and Context

This PR addresses: BED-5524

There was a constant in the BHE repository that is also called `TIER_ZERO_LABEL` which has a different string value assigned to it. The constant name update helps with disambiguation and makes it clear that these constants do not have the same value.

## How Has This Been Tested?

The bug is upstream. The project builds as the updated constant name is updated where it was used.

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)
- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
