### PR TITLE
Disable the try it button for API docs

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -30,6 +30,11 @@
   "background": {
     "style": "gradient"
   },
+ "api": {
+  "playground": {
+    "mode": "hide"
+  }
+},
   "topbarLinks": [
     {
       "name": "Support",


### PR DESCRIPTION
As part of the Mintlify doc revamp, this PR disables the "Try it" button on the API docs, per Kate's request. 

## Motivation and Context
This PR addresses: [#1085](https://github.com/SpecterOps/BloodHound/issues/1085)

## Testing
Tested locally with Mintlify 

$$ Types of changes
- Chore
- Docs


I have read the CLA Document and I hereby sign the CLA
