### PR TITLE
BED-5732: Fix Collapse All button in Entity/Edge panels

### DIFF
--- a/cmd/ui/src/views/Explore/EdgeInfo/EdgeInfoContent.test.tsx
+++ b/cmd/ui/src/views/Explore/EdgeInfo/EdgeInfoContent.test.tsx
@@ -153,13 +153,19 @@ const hasLapsDisabledTestText = windowsAbuseHasLapsText(
     selectedEdgeHasLapsDisabled.targetNode.name
 );
 
+const EdgeInfoContentWithProvider = (selectedEdge: bhSharedUi.SelectedEdge) => (
+    <bhSharedUi.ObjectInfoPanelContextProvider>
+        <EdgeInfoContent selectedEdge={selectedEdge!} />
+    </bhSharedUi.ObjectInfoPanelContextProvider>
+);
+
 beforeAll(() => server.listen());
 afterEach(() => server.resetHandlers());
 afterAll(() => server.close());
 
 describe('EdgeInfoContent', () => {
     test('Trying to view the edge info does not crash the app when selecting an unrecognized edge', async () => {
-        render(<EdgeInfoContent selectedEdge={selectedEdge} />);
+        render(EdgeInfoContentWithProvider(selectedEdge));
 
         expect(await screen.findByText(/source node/)).toBeInTheDocument();
 
@@ -183,7 +189,7 @@ describe('EdgeInfoContent', () => {
         ).not.toBeInTheDocument();
     });
     test('Selecting an edge with a Computer target node that haslaps is enabled shows correct Windows Abuse text', async () => {
-        render(<EdgeInfoContent selectedEdge={selectedEdgeHasLapsEnabled} />);
+        render(EdgeInfoContentWithProvider(selectedEdgeHasLapsEnabled));
 
         const user = userEvent.setup();
         const windowAbuseAccordion = screen.getByText('Windows Abuse');
@@ -192,7 +198,7 @@ describe('EdgeInfoContent', () => {
         expect(screen.getByText(hasLapsEnabledTestText, { exact: false })).toBeInTheDocument();
     });
     test('Selecting an edge with a Computer target node that does not have haslaps enabled shows correct Windows Abuse text', async () => {
-        render(<EdgeInfoContent selectedEdge={selectedEdgeHasLapsDisabled} />);
+        render(EdgeInfoContentWithProvider(selectedEdgeHasLapsDisabled));
 
         const user = userEvent.setup();
         const windowAbuseAccordion = screen.getByText('Windows Abuse');
@@ -203,7 +209,7 @@ describe('EdgeInfoContent', () => {
 
     describe('EdgeInfoContent support for Deep Linking', () => {
         const setup = () => {
-            const screen = render(<EdgeInfoContent selectedEdge={selectedEdgeADCSESC4} />);
+            const screen = render(EdgeInfoContentWithProvider(selectedEdgeADCSESC4));
             const user = userEvent.setup();
 
             server.use(

--- a/cmd/ui/src/views/Explore/EdgeInfo/EdgeInfoContent.test.tsx
+++ b/cmd/ui/src/views/Explore/EdgeInfo/EdgeInfoContent.test.tsx
@@ -153,7 +153,7 @@ const hasLapsDisabledTestText = windowsAbuseHasLapsText(
     selectedEdgeHasLapsDisabled.targetNode.name
 );
 
-const EdgeInfoContentWithProvider = (selectedEdge: bhSharedUi.SelectedEdge) => (
+const EdgeInfoContentWithProvider = ({ selectedEdge }: { selectedEdge: bhSharedUi.SelectedEdge }) => (
     <bhSharedUi.ObjectInfoPanelContextProvider>
         <EdgeInfoContent selectedEdge={selectedEdge!} />
     </bhSharedUi.ObjectInfoPanelContextProvider>
@@ -165,7 +165,7 @@ afterAll(() => server.close());
 
 describe('EdgeInfoContent', () => {
     test('Trying to view the edge info does not crash the app when selecting an unrecognized edge', async () => {
-        render(EdgeInfoContentWithProvider(selectedEdge));
+        render(<EdgeInfoContentWithProvider selectedEdge={selectedEdge} />);
 
         expect(await screen.findByText(/source node/)).toBeInTheDocument();
 
@@ -189,7 +189,7 @@ describe('EdgeInfoContent', () => {
         ).not.toBeInTheDocument();
     });
     test('Selecting an edge with a Computer target node that haslaps is enabled shows correct Windows Abuse text', async () => {
-        render(EdgeInfoContentWithProvider(selectedEdgeHasLapsEnabled));
+        render(<EdgeInfoContentWithProvider selectedEdge={selectedEdgeHasLapsEnabled} />);
 
         const user = userEvent.setup();
         const windowAbuseAccordion = screen.getByText('Windows Abuse');
@@ -198,7 +198,7 @@ describe('EdgeInfoContent', () => {
         expect(screen.getByText(hasLapsEnabledTestText, { exact: false })).toBeInTheDocument();
     });
     test('Selecting an edge with a Computer target node that does not have haslaps enabled shows correct Windows Abuse text', async () => {
-        render(EdgeInfoContentWithProvider(selectedEdgeHasLapsDisabled));
+        render(<EdgeInfoContentWithProvider selectedEdge={selectedEdgeHasLapsDisabled} />);
 
         const user = userEvent.setup();
         const windowAbuseAccordion = screen.getByText('Windows Abuse');
@@ -209,7 +209,7 @@ describe('EdgeInfoContent', () => {
 
     describe('EdgeInfoContent support for Deep Linking', () => {
         const setup = () => {
-            const screen = render(EdgeInfoContentWithProvider(selectedEdgeADCSESC4));
+            const screen = render(<EdgeInfoContentWithProvider selectedEdge={selectedEdgeADCSESC4} />);
             const user = userEvent.setup();
 
             server.use(

--- a/cmd/ui/src/views/Explore/EdgeInfo/EdgeInfoHeader.test.tsx
+++ b/cmd/ui/src/views/Explore/EdgeInfo/EdgeInfoHeader.test.tsx
@@ -1,3 +1,18 @@
+// Copyright 2025 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 import { rest } from 'msw';
 import { setupServer } from 'msw/node';
 import { act, render } from 'src/test-utils';

--- a/cmd/ui/src/views/Explore/EdgeInfo/EdgeInfoHeader.test.tsx
+++ b/cmd/ui/src/views/Explore/EdgeInfo/EdgeInfoHeader.test.tsx
@@ -1,0 +1,85 @@
+import { rest } from 'msw';
+import { setupServer } from 'msw/node';
+import { act, render } from 'src/test-utils';
+
+import userEvent from '@testing-library/user-event';
+import { ObjectInfoPanelContext } from 'bh-shared-ui';
+import { createMemoryHistory } from 'history';
+import EdgeInfoHeader, { HeaderProps } from './EdgeInfoHeader';
+
+const testProps: HeaderProps = {
+    expanded: true,
+    name: 'testName',
+    onToggleExpanded: vi.fn(),
+};
+
+const backButtonSupportFF = {
+    key: 'back_button_support',
+    enabled: true,
+};
+
+const setIsObjectInfoPanelOpen = (newValue: boolean) => {
+    mockContextValue.isObjectInfoPanelOpen = newValue;
+};
+
+const mockContextValue = {
+    isObjectInfoPanelOpen: true,
+    setIsObjectInfoPanelOpen,
+};
+
+const server = setupServer(
+    rest.get('/api/v2/features', (_req, res, ctx) => {
+        return res(
+            ctx.json({
+                data: [backButtonSupportFF],
+            })
+        );
+    })
+);
+
+beforeAll(() => server.listen());
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+const setup = async () => {
+    const url = `?expandedPanelSections=['test','test1']`;
+
+    const history = createMemoryHistory({ initialEntries: [url] });
+
+    const screen = await act(async () => {
+        return render(
+            <ObjectInfoPanelContext.Provider value={mockContextValue}>
+                <EdgeInfoHeader {...testProps} />
+            </ObjectInfoPanelContext.Provider>,
+            { history }
+        );
+    });
+
+    const user = userEvent.setup();
+
+    return { screen, user, history };
+};
+
+describe('EdgeInfoHeader', async () => {
+    it('should render', async () => {
+        const { screen } = await setup();
+
+        const collapsePanelButton = screen.getByRole('button', { name: /minus/i });
+        const edgeTitle = screen.getByRole('heading');
+        const collapseAllButton = screen.getByRole('button', { name: /collapse all/i });
+
+        expect(collapsePanelButton).toBeInTheDocument();
+        expect(edgeTitle).toBeInTheDocument();
+        expect(edgeTitle).toHaveTextContent(testProps.name);
+        expect(collapseAllButton).toBeInTheDocument();
+    });
+    it('should on clicking collapse all remove expandedPanelSections param from url and set isObjectInfoPanelOpen in context to false', async () => {
+        const { screen, history, user } = await setup();
+        const collapseAllButton = screen.getByRole('button', { name: /collapse all/i });
+
+        await user.click(collapseAllButton);
+
+        expect(history.location.search).not.toContain('expandedPanelSections');
+        expect(mockContextValue.isObjectInfoPanelOpen).toBe(false);
+    });
+});

--- a/cmd/ui/src/views/Explore/EdgeInfo/EdgeInfoHeader.tsx
+++ b/cmd/ui/src/views/Explore/EdgeInfo/EdgeInfoHeader.tsx
@@ -17,7 +17,14 @@
 import { faAngleDoubleUp, faMinus, faPlus } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Typography } from '@mui/material';
-import { Icon, collapseAllSections, useHeaderStyles } from 'bh-shared-ui';
+import {
+    Icon,
+    collapseAllSections,
+    useExploreParams,
+    useFeatureFlag,
+    useHeaderStyles,
+    useObjectInfoPanelContext,
+} from 'bh-shared-ui';
 import React from 'react';
 import { useAppDispatch } from 'src/store';
 
@@ -30,6 +37,20 @@ interface HeaderProps {
 const Header: React.FC<HeaderProps> = ({ name = 'None Selected', onToggleExpanded, expanded }) => {
     const styles = useHeaderStyles();
     const dispatch = useAppDispatch();
+    const { data: backButtonFlag } = useFeatureFlag('back_button_support');
+    const { setIsObjectInfoPanelOpen } = useObjectInfoPanelContext();
+    const { setExploreParams } = useExploreParams();
+
+    const handleCollapseAll = () => {
+        setIsObjectInfoPanelOpen(false);
+        if (backButtonFlag?.enabled) {
+            setExploreParams({
+                expandedPanelSections: [],
+            });
+        } else {
+            dispatch(collapseAllSections());
+        }
+    };
 
     return (
         <div className={styles.header}>
@@ -51,9 +72,7 @@ const Header: React.FC<HeaderProps> = ({ name = 'None Selected', onToggleExpande
 
             <Icon
                 tip='Collapse All'
-                click={() => {
-                    dispatch(collapseAllSections());
-                }}
+                click={handleCollapseAll}
                 className={styles.icon}
                 data-testid='explore_edge-information-pane_button-collapse-all'>
                 <FontAwesomeIcon icon={faAngleDoubleUp} />

--- a/cmd/ui/src/views/Explore/EdgeInfo/EdgeInfoHeader.tsx
+++ b/cmd/ui/src/views/Explore/EdgeInfo/EdgeInfoHeader.tsx
@@ -28,7 +28,7 @@ import {
 import React from 'react';
 import { useAppDispatch } from 'src/store';
 
-interface HeaderProps {
+export interface HeaderProps {
     name: string;
     expanded: boolean;
     onToggleExpanded: (expanded: boolean) => void;

--- a/cmd/ui/src/views/Explore/EdgeInfo/EdgeInfoPane.tsx
+++ b/cmd/ui/src/views/Explore/EdgeInfo/EdgeInfoPane.tsx
@@ -15,14 +15,26 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Box, Paper, SxProps } from '@mui/material';
-import { SelectedEdge, collapseAllSections, useExploreParams, useFeatureFlag, usePaneStyles } from 'bh-shared-ui';
+import {
+    ObjectInfoPanelContextProvider,
+    SelectedEdge,
+    collapseAllSections,
+    useExploreParams,
+    useFeatureFlag,
+    usePaneStyles,
+} from 'bh-shared-ui';
 import React, { useEffect, useState } from 'react';
 import usePreviousValue from 'src/hooks/usePreviousValue';
 import { useAppDispatch } from 'src/store';
 import EdgeInfoContent from 'src/views/Explore/EdgeInfo/EdgeInfoContent';
 import Header from 'src/views/Explore/EdgeInfo/EdgeInfoHeader';
 
-const EdgeInfoPane: React.FC<{ sx?: SxProps; selectedEdge: SelectedEdge | null }> = ({ sx, selectedEdge }) => {
+interface EdgeInfoPaneProps {
+    sx?: SxProps;
+    selectedEdge: SelectedEdge | null;
+}
+
+const EdgeInfoPane: React.FC<EdgeInfoPaneProps> = ({ sx, selectedEdge }) => {
     const styles = usePaneStyles();
     const [expanded, setExpanded] = useState(true);
     const { expandedPanelSections } = useExploreParams();
@@ -59,4 +71,10 @@ const EdgeInfoPane: React.FC<{ sx?: SxProps; selectedEdge: SelectedEdge | null }
     );
 };
 
-export default EdgeInfoPane;
+const WrappedEdgeInfoPane: React.FC<EdgeInfoPaneProps> = (props) => (
+    <ObjectInfoPanelContextProvider>
+        <EdgeInfoPane {...props} />
+    </ObjectInfoPanelContextProvider>
+);
+
+export default WrappedEdgeInfoPane;

--- a/cmd/ui/src/views/Explore/EdgeInfo/EdgeObjectInformation.test.tsx
+++ b/cmd/ui/src/views/Explore/EdgeInfo/EdgeObjectInformation.test.tsx
@@ -35,7 +35,7 @@ const selectedEdge: SelectedEdge = {
     targetNode: { name: 'target_node', id: '2', objectId: '2', type: 'User' },
 };
 
-const EdgeObjectInformationWithProvider = (
+const EdgeObjectInformationWithProvider = () => (
     <ObjectInfoPanelContextProvider>
         <EdgeObjectInformation selectedEdge={selectedEdge} />
     </ObjectInfoPanelContextProvider>
@@ -72,7 +72,7 @@ describe('EdgeObjectInformation', () => {
             })
         );
 
-        render(EdgeObjectInformationWithProvider);
+        render(<EdgeObjectInformationWithProvider />);
 
         expect(await screen.findByText(/source_node/)).toBeInTheDocument();
 
@@ -99,7 +99,7 @@ describe('EdgeObjectInformation', () => {
             })
         );
 
-        render(EdgeObjectInformationWithProvider);
+        render(<EdgeObjectInformationWithProvider />);
 
         expect(await screen.findByText(/source_node/)).toBeInTheDocument();
 

--- a/cmd/ui/src/views/Explore/EdgeInfo/EdgeObjectInformation.test.tsx
+++ b/cmd/ui/src/views/Explore/EdgeInfo/EdgeObjectInformation.test.tsx
@@ -14,7 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { SelectedEdge } from 'bh-shared-ui';
+import { ObjectInfoPanelContextProvider, SelectedEdge } from 'bh-shared-ui';
 import { rest } from 'msw';
 import { setupServer } from 'msw/node';
 import { render, screen } from 'src/test-utils';
@@ -34,6 +34,12 @@ const selectedEdge: SelectedEdge = {
     },
     targetNode: { name: 'target_node', id: '2', objectId: '2', type: 'User' },
 };
+
+const EdgeObjectInformationWithProvider = (
+    <ObjectInfoPanelContextProvider>
+        <EdgeObjectInformation selectedEdge={selectedEdge} />
+    </ObjectInfoPanelContextProvider>
+);
 
 beforeAll(() => server.listen());
 afterEach(() => server.resetHandlers());
@@ -66,7 +72,7 @@ describe('EdgeObjectInformation', () => {
             })
         );
 
-        render(<EdgeObjectInformation selectedEdge={selectedEdge} />);
+        render(EdgeObjectInformationWithProvider);
 
         expect(await screen.findByText(/source_node/)).toBeInTheDocument();
 
@@ -93,7 +99,7 @@ describe('EdgeObjectInformation', () => {
             })
         );
 
-        render(<EdgeObjectInformation selectedEdge={selectedEdge} />);
+        render(EdgeObjectInformationWithProvider);
 
         expect(await screen.findByText(/source_node/)).toBeInTheDocument();
 

--- a/cmd/ui/src/views/Explore/EdgeInfo/EdgeObjectInformation.tsx
+++ b/cmd/ui/src/views/Explore/EdgeInfo/EdgeObjectInformation.tsx
@@ -22,8 +22,9 @@ import {
     SelectedEdge,
     apiClient,
     formatObjectInfoFields,
+    useObjectInfoPanelContext,
 } from 'bh-shared-ui';
-import { FC, useEffect, useState } from 'react';
+import { FC, useEffect } from 'react';
 import { useQuery } from 'react-query';
 import usePreviousValue from 'src/hooks/usePreviousValue';
 import EdgeInfoCollapsibleSection from 'src/views/Explore/EdgeInfo/EdgeInfoCollapsibleSection';
@@ -32,15 +33,15 @@ const selectedEdgeCypherQuery = (sourceId: string | number, targetId: string | n
     `MATCH (s)-[r:${edgeKind}]->(t) WHERE ID(s) = ${sourceId} AND ID(t) = ${targetId} RETURN r LIMIT 1`;
 
 const EdgeObjectInformation: FC<{ selectedEdge: NonNullable<SelectedEdge> }> = ({ selectedEdge }) => {
-    const [isExpanded, setIsExpanded] = useState(true);
+    const { isObjectInfoPanelOpen, setIsObjectInfoPanelOpen } = useObjectInfoPanelContext();
 
     const previousId = usePreviousValue(selectedEdge.id);
 
     useEffect(() => {
         if (previousId !== selectedEdge.id) {
-            setIsExpanded(true);
+            setIsObjectInfoPanelOpen(true);
         }
-    }, [previousId, selectedEdge.id]);
+    }, [previousId, selectedEdge.id, setIsObjectInfoPanelOpen]);
 
     const {
         data: cypherResponse,
@@ -87,11 +88,11 @@ const EdgeObjectInformation: FC<{ selectedEdge: NonNullable<SelectedEdge> }> = (
     const sectionLabel = 'Relationship Information';
 
     const handleOnChange = () => {
-        setIsExpanded(!isExpanded);
+        setIsObjectInfoPanelOpen(!isObjectInfoPanelOpen);
     };
 
     return (
-        <EdgeInfoCollapsibleSection isExpanded={isExpanded} onChange={handleOnChange} label={sectionLabel}>
+        <EdgeInfoCollapsibleSection isExpanded={isObjectInfoPanelOpen} onChange={handleOnChange} label={sectionLabel}>
             <FieldsContainer>
                 <ObjectInfoFields fields={formattedObjectFields} />
             </FieldsContainer>

--- a/cmd/ui/src/views/Explore/EntityInfo/EntityInfoContent.test.tsx
+++ b/cmd/ui/src/views/Explore/EntityInfo/EntityInfoContent.test.tsx
@@ -67,7 +67,15 @@ const server = setupServer(
     })
 );
 
-const EntityInfoContentWithProvider = (testId: string, nodeType: EntityKinds | string, databaseId?: string) => (
+const EntityInfoContentWithProvider = ({
+    testId,
+    nodeType,
+    databaseId,
+}: {
+    testId: string;
+    nodeType: EntityKinds | string;
+    databaseId?: string;
+}) => (
     <EntityInfoPanelContextProvider>
         <ObjectInfoPanelContextProvider>
             <EntityInfoContent id={testId} nodeType={nodeType} databaseId={databaseId} />
@@ -84,7 +92,7 @@ describe('EntityInfoContent', () => {
         const testId = '1';
         const nodeType = AzureNodeKind.Role;
 
-        render(EntityInfoContentWithProvider(testId, nodeType));
+        render(<EntityInfoContentWithProvider testId={testId} nodeType={nodeType} />);
         await waitForElementToBeRemoved(() => screen.getByTestId('entity-object-information-skeleton'));
         expect(screen.queryByText('PIM Assignments')).not.toBeInTheDocument();
     });
@@ -95,7 +103,7 @@ describe('EntityObjectInformation', () => {
         const testId = '1';
         const nodeType = ActiveDirectoryNodeKind.LocalGroup;
 
-        render(EntityInfoContentWithProvider(testId, nodeType));
+        render(<EntityInfoContentWithProvider testId={testId} nodeType={nodeType} />);
 
         await waitForElementToBeRemoved(() => screen.getByTestId('entity-object-information-skeleton'));
 
@@ -106,7 +114,7 @@ describe('EntityObjectInformation', () => {
         const testId = '1';
         const nodeType = ActiveDirectoryNodeKind.LocalUser;
 
-        render(EntityInfoContentWithProvider(testId, nodeType));
+        render(<EntityInfoContentWithProvider testId={testId} nodeType={nodeType} />);
 
         await waitForElementToBeRemoved(() => screen.getByTestId('entity-object-information-skeleton'));
 
@@ -118,7 +126,7 @@ describe('EntityObjectInformation', () => {
         const nodeType = 'Unknown';
         const databaseId = '42';
 
-        render(EntityInfoContentWithProvider(testId, nodeType, databaseId));
+        render(<EntityInfoContentWithProvider testId={testId} nodeType={nodeType} databaseId={databaseId} />);
 
         await waitForElementToBeRemoved(() => screen.getByTestId('entity-object-information-skeleton'));
 

--- a/cmd/ui/src/views/Explore/EntityInfo/EntityInfoContent.test.tsx
+++ b/cmd/ui/src/views/Explore/EntityInfo/EntityInfoContent.test.tsx
@@ -14,7 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { ActiveDirectoryNodeKind, AzureNodeKind } from 'bh-shared-ui';
+import { ActiveDirectoryNodeKind, AzureNodeKind, EntityKinds, ObjectInfoPanelContextProvider } from 'bh-shared-ui';
 import { rest } from 'msw';
 import { setupServer } from 'msw/node';
 import { render, screen, waitForElementToBeRemoved } from 'src/test-utils';
@@ -67,6 +67,14 @@ const server = setupServer(
     })
 );
 
+const EntityInfoContentWithProvider = (testId: string, nodeType: EntityKinds | string, databaseId?: string) => (
+    <EntityInfoPanelContextProvider>
+        <ObjectInfoPanelContextProvider>
+            <EntityInfoContent id={testId} nodeType={nodeType} databaseId={databaseId} />
+        </ObjectInfoPanelContextProvider>
+    </EntityInfoPanelContextProvider>
+);
+
 beforeAll(() => server.listen());
 afterEach(() => server.resetHandlers());
 afterAll(() => server.close());
@@ -74,12 +82,9 @@ afterAll(() => server.close());
 describe('EntityInfoContent', () => {
     it('AZRole information panel will not display a section for PIM Assignments', async () => {
         const testId = '1';
+        const nodeType = AzureNodeKind.Role;
 
-        render(
-            <EntityInfoPanelContextProvider>
-                <EntityInfoContent id={testId} nodeType={AzureNodeKind.Role} />
-            </EntityInfoPanelContextProvider>
-        );
+        render(EntityInfoContentWithProvider(testId, nodeType));
         await waitForElementToBeRemoved(() => screen.getByTestId('entity-object-information-skeleton'));
         expect(screen.queryByText('PIM Assignments')).not.toBeInTheDocument();
     });
@@ -88,12 +93,9 @@ describe('EntityInfoContent', () => {
 describe('EntityObjectInformation', () => {
     it('Calls the `Base` endpoint for a LocalGroup type node', async () => {
         const testId = '1';
+        const nodeType = ActiveDirectoryNodeKind.LocalGroup;
 
-        render(
-            <EntityInfoPanelContextProvider>
-                <EntityInfoContent id={testId} nodeType={ActiveDirectoryNodeKind.LocalGroup} />
-            </EntityInfoPanelContextProvider>
-        );
+        render(EntityInfoContentWithProvider(testId, nodeType));
 
         await waitForElementToBeRemoved(() => screen.getByTestId('entity-object-information-skeleton'));
 
@@ -102,12 +104,9 @@ describe('EntityObjectInformation', () => {
 
     it('Calls the `Base` endpoint for a LocalUser type node', async () => {
         const testId = '1';
+        const nodeType = ActiveDirectoryNodeKind.LocalUser;
 
-        render(
-            <EntityInfoPanelContextProvider>
-                <EntityInfoContent id={testId} nodeType={ActiveDirectoryNodeKind.LocalUser} />
-            </EntityInfoPanelContextProvider>
-        );
+        render(EntityInfoContentWithProvider(testId, nodeType));
 
         await waitForElementToBeRemoved(() => screen.getByTestId('entity-object-information-skeleton'));
 
@@ -116,12 +115,10 @@ describe('EntityObjectInformation', () => {
 
     it('Calls the cypher search endpoint for a node with a type that is not in our schema', async () => {
         const testId = '1';
+        const nodeType = 'Unknown';
+        const databaseId = '42';
 
-        render(
-            <EntityInfoPanelContextProvider>
-                <EntityInfoContent id={testId} nodeType={'Unknown'} databaseId='42' />
-            </EntityInfoPanelContextProvider>
-        );
+        render(EntityInfoContentWithProvider(testId, nodeType, databaseId));
 
         await waitForElementToBeRemoved(() => screen.getByTestId('entity-object-information-skeleton'));
 

--- a/cmd/ui/src/views/Explore/EntityInfo/EntityInfoHeader.test.tsx
+++ b/cmd/ui/src/views/Explore/EntityInfo/EntityInfoHeader.test.tsx
@@ -1,0 +1,91 @@
+import { rest } from 'msw';
+import { setupServer } from 'msw/node';
+import { act, render } from 'src/test-utils';
+
+import userEvent from '@testing-library/user-event';
+import { AzureNodeKind, ObjectInfoPanelContext } from 'bh-shared-ui';
+import { createMemoryHistory } from 'history';
+import EntityInfoHeader, { HeaderProps } from './EntityInfoHeader';
+import { EntityInfoPanelContextProvider } from './EntityInfoPanelContextProvider';
+
+const testProps: HeaderProps = {
+    expanded: true,
+    name: 'testName',
+    onToggleExpanded: vi.fn(),
+    nodeType: AzureNodeKind.Group,
+};
+
+const backButtonSupportFF = {
+    key: 'back_button_support',
+    enabled: true,
+};
+
+const setIsObjectInfoPanelOpen = (newValue: boolean) => {
+    mockContextValue.isObjectInfoPanelOpen = newValue;
+};
+
+const mockContextValue = {
+    isObjectInfoPanelOpen: true,
+    setIsObjectInfoPanelOpen,
+};
+
+const server = setupServer(
+    rest.get('/api/v2/features', (_req, res, ctx) => {
+        return res(
+            ctx.json({
+                data: [backButtonSupportFF],
+            })
+        );
+    })
+);
+
+beforeAll(() => server.listen());
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+const setup = async () => {
+    const url = `?expandedPanelSections=['test','test1']`;
+
+    const history = createMemoryHistory({ initialEntries: [url] });
+
+    const screen = await act(async () => {
+        return render(
+            <EntityInfoPanelContextProvider>
+                <ObjectInfoPanelContext.Provider value={mockContextValue}>
+                    <EntityInfoHeader {...testProps} />
+                </ObjectInfoPanelContext.Provider>
+            </EntityInfoPanelContextProvider>,
+            { history }
+        );
+    });
+
+    const user = userEvent.setup();
+
+    return { screen, user, history };
+};
+
+describe('EntityInfoHeader', async () => {
+    it('should render', async () => {
+        const { screen } = await setup();
+
+        const collapsePanelButton = screen.getByRole('button', { name: /minus/i });
+        const nodeIcon = screen.getByTitle(testProps.nodeType!);
+        const nodeTitle = screen.getByRole('heading');
+        const collapseAllButton = screen.getByRole('button', { name: /collapse all/i });
+
+        expect(collapsePanelButton).toBeInTheDocument();
+        expect(nodeIcon).toBeInTheDocument();
+        expect(nodeTitle).toBeInTheDocument();
+        expect(nodeTitle).toHaveTextContent(testProps.name);
+        expect(collapseAllButton).toBeInTheDocument();
+    });
+    it('should on clicking collapse all remove expandedPanelSections param from url and set isObjectInfoPanelOpen in context to false', async () => {
+        const { screen, history, user } = await setup();
+        const collapseAllButton = screen.getByRole('button', { name: /collapse all/i });
+
+        await user.click(collapseAllButton);
+
+        expect(history.location.search).not.toContain('expandedPanelSections');
+        expect(mockContextValue.isObjectInfoPanelOpen).toBe(false);
+    });
+});

--- a/cmd/ui/src/views/Explore/EntityInfo/EntityInfoHeader.test.tsx
+++ b/cmd/ui/src/views/Explore/EntityInfo/EntityInfoHeader.test.tsx
@@ -1,3 +1,19 @@
+// Copyright 2025 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { rest } from 'msw';
 import { setupServer } from 'msw/node';
 import { act, render } from 'src/test-utils';

--- a/cmd/ui/src/views/Explore/EntityInfo/EntityInfoHeader.tsx
+++ b/cmd/ui/src/views/Explore/EntityInfo/EntityInfoHeader.tsx
@@ -28,7 +28,7 @@ import {
 import React from 'react';
 import { useEntityInfoPanelContext } from 'src/views/Explore/EntityInfo/EntityInfoPanelContext';
 
-interface HeaderProps {
+export interface HeaderProps {
     expanded: boolean;
     name: string;
     onToggleExpanded: (expanded: boolean) => void;

--- a/cmd/ui/src/views/Explore/EntityInfo/EntityInfoHeader.tsx
+++ b/cmd/ui/src/views/Explore/EntityInfo/EntityInfoHeader.tsx
@@ -40,14 +40,16 @@ const Header: React.FC<HeaderProps> = ({ name, nodeType, onToggleExpanded, expan
     const { data: backButtonFlag } = useFeatureFlag('back_button_support');
     const { collapseAllSections } = useEntityInfoPanelContext();
     const { setIsObjectInfoPanelOpen } = useObjectInfoPanelContext();
-    const { setExploreParams } = useExploreParams();
+    const { setExploreParams, expandedPanelSections } = useExploreParams();
 
     const handleCollapseAll = () => {
         setIsObjectInfoPanelOpen(false);
         if (backButtonFlag?.enabled) {
-            setExploreParams({
-                expandedPanelSections: [],
-            });
+            if (expandedPanelSections?.length) {
+                setExploreParams({
+                    expandedPanelSections: [],
+                });
+            }
         } else {
             collapseAllSections();
         }

--- a/cmd/ui/src/views/Explore/EntityInfo/EntityInfoHeader.tsx
+++ b/cmd/ui/src/views/Explore/EntityInfo/EntityInfoHeader.tsx
@@ -17,7 +17,14 @@
 import { faAngleDoubleUp, faMinus, faPlus } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Box, Typography } from '@mui/material';
-import { Icon, NodeIcon, useHeaderStyles } from 'bh-shared-ui';
+import {
+    Icon,
+    NodeIcon,
+    useExploreParams,
+    useFeatureFlag,
+    useHeaderStyles,
+    useObjectInfoPanelContext,
+} from 'bh-shared-ui';
 import React from 'react';
 import { useEntityInfoPanelContext } from 'src/views/Explore/EntityInfo/EntityInfoPanelContext';
 
@@ -30,7 +37,21 @@ interface HeaderProps {
 
 const Header: React.FC<HeaderProps> = ({ name, nodeType, onToggleExpanded, expanded }) => {
     const styles = useHeaderStyles();
-    const entityInfoPanelContext = useEntityInfoPanelContext();
+    const { data: backButtonFlag } = useFeatureFlag('back_button_support');
+    const { collapseAllSections } = useEntityInfoPanelContext();
+    const { setIsObjectInfoPanelOpen } = useObjectInfoPanelContext();
+    const { setExploreParams } = useExploreParams();
+
+    const handleCollapseAll = () => {
+        setIsObjectInfoPanelOpen(false);
+        if (backButtonFlag?.enabled) {
+            setExploreParams({
+                expandedPanelSections: [],
+            });
+        } else {
+            collapseAllSections();
+        }
+    };
 
     return (
         <Box className={styles.header}>
@@ -54,7 +75,7 @@ const Header: React.FC<HeaderProps> = ({ name, nodeType, onToggleExpanded, expan
 
             <Icon
                 tip='Collapse All'
-                click={() => entityInfoPanelContext.collapseAllSections()}
+                click={handleCollapseAll}
                 className={styles.icon}
                 data-testid='explore_entity-information-panel_button-collapse-all'>
                 <FontAwesomeIcon icon={faAngleDoubleUp} />

--- a/cmd/ui/src/views/Explore/EntityInfo/EntityInfoPanel.tsx
+++ b/cmd/ui/src/views/Explore/EntityInfo/EntityInfoPanel.tsx
@@ -15,7 +15,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Box, Paper, SxProps, Typography } from '@mui/material';
-import { NoEntitySelectedHeader, NoEntitySelectedMessage, useFeatureFlag, usePaneStyles } from 'bh-shared-ui';
+import {
+    NoEntitySelectedHeader,
+    NoEntitySelectedMessage,
+    ObjectInfoPanelContextProvider,
+    useFeatureFlag,
+    usePaneStyles,
+} from 'bh-shared-ui';
 import React, { useEffect, useState } from 'react';
 import { SelectedNode } from 'src/ducks/entityinfo/types';
 import usePreviousValue from 'src/hooks/usePreviousValue';
@@ -76,7 +82,9 @@ const EntityInfoPanel: React.FC<EntityInfoPanelProps> = ({ selectedNode, sx }) =
 
 const WrappedEntityInfoPanel: React.FC<EntityInfoPanelProps> = (props) => (
     <EntityInfoPanelContextProvider>
-        <EntityInfoPanel {...props} />
+        <ObjectInfoPanelContextProvider>
+            <EntityInfoPanel {...props} />
+        </ObjectInfoPanelContextProvider>
     </EntityInfoPanelContextProvider>
 );
 

--- a/cmd/ui/src/views/Explore/EntityInfo/EntityObjectInformation.tsx
+++ b/cmd/ui/src/views/Explore/EntityInfo/EntityObjectInformation.tsx
@@ -21,41 +21,44 @@ import {
     ObjectInfoFields,
     formatObjectInfoFields,
     useFetchEntityProperties,
+    useObjectInfoPanelContext,
 } from 'bh-shared-ui';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import usePreviousValue from 'src/hooks/usePreviousValue';
 import { BasicObjectInfoFields } from '../BasicObjectInfoFields';
 import EntityInfoCollapsibleSection from './EntityInfoCollapsibleSection';
 import { EntityInfoContentProps } from './EntityInfoContent';
 
 const EntityObjectInformation: React.FC<EntityInfoContentProps> = ({ id, nodeType, databaseId }) => {
+    const { isObjectInfoPanelOpen, setIsObjectInfoPanelOpen } = useObjectInfoPanelContext();
     const { entityProperties, informationAvailable, isLoading, isError } = useFetchEntityProperties({
         objectId: id,
         nodeType,
         databaseId,
     });
 
-    const [isExpanded, setIsExpanded] = useState(true);
-
     const previousId = usePreviousValue(id);
 
     useEffect(() => {
         if (previousId !== id) {
-            setIsExpanded(true);
+            setIsObjectInfoPanelOpen(true);
         }
-    }, [previousId, id]);
+    }, [previousId, id, setIsObjectInfoPanelOpen]);
 
     const sectionLabel = 'Object Information';
 
     const handleOnChange = () => {
-        setIsExpanded(!isExpanded);
+        setIsObjectInfoPanelOpen(!isObjectInfoPanelOpen);
     };
 
     if (isLoading) return <Skeleton data-testid='entity-object-information-skeleton' variant='text' />;
 
     if (isError || !informationAvailable)
         return (
-            <EntityInfoCollapsibleSection onChange={handleOnChange} isExpanded={isExpanded} label={sectionLabel}>
+            <EntityInfoCollapsibleSection
+                onChange={handleOnChange}
+                isExpanded={isObjectInfoPanelOpen}
+                label={sectionLabel}>
                 <FieldsContainer>
                     <Alert severity='error'>Unable to load object information for this node.</Alert>
                 </FieldsContainer>
@@ -65,7 +68,7 @@ const EntityObjectInformation: React.FC<EntityInfoContentProps> = ({ id, nodeTyp
     const formattedObjectFields: EntityField[] = formatObjectInfoFields(entityProperties);
 
     return (
-        <EntityInfoCollapsibleSection onChange={handleOnChange} isExpanded={isExpanded} label={sectionLabel}>
+        <EntityInfoCollapsibleSection onChange={handleOnChange} isExpanded={isObjectInfoPanelOpen} label={sectionLabel}>
             <FieldsContainer>
                 <BasicObjectInfoFields {...entityProperties} />
                 <ObjectInfoFields fields={formattedObjectFields} />

--- a/packages/javascript/bh-shared-ui/src/providers/ObjectInfoPanelProvider/ObjectInfoPanelContext.ts
+++ b/packages/javascript/bh-shared-ui/src/providers/ObjectInfoPanelProvider/ObjectInfoPanelContext.ts
@@ -14,5 +14,20 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-export * from './NotificationProvider';
-export * from './ObjectInfoPanelProvider';
+import React from 'react';
+
+export const ObjectInfoPanelContext = React.createContext<
+    | {
+          isObjectInfoPanelOpen: boolean;
+          setIsObjectInfoPanelOpen: (isOpen: boolean) => void;
+      }
+    | undefined
+>(undefined);
+
+export function useObjectInfoPanelContext() {
+    const context = React.useContext(ObjectInfoPanelContext);
+    if (context === undefined) {
+        throw new Error('useObjectInfoPanelContext must be used within a ObjectInfoPanelContextProvider');
+    }
+    return context;
+}

--- a/packages/javascript/bh-shared-ui/src/providers/ObjectInfoPanelProvider/ObjectInfoPanelContext.ts
+++ b/packages/javascript/bh-shared-ui/src/providers/ObjectInfoPanelProvider/ObjectInfoPanelContext.ts
@@ -1,4 +1,4 @@
-// Copyright 2023 Specter Ops, Inc.
+// Copyright 2025 Specter Ops, Inc.
 //
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.

--- a/packages/javascript/bh-shared-ui/src/providers/ObjectInfoPanelProvider/ObjectInfoPanelContextProvider.tsx
+++ b/packages/javascript/bh-shared-ui/src/providers/ObjectInfoPanelProvider/ObjectInfoPanelContextProvider.tsx
@@ -1,0 +1,32 @@
+// Copyright 2023 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { useMemo, useState } from 'react';
+import { ObjectInfoPanelContext } from './ObjectInfoPanelContext';
+
+type ObjectInfoPanelContextProviderProps = { children: React.ReactNode };
+
+export function ObjectInfoPanelContextProvider({ children }: ObjectInfoPanelContextProviderProps) {
+    const [isObjectInfoPanelOpen, setIsObjectInfoPanelOpen] = useState<boolean>(true);
+    const value = useMemo(
+        () => ({
+            isObjectInfoPanelOpen,
+            setIsObjectInfoPanelOpen,
+        }),
+        [isObjectInfoPanelOpen]
+    );
+    return <ObjectInfoPanelContext.Provider value={value}>{children}</ObjectInfoPanelContext.Provider>;
+}

--- a/packages/javascript/bh-shared-ui/src/providers/ObjectInfoPanelProvider/ObjectInfoPanelContextProvider.tsx
+++ b/packages/javascript/bh-shared-ui/src/providers/ObjectInfoPanelProvider/ObjectInfoPanelContextProvider.tsx
@@ -1,4 +1,4 @@
-// Copyright 2023 Specter Ops, Inc.
+// Copyright 2025 Specter Ops, Inc.
 //
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.

--- a/packages/javascript/bh-shared-ui/src/providers/ObjectInfoPanelProvider/index.ts
+++ b/packages/javascript/bh-shared-ui/src/providers/ObjectInfoPanelProvider/index.ts
@@ -14,5 +14,5 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-export * from './NotificationProvider';
-export * from './ObjectInfoPanelProvider';
+export * from './ObjectInfoPanelContext';
+export * from './ObjectInfoPanelContextProvider';

--- a/packages/javascript/bh-shared-ui/src/providers/ObjectInfoPanelProvider/index.ts
+++ b/packages/javascript/bh-shared-ui/src/providers/ObjectInfoPanelProvider/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2023 Specter Ops, Inc.
+// Copyright 2025 Specter Ops, Inc.
 //
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Description

This fixed the collapse all button and now when clicked collapses all open panels in Edge or Entity Panels

## Motivation and Context

This PR addresses ticket: [BED-5732](https://specterops.atlassian.net/browse/BED-5732)

## How Has This Been Tested?

Manually, added new tests and existing tests passed

## Screenshots (optional):

https://github.com/user-attachments/assets/dbdbd650-5a09-47fc-afde-334fb12058d1

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


[BED-5732]: https://specterops.atlassian.net/browse/BED-5732?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ