### PR TITLE
BED-5638 changed start and end id parsing to 64 bit to support larger…

### DIFF
--- a/cmd/api/src/api/v2/edge.go
+++ b/cmd/api/src/api/v2/edge.go
@@ -90,9 +90,9 @@ func (s *Resources) GetEdgeComposition(response http.ResponseWriter, request *ht
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, fmt.Sprintf("Expected only one %s.", edgeParameterTargetNode), request), response)
 	} else if kind, err := analysis.ParseKind(edgeType[0]); err != nil {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, fmt.Sprintf("Invalid edge requested: %s", edgeType[0]), request), response)
-	} else if startID, err := strconv.ParseInt(sourceNode[0], 10, 32); err != nil {
+	} else if startID, err := strconv.ParseInt(sourceNode[0], 10, 64); err != nil {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, fmt.Sprintf("Invalid value for startID: %s", sourceNode[0]), request), response)
-	} else if endID, err := strconv.ParseInt(targetNode[0], 10, 32); err != nil {
+	} else if endID, err := strconv.ParseInt(targetNode[0], 10, 64); err != nil {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, fmt.Sprintf("Invalid value for endID: %s", targetNode[0]), request), response)
 	} else if edge, err := analysis.FetchEdgeByStartAndEnd(request.Context(), s.Graph, graph.ID(startID), graph.ID(endID), kind); err != nil {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, fmt.Sprintf("Could not find edge matching criteria: %v", err), request), response)


### PR DESCRIPTION
## Description

In some environments it was found that we are also past the 32 bit capacities for node ids, this is simply bumping our string parsing for 64 bit integer support

## Motivation and Context

This PR addresses: BED-5638

## How Has This Been Tested?

*Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc.*

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [ ] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [ ] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [ ] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
