### PR TITLE
Update API reference landing page

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -169,8 +169,8 @@
               {
                 "group": "BloodHound API",
                 "pages": [
-                  "integrations/bloodhound-api/json-formats",
-                  "integrations/bloodhound-api/working-with-api"
+                  "integrations/bloodhound-api/working-with-api",
+                  "integrations/bloodhound-api/json-formats"
                 ]
               },
               {
@@ -424,6 +424,12 @@
       {
         "tab": "API Reference",
         "groups": [
+          {
+            "group": "Get Started",
+            "pages": [
+              "reference/overview"
+            ]
+          },
           {
             "group": "Auth",
             "pages": [

--- a/docs/integrations/bloodhound-api/working-with-api.mdx
+++ b/docs/integrations/bloodhound-api/working-with-api.mdx
@@ -7,7 +7,7 @@ title: Work With the BloodHound API
 The BloodHound product family are API-first products, meaning everything functions on the underlying API layer. All data displayed in the portal, all commands given to SharpHound or AzureHound Enterprise collectors, and all data uploaded pass through the BloodHound APIs. Customers may utilize these APIs to extend the use of the BloodHound product to function with other tools in their environment. This article will show how to access the API and include some example use cases.
 
 ## API Documentation
-Our API reference is available [here](/reference/).
+Our API reference is available [here](../../reference/).
 
 Additionally, API documentation is hosted utilizing Swagger behind authentication within your tenant environment. After logging in, you may access it by clicking the cog in the top right corner of your tenant and clicking **API Explorer.**
 
@@ -15,44 +15,43 @@ Additionally, API documentation is hosted utilizing Swagger behind authenticatio
     <img src="/assets/image1-1.png"/>
 </Frame>
 
-
-## Using the API
+## Authentication
 
 The BloodHound API accepts two forms of authentication, each with its own limitations for security.
 
-- A JWT is generated through the login process utilizing your username, password, and 2FA token (or SAML-based authentication flow). These JWT tokens are active for 8 hours and are primarily for end-user access to the web-based application.
+- A JWT is generated through the login process using your username, password, and 2FA token (or SAML-based authentication flow). These JWT tokens are active for 8 hours and are primarily for end-user access to the web-based application.
 - An API key/ID pair is generated within the Administration interface. These do not expire and are primarily for long-term API integrations.
 
-BloodHound users should understand that there are two methods of creating API key/ID pairs, each serving a different purpose:
+There are two methods for creating API key/ID pairs, each serving a different purpose:
 
-- Non-personal API key/ID pairs, for integrations like [Splunk](/integrations/integrations/splunk)
-- [Personal API key/ID pairs](#create-a-personal-api-key-id-pair), for day-to-day use like [BloodHound Operator](https://www.youtube.com/watch?v=9Og-6_qyw_A)
+- Non-personal API key/ID pairs for integrations like [Splunk](../integrations/splunk)
+- [Personal API key/ID pairs](#create-a-personal-api-key-and-id-pair) for day-to-day use like [BloodHound Operator](https://www.youtube.com/watch?v=9Og-6_qyw_A)
 
-## Create a non-personal API key/ID pair
+### Create a non-personal API key/ID pair
 
 Administrators can create non-personal BloodHound users solely meant for API integrations.
 
 1. Log in as a user with the Administrator role.
-2. Create a new BloodHound user, see Creating Users.
+2. [Create a new BloodHound user](../../manage-bloodhound/auth/users-and-roles).
    - Give the user a long and unique password.
-3. **_Optional recommendation:_** Login as the newly created user and enable MFA.
+3. **_Optional recommendation:_** Log in as the newly created user and enable MFA.
 4. **_Optional recommendation:_** Securely dispose of the password and MFA configuration, as they are not needed for authenticating with a key/ID pair and they can be reset by an Administrator if needed.
-5. As the Administrator, go back to the Manage Users page.
-6. On the API user, click the hamburger menu and select **Generate / Revoke API Tokens**.
+5. As the Administrator, go back to the **Manage Users** page.
+6. On the API user, click the hamburger menu > **Generate / Revoke API Tokens**.
 
 <Frame>
   <img src="/assets/image1-2.png" alt="Generate API Tokens"/>
 </Frame>
 
-7. Select **Create Token**.
+7. Click **Create Token**.
 8. Give the token a descriptive name and click **Save**.
 9. Save the presented API key/ID pair and click **Close**.
    - **The API key will never be shown again. If you lose it, you must revoke the previous key and regenerate a new one.**
-10. You may now utilize this key ID pair for [calling the API](#calling-the-api)
+10. You may now use this key ID pair for [calling the API](#call-the-api)
 
-## Create a personal API Key/ID pair
+### Create a personal API Key and ID pair
 
-BloodHound users can create personal API Key/ID pairs from their "My Profile" section.
+Create a personal API Key/ID pair from the **My Profile** section.
 
 1. <p>In the top-right corner click <Icon icon="gear"iconType="solid"/> <Icon icon="arrow-right"iconType="solid"/> **My Profile**.</p>
 <Frame>
@@ -77,24 +76,24 @@ BloodHound users can create personal API Key/ID pairs from their "My Profile" se
   <img src="/assets/image1-6.png" alt="API Key Pair"/>
 </Frame>
 
-6. You may now utilize this key/ID pair for calling the API.
+Use this key/ID pair for calling the API.
 
-## Calling the API
+## Call the API
 
 Once you have your token, you can call the BloodHound API.
 
-**Using a JWT/Bearer Token**
+### Use a JWT/bearer token
 
-For quick tests or one-time calls, the JWT used by your browser may be the simplest route. The API will accept calls using the following header structure in the HTTP request:
+For quick tests or one-time calls, the JWT used by your browser may be the simplest route. The API accepts calls using the following header structure in the HTTP request:
 
-```
+```json
 'Authorization': Bearer $JWT_TOKEN
 ```
-If you open the Network tab within your browser, you will see calls against the API made utilizing this structure.
+If you open the **Network** tab in your browser, you'll see calls against the API made using this structure.
 
-**Using your API Key/ID Pair**
+### Use your API Key/ID pair
 
-For long-running API integrations, BloodHound's API utilizes hash-based message authentication code (HMAC) authentication using the API key as the secret key to verify the authenticity and integrity of the request. Calls against the API must include the following in the signed hash:
+For long-running API integrations, BloodHound's API uses hash-based message authentication code (HMAC) authentication using the API key as the secret key to verify the authenticity and integrity of the request. Calls against the API must include the following in the signed hash:
 
 - API key
 - HTTP method and URI
@@ -103,16 +102,16 @@ For long-running API integrations, BloodHound's API utilizes hash-based message 
 
 Calls against the API would need to include the following headers in the HTTP request:
 
-```
+```json
 'Authorization': bhesignature $TOKEN_ID
 'RequestDate': $RFC3339_DATETIME
 'Signature': $BASE64ENCODED_HMAC_SIGNATURE
 ```
 By validating the hash signature against the request, the API can validate that the calls were made by the original requestor, within a reasonable timeframe, against the proper API endpoint, including the original content body, and that no replay or content modification has occurred.
 
-The attached Python script is a full example implementation for calling the BloodHound APIs utilizing the API key/ID pair, however, the code block specific to calling the API has been extracted below.
+The attached Python script is a full example implementation for calling the BloodHound APIs using the API key/ID pair. The code block specific to calling the API is shown below.
 
-```
+```python
 def_request(self, method: str, uri: str, body: Optional[bytes] = None) -> requests.Response:
     # Digester is initialized with HMAC-SHA-256 using the token key as the HMAC digest key.
     digester = hmac.new(self._credentials.token_key.encode(), None, hashlib.sha256)

--- a/docs/openapi-spec.json
+++ b/docs/openapi-spec.json
@@ -2066,22 +2066,6 @@
           "Community",
           "Enterprise"
         ],
-        "requestBody": {
-          "description": "The request body for unenrolling a user from multi-factor authentication",
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "secret": {
-                    "type": "string"
-                  }
-                }
-              }
-            }
-          }
-        },
         "responses": {
           "200": {
             "description": "OK",
@@ -5042,27 +5026,6 @@
           "Community",
           "Enterprise"
         ],
-        "requestBody": {
-          "description": "The request body for revoking permissions of a saved query from users",
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "user_ids": {
-                    "type": "array",
-                    "description": "A list of user ids that will have their permission revoked from the given saved query",
-                    "items": {
-                      "type": "string",
-                      "format": "uuid"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
         "responses": {
           "204": {
             "$ref": "#/components/responses/no-content"

--- a/docs/openapi-spec.json
+++ b/docs/openapi-spec.json
@@ -4936,27 +4936,6 @@
           "Community",
           "Enterprise"
         ],
-        "requestBody": {
-          "description": "The request body for revoking permissions of a saved query from users",
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "user_ids": {
-                    "type": "array",
-                    "description": "A list of user ids that will have their permission revoked from the given saved query",
-                    "items": {
-                      "type": "string",
-                      "format": "uuid"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
         "responses": {
           "204": {
             "$ref": "#/components/responses/no-content"
@@ -5063,6 +5042,27 @@
           "Community",
           "Enterprise"
         ],
+        "requestBody": {
+          "description": "The request body for revoking permissions of a saved query from users",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "user_ids": {
+                    "type": "array",
+                    "description": "A list of user ids that will have their permission revoked from the given saved query",
+                    "items": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
         "responses": {
           "204": {
             "$ref": "#/components/responses/no-content"

--- a/docs/openapi-spec.json
+++ b/docs/openapi-spec.json
@@ -2066,6 +2066,22 @@
           "Community",
           "Enterprise"
         ],
+        "requestBody": {
+          "description": "The request body for unenrolling a user from multi-factor authentication",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "secret": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK",
@@ -4920,6 +4936,27 @@
           "Community",
           "Enterprise"
         ],
+        "requestBody": {
+          "description": "The request body for revoking permissions of a saved query from users",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "user_ids": {
+                    "type": "array",
+                    "description": "A list of user ids that will have their permission revoked from the given saved query",
+                    "items": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
         "responses": {
           "204": {
             "$ref": "#/components/responses/no-content"

--- a/docs/reference/ad-base-entities/get-entity-controllables.mdx
+++ b/docs/reference/ad-base-entities/get-entity-controllables.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/base/{object_id}/controllables
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/ad-base-entities/get-entity-controllers.mdx
+++ b/docs/reference/ad-base-entities/get-entity-controllers.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/base/{object_id}/controllers
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/ad-base-entities/get-entity-info.mdx
+++ b/docs/reference/ad-base-entities/get-entity-info.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/base/{object_id}
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/ad-users/get-user-entity-admin-rights.mdx
+++ b/docs/reference/ad-users/get-user-entity-admin-rights.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/users/{object_id}/admin-rights
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/ad-users/get-user-entity-constrained-delegation-rights.mdx
+++ b/docs/reference/ad-users/get-user-entity-constrained-delegation-rights.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/users/{object_id}/constrained-delegation-rights
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/ad-users/get-user-entity-controllables.mdx
+++ b/docs/reference/ad-users/get-user-entity-controllables.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/users/{object_id}/controllables
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/ad-users/get-user-entity-controllers.mdx
+++ b/docs/reference/ad-users/get-user-entity-controllers.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/users/{object_id}/controllers
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/ad-users/get-user-entity-dcom-rights.mdx
+++ b/docs/reference/ad-users/get-user-entity-dcom-rights.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/users/{object_id}/dcom-rights
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/ad-users/get-user-entity-info.mdx
+++ b/docs/reference/ad-users/get-user-entity-info.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/users/{object_id}
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/ad-users/get-user-entity-membership.mdx
+++ b/docs/reference/ad-users/get-user-entity-membership.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/users/{object_id}/memberships
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/ad-users/get-user-entity-powershell-remote-rights.mdx
+++ b/docs/reference/ad-users/get-user-entity-powershell-remote-rights.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/users/{object_id}/ps-remote-rights
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/ad-users/get-user-entity-rdp-rights.mdx
+++ b/docs/reference/ad-users/get-user-entity-rdp-rights.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/users/{object_id}/rdp-rights
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/ad-users/get-user-entity-sessions.mdx
+++ b/docs/reference/ad-users/get-user-entity-sessions.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/users/{object_id}/sessions
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/ad-users/get-user-entity-sql-admin-rights.mdx
+++ b/docs/reference/ad-users/get-user-entity-sql-admin-rights.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/users/{object_id}/sql-admin-rights
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/aia-cas/get-aia-ca-entity-controllers.mdx
+++ b/docs/reference/aia-cas/get-aia-ca-entity-controllers.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/aiacas/{object_id}/controllers
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/aia-cas/get-aia-ca-entity-info.mdx
+++ b/docs/reference/aia-cas/get-aia-ca-entity-info.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/aiacas/{object_id}
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/analysis/get-latest-tier-zero-combo-node.mdx
+++ b/docs/reference/analysis/get-latest-tier-zero-combo-node.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/meta-nodes/{domain_id}
 ---
+
+<img src="/assets/enterprise-edition-pill-tag.svg"/>

--- a/docs/reference/analysis/get-the-combo-tree-for-an-asset-group.mdx
+++ b/docs/reference/analysis/get-the-combo-tree-for-an-asset-group.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/asset-groups/{asset_group_id}/combo-node
 ---
+
+<img src="/assets/enterprise-edition-pill-tag.svg"/>

--- a/docs/reference/analysis/get-the-graph-for-meta-tree.mdx
+++ b/docs/reference/analysis/get-the-graph-for-meta-tree.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/meta-trees/{domain_id}
 ---
+
+<img src="/assets/enterprise-edition-pill-tag.svg"/>

--- a/docs/reference/api-info/get-api-spec.mdx
+++ b/docs/reference/api-info/get-api-spec.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/spec/openapi.yaml
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/api-info/get-api-version.mdx
+++ b/docs/reference/api-info/get-api-version.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/version
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/api-tokens/create-token-for-user.mdx
+++ b/docs/reference/api-tokens/create-token-for-user.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: post /api/v2/tokens
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/api-tokens/delete-a-user-token.mdx
+++ b/docs/reference/api-tokens/delete-a-user-token.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: delete /api/v2/tokens/{token_id}
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/api-tokens/list-auth-tokens.mdx
+++ b/docs/reference/api-tokens/list-auth-tokens.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/tokens
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/asset-isolation/create-an-asset-group.mdx
+++ b/docs/reference/asset-isolation/create-an-asset-group.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: post /api/v2/asset-groups
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/asset-isolation/delete-an-asset-group-selector.mdx
+++ b/docs/reference/asset-isolation/delete-an-asset-group-selector.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: delete /api/v2/asset-groups/{asset_group_id}/selectors/{asset_group_selector_id}
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/asset-isolation/delete-an-asset-group.mdx
+++ b/docs/reference/asset-isolation/delete-an-asset-group.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: delete /api/v2/asset-groups/{asset_group_id}
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/asset-isolation/get-asset-group-by-id.mdx
+++ b/docs/reference/asset-isolation/get-asset-group-by-id.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/asset-groups/{asset_group_id}
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/asset-isolation/get-asset-group-custom-member-count.mdx
+++ b/docs/reference/asset-isolation/get-asset-group-custom-member-count.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/asset-groups/{asset_group_id}/custom-selectors
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/asset-isolation/list-all-asset-isolation-group-members.mdx
+++ b/docs/reference/asset-isolation/list-all-asset-isolation-group-members.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/asset-groups/{asset_group_id}/members
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/asset-isolation/list-all-asset-isolation-groups.mdx
+++ b/docs/reference/asset-isolation/list-all-asset-isolation-groups.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/asset-groups
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/asset-isolation/list-asset-group-collections.mdx
+++ b/docs/reference/asset-isolation/list-asset-group-collections.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/asset-groups/{asset_group_id}/collections
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/asset-isolation/list-asset-group-member-count-by-kind.mdx
+++ b/docs/reference/asset-isolation/list-asset-group-member-count-by-kind.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/asset-groups/{asset_group_id}/members/counts
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/asset-isolation/update-an-asset-group.mdx
+++ b/docs/reference/asset-isolation/update-an-asset-group.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: put /api/v2/asset-groups/{asset_group_id}
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/asset-isolation/update-asset-group-selectors-1.mdx
+++ b/docs/reference/asset-isolation/update-asset-group-selectors-1.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: post /api/v2/asset-groups/{asset_group_id}/selectors
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/asset-isolation/update-asset-group-selectors.mdx
+++ b/docs/reference/asset-isolation/update-asset-group-selectors.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: put /api/v2/asset-groups/{asset_group_id}/selectors
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/attack-paths/export-attack-path-findings.mdx
+++ b/docs/reference/attack-paths/export-attack-path-findings.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/domains/{domain_id}/attack-path-findings
 ---
+
+<img src="/assets/enterprise-edition-pill-tag.svg"/>

--- a/docs/reference/attack-paths/list-all-attack-path-types.mdx
+++ b/docs/reference/attack-paths/list-all-attack-path-types.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/attack-path-types
 ---
+
+<img src="/assets/enterprise-edition-pill-tag.svg"/>

--- a/docs/reference/attack-paths/list-attack-path-sparkline-values.mdx
+++ b/docs/reference/attack-paths/list-attack-path-sparkline-values.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/domains/{domain_id}/sparkline
 ---
+
+<img src="/assets/enterprise-edition-pill-tag.svg"/>

--- a/docs/reference/attack-paths/list-available-attack-paths.mdx
+++ b/docs/reference/attack-paths/list-available-attack-paths.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/domains/{domain_id}/available-types
 ---
+
+<img src="/assets/enterprise-edition-pill-tag.svg"/>

--- a/docs/reference/attack-paths/list-domain-attack-paths-details.mdx
+++ b/docs/reference/attack-paths/list-domain-attack-paths-details.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/domains/{domain_id}/details
 ---
+
+<img src="/assets/enterprise-edition-pill-tag.svg"/>

--- a/docs/reference/attack-paths/start-analysis.mdx
+++ b/docs/reference/attack-paths/start-analysis.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: put /api/v2/attack-paths
 ---
+
+<img src="/assets/enterprise-edition-pill-tag.svg"/>

--- a/docs/reference/attack-paths/update-attack-path-risk.mdx
+++ b/docs/reference/attack-paths/update-attack-path-risk.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: put /api/v2/attack-paths/{attack_path_id}/acceptance
 ---
+
+<img src="/assets/enterprise-edition-pill-tag.svg"/>

--- a/docs/reference/audit/list-audit-logs.mdx
+++ b/docs/reference/audit/list-audit-logs.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/audit
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/auth/create-a-new-saml-provider-from-metadata-1.mdx
+++ b/docs/reference/auth/create-a-new-saml-provider-from-metadata-1.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: post /api/v2/sso-providers/saml
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/auth/create-a-new-saml-provider-from-metadata.mdx
+++ b/docs/reference/auth/create-a-new-saml-provider-from-metadata.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: post /api/v2/saml/providers
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/auth/create-oidc-provider.mdx
+++ b/docs/reference/auth/create-oidc-provider.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: post /api/v2/sso-providers/oidc
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/auth/delete-a-saml-provider.mdx
+++ b/docs/reference/auth/delete-a-saml-provider.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: delete /api/v2/saml/providers/{saml_provider_id}
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/auth/delete-sso-provider.mdx
+++ b/docs/reference/auth/delete-sso-provider.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: delete /api/v2/sso-providers/{sso_provider_id}
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/auth/get-all-saml-sign-on-endpoints.mdx
+++ b/docs/reference/auth/get-all-saml-sign-on-endpoints.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/saml/sso
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/auth/get-saml-provider-signing-certificate.mdx
+++ b/docs/reference/auth/get-saml-provider-signing-certificate.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/sso-providers/{sso_provider_id}/signing-certificate
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/auth/get-saml-provider.mdx
+++ b/docs/reference/auth/get-saml-provider.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/saml/providers/{saml_provider_id}
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/auth/get-self.mdx
+++ b/docs/reference/auth/get-self.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/self
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/auth/list-saml-providers.mdx
+++ b/docs/reference/auth/list-saml-providers.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/saml
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/auth/list-sso-providers.mdx
+++ b/docs/reference/auth/list-sso-providers.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/sso-providers
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/auth/login-to-bloodhound.mdx
+++ b/docs/reference/auth/login-to-bloodhound.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: post /api/v2/login
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/auth/logout-of-bloodhound.mdx
+++ b/docs/reference/auth/logout-of-bloodhound.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: post /api/v2/logout
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/auth/update-sso-provider.mdx
+++ b/docs/reference/auth/update-sso-provider.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: patch /api/v2/sso-providers/{sso_provider_id}
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/azure-entities/get-azure-entity.mdx
+++ b/docs/reference/azure-entities/get-azure-entity.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/azure/{entity_type}
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/bloodhound-users/activates-mfa-for-an-enrolled-user.mdx
+++ b/docs/reference/bloodhound-users/activates-mfa-for-an-enrolled-user.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: post /api/v2/bloodhound-users/{user_id}/mfa-activation
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/bloodhound-users/create-a-new-user.mdx
+++ b/docs/reference/bloodhound-users/create-a-new-user.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: post /api/v2/bloodhound-users
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/bloodhound-users/create-or-set-user-secret.mdx
+++ b/docs/reference/bloodhound-users/create-or-set-user-secret.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: put /api/v2/bloodhound-users/{user_id}/secret
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/bloodhound-users/delete-a-user.mdx
+++ b/docs/reference/bloodhound-users/delete-a-user.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: delete /api/v2/bloodhound-users/{user_id}
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/bloodhound-users/enrolls-user-in-multi-factor-authentication.mdx
+++ b/docs/reference/bloodhound-users/enrolls-user-in-multi-factor-authentication.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: post /api/v2/bloodhound-users/{user_id}/mfa
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/bloodhound-users/expire-user-secret.mdx
+++ b/docs/reference/bloodhound-users/expire-user-secret.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: delete /api/v2/bloodhound-users/{user_id}/secret
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/bloodhound-users/get-a-user.mdx
+++ b/docs/reference/bloodhound-users/get-a-user.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/bloodhound-users/{user_id}
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/bloodhound-users/list-users.mdx
+++ b/docs/reference/bloodhound-users/list-users.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/bloodhound-users
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/bloodhound-users/returns-mfa-activation-status-for-a-user.mdx
+++ b/docs/reference/bloodhound-users/returns-mfa-activation-status-for-a-user.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/bloodhound-users/{user_id}/mfa-activation
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/bloodhound-users/unenroll-user-from-multi-factor-authentication.mdx
+++ b/docs/reference/bloodhound-users/unenroll-user-from-multi-factor-authentication.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: delete /api/v2/bloodhound-users/{user_id}/mfa
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/bloodhound-users/update-a-user.mdx
+++ b/docs/reference/bloodhound-users/update-a-user.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: patch /api/v2/bloodhound-users/{user_id}
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/cert-templates/get-cert-template-entity-controllers.mdx
+++ b/docs/reference/cert-templates/get-cert-template-entity-controllers.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/certtemplates/{object_id}/controllers
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/cert-templates/get-cert-template-entity-info.mdx
+++ b/docs/reference/cert-templates/get-cert-template-entity-info.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/certtemplates/{object_id}
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/client-ingest/endpoint-for-data-ingestion.mdx
+++ b/docs/reference/client-ingest/endpoint-for-data-ingestion.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: post /api/v2/ingest
 ---
+
+<img src="/assets/enterprise-edition-pill-tag.svg"/>

--- a/docs/reference/clients/client-error.mdx
+++ b/docs/reference/clients/client-error.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: post /api/v2/clients/error
 ---
+
+<img src="/assets/enterprise-edition-pill-tag.svg"/>

--- a/docs/reference/clients/create-client.mdx
+++ b/docs/reference/clients/create-client.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: post /api/v2/clients
 ---
+
+<img src="/assets/enterprise-edition-pill-tag.svg"/>

--- a/docs/reference/clients/creates-a-scheduled-job.mdx
+++ b/docs/reference/clients/creates-a-scheduled-job.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: post /api/v2/clients/{client_id}/jobs
 ---
+
+<img src="/assets/enterprise-edition-pill-tag.svg"/>

--- a/docs/reference/clients/creates-a-scheduled-task.mdx
+++ b/docs/reference/clients/creates-a-scheduled-task.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: post /api/v2/clients/{client_id}/tasks
 ---
+
+<img src="/assets/enterprise-edition-pill-tag.svg"/>

--- a/docs/reference/clients/delete-client.mdx
+++ b/docs/reference/clients/delete-client.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: delete /api/v2/clients/{client_id}
 ---
+
+<img src="/assets/enterprise-edition-pill-tag.svg"/>

--- a/docs/reference/clients/get-client.mdx
+++ b/docs/reference/clients/get-client.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/clients/{client_id}
 ---
+
+<img src="/assets/enterprise-edition-pill-tag.svg"/>

--- a/docs/reference/clients/list-all-completed-jobs-for-a-client.mdx
+++ b/docs/reference/clients/list-all-completed-jobs-for-a-client.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/clients/{client_id}/completed-jobs
 ---
+
+<img src="/assets/enterprise-edition-pill-tag.svg"/>

--- a/docs/reference/clients/list-all-completed-tasks-for-a-client.mdx
+++ b/docs/reference/clients/list-all-completed-tasks-for-a-client.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/clients/{client_id}/completed-tasks
 ---
+
+<img src="/assets/enterprise-edition-pill-tag.svg"/>

--- a/docs/reference/clients/list-clients.mdx
+++ b/docs/reference/clients/list-clients.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/clients
 ---
+
+<img src="/assets/enterprise-edition-pill-tag.svg"/>

--- a/docs/reference/clients/regenerate-the-authentication-token-for-a-client.mdx
+++ b/docs/reference/clients/regenerate-the-authentication-token-for-a-client.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: put /api/v2/clients/{client_id}/token
 ---
+
+<img src="/assets/enterprise-edition-pill-tag.svg"/>

--- a/docs/reference/clients/update-client-values.mdx
+++ b/docs/reference/clients/update-client-values.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: put /api/v2/clients/update
 ---
+
+<img src="/assets/enterprise-edition-pill-tag.svg"/>

--- a/docs/reference/clients/update-client.mdx
+++ b/docs/reference/clients/update-client.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: put /api/v2/clients/{client_id}
 ---
+
+<img src="/assets/enterprise-edition-pill-tag.svg"/>

--- a/docs/reference/collection-uploads/create-file-upload-job.mdx
+++ b/docs/reference/collection-uploads/create-file-upload-job.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: post /api/v2/file-upload/start
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/collection-uploads/end-file-upload-job.mdx
+++ b/docs/reference/collection-uploads/end-file-upload-job.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: post /api/v2/file-upload/{file_upload_job_id}/end
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/collection-uploads/list-accepted-file-upload-types.mdx
+++ b/docs/reference/collection-uploads/list-accepted-file-upload-types.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/file-upload/accepted-types
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/collection-uploads/list-file-upload-jobs.mdx
+++ b/docs/reference/collection-uploads/list-file-upload-jobs.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/file-upload
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/collection-uploads/upload-file-to-job.mdx
+++ b/docs/reference/collection-uploads/upload-file-to-job.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: post /api/v2/file-upload/{file_upload_job_id}
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/collectors/get-collector-checksum-by-version.mdx
+++ b/docs/reference/collectors/get-collector-checksum-by-version.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/collectors/{collector_type}/{release_tag}/checksum
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/collectors/get-collector-download-by-version.mdx
+++ b/docs/reference/collectors/get-collector-download-by-version.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/collectors/{collector_type}/{release_tag}
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/collectors/get-collector-manifest.mdx
+++ b/docs/reference/collectors/get-collector-manifest.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/collectors/{collector_type}
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/computers/get-computer-entity-admin-rights.mdx
+++ b/docs/reference/computers/get-computer-entity-admin-rights.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/computers/{object_id}/admin-rights
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/computers/get-computer-entity-admins.mdx
+++ b/docs/reference/computers/get-computer-entity-admins.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/computers/{object_id}/admin-users
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/computers/get-computer-entity-constrained-delegation-rights.mdx
+++ b/docs/reference/computers/get-computer-entity-constrained-delegation-rights.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/computers/{object_id}/constrained-delegation-rights
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/computers/get-computer-entity-constrained-users.mdx
+++ b/docs/reference/computers/get-computer-entity-constrained-users.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/computers/{object_id}/constrained-users
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/computers/get-computer-entity-controllables.mdx
+++ b/docs/reference/computers/get-computer-entity-controllables.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/computers/{object_id}/controllables
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/computers/get-computer-entity-controllers.mdx
+++ b/docs/reference/computers/get-computer-entity-controllers.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/computers/{object_id}/controllers
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/computers/get-computer-entity-dcom-rights.mdx
+++ b/docs/reference/computers/get-computer-entity-dcom-rights.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/computers/{object_id}/dcom-rights
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/computers/get-computer-entity-dcom-users.mdx
+++ b/docs/reference/computers/get-computer-entity-dcom-users.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/computers/{object_id}/dcom-users
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/computers/get-computer-entity-group-membership.mdx
+++ b/docs/reference/computers/get-computer-entity-group-membership.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/computers/{object_id}/group-membership
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/computers/get-computer-entity-info.mdx
+++ b/docs/reference/computers/get-computer-entity-info.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/computers/{object_id}
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/computers/get-computer-entity-rdp-rights.mdx
+++ b/docs/reference/computers/get-computer-entity-rdp-rights.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/computers/{object_id}/rdp-rights
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/computers/get-computer-entity-rdp-users.mdx
+++ b/docs/reference/computers/get-computer-entity-rdp-users.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/computers/{object_id}/rdp-users
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/computers/get-computer-entity-remote-powershell-rights.mdx
+++ b/docs/reference/computers/get-computer-entity-remote-powershell-rights.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/computers/{object_id}/ps-remote-rights
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/computers/get-computer-entity-remote-powershell-users.mdx
+++ b/docs/reference/computers/get-computer-entity-remote-powershell-users.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/computers/{object_id}/ps-remote-users
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/computers/get-computer-entity-sessions.mdx
+++ b/docs/reference/computers/get-computer-entity-sessions.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/computers/{object_id}/sessions
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/computers/get-computer-entity-sql-admins.mdx
+++ b/docs/reference/computers/get-computer-entity-sql-admins.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/computers/{object_id}/sql-admins
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/config/list-application-config-parameters.mdx
+++ b/docs/reference/config/list-application-config-parameters.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/config
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/config/list-feature-flags.mdx
+++ b/docs/reference/config/list-feature-flags.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/features
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/config/toggle-a-feature-flags-enabled-status-to-either-enable-or-disable-it.mdx
+++ b/docs/reference/config/toggle-a-feature-flags-enabled-status-to-either-enable-or-disable-it.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: put /api/v2/features/{feature_id}/toggle
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/config/write-application-configuration-parameters.mdx
+++ b/docs/reference/config/write-application-configuration-parameters.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: put /api/v2/config
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/containers/get-container-entity-controllers.mdx
+++ b/docs/reference/containers/get-container-entity-controllers.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/containers/{object_id}/controllers
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/containers/get-container-entity-info.mdx
+++ b/docs/reference/containers/get-container-entity-info.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/containers/{object_id}
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/cypher/create-a-saved-query.mdx
+++ b/docs/reference/cypher/create-a-saved-query.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: post /api/v2/saved-queries
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/cypher/delete-a-saved-query.mdx
+++ b/docs/reference/cypher/delete-a-saved-query.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: delete /api/v2/saved-queries/{saved_query_id}
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/cypher/list-saved-queries.mdx
+++ b/docs/reference/cypher/list-saved-queries.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/saved-queries
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/cypher/revokes-permission-of-a-saved-query-from-users.mdx
+++ b/docs/reference/cypher/revokes-permission-of-a-saved-query-from-users.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: delete /api/v2/saved-queries/{saved_query_id}/permissions
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/cypher/run-a-cypher-query.mdx
+++ b/docs/reference/cypher/run-a-cypher-query.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: post /api/v2/graphs/cypher
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/cypher/share-a-saved-query-or-set-it-to-public.mdx
+++ b/docs/reference/cypher/share-a-saved-query-or-set-it-to-public.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: put /api/v2/saved-queries/{saved_query_id}/permissions
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/cypher/update-a-saved-query.mdx
+++ b/docs/reference/cypher/update-a-saved-query.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: put /api/v2/saved-queries/{saved_query_id}
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/data-quality/get-ad-domain-data-quality-stats.mdx
+++ b/docs/reference/data-quality/get-ad-domain-data-quality-stats.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/ad-domains/{domain_id}/data-quality-stats
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/data-quality/get-azure-tenant-data-quality-stats.mdx
+++ b/docs/reference/data-quality/get-azure-tenant-data-quality-stats.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/azure-tenants/{tenant_id}/data-quality-stats
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/data-quality/get-database-completeness-stats.mdx
+++ b/docs/reference/data-quality/get-database-completeness-stats.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/completeness
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/data-quality/get-platform-data-quality-aggregate.mdx
+++ b/docs/reference/data-quality/get-platform-data-quality-aggregate.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/platform/{platform_id}/data-quality-stats
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/database/delete-your-bloodhound-data.mdx
+++ b/docs/reference/database/delete-your-bloodhound-data.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: post /api/v2/clear-database
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/datapipe/get-datapipe-status.mdx
+++ b/docs/reference/datapipe/get-datapipe-status.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/datapipe/status
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/datapipe/start-analysis.mdx
+++ b/docs/reference/datapipe/start-analysis.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: put /api/v2/analysis
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/domains/get-domain-entity-computers.mdx
+++ b/docs/reference/domains/get-domain-entity-computers.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/domains/{object_id}/computers
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/domains/get-domain-entity-controllers.mdx
+++ b/docs/reference/domains/get-domain-entity-controllers.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/domains/{object_id}/controllers
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/domains/get-domain-entity-dc-syncers.mdx
+++ b/docs/reference/domains/get-domain-entity-dc-syncers.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/domains/{object_id}/dc-syncers
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/domains/get-domain-entity-foregin-groups.mdx
+++ b/docs/reference/domains/get-domain-entity-foregin-groups.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/domains/{object_id}/foreign-groups
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/domains/get-domain-entity-foreign-admins.mdx
+++ b/docs/reference/domains/get-domain-entity-foreign-admins.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/domains/{object_id}/foreign-admins
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/domains/get-domain-entity-foreign-gpo-controllers.mdx
+++ b/docs/reference/domains/get-domain-entity-foreign-gpo-controllers.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/domains/{object_id}/foreign-gpo-controllers
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/domains/get-domain-entity-foreign-users.mdx
+++ b/docs/reference/domains/get-domain-entity-foreign-users.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/domains/{object_id}/foreign-users
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/domains/get-domain-entity-gpos.mdx
+++ b/docs/reference/domains/get-domain-entity-gpos.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/domains/{object_id}/gpos
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/domains/get-domain-entity-groups.mdx
+++ b/docs/reference/domains/get-domain-entity-groups.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/domains/{object_id}/groups
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/domains/get-domain-entity-inbound-trusts.mdx
+++ b/docs/reference/domains/get-domain-entity-inbound-trusts.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/domains/{object_id}/inbound-trusts
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/domains/get-domain-entity-info.mdx
+++ b/docs/reference/domains/get-domain-entity-info.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/domains/{object_id}
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/domains/get-domain-entity-linked-gpos.mdx
+++ b/docs/reference/domains/get-domain-entity-linked-gpos.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/domains/{object_id}/linked-gpos
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/domains/get-domain-entity-ous.mdx
+++ b/docs/reference/domains/get-domain-entity-ous.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/domains/{object_id}/ous
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/domains/get-domain-entity-outbound-trusts.mdx
+++ b/docs/reference/domains/get-domain-entity-outbound-trusts.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/domains/{object_id}/outbound-trusts
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/domains/get-domain-entity-users.mdx
+++ b/docs/reference/domains/get-domain-entity-users.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/domains/{object_id}/users
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/domains/update-the-domain-entity.mdx
+++ b/docs/reference/domains/update-the-domain-entity.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: patch /api/v2/domains/{object_id}
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/enterprise-cas/get-enterprise-ca-entity-controllers.mdx
+++ b/docs/reference/enterprise-cas/get-enterprise-ca-entity-controllers.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/enterprisecas/{object_id}/controllers
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/enterprise-cas/get-enterprise-ca-entity-info.mdx
+++ b/docs/reference/enterprise-cas/get-enterprise-ca-entity-info.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/enterprisecas/{object_id}
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/eula/accept-eula.mdx
+++ b/docs/reference/eula/accept-eula.mdx
@@ -1,3 +1,5 @@
 ---
-openapi: put /api/v2/accept-eula
+openapi: get /api/v2/accept-eula
 ---
+
+<img src="/assets/enterprise-edition-pill-tag.svg"/>

--- a/docs/reference/events-schedules/create-event.mdx
+++ b/docs/reference/events-schedules/create-event.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: post /api/v2/events
 ---
+
+<img src="/assets/enterprise-edition-pill-tag.svg"/>

--- a/docs/reference/events-schedules/delete-event.mdx
+++ b/docs/reference/events-schedules/delete-event.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: delete /api/v2/events/{event_id}
 ---
+
+<img src="/assets/enterprise-edition-pill-tag.svg"/>

--- a/docs/reference/events-schedules/get-event.mdx
+++ b/docs/reference/events-schedules/get-event.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/events/{event_id}
 ---
+
+<img src="/assets/enterprise-edition-pill-tag.svg"/>

--- a/docs/reference/events-schedules/list-events.mdx
+++ b/docs/reference/events-schedules/list-events.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/events
 ---
+
+<img src="/assets/enterprise-edition-pill-tag.svg"/>

--- a/docs/reference/events-schedules/update-event.mdx
+++ b/docs/reference/events-schedules/update-event.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: put /api/v2/events/{event_id}
 ---
+
+<img src="/assets/enterprise-edition-pill-tag.svg"/>

--- a/docs/reference/gpos/get-gpo-entity-computer.mdx
+++ b/docs/reference/gpos/get-gpo-entity-computer.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/gpos/{object_id}/computers
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/gpos/get-gpo-entity-controllers.mdx
+++ b/docs/reference/gpos/get-gpo-entity-controllers.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/gpos/{object_id}/controllers
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/gpos/get-gpo-entity-info.mdx
+++ b/docs/reference/gpos/get-gpo-entity-info.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/gpos/{object_id}
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/gpos/get-gpo-entity-ous.mdx
+++ b/docs/reference/gpos/get-gpo-entity-ous.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/gpos/{object_id}/ous
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/gpos/get-gpo-entity-tier-zero.mdx
+++ b/docs/reference/gpos/get-gpo-entity-tier-zero.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/gpos/{object_id}/tier-zero
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/gpos/get-gpo-entity-users.mdx
+++ b/docs/reference/gpos/get-gpo-entity-users.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/gpos/{object_id}/users
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/graph/get-path-composition.mdx
+++ b/docs/reference/graph/get-path-composition.mdx
@@ -1,3 +1,6 @@
 ---
 openapi: get /api/v2/graphs/edge-composition
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>
+

--- a/docs/reference/graph/get-pathfinding-result.mdx
+++ b/docs/reference/graph/get-pathfinding-result.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/pathfinding
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/graph/get-search-result.mdx
+++ b/docs/reference/graph/get-search-result.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/graph-search
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/graph/get-the-shortest-path-graph.mdx
+++ b/docs/reference/graph/get-the-shortest-path-graph.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/graphs/shortest-path
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/groups/get-group-entity-admin-rights.mdx
+++ b/docs/reference/groups/get-group-entity-admin-rights.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/groups/{object_id}/admin-rights
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/groups/get-group-entity-controllables.mdx
+++ b/docs/reference/groups/get-group-entity-controllables.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/groups/{object_id}/controllables
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/groups/get-group-entity-controllers.mdx
+++ b/docs/reference/groups/get-group-entity-controllers.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/groups/{object_id}/controllers
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/groups/get-group-entity-dcomrights.mdx
+++ b/docs/reference/groups/get-group-entity-dcomrights.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/groups/{object_id}/dcom-rights
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/groups/get-group-entity-info.mdx
+++ b/docs/reference/groups/get-group-entity-info.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/groups/{object_id}
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/groups/get-group-entity-members.mdx
+++ b/docs/reference/groups/get-group-entity-members.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/groups/{object_id}/members
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/groups/get-group-entity-memberships.mdx
+++ b/docs/reference/groups/get-group-entity-memberships.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/groups/{object_id}/memberships
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/groups/get-group-entity-powershell-remote-rights.mdx
+++ b/docs/reference/groups/get-group-entity-powershell-remote-rights.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/groups/{object_id}/ps-remote-rights
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/groups/get-group-entity-rdp-rights.mdx
+++ b/docs/reference/groups/get-group-entity-rdp-rights.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/groups/{object_id}/rdp-rights
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/groups/get-group-entity-sessions.mdx
+++ b/docs/reference/groups/get-group-entity-sessions.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/groups/{object_id}/sessions
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/jobs/cancels-a-scheduled-job.mdx
+++ b/docs/reference/jobs/cancels-a-scheduled-job.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: put /api/v2/jobs/{job_id}/cancel
 ---
+
+<img src="/assets/enterprise-edition-pill-tag.svg"/>

--- a/docs/reference/jobs/get-client-current-job.mdx
+++ b/docs/reference/jobs/get-client-current-job.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/jobs/current
 ---
+
+<img src="/assets/enterprise-edition-pill-tag.svg"/>

--- a/docs/reference/jobs/get-client-job.mdx
+++ b/docs/reference/jobs/get-client-job.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/jobs/{job_id}
 ---
+
+<img src="/assets/enterprise-edition-pill-tag.svg"/>

--- a/docs/reference/jobs/get-job-log-file.mdx
+++ b/docs/reference/jobs/get-job-log-file.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/jobs/{job_id}/log
 ---
+
+<img src="/assets/enterprise-edition-pill-tag.svg"/>

--- a/docs/reference/jobs/get-jobs.mdx
+++ b/docs/reference/jobs/get-jobs.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/jobs
 ---
+
+<img src="/assets/enterprise-edition-pill-tag.svg"/>

--- a/docs/reference/jobs/list-available-client-jobs.mdx
+++ b/docs/reference/jobs/list-available-client-jobs.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/jobs/available
 ---
+
+<img src="/assets/enterprise-edition-pill-tag.svg"/>

--- a/docs/reference/jobs/list-finished-jobs.mdx
+++ b/docs/reference/jobs/list-finished-jobs.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/jobs/finished
 ---
+
+<img src="/assets/enterprise-edition-pill-tag.svg"/>

--- a/docs/reference/jobs/notifies-the-api-of-a-job-ending.mdx
+++ b/docs/reference/jobs/notifies-the-api-of-a-job-ending.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: post /api/v2/jobs/end
 ---
+
+<img src="/assets/enterprise-edition-pill-tag.svg"/>

--- a/docs/reference/jobs/notifies-the-api-of-a-job-start.mdx
+++ b/docs/reference/jobs/notifies-the-api-of-a-job-start.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: post /api/v2/jobs/start
 ---
+
+<img src="/assets/enterprise-edition-pill-tag.svg"/>

--- a/docs/reference/meta-entities/get-meta-entity-info.mdx
+++ b/docs/reference/meta-entities/get-meta-entity-info.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/meta/{object_id}
 ---
+
+<img src="/assets/enterprise-edition-pill-tag.svg"/>

--- a/docs/reference/nt-auth-stores/get-nt-auth-store-entity-controllers.mdx
+++ b/docs/reference/nt-auth-stores/get-nt-auth-store-entity-controllers.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/ntauthstores/{object_id}/controllers
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/nt-auth-stores/get-nt-auth-store-entity-info.mdx
+++ b/docs/reference/nt-auth-stores/get-nt-auth-store-entity-info.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/ntauthstores/{object_id}
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/ous/get-ou-entity-computers.mdx
+++ b/docs/reference/ous/get-ou-entity-computers.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/ous/{object_id}/computers
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/ous/get-ou-entity-gpos.mdx
+++ b/docs/reference/ous/get-ou-entity-gpos.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/ous/{object_id}/gpos
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/ous/get-ou-entity-groups.mdx
+++ b/docs/reference/ous/get-ou-entity-groups.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/ous/{object_id}/groups
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/ous/get-ou-entity-info.mdx
+++ b/docs/reference/ous/get-ou-entity-info.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/ous/{object_id}
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/ous/get-ou-entity-users.mdx
+++ b/docs/reference/ous/get-ou-entity-users.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/ous/{object_id}/users
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/overview.mdx
+++ b/docs/reference/overview.mdx
@@ -1,0 +1,115 @@
+---
+title: Use the BloodHound API
+---
+
+This is the API that drives BloodHound Enterprise and Community Edition.
+Use it to extend the use of the BloodHound product to work with other tools in your environment. 
+
+Endpoint availability is noted using the `Community` and `Enterprise` tags.
+
+To get help with BloodHound Community Edition, join our [Slack community](https://ghst.ly/BHSlack/).
+**BloodHound Enterprise** customers can [submit tickets](../resources/community-support/getting-help).
+
+## Authentication
+
+The BloodHound API supports two kinds of authentication: JWT bearer tokens and signed requests.
+
+For quick tests or one-time calls, the JWT used by your browser may be the simplest route. 
+For more secure and long lived API integrations, we recommend using signed requests.
+
+### JWT bearer token
+
+ The API accepts calls using the following header structure in the HTTP request:
+
+```
+Authorization: Bearer $JWT_TOKEN
+```
+
+If you open the **Network** tab in your browser, you'll see calls against the API made using
+this structure. JWT bearer tokens are supported by the BloodHound API, but they
+should only be used for temporary access. JWT tokens expire after a set amount of time and require
+re-authentication using secret credentials.
+
+### Signed requests
+
+Signed requests are the recommended form of authentication for the BloodHound API. Not only are
+signed requests better for long lived integrations, they also provide more security for the
+requests being sent. They provide authentication of the client, as well as verification of request
+integrity when received by the server.
+
+Signed requests consist of three main parts: The client token ID, the request timestamp, and a
+base64 encoded HMAC signature. These three pieces of information are sent with the request using
+the following header structure:
+
+```
+Authorization: bhesignature $TOKEN_ID
+RequestDate: $RFC3339_DATETIME
+Signature: $BASE64ENCODED_HMAC_SIGNATURE
+```
+
+To use signed requests, you need to generate an API token. Each API token generated in the
+BloodHound API comes with two parts: The Token ID, which is used in the `Authorization` header,
+and the Token Key, which is used as part of the HMAC hashing process. The token ID should be
+considered as public (like a username) and the token key should be considered secret (like a
+password). Once an API token is generated, you can use the key to sign requests.
+
+For more documentation about how to work with authentication in the API, including examples
+of how to generate an API token in the BloodHound UI, see [Working With the BloodHound API](../integrations/bloodhound-api/working-with-api).
+
+ #### Example: Signed request pseudo-code
+
+First, a digest is initiated with HMAC-SHA-256 using the token key as the digest key:
+
+```python
+digester = hmac.new(sha256, api_token_key)
+```
+
+OperationKey is the first HMAC digest link in the signature chain. This prevents replay attacks that
+seek to modify the request method or URI. It is composed of concatenating the request method and
+the request URI with no delimiter and computing the HMAC digest using the token key as the digest
+secret:
+
+```python
+# Example: GET /api/v2/test/resource HTTP/1.1
+# Signature Component: GET/api/v2/test/resource
+digester.write(request_method + request_uri)
+
+# Update the digester for further chaining
+digester = hmac.New(sha256, digester.hash())
+```
+
+DateKey is the next HMAC digest link in the signature chain. This encodes the RFC3339
+formatted datetime value as part of the signature to the hour to prevent replay
+attacks that are older than max two hours. This value is added to the signature chain
+by cutting off all values from the RFC3339 formatted datetime from the hours value
+forward:
+
+```python
+# Example: 2020-12-01T23:59:60Z
+# Signature Component: 2020-12-01T23
+request_datetime = date.now()
+digester.write(request_datetime[:13])
+
+# Update the digester for further chaining
+digester = hmac.New(sha256, digester.hash())
+```
+
+Body signing is the last HMAC digest link in the signature chain. This encodes the
+request body as part of the signature to prevent replay attacks that seek to modify
+the payload of a signed request. In the case where there is no body content the
+HMAC digest is computed anyway, simply with no values written to the digester:
+
+```python
+if request.body is not empty:
+digester.write(request.body)
+```
+
+Finally, base64 encode the final hash and write the three required headers before
+sending the request:
+
+```python
+encoded_hash = base64_encode(digester.hash())
+request.header.write('Authorization', 'bhesignature ' + token_id)
+request.header.write('RequestDate', request_datetime)
+request.header.write('Signature', encoded_hash)
+```

--- a/docs/reference/permissions/get-permission.mdx
+++ b/docs/reference/permissions/get-permission.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/permissions/{permission_id}
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/permissions/list-permissions.mdx
+++ b/docs/reference/permissions/list-permissions.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/permissions
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/risk-posture/get-posture-statistics.mdx
+++ b/docs/reference/risk-posture/get-posture-statistics.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/posture-stats
 ---
+
+<img src="/assets/enterprise-edition-pill-tag.svg"/>

--- a/docs/reference/roles/get-role.mdx
+++ b/docs/reference/roles/get-role.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/roles/{role_id}
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/roles/list-roles.mdx
+++ b/docs/reference/roles/list-roles.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/roles
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/root-cas/get-root-ca-entity-controllers.mdx
+++ b/docs/reference/root-cas/get-root-ca-entity-controllers.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/rootcas/{object_id}/controllers
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/root-cas/get-root-ca-entity-info.mdx
+++ b/docs/reference/root-cas/get-root-ca-entity-info.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/rootcas/{object_id}
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/search/get-available-domains.mdx
+++ b/docs/reference/search/get-available-domains.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/available-domains
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>

--- a/docs/reference/search/search-for-objects.mdx
+++ b/docs/reference/search/search-for-objects.mdx
@@ -1,3 +1,5 @@
 ---
 openapi: get /api/v2/search
 ---
+
+<img src="/assets/enterprise-AND-community-edition-pill-tag.svg"/>


### PR DESCRIPTION
As part of the Mintlify doc revamp, this PR:
- Adds a landing page to the API reference using the contents of the description in https://github.com/SpecterOps/BloodHound/blob/main/packages/go/openapi/src/openapi.yaml#L33
- Cleans up the Working with the BloodHound API page


This PR addresses: [#1085](https://github.com/SpecterOps/BloodHound/issues/1085)

Tested locally with Mintlify for broken links and broken site

Types of changes
- Chore
- Docs

I have read the CLA Document and I hereby sign the CLA
