### PR TITLE
Add phrase as text to confirm deletion dialog

### DIFF
--- a/cmd/ui/src/views/DatabaseManagement/ConfirmationDialog.tsx
+++ b/cmd/ui/src/views/DatabaseManagement/ConfirmationDialog.tsx
@@ -69,6 +69,12 @@ const ConfirmationDialog: FC<{ open: boolean; handleClose: () => void; handleDel
                         fontWeight={theme.typography.fontWeightMedium}>
                         This change is irreversible.
                     </Typography>
+                    <Typography
+                        variant='body1'
+                        color={theme.palette.error.main}
+                        fontWeight={theme.typography.fontWeightMedium}>
+                        Phrase: {confirmationText}
+                    </Typography>
                     <Typography variant='body1'>Please input the phrase prior to click confirm.</Typography>
                     <TextField
                         placeholder={confirmationText}


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Improved the delete confirmation dialog by explicitly displaying the required confirmation phrase ("Please delete my data") inside the dialog.  
This clarifies to users exactly what text they need to input, preventing confusion caused by unclear instructions.

## Motivation and Context

Resolves: #1406

Previously, users might have been unsure what phrase to input when confirming data deletion, leading to getting stuck and can't delete data.
By explicitly writing the required phrase in the dialog ("Phrase: Please delete my data"), the user experience becomes smoother and clear.

## How Has This Been Tested?

Manually tested the deletion confirmation dialog:
- Opened the confirmation modal.
- Verified that the phrase to input is clearly shown.
- Confirmed that copying the exact phrase successfully enables deletion.
- No other functionality was impacted.

Tested on:
- Local development environment
- Browser: Chrome 123

## Screenshots (optional):

| Before | After |
| :---: | :---: |
| ![image](https://github.com/user-attachments/assets/d4f472ab-1814-4aaf-99c6-6c32c32af6b6) | ![image](https://github.com/user-attachments/assets/c239abda-d383-41c5-a22d-eec9a85a5981) |

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: [#1406](https://github.com/SpecterOps/BloodHound/issues/1406)
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
- [x] I have followed proper test practices
  - Manually tested the UI behavior
  - All existing tests still pass
