### PR TITLE
BED-5564 Deny Users From Self-Deleting via the API

### DIFF
--- a/cmd/api/src/api/v2/auth/auth.go
+++ b/cmd/api/src/api/v2/auth/auth.go
@@ -516,12 +516,17 @@ func (s ManagementResource) DeleteUser(response http.ResponseWriter, request *ht
 		user      model.User
 		pathVars  = mux.Vars(request)
 		rawUserID = pathVars[api.URIPathVariableUserID]
+		bhCtx     = ctx.FromRequest(request)
 	)
 
 	if userID, err := uuid.FromString(rawUserID); err != nil {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, api.ErrorResponseDetailsIDMalformed, request), response)
 	} else if user, err = s.db.GetUser(request.Context(), userID); err != nil {
 		api.HandleDatabaseError(request, response, err)
+	} else if currentUser, found := auth.GetUserFromAuthCtx(bhCtx.AuthCtx); !found {
+		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, "No associated user found with request", request), response)
+	} else if userID.String() == currentUser.ID.String() {
+		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, "User cannot delete themselves", request), response)
 	} else if err := s.db.DeleteUser(request.Context(), user); err != nil {
 		api.HandleDatabaseError(request, response, err)
 	} else {

--- a/cmd/api/src/api/v2/auth/auth_test.go
+++ b/cmd/api/src/api/v2/auth/auth_test.go
@@ -1875,10 +1875,11 @@ func TestManagementResource_DeleteUser_BadUserID(t *testing.T) {
 }
 
 func TestManagementResource_DeleteUser_UserNotFound(t *testing.T) {
-	mockCtrl := gomock.NewController(t)
+	var (
+		mockCtrl = gomock.NewController(t)
+		endpoint = "/api/v2/bloodhound-users"
+	)
 	defer mockCtrl.Finish()
-
-	endpoint := "/api/v2/bloodhound-users"
 
 	userID, err := uuid.NewV4()
 	require.Nil(t, err)
@@ -1898,6 +1899,82 @@ func TestManagementResource_DeleteUser_UserNotFound(t *testing.T) {
 	handler.ServeHTTP(rr, req)
 
 	require.Equal(t, rr.Code, http.StatusNotFound)
+}
+
+func TestManagementResource_DeleteUser_UserBhCtxNotFound(t *testing.T) {
+	var (
+		mockCtrl = gomock.NewController(t)
+		endpoint = "/api/v2/bloodhound-users"
+	)
+
+	defer mockCtrl.Finish()
+
+	userID, err := uuid.NewV4()
+	require.NoError(t, err)
+
+	resources, mockDB := apitest.NewAuthManagementResource(mockCtrl)
+	mockDB.EXPECT().GetUser(gomock.Any(), userID).Return(model.User{
+		Unique: model.Unique{
+			ID: userID,
+		},
+	}, nil)
+
+	ctx := context.WithValue(context.Background(), ctx.ValueKey, &ctx.Context{})
+
+	req, err := http.NewRequestWithContext(ctx, "DELETE", endpoint, nil)
+	require.Nil(t, err)
+
+	req = mux.SetURLVars(req, map[string]string{api.URIPathVariableUserID: userID.String()})
+	req.Header.Set(headers.ContentType.String(), mediatypes.ApplicationJson.String())
+
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(resources.DeleteUser)
+	handler.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+	require.Contains(t, rr.Body.String(), "No associated user found")
+}
+
+func TestManagementResource_DeleteUser_UserCannotSelfDelete(t *testing.T) {
+	var (
+		mockCtrl  = gomock.NewController(t)
+		adminRole = model.Role{
+			Serial: model.Serial{
+				ID: 1,
+			},
+		}
+	)
+	endpoint := "/api/v2/bloodhound-users"
+
+	defer mockCtrl.Finish()
+
+	userID, err := uuid.NewV4()
+	require.NoError(t, err)
+
+	adminUser := model.User{AuthSecret: defaultDigestAuthSecret(t, "currentPassword"), Unique: model.Unique{ID: userID}, Roles: model.Roles{adminRole}}
+
+	resources, mockDB := apitest.NewAuthManagementResource(mockCtrl)
+	mockDB.EXPECT().GetUser(gomock.Any(), userID).Return(model.User{
+		Unique: model.Unique{
+			ID: userID,
+		},
+	}, nil)
+
+	bhCtx := ctx.Get(context.WithValue(context.Background(), ctx.ValueKey, &ctx.Context{}))
+	bhCtx.AuthCtx.Owner = adminUser
+
+	req, err := http.NewRequestWithContext(bhCtx.ConstructGoContext(), "DELETE", endpoint, nil)
+	require.Nil(t, err)
+
+	req = mux.SetURLVars(req, map[string]string{api.URIPathVariableUserID: userID.String()})
+	req.Header.Set(headers.ContentType.String(), mediatypes.ApplicationJson.String())
+
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(resources.DeleteUser)
+	handler.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+	require.Contains(t, rr.Body.String(), "User cannot delete themselves")
 }
 
 func TestManagementResource_DeleteUser_GetUserError(t *testing.T) {


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

*Describe your changes in detail*

## Motivation and Context

This PR addresses: [GitHub issue or Jira ticket number]

*Why is this change required? What problem does it solve?*

## How Has This Been Tested?

*Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc.*

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)
- Database Migrations

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [ ] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [ ] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [ ] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
