### PR TITLE
BED-5621 fix: incorrect refactor file placement

### DIFF
--- a/packages/go/graphschema/go.mod
+++ b/packages/go/graphschema/go.mod
@@ -1,19 +1,30 @@
 // Copyright 2023 Specter Ops, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// 
+//
 // SPDX-License-Identifier: Apache-2.0
 
 module github.com/specterops/bloodhound/graphschema
 
 go 1.23
+
+require github.com/stretchr/testify v1.10.0
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/kr/pretty v0.3.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/rogpeppe/go-internal v1.13.1 // indirect
+	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/packages/go/graphschema/go.sum
+++ b/packages/go/graphschema/go.sum
@@ -1,0 +1,8 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/packages/go/graphschema/primarykind.go
+++ b/packages/go/graphschema/primarykind.go
@@ -1,0 +1,88 @@
+// Copyright 2025 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package graphschema
+
+import (
+	"github.com/specterops/bloodhound/dawgs/graph"
+	"github.com/specterops/bloodhound/graphschema/ad"
+	"github.com/specterops/bloodhound/graphschema/azure"
+	"github.com/specterops/bloodhound/graphschema/common"
+)
+
+var (
+	// Originates from BHE but copied here
+	meta         = graph.StringKind("Meta")
+	metaDetail   = graph.StringKind("MetaDetail")
+	metaIncludes = graph.StringKind("MetaIncludes")
+	metaKinds    = []graph.Kind{meta, metaDetail, metaIncludes}
+
+	unknownKind = graph.StringKind("Unknown")
+
+	// Used for quick O(1) kind lookups
+	ValidKinds = buildValidKinds()
+)
+
+func buildValidKinds() map[graph.Kind]bool {
+	var (
+		validKinds = make(map[graph.Kind]bool)
+		kindSlices = []graph.Kinds{
+			ad.NodeKinds(),
+			ad.Relationships(),
+			azure.NodeKinds(),
+			azure.Relationships(),
+			common.NodeKinds(),
+			common.Relationships(),
+		}
+	)
+
+	for _, kindSlice := range kindSlices {
+		for _, kind := range kindSlice {
+			validKinds[kind] = true
+		}
+	}
+
+	return validKinds
+}
+
+func PrimaryNodeKind(kinds graph.Kinds) graph.Kind {
+	var (
+		resultKind = unknownKind
+		baseKind   = resultKind
+	)
+
+	for _, kind := range kinds {
+		// If this is a BHE meta kind, return early
+		if kind.Is(metaKinds...) {
+			return meta
+		} else if kind.Is(ad.Entity, azure.Entity) {
+			baseKind = kind
+		} else if kind.Is(ad.LocalGroup) {
+			// Allow ad.LocalGroup to overwrite NodeKindUnknown, but nothing else
+			if resultKind == unknownKind {
+				resultKind = kind
+			}
+		} else if ValidKinds[kind] {
+			resultKind = kind
+		}
+	}
+
+	if resultKind.Is(unknownKind) {
+		return baseKind
+	} else {
+		return resultKind
+	}
+}

--- a/packages/go/graphschema/primarykind_test.go
+++ b/packages/go/graphschema/primarykind_test.go
@@ -1,0 +1,54 @@
+// Copyright 2025 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package graphschema
+
+import (
+	"testing"
+
+	"github.com/specterops/bloodhound/dawgs/graph"
+	"github.com/specterops/bloodhound/graphschema/ad"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_PrimaryNodeKind(t *testing.T) {
+
+	t.Run("detects meta kinds", func(t *testing.T) {
+		primaryKind := PrimaryNodeKind(graph.Kinds{meta})
+		require.Equal(t, meta, primaryKind)
+	})
+
+	t.Run("ad local group overrides unknown", func(t *testing.T) {
+		primaryKind := PrimaryNodeKind(graph.Kinds{ad.Entity, ad.LocalGroup})
+		require.Equal(t, ad.LocalGroup, primaryKind)
+	})
+
+	t.Run("detects valid kind", func(t *testing.T) {
+		primaryKind := PrimaryNodeKind(graph.Kinds{ad.Entity, ad.Computer})
+		require.Equal(t, ad.Computer, primaryKind)
+	})
+
+	t.Run("falls back to base kind if no valid kinds", func(t *testing.T) {
+		primaryKind := PrimaryNodeKind(graph.Kinds{ad.Entity, graph.StringKind("Villain")})
+		require.Equal(t, ad.Entity, primaryKind)
+	})
+
+	t.Run("falls back to unknown if nothing detected", func(t *testing.T) {
+		primaryKind := PrimaryNodeKind(graph.Kinds{graph.StringKind("Hero")})
+		require.Equal(t, unknownKind, primaryKind)
+	})
+
+}


### PR DESCRIPTION
## Description

The helper function PrimaryNodeKind was placed in the wrong file. This moves it to it's own file (and adds tests)

## Motivation and Context

This PR addresses: BED-5621

*Why is this change required? What problem does it solve?*

## How Has This Been Tested?
Added unit tests

## Types of changes

<!-- Please remove any items that do not apply. -->
- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
