### PR TITLE
BED-5564: Deny Users From Self-Deleting Via The API

### DIFF
--- a/cmd/api/src/api/v2/auth/auth.go
+++ b/cmd/api/src/api/v2/auth/auth.go
@@ -525,7 +525,7 @@ func (s ManagementResource) DeleteUser(response http.ResponseWriter, request *ht
 		api.HandleDatabaseError(request, response, err)
 	} else if currentUser, found := auth.GetUserFromAuthCtx(bhCtx.AuthCtx); !found {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, "No associated user found with request", request), response)
-	} else if userID.String() == currentUser.ID.String() {
+	} else if userID == currentUser.ID {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, "User cannot delete themselves", request), response)
 	} else if err := s.db.DeleteUser(request.Context(), user); err != nil {
 		api.HandleDatabaseError(request, response, err)

--- a/cmd/api/src/api/v2/auth/auth.go
+++ b/cmd/api/src/api/v2/auth/auth.go
@@ -516,12 +516,17 @@ func (s ManagementResource) DeleteUser(response http.ResponseWriter, request *ht
 		user      model.User
 		pathVars  = mux.Vars(request)
 		rawUserID = pathVars[api.URIPathVariableUserID]
+		bhCtx     = ctx.FromRequest(request)
 	)
 
 	if userID, err := uuid.FromString(rawUserID); err != nil {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, api.ErrorResponseDetailsIDMalformed, request), response)
 	} else if user, err = s.db.GetUser(request.Context(), userID); err != nil {
 		api.HandleDatabaseError(request, response, err)
+	} else if currentUser, found := auth.GetUserFromAuthCtx(bhCtx.AuthCtx); !found {
+		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, "No associated user found with request", request), response)
+	} else if userID.String() == currentUser.ID.String() {
+		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, "User cannot delete themselves", request), response)
 	} else if err := s.db.DeleteUser(request.Context(), user); err != nil {
 		api.HandleDatabaseError(request, response, err)
 	} else {


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

It was found during a pen test that users could delete themselves from the API.
This became a particular problem when it was found that admins could delete themselves, which disallowed them from managing the BH instance

## Motivation and Context

This PR addresses: BED-5564


## How Has This Been Tested?

I sent a DELETE request to /api/v2/bloodhound-users/c9051693-59ef-479a-ba68-2e1143a333e9 and verified that I could not delete myself
<img width="2582" alt="image" src="https://github.com/user-attachments/assets/0b7507ec-f9cc-4d75-b4b0-438a49172dc8" />


## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
