### PR TITLE
BED-5806 - Rework Size Estimation to Account for Go 1.24

### DIFF
--- a/packages/go/dawgs/graph/properties_test.go
+++ b/packages/go/dawgs/graph/properties_test.go
@@ -41,11 +41,11 @@ func TestNewProperties(t *testing.T) {
 	properties.Set("test", "test")
 	properties.Set("value", "test")
 
-	require.Equal(t, 736, int(properties.SizeOf()))
+	require.Equal(t, 440, int(properties.SizeOf()))
 
 	properties.Delete("value")
 
-	require.Equal(t, 732, int(properties.SizeOf()))
+	require.Equal(t, 296, int(properties.SizeOf()))
 
 	require.False(t, properties.Exists("not found"))
 	require.Equal(t, 1, properties.Len())
@@ -64,21 +64,20 @@ func TestNewProperties(t *testing.T) {
 }
 
 func TestSizeOfProperties(t *testing.T) {
-	t.Skip("Skipping SizeOf due to flake")
 	properties := graph.NewProperties()
 
 	require.Equal(t, 24, int(properties.SizeOf()))
 
 	// Set an initial value to force allocation
 	properties.Set("initial", 0)
-	require.Equal(t, 536, int(properties.SizeOf()))
+	require.Equal(t, 256, int(properties.SizeOf()))
 
 	// Further allocation past 8 forces a new bucket to be allocated for the backing maps in the properties struct
 	for iter := 0; iter < 8; iter++ {
 		properties.Set("test"+strconv.Itoa(iter), iter)
 	}
 
-	require.Equal(t, 1784, int(properties.SizeOf()))
+	require.Equal(t, 1600, int(properties.SizeOf()))
 
 }
 

--- a/packages/go/dawgs/util/size/size.go
+++ b/packages/go/dawgs/util/size/size.go
@@ -20,6 +20,8 @@ import (
 	"unsafe"
 )
 
+// Sizable is an interface describing a type that may have its runtime memory resident size
+// estimated.
 type Sizable interface {
 	// SizeOf returns the size of this entity.
 	SizeOf() Size
@@ -30,78 +32,143 @@ type Sizable interface {
 // as opposed to the size of the memory referenced. This function
 // cannot infer the data type of nil, so nil checks need to be
 // performed before calling this function.
-func Of[T any](raw T) Size {
-	return Size(unsafe.Sizeof(raw))
-}
+func Of[T any](templatedValue T) Size {
+	totalSize := Size(unsafe.Sizeof(templatedValue))
 
-func OfSlice[T comparable](raw []T) Size {
-	var template T
-	return Of(raw) + Of(template)*Size(cap(raw))
-}
-
-func OfContents[T any](raw T) Size {
-	switch typed := any(raw).(type) {
+	switch typedValue := any(templatedValue).(type) {
 	case string:
-		return Size(len(typed))
+		// Strings must have their inner allocation counted
+		totalSize *= Size(len(typedValue))
+	}
+
+	return totalSize
+}
+
+// OfSlice will return the size of a type templated slice.
+//
+// The slice descriptor consists of three fields:
+// * A pointer to the underlying array.
+// * The length of the slice (the number of elements currently in use).
+// * The capacity of the slice (the total number of elements in the underlying array, from the start of the slice).
+//
+// On a 64-bit architecture, each of these fields is 8 bytes, so the size of a slice is 24 bytes. On a 32-bit
+// architecture, each field is 4 bytes, making the slice size 12 bytes. The unsafe.Sizeof() function will return
+// this size of the descriptor, not the size of the underlying array.
+//
+// For correctly typed templates the capacity of the slice is multiplied by the size of the template.
+func OfSlice[T comparable](sliceT []T) Size {
+	totalSize := Of(sliceT)
+
+	switch any(sliceT).(type) {
+	case []string:
+		// Strings are variable allocations and must be walked
+		for _, strValue := range sliceT {
+			totalSize += Of(strValue)
+		}
+
 	default:
+		var template T
+		totalSize += Of(template) * Size(cap(sliceT))
+	}
+
+	return totalSize
+}
+
+// OfAny attempts to return the size of a value passed as `any`. This is done via
+// type negotiation to unwrap the `any` type in a best-effort attempt to estimate
+// the value's size.
+//
+// It is important to note that this function comes with usage caveats:
+// * Maps are not estimated by this function
+// * Nested slices of type `[]any` are supported but have ill-defined runtime measurement costs
+// * If the type of the value is known, this function is less performant that calling Of(...)
+func OfAny(value any) Size {
+	switch typedValue := value.(type) {
+	case int:
+		return Of(typedValue)
+	case int8:
+		return Of(typedValue)
+	case int16:
+		return Of(typedValue)
+	case int32:
+		return Of(typedValue)
+	case int64:
+		return Of(typedValue)
+	case uint:
+		return Of(typedValue)
+	case uint8:
+		return Of(typedValue)
+	case uint16:
+		return Of(typedValue)
+	case uint32:
+		return Of(typedValue)
+	case uint64:
+		return Of(typedValue)
+	case float32:
+		return Of(typedValue)
+	case float64:
+		return Of(typedValue)
+	case string:
+		return Of(typedValue)
+	case bool:
+		return Of(typedValue)
+	case uintptr:
+		return Of(typedValue)
+	case complex64:
+		return Of(typedValue)
+	case complex128:
+		return Of(typedValue)
+	case []int:
+		return OfSlice(typedValue)
+	case []int8:
+		return OfSlice(typedValue)
+	case []int16:
+		return OfSlice(typedValue)
+	case []int32:
+		return OfSlice(typedValue)
+	case []int64:
+		return OfSlice(typedValue)
+	case []uint:
+		return OfSlice(typedValue)
+	case []uint8:
+		return OfSlice(typedValue)
+	case []uint16:
+		return OfSlice(typedValue)
+	case []uint32:
+		return OfSlice(typedValue)
+	case []uint64:
+		return OfSlice(typedValue)
+	case []float32:
+		return OfSlice(typedValue)
+	case []float64:
+		return OfSlice(typedValue)
+	case []string:
+		return OfSlice(typedValue)
+	case []bool:
+		return OfSlice(typedValue)
+	case []uintptr:
+		return OfSlice(typedValue)
+	case []complex64:
+		return OfSlice(typedValue)
+	case []complex128:
+		return OfSlice(typedValue)
+	case []any:
+		return OfAnySlice(typedValue)
+	case struct{}:
 		return 0
+	default:
+		// Best effort which is the pointer size of the any-value
+		return Size(unsafe.Sizeof(value))
 	}
 }
 
-type mapHeader struct {
-	_type unsafe.Pointer
-	value unsafe.Pointer
-}
+// OfAnySlice calculates the estimated size of a given slice of type `[]any`.
+func OfAnySlice(anySlice []any) Size {
+	sliceValueSize := Size(0)
 
-func mapTypeAndValue(mapInstance any) (*maptype, *hmap) {
-	// This is filthy
-	header := (*mapHeader)(unsafe.Pointer(&mapInstance))
-	return (*maptype)(header._type), (*hmap)(header.value)
-}
-
-func OfMap[K comparable, V any](mapInstance map[K]V) Size {
-	var (
-		// This must remain under test for each distinct golang version supported. This unsafe contract could break
-		// due to stdlib changes in newer golang versions.
-		mapType, hmapInstance = mapTypeAndValue(mapInstance)
-
-		// assume 1 allocated buckets to begin with
-		numAllocatedBuckets = 2
-	)
-
-	// Best effort escape hatch for unexpected types being passed to this function
-	if mapType == nil || hmapInstance == nil {
-		return 0
+	for _, anyValue := range anySlice {
+		sliceValueSize += OfAny(anyValue)
 	}
 
-	// the hmap field B represents the log_2 of # of buckets in the hash map
-	if hmapInstance.B == 0 {
-		numAllocatedBuckets = 1
-	}
-
-	// size starts with the number of allocated buckets multiplied by the maptype bucketsize
-	size := Size(numAllocatedBuckets<<hmapInstance.B) * Size(mapType.bucketsize)
-
-	// track overflow buckets
-	if hmapInstance.noverflow != 0 {
-		size += Size(hmapInstance.noverflow) * Size(mapType.bucketsize)
-	}
-
-	// track old allocated buckets
-	if hmapInstance.oldbuckets != nil {
-		size += (2 << (hmapInstance.B - 1)) * Size(mapType.bucketsize)
-	}
-
-	// lastly compute the size of the map header
-	return Of(*hmapInstance) + size
-}
-
-func OfMapValues[K comparable, V any](mapInstance map[K]V) Size {
-	size := OfMap(mapInstance)
-
-	for _, value := range mapInstance {
-		size += OfContents(value)
-	}
-
-	return size
+	return Of(anySlice) + Size(cap(anySlice)) + sliceValueSize
 }


### PR DESCRIPTION
## Description

Previously the size measurement logic would attempt to accurately measure map type overhead. This relied on runtime behavior that often breaks with upstream golang version changes. Instead, the measurement logic should attempt a best-effort and avoid relying on hidden runtime details.

## Motivation and Context

Without this change version upgrades for golang are precarious at-best.

## How Has This Been Tested?

Unit tested.

## Types of changes

<!-- Please remove any items that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
