### PR TITLE
Add GPOLocalGroup Ingestion to Domain Objects

### DIFF
--- a/cmd/api/src/daemons/datapipe/convertors.go
+++ b/cmd/api/src/daemons/datapipe/convertors.go
@@ -100,6 +100,10 @@ func convertDomainData(domain ein.Domain, converted *ConvertedData) {
 	domainTrustData := ein.ParseDomainTrusts(domain)
 	converted.RelProps = append(converted.RelProps, domainTrustData.TrustRelationships...)
 	converted.NodeProps = append(converted.NodeProps, domainTrustData.ExtraNodeProps...)
+
+	parsedLocalGroupData := ein.ParseGPOChanges(domain.GPOChanges)
+	converted.RelProps = append(converted.RelProps, parsedLocalGroupData.Relationships...)
+	converted.NodeProps = append(converted.NodeProps, parsedLocalGroupData.Nodes...)
 }
 
 func convertGPOData(gpo ein.GPO, converted *ConvertedData) {

--- a/cmd/api/src/test/fixtures/fixtures/expected_ingest.go
+++ b/cmd/api/src/test/fixtures/fixtures/expected_ingest.go
@@ -81,6 +81,12 @@ var (
 			query.Kind(query.Relationship(), ad.Contains),
 			query.Kind(query.End(), ad.Container),
 			query.Equals(query.EndProperty(common.ObjectID.String()), "AB616901-D423-4B9A-B68F-D24CEE1E36EF")),
+		query.And(
+			query.Kind(query.Start(), ad.User),
+			query.Equals(query.StartProperty(common.ObjectID.String()), "S-1-5-21-3130019616-2776909439-2417379446-1114"),
+			query.Kind(query.Relationship(), ad.AdminTo),
+			query.Kind(query.End(), ad.Computer),
+			query.Equals(query.EndProperty(common.ObjectID.String()), "S-1-5-21-3130019616-2776909439-2417379446-1000")),
 
 		//// CONTAINERS
 		query.And(

--- a/cmd/api/src/test/fixtures/fixtures/v6/all/domains.json
+++ b/cmd/api/src/test/fixtures/fixtures/v6/all/domains.json
@@ -20,7 +20,12 @@
     },
     {
       "GPOChanges": {
-        "LocalAdmins": [],
+        "LocalAdmins": [
+            {
+                "ObjectIdentifier": "S-1-5-21-909015691-3030120388-2582151266-1114",
+                "ObjectType": "User"
+            }
+        ],
         "RemoteDesktopUsers": [],
         "DcomUsers": [],
         "PSRemoteUsers": [],

--- a/packages/go/ein/incoming_models.go
+++ b/packages/go/ein/incoming_models.go
@@ -246,6 +246,7 @@ type Domain struct {
 	ChildObjects []TypedPrincipal
 	Trusts       []Trust
 	Links        []GPLink
+	GPOChanges   GPOChanges
 }
 
 type SessionAPIResult struct {


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description
The original PR for GPOLocalGroup (https://github.com/SpecterOps/BloodHound/pull/1147) did not include the domain nodes which also have the same information. This PR corrects that.

## Motivation and Context

This PR addresses: https://specterops.atlassian.net/browse/BED-5384

## How Has This Been Tested?

Tested using lab data

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- New feature (non-breaking change which adds functionality)


## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
