### PR TITLE
Issue #1369: Convert domain properties with float values to integers

### DIFF
--- a/packages/go/ein/ad.go
+++ b/packages/go/ein/ad.go
@@ -217,6 +217,10 @@ func stringToInt(itemProps map[string]any, keyName string) {
 			} else {
 				itemProps[keyName] = final
 			}
+		case float32:
+			itemProps[keyName] = int(converted)
+		case float64:
+			itemProps[keyName] = int(converted)
 		case int:
 		// pass
 		default:


### PR DESCRIPTION
## Description

The stringToInt function expects either a string or an int value for domain properties when ingesting SharpHound data. Any others data types are discarded. Integers from SharpHound collect are currently being inserted as float64 values and then deleted. This change will convert float values to integers to avoid deletion.

## Motivation and Context

Resolves issue 1369

*Why is this change required? What problem does it solve?*

## How Has This Been Tested?

Tested locally with valid SharpHound collection data. Changes resulted in the missing properties values now being available in Neo4J.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/1369
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
