### PR TITLE
fix(Hounds Downloads): Add collectors bucket URL to default config

### DIFF
--- a/cmd/api/src/config/default.go
+++ b/cmd/api/src/config/default.go
@@ -43,6 +43,7 @@ func NewDefaultConfiguration() (Configuration, error) {
 			WorkDir:                      "/opt/bhe/work",
 			LogLevel:                     "INFO",
 			CollectorsBasePath:           "/etc/bloodhound/collectors",
+			CollectorsBucketURL:          serde.MustParseURL("https://bhe-hound-artifacts.s3.amazonaws.com/"),
 			DatapipeInterval:             60,
 			EnableStartupWaitPeriod:      true,
 			EnableAPILogging:             true,


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Add collectors bucket URL to default config

## Motivation and Context

This PR addresses: BED-4715

*Why is this change required? What problem does it solve?*

The default value for the collectors bucket was not getting set

## How Has This Been Tested?

Locally

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)
- 
## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
