### PR TITLE
BED-5714 Small Bug Fix in St Bernard Package

### DIFF
--- a/packages/go/stbernard/main.go
+++ b/packages/go/stbernard/main.go
@@ -43,7 +43,7 @@ func main() {
 	if lvl, err := bhlog.ParseLevel(rawLvl); err != nil {
 		slog.Error(fmt.Sprintf("Could not parse log level from %s: %v", environment.LogLevelVarName, err))
 	} else {
-		level.GlobalAccepts(lvl)
+		level.SetGlobalLevel(lvl)
 	}
 
 	if cmd, err := command.ParseCLI(env); errors.Is(err, command.ErrNoCmd) {


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

When trying to use the St Bernard package, I needed to set the Log Level to DEBUG so I could troubleshoot an issue I was having when trying to run the analysis. It was discovered that a change needed to be made inside of the St Bernard package to set the log level correctly. This ticket reflects said change.

## Motivation and Context

This PR addresses: https://specterops.atlassian.net/browse/BED-5714

Fixes the ability to set the log level when running the St Bernard Package

## How Has This Been Tested?

Manually tested running `SB_LOG_LEVEL=debug just analyze`

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [X] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [ ] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [X] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
