### PR TITLE
fix(BED-5539): Update image flavor tag generation logic in workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -37,7 +37,7 @@ jobs:
       dockerfile: dockerfiles/bloodhound.Dockerfile
       image_cache_from: type=registry,ref=ghcr.io/specterops/bloodhound:buildcache
       image_cache_to: type=registry,ref=ghcr.io/specterops/bloodhound:buildcache,mode=max
-      image_flavor: ${{ (github.ref_name == 'main' || contains(github.ref_name, '-rc')) && 'latest=false' }}
+      image_flavor: latest=${{ (github.ref_name == 'main' || contains(github.ref_name, '-rc')) == false }}
       image_tags: |
         type=edge,branch=main
         type=semver,pattern={{version}}


### PR DESCRIPTION
## Description

This PR fixes the Docker image tagging in the CD workflow. The change modifies the `image_flavor` parameter in the GitHub Actions workflow to set the "latest" tag for Docker images correctly.

The change updates the syntax from:
```yaml
image_flavor: ${{ (github.ref_name == 'main' || contains(github.ref_name, '-rc')) && 'latest=false' }}
```

To:
```yaml
image_flavor: latest=${{ (github.ref_name == 'main' || contains(github.ref_name, '-rc')) == false }}
```

This ensures the "latest" tag is applied correctly based on the branch conditions.

## Motivation and Context

This PR addresses [BED-5539](https://specterops.atlassian.net/browse/BED-5539)

The current implementation of Docker image tagging in the CD workflow does not correctly apply the "latest" tag. This change fixes the syntax to ensure images are correctly tagged according to the branch conditions.

## How Has This Been Tested?

Veifiried manually using `act` by validating the `cd.yml` template through a workflow run.

## Types of changes

- [x] Chore (a change that does not modify the application functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


[BED-5539]: https://specterops.atlassian.net/browse/BED-5539?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ