### PR TITLE
fix(migrations): Added migration to remove admin_rights_count property from User nodes

### DIFF
--- a/cmd/api/src/migrations/manifest.go
+++ b/cmd/api/src/migrations/manifest.go
@@ -47,8 +47,8 @@ func RequiresMigration(ctx context.Context, db graph.Database) (bool, error) {
 	}
 }
 
-// Version_740_Migration removes the leftover 'adminrightscount' property from User nodes
-func Version_740_Migration(ctx context.Context, db graph.Database) error {
+// Version_730_Migration removes the leftover 'adminrightscount' property from User nodes
+func Version_730_Migration(ctx context.Context, db graph.Database) error {
 	const adminRightsCount = "adminrightscount"
 
 	defer measure.LogAndMeasure(slog.LevelInfo, "Migration to remove admin_rights_count property from user nodes")
@@ -368,8 +368,8 @@ var Manifest = []Migration{
 		Execute: Version_620_Migration,
 	},
 	{
-		Version: version.Version{Major: 7, Minor: 4, Patch: 0},
-		Execute: Version_740_Migration,
+		Version: version.Version{Major: 7, Minor: 3, Patch: 0},
+		Execute: Version_730_Migration,
 	},
 }
 

--- a/cmd/api/src/migrations/manifest.go
+++ b/cmd/api/src/migrations/manifest.go
@@ -55,23 +55,23 @@ func Version_730_Migration(ctx context.Context, db graph.Database) error {
 
 	return db.WriteTransaction(ctx, func(tx graph.Transaction) error {
 		// MATCH(n:User) WHERE n.adminrightscount <> null
-		nodes, err := ops.FetchNodes(tx.Nodes().Filterf(func() graph.Criteria {
+		if nodes, err := ops.FetchNodes(tx.Nodes().Filterf(func() graph.Criteria {
 			return query.And(
 				query.Kind(query.Node(), ad.User),
 				query.IsNotNull(query.NodeProperty(adminRightsCount)),
 			)
-		}))
-		if err != nil {
+		})); err != nil {
 			return err
-		}
-
-		for _, node := range nodes {
-			node.Properties.Delete(adminRightsCount)
-			if err := tx.UpdateNode(node); err != nil {
-				return err
+		} else {
+			for _, node := range nodes {
+				node.Properties.Delete(adminRightsCount)
+				if err := tx.UpdateNode(node); err != nil {
+					return err
+				}
 			}
+
+			return nil
 		}
-		return nil
 	})
 }
 

--- a/cmd/api/src/migrations/manifest.go
+++ b/cmd/api/src/migrations/manifest.go
@@ -54,7 +54,6 @@ func Version_730_Migration(ctx context.Context, db graph.Database) error {
 	defer measure.LogAndMeasure(slog.LevelInfo, "Migration to remove admin_rights_count property from user nodes")
 
 	return db.BatchOperation(ctx, func(batch graph.Batch) error {
-		fmt.Println("GOT HERE")
 
 		// MATCH(n:User) WHERE n.adminrightscount <> null
 		nodes, err := ops.FetchNodes(batch.Nodes().Filterf(func() graph.Criteria {


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

This is a simple migration to remove the admin_rights_count property from User nodes

## Motivation and Context

This PR addresses: BED-4886

## How Has This Been Tested?
Update the migration data node to version 7.2.0
SELECT * FROM node WHERE kind_ids @> ARRAY[1]

Find a User node in the `node` table (kind_id 23)
Take node of the ID and properties of the node
Add `"adminrightscount": 1` to the properties of the User node

kind_ids @> properties ? 'adminrightscount'
Ensure that this query works, and take a note of the node’s ID that you modified

Run the application and ensure you see in the logs:
`Migration to remove admin_rights_count property from user nodes","measurement_id":1`

Re-run this query
kind_ids @> properties ? 'adminrightscount'
And ensure that the node is no longer returned

Query for the node you changed and ensure the properties match what was there previously, but without `adminrightscount`

Query for the migration data node again and ensure it's on version 7.3.0
SELECT * FROM node WHERE kind_ids @> ARRAY[1]

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Database Migrations

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
