### PR TITLE
BED-4948: Set initial node label color based on dark mode setting

### DIFF
--- a/cmd/ui/src/components/SigmaChart.tsx
+++ b/cmd/ui/src/components/SigmaChart.tsx
@@ -96,6 +96,7 @@ const SigmaChart = forwardRef(function SigmaChart(
                     edgeLabelSize: 12,
                     labelSize: 12,
                     labelFont: 'Roboto',
+                    labelColor: { color: theme.palette.color.primary },
                     labelRenderer: drawLabel,
                     maxCameraRatio: MAX_CAMERA_RATIO,
                     minCameraRatio: MIN_CAMERA_RATIO,


### PR DESCRIPTION
## Description
Updates our initial sigma settings to use the correct color for node labels based on the current dark mode setting.

## Motivation and Context

This PR addresses: [BED-4948](https://specterops.atlassian.net/browse/BED-4948)

Currently, the node labels on initial load in dark mode (or after toggling dark mode on/off) are the incorrect color and can't be read against the application's background.

## How Has This Been Tested?
Manual testing

## Screenshots (optional):

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


[BED-4948]: https://specterops.atlassian.net/browse/BED-4948?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ