### PR TITLE
Fix missing API endpoints

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -860,7 +860,7 @@
   },
   "api": {
     "playground": {
-      "display": "none"
+      "display": "simple"
     }
   },
   "appearance": {


### PR DESCRIPTION
As part of the Mintlify doc revamp, this PR makes a config change to properly display API methods and paths in the reference docs. 

Motivation and Context
- This PR addresses: [#1085](https://github.com/SpecterOps/BloodHound/issues/1085)
Testing
- Tested locally with Mintlify for broken links and broken site

Types of changes
- Chore
- Docs


I have read the CLA Document and I hereby sign the CLA
