### PR TITLE
BED-5525 Set NTLM Feature Flag Default To Disabled & Update NTLMSMB General Copy

### DIFF
--- a/cmd/api/src/database/migration/migrations/v7.1.0.sql
+++ b/cmd/api/src/database/migration/migrations/v7.1.0.sql
@@ -52,6 +52,6 @@ VALUES (current_timestamp,
         'ntlm_post_processing',
         'NTLM Post Processing Support',
         'Enable the post processing of NTLM relay attack paths, this will enable the creation of CoerceAndRelayNTLMTo[LDAP, LDAPS, ADCS, SMB] edges.',
-        true,
+        false,
         true)
 ON CONFLICT DO NOTHING;

--- a/packages/go/analysis/ad/ntlm.go
+++ b/packages/go/analysis/ad/ntlm.go
@@ -38,11 +38,6 @@ import (
 
 // PostNTLM is the initial function used to execute our NTLM analysis
 func PostNTLM(ctx context.Context, db graph.Database, groupExpansions impact.PathAggregator, adcsCache ADCSCache, ntlmEnabled bool, compositionCounter *analysis.CompositionCounter) (*analysis.AtomicPostProcessingStats, error) {
-	// NTLM must be enabled through the feature flag
-	if !ntlmEnabled {
-		return nil, nil
-	}
-
 	var (
 		adcsComputerCache       = make(map[string]cardinality.Duplex[uint64])
 		operation               = analysis.NewPostRelationshipOperation(ctx, db, "PostNTLM")
@@ -50,6 +45,12 @@ func PostNTLM(ctx context.Context, db graph.Database, groupExpansions impact.Pat
 		// compositionChannel      = make(chan analysis.CompositionInfo)
 		protectedUsersCache = make(map[string]cardinality.Duplex[uint64])
 	)
+
+	// NTLM must be enabled through the feature flag
+	if !ntlmEnabled {
+		operation.Done()
+		return &operation.Stats, nil
+	}
 
 	// This is a POC on how to pipe composition info up through the operations
 	// go func() {

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/CoerceAndRelayNTLMToSMB/General.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/CoerceAndRelayNTLMToSMB/General.tsx
@@ -29,7 +29,7 @@ const General: FC<EdgeInfoProps> = () => {
             </Typography>
 
             <Typography variant='body2'>
-                Click on Relay Targets to view victim computers with administrative rights on the target computer.
+                Click on Composition to view victim computers with administrative rights on the target computer.
             </Typography>
         </>
     );


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Change NTLMToSMB's General copy to reference `Composition` instead of `Relay Targets`
Default NTLM feature flag to disabled

## Motivation and Context

This PR addresses: BED-5525


## How Has This Been Tested?

<img width="1914" alt="image" src="https://github.com/user-attachments/assets/00461265-b0f3-4794-a8ea-843fb34a0074" />

With a fresh instance of BHE I ingested data and ensured no NTLM edges were created.
I then enabled the NTLM feature flag and re-ingested the same zip and confirmed that the edges were created


## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)
- Database Migrations

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
