### PR TITLE
Update the return type definiton for `setParamsFactory`

### DIFF
--- a/packages/javascript/bh-shared-ui/src/hooks/useExploreParams/useExploreParams.tsx
+++ b/packages/javascript/bh-shared-ui/src/hooks/useExploreParams/useExploreParams.tsx
@@ -87,22 +87,20 @@ export const useExploreParams = (): UseExploreParamsReturn => {
         relationshipQueryType: parseRelationshipQueryType(searchParams.get('relationshipQueryType')),
         relationshipQueryItemId: searchParams.get('relationshipQueryItemId'),
         pathFilters: searchParams.getAll('pathFilters'),
-        // react doesnt like this because it doesnt know the params needed for the function factory return function.
-        // but the params needed are not needed in the deps array
-        // eslint-disable-next-line react-hooks/exhaustive-deps
         setExploreParams: useCallback(
-            setParamsFactory(setSearchParams, [
-                'exploreSearchTab',
-                'primarySearch',
-                'secondarySearch',
-                'cypherSearch',
-                'searchType',
-                'expandedPanelSections',
-                'selectedItem',
-                'relationshipQueryType',
-                'relationshipQueryItemId',
-                'pathFilters',
-            ]),
+            (updatedParams: Partial<ExploreQueryParams>) =>
+                setParamsFactory(setSearchParams, [
+                    'exploreSearchTab',
+                    'primarySearch',
+                    'secondarySearch',
+                    'cypherSearch',
+                    'searchType',
+                    'expandedPanelSections',
+                    'selectedItem',
+                    'relationshipQueryType',
+                    'relationshipQueryItemId',
+                    'pathFilters',
+                ])(updatedParams),
             [setSearchParams]
         ),
     };

--- a/packages/javascript/bh-shared-ui/src/utils/searchParams/searchParams.ts
+++ b/packages/javascript/bh-shared-ui/src/utils/searchParams/searchParams.ts
@@ -64,7 +64,7 @@ export const setSingleParamFactory = <T>(updatedParams: T, searchParams: URLSear
  * @returns
  */
 export const setParamsFactory = <T>(setSearchParams: SetURLSearchParams, availableParams: Array<keyof T>) => {
-    return (updatedParams: T) => {
+    return (updatedParams: Partial<T>) => {
         setSearchParams((params) => {
             const setParam = setSingleParamFactory(updatedParams, params);
 


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Corrects the return type of `setParamsFactory` from `(updatedParams: T) => void` to `(updatedParams: Partial<T>) => void` as the returned function is able to accept a partial object of query params.

## Motivation and Context

This PR addresses: BED-5450

This change allows us to clean up a linting error in the `useExploreParams` hook.

## How Has This Been Tested?

All existing unit tests pass.

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
