### PR TITLE
BED-5576: Unset overflow when FixedSizeList has fewer than 2 nodes

### DIFF
--- a/packages/javascript/bh-shared-ui/src/components/VirtualizedNodeList.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/VirtualizedNodeList.tsx
@@ -38,7 +38,9 @@ const normalizeItem = (item: VirtualizedNodeListItem): VirtualizedNodeListItem =
 });
 
 const InnerElement = ({ style, ...rest }: any) => (
-    <List component='ul' disablePadding style={{ ...style, overflowX: 'hidden' }} {...rest} />
+    // Top margin is adjusted to account for FixedSizeList's default of 'overflow: auto'
+    // causing the scrollbar to render even for a single node
+    <List component='ul' disablePadding style={{ ...style, overflowX: 'hidden', marginTop: 0 }} {...rest} />
 );
 
 const Row = ({ data, index, style }: ListChildComponentProps<VirtualizedNodeListItem[]>) => {


### PR DESCRIPTION
## Description

This PR adds a conditional styling override to VirtualizedNodeList. If there are fewer than 2 nodes, overflow will not be applied.

## Motivation and Context

This PR addresses: BED-5576

Our VirtualizedNodeList components will display the scrollbar even if single node is rendered. This components uses [React Window's](https://github.com/bvaughn/react-window) FixedSizeList component, which [unconditionally applies](https://github.com/bvaughn/react-window/blob/72db696dd8ebb7f0f287c78d037ff68ba9534183/src/createListComponent.js#L373) an 'auto' overflow, causing the scrollbar to always be displayed.

## How Has This Been Tested?

Manually tested using demo data set.

## Screenshots:

Before (notice `DC01.PHANTOM.CORP` is slightly cut off at bottom): 
![image](https://github.com/user-attachments/assets/fadd6385-f031-4b1f-b1bb-6724878da50d)

After:

![image](https://github.com/user-attachments/assets/a5f35dc0-68f9-4e90-b4d1-ecc21d5a7f21)


## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


[BED-5576]: https://specterops.atlassian.net/browse/BED-5576?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ