### PR TITLE
Adding note to prefer bloodhound-cli instructions & adding link to docs

### DIFF
--- a/examples/docker-compose/README.md
+++ b/examples/docker-compose/README.md
@@ -1,5 +1,7 @@
 # BloodHound Community Edition Docker Compose Example
 
+**NOTE:** We recommend [installing BloodHound Community Edition using bloodhound-cli](https://bloodhound.specterops.io/get-started/quickstart/enterprise-quickstart). However, if you'd prefer to install it via Docker Compose, please follow the instructions below. 
+
 BloodHound Community Edition is composed of three distinct parts:
 
 -   A PostgreSQL database used for application state storage


### PR DESCRIPTION
This page recommends the old way of installing BHCE. Added note to recommend the new way. 