### PR TITLE
[BED-4714] Correct filename embedded into image

### DIFF
--- a/dockerfiles/bloodhound.Dockerfile
+++ b/dockerfiles/bloodhound.Dockerfile
@@ -104,6 +104,8 @@ FROM gcr.io/distroless/static-debian11 AS bloodhound
 ARG SHARPHOUND_VERSION
 ARG AZUREHOUND_VERSION
 
+# api/v2/collectors/[collector-type]/[version] for collector download specifically expects
+# '[collector-type]-[version].zip(.sha256)' - all lowercase for embedded files
 COPY dockerfiles/configs/bloodhound.config.json /bloodhound.config.json
 COPY --from=builder /bloodhound/dist/bhapi /bloodhound
 COPY --from=hound-builder /opt/bloodhound /etc/bloodhound /var/log /

--- a/dockerfiles/bloodhound.Dockerfile
+++ b/dockerfiles/bloodhound.Dockerfile
@@ -70,8 +70,8 @@ RUN mkdir -p /opt/bloodhound /etc/bloodhound /var/log
 RUN apk --no-cache add p7zip
 
 # Package Sharphound
-RUN wget https://github.com/SpecterOps/SharpHound/releases/download/${SHARPHOUND_VERSION}/SharpHound_${SHARPHOUND_VERSION}_windows_x86.zip -O SharpHound_${SHARPHOUND_VERSION}.zip
-RUN wget https://github.com/SpecterOps/SharpHound/releases/download/${SHARPHOUND_VERSION}/SharpHound_${SHARPHOUND_VERSION}_windows_x86.zip.sha256 -O SharpHound_${SHARPHOUND_VERSION}.zip.sha256
+RUN wget https://github.com/SpecterOps/SharpHound/releases/download/${SHARPHOUND_VERSION}/SharpHound_${SHARPHOUND_VERSION}_windows_x86.zip -O sharphound-${SHARPHOUND_VERSION}.zip
+RUN wget https://github.com/SpecterOps/SharpHound/releases/download/${SHARPHOUND_VERSION}/SharpHound_${SHARPHOUND_VERSION}_windows_x86.zip.sha256 -O sharphound-${SHARPHOUND_VERSION}.zip.sha256
 
 WORKDIR /tmp/azurehound
 
@@ -94,8 +94,8 @@ RUN 7z x '*.zip' -oartifacts/*
 RUN ls
 
 WORKDIR /tmp/azurehound/artifacts
-RUN 7z a -tzip -mx9 AzureHound_${AZUREHOUND_VERSION}.zip AzureHound_*
-RUN sha256sum AzureHound_${AZUREHOUND_VERSION}.zip > AzureHound_${AZUREHOUND_VERSION}.zip.sha256
+RUN 7z a -tzip -mx9 azurehound-${AZUREHOUND_VERSION}.zip AzureHound_*
+RUN sha256sum azurehound-${AZUREHOUND_VERSION}.zip > azurehound-${AZUREHOUND_VERSION}.zip.sha256
 
 ########
 # Package Bloodhound
@@ -107,9 +107,9 @@ ARG AZUREHOUND_VERSION
 COPY dockerfiles/configs/bloodhound.config.json /bloodhound.config.json
 COPY --from=builder /bloodhound/dist/bhapi /bloodhound
 COPY --from=hound-builder /opt/bloodhound /etc/bloodhound /var/log /
-COPY --from=hound-builder /tmp/sharphound/SharpHound_${SHARPHOUND_VERSION}.zip /etc/bloodhound/collectors/sharphound/
-COPY --from=hound-builder /tmp/sharphound/SharpHound_${SHARPHOUND_VERSION}.zip.sha256 /etc/bloodhound/collectors/sharphound/
-COPY --from=hound-builder /tmp/azurehound/artifacts/AzureHound_${AZUREHOUND_VERSION}.zip /etc/bloodhound/collectors/azurehound/
-COPY --from=hound-builder /tmp/azurehound/artifacts/AzureHound_${AZUREHOUND_VERSION}.zip.sha256 /etc/bloodhound/collectors/azurehound/
+COPY --from=hound-builder /tmp/sharphound/sharphound-${SHARPHOUND_VERSION}.zip /etc/bloodhound/collectors/sharphound/
+COPY --from=hound-builder /tmp/sharphound/sharphound-${SHARPHOUND_VERSION}.zip.sha256 /etc/bloodhound/collectors/sharphound/
+COPY --from=hound-builder /tmp/azurehound/artifacts/azurehound-${AZUREHOUND_VERSION}.zip /etc/bloodhound/collectors/azurehound/
+COPY --from=hound-builder /tmp/azurehound/artifacts/azurehound-${AZUREHOUND_VERSION}.zip.sha256 /etc/bloodhound/collectors/azurehound/
 
 ENTRYPOINT ["/bloodhound", "-configfile", "/bloodhound.config.json"]

--- a/dockerfiles/bloodhound.Dockerfile
+++ b/dockerfiles/bloodhound.Dockerfile
@@ -94,7 +94,7 @@ RUN 7z x '*.zip' -oartifacts/*
 RUN ls
 
 WORKDIR /tmp/azurehound/artifacts
-RUN 7z a -tzip -mx9 azurehound-${AZUREHOUND_VERSION}.zip AzureHound_*
+RUN 7z a -tzip -mx9 azurehound-${AZUREHOUND_VERSION}.zip *
 RUN sha256sum azurehound-${AZUREHOUND_VERSION}.zip > azurehound-${AZUREHOUND_VERSION}.zip.sha256
 
 ########

--- a/tools/docker-compose/api.Dockerfile
+++ b/tools/docker-compose/api.Dockerfile
@@ -72,6 +72,8 @@ RUN mkdir -p /bhapi/collectors/azurehound /bhapi/collectors/sharphound /bhapi/wo
 RUN go install github.com/go-delve/delve/cmd/dlv@v1.23.0
 RUN go install github.com/air-verse/air@v1.52.3
 
+# api/v2/collectors/[collector-type]/[version] for collector download specifically expects
+# '[collector-type]-[version].zip(.sha256)' - all lowercase for embedded files
 COPY --from=hound-builder /tmp/sharphound/sharphound-${SHARPHOUND_VERSION}.zip /bhapi/collectors/sharphound/
 COPY --from=hound-builder /tmp/sharphound/sharphound-${SHARPHOUND_VERSION}.zip.sha256 /bhapi/collectors/sharphound/
 COPY --from=hound-builder /tmp/azurehound/artifacts/azurehound-${AZUREHOUND_VERSION}.zip /bhapi/collectors/azurehound/

--- a/tools/docker-compose/api.Dockerfile
+++ b/tools/docker-compose/api.Dockerfile
@@ -34,8 +34,8 @@ RUN mkdir -p /opt/bloodhound /etc/bloodhound /var/log
 RUN apk --no-cache add p7zip
 
 # Package Sharphound
-RUN wget https://github.com/SpecterOps/SharpHound/releases/download/${SHARPHOUND_VERSION}/SharpHound_${SHARPHOUND_VERSION}_windows_x86.zip -O SharpHound_${SHARPHOUND_VERSION}.zip
-RUN wget https://github.com/SpecterOps/SharpHound/releases/download/${SHARPHOUND_VERSION}/SharpHound_${SHARPHOUND_VERSION}_windows_x86.zip.sha256 -O SharpHound_${SHARPHOUND_VERSION}.zip.sha256
+RUN wget https://github.com/SpecterOps/SharpHound/releases/download/${SHARPHOUND_VERSION}/SharpHound_${SHARPHOUND_VERSION}_windows_x86.zip -O sharphound-${SHARPHOUND_VERSION}.zip
+RUN wget https://github.com/SpecterOps/SharpHound/releases/download/${SHARPHOUND_VERSION}/SharpHound_${SHARPHOUND_VERSION}_windows_x86.zip.sha256 -O sharphound-${SHARPHOUND_VERSION}.zip.sha256
 
 WORKDIR /tmp/azurehound
 
@@ -58,8 +58,8 @@ RUN 7z x '*.zip' -oartifacts/*
 RUN ls
 
 WORKDIR /tmp/azurehound/artifacts
-RUN 7z a -tzip -mx9 AzureHound_${AZUREHOUND_VERSION}.zip AzureHound_*
-RUN sha256sum AzureHound_${AZUREHOUND_VERSION}.zip > AzureHound_${AZUREHOUND_VERSION}.zip.sha256
+RUN 7z a -tzip -mx9 azurehound-${AZUREHOUND_VERSION}.zip AzureHound_*
+RUN sha256sum azurehound-${AZUREHOUND_VERSION}.zip > azurehound-${AZUREHOUND_VERSION}.zip.sha256
 
 FROM docker.io/library/golang:1.23
 ARG SHARPHOUND_VERSION
@@ -72,9 +72,9 @@ RUN mkdir -p /bhapi/collectors/azurehound /bhapi/collectors/sharphound /bhapi/wo
 RUN go install github.com/go-delve/delve/cmd/dlv@v1.23.0
 RUN go install github.com/air-verse/air@v1.52.3
 
-COPY --from=hound-builder /tmp/sharphound/SharpHound_${SHARPHOUND_VERSION}.zip /bhapi/collectors/sharphound/
-COPY --from=hound-builder /tmp/sharphound/SharpHound_${SHARPHOUND_VERSION}.zip.sha256 /bhapi/collectors/sharphound/
-COPY --from=hound-builder /tmp/azurehound/artifacts/AzureHound_${AZUREHOUND_VERSION}.zip /bhapi/collectors/azurehound/
-COPY --from=hound-builder /tmp/azurehound/artifacts/AzureHound_${AZUREHOUND_VERSION}.zip.sha256 /bhapi/collectors/azurehound/
+COPY --from=hound-builder /tmp/sharphound/sharphound-${SHARPHOUND_VERSION}.zip /bhapi/collectors/sharphound/
+COPY --from=hound-builder /tmp/sharphound/sharphound-${SHARPHOUND_VERSION}.zip.sha256 /bhapi/collectors/sharphound/
+COPY --from=hound-builder /tmp/azurehound/artifacts/azurehound-${AZUREHOUND_VERSION}.zip /bhapi/collectors/azurehound/
+COPY --from=hound-builder /tmp/azurehound/artifacts/azurehound-${AZUREHOUND_VERSION}.zip.sha256 /bhapi/collectors/azurehound/
 
 ENTRYPOINT ["air"]

--- a/tools/docker-compose/api.Dockerfile
+++ b/tools/docker-compose/api.Dockerfile
@@ -58,7 +58,7 @@ RUN 7z x '*.zip' -oartifacts/*
 RUN ls
 
 WORKDIR /tmp/azurehound/artifacts
-RUN 7z a -tzip -mx9 azurehound-${AZUREHOUND_VERSION}.zip AzureHound_*
+RUN 7z a -tzip -mx9 azurehound-${AZUREHOUND_VERSION}.zip *
 RUN sha256sum azurehound-${AZUREHOUND_VERSION}.zip > azurehound-${AZUREHOUND_VERSION}.zip.sha256
 
 FROM docker.io/library/golang:1.23


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description
`api/v2/collectors/*` endpoints won't find the embedded files by their new names, must be named '<collectortype>-<version>.zip(.sha256)', all lowercase.

## Motivation and Context

This PR addresses: [BED-4714]

## How Has This Been Tested?
just bh-dev
docker build -f dockerfiles/bloodhound.Dockerfile .

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


[BED-4714]: https://specterops.atlassian.net/browse/BED-4714?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ