### PR TITLE
BED-5504: Move common query utils to shared-ui

### DIFF
--- a/packages/javascript/bh-shared-ui/src/utils/queries/index.ts
+++ b/packages/javascript/bh-shared-ui/src/utils/queries/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2023 Specter Ops, Inc.
+// Copyright 2025 Specter Ops, Inc.
 //
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
@@ -14,20 +14,4 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-export * from './api';
-export * from './colors';
-export * from './compatibility';
-export * from './content';
-export * from './copyToClipboard';
-export * from './datetime';
-export * from './entityInfoDisplay';
-export * from './exportGraphData';
-export * from './icons';
-export * from './mocks';
-export * from './parseItemId';
-export * from './passwd';
-export * from './permissions';
 export * from './queries';
-export * from './searchParams';
-export * from './theme';
-export * from './user';

--- a/packages/javascript/bh-shared-ui/src/utils/queries/queries.test.ts
+++ b/packages/javascript/bh-shared-ui/src/utils/queries/queries.test.ts
@@ -1,0 +1,45 @@
+// Copyright 2025 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { queriesAreLoadingOrErrored } from './queries';
+
+describe('queriesAreLoadingOrErrored', () => {
+    it.each(['isLoading', 'isError'] as const)('%s returns as expected based on all queries combined', (key) => {
+        // all keys to true
+        const allTrueActual = queriesAreLoadingOrErrored(
+            { [key]: true } as any,
+            ...([{ [key]: true }, { [key]: true }] as any),
+            ...([{ [key]: true }] as any)
+        );
+        expect(allTrueActual[key]).toBe(true);
+
+        // Partial keys are true
+        const partialTrueActual = queriesAreLoadingOrErrored(
+            { [key]: true } as any,
+            ...([{ [key]: false }, { [key]: true }] as any),
+            ...([{ [key]: false }] as any)
+        );
+        expect(partialTrueActual[key]).toBe(true);
+
+        // set all keys to false
+        const allFalseActual = queriesAreLoadingOrErrored(
+            { [key]: false } as any,
+            ...([{ [key]: false }, { [key]: false }] as any),
+            ...([{ [key]: false }] as any)
+        );
+        expect(allFalseActual[key]).toBe(false);
+    });
+});

--- a/packages/javascript/bh-shared-ui/src/utils/queries/queries.ts
+++ b/packages/javascript/bh-shared-ui/src/utils/queries/queries.ts
@@ -1,0 +1,41 @@
+// Copyright 2025 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { UseQueryOptions, UseQueryResult } from 'react-query';
+
+export type GenericQueryOptions<T> = Omit<UseQueryOptions<T, unknown, T, string[]>, 'queryFn'>;
+
+export const getQueryKey = (baseKey: string[], customKeys?: string[]) => {
+    return customKeys?.length ? [...baseKey, ...customKeys] : baseKey;
+};
+
+/**
+ * Use this when you want to treat the loading or error state of multiple queries as one.
+ * For example, display a component when 2 separate APIs are done loading.
+ * @param queries Variadic function that will check if any query isLoading or isError
+ * @returns isLoading = true if any query is loading, and isError = true if any query has an error
+ */
+export const queriesAreLoadingOrErrored = (...queries: UseQueryResult<unknown, unknown>[]) => {
+    let isLoading = false;
+    let isError = false;
+
+    queries.forEach((query) => {
+        if (query.isLoading) isLoading = true;
+        if (query.isError) isError = true;
+    });
+
+    return { isLoading, isError };
+};


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Moves some of the common shared react-query utils to the shared-ui to be shared with other query hooks

## Motivation and Context

This PR addresses: BED-5504

We keep recreating these functions so this PR moves them to the shared-ui so we only have one version.

## How Has This Been Tested?
Moved existing unit tests

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)
- New feature (non-breaking change which adds functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
