### PR TITLE
ci(docs,rfc): skip ci when there are only changes to documentation or rfcs

### DIFF
--- a/.github/workflows/build-ui.yml
+++ b/.github/workflows/build-ui.yml
@@ -1,4 +1,4 @@
-# Copyright 2024 Specter Ops, Inc.
+# Copyright 2025 Specter Ops, Inc.
 #
 # Licensed under the Apache License, Version 2.0
 # you may not use this file except in compliance with the License.
@@ -17,10 +17,15 @@
 name: Build UI
 
 on:
-  push:
-    branches: [main]
   pull_request:
-    types: [opened, synchronize]
+    branches:
+      - main
+    types:
+      - opened
+      - synchronize
+    paths-ignore:
+      - 'docs/**'
+      - 'rfc/**'
 
 jobs:
   build-ui:
@@ -42,7 +47,7 @@ jobs:
       - name: Install Deps
         run: |
           cd cmd/ui && yarn
-      
+
       - name: Format js-client-library with Prettier
         run: |
           cd packages/javascript/js-client-library && yarn format && cd ../bh-shared-ui/ && yarn format && cd ../../../cmd/ui/ && yarn format

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright 2024 Specter Ops, Inc.
+# Copyright 2025 Specter Ops, Inc.
 #
 # Licensed under the Apache License, Version 2.0
 # you may not use this file except in compliance with the License.
@@ -23,6 +23,9 @@ on:
     types:
       - opened
       - synchronize
+    paths-ignore:
+      - 'docs/**'
+      - 'rfc/**'
 
 jobs:
   cla-check:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,4 +1,4 @@
-# Copyright 2023 Specter Ops, Inc.
+# Copyright 2025 Specter Ops, Inc.
 #
 # Licensed under the Apache License, Version 2.0
 # you may not use this file except in compliance with the License.
@@ -17,10 +17,15 @@
 name: Run Tests
 
 on:
-  push:
-    branches: [main]
   pull_request:
-    types: [opened, synchronize]
+    branches:
+      - main
+    types:
+      - opened
+      - synchronize
+    paths-ignore:
+      - 'docs/**'
+      - 'rfc/**'
 
 jobs:
   run-tests:

--- a/.github/workflows/static-code-analysis.yml
+++ b/.github/workflows/static-code-analysis.yml
@@ -1,4 +1,4 @@
-# Copyright 2024 Specter Ops, Inc.
+# Copyright 2025 Specter Ops, Inc.
 #
 # Licensed under the Apache License, Version 2.0
 # you may not use this file except in compliance with the License.
@@ -17,10 +17,15 @@
 name: Static Code Analysis
 
 on:
-  push:
-    branches: [main]
   pull_request:
-    types: [opened, synchronize]
+    branches:
+      - main
+    types:
+      - opened
+      - synchronize
+    paths-ignore:
+      - 'docs/**'
+      - 'rfc/**'
 
 jobs:
   run-analysis:

--- a/.github/workflows/vuln-scan.yml
+++ b/.github/workflows/vuln-scan.yml
@@ -1,4 +1,4 @@
-# Copyright 2024 Specter Ops, Inc.
+# Copyright 2025 Specter Ops, Inc.
 #
 # Licensed under the Apache License, Version 2.0
 # you may not use this file except in compliance with the License.
@@ -17,10 +17,15 @@
 name: Vulnerability Scan
 
 on:
-  push:
-    branches: [main]
   pull_request:
-    types: [opened, synchronize]
+    branches:
+      - main
+    types:
+      - opened
+      - synchronize
+    paths-ignore:
+      - 'docs/**'
+      - 'rfc/**'
 
 jobs:
   run-analysis:


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Skip CI when there are only changes to product or process documentation.

## Motivation and Context

It is unnecessary and time-consuming to build & test changesets that do not directly affect the product. This PR excludes certain checks from running when there are only changes to product or process documentation.

https://specterops.atlassian.net/browse/BED-5561

## How Has This Been Tested?

n/a

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
