### PR TITLE
BED-5544 remove self relay from SMB and LDAP(S)

### DIFF
--- a/cmd/api/src/analysis/ad/ntlm_integration_test.go
+++ b/cmd/api/src/analysis/ad/ntlm_integration_test.go
@@ -561,6 +561,60 @@ func TestPostCoerceAndRelayNTLMToLDAP(t *testing.T) {
 
 	t.Run("NTLMCoerceAndRelayNTLMToLDAPS Self Relay Does Not Create Edge", func(t *testing.T) {
 		testContext.DatabaseTestWithSetup(func(harness *integration.HarnessDetails) error {
+			harness.NTLMCoerceAndRelayToLDAPSSelfRelay.Setup(testContext)
+			return nil
+		}, func(harness integration.HarnessDetails, db graph.Database) {
+			operation := analysis.NewPostRelationshipOperation(context.Background(), db, "NTLM Post Process Test - CoerceAndRelayNTLMToLDAPS - Self Relay")
+
+			groupExpansions, computers, _, authenticatedUsers, err := fetchNTLMPrereqs(db)
+			require.NoError(t, err)
+
+			ldapSigningCache, err := ad2.FetchLDAPSigningCache(testContext.Context(), db)
+			require.NoError(t, err)
+
+			protectedUsersCache, err := ad2.FetchProtectedUsersMappedToDomains(testContext.Context(), db, groupExpansions)
+			require.NoError(t, err)
+
+			err = operation.Operation.SubmitReader(func(ctx context.Context, tx graph.Transaction, outC chan<- analysis.CreatePostRelationshipJob) error {
+				for _, computer := range computers {
+					innerComputer := computer
+					domainSid, err := innerComputer.Properties.Get(ad.DomainSID.String()).String()
+					require.NoError(t, err)
+
+					if authenticatedUserID, ok := authenticatedUsers[domainSid]; !ok {
+						t.Fatalf("authenticated user not found for %s", domainSid)
+					} else if protectedUsersForDomain, ok := protectedUsersCache[domainSid]; !ok {
+						continue
+					} else if ldapSigningForDomain, ok := ldapSigningCache[domainSid]; !ok {
+						continue
+					} else if protectedUsersForDomain.Contains(innerComputer.ID.Uint64()) && !ldapSigningForDomain.IsValidFunctionalLevel {
+						continue
+					} else if err = ad2.PostCoerceAndRelayNTLMToLDAP(outC, innerComputer, authenticatedUserID, ldapSigningCache); err != nil {
+						t.Logf("failed post processing for %s: %v", ad.CoerceAndRelayNTLMToLDAPS.String(), err)
+					}
+				}
+				return nil
+			})
+			require.NoError(t, err)
+
+			err = operation.Done()
+			require.NoError(t, err)
+
+			db.ReadTransaction(context.Background(), func(tx graph.Transaction) error {
+				if results, err := ops.FetchRelationships(tx.Relationships().Filterf(func() graph.Criteria {
+					return query.Kind(query.Relationship(), ad.CoerceAndRelayNTLMToLDAPS)
+				})); err != nil {
+					t.Fatalf("error fetching NTLM to LDAPS edges in integration test; %v", err)
+				} else {
+					require.Len(t, results, 0)
+				}
+				return nil
+			})
+		})
+	})
+
+	t.Run("NTLMCoerceAndRelayNTLMToLDAP Self Relay Does Not Create Edge", func(t *testing.T) {
+		testContext.DatabaseTestWithSetup(func(harness *integration.HarnessDetails) error {
 			harness.NTLMCoerceAndRelayToLDAPSelfRelay.Setup(testContext)
 			return nil
 		}, func(harness integration.HarnessDetails, db graph.Database) {
@@ -604,7 +658,7 @@ func TestPostCoerceAndRelayNTLMToLDAP(t *testing.T) {
 				if results, err := ops.FetchRelationships(tx.Relationships().Filterf(func() graph.Criteria {
 					return query.Kind(query.Relationship(), ad.CoerceAndRelayNTLMToLDAP)
 				})); err != nil {
-					t.Fatalf("error fetching NTLM to LDAPS edges in integration test; %v", err)
+					t.Fatalf("error fetching NTLM to LDAP edges in integration test; %v", err)
 				} else {
 					require.Len(t, results, 0)
 				}

--- a/cmd/api/src/analysis/ad/ntlm_integration_test.go
+++ b/cmd/api/src/analysis/ad/ntlm_integration_test.go
@@ -155,74 +155,136 @@ func TestPostNTLMRelaySMB(t *testing.T) {
 	// TODO: Add some negative tests here
 	testContext := integration.NewGraphTestContext(t, graphschema.DefaultGraphSchema())
 
-	testContext.DatabaseTestWithSetup(func(harness *integration.HarnessDetails) error {
-		harness.NTLMCoerceAndRelayNTLMToSMB.Setup(testContext)
-		return nil
-	}, func(harness integration.HarnessDetails, db graph.Database) {
-		operation := analysis.NewPostRelationshipOperation(context.Background(), db, "NTLM Post Process Test - CoerceAndRelayNTLMToSMB")
+	t.Run("NTLMCoerceAndRelayNTLMToSMB Success", func(t *testing.T) {
+		testContext.DatabaseTestWithSetup(func(harness *integration.HarnessDetails) error {
+			harness.NTLMCoerceAndRelayNTLMToSMB.Setup(testContext)
+			return nil
+		}, func(harness integration.HarnessDetails, db graph.Database) {
+			operation := analysis.NewPostRelationshipOperation(context.Background(), db, "NTLM Post Process Test - CoerceAndRelayNTLMToSMB")
 
-		groupExpansions, computers, domains, authenticatedUsers, err := fetchNTLMPrereqs(db)
-		require.NoError(t, err)
+			groupExpansions, computers, domains, authenticatedUsers, err := fetchNTLMPrereqs(db)
+			require.NoError(t, err)
 
-		ldapSigningCache, err := ad2.FetchLDAPSigningCache(testContext.Context(), db)
-		require.NoError(t, err)
+			ldapSigningCache, err := ad2.FetchLDAPSigningCache(testContext.Context(), db)
+			require.NoError(t, err)
 
-		protectedUsersCache, err := ad2.FetchProtectedUsersMappedToDomains(testContext.Context(), db, groupExpansions)
-		require.NoError(t, err)
+			protectedUsersCache, err := ad2.FetchProtectedUsersMappedToDomains(testContext.Context(), db, groupExpansions)
+			require.NoError(t, err)
 
-		compositionCounter := analysis.NewCompositionCounter()
+			compositionCounter := analysis.NewCompositionCounter()
 
-		for _, domain := range domains {
-			innerDomain := domain
+			for _, domain := range domains {
+				innerDomain := domain
 
-			err = operation.Operation.SubmitReader(func(ctx context.Context, tx graph.Transaction, outC chan<- analysis.CreatePostRelationshipJob) error {
-				for _, computer := range computers {
-					innerComputer := computer
-					domainSid, _ := innerDomain.Properties.Get(ad.DomainSID.String()).String()
+				err = operation.Operation.SubmitReader(func(ctx context.Context, tx graph.Transaction, outC chan<- analysis.CreatePostRelationshipJob) error {
+					for _, computer := range computers {
+						innerComputer := computer
+						domainSid, _ := innerDomain.Properties.Get(ad.DomainSID.String()).String()
 
-					if authenticatedUserID, ok := authenticatedUsers[domainSid]; !ok {
-						t.Fatalf("authenticated user not found for %s", domainSid)
-					} else if protectedUsersForDomain, ok := protectedUsersCache[domainSid]; !ok {
-						continue
-					} else if ldapSigningForDomain, ok := ldapSigningCache[domainSid]; !ok {
-						continue
-					} else if protectedUsersForDomain.Contains(innerComputer.ID.Uint64()) && !ldapSigningForDomain.IsValidFunctionalLevel {
-						continue
-					} else if err = ad2.PostCoerceAndRelayNTLMToSMB(tx, outC, groupExpansions, innerComputer, authenticatedUserID, &compositionCounter); err != nil {
-						t.Logf("failed post processing for %s: %v", ad.CoerceAndRelayNTLMToSMB.String(), err)
+						if authenticatedUserID, ok := authenticatedUsers[domainSid]; !ok {
+							t.Fatalf("authenticated user not found for %s", domainSid)
+						} else if protectedUsersForDomain, ok := protectedUsersCache[domainSid]; !ok {
+							continue
+						} else if ldapSigningForDomain, ok := ldapSigningCache[domainSid]; !ok {
+							continue
+						} else if protectedUsersForDomain.Contains(innerComputer.ID.Uint64()) && !ldapSigningForDomain.IsValidFunctionalLevel {
+							continue
+						} else if err = ad2.PostCoerceAndRelayNTLMToSMB(tx, outC, groupExpansions, innerComputer, authenticatedUserID, &compositionCounter); err != nil {
+							t.Logf("failed post processing for %s: %v", ad.CoerceAndRelayNTLMToSMB.String(), err)
+						}
+					}
+					return nil
+				})
+				require.NoError(t, err)
+			}
+
+			err = operation.Done()
+			require.NoError(t, err)
+
+			// Test start node
+			db.ReadTransaction(context.Background(), func(tx graph.Transaction) error {
+				if results, err := ops.FetchRelationships(tx.Relationships().Filterf(func() graph.Criteria {
+					return query.Kind(query.Relationship(), ad.CoerceAndRelayNTLMToSMB)
+				})); err != nil {
+					t.Fatalf("error fetching ntlm to smb edges in integration test; %v", err)
+				} else {
+					require.Len(t, results, 2)
+
+					for _, result := range results {
+						start, end, err := ops.FetchRelationshipNodes(tx, result)
+						require.NoError(t, err)
+
+						if start.ID == harness.NTLMCoerceAndRelayNTLMToSMB.Group2.ID {
+							assert.Equal(t, end.ID, harness.NTLMCoerceAndRelayNTLMToSMB.Computer9.ID)
+						} else if start.ID == harness.NTLMCoerceAndRelayNTLMToSMB.Group1.ID {
+							assert.Equal(t, end.ID, harness.NTLMCoerceAndRelayNTLMToSMB.Computer2.ID)
+						} else {
+							require.FailNow(t, "unrecognized start node id")
+						}
 					}
 				}
 				return nil
 			})
-			require.NoError(t, err)
-		}
+		})
+	})
 
-		err = operation.Done()
-		require.NoError(t, err)
-
-		// Test start node
-		db.ReadTransaction(context.Background(), func(tx graph.Transaction) error {
-			if results, err := ops.FetchRelationships(tx.Relationships().Filterf(func() graph.Criteria {
-				return query.Kind(query.Relationship(), ad.CoerceAndRelayNTLMToSMB)
-			})); err != nil {
-				t.Fatalf("error fetching ntlm to smb edges in integration test; %v", err)
-			} else {
-				require.Len(t, results, 2)
-
-				for _, result := range results {
-					start, end, err := ops.FetchRelationshipNodes(tx, result)
-					require.NoError(t, err)
-
-					if start.ID == harness.NTLMCoerceAndRelayNTLMToSMB.Group2.ID {
-						assert.Equal(t, end.ID, harness.NTLMCoerceAndRelayNTLMToSMB.Computer9.ID)
-					} else if start.ID == harness.NTLMCoerceAndRelayNTLMToSMB.Group1.ID {
-						assert.Equal(t, end.ID, harness.NTLMCoerceAndRelayNTLMToSMB.Computer2.ID)
-					} else {
-						require.FailNow(t, "unrecognized start node id")
-					}
-				}
-			}
+	t.Run("NTLMCoerceAndRelayNTLMToSMB Self Relay Does Not Create Edge", func(t *testing.T) {
+		testContext.DatabaseTestWithSetup(func(harness *integration.HarnessDetails) error {
+			harness.NTLMCoerceAndRelayNTLMToSMBSelfRelay.Setup(testContext)
 			return nil
+		}, func(harness integration.HarnessDetails, db graph.Database) {
+			operation := analysis.NewPostRelationshipOperation(context.Background(), db, "NTLM - CoerceAndRelayNTLMToSMB - Relay To Self")
+
+			groupExpansions, computers, domains, authenticatedUsers, err := fetchNTLMPrereqs(db)
+			require.NoError(t, err)
+
+			ldapSigningCache, err := ad2.FetchLDAPSigningCache(testContext.Context(), db)
+			require.NoError(t, err)
+
+			protectedUsersCache, err := ad2.FetchProtectedUsersMappedToDomains(testContext.Context(), db, groupExpansions)
+			require.NoError(t, err)
+
+			compositionCounter := analysis.NewCompositionCounter()
+
+			for _, domain := range domains {
+				innerDomain := domain
+
+				err = operation.Operation.SubmitReader(func(ctx context.Context, tx graph.Transaction, outC chan<- analysis.CreatePostRelationshipJob) error {
+					for _, computer := range computers {
+						innerComputer := computer
+						domainSid, _ := innerDomain.Properties.Get(ad.DomainSID.String()).String()
+
+						if authenticatedUserID, ok := authenticatedUsers[domainSid]; !ok {
+							t.Fatalf("authenticated user not found for %s", domainSid)
+						} else if protectedUsersForDomain, ok := protectedUsersCache[domainSid]; !ok {
+							continue
+						} else if ldapSigningForDomain, ok := ldapSigningCache[domainSid]; !ok {
+							continue
+						} else if protectedUsersForDomain.Contains(innerComputer.ID.Uint64()) && !ldapSigningForDomain.IsValidFunctionalLevel {
+							continue
+						} else if err = ad2.PostCoerceAndRelayNTLMToSMB(tx, outC, groupExpansions, innerComputer, authenticatedUserID, &compositionCounter); err != nil {
+							t.Logf("failed post processing for %s: %v", ad.CoerceAndRelayNTLMToSMB.String(), err)
+						}
+					}
+					return nil
+				})
+				require.NoError(t, err)
+			}
+
+			err = operation.Done()
+			require.NoError(t, err)
+
+			db.ReadTransaction(context.Background(), func(tx graph.Transaction) error {
+				if results, err := ops.FetchRelationships(tx.Relationships().Filterf(func() graph.Criteria {
+					return query.Kind(query.Relationship(), ad.CoerceAndRelayNTLMToSMB)
+				})); err != nil {
+					t.Fatalf("error fetching NTLM to LDAPS edges in integration test; %v", err)
+				} else {
+					require.Len(t, results, 0)
+				}
+				return nil
+			})
+
 		})
 	})
 }
@@ -350,7 +412,7 @@ func fetchComputerCache(db graph.Database, domain *graph.Node) (map[string]cardi
 func TestPostCoerceAndRelayNTLMToLDAP(t *testing.T) {
 	testContext := integration.NewGraphTestContext(t, graphschema.DefaultGraphSchema())
 
-	t.Run("NTLMCoerceAndRelayNTLMToLDAP", func(t *testing.T) {
+	t.Run("NTLMCoerceAndRelayNTLMToLDAP Success", func(t *testing.T) {
 		testContext.DatabaseTestWithSetup(func(harness *integration.HarnessDetails) error {
 			harness.NTLMCoerceAndRelayNTLMToLDAP.Setup(testContext)
 			return nil
@@ -491,6 +553,60 @@ func TestPostCoerceAndRelayNTLMToLDAP(t *testing.T) {
 							require.FailNow(t, "unrecognized start node id")
 						}
 					}
+				}
+				return nil
+			})
+		})
+	})
+
+	t.Run("NTLMCoerceAndRelayNTLMToLDAPS Self Relay Does Not Create Edge", func(t *testing.T) {
+		testContext.DatabaseTestWithSetup(func(harness *integration.HarnessDetails) error {
+			harness.NTLMCoerceAndRelayToLDAPSelfRelay.Setup(testContext)
+			return nil
+		}, func(harness integration.HarnessDetails, db graph.Database) {
+			operation := analysis.NewPostRelationshipOperation(context.Background(), db, "NTLM Post Process Test - CoerceAndRelayNTLMToLDAP - Self Relay")
+
+			groupExpansions, computers, _, authenticatedUsers, err := fetchNTLMPrereqs(db)
+			require.NoError(t, err)
+
+			ldapSigningCache, err := ad2.FetchLDAPSigningCache(testContext.Context(), db)
+			require.NoError(t, err)
+
+			protectedUsersCache, err := ad2.FetchProtectedUsersMappedToDomains(testContext.Context(), db, groupExpansions)
+			require.NoError(t, err)
+
+			err = operation.Operation.SubmitReader(func(ctx context.Context, tx graph.Transaction, outC chan<- analysis.CreatePostRelationshipJob) error {
+				for _, computer := range computers {
+					innerComputer := computer
+					domainSid, err := innerComputer.Properties.Get(ad.DomainSID.String()).String()
+					require.NoError(t, err)
+
+					if authenticatedUserID, ok := authenticatedUsers[domainSid]; !ok {
+						t.Fatalf("authenticated user not found for %s", domainSid)
+					} else if protectedUsersForDomain, ok := protectedUsersCache[domainSid]; !ok {
+						continue
+					} else if ldapSigningForDomain, ok := ldapSigningCache[domainSid]; !ok {
+						continue
+					} else if protectedUsersForDomain.Contains(innerComputer.ID.Uint64()) && !ldapSigningForDomain.IsValidFunctionalLevel {
+						continue
+					} else if err = ad2.PostCoerceAndRelayNTLMToLDAP(outC, innerComputer, authenticatedUserID, ldapSigningCache); err != nil {
+						t.Logf("failed post processing for %s: %v", ad.CoerceAndRelayNTLMToLDAP.String(), err)
+					}
+				}
+				return nil
+			})
+			require.NoError(t, err)
+
+			err = operation.Done()
+			require.NoError(t, err)
+
+			db.ReadTransaction(context.Background(), func(tx graph.Transaction) error {
+				if results, err := ops.FetchRelationships(tx.Relationships().Filterf(func() graph.Criteria {
+					return query.Kind(query.Relationship(), ad.CoerceAndRelayNTLMToLDAP)
+				})); err != nil {
+					t.Fatalf("error fetching NTLM to LDAPS edges in integration test; %v", err)
+				} else {
+					require.Len(t, results, 0)
 				}
 				return nil
 			})

--- a/cmd/api/src/test/integration/harnesses.go
+++ b/cmd/api/src/test/integration/harnesses.go
@@ -9584,7 +9584,6 @@ func (s *CoerceAndRelayNTLMToLDAP) Setup(graphTestContext *GraphTestContext) {
 
 type CoerceAndRelayNTLMToLDAPSelfRelay struct {
 	Computer1 *graph.Node
-	Computer2 *graph.Node
 	Domain1   *graph.Node
 	Group1    *graph.Node
 	Group2    *graph.Node
@@ -9613,7 +9612,6 @@ func (s *CoerceAndRelayNTLMToLDAPSelfRelay) Setup(graphTestContext *GraphTestCon
 	graphTestContext.UpdateNode(s.Group2)
 
 	graphTestContext.NewRelationship(s.Computer1, s.Domain1, ad.DCFor)
-	graphTestContext.NewRelationship(s.Computer2, s.Group1, ad.MemberOf)
 }
 
 type CoerceAndRelayNTLMToLDAPS struct {
@@ -9757,6 +9755,38 @@ func (s *CoerceAndRelayNTLMToLDAPS) Setup(graphTestContext *GraphTestContext) {
 	graphTestContext.NewRelationship(s.Computer12, s.Domain3, ad.DCFor)
 }
 
+type CoerceAndRelayNTLMToLDAPSSelfRelay struct {
+	Computer1 *graph.Node
+	Domain1   *graph.Node
+	Group1    *graph.Node
+	Group2    *graph.Node
+}
+
+func (s *CoerceAndRelayNTLMToLDAPSSelfRelay) Setup(graphTestContext *GraphTestContext) {
+	domain1Sid := RandomDomainSID()
+
+	s.Computer1 = graphTestContext.NewActiveDirectoryComputer("Computer1", domain1Sid)
+	s.Computer1.Properties.Set(ad.IsDC.String(), true)
+	s.Computer1.Properties.Set(ad.LDAPSEPA.String(), false)
+	s.Computer1.Properties.Set(ad.LDAPSAvailable.String(), true)
+	s.Computer1.Properties.Set(ad.WebClientRunning.String(), true)
+	graphTestContext.UpdateNode(s.Computer1)
+
+	s.Domain1 = graphTestContext.NewActiveDirectoryDomain("Domain1", domain1Sid, false, true)
+	s.Domain1.Properties.Set(ad.FunctionalLevel.String(), "2016")
+	graphTestContext.UpdateNode(s.Domain1)
+
+	s.Group1 = graphTestContext.NewActiveDirectoryGroup("Group1", domain1Sid)
+	s.Group1.Properties.Set(common.ObjectID.String(), fmt.Sprintf("group1-%s%s", domain1Sid, adAnalysis.ProtectedUsersSuffix))
+	graphTestContext.UpdateNode(s.Group1)
+
+	s.Group2 = graphTestContext.NewActiveDirectoryGroup("Group2", domain1Sid)
+	s.Group2.Properties.Set(common.ObjectID.String(), fmt.Sprintf("group2-%s%s", domain1Sid, adAnalysis.AuthenticatedUsersSuffix))
+	graphTestContext.UpdateNode(s.Group2)
+
+	graphTestContext.NewRelationship(s.Computer1, s.Domain1, ad.DCFor)
+}
+
 type HarnessDetails struct {
 	RDP                                             RDPHarness
 	RDPB                                            RDPHarness2
@@ -9863,6 +9893,7 @@ type HarnessDetails struct {
 	NTLMCoerceAndRelayNTLMToLDAPS                   CoerceAndRelayNTLMToLDAPS
 	NTLMCoerceAndRelayNTLMToADCS                    CoerceAndRelayNTLMtoADCS
 	NTLMCoerceAndRelayToLDAPSelfRelay               CoerceAndRelayNTLMToLDAPSelfRelay
+	NTLMCoerceAndRelayToLDAPSSelfRelay              CoerceAndRelayNTLMToLDAPSSelfRelay
 	NTLMCoerceAndRelayNTLMToSMBSelfRelay            CoerceAndRelayNTLMToSMBSelfRelay
 	OwnsWriteOwnerPriorCollectorVersions            OwnsWriteOwnerPriorCollectorVersions
 }

--- a/cmd/api/src/test/integration/harnesses.go
+++ b/cmd/api/src/test/integration/harnesses.go
@@ -9018,6 +9018,39 @@ func (s *CoerceAndRelayNTLMToSMB) Setup(graphTestContext *GraphTestContext) {
 	graphTestContext.NewRelationship(s.Computer10, s.Computer6, ad.AdminTo)
 }
 
+type CoerceAndRelayNTLMToSMBSelfRelay struct {
+	Computer1 *graph.Node
+	Computer2 *graph.Node
+	Domain1   *graph.Node
+	Group1    *graph.Node
+	Group2    *graph.Node
+}
+
+func (s *CoerceAndRelayNTLMToSMBSelfRelay) Setup(graphTestContext *GraphTestContext) {
+	domain1Sid := RandomDomainSID()
+
+	s.Computer1 = graphTestContext.NewActiveDirectoryComputer("Computer1", domain1Sid)
+	s.Computer1.Properties.Set(ad.SMBSigning.String(), false)
+	s.Computer1.Properties.Set(ad.RestrictOutboundNTLM.String(), false)
+	graphTestContext.UpdateNode(s.Computer1)
+
+	s.Group1 = graphTestContext.NewActiveDirectoryGroup("Group1", domain1Sid)
+	s.Group1.Properties.Set(common.ObjectID.String(), fmt.Sprintf("group1%s", adAnalysis.ProtectedUsersSuffix))
+	graphTestContext.UpdateNode(s.Group1)
+
+	s.Group2 = graphTestContext.NewActiveDirectoryGroup("Group2", domain1Sid)
+	s.Group2.Properties.Set(common.ObjectID.String(), fmt.Sprintf("group2%s", adAnalysis.AuthenticatedUsersSuffix))
+	graphTestContext.UpdateNode(s.Group2)
+
+	s.Domain1 = graphTestContext.NewActiveDirectoryDomain("Domain1", domain1Sid, false, true)
+	s.Domain1.Properties.Set(ad.FunctionalLevel.String(), "2008")
+	graphTestContext.UpdateNode(s.Domain1)
+
+	graphTestContext.NewRelationship(s.Computer1, s.Domain1, ad.DCFor)
+	graphTestContext.NewRelationship(s.Computer1, s.Group1, ad.MemberOf)
+	graphTestContext.NewRelationship(s.Group1, s.Computer1, ad.AdminTo)
+}
+
 type OwnsWriteOwner struct {
 
 	// Domain 1
@@ -9549,6 +9582,40 @@ func (s *CoerceAndRelayNTLMToLDAP) Setup(graphTestContext *GraphTestContext) {
 	graphTestContext.NewRelationship(s.Computer9, s.Domain3, ad.DCFor)
 }
 
+type CoerceAndRelayNTLMToLDAPSelfRelay struct {
+	Computer1 *graph.Node
+	Computer2 *graph.Node
+	Domain1   *graph.Node
+	Group1    *graph.Node
+	Group2    *graph.Node
+}
+
+func (s *CoerceAndRelayNTLMToLDAPSelfRelay) Setup(graphTestContext *GraphTestContext) {
+	domain1Sid := RandomDomainSID()
+
+	s.Computer1 = graphTestContext.NewActiveDirectoryComputer("Computer1", domain1Sid)
+	s.Computer1.Properties.Set(ad.LDAPAvailable.String(), true)
+	s.Computer1.Properties.Set(ad.LDAPSigning.String(), false)
+	s.Computer1.Properties.Set(ad.IsDC.String(), true)
+	s.Computer1.Properties.Set(ad.WebClientRunning.String(), true)
+	graphTestContext.UpdateNode(s.Computer1)
+
+	s.Domain1 = graphTestContext.NewActiveDirectoryDomain("Domain1", domain1Sid, false, true)
+	s.Domain1.Properties.Set(ad.FunctionalLevel.String(), "2016")
+	graphTestContext.UpdateNode(s.Domain1)
+
+	s.Group1 = graphTestContext.NewActiveDirectoryGroup("Group1", domain1Sid)
+	s.Group1.Properties.Set(common.ObjectID.String(), fmt.Sprintf("group1-%s%s", domain1Sid, adAnalysis.ProtectedUsersSuffix))
+	graphTestContext.UpdateNode(s.Group1)
+
+	s.Group2 = graphTestContext.NewActiveDirectoryGroup("Group2", domain1Sid)
+	s.Group2.Properties.Set(common.ObjectID.String(), fmt.Sprintf("group2-%s%s", domain1Sid, adAnalysis.AuthenticatedUsersSuffix))
+	graphTestContext.UpdateNode(s.Group2)
+
+	graphTestContext.NewRelationship(s.Computer1, s.Domain1, ad.DCFor)
+	graphTestContext.NewRelationship(s.Computer2, s.Group1, ad.MemberOf)
+}
+
 type CoerceAndRelayNTLMToLDAPS struct {
 	Computer1  *graph.Node
 	Computer10 *graph.Node
@@ -9795,5 +9862,7 @@ type HarnessDetails struct {
 	NTLMCoerceAndRelayNTLMToLDAP                    CoerceAndRelayNTLMToLDAP
 	NTLMCoerceAndRelayNTLMToLDAPS                   CoerceAndRelayNTLMToLDAPS
 	NTLMCoerceAndRelayNTLMToADCS                    CoerceAndRelayNTLMtoADCS
+	NTLMCoerceAndRelayToLDAPSelfRelay               CoerceAndRelayNTLMToLDAPSelfRelay
+	NTLMCoerceAndRelayNTLMToSMBSelfRelay            CoerceAndRelayNTLMToSMBSelfRelay
 	OwnsWriteOwnerPriorCollectorVersions            OwnsWriteOwnerPriorCollectorVersions
 }

--- a/packages/go/analysis/ad/ntlm.go
+++ b/packages/go/analysis/ad/ntlm.go
@@ -344,7 +344,14 @@ func PostCoerceAndRelayNTLMToADCS(adcsCache ADCSCache, operation analysis.StatTr
 						return nil
 					}
 
+					checkedCerts := make([]graph.ID, 0)
 					for _, certTemplate := range publishedCertTemplates {
+						if slices.Contains(checkedCerts, certTemplate.ID) {
+							continue
+						} else {
+							checkedCerts = append(checkedCerts, certTemplate.ID)
+						}
+
 						if valid, err := isCertTemplateValidForADCSRelay(certTemplate); err != nil {
 							slog.ErrorContext(ctx, fmt.Sprintf("Error validating cert template %d for NTLM ADCS relay: %v", certTemplate.ID, err))
 							continue
@@ -640,7 +647,7 @@ func PostCoerceAndRelayNTLMToLDAP(outC chan<- analysis.CreatePostRelationshipJob
 					outC <- analysis.CreatePostRelationshipJob{
 						FromID: authenticatedUserGroupID,
 						ToID:   computer.ID,
-						Kind:   ad.CoerceAndRelayNTLMToLDAP,
+						Kind:   ad.CoerceAndRelayNTLMToLDAPS,
 					}
 				} else if len(signingCache.relayableToDCLDAPS) > 1 {
 					outC <- analysis.CreatePostRelationshipJob{


### PR DESCRIPTION
## Description

This PR prevents computers from self relaying in post processing for NTLM attack paths pertaining to SMB, LDAP, and LDAPS.

## Motivation and Context

This PR addresses: BED-5544

## How Has This Been Tested?

Test harnesses were setup with self relay scenarios and integration tests were written around those to ensure no edges were being created.
Existing integration tests pass with the expected number of edges being created, ensuring that the new logic only affects scenarios where a self relay is possible

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
