### PR TITLE
BED-5696 chore: Add migrations for existing agi to agt systems

### DIFF
--- a/cmd/api/src/database/migration/migrations/v7.4.0.sql
+++ b/cmd/api/src/database/migration/migrations/v7.4.0.sql
@@ -38,39 +38,34 @@ CREATE TABLE IF NOT EXISTS asset_group_tag_selector_nodes
 
 -- Migrate existing Tier Zero selectors
 WITH inserted_selector AS (
-INSERT INTO asset_group_tag_selectors (asset_group_tag_id, created_at, created_by, updated_at, updated_by, name, description, is_default, allow_disable, auto_certify)
-SELECT agt.id, current_timestamp, 'SYSTEM', current_timestamp, 'SYSTEM', s.name, s.selector, false, true, false
-FROM asset_group_selectors s
-         JOIN asset_groups ag ON ag.id = s.asset_group_id
-         JOIN asset_group_tags agt ON agt.name = 'Tier Zero'
-         LEFT JOIN asset_group_tag_selectors agts ON agts.name = s.name
-WHERE ag.tag = 'admin_tier_0' and agts.name IS NULL
-    RETURNING id, description
+  INSERT INTO asset_group_tag_selectors (asset_group_tag_id, created_at, created_by, updated_at, updated_by, name, description, is_default, allow_disable, auto_certify)
+  SELECT (SELECT id FROM asset_group_tags WHERE name = 'Tier Zero'), current_timestamp, 'SYSTEM', current_timestamp, 'SYSTEM', s.name, s.selector, false, true, false
+  FROM asset_group_selectors s JOIN asset_groups ag ON ag.id = s.asset_group_id
+  WHERE ag.tag = 'admin_tier_0' and NOT EXISTS(SELECT 1 FROM asset_group_tag_selectors WHERE name = s.name)
+  RETURNING id, description
 )
 INSERT INTO asset_group_tag_selector_seeds (selector_id, type, value) SELECT id, 1, description FROM inserted_selector;
 
 -- Migrate existing Owned selectors
 WITH inserted_kind AS (
-    INSERT INTO kind (name)
-    SELECT 'Tag_' || replace(name, ' ', '_') as name
-    FROM asset_groups
-    WHERE tag = 'owned'
-    ON CONFLICT DO NOTHING
-    RETURNING id, name
+  INSERT INTO kind (name)
+  SELECT 'Tag_' || replace(name, ' ', '_') as name
+  FROM asset_groups
+  WHERE tag = 'owned'
+  ON CONFLICT DO NOTHING
+  RETURNING id, name
 ),
 inserted_tag AS (
-    INSERT INTO asset_group_tags (kind_id, type, name, description, created_at, created_by, updated_at, updated_by)
-    SELECT ik.id, 3, ag.name, ag.name, current_timestamp, 'SYSTEM', current_timestamp, 'SYSTEM'
-    FROM inserted_kind ik JOIN asset_groups ag ON ik.name = 'Tag_' || replace(ag.name, ' ', '_')
-    RETURNING id, name
+  INSERT INTO asset_group_tags (kind_id, type, name, description, created_at, created_by, updated_at, updated_by)
+  SELECT ik.id, 3, ag.name, ag.name, current_timestamp, 'SYSTEM', current_timestamp, 'SYSTEM'
+  FROM inserted_kind ik JOIN asset_groups ag ON ik.name = 'Tag_' || replace(ag.name, ' ', '_')
+  RETURNING id, name
 ),
 inserted_selector AS (
-    INSERT INTO asset_group_tag_selectors (asset_group_tag_id, created_at, created_by, updated_at, updated_by, name, description, is_default, allow_disable, auto_certify)
-    SELECT (SELECT id from inserted_tag), current_timestamp, 'SYSTEM', current_timestamp, 'SYSTEM', s.name, s.selector, false, true, false
-    FROM asset_group_selectors s
-             JOIN asset_groups ag ON ag.id = s.asset_group_id
-             LEFT JOIN asset_group_tag_selectors agts ON agts.name = s.name
-    WHERE ag.tag = 'owned' and agts.name IS NULL
-        RETURNING id, description
-    )
+  INSERT INTO asset_group_tag_selectors (asset_group_tag_id, created_at, created_by, updated_at, updated_by, name, description, is_default, allow_disable, auto_certify)
+  SELECT (SELECT id from inserted_tag), current_timestamp, 'SYSTEM', current_timestamp, 'SYSTEM', s.name, s.selector, false, true, false
+  FROM asset_group_selectors s JOIN asset_groups ag ON ag.id = s.asset_group_id
+  WHERE ag.tag = 'owned' and NOT EXISTS(SELECT 1 FROM asset_group_tag_selectors WHERE name = s.name)
+  RETURNING id, description
+)
 INSERT INTO asset_group_tag_selector_seeds (selector_id, type, value) SELECT id, 1, description FROM inserted_selector;


### PR DESCRIPTION
## Description

*Describe your changes in detail*
- Add migration for custom asset tier zero and owned selectors to new Tiering engine

## Motivation and Context
Addresses: BED-5696

*Why is this change required? What problem does it solve?*

## How Has This Been Tested?

*Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc.*

## Types of changes

<!-- Please remove any items that do not apply. -->
- Database Migrations

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
