### PR TITLE
BED-5764: Relationship search / Graph rendering only happening if member count under query limit

### DIFF
--- a/cmd/ui/src/views/Explore/EntityInfo/EntityInfoDataTable.tsx
+++ b/cmd/ui/src/views/Explore/EntityInfo/EntityInfoDataTable.tsx
@@ -88,9 +88,11 @@ const EntityInfoDataTable: React.FC<EntityInfoDataTableProps> = ({
 
         setExploreParams({
             expandedPanelSections: labelList,
-            searchType: 'relationship',
-            relationshipQueryType: queryType,
-            relationshipQueryItemId: id,
+            ...(isUnderRenderLimit && {
+                searchType: 'relationship',
+                relationshipQueryType: queryType,
+                relationshipQueryItemId: id,
+            }),
         });
     };
 
@@ -104,8 +106,9 @@ const EntityInfoDataTable: React.FC<EntityInfoDataTableProps> = ({
         }
     };
     const handleSetV2Graph = async () => {
-        if (!endpoint) setParentExpandedSectionParam();
-        if (endpoint && isUnderRenderLimit) {
+        if (!endpoint) {
+            setParentExpandedSectionParam();
+        } else {
             setExpandedPanelSectionsParams();
         }
     };


### PR DESCRIPTION
## Description

This change conditions the relationship search to only panels that have a member count less then the limit (1000). It addresses the bug that did not allow to open panels when count was over the limit.

## Motivation and Context

This PR addresses: [BED-5454](https://specterops.atlassian.net/browse/BED-5454)

## How Has This Been Tested?

Manually and all existing tests passed.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


[BED-5454]: https://specterops.atlassian.net/browse/BED-5454?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ