### PR TITLE
Revert "BHE-5639 Integration Test Removal (preparation for replacement)"

### DIFF
--- a/cmd/api/src/api/v2/analysisrequest_integration_test.go
+++ b/cmd/api/src/api/v2/analysisrequest_integration_test.go
@@ -1,0 +1,39 @@
+// Copyright 2024 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build integration
+// +build integration
+
+package v2_test
+
+import (
+	"testing"
+
+	"github.com/specterops/bloodhound/src/api/v2/integration"
+	"github.com/specterops/bloodhound/src/model"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRequestAnalysis(t *testing.T) {
+	testCtx := integration.NewFOSSContext(t)
+
+	err := testCtx.AdminClient().RequestAnalysis()
+	require.Nil(t, err)
+
+	analReq, err := testCtx.AdminClient().GetAnalysisRequest()
+	require.Nil(t, err)
+	require.Equal(t, analReq.RequestType, model.AnalysisRequestAnalysis)
+}

--- a/cmd/api/src/api/v2/app_config_integration_test.go
+++ b/cmd/api/src/api/v2/app_config_integration_test.go
@@ -1,0 +1,139 @@
+// Copyright 2023 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build serial_integration
+// +build serial_integration
+
+package v2_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/specterops/bloodhound/dawgs/drivers/neo4j"
+	v2 "github.com/specterops/bloodhound/src/api/v2"
+	"github.com/specterops/bloodhound/src/api/v2/integration"
+	"github.com/specterops/bloodhound/src/model/appcfg"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_GetAppConfigs(t *testing.T) {
+	var (
+		testCtx = integration.NewFOSSContext(t)
+
+		passwordExpirationWindowFound = false
+		passwordExpirationValue       appcfg.PasswordExpiration
+
+		neo4jConfigsFound    = false
+		neo4jParametersValue appcfg.Neo4jParameters
+
+		citrixConfigsFound = false
+		citrixConfigValue  appcfg.CitrixRDPSupport
+
+		pruneFound           = false
+		pruneParametersValue appcfg.PruneTTLParameters
+
+		reconciliationFound           = false
+		reconciliationParametersValue appcfg.ReconciliationParameter
+	)
+
+	config, err := testCtx.AdminClient().GetAppConfigs()
+	require.Nilf(t, err, "Error while getting app config: %v", err)
+
+	for _, parameter := range config {
+		switch parameter.Key {
+		case appcfg.PasswordExpirationWindow:
+			mapParameter(t, &passwordExpirationValue, parameter)
+			require.Equal(t, appcfg.DefaultPasswordExpirationWindow, passwordExpirationValue.Duration)
+			passwordExpirationWindowFound = true
+		case appcfg.Neo4jConfigs:
+			mapParameter(t, &neo4jParametersValue, parameter)
+			require.Equal(t, neo4j.DefaultBatchWriteSize, neo4jParametersValue.BatchWriteSize)
+			require.Equal(t, neo4j.DefaultWriteFlushSize, neo4jParametersValue.WriteFlushSize)
+			neo4jConfigsFound = true
+		case appcfg.CitrixRDPSupportKey:
+			mapParameter(t, &citrixConfigValue, parameter)
+			require.False(t, citrixConfigValue.Enabled)
+			citrixConfigsFound = true
+		case appcfg.PruneTTL:
+			mapParameter(t, &pruneParametersValue, parameter)
+			require.Equal(t, appcfg.DefaultPruneBaseTTL, pruneParametersValue.BaseTTL)
+			require.Equal(t, appcfg.DefaultPruneHasSessionEdgeTTL, pruneParametersValue.HasSessionEdgeTTL)
+			pruneFound = true
+		case appcfg.ReconciliationKey:
+			mapParameter(t, &reconciliationParametersValue, parameter)
+			require.True(t, reconciliationParametersValue.Enabled)
+			reconciliationFound = true
+		}
+	}
+
+	require.True(t, passwordExpirationWindowFound, "Failed to find Password Expiration Window in response")
+	require.True(t, neo4jConfigsFound, "Failed to find Neo4J Configs in response")
+	require.True(t, citrixConfigsFound, "Failed to find Citrix configs in response")
+	require.True(t, pruneFound, "Failed to find Prune TTL  in response")
+	require.True(t, reconciliationFound, "Failed to find Reconciliation in response")
+}
+
+func Test_GetAppConfigWithParameter(t *testing.T) {
+	var (
+		passwordExpirationValue appcfg.PasswordExpiration
+		testCtx                 = integration.NewFOSSContext(t)
+	)
+
+	config, err := testCtx.AdminClient().GetAppConfig(appcfg.PasswordExpirationWindow)
+	require.Nilf(t, err, "Error while getting app config: %v", err)
+	require.True(t, len(config) == 1, "Response contains too many results")
+	require.Equal(t, appcfg.PasswordExpirationWindow, config[0].Key)
+	mapParameter(t, &passwordExpirationValue, config[0])
+	require.Equal(t, appcfg.DefaultPasswordExpirationWindow, passwordExpirationValue.Duration)
+}
+
+func Test_PutAppConfig(t *testing.T) {
+	const updatedDuration = "P30D"
+
+	var (
+		updatedPasswordExpiration                appcfg.PasswordExpiration
+		updatedPasswordExpirationWindowParameter = v2.AppConfigUpdateRequest{
+			Key: appcfg.PasswordExpirationWindow,
+			Value: map[string]any{
+				"duration": updatedDuration,
+			},
+		}
+		testCtx = integration.NewFOSSContext(t)
+	)
+
+	parameter, err := testCtx.AdminClient().PutAppConfig(updatedPasswordExpirationWindowParameter)
+	require.Nilf(t, err, "Error while updating app config: %v", err)
+
+	mapParameter(t, &updatedPasswordExpiration, parameter)
+	require.Equal(t, time.Hour*24*30, updatedPasswordExpiration.Duration)
+
+	// Check that our change really is in the database
+	config, err := testCtx.AdminClient().GetAppConfig(appcfg.PasswordExpirationWindow)
+	require.Nilf(t, err, "Error while getting updated app config: %v", err)
+
+	mapParameter(t, &updatedPasswordExpiration, config[0])
+	require.Equal(t, time.Hour*24*30, updatedPasswordExpiration.Duration)
+}
+
+func mapParameter[T *appcfg.PasswordExpiration |
+	*appcfg.Neo4jParameters |
+	*appcfg.CitrixRDPSupport |
+	*appcfg.PruneTTLParameters |
+	*appcfg.ReconciliationParameter](t *testing.T, value T, parameter appcfg.Parameter) {
+	err := parameter.Value.Map(&value)
+	require.Nilf(t, err, "Failed to map parameter value to %T type: %v", value, err)
+}

--- a/cmd/api/src/api/v2/audit_integration_test.go
+++ b/cmd/api/src/api/v2/audit_integration_test.go
@@ -1,0 +1,80 @@
+// Copyright 2023 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build serial_integration
+// +build serial_integration
+
+package v2_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/specterops/bloodhound/src/api/v2/integration"
+	"github.com/specterops/bloodhound/src/model"
+	"github.com/specterops/bloodhound/src/utils/test"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_ListAuditLogs(t *testing.T) {
+	testCtx := integration.NewFOSSContext(t)
+
+	t.Run("Test Getting Latest Audit Logs", func(t *testing.T) {
+		var (
+			newAssetGroup          = testCtx.CreateAssetGroup("Testing Audit Logs", "test_get_auditLogs")
+			expectedAuditLogFields = map[string]any{
+				"asset_group_name": newAssetGroup.Name,
+				"asset_group_tag":  newAssetGroup.Tag,
+			}
+		)
+
+		testCtx.DeleteAssetGroup(newAssetGroup.ID)
+
+		err := test.AssertAuditLogs(testCtx.GetLatestAuditLogs(), model.AuditLogActionCreateAssetGroup, model.AuditLogStatusSuccess, expectedAuditLogFields)
+		require.Nil(t, err)
+
+		err = test.AssertAuditLogs(testCtx.GetLatestAuditLogs(), model.AuditLogActionDeleteAssetGroup, model.AuditLogStatusSuccess, expectedAuditLogFields)
+		require.Nil(t, err)
+	})
+
+	t.Run("Test Getting Audit Logs by Time Range", func(t *testing.T) {
+		var (
+			newAssetGroup          = testCtx.CreateAssetGroup("Testing Audit Logs", "test_get_auditLogs")
+			expectedAuditLogFields = map[string]any{
+				"asset_group_name": newAssetGroup.Name,
+				"asset_group_tag":  newAssetGroup.Tag,
+			}
+		)
+
+		// Sleep just a moment to give the API some time to avoid audit log jitter
+		time.Sleep(500 * time.Millisecond)
+
+		beforeDeletionTimestamp := time.Now()
+
+		testCtx.DeleteAssetGroup(newAssetGroup.ID)
+
+		// Expect two audit log entries from the deletion
+		auditLogs := testCtx.ListAuditLogs(beforeDeletionTimestamp, time.Now(), 0, 0)
+		require.Equal(t, 2, len(auditLogs), "Expected exactly 2 audit log entries but saw %d", len(auditLogs))
+
+		err := test.AssertAuditLogs(auditLogs, model.AuditLogActionDeleteAssetGroup, model.AuditLogStatusSuccess, expectedAuditLogFields)
+		require.Nil(t, err)
+
+		// Audit logs are in LIFO order
+		require.Equal(t, auditLogs[0].Status, model.AuditLogStatusSuccess)
+		require.Equal(t, auditLogs[1].Status, model.AuditLogStatusIntent)
+	})
+}

--- a/cmd/api/src/api/v2/auth/auth_integration_test.go
+++ b/cmd/api/src/api/v2/auth/auth_integration_test.go
@@ -1,0 +1,228 @@
+// Copyright 2023 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build serial_integration
+// +build serial_integration
+
+package auth_test
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/specterops/bloodhound/src/api"
+	"github.com/specterops/bloodhound/src/api/v2/integration"
+	"github.com/specterops/bloodhound/src/auth"
+	"github.com/specterops/bloodhound/src/model"
+	"github.com/specterops/bloodhound/src/utils/test"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	otherUser   = "other@example.com"
+	otherSecret = "secretTERCES123***"
+	nonAdmin    = "not@dmin.com"
+)
+
+func Test_PermissionHandling(t *testing.T) {
+	var (
+		testCtx       = integration.NewFOSSContext(t)
+		newUser       = testCtx.CreateUser(otherUser, otherUser, auth.RoleReadOnly)
+		newUserToken  = testCtx.CreateAuthToken(newUser.ID, "TestToken")
+		newUserClient = testCtx.NewAPIClientWithToken(newUserToken)
+
+		_, versionErr   = newUserClient.Version()
+		_, listUsersErr = newUserClient.ListUsers()
+	)
+
+	require.Nil(t, versionErr, "Version endpoint should allow requests from users with no permissions: %v", versionErr)
+	require.NotNil(t, listUsersErr, "Users endpoint should not allow requests from users with no permissions: %v", listUsersErr)
+}
+
+func Test_AuthRolesMatchInternalDefinitions(t *testing.T) {
+	var (
+		testCtx     = integration.NewFOSSContext(t)
+		actualRoles = testCtx.ListRoles()
+	)
+
+	require.Equal(t, len(auth.Roles()), len(actualRoles))
+
+	for _, expectedRole := range auth.Roles() {
+		if _, hasRole := actualRoles.FindByName(expectedRole.Name); !hasRole {
+			t.Fatalf("Unable to find expected role %s", expectedRole.Name)
+		}
+	}
+}
+
+func Test_UserManagement(t *testing.T) {
+	var (
+		testCtx = integration.NewFOSSContext(t)
+		newUser = testCtx.CreateUser(otherUser, otherUser, auth.RoleReadOnly)
+	)
+
+	t.Run("Delete User", func(t *testing.T) {
+		// Expect to start with two users - admin and the new user
+		testCtx.AssertUserCount(2)
+
+		// Delete the user and expect to see one user remaining on the next count assertion
+		testCtx.DeleteUser(newUser.ID)
+		testCtx.AssertUserCount(1)
+
+		// Exit reassigning a new, live user to the new user variable
+		newUser = testCtx.CreateUser(otherUser, otherUser, auth.RoleReadOnly)
+		testCtx.AssertUserCount(2)
+	})
+
+	t.Run("Set User Secret", func(t *testing.T) {
+		var (
+			newUserToken  = testCtx.CreateAuthToken(newUser.ID, "Set User Secret")
+			newUserClient = testCtx.NewAPIClientWithToken(newUserToken)
+			badSecretErr  = newUserClient.SetUserSecret(newUser.ID, "badsecret", false)
+		)
+
+		require.NotNil(t, badSecretErr, "Expected an error when using a bad user secret")
+
+		testCtx.SetUserSecret(newUser.ID, integration.AdminUpdatedSecret, true)
+
+		loginResponse, err := newUserClient.LoginSecret(newUser.EmailAddress.String, integration.AdminUpdatedSecret)
+		require.Nilf(t, err, "Unexpected error encountered while logging in with updated secret: %v", err)
+		require.True(t, loginResponse.AuthExpired, "Expected user auth to be expired after secret reset with needsPasswordSet enabled")
+
+		testCtx.SetUserSecret(newUser.ID, otherSecret, false)
+
+		loginResponse, err = newUserClient.LoginSecret(newUser.EmailAddress.String, otherSecret)
+		require.Nilf(t, err, "Unexpected error encountered while logging in with updated secret: %v", err)
+		require.False(t, loginResponse.AuthExpired, "Expected user auth to not be expired after secret reset")
+
+		// Clean up the token
+		testCtx.DeleteAuthToken(newUser.ID, newUserToken.ID)
+	})
+
+	t.Run("Create tokens for other user as an admin", func(t *testing.T) {
+		testCtx.CreateAuthToken(newUser.ID, "TestToken1")
+		testCtx.CreateAuthToken(newUser.ID, "TestToken2")
+		testCtx.CreateAuthToken(newUser.ID, "TestToken3")
+
+		actualTokens := testCtx.ListUserTokens(newUser.ID)
+
+		require.Equalf(t, 3, len(actualTokens), "Expected 3 tokens but found %d", len(actualTokens))
+
+		for _, actualToken := range actualTokens {
+			// All tokens must strip their key after creation
+			require.Equal(t, "", actualToken.Key)
+
+			testCtx.DeleteAuthToken(newUser.ID, actualToken.ID)
+		}
+
+		actualTokens = testCtx.ListUserTokens(newUser.ID)
+		require.Equal(t, 0, len(actualTokens), "Expected no remaining auth tokens for user %s but found %d", newUser.ID.String(), len(actualTokens))
+	})
+}
+
+func Test_NonAdminFunctionality(t *testing.T) {
+	var (
+		testCtx        = integration.NewFOSSContext(t)
+		newUser        = testCtx.CreateUser(otherUser, otherUser, auth.RoleReadOnly)
+		nonAdminUser   = testCtx.CreateUser(nonAdmin, nonAdmin, auth.RoleUser)
+		nonAdminToken  = testCtx.CreateAuthToken(nonAdminUser.ID, "NonAdmin Token")
+		nonAdminClient = testCtx.NewAPIClientWithToken(nonAdminToken)
+	)
+
+	t.Run("Creating and listing tokens as a nonadmin is successful", func(t *testing.T) {
+		newToken, err := nonAdminClient.CreateUserToken(nonAdminUser.ID, "NonAdmin Token 2")
+		require.Nil(t, err, "Expected a successful response, got: %v", err)
+
+		nonAdminActualTokens, err := nonAdminClient.ListAuthTokens()
+		if err != nil {
+			t.Logf("Encountered error checking auth tokens: %s", err)
+			t.Fail()
+		}
+
+		require.Equalf(t, 2, len(nonAdminActualTokens.Tokens), "Expected 2 tokens but found %d", len(nonAdminActualTokens.Tokens))
+		require.Equalf(t, nonAdminActualTokens.Tokens[0].UserID.UUID, nonAdminUser.ID, "Non-admins should not return tokens for other users: %v", nonAdminActualTokens)
+		require.Equalf(t, nonAdminActualTokens.Tokens[1].UserID.UUID, nonAdminUser.ID, "Non-admins should not return tokens for other users: %v", nonAdminActualTokens)
+
+		for _, actualToken := range nonAdminActualTokens.Tokens {
+			// All tokens must strip their key after creation
+			require.Equal(t, "", actualToken.Key)
+
+			// Cleanup the token we created so it doesnt affect other tests
+			if actualToken.ID == newToken.ID {
+				testCtx.DeleteAuthToken(nonAdminToken.ID, actualToken.ID)
+			}
+		}
+
+		actualTokens := testCtx.ListUserTokens(nonAdminUser.ID)
+		require.Equal(t, 1, len(actualTokens), "Expected no new auth tokens for user %s but found %d", nonAdminUser.ID.String(), len(actualTokens))
+	})
+
+	t.Run("Creating tokens for other user as nonadmin should fail", func(t *testing.T) {
+		_, err := nonAdminClient.CreateUserToken(newUser.ID, "NewUser Token")
+		wrapper, ok := err.(api.ErrorWrapper)
+		if !ok {
+			t.Logf("Expected a valid API Error response. Failed unmarshalling to api.ErrorWrapper: %v", err)
+			t.Fail()
+		}
+		require.Equal(t, http.StatusForbidden, wrapper.HTTPStatus)
+
+		nonAdminActualTokens, err := nonAdminClient.ListAuthTokens()
+		if err != nil {
+			t.Logf("Encountered error checking auth tokens: %s", err)
+			t.Fail()
+		}
+
+		require.Equalf(t, 1, len(nonAdminActualTokens.Tokens), "Expected 1 tokens but found %d", len(nonAdminActualTokens.Tokens))
+		require.Equalf(t, nonAdminActualTokens.Tokens[0].UserID.UUID, nonAdminUser.ID, "Non-admins should not return tokens for other users: %v", nonAdminActualTokens.Tokens)
+	})
+
+	t.Run("Deleting tokens as nonadmin is successful", func(t *testing.T) {
+		tokenToDelete, err := nonAdminClient.CreateUserToken(nonAdminUser.ID, "nonAdminUser token to delete")
+		if err != nil {
+			t.Logf("Encountered error creating auth token: %s", err)
+			t.Fail()
+		}
+
+		err = nonAdminClient.DeleteUserToken(tokenToDelete.ID)
+		require.Nilf(t, err, "Received unexpected error when deleting token: %s", err)
+
+		// Ensure the token gets cleaned up if there was an error above
+		if err != nil {
+			// Use the admin session to cleanup the newly created token
+			testCtx.DeleteAuthToken(nonAdminUser.ID, tokenToDelete.ID)
+		}
+	})
+
+	t.Run("Deleting tokens for other user as nonadmin should fail", func(t *testing.T) {
+		tokenToDelete := testCtx.CreateAuthToken(newUser.ID, "newUser token to delete")
+
+		err := nonAdminClient.DeleteUserToken(tokenToDelete.ID)
+		errWrapper := api.ErrorWrapper{}
+		if errors.As(err, &errWrapper) {
+			require.Equal(t, errWrapper.HTTPStatus, http.StatusForbidden)
+		} else {
+			t.Logf("Encountered unknown error deleting auth token: %s", err)
+			t.Fail()
+		}
+
+		err = test.AssertAuditLogs(testCtx.GetLatestAuditLogs(), model.AuditLogActionDeleteAuthToken, model.AuditLogStatusFailure, model.AuditData{
+			"target_user_id": newUser.ID.String(), "id": tokenToDelete.ID.String()})
+		require.Nil(t, err)
+
+		// Use the admin session to cleanup the newly created token
+		testCtx.DeleteAuthToken(newUser.ID, tokenToDelete.ID)
+	})
+}

--- a/cmd/api/src/api/v2/azure_integration_test.go
+++ b/cmd/api/src/api/v2/azure_integration_test.go
@@ -1,0 +1,53 @@
+// Copyright 2023 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build integration
+// +build integration
+
+package v2_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/specterops/bloodhound/analysis/azure"
+	"github.com/specterops/bloodhound/dawgs/graph"
+	schema "github.com/specterops/bloodhound/graphschema"
+	"github.com/specterops/bloodhound/graphschema/common"
+	v2 "github.com/specterops/bloodhound/src/api/v2"
+	"github.com/specterops/bloodhound/src/test/integration"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetAZEntityInformation(t *testing.T) {
+	testContext := integration.NewGraphTestContext(t, schema.DefaultGraphSchema())
+
+	testContext.TransactionalTest(func(harness integration.HarnessDetails, tx graph.Transaction) {
+		objectID, err := harness.AZGroupMembership.Group.Properties.Get(common.ObjectID.String()).String()
+		require.Nil(t, err)
+
+		groupInformation, err := v2.GetAZEntityInformation(context.Background(), testContext.Graph.Database, "groups", objectID, true)
+		require.Nil(t, err)
+
+		groupInformationJSON, err := json.Marshal(groupInformation)
+		require.Nil(t, err)
+
+		groupDetails := azure.GroupDetails{}
+		require.Nil(t, json.Unmarshal(groupInformationJSON, &groupDetails))
+		require.Equal(t, 3, groupDetails.GroupMembers)
+	})
+}

--- a/cmd/api/src/api/v2/cypherquery_integration_test.go
+++ b/cmd/api/src/api/v2/cypherquery_integration_test.go
@@ -1,0 +1,218 @@
+// Copyright 2023 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build integration
+// +build integration
+
+package v2_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/specterops/bloodhound/cypher/models/cypher/format"
+	"github.com/specterops/bloodhound/src/auth"
+	"github.com/specterops/bloodhound/src/model"
+	"github.com/specterops/bloodhound/src/utils/test"
+
+	"github.com/specterops/bloodhound/cypher/frontend"
+	"github.com/specterops/bloodhound/graphschema/common"
+	"github.com/specterops/bloodhound/lab"
+	v2 "github.com/specterops/bloodhound/src/api/v2"
+	"github.com/specterops/bloodhound/src/test/integration/utils"
+	"github.com/specterops/bloodhound/src/test/lab/fixtures"
+	"github.com/specterops/bloodhound/src/test/lab/harnesses"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_CypherSearch(t *testing.T) {
+	var (
+		harness = harnesses.NewIntegrationTestHarness(fixtures.BHAdminApiClientFixture)
+	)
+
+	lab.Pack(harness, fixtures.BasicComputerFixture)
+
+	lab.NewSpec(t, harness).Run(
+		lab.TestCase("errors on empty input", func(assert *require.Assertions, harness *lab.Harness) {
+			apiClient, ok := lab.Unpack(harness, fixtures.BHAdminApiClientFixture)
+			assert.True(ok)
+
+			_, err := apiClient.CypherQuery(v2.CypherQueryPayload{})
+			assert.ErrorContains(err, frontend.ErrInvalidInput.Error())
+		}),
+		lab.TestCase("errors on syntax mistake", func(assert *require.Assertions, harness *lab.Harness) {
+			apiClient, ok := lab.Unpack(harness, fixtures.BHAdminApiClientFixture)
+			assert.True(ok)
+
+			_, err := apiClient.CypherQuery(v2.CypherQueryPayload{
+				Query: "my syntax stinks",
+			})
+			assert.ErrorContains(err, "extraneous input")
+		}),
+		lab.TestCase("errors on queries that are not supported", func(assert *require.Assertions, harness *lab.Harness) {
+			apiClient, ok := lab.Unpack(harness, fixtures.BHAdminApiClientFixture)
+			assert.True(ok)
+
+			queryWithUserSpecifiedParameters := "match (n:Guardian {name: $name}) return n"
+			_, err := apiClient.CypherQuery(v2.CypherQueryPayload{
+				Query: queryWithUserSpecifiedParameters,
+			})
+			assert.ErrorContains(err, frontend.ErrUserSpecifiedParametersNotSupported.Error())
+		}),
+		lab.TestCase("successfully runs cypher query", func(assert *require.Assertions, harness *lab.Harness) {
+			apiClient, ok := lab.Unpack(harness, fixtures.BHAdminApiClientFixture)
+			assert.True(ok)
+
+			graphResponse, err := apiClient.CypherQuery(v2.CypherQueryPayload{
+				Query: "match (n:Computer) where n.objectid = '" + fixtures.BasicComputerSID.String() + "' return n",
+			})
+			assert.NoError(err)
+			assert.Equal(1, len(graphResponse.Nodes))
+			assert.Equal(0, len(graphResponse.Edges))
+
+			expectedComputer, ok := lab.Unpack(harness, fixtures.BasicComputerFixture)
+			assert.True(ok)
+
+			expectedComputerId, _ := expectedComputer.Properties.Get(common.ObjectID.String()).String()
+			actualComputerId := graphResponse.Nodes[expectedComputer.ID.String()].ObjectId
+			assert.Equal(expectedComputerId, actualComputerId)
+		}),
+	)
+}
+
+func Test_CypherSearch_WithoutCypherMutationsEnabled(t *testing.T) {
+	harness := lab.NewHarness()
+
+	// Default ConfigFixture does not have cypher mutations enabled
+	adminApiClientFixture := fixtures.NewAdminApiClientFixture(fixtures.ConfigFixture, fixtures.NewApiFixture())
+	lab.Pack(harness, adminApiClientFixture)
+
+	lab.NewSpec(t, harness).Run(
+		lab.TestCase("errors on mutations with enable cypher_mutations false", func(assert *require.Assertions, harness *lab.Harness) {
+			apiClient, ok := lab.Unpack(harness, adminApiClientFixture)
+			assert.True(ok)
+
+			_, err := apiClient.CypherQuery(v2.CypherQueryPayload{Query: "match (w) where w.name = 'voldemort' remove w.name return w"})
+			assert.ErrorContains(err, frontend.ErrUpdateClauseNotSupported.Error())
+		}),
+	)
+}
+
+func Test_CypherSearch_WithCypherMutationsEnabled(t *testing.T) {
+	customCfg, err := utils.LoadIntegrationTestConfig()
+	require.Nil(t, err)
+
+	// Enable cypher mutations in API
+	customCfg.EnableCypherMutations = true
+
+	harness := lab.NewHarness()
+	customCfgFixture := fixtures.NewCustomConfigFixture(customCfg)
+	lab.Pack(harness, customCfgFixture)
+	customApiFixture := fixtures.NewCustomApiFixture(customCfgFixture)
+	lab.Pack(harness, customApiFixture)
+	adminApiClientFixture := fixtures.NewAdminApiClientFixture(customCfgFixture, customApiFixture)
+	lab.Pack(harness, adminApiClientFixture)
+	userApiClientFixture := fixtures.NewUserApiClientFixture(customCfgFixture, adminApiClientFixture, auth.RoleUser)
+	lab.Pack(harness, userApiClientFixture)
+
+	var (
+		parseCtx = frontend.NewContext(
+			&frontend.ExplicitProcedureInvocationFilter{},
+			&frontend.ImplicitProcedureInvocationFilter{},
+			&frontend.SpecifiedParametersFilter{},
+		)
+		stripper = format.NewCypherEmitter(true)
+	)
+
+	lab.NewSpec(t, harness).Run(
+		lab.TestCase("allows mutations with enable cypher_mutations true", func(assert *require.Assertions, harness *lab.Harness) {
+			apiClient, ok := lab.Unpack(harness, adminApiClientFixture)
+			assert.True(ok)
+
+			var (
+				query         = "match (w: User) where w.name = 'vldmrt' remove w.name return w"
+				strippedQuery = &bytes.Buffer{}
+			)
+			parsedQuery, err := frontend.ParseCypher(parseCtx, query)
+			require.Nil(t, err)
+			err = stripper.Write(parsedQuery, strippedQuery)
+			require.Nil(t, err)
+
+			_, err = apiClient.CypherQuery(v2.CypherQueryPayload{Query: query})
+			assert.Nil(err)
+
+			auditLogs, err := apiClient.GetLatestAuditLogs()
+			assert.Nil(err)
+
+			err = test.AssertAuditLogs(auditLogs.Logs, model.AuditLogActionMutateGraph, model.AuditLogStatusSuccess, model.AuditData{"query": strippedQuery.String()})
+			assert.Nil(err)
+		}),
+
+		lab.TestCase("fails unauthorized mutation attempts and adds it to audit log", func(assert *require.Assertions, harness *lab.Harness) {
+			adminApiClient, ok := lab.Unpack(harness, adminApiClientFixture)
+			assert.True(ok)
+			userApiClient, ok := lab.Unpack(harness, userApiClientFixture)
+			assert.True(ok)
+
+			var (
+				query         = "match (w: User) where w.name = 'harryp' delete w"
+				strippedQuery = &bytes.Buffer{}
+			)
+			parsedQuery, err := frontend.ParseCypher(parseCtx, query)
+			require.Nil(t, err)
+			err = stripper.Write(parsedQuery, strippedQuery)
+			require.Nil(t, err)
+
+			_, err = userApiClient.CypherQuery(v2.CypherQueryPayload{Query: query})
+			assert.ErrorContains(err, "Permission denied: User may not modify the graph")
+
+			auditLogs, err := adminApiClient.GetLatestAuditLogs()
+			assert.Nil(err)
+
+			found := false
+			for _, al := range auditLogs.Logs {
+				if al.Action == model.AuditLogActionUnauthorizedAccessAttempt {
+					found = true
+				}
+			}
+			assert.True(found)
+		}),
+
+		lab.TestCase("adds mutation attempts to audit log", func(assert *require.Assertions, harness *lab.Harness) {
+			apiClient, ok := lab.Unpack(harness, adminApiClientFixture)
+			assert.True(ok)
+
+			var (
+				query         = "match (w: User) set w.wizard = true return w"
+				strippedQuery = &bytes.Buffer{}
+			)
+
+			parsedQuery, err := frontend.ParseCypher(parseCtx, query)
+			require.Nil(t, err)
+			err = stripper.Write(parsedQuery, strippedQuery)
+			require.Nil(t, err)
+
+			_, err = apiClient.CypherQuery(v2.CypherQueryPayload{Query: query})
+			require.Nil(t, err)
+
+			auditLogs, err := apiClient.GetLatestAuditLogs()
+			assert.Nil(err)
+
+			err = test.AssertAuditLogs(auditLogs.Logs, model.AuditLogActionMutateGraph, model.AuditLogStatusSuccess, model.AuditData{"query": strippedQuery.String()})
+			assert.Nil(err)
+		}),
+	)
+}

--- a/cmd/api/src/api/v2/datapipe_integration_test.go
+++ b/cmd/api/src/api/v2/datapipe_integration_test.go
@@ -1,0 +1,39 @@
+// Copyright 2024 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build serial_integration
+// +build serial_integration
+
+package v2_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/specterops/bloodhound/src/api/v2/integration"
+	"github.com/specterops/bloodhound/src/model"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetDatapipeStatus(t *testing.T) {
+	testCtx := integration.NewFOSSContext(t)
+
+	testCtx.WaitForDatapipeIdle(90 * time.Second)
+
+	datapipeStatus, err := testCtx.AdminClient().GetDatapipeStatus()
+	require.Nil(t, err)
+	require.Equal(t, datapipeStatus.Status, model.DatapipeStatusIdle)
+}

--- a/cmd/api/src/api/v2/file_uploads_integration_test.go
+++ b/cmd/api/src/api/v2/file_uploads_integration_test.go
@@ -1,0 +1,278 @@
+// Copyright 2023 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build serial_integration
+// +build serial_integration
+
+package v2_test
+
+import (
+	"bytes"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/specterops/bloodhound/headers"
+	"github.com/specterops/bloodhound/mediatypes"
+	"github.com/specterops/bloodhound/src/api/v2/integration"
+	"github.com/specterops/bloodhound/src/services/ingest"
+	"github.com/specterops/bloodhound/src/test/fixtures/fixtures"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_FileUpload(t *testing.T) {
+	testCtx := integration.NewFOSSContext(t)
+	apiClient := testCtx.AdminClient()
+	loader := testCtx.FixtureLoader
+
+	uploadJob, err := apiClient.CreateFileUploadTask()
+	assert.Nil(t, err)
+
+	jobEndpoint := fmt.Sprintf("api/v2/file-upload/%d", uploadJob.ID)
+
+	t.Run("JSON input with success", func(tx *testing.T) {
+		jsonInput := loader.GetReader("v6/ingest/computers.json")
+		defer jsonInput.Close()
+		req, err := apiClient.NewRequest(http.MethodPost, jobEndpoint, nil, jsonInput, http.Header{headers.ContentType.String(): []string{mediatypes.ApplicationJson.String()}})
+		assert.Nil(tx, err)
+		resp, err := apiClient.Raw(req)
+		assert.Nil(tx, err)
+		assert.Equal(tx, http.StatusAccepted, resp.StatusCode)
+	})
+
+	t.Run("JSON input with charset header success", func(tx *testing.T) {
+		jsonInput := loader.GetReader("v6/ingest/computers.json")
+		defer jsonInput.Close()
+		req, err := apiClient.NewRequest(http.MethodPost, jobEndpoint, nil, jsonInput, http.Header{headers.ContentType.String(): []string{mediatypes.ApplicationJson.WithCharset("utf-8")}})
+		assert.Nil(tx, err)
+		resp, err := apiClient.Raw(req)
+		assert.Nil(tx, err)
+		assert.Equal(tx, http.StatusAccepted, resp.StatusCode)
+	})
+
+	t.Run("JSON input with incorrect compression header", func(tx *testing.T) {
+		jsonInput := loader.GetReader("v6/ingest/containers.json")
+		defer jsonInput.Close()
+		req, err := apiClient.NewRequest(http.MethodPost, jobEndpoint, nil, jsonInput)
+		assert.Nil(tx, err)
+		req.Header.Set(headers.ContentEncoding.String(), "gzip")
+		resp, err := apiClient.Raw(req)
+		assert.Nil(tx, err)
+		assert.Equal(tx, http.StatusBadRequest, resp.StatusCode)
+	})
+
+	t.Run("Gzip input with correct compression header", func(tx *testing.T) {
+		var (
+			body bytes.Buffer
+			gw   = gzip.NewWriter(&body)
+		)
+		jsonInput := loader.GetReader("v6/ingest/domains.json")
+		defer jsonInput.Close()
+		n, err := io.Copy(gw, jsonInput)
+		assert.Nil(tx, err)
+		assert.NotEqual(tx, 0, n)
+		assert.Nil(tx, gw.Close())
+		req, err := apiClient.NewRequest(http.MethodPost, jobEndpoint, nil, io.NopCloser(&body), http.Header{headers.ContentType.String(): []string{mediatypes.ApplicationJson.String()}})
+		assert.Nil(tx, err)
+		req.Header.Set(headers.ContentEncoding.String(), "gzip")
+		resp, err := apiClient.Raw(req)
+		assert.Nil(tx, err)
+		assert.Equal(tx, http.StatusAccepted, resp.StatusCode)
+	})
+
+	t.Run("Gzip input with incorrect compression header", func(tx *testing.T) {
+		var (
+			body bytes.Buffer
+			gw   = gzip.NewWriter(&body)
+		)
+		jsonInput := loader.GetReader("v6/ingest/gpos.json")
+		defer jsonInput.Close()
+		n, err := io.Copy(gw, jsonInput)
+		assert.Nil(tx, err)
+		assert.NotEqual(tx, 0, n)
+		assert.Nil(tx, gw.Close())
+		req, err := apiClient.NewRequest(http.MethodPost, jobEndpoint, nil, io.NopCloser(&body))
+		assert.Nil(tx, err)
+		req.Header.Set(headers.ContentEncoding.String(), "deflate")
+		resp, err := apiClient.Raw(req)
+		assert.Nil(tx, err)
+		assert.Equal(tx, http.StatusBadRequest, resp.StatusCode)
+	})
+
+	t.Run("gzip input with missing compression header", func(tx *testing.T) {
+		var (
+			body bytes.Buffer
+			gw   = gzip.NewWriter(&body)
+		)
+		jsonInput := loader.GetReader("v6/ingest/groups.json")
+		defer jsonInput.Close()
+		n, err := io.Copy(gw, jsonInput)
+		assert.Nil(tx, err)
+		assert.NotEqual(tx, 0, n)
+		assert.Nil(tx, gw.Close())
+		req, err := apiClient.NewRequest(http.MethodPost, jobEndpoint, nil, io.NopCloser(&body))
+		assert.Nil(tx, err)
+		resp, err := apiClient.Raw(req)
+		assert.Nil(tx, err)
+		assert.Equal(tx, http.StatusBadRequest, resp.StatusCode)
+	})
+
+	t.Run("unsupported compression type", func(tx *testing.T) {
+		jsonInput := loader.GetReader("v6/ingest/containers.json")
+		defer jsonInput.Close()
+		req, err := apiClient.NewRequest(http.MethodPost, jobEndpoint, nil, jsonInput)
+		assert.Nil(tx, err)
+		req.Header.Set(headers.ContentEncoding.String(), "br")
+		resp, err := apiClient.Raw(req)
+		assert.Nil(tx, err)
+		assert.Equal(tx, http.StatusUnsupportedMediaType, resp.StatusCode)
+	})
+
+	t.Run("not valid json", func(tx *testing.T) {
+		jsonInput := loader.GetReader("v6/ingest/jker.jpg")
+		defer jsonInput.Close()
+		req, err := apiClient.NewRequest(http.MethodPost, jobEndpoint, nil, jsonInput)
+		assert.Nil(tx, err)
+		resp, err := apiClient.Raw(req)
+		assert.Nil(tx, err)
+		assert.Equal(tx, http.StatusBadRequest, resp.StatusCode)
+	})
+}
+
+func Test_FileUploadWorkFlowVersion5(t *testing.T) { //***
+	t.Skip("1 Disabling test to allow engineers to continue submitting PRs and not have significant errors BED-4747")
+	testCtx := integration.NewFOSSContext(t)
+
+	testCtx.SendFileIngest([]string{
+		"v5/ingest/domains.json",
+		"v5/ingest/computers.json",
+		"v5/ingest/containers.json",
+		"v5/ingest/gpos.json",
+		"v5/ingest/groups.json",
+		"v5/ingest/ous.json",
+		"v5/ingest/users.json",
+		"v5/ingest/deleted.json",
+		"v5/ingest/sessions.json",
+	})
+
+	// Assert that we created stuff we expected
+	testCtx.AssertIngest(fixtures.IngestAssertions)
+}
+
+func Test_FileUploadWorkFlowVersion6(t *testing.T) { //***
+	t.Skip("2 Disabling test to allow engineers to continue submitting PRs and not have significant errors BED-4747")
+	testCtx := integration.NewFOSSContext(t)
+
+	testCtx.SendFileIngest([]string{
+		"v6/ingest/domains.json",
+		"v6/ingest/computers.json",
+		"v6/ingest/containers.json",
+		"v6/ingest/gpos.json",
+		"v6/ingest/groups.json",
+		"v6/ingest/ous.json",
+		"v6/ingest/users.json",
+		"v6/ingest/deleted.json",
+		"v6/ingest/sessions.json",
+	})
+
+	// Assert that we created stuff we expected
+	testCtx.AssertIngest(fixtures.IngestAssertions)
+	testCtx.AssertIngest(fixtures.IngestAssertionsv6)
+	testCtx.AssertIngest(fixtures.PropertyAssertions)
+}
+
+func Test_FileUploadVersion6AllOptionADCS(t *testing.T) { //***
+	t.Skip("3 Disabling test to allow engineers to continue submitting PRs and not have significant errors BED-4747")
+	testCtx := integration.NewFOSSContext(t)
+
+	testCtx.SendFileIngest([]string{
+		"v6/all/aiacas.json",
+		"v6/all/certtemplates.json",
+		"v6/all/computers.json",
+		"v6/all/containers.json",
+		"v6/all/domains.json",
+		"v6/all/enterprisecas.json",
+		"v6/all/gpos.json",
+		"v6/all/groups.json",
+		"v6/all/ntauthstores.json",
+		"v6/all/ous.json",
+		"v6/all/rootcas.json",
+		"v6/all/users.json",
+		"v6/all/issuancepolicies.json",
+	})
+
+	testCtx.AssertIngest(fixtures.IngestADCSAssertions)
+}
+
+func Test_FileUploadVersion6AllOptionADCSZip(t *testing.T) { //***
+	t.Skip("4 Disabling test to allow engineers to continue submitting PRs and not have significant errors BED-4747")
+	testCtx := integration.NewFOSSContext(t)
+
+	testCtx.SendZipFileIngest("v6/all/adcs.zip")
+
+	testCtx.AssertIngest(fixtures.IngestADCSAssertions)
+}
+
+func Test_CompressedFileUploadWorkFlowVersion5(t *testing.T) { //***
+	t.Skip("5 Disabling test to allow engineers to continue submitting PRs and not have significant errors BED-4747")
+	testCtx := integration.NewFOSSContext(t)
+
+	testCtx.SendCompressedFileIngest([]string{
+		"v5/ingest/domains.json",
+		"v5/ingest/computers.json",
+		"v5/ingest/containers.json",
+		"v5/ingest/gpos.json",
+		"v5/ingest/groups.json",
+		"v5/ingest/ous.json",
+		"v5/ingest/users.json",
+		"v5/ingest/deleted.json",
+		"v5/ingest/sessions.json",
+	})
+
+	// Assert that we created stuff we expected
+	testCtx.AssertIngest(fixtures.IngestAssertions)
+	testCtx.AssertIngest(fixtures.PropertyAssertions)
+}
+
+func Test_CompressedFileUploadWorkFlowVersion6(t *testing.T) { //***
+	t.Skip("6 Disabling test to allow engineers to continue submitting PRs and not have significant errors BED-4747")
+	testCtx := integration.NewFOSSContext(t)
+
+	testCtx.SendCompressedFileIngest([]string{
+		"v6/ingest/domains.json",
+		"v6/ingest/computers.json",
+		"v6/ingest/containers.json",
+		"v6/ingest/gpos.json",
+		"v6/ingest/groups.json",
+		"v6/ingest/ous.json",
+		"v6/ingest/users.json",
+		"v6/ingest/deleted.json",
+		"v6/ingest/sessions.json",
+	})
+
+	// Assert that we created stuff we expected
+	testCtx.AssertIngest(fixtures.IngestAssertions)
+	testCtx.AssertIngest(fixtures.IngestAssertionsv6)
+	testCtx.AssertIngest(fixtures.PropertyAssertions)
+}
+
+func Test_BadFileUploadError(t *testing.T) {
+	testCtx := integration.NewFOSSContext(t)
+
+	testCtx.SendInvalidFileIngest("v6/ingest/jker.jpg", ingest.ErrInvalidJSON)
+}

--- a/cmd/api/src/auth/role_test.go
+++ b/cmd/api/src/auth/role_test.go
@@ -1,0 +1,281 @@
+// Copyright 2023 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build integration
+// +build integration
+
+package auth_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/gofrs/uuid"
+	"github.com/specterops/bloodhound/lab"
+	"github.com/specterops/bloodhound/src/api"
+	v2 "github.com/specterops/bloodhound/src/api/v2"
+	"github.com/specterops/bloodhound/src/auth"
+	"github.com/specterops/bloodhound/src/model"
+	"github.com/specterops/bloodhound/src/model/appcfg"
+	"github.com/specterops/bloodhound/src/test/integration/utils"
+	"github.com/specterops/bloodhound/src/test/lab/fixtures"
+	"github.com/stretchr/testify/require"
+)
+
+func testCondition(role auth.RoleTemplate, permission model.Permission) string {
+	if role.Permissions.Has(permission) {
+		return "SHOULD"
+	}
+	return "SHOULD NOT"
+}
+
+func requireForbidden(assert *require.Assertions, err error) {
+	var errByte []byte
+	errByte, err = json.Marshal(err)
+	assert.Nil(err)
+
+	errWrapper := api.ErrorWrapper{}
+	err = json.Unmarshal(errByte, &errWrapper)
+	assert.Nilf(err, "Failed to unmarshal error %v", string(errByte))
+	assert.Equal(errWrapper.HTTPStatus, http.StatusForbidden)
+}
+
+func testRoleAccess(t *testing.T, roleName string) {
+	role, ok := auth.Roles()[roleName]
+	require.Truef(t, ok, "invalid role name")
+
+	customCfg, err := utils.LoadIntegrationTestConfig()
+	require.Nil(t, err)
+
+	// In order to role test access, enable_cypher_mutations must be true
+	customCfg.EnableCypherMutations = true
+
+	harness := lab.NewHarness()
+	customCfgFixture := fixtures.NewCustomConfigFixture(customCfg)
+	lab.Pack(harness, customCfgFixture)
+	customApiFixture := fixtures.NewCustomApiFixture(customCfgFixture)
+	lab.Pack(harness, customApiFixture)
+	adminApiClientFixture := fixtures.NewAdminApiClientFixture(customCfgFixture, customApiFixture)
+	lab.Pack(harness, adminApiClientFixture)
+	userClientFixture := fixtures.NewUserApiClientFixture(fixtures.ConfigFixture, adminApiClientFixture, role.Name)
+	lab.Pack(harness, userClientFixture)
+
+	lab.NewSpec(t, harness).Run(
+		lab.TestCase(fmt.Sprintf("%s be able to access AppReadApplicationConfiguration endpoints", testCondition(role, auth.Permissions().AppReadApplicationConfiguration)), func(assert *require.Assertions, harness *lab.Harness) {
+			userClient, ok := lab.Unpack(harness, userClientFixture)
+			assert.True(ok)
+
+			_, err := userClient.GetAppConfigs()
+			if role.Permissions.Has(auth.Permissions().AppReadApplicationConfiguration) {
+				assert.Nil(err)
+			} else {
+				requireForbidden(assert, err)
+			}
+		}),
+
+		lab.TestCase(fmt.Sprintf("%s be able to access AppWriteApplicationConfiguration endpoints", testCondition(role, auth.Permissions().AppWriteApplicationConfiguration)), func(assert *require.Assertions, harness *lab.Harness) {
+			userClient, ok := lab.Unpack(harness, userClientFixture)
+			assert.True(ok)
+
+			updatedPasswordExpirationWindowParameter := v2.AppConfigUpdateRequest{
+				Key: appcfg.PasswordExpirationWindow,
+				Value: map[string]any{
+					"duration": "P30D",
+				},
+			}
+			_, err := userClient.PutAppConfig(updatedPasswordExpirationWindowParameter)
+			if role.Permissions.Has(auth.Permissions().AppWriteApplicationConfiguration) {
+				assert.Nil(err)
+			} else {
+				requireForbidden(assert, err)
+			}
+		}),
+
+		lab.TestCase(fmt.Sprintf("%s be able to access own AuthCreateToken endpoints", testCondition(role, auth.Permissions().AuthCreateToken)), func(assert *require.Assertions, harness *lab.Harness) {
+			userClient, ok := lab.Unpack(harness, userClientFixture)
+			assert.True(ok)
+
+			user, err := userClient.GetSelf()
+			assert.Nilf(err, "failed looking up user details")
+
+			_, err = userClient.ListUserTokens(user.ID)
+			if role.Permissions.Has(auth.Permissions().AuthCreateToken) {
+				assert.Nil(err)
+			} else {
+				requireForbidden(assert, err)
+			}
+		}),
+
+		lab.TestCase(fmt.Sprintf("%s NOT be able to access others AuthCreateToken endpoints unless admin", testCondition(role, auth.Permissions().AuthCreateToken)), func(assert *require.Assertions, harness *lab.Harness) {
+			userClient, ok := lab.Unpack(harness, userClientFixture)
+			assert.True(ok)
+
+			randoUser, err := uuid.NewV4()
+			assert.Nilf(err, "failed to create rando user")
+
+			_, err = userClient.ListUserTokens(randoUser)
+			if role.Name == auth.RoleAdministrator {
+				assert.Nil(err)
+			} else {
+				requireForbidden(assert, err)
+			}
+		}),
+
+		lab.TestCase(fmt.Sprintf("%s be able to access AuthManageProviders endpoints", testCondition(role, auth.Permissions().AuthManageProviders)), func(assert *require.Assertions, harness *lab.Harness) {
+			userClient, ok := lab.Unpack(harness, userClientFixture)
+			assert.True(ok)
+
+			// TODO when formally deprecated update this to another endpoint
+			_, err := userClient.ListSAMLIdentityProviders()
+			if role.Permissions.Has(auth.Permissions().AuthManageProviders) {
+				assert.Nil(err)
+			} else {
+				requireForbidden(assert, err)
+			}
+		}),
+
+		lab.TestCase(fmt.Sprintf("%s be able to access AuthManageSelf endpoints", testCondition(role, auth.Permissions().AuthManageSelf)), func(assert *require.Assertions, harness *lab.Harness) {
+			userClient, ok := lab.Unpack(harness, userClientFixture)
+			assert.True(ok)
+
+			_, err := userClient.ListPermissions()
+			if role.Permissions.Has(auth.Permissions().AuthManageSelf) {
+				assert.Nil(err)
+			} else {
+				requireForbidden(assert, err)
+			}
+		}),
+
+		lab.TestCase(fmt.Sprintf("%s be able to access AuthManageUsers endpoints", testCondition(role, auth.Permissions().AuthManageUsers)), func(assert *require.Assertions, harness *lab.Harness) {
+			userClient, ok := lab.Unpack(harness, userClientFixture)
+			assert.True(ok)
+
+			_, err := userClient.ListAuditLogs(time.Now(), time.Now(), 0, 0)
+			if role.Permissions.Has(auth.Permissions().AuthManageUsers) {
+				assert.Nil(err)
+			} else {
+				requireForbidden(assert, err)
+			}
+		}),
+
+		lab.TestCase(fmt.Sprintf("%s be able to access GraphDBMutate endpoints", testCondition(role, auth.Permissions().GraphDBMutate)), func(assert *require.Assertions, harness *lab.Harness) {
+			userClient, ok := lab.Unpack(harness, userClientFixture)
+			assert.True(ok)
+
+			_, err := userClient.CypherQuery(v2.CypherQueryPayload{Query: "match (w) where w.name = 'voldemort' remove w.name return w"})
+			if role.Permissions.Has(auth.Permissions().GraphDBMutate) {
+				assert.Nil(err)
+			} else {
+				requireForbidden(assert, err)
+			}
+		}),
+
+		lab.TestCase(fmt.Sprintf("%s be able to access GraphDBWrite endpoints", testCondition(role, auth.Permissions().GraphDBWrite)), func(assert *require.Assertions, harness *lab.Harness) {
+			userClient, ok := lab.Unpack(harness, userClientFixture)
+			assert.True(ok)
+
+			_, err := userClient.CreateAssetGroup(v2.CreateAssetGroupRequest{Name: "test", Tag: "test"})
+			if role.Permissions.Has(auth.Permissions().GraphDBWrite) {
+				assert.Nil(err)
+			} else {
+				requireForbidden(assert, err)
+			}
+		}),
+
+		lab.TestCase(fmt.Sprintf("%s be able to access GraphDBIngest endpoints", testCondition(role, auth.Permissions().GraphDBIngest)), func(assert *require.Assertions, harness *lab.Harness) {
+			userClient, ok := lab.Unpack(harness, userClientFixture)
+			assert.True(ok)
+
+			_, err := userClient.CreateFileUploadTask()
+			if role.Permissions.Has(auth.Permissions().GraphDBIngest) {
+				assert.Nil(err)
+			} else {
+				requireForbidden(assert, err)
+			}
+		}),
+
+		lab.TestCase(fmt.Sprintf("%s be able to access GraphDBRead endpoints", testCondition(role, auth.Permissions().GraphDBRead)), func(assert *require.Assertions, harness *lab.Harness) {
+			userClient, ok := lab.Unpack(harness, userClientFixture)
+			assert.True(ok)
+
+			_, err := userClient.ListAssetGroups()
+			if role.Permissions.Has(auth.Permissions().GraphDBRead) {
+				assert.Nil(err)
+			} else {
+				requireForbidden(assert, err)
+			}
+		}),
+
+		lab.TestCase(fmt.Sprintf("%s be able to access SavedQueriesRead endpoints", testCondition(role, auth.Permissions().SavedQueriesRead)), func(assert *require.Assertions, harness *lab.Harness) {
+			userClient, ok := lab.Unpack(harness, userClientFixture)
+			assert.True(ok)
+
+			_, err := userClient.ListSavedQueries()
+			if role.Permissions.Has(auth.Permissions().SavedQueriesRead) {
+				assert.Nil(err)
+			} else {
+				requireForbidden(assert, err)
+			}
+		}),
+
+		lab.TestCase(fmt.Sprintf("%s be able to access SavedQueriesWrite endpoints", testCondition(role, auth.Permissions().SavedQueriesWrite)), func(assert *require.Assertions, harness *lab.Harness) {
+			userClient, ok := lab.Unpack(harness, userClientFixture)
+			assert.True(ok)
+
+			_, err := userClient.CreateSavedQuery()
+			if role.Permissions.Has(auth.Permissions().SavedQueriesWrite) {
+				assert.Nil(err)
+			} else {
+				requireForbidden(assert, err)
+			}
+		}),
+
+		lab.TestCase(fmt.Sprintf("%s be able to access WipeDB endpoints", testCondition(role, auth.Permissions().WipeDB)), func(assert *require.Assertions, harness *lab.Harness) {
+			userClient, ok := lab.Unpack(harness, userClientFixture)
+			assert.True(ok)
+
+			err := userClient.HandleDatabaseWipe(v2.DatabaseWipe{DeleteCollectedGraphData: true})
+			if role.Permissions.Has(auth.Permissions().WipeDB) {
+				assert.Nil(err)
+			} else {
+				requireForbidden(assert, err)
+			}
+		}),
+	)
+}
+
+func TestRole_ReadOnly(t *testing.T) {
+	testRoleAccess(t, auth.RoleReadOnly)
+}
+
+func TestRole_UploadOnly(t *testing.T) {
+	testRoleAccess(t, auth.RoleUploadOnly)
+}
+
+func TestRole_User(t *testing.T) {
+	testRoleAccess(t, auth.RoleUser)
+}
+
+func TestRole_PowerUser(t *testing.T) {
+	testRoleAccess(t, auth.RolePowerUser)
+}
+
+func TestRole_Administrator(t *testing.T) {
+	testRoleAccess(t, auth.RoleAdministrator)
+}


### PR DESCRIPTION
Reverts SpecterOps/BloodHound#1289

We need these tests a bit longer. There was a miss in intent that led to premature removal of these tests. Bringing them back for now