### PR TITLE
chore: remove tests from just prepare-for-codereview

### DIFF
--- a/justfile
+++ b/justfile
@@ -64,7 +64,6 @@ _prep-steps:
   @just goimports
   @just show > tmp/repo-status.txt
   @just analyze > tmp/analysis-report.txt
-  @just build > tmp/build-output.txt
 
 goimports:
   @ echo "Running goimports, check for file drift"

--- a/justfile
+++ b/justfile
@@ -65,8 +65,6 @@ _prep-steps:
   @just show > tmp/repo-status.txt
   @just analyze > tmp/analysis-report.txt
   @just build > tmp/build-output.txt
-  @just test -y > tmp/yarn-test-output.txt
-  @just test -g -i > tmp/go-test-output.txt
 
 goimports:
   @ echo "Running goimports, check for file drift"


### PR DESCRIPTION
## Description

Removes the yarn and go testing steps from the `just prepare-for-codereview` script.

## Motivation and Context

This PR addresses: [BED-5730]

There was recently a discussion in the engineering-council channel to move tests to a CI check. So tests are being removed from the prc just script as to not be redundant

## How Has This Been Tested?

The `just pfc` script was ran again to ensure that it still works and does not run the tests. 

## Types of changes

- Chore (a change that does not modify the application functionality)

## Checklist:

- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


[BED-5730]: https://specterops.atlassian.net/browse/BED-5730?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ