### PR TITLE
feat(ui): enhance not-found page

### DIFF
--- a/cmd/ui/src/views/DisabledUser.tsx
+++ b/cmd/ui/src/views/DisabledUser.tsx
@@ -15,7 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Button } from '@bloodhoundenterprise/doodleui';
-import { Alert, AlertTitle, Box, Grid } from '@mui/material';
+import { Alert, AlertTitle } from '@mui/material';
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import LoginPage from 'src/components/LoginPage';
@@ -28,29 +28,24 @@ const DisabledUser: React.FC = () => {
     const navigate = useNavigate();
     return (
         <LoginPage>
-            <Grid container spacing={4} justifyContent='center'>
-                <Grid item xs={12}>
-                    <Alert severity='warning'>
-                        <AlertTitle>Your Account Has Been Disabled</AlertTitle>
-                        Please contact your system administrator for assistance.
-                    </Alert>
-                </Grid>
-                <Grid item xs={12}>
-                    <Box mt={2}>
-                        <Button
-                            onClick={() => {
-                                dispatch(logout());
-                                navigate(ROUTE_LOGIN);
-                            }}
-                            data-testid='disabled-user-back-to-login'
-                            size='large'
-                            type='button'
-                            className='w-full'>
-                            Back to Login
-                        </Button>
-                    </Box>
-                </Grid>
-            </Grid>
+            <div className='flex flex-col gap-8'>
+                <Alert severity='warning'>
+                    <AlertTitle>Your Account Has Been Disabled</AlertTitle>
+                    Please contact your system administrator for assistance.
+                </Alert>
+
+                <Button
+                    onClick={() => {
+                        dispatch(logout());
+                        navigate(ROUTE_LOGIN);
+                    }}
+                    data-testid='disabled-user-back-to-login'
+                    size='large'
+                    type='button'
+                    className='w-full'>
+                    Back to Login
+                </Button>
+            </div>
         </LoginPage>
     );
 };

--- a/cmd/ui/src/views/NotFound.tsx
+++ b/cmd/ui/src/views/NotFound.tsx
@@ -14,13 +14,54 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { Typography } from '@mui/material';
+import { Button } from '@bloodhoundenterprise/doodleui';
+import { Alert, AlertTitle, Box, Grid } from '@mui/material';
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import LoginPage from 'src/components/LoginPage';
+import { fullyAuthenticatedSelector } from 'src/ducks/auth/authSlice';
+import { ROUTE_EXPLORE, ROUTE_LOGIN } from 'src/routes/constants';
+import { useAppSelector } from 'src/store';
 
 const NotFound: React.FC = () => {
+    const navigate = useNavigate();
+    const isFullyAuthenticated = useAppSelector(fullyAuthenticatedSelector);
+
+    // Redirect to login if unauthenticated
+    useEffect(() => {
+        if (isFullyAuthenticated) {
+            return;
+        }
+
+        navigate(ROUTE_LOGIN);
+    }, [isFullyAuthenticated]);
+
     return (
-        <div>
-            <Typography variant='h3'>Page Not Found</Typography>
-        </div>
+        <LoginPage>
+            <Grid container spacing={4} justifyContent='center'>
+                <Grid item xs={12}>
+                    <Alert severity='warning'>
+                        <AlertTitle>404 - Page not found</AlertTitle>
+                        There is no page associated with this route. Please contact your system administrator for
+                        assistance.
+                    </Alert>
+                </Grid>
+                <Grid item xs={12}>
+                    <Box mt={2}>
+                        <Button
+                            onClick={() => {
+                                navigate(ROUTE_EXPLORE);
+                            }}
+                            data-testid='page-not-found-go-to-explore'
+                            size='large'
+                            type='button'
+                            className='w-full'>
+                            Go to Explore
+                        </Button>
+                    </Box>
+                </Grid>
+            </Grid>
+        </LoginPage>
     );
 };
 

--- a/cmd/ui/src/views/NotFound.tsx
+++ b/cmd/ui/src/views/NotFound.tsx
@@ -15,7 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Button } from '@bloodhoundenterprise/doodleui';
-import { Alert, AlertTitle, Box, Grid } from '@mui/material';
+import { Alert, AlertTitle } from '@mui/material';
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import LoginPage from 'src/components/LoginPage';
@@ -34,33 +34,28 @@ const NotFound: React.FC = () => {
         }
 
         navigate(ROUTE_LOGIN);
-    }, [isFullyAuthenticated]);
+    }, [isFullyAuthenticated, navigate]);
 
     return (
         <LoginPage>
-            <Grid container spacing={4} justifyContent='center'>
-                <Grid item xs={12}>
-                    <Alert severity='warning'>
-                        <AlertTitle>404 - Page not found</AlertTitle>
-                        There is no page associated with this route. Please contact your system administrator for
-                        assistance.
-                    </Alert>
-                </Grid>
-                <Grid item xs={12}>
-                    <Box mt={2}>
-                        <Button
-                            onClick={() => {
-                                navigate(ROUTE_EXPLORE);
-                            }}
-                            data-testid='page-not-found-go-to-explore'
-                            size='large'
-                            type='button'
-                            className='w-full'>
-                            Go to Explore
-                        </Button>
-                    </Box>
-                </Grid>
-            </Grid>
+            <div className='flex flex-col gap-6'>
+                <Alert severity='warning'>
+                    <AlertTitle>404 - Page not found</AlertTitle>
+                    There is no page associated with this route. Please contact your system administrator for
+                    assistance.
+                </Alert>
+
+                <Button
+                    onClick={() => {
+                        navigate(ROUTE_EXPLORE);
+                    }}
+                    data-testid='page-not-found-go-to-explore'
+                    size='large'
+                    type='button'
+                    className='w-full'>
+                    Go to Explore
+                </Button>
+            </div>
         </LoginPage>
     );
 };


### PR DESCRIPTION
## Description

Update NotFound page to clearly state 404 status and to redirect to login if unauthenticated.

## Motivation and Context

Resolves BED-5326

## How Has This Been Tested?

Manually tested. Visited bad routes while authenticated and again while unauthenticated.

ex. http://bloodhound.localhost/ui/not-a-route

## Screenshots:

Before
![image](https://github.com/user-attachments/assets/506b57b5-0b22-4d10-ac42-ca29cf9b95f4)

After
![image](https://github.com/user-attachments/assets/e35870f0-1220-43e7-b250-5e8c8b0f7d24)

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
