### PR TITLE
BED-5810 - Make stbernard Less Aggressive during Golang Code Generation

### DIFF
--- a/packages/go/stbernard/workspace/golang/generate.go
+++ b/packages/go/stbernard/workspace/golang/generate.go
@@ -17,69 +17,136 @@
 package golang
 
 import (
+	"bufio"
+	"context"
 	"errors"
 	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
 	"sync"
 
+	"github.com/specterops/bloodhound/dawgs/util/channels"
 	"github.com/specterops/bloodhound/packages/go/stbernard/cmdrunner"
 	"github.com/specterops/bloodhound/packages/go/stbernard/environment"
 )
 
+// fileContentContainsGenerationDirective uses a bufio.Scanner to search a given reader line-by-line
+// looking for golang code generation directives. Upon finding the first code generation directive
+// this function returns true with no error. If no code generation directives exist this function will
+// return false instead.
+func fileContentContainsGenerationDirective(fin io.Reader) (bool, error) {
+	scanner := bufio.NewScanner(fin)
+
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+
+		if strings.HasPrefix(line, "//go:generate") {
+			// If we find a go generate directive return right away
+			return true, nil
+		}
+	}
+
+	return false, scanner.Err()
+}
+
+// packageHasGenerationDirectives scans a golang package at a given path for any files that contain a
+// golang code generation directive. Upon finding any file in the package that contains a code
+// generation directive, this function returns true with no error. If no code generation directives exist
+// in the package, this function returns false instead.
+func packageHasGenerationDirectives(packagePath string) (bool, error) {
+	hasGolangCodeGenDirectives := false
+
+	if err := filepath.Walk(packagePath, func(path string, info os.FileInfo, err error) error {
+		// Don't bother reading anything that isn't a golang source file
+		if info.IsDir() || filepath.Ext(info.Name()) != ".go" {
+			return nil
+		}
+
+		// Open the file and search for code generation directives
+		if fin, err := os.Open(path); err != nil {
+			return err
+		} else {
+			defer fin.Close()
+
+			if hasGolangCodeGenDirectives, err = fileContentContainsGenerationDirective(fin); err != nil {
+				return err
+			} else if hasGolangCodeGenDirectives {
+				// Skip the rest of the FS walk for this package
+				return filepath.SkipAll
+			}
+		}
+
+		return nil
+	}); err != nil {
+		return false, err
+	}
+
+	return hasGolangCodeGenDirectives, nil
+}
+
+// parallelGenerateModulePackages spins up runtime.NumCPU() concurrent workers that will attempt golang code generation
+// for each GoPackage transmitted over the jobC channel.
+func parallelGenerateModulePackages(jobC <-chan GoPackage, waitGroup *sync.WaitGroup, env environment.Environment, addErr func(err error)) {
+	for workerID := 1; workerID <= runtime.NumCPU(); workerID++ {
+		waitGroup.Add(1)
+
+		go func() {
+			defer waitGroup.Done()
+
+			for {
+				if nextPackage, canContinue := channels.Receive(context.TODO(), jobC); !canContinue {
+					break
+				} else if hasGenerationDirectives, err := packageHasGenerationDirectives(nextPackage.Dir); err != nil {
+					addErr(err)
+				} else if hasGenerationDirectives {
+					var (
+						command = "go"
+						args    = []string{"generate", nextPackage.Dir}
+					)
+
+					if err := cmdrunner.Run(command, args, nextPackage.Dir, env); err != nil {
+						addErr(err)
+					}
+				}
+			}
+		}()
+	}
+}
+
 // WorkspaceGenerate runs go generate ./... for all module paths passed
 func WorkspaceGenerate(modPaths []string, env environment.Environment) error {
 	var (
-		errs []error
-		wg   sync.WaitGroup
-		mu   sync.Mutex
-	)
+		errs     []error
+		errsLock = &sync.Mutex{}
+		addErr   = func(err error) {
+			errsLock.Lock()
+			defer errsLock.Unlock()
 
-	for _, modPath := range modPaths {
-		wg.Add(1)
-		go func(modPath string) {
-			defer wg.Done()
-			if err := moduleGenerate(modPath, env); err != nil {
-				mu.Lock()
-				errs = append(errs, fmt.Errorf("code generation for module %s: %w", modPath, err))
-				mu.Unlock()
-			}
-		}(modPath)
-	}
-
-	wg.Wait()
-
-	return errors.Join(errs...)
-}
-
-func moduleGenerate(modPath string, env environment.Environment) error {
-	var (
-		errs []error
-		wg   sync.WaitGroup
-		mu   sync.Mutex
-	)
-
-	if packages, err := moduleListPackages(modPath); err != nil {
-		return fmt.Errorf("listing packages for module %s: %w", modPath, err)
-	} else {
-		for _, pkg := range packages {
-			wg.Add(1)
-			go func(pkg GoPackage) {
-				defer wg.Done()
-
-				var (
-					command = "go"
-					args    = []string{"generate", pkg.Dir}
-				)
-
-				if err := cmdrunner.Run(command, args, pkg.Dir, env); err != nil {
-					mu.Lock()
-					errs = append(errs, fmt.Errorf("generate code for package %s: %w", pkg, err))
-					mu.Unlock()
-				}
-			}(pkg)
+			errs = append(errs, err)
 		}
 
-		wg.Wait()
+		jobC      = make(chan GoPackage)
+		waitGroup = &sync.WaitGroup{}
+	)
 
-		return errors.Join(errs...)
+	// Start the parallel workers first
+	go parallelGenerateModulePackages(jobC, waitGroup, env, addErr)
+
+	// For each known module path attempt generation of each module package
+	for _, modPath := range modPaths {
+		if modulePackages, err := moduleListPackages(modPath); err != nil {
+			return fmt.Errorf("listing packages for module %s: %w", modPath, err)
+		} else {
+			for _, modulePackage := range modulePackages {
+				if !channels.Submit(context.Background(), jobC, modulePackage) {
+					return fmt.Errorf("canceled")
+				}
+			}
+		}
 	}
+
+	return errors.Join(errs...)
 }

--- a/packages/go/stbernard/workspace/golang/mod.go
+++ b/packages/go/stbernard/workspace/golang/mod.go
@@ -72,7 +72,7 @@ func moduleListPackages(modPath string) ([]GoPackage, error) {
 			}
 			packages = append(packages, p)
 		}
-		cmd.Wait()
-		return packages, nil
+
+		return packages, cmd.Wait()
 	}
 }


### PR DESCRIPTION
## Description

The golang code generation step contains a goroutine amplification trap that clobbers the snot out of my local machine every time I run generation steps. This causes skips in my Doom playthrough videos which requires me to then break flow and rewind them.

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-5810

This is just a little nicer to developer machines by limiting concurrency and consuming more IO operations. The changeset also addresses the nested goroutine amplification trap.

## How Has This Been Tested?

Code generation looks good!

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
