### PR TITLE
BED-5484 Removed extra step from NTLM [LDAP, LDAPS, ADCS] WindowsAbuse copy

### DIFF
--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/CoerceAndRelayNTLMToADCS/WindowsAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/CoerceAndRelayNTLMToADCS/WindowsAbuse.tsx
@@ -22,15 +22,10 @@ const WindowsAbuse: FC<EdgeInfoProps> = () => {
     return (
         <>
             <Typography variant='body2'>
-                1: Take Over the SMB Port on the Attacker Host To avoid a conflict with SMB running on the
-                attacker-controlled Windows computer, it is necessary to takeover the SMB port. This can be achieved
-                with smbtakeover.
+                1: Start the Relay Server The NTLM relay can be executed with Inveigh.
             </Typography>
             <Typography variant='body2'>
-                2: Start the Relay Server The NTLM relay can be executed with Inveigh.
-            </Typography>
-            <Typography variant='body2'>
-                3: Coerce the Target Computer Several coercion methods are documented here:{' '}
+                2: Coerce the Target Computer Several coercion methods are documented here:{' '}
                 <a href={'https://github.com/p0dalirius/windows-coerced-authentication-methods'}>
                     Windows Coerced Authentication Methods
                 </a>

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/CoerceAndRelayNTLMToLDAP/WindowsAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/CoerceAndRelayNTLMToLDAP/WindowsAbuse.tsx
@@ -22,15 +22,10 @@ const WindowsAbuse: FC<EdgeInfoProps> = () => {
     return (
         <>
             <Typography variant='body2'>
-                1: Take Over the SMB Port on the Attacker Host To avoid a conflict with SMB running on the
-                attacker-controlled Windows computer, it is necessary to takeover the SMB port. This can be achieved
-                with smbtakeover.
+                1: Start the Relay Server The NTLM relay can be executed with Inveigh.
             </Typography>
             <Typography variant='body2'>
-                2: Start the Relay Server The NTLM relay can be executed with Inveigh.
-            </Typography>
-            <Typography variant='body2'>
-                3: Coerce the Target Computer Several coercion methods are documented here:{' '}
+                2: Coerce the Target Computer Several coercion methods are documented here:{' '}
                 <a href={'https://github.com/p0dalirius/windows-coerced-authentication-methods'}>
                     Windows Coerced Authentication Methods
                 </a>

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/CoerceAndRelayNTLMToLDAPS/WindowsAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/CoerceAndRelayNTLMToLDAPS/WindowsAbuse.tsx
@@ -22,15 +22,10 @@ const WindowsAbuse: FC<EdgeInfoProps> = () => {
     return (
         <>
             <Typography variant='body2'>
-                1: Take Over the SMB Port on the Attacker Host To avoid a conflict with SMB running on the
-                attacker-controlled Windows computer, it is necessary to takeover the SMB port. This can be achieved
-                with smbtakeover.
+                1: Start the Relay Server The NTLM relay can be executed with Inveigh.
             </Typography>
             <Typography variant='body2'>
-                2: Start the Relay Server The NTLM relay can be executed with Inveigh.
-            </Typography>
-            <Typography variant='body2'>
-                3: Coerce the Target Computer Several coercion methods are documented here:{' '}
+                2: Coerce the Target Computer Several coercion methods are documented here:{' '}
                 <a href={'https://github.com/p0dalirius/windows-coerced-authentication-methods'}>
                     Windows Coerced Authentication Methods
                 </a>


### PR DESCRIPTION
## Description

SMB steps were accidentally added to the LDAP, LDAPS, and ADCS WindowsAbuse copy
This simply removes the step

## Motivation and Context

This PR addresses: BED-5484

## How Has This Been Tested?

<img width="1457" alt="image" src="https://github.com/user-attachments/assets/d08cc17d-da28-4b7c-97e8-20206d96d5e8" />
<img width="1458" alt="image" src="https://github.com/user-attachments/assets/d0644aac-4a30-4cff-92b4-c68b0d328bc7" />


## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
