### PR TITLE
BED-5582: deep linking bug fix for removing searchType when opening edge accordions

### DIFF
--- a/cmd/ui/src/views/Explore/EdgeInfo/EdgeInfoContent.tsx
+++ b/cmd/ui/src/views/Explore/EdgeInfo/EdgeInfoContent.tsx
@@ -95,9 +95,10 @@ const EdgeInfoContent: FC<{ selectedEdge: NonNullable<SelectedEdge> }> = ({ sele
                         const setExpandedPanelSectionsParam = () => {
                             setExploreParams({
                                 expandedPanelSections: [sectionKeyLabel],
-                                ...(sectionKeyLabel === 'composition'
-                                    ? { searchType: 'composition', relationshipQueryItemId: selectedItem }
-                                    : { searchType: null }),
+                                ...(sectionKeyLabel === 'composition' && {
+                                    searchType: 'composition',
+                                    relationshipQueryItemId: selectedItem,
+                                }),
                             });
                         };
 


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description
Deep linking bug fix for removing `searchType` when opening edge accordions. That param should persist and only be updated via the Edge panel when selecting a composition accordion

## Motivation and Context

This PR addresses: BED-5582

## How Has This Been Tested?
Manually tested and added unit tests

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)
- Database Migrations

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [ ] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [ ] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [ ] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
