### PR TITLE
BED-5557: Allow users to enable or disable `back_button_support` feature

### DIFF
--- a/cmd/api/src/database/migration/migrations/v7.2.0.sql
+++ b/cmd/api/src/database/migration/migrations/v7.2.0.sql
@@ -1,3 +1,19 @@
+-- Copyright 2025 Specter Ops, Inc.
+--
+-- Licensed under the Apache License, Version 2.0
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- SPDX-License-Identifier: Apache-2.0
+
 -- Set `back_button_support` feature flag as user updatable
 UPDATE feature_flags SET user_updatable = true WHERE key = 'back_button_support';
 

--- a/cmd/api/src/database/migration/migrations/v7.2.0.sql
+++ b/cmd/api/src/database/migration/migrations/v7.2.0.sql
@@ -1,0 +1,2 @@
+-- Set `back_button_support` feature flag as user updatable
+UPDATE feature_flags SET user_updatable = true WHERE key = 'back_button_support';

--- a/cmd/api/src/database/migration/migrations/v7.2.0.sql
+++ b/cmd/api/src/database/migration/migrations/v7.2.0.sql
@@ -1,2 +1,5 @@
 -- Set `back_button_support` feature flag as user updatable
 UPDATE feature_flags SET user_updatable = true WHERE key = 'back_button_support';
+
+-- Specify the `back_button_support` feature flag is currently only for BHCE users
+UPDATE feature_flags SET description = 'Enable users to quickly navigate between views in a wider range of scenarios by utilizing the browser navigation buttons. Currently for BloodHound Community Edition users only.' WHERE key = 'back_button_support';


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

- Allows users to enable or disable the `back_button_support` feature flag via the Early Access Features page.

## Motivation and Context

This PR addresses: https://specterops.atlassian.net/browse/BED-5557

## How Has This Been Tested?

No tests have been added or updated.

## Types of changes

<!-- Please remove any items that do not apply. -->

- New feature (non-breaking change which adds functionality)
- Database Migrations

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
