### PR TITLE
BED-5505: Entity/Edge Panels Deep linking cleanup for parity with BHE

### DIFF
--- a/cmd/ui/src/views/Explore/EdgeInfo/EdgeInfoPane.tsx
+++ b/cmd/ui/src/views/Explore/EdgeInfo/EdgeInfoPane.tsx
@@ -15,21 +15,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Box, Paper, SxProps } from '@mui/material';
-import {
-    EdgeSections,
-    collapseAllSections,
-    edgeSectionToggle,
-    useExploreParams,
-    useFeatureFlag,
-    usePaneStyles,
-} from 'bh-shared-ui';
+import { SelectedEdge, collapseAllSections, useExploreParams, useFeatureFlag, usePaneStyles } from 'bh-shared-ui';
 import React, { useEffect, useState } from 'react';
 import usePreviousValue from 'src/hooks/usePreviousValue';
 import { useAppDispatch } from 'src/store';
 import EdgeInfoContent from 'src/views/Explore/EdgeInfo/EdgeInfoContent';
 import Header from 'src/views/Explore/EdgeInfo/EdgeInfoHeader';
 
-const EdgeInfoPane: React.FC<{ sx?: SxProps; selectedEdge?: any }> = ({ sx, selectedEdge }) => {
+const EdgeInfoPane: React.FC<{ sx?: SxProps; selectedEdge: SelectedEdge | null }> = ({ sx, selectedEdge }) => {
     const styles = usePaneStyles();
     const [expanded, setExpanded] = useState(true);
     const { expandedPanelSections } = useExploreParams();
@@ -38,14 +31,7 @@ const EdgeInfoPane: React.FC<{ sx?: SxProps; selectedEdge?: any }> = ({ sx, sele
     const dispatch = useAppDispatch();
 
     useEffect(() => {
-        if (previousSelectedEdge?.id !== selectedEdge?.id && backButtonFlag?.enabled && expandedPanelSections) {
-            dispatch(
-                edgeSectionToggle({
-                    section: expandedPanelSections?.at(0) as keyof typeof EdgeSections,
-                    expanded: true,
-                })
-            );
-        } else if (!backButtonFlag?.enabled && previousSelectedEdge?.id !== selectedEdge?.id) {
+        if (!backButtonFlag?.enabled && previousSelectedEdge?.id !== selectedEdge?.id) {
             dispatch(collapseAllSections());
         }
     }, [expandedPanelSections, dispatch, backButtonFlag, previousSelectedEdge, selectedEdge]);
@@ -54,7 +40,7 @@ const EdgeInfoPane: React.FC<{ sx?: SxProps; selectedEdge?: any }> = ({ sx, sele
         <Box sx={sx} className={styles.container} data-testid='explore_edge-information-pane'>
             <Paper elevation={0} classes={{ root: styles.headerPaperRoot }}>
                 <Header
-                    name={selectedEdge.name || 'None'}
+                    name={selectedEdge?.name || 'None'}
                     expanded={expanded}
                     onToggleExpanded={(expanded) => {
                         setExpanded(expanded);


### PR DESCRIPTION
## Description

Small cleanup of code for edge info panel. There was a conditional block that wasn't doing anything as well as a missing SelectedEdge type. Figured I would add it in as sister PR as it was relevant for parity between bhce and bhe.

## Motivation and Context

This ticket is complementary to keep parity with [BED-5505](https://specterops.atlassian.net/browse/BED-5505)

## How Has This Been Tested?

Manually and existing tests passing

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


[BED-5505]: https://specterops.atlassian.net/browse/BED-5505?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ