### PR TITLE
BED-5581: Remove extra browser history entries from pathfinding swap

### DIFF
--- a/cmd/ui/src/views/Explore/ExploreSearch/PathfindingSearch.tsx
+++ b/cmd/ui/src/views/Explore/ExploreSearch/PathfindingSearch.tsx
@@ -31,6 +31,7 @@ type PathfindingSearchState = {
     handleDestinationNodeEdited: (edit: string) => void;
     handleSourceNodeSelected: (selected: SearchValue) => void;
     handleDestinationNodeSelected: (selected: SearchValue) => void;
+    handleSwapPathfindingInputs: () => void;
 };
 
 const PathfindingSearch = ({ pathfindingSearchState }: { pathfindingSearchState: PathfindingSearchState }) => {
@@ -43,14 +44,8 @@ const PathfindingSearch = ({ pathfindingSearchState }: { pathfindingSearchState:
         handleDestinationNodeEdited,
         handleSourceNodeSelected,
         handleDestinationNodeSelected,
+        handleSwapPathfindingInputs,
     } = pathfindingSearchState;
-
-    const handleSwapPathfindingInputs = () => {
-        if (sourceSelectedItem && destinationSelectedItem) {
-            handleSourceNodeSelected(destinationSelectedItem);
-            handleDestinationNodeSelected(sourceSelectedItem);
-        }
-    };
 
     return (
         <Box display={'flex'} alignItems={'center'} gap={1}>

--- a/cmd/ui/src/views/Explore/ExploreSearch/switches/usePathfindingSearchSwitch.ts
+++ b/cmd/ui/src/views/Explore/ExploreSearch/switches/usePathfindingSearchSwitch.ts
@@ -43,6 +43,13 @@ export const usePathfindingSearchSwitch = () => {
         dispatch(searchbarActions.destinationNodeSelected(selected));
     };
 
+    const handleSwapPathfindingInputs = () => {
+        if (sourceSelectedItem && destinationSelectedItem) {
+            handleSourceNodeSelected(destinationSelectedItem);
+            handleDestinationNodeSelected(sourceSelectedItem);
+        }
+    };
+
     return {
         sourceSearchTerm,
         destinationSearchTerm,
@@ -52,5 +59,6 @@ export const usePathfindingSearchSwitch = () => {
         handleDestinationNodeEdited,
         handleSourceNodeSelected,
         handleDestinationNodeSelected,
+        handleSwapPathfindingInputs,
     };
 };

--- a/packages/javascript/bh-shared-ui/src/hooks/useExploreGraph/usePathfindingSearch.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/hooks/useExploreGraph/usePathfindingSearch.test.tsx
@@ -110,4 +110,20 @@ describe('usePathfindingSearch', () => {
             })
         );
     });
+
+    it('allows a consumer to swap the values of the two inputs and update the query params accordingly', async () => {
+        const url = `?primarySearch=${TEST_STRING_1}&secondarySearch=${TEST_STRING_2}&searchType=pathfinding`;
+        const history = createMemoryHistory({ initialEntries: [url] });
+
+        const hook = renderHook(() => usePathfindingSearch(), { history });
+
+        await waitFor(() => expect(hook.result.current.sourceSearchTerm).toEqual(TEST_STRING_1));
+        await waitFor(() => expect(hook.result.current.destinationSearchTerm).toEqual(TEST_STRING_2));
+
+        await act(async () => hook.result.current.handleSwapPathfindingInputs());
+
+        expect(history.location.search).toContain(`primarySearch=${TEST_STRING_2}`);
+        expect(history.location.search).toContain(`secondarySearch=${TEST_STRING_1}`);
+        expect(history.location.search).toContain('searchType=pathfinding');
+    });
 });

--- a/packages/javascript/bh-shared-ui/src/hooks/useExploreGraph/usePathfindingSearch.ts
+++ b/packages/javascript/bh-shared-ui/src/hooks/useExploreGraph/usePathfindingSearch.ts
@@ -110,7 +110,6 @@ export const usePathfindingSearch = () => {
 
     const handleSwapPathfindingInputs = () => {
         if (sourceSelectedItem && destinationSelectedItem) {
-            console.log('setting params: ', destinationSelectedItem, sourceSelectedItem);
             setExploreParams({
                 searchType: 'pathfinding',
                 primarySearch: destinationSelectedItem.objectid,

--- a/packages/javascript/bh-shared-ui/src/hooks/useExploreGraph/usePathfindingSearch.ts
+++ b/packages/javascript/bh-shared-ui/src/hooks/useExploreGraph/usePathfindingSearch.ts
@@ -108,6 +108,17 @@ export const usePathfindingSearch = () => {
         }
     };
 
+    const handleSwapPathfindingInputs = () => {
+        if (sourceSelectedItem && destinationSelectedItem) {
+            console.log('setting params: ', destinationSelectedItem, sourceSelectedItem);
+            setExploreParams({
+                searchType: 'pathfinding',
+                primarySearch: destinationSelectedItem.objectid,
+                secondarySearch: sourceSelectedItem.objectid,
+            });
+        }
+    };
+
     // Handle changes internal to the search form that should not trigger a graph query. Each param should sync independently
     const handleSourceNodeEdited = (edit: string) => {
         setSourceSelectedItem(undefined);
@@ -128,5 +139,6 @@ export const usePathfindingSearch = () => {
         handleSourceNodeSelected,
         handleDestinationNodeEdited,
         handleDestinationNodeSelected,
+        handleSwapPathfindingInputs,
     };
 };


### PR DESCRIPTION
## Description
With our new deep linking changes to the Explore page, clicking the pathfinding swap button and then navigating back through browser history shows two history locations have been created, and the intermediary state has the source and destination nodes set to the same value.

This fix updates our pathfinding swap process to make sure all URL changes occur in one step.

## Motivation and Context

This PR addresses: [BED-5581](https://specterops.atlassian.net/browse/BED-5581)

This intermediary state where both inputs are the same is unhelpful to users and will always create an invalid pathfinding result.

## How Has This Been Tested?
Added an additional unit test to cover the new function.

## Screenshots (optional):

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


[BED-5581]: https://specterops.atlassian.net/browse/BED-5581?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ