### PR TITLE
BED-5816 (chore) adding tests for GetEdgeRelayTargets & changing TestVersion_730_Migration to integration test

### DIFF
--- a/cmd/api/src/api/v2/edge_test.go
+++ b/cmd/api/src/api/v2/edge_test.go
@@ -535,7 +535,7 @@ func TestResources_GetEdgeRelayTargets_CannotMatchEdge(t *testing.T) {
 
 			assert.Equal(t, testCase.Expected.Code, actualCode)
 			assert.Equal(t, testCase.Expected.Header, actualHeader)
-			assert.Equal(t, testCase.Expected.Body, actualBody)
+			assert.JSONEq(t, testCase.Expected.Body, actualBody)
 		})
 	}
 }
@@ -599,7 +599,7 @@ func TestResources_GetEdgeRelayTargets_CannotGetNodes(t *testing.T) {
 
 			assert.Equal(t, testCase.Expected.Code, actualCode)
 			assert.Equal(t, testCase.Expected.Header, actualHeader)
-			assert.Equal(t, testCase.Expected.Body, actualBody)
+			assert.JSONEq(t, testCase.Expected.Body, actualBody)
 		})
 	}
 }
@@ -663,7 +663,7 @@ func TestResources_GetEdgeRelayTargets_PositiveTest(t *testing.T) {
 
 			assert.Equal(t, testCase.Expected.Code, actualCode)
 			assert.Equal(t, testCase.Expected.Header, actualHeader)
-			assert.Equal(t, testCase.Expected.Body, actualBody)
+			assert.JSONEq(t, testCase.Expected.Body, actualBody)
 		})
 	}
 }

--- a/cmd/api/src/api/v2/edge_test.go
+++ b/cmd/api/src/api/v2/edge_test.go
@@ -619,7 +619,7 @@ func TestResources_GetEdgeRelayTargets_PositiveTest(t *testing.T) {
 		Expected httpValues
 	}{
 		{
-			Name: "Error Trying to get Nodes",
+			Name: "Successful Request",
 			Request: http.Request{
 				URL: &url.URL{
 					RawQuery: "edge_type=AZBase&source_node=1&target_node=2",

--- a/cmd/api/src/api/v2/edge_test.go
+++ b/cmd/api/src/api/v2/edge_test.go
@@ -308,362 +308,246 @@ func TestManagementResource_GetEdgeComposition(t *testing.T) {
 	}
 }
 
-func TestResources_GetEdgeRelayTargets_BadParameters(t *testing.T) {
+func TestResources_GetEdgeRelayTargets(t *testing.T) {
 	t.Parallel()
 
 	type httpValues struct {
-		Code   int
-		Header http.Header
-		Body   string
+		code   int
+		header http.Header
+		body   string
 	}
 
 	cases := []struct {
-		Name     string
-		Request  http.Request
-		Expected httpValues
+		name      string
+		request   http.Request
+		expected  httpValues
+		testSetup func(t *testing.T, ctx context.Context, res *v2.Resources)
 	}{
 		{
-			Name: "No Parameters",
-			Request: http.Request{
+			name: "No Parameters",
+			request: http.Request{
 				URL: &url.URL{},
 			},
-			Expected: httpValues{
-				Code:   http.StatusBadRequest,
-				Header: http.Header{"Content-Type": []string{"application/json"}, "Location": []string{"/"}},
-				Body:   `{"errors":[{"context":"","message":"Expected edge_type parameter to be set."}],"http_status":400,"request_id":"","timestamp":"0001-01-01T00:00:00Z"}`,
+			expected: httpValues{
+				code:   http.StatusBadRequest,
+				header: http.Header{"Content-Type": []string{"application/json"}, "Location": []string{"/"}},
+				body:   `{"errors":[{"context":"","message":"Expected edge_type parameter to be set."}],"http_status":400,"request_id":"","timestamp":"0001-01-01T00:00:00Z"}`,
 			},
+			testSetup: func(t *testing.T, ctx context.Context, res *v2.Resources) {},
 		},
 		{
-			Name: "Missing Parameters",
-			Request: http.Request{
+			name: "Missing Parameters",
+			request: http.Request{
 				URL: &url.URL{
 					RawQuery: "edge_type=AZBase",
 				},
 			},
-			Expected: httpValues{
-				Code:   http.StatusBadRequest,
-				Header: http.Header{"Content-Type": []string{"application/json"}, "Location": []string{"/?edge_type=AZBase"}},
-				Body:   `{"errors":[{"context":"","message":"Expected source_node parameter to be set."}],"http_status":400,"request_id":"","timestamp":"0001-01-01T00:00:00Z"}`,
+			expected: httpValues{
+				code:   http.StatusBadRequest,
+				header: http.Header{"Content-Type": []string{"application/json"}, "Location": []string{"/?edge_type=AZBase"}},
+				body:   `{"errors":[{"context":"","message":"Expected source_node parameter to be set."}],"http_status":400,"request_id":"","timestamp":"0001-01-01T00:00:00Z"}`,
 			},
+			testSetup: func(t *testing.T, ctx context.Context, res *v2.Resources) {},
 		},
 		{
-			Name: "Missing Parameters 2",
-			Request: http.Request{
+			name: "Missing Parameters 2",
+			request: http.Request{
 				URL: &url.URL{
 					RawQuery: "edge_type=AZBase&source_node=1",
 				},
 			},
-			Expected: httpValues{
-				Code:   http.StatusBadRequest,
-				Header: http.Header{"Content-Type": []string{"application/json"}, "Location": []string{"/?edge_type=AZBase&source_node=1"}},
-				Body:   `{"errors":[{"context":"","message":"Expected target_node parameter to be set."}],"http_status":400,"request_id":"","timestamp":"0001-01-01T00:00:00Z"}`,
+			expected: httpValues{
+				code:   http.StatusBadRequest,
+				header: http.Header{"Content-Type": []string{"application/json"}, "Location": []string{"/?edge_type=AZBase&source_node=1"}},
+				body:   `{"errors":[{"context":"","message":"Expected target_node parameter to be set."}],"http_status":400,"request_id":"","timestamp":"0001-01-01T00:00:00Z"}`,
 			},
+			testSetup: func(t *testing.T, ctx context.Context, res *v2.Resources) {},
 		},
 		{
-			Name: "Wrong Number of Parameters",
-			Request: http.Request{
+			name: "Wrong Number of Parameters",
+			request: http.Request{
 				URL: &url.URL{
 					RawQuery: "edge_type=AZBase&source_node=1&target_node=2&edge_type=AZRole",
 				},
 			},
-			Expected: httpValues{
-				Code:   http.StatusBadRequest,
-				Header: http.Header{"Content-Type": []string{"application/json"}, "Location": []string{"/?edge_type=AZBase&source_node=1&target_node=2&edge_type=AZRole"}},
-				Body:   `{"errors":[{"context":"","message":"Expected only one edge_type."}],"http_status":400,"request_id":"","timestamp":"0001-01-01T00:00:00Z"}`,
+			expected: httpValues{
+				code:   http.StatusBadRequest,
+				header: http.Header{"Content-Type": []string{"application/json"}, "Location": []string{"/?edge_type=AZBase&source_node=1&target_node=2&edge_type=AZRole"}},
+				body:   `{"errors":[{"context":"","message":"Expected only one edge_type."}],"http_status":400,"request_id":"","timestamp":"0001-01-01T00:00:00Z"}`,
 			},
+			testSetup: func(t *testing.T, ctx context.Context, res *v2.Resources) {},
 		},
 		{
-			Name: "Wrong Number of Parameters 2",
-			Request: http.Request{
+			name: "Wrong Number of Parameters 2",
+			request: http.Request{
 				URL: &url.URL{
 					RawQuery: "edge_type=AZBase&source_node=1&target_node=2&source_node=3",
 				},
 			},
-			Expected: httpValues{
-				Code:   http.StatusBadRequest,
-				Header: http.Header{"Content-Type": []string{"application/json"}, "Location": []string{"/?edge_type=AZBase&source_node=1&target_node=2&source_node=3"}},
-				Body:   `{"errors":[{"context":"","message":"Expected only one source_node."}],"http_status":400,"request_id":"","timestamp":"0001-01-01T00:00:00Z"}`,
+			expected: httpValues{
+				code:   http.StatusBadRequest,
+				header: http.Header{"Content-Type": []string{"application/json"}, "Location": []string{"/?edge_type=AZBase&source_node=1&target_node=2&source_node=3"}},
+				body:   `{"errors":[{"context":"","message":"Expected only one source_node."}],"http_status":400,"request_id":"","timestamp":"0001-01-01T00:00:00Z"}`,
 			},
+			testSetup: func(t *testing.T, ctx context.Context, res *v2.Resources) {},
 		},
 		{
-			Name: "Wrong Number of Parameters 3",
-			Request: http.Request{
+			name: "Wrong Number of Parameters 3",
+			request: http.Request{
 				URL: &url.URL{
 					RawQuery: "edge_type=AZBase&source_node=1&target_node=2&target_node=3",
 				},
 			},
-			Expected: httpValues{
-				Code:   http.StatusBadRequest,
-				Header: http.Header{"Content-Type": []string{"application/json"}, "Location": []string{"/?edge_type=AZBase&source_node=1&target_node=2&target_node=3"}},
-				Body:   `{"errors":[{"context":"","message":"Expected only one target_node."}],"http_status":400,"request_id":"","timestamp":"0001-01-01T00:00:00Z"}`,
+			expected: httpValues{
+				code:   http.StatusBadRequest,
+				header: http.Header{"Content-Type": []string{"application/json"}, "Location": []string{"/?edge_type=AZBase&source_node=1&target_node=2&target_node=3"}},
+				body:   `{"errors":[{"context":"","message":"Expected only one target_node."}],"http_status":400,"request_id":"","timestamp":"0001-01-01T00:00:00Z"}`,
 			},
+			testSetup: func(t *testing.T, ctx context.Context, res *v2.Resources) {},
 		},
 		{
-			Name: "Bad Parameter Type",
-			Request: http.Request{
+			name: "Bad Parameter Type",
+			request: http.Request{
 				URL: &url.URL{
 					RawQuery: "edge_type=LOREMIPSUM&source_node=1&target_node=2",
 				},
 			},
-			Expected: httpValues{
-				Code:   http.StatusBadRequest,
-				Header: http.Header{"Content-Type": []string{"application/json"}, "Location": []string{"/?edge_type=LOREMIPSUM&source_node=1&target_node=2"}},
-				Body:   `{"errors":[{"context":"","message":"Invalid edge requested: LOREMIPSUM"}],"http_status":400,"request_id":"","timestamp":"0001-01-01T00:00:00Z"}`,
+			expected: httpValues{
+				code:   http.StatusBadRequest,
+				header: http.Header{"Content-Type": []string{"application/json"}, "Location": []string{"/?edge_type=LOREMIPSUM&source_node=1&target_node=2"}},
+				body:   `{"errors":[{"context":"","message":"Invalid edge requested: LOREMIPSUM"}],"http_status":400,"request_id":"","timestamp":"0001-01-01T00:00:00Z"}`,
 			},
+			testSetup: func(t *testing.T, ctx context.Context, res *v2.Resources) {},
 		},
 		{
-			Name: "Bad Parameter Type 2",
-			Request: http.Request{
+			name: "Bad Parameter Type 2",
+			request: http.Request{
 				URL: &url.URL{
 					RawQuery: "edge_type=AZBase&source_node=GABAGOOL&target_node=2",
 				},
 			},
-			Expected: httpValues{
-				Code:   http.StatusBadRequest,
-				Header: http.Header{"Content-Type": []string{"application/json"}, "Location": []string{"/?edge_type=AZBase&source_node=GABAGOOL&target_node=2"}},
-				Body:   `{"errors":[{"context":"","message":"Invalid value for startID: GABAGOOL"}],"http_status":400,"request_id":"","timestamp":"0001-01-01T00:00:00Z"}`,
+			expected: httpValues{
+				code:   http.StatusBadRequest,
+				header: http.Header{"Content-Type": []string{"application/json"}, "Location": []string{"/?edge_type=AZBase&source_node=GABAGOOL&target_node=2"}},
+				body:   `{"errors":[{"context":"","message":"Invalid value for startID: GABAGOOL"}],"http_status":400,"request_id":"","timestamp":"0001-01-01T00:00:00Z"}`,
 			},
+			testSetup: func(t *testing.T, ctx context.Context, res *v2.Resources) {},
 		},
 		{
-			Name: "Bad Parameter Type 3",
-			Request: http.Request{
+			name: "Bad Parameter Type 3",
+			request: http.Request{
 				URL: &url.URL{
 					RawQuery: "edge_type=AZBase&source_node=1.67&target_node=2",
 				},
 			},
-			Expected: httpValues{
-				Code:   http.StatusBadRequest,
-				Header: http.Header{"Content-Type": []string{"application/json"}, "Location": []string{"/?edge_type=AZBase&source_node=1.67&target_node=2"}},
-				Body:   `{"errors":[{"context":"","message":"Invalid value for startID: 1.67"}],"http_status":400,"request_id":"","timestamp":"0001-01-01T00:00:00Z"}`,
+			expected: httpValues{
+				code:   http.StatusBadRequest,
+				header: http.Header{"Content-Type": []string{"application/json"}, "Location": []string{"/?edge_type=AZBase&source_node=1.67&target_node=2"}},
+				body:   `{"errors":[{"context":"","message":"Invalid value for startID: 1.67"}],"http_status":400,"request_id":"","timestamp":"0001-01-01T00:00:00Z"}`,
 			},
+			testSetup: func(t *testing.T, ctx context.Context, res *v2.Resources) {},
 		},
 		{
-			Name: "Bad Parameter Type 4",
-			Request: http.Request{
+			name: "Bad Parameter Type 4",
+			request: http.Request{
 				URL: &url.URL{
 					RawQuery: "edge_type=AZBase&source_node=1&target_node=lorem%20ipsum",
 				},
 			},
-			Expected: httpValues{
-				Code:   http.StatusBadRequest,
-				Header: http.Header{"Content-Type": []string{"application/json"}, "Location": []string{"/?edge_type=AZBase&source_node=1&target_node=lorem%20ipsum"}},
-				Body:   `{"errors":[{"context":"","message":"Invalid value for endID: lorem ipsum"}],"http_status":400,"request_id":"","timestamp":"0001-01-01T00:00:00Z"}`,
+			expected: httpValues{
+				code:   http.StatusBadRequest,
+				header: http.Header{"Content-Type": []string{"application/json"}, "Location": []string{"/?edge_type=AZBase&source_node=1&target_node=lorem%20ipsum"}},
+				body:   `{"errors":[{"context":"","message":"Invalid value for endID: lorem ipsum"}],"http_status":400,"request_id":"","timestamp":"0001-01-01T00:00:00Z"}`,
 			},
+			testSetup: func(t *testing.T, ctx context.Context, res *v2.Resources) {},
 		},
-	}
-
-	setupInternalState := func() v2.Resources {
-		t.Helper()
-		return v2.Resources{}
-	}
-
-	for _, testCase := range cases {
-		t.Run(testCase.Name, func(t *testing.T) {
-			t.Parallel()
-
-			resources := setupInternalState()
-
-			response := httptest.NewRecorder()
-
-			resources.GetEdgeRelayTargets(response, &testCase.Request)
-			mux.NewRouter().ServeHTTP(response, &testCase.Request)
-
-			actualCode, actualHeader, actualBody := test.ProcessResponse(t, response)
-
-			assert.Equal(t, testCase.Expected.Code, actualCode)
-			assert.Equal(t, testCase.Expected.Header, actualHeader)
-			assert.Equal(t, testCase.Expected.Body, actualBody)
-		})
-	}
-}
-
-func TestResources_GetEdgeRelayTargets_CannotMatchEdge(t *testing.T) {
-	t.Parallel()
-
-	type httpValues struct {
-		Code   int
-		Header http.Header
-		Body   string
-	}
-
-	cases := []struct {
-		Name     string
-		Request  http.Request
-		Expected httpValues
-	}{
 		{
-			Name: "Error Trying to get Matching Edge",
-			Request: http.Request{
+			name: "Error Trying to get Matching Edge",
+			request: http.Request{
 				URL: &url.URL{
 					RawQuery: "edge_type=AZBase&source_node=1&target_node=2",
 				},
 			},
-			Expected: httpValues{
-				Code:   http.StatusBadRequest,
-				Header: http.Header{"Content-Type": []string{"application/json"}, "Location": []string{"/?edge_type=AZBase&source_node=1&target_node=2"}},
-				Body:   `{"errors":[{"context":"","message":"Could not find edge matching criteria: Something went wrong"}],"http_status":400,"request_id":"","timestamp":"0001-01-01T00:00:00Z"}`,
+			expected: httpValues{
+				code:   http.StatusBadRequest,
+				header: http.Header{"Content-Type": []string{"application/json"}, "Location": []string{"/?edge_type=AZBase&source_node=1&target_node=2"}},
+				body:   `{"errors":[{"context":"","message":"Could not find edge matching criteria: Something went wrong"}],"http_status":400,"request_id":"","timestamp":"0001-01-01T00:00:00Z"}`,
+			},
+			testSetup: func(t *testing.T, ctx context.Context, res *v2.Resources) {
+				t.Helper()
+				ctrl := gomock.NewController(t)
+				mockGraph := graphmocks.NewMockDatabase(ctrl)
+				mockGraph.EXPECT().ReadTransaction(ctx, gomock.Any()).Return(errors.New("Something went wrong"))
+
+				res.Graph = mockGraph
 			},
 		},
-	}
-
-	setupInternalState := func(ctx context.Context) v2.Resources {
-		t.Helper()
-
-		ctrl := gomock.NewController(t)
-		mockGraph := graphmocks.NewMockDatabase(ctrl)
-		mockGraph.EXPECT().ReadTransaction(ctx, gomock.Any()).Return(errors.New("Something went wrong"))
-
-		res := v2.Resources{
-			Graph: mockGraph,
-		}
-
-		return res
-	}
-
-	for _, testCase := range cases {
-		t.Run(testCase.Name, func(t *testing.T) {
-			t.Parallel()
-
-			resources := setupInternalState(testCase.Request.Context())
-
-			response := httptest.NewRecorder()
-
-			resources.GetEdgeRelayTargets(response, &testCase.Request)
-			mux.NewRouter().ServeHTTP(response, &testCase.Request)
-
-			actualCode, actualHeader, actualBody := test.ProcessResponse(t, response)
-
-			assert.Equal(t, testCase.Expected.Code, actualCode)
-			assert.Equal(t, testCase.Expected.Header, actualHeader)
-			assert.JSONEq(t, testCase.Expected.Body, actualBody)
-		})
-	}
-}
-
-func TestResources_GetEdgeRelayTargets_CannotGetNodes(t *testing.T) {
-	t.Parallel()
-
-	type httpValues struct {
-		Code   int
-		Header http.Header
-		Body   string
-	}
-
-	cases := []struct {
-		Name     string
-		Request  http.Request
-		Expected httpValues
-	}{
 		{
-			Name: "Error Trying to get Nodes",
-			Request: http.Request{
+			name: "Error Trying to get Nodes",
+			request: http.Request{
 				URL: &url.URL{
 					RawQuery: "edge_type=AZBase&source_node=1&target_node=2",
 				},
 			},
-			Expected: httpValues{
-				Code:   http.StatusInternalServerError,
-				Header: http.Header{"Content-Type": []string{"application/json"}, "Location": []string{"/?edge_type=AZBase&source_node=1&target_node=2"}},
-				Body:   `{"errors":[{"context":"","message":"Error getting composition for edge: Something went wrong"}],"http_status":500,"request_id":"","timestamp":"0001-01-01T00:00:00Z"}`,
+			expected: httpValues{
+				code:   http.StatusInternalServerError,
+				header: http.Header{"Content-Type": []string{"application/json"}, "Location": []string{"/?edge_type=AZBase&source_node=1&target_node=2"}},
+				body:   `{"errors":[{"context":"","message":"Error getting composition for edge: Something went wrong"}],"http_status":500,"request_id":"","timestamp":"0001-01-01T00:00:00Z"}`,
+			},
+			testSetup: func(t *testing.T, ctx context.Context, res *v2.Resources) {
+				t.Helper()
+
+				ctrl := gomock.NewController(t)
+				mockGraph := graphmocks.NewMockDatabase(ctrl)
+				mockGraph.EXPECT().ReadTransaction(ctx, gomock.Any()).Return(nil)
+				mockGraph.EXPECT().ReadTransaction(ctx, gomock.Any()).Return(errors.New("Something went wrong"))
+
+				res.Graph = mockGraph
 			},
 		},
-	}
-
-	setupInternalState := func(ctx context.Context) v2.Resources {
-		t.Helper()
-
-		ctrl := gomock.NewController(t)
-		mockGraph := graphmocks.NewMockDatabase(ctrl)
-		mockGraph.EXPECT().ReadTransaction(ctx, gomock.Any()).Return(nil)
-		mockGraph.EXPECT().ReadTransaction(ctx, gomock.Any()).Return(errors.New("Something went wrong"))
-
-		res := v2.Resources{
-			Graph: mockGraph,
-		}
-
-		return res
-	}
-
-	for _, testCase := range cases {
-		t.Run(testCase.Name, func(t *testing.T) {
-			t.Parallel()
-
-			resources := setupInternalState(testCase.Request.Context())
-
-			response := httptest.NewRecorder()
-
-			resources.GetEdgeRelayTargets(response, &testCase.Request)
-			mux.NewRouter().ServeHTTP(response, &testCase.Request)
-
-			actualCode, actualHeader, actualBody := test.ProcessResponse(t, response)
-
-			assert.Equal(t, testCase.Expected.Code, actualCode)
-			assert.Equal(t, testCase.Expected.Header, actualHeader)
-			assert.JSONEq(t, testCase.Expected.Body, actualBody)
-		})
-	}
-}
-
-func TestResources_GetEdgeRelayTargets_PositiveTest(t *testing.T) {
-	t.Parallel()
-
-	type httpValues struct {
-		Code   int
-		Header http.Header
-		Body   string
-	}
-
-	cases := []struct {
-		Name     string
-		Request  http.Request
-		Expected httpValues
-	}{
 		{
-			Name: "Successful Request",
-			Request: http.Request{
+			name: "Successful Request",
+			request: http.Request{
 				URL: &url.URL{
 					RawQuery: "edge_type=AZBase&source_node=1&target_node=2",
 				},
 			},
-			Expected: httpValues{
-				Code:   http.StatusOK,
-				Header: http.Header{"Content-Type": []string{"application/json"}, "Location": []string{"/?edge_type=AZBase&source_node=1&target_node=2"}},
-				Body:   `{"data":{"nodes":{},"edges":[]}}`,
+			expected: httpValues{
+				code:   http.StatusOK,
+				header: http.Header{"Content-Type": []string{"application/json"}, "Location": []string{"/?edge_type=AZBase&source_node=1&target_node=2"}},
+				body:   `{"data":{"nodes":{},"edges":[]}}`,
+			},
+			testSetup: func(t *testing.T, ctx context.Context, res *v2.Resources) {
+				t.Helper()
+
+				ctrl := gomock.NewController(t)
+				mockGraph := graphmocks.NewMockDatabase(ctrl)
+				mockGraph.EXPECT().ReadTransaction(ctx, gomock.Any()).Return(nil)
+				mockGraph.EXPECT().ReadTransaction(ctx, gomock.Any()).Return(nil)
+
+				res.Graph = mockGraph
 			},
 		},
 	}
 
-	setupInternalState := func(ctx context.Context) v2.Resources {
-		t.Helper()
-
-		ctrl := gomock.NewController(t)
-		mockGraph := graphmocks.NewMockDatabase(ctrl)
-		mockGraph.EXPECT().ReadTransaction(ctx, gomock.Any()).Return(nil)
-		mockGraph.EXPECT().ReadTransaction(ctx, gomock.Any()).Return(nil)
-
-		res := v2.Resources{
-			Graph: mockGraph,
-		}
-
-		return res
-	}
-
 	for _, testCase := range cases {
-		t.Run(testCase.Name, func(t *testing.T) {
+		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
-			resources := setupInternalState(testCase.Request.Context())
+			resources := v2.Resources{}
+
+			testCase.testSetup(t, testCase.request.Context(), &resources)
 
 			response := httptest.NewRecorder()
 
-			resources.GetEdgeRelayTargets(response, &testCase.Request)
-			mux.NewRouter().ServeHTTP(response, &testCase.Request)
+			resources.GetEdgeRelayTargets(response, &testCase.request)
+			mux.NewRouter().ServeHTTP(response, &testCase.request)
 
 			actualCode, actualHeader, actualBody := test.ProcessResponse(t, response)
 
-			assert.Equal(t, testCase.Expected.Code, actualCode)
-			assert.Equal(t, testCase.Expected.Header, actualHeader)
-			assert.JSONEq(t, testCase.Expected.Body, actualBody)
+			assert.Equal(t, testCase.expected.code, actualCode)
+			assert.Equal(t, testCase.expected.header, actualHeader)
+			assert.Equal(t, testCase.expected.body, actualBody)
 		})
 	}
 }

--- a/cmd/api/src/migrations/migrations_integration_test.go
+++ b/cmd/api/src/migrations/migrations_integration_test.go
@@ -15,7 +15,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build integration
-// +build integration
 
 package migrations_test
 

--- a/cmd/api/src/migrations/migrations_integration_test.go
+++ b/cmd/api/src/migrations/migrations_integration_test.go
@@ -14,6 +14,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build integration
+// +build integration
+
 package migrations_test
 
 import (


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

I added tests for the handler `GetEdgeRelayTargets` and changed the test `TestVersion_730_Migration` to be an integration test.

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves [BED-5816](https://specterops.atlassian.net/browse/BED-5816?atlOrigin=eyJpIjoiZTQyZjZmYjQ5M2U3NGJhOTk3NjI1MzJlNDg4ZTAwMTQiLCJwIjoiaiJ9)

*Why is this change required? What problem does it solve?*

Add code coverage for `GetEdgeRelayTargets` and fix the test `TestVersion_730_Migration` being miscategorized as a unit test when it should be an integration test. 

## How Has This Been Tested?

Unit tests and integration tests have been run locally.

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [X] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [X] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [X] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


[BED-5816]: https://specterops.atlassian.net/browse/BED-5816?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ