### PR TITLE
chore: set debug log level on entity count query

### DIFF
--- a/cmd/api/src/queries/graph.go
+++ b/cmd/api/src/queries/graph.go
@@ -640,7 +640,7 @@ func (s *GraphQuery) GetEntityCountResults(ctx context.Context, node *graph.Node
 	for delegateKey, delegate := range delegates {
 		waitGroup.Add(1)
 
-		slog.Debug(fmt.Sprintf("Running entity query %s", delegateKey))
+		slog.DebugContext(ctx, fmt.Sprintf("Running entity query %s", delegateKey))
 
 		go func(delegateKey string, delegate any) {
 			defer waitGroup.Done()

--- a/cmd/api/src/queries/graph.go
+++ b/cmd/api/src/queries/graph.go
@@ -640,7 +640,7 @@ func (s *GraphQuery) GetEntityCountResults(ctx context.Context, node *graph.Node
 	for delegateKey, delegate := range delegates {
 		waitGroup.Add(1)
 
-		slog.InfoContext(ctx, fmt.Sprintf("Running entity query %s", delegateKey))
+		slog.Debug(fmt.Sprintf("Running entity query %s", delegateKey))
 
 		go func(delegateKey string, delegate any) {
 			defer waitGroup.Done()


### PR DESCRIPTION
Changing the log level from Info to debug when fetching the count of the entity

Fixes BED-5768

<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Changing the log level from Info to debug when fetching the count of the entity

## Motivation and Context

Running queries at `Info` level generates a lot of logs which adds resource constraints on the system.

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->

Resolves BED-5768

*Why is this change required? What problem does it solve?*

## How Has This Been Tested?
Verified locally
![debugging_context_running_entity_count](https://github.com/user-attachments/assets/e2420af3-b993-4dc1-a969-31d23dd37c22)


*Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc.*

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)
- Database Migrations

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
