### PR TITLE
fix: tier details object sort order

### DIFF
--- a/packages/javascript/bh-shared-ui/src/views/TierManagement/Details/Details.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/TierManagement/Details/Details.test.tsx
@@ -74,12 +74,13 @@ describe('Details', async () => {
     it('handles object selection when a tier is already selected', async () => {
         render(<Details />);
 
-        const object5 = await screen.findByText('tier-0-object-5');
+        longWait(async () => {
+            const object5 = await screen.findByText('tier-0-object-5');
+            await user.click(object5);
+        });
 
         const selectors = await screen.findByTestId('tier-management_details_selectors-list');
         const selectorsListItems = within(selectors).getAllByRole('listitem');
-
-        await user.click(object5);
 
         // After selecting an object, the edit action is not viable and thus the button is not rendered
         expect(screen.queryByRole('button', { name: /Edit/ })).toBeNull();

--- a/packages/javascript/bh-shared-ui/src/views/TierManagement/Details/Details.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/TierManagement/Details/Details.tsx
@@ -78,11 +78,11 @@ const Details: FC = () => {
             if (!tagId) return 0;
 
             if (!selectorId)
-                return apiClient.getAssetGroupTagMembers(tagId, 0, 1).then((res) => {
+                return apiClient.getAssetGroupTagMembers(tagId, 0, 1, 'name').then((res) => {
                     return res.data.count;
                 });
 
-            return apiClient.getAssetGroupSelectorMembers(tagId, selectorId, 0, 1).then((res) => {
+            return apiClient.getAssetGroupSelectorMembers(tagId, selectorId, 0, 1, 'name').then((res) => {
                 return res.data.count;
             });
         },
@@ -93,34 +93,36 @@ const Details: FC = () => {
     return (
         <div>
             <div className='flex mt-6 gap-8'>
-                <CreateMenu
-                    createMenuTitle='Create Selector'
-                    disabled={!tagId}
-                    menuItems={[
-                        {
-                            title: 'Create Selector',
-                            onClick: () => {
-                                navigate(getEditPath(tagId, selectorId));
-                            },
-                        },
-                    ]}
-                />
                 <div className='flex justify-around basis-2/3'>
-                    <div className='flex justify-start gap-4 items-center basis-2/3 invisible'>
+                    <div className='flex justify-start gap-4 items-center basis-2/3'>
                         <div className='flex items-center align-middle'>
-                            <div>
-                                <AppIcon.Info className='mr-4 ml-2' size={24} />
+                            <CreateMenu
+                                createMenuTitle='Create Selector'
+                                disabled={!tagId}
+                                menuItems={[
+                                    {
+                                        title: 'Create Selector',
+                                        onClick: () => {
+                                            navigate(`/tier-management/edit/tag/${tagId}/selector`);
+                                        },
+                                    },
+                                ]}
+                            />
+                            <div className='hidden'>
+                                <div>
+                                    <AppIcon.Info className='mr-4 ml-2' size={24} />
+                                </div>
+                                <span>
+                                    To create additional tiers{' '}
+                                    <Button
+                                        variant='text'
+                                        asChild
+                                        className='p-0 text-base text-secondary dark:text-secondary-variant-2'>
+                                        <a href='#'>contact sales</a>
+                                    </Button>{' '}
+                                    in order to upgrade for multi-tier analysis.
+                                </span>
                             </div>
-                            <span>
-                                To create additional tiers{' '}
-                                <Button
-                                    variant='text'
-                                    asChild
-                                    className='p-0 text-base text-secondary dark:text-secondary-variant-2'>
-                                    <a href='#'>contact sales</a>
-                                </Button>{' '}
-                                in order to upgrade for multi-tier analysis.
-                            </span>
                         </div>
                     </div>
                     <div className='flex justify-start basis-1/3'>

--- a/packages/javascript/bh-shared-ui/src/views/TierManagement/Details/Details.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/TierManagement/Details/Details.tsx
@@ -15,6 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Button } from '@bloodhoundenterprise/doodleui';
+import { AssetGroupTagSelectorsListItem, AssetGroupTagsListItem } from 'js-client-library';
 import { FC } from 'react';
 import { UseQueryResult, useQuery } from 'react-query';
 import { Link, useParams } from 'react-router-dom';
@@ -25,7 +26,7 @@ import { DetailsList } from './DetailsList';
 import { MembersList } from './MembersList';
 import { SelectedDetails } from './SelectedDetails';
 
-export const getEditPath = (tagId: string | undefined, selectorId: string | undefined) => {
+const getEditPath = (tagId: string | undefined, selectorId: string | undefined) => {
     const editPath = '/tier-management/edit';
 
     if (selectorId && tagId) return `/tier-management/edit/tag/${tagId}/selector/${selectorId}`;
@@ -33,6 +34,27 @@ export const getEditPath = (tagId: string | undefined, selectorId: string | unde
     if (!selectorId && tagId) return `/tier-management/edit/tag/${tagId}`;
 
     return editPath;
+};
+
+const getItemCount = (
+    tagId: string | undefined,
+    tagsQuery: UseQueryResult<AssetGroupTagsListItem[]>,
+    selectorId: string | undefined,
+    selectorsQuery: UseQueryResult<AssetGroupTagSelectorsListItem[]>
+) => {
+    if (selectorId !== undefined) {
+        const selectedSelector = selectorsQuery.data?.find((selector) => {
+            return selectorId === selector.id.toString();
+        });
+        return selectedSelector?.counts?.members || 0;
+    } else if (tagId !== undefined) {
+        const selectedTag = tagsQuery.data?.find((tag) => {
+            return tagId === tag.id.toString();
+        });
+        return selectedTag?.counts?.members || 0;
+    } else {
+        return 0;
+    }
 };
 
 export const getEditButtonState = (
@@ -68,22 +90,6 @@ const Details: FC = () => {
             if (!tagId) return [];
             return apiClient.getAssetGroupTagSelectors(tagId, { params: { counts: true } }).then((res) => {
                 return res.data.data['selectors'];
-            });
-        },
-    });
-
-    const objectsQuery = useQuery({
-        queryKey: ['asset-group-members', tagId, selectorId],
-        queryFn: async () => {
-            if (!tagId) return 0;
-
-            if (!selectorId)
-                return apiClient.getAssetGroupTagMembers(tagId, 0, 1, 'name').then((res) => {
-                    return res.data.count;
-                });
-
-            return apiClient.getAssetGroupSelectorMembers(tagId, selectorId, 0, 1, 'name').then((res) => {
-                return res.data.count;
             });
         },
     });
@@ -164,15 +170,13 @@ const Details: FC = () => {
                     </div>
                     <div>
                         <MembersList
-                            itemCount={objectsQuery.data}
+                            itemCount={getItemCount(tagId, tagsQuery, selectorId, selectorsQuery)}
                             onClick={(id) => {
                                 navigate(
                                     `/tier-management/${ROUTE_TIER_MANAGEMENT_DETAILS}/tag/${tagId}/selector/${selectorId}/member/${id}`
                                 );
                             }}
                             selected={memberId}
-                            selectedSelector={selectorId}
-                            selectedTag={tagId}
                         />
                     </div>
                 </div>

--- a/packages/javascript/bh-shared-ui/src/views/TierManagement/Details/MembersList.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/TierManagement/Details/MembersList.test.tsx
@@ -1,0 +1,45 @@
+import userEvent from '@testing-library/user-event';
+import { createMemoryHistory } from 'history';
+import { setupServer } from 'msw/node';
+import { Route, Routes } from 'react-router-dom';
+import { tierHandlers } from '../../../mocks';
+import { render, screen } from '../../../test-utils';
+import { apiClient } from '../../../utils';
+import { MembersList } from './MembersList';
+
+const handlers = [...tierHandlers];
+
+const server = setupServer(...handlers);
+
+beforeAll(() => server.listen());
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+const membersListSpy = vi.spyOn(apiClient, 'getAssetGroupSelectorMembers');
+
+describe('MembersList', () => {
+    it('sorting the list updates the list by changing the call made to the API', async () => {
+        const user = userEvent.setup();
+
+        const history = createMemoryHistory({
+            initialEntries: ['/tier-management/details/tag/1/selector/1'],
+        });
+
+        render(
+            <Routes>
+                <Route path={'/'} element={<MembersList selected='1' onClick={vi.fn()} />} />;
+                <Route
+                    path={'/tier-management/details/tag/:tagId/selector/:selectorId'}
+                    element={<MembersList selected='1' onClick={vi.fn()} />}
+                />
+            </Routes>,
+            { history }
+        );
+
+        expect(membersListSpy).toBeCalledWith('1', '1', 0, 128, 'name');
+
+        await user.click(screen.getByText('Objects', { exact: false }));
+
+        expect(membersListSpy).toBeCalledWith('1', '1', 0, 128, '-name');
+    });
+});

--- a/packages/javascript/bh-shared-ui/src/views/TierManagement/index.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/TierManagement/index.tsx
@@ -19,7 +19,6 @@ import React, { FC, Suspense } from 'react';
 import { Navigate, Route, Routes } from 'react-router-dom';
 import {
     ROUTE_TIER_MANAGEMENT_CREATE_SELECTOR,
-    ROUTE_TIER_MANAGEMENT_DETAILS,
     ROUTE_TIER_MANAGEMENT_EDIT,
     ROUTE_TIER_MANAGEMENT_EDIT_SELECTOR,
     ROUTE_TIER_MANAGEMENT_EDIT_TAG,
@@ -33,7 +32,6 @@ const Details = React.lazy(() => import('./Details/Details'));
 const Save = React.lazy(() => import('./Save'));
 
 const childRoutes: Routable[] = [
-    { path: ROUTE_TIER_MANAGEMENT_DETAILS, component: Details, authenticationRequired: true, navigation: true },
     { path: ROUTE_TIER_MANAGEMENT_TAG_DETAILS, component: Details, authenticationRequired: true, navigation: true },
     {
         path: ROUTE_TIER_MANAGEMENT_SELECTOR_DETAILS,

--- a/packages/javascript/js-client-library/src/client.ts
+++ b/packages/javascript/js-client-library/src/client.ts
@@ -200,6 +200,7 @@ class BHEAPIClient {
         assetGroupTagId: number | string,
         skip: number | string,
         limit: number,
+        sort_by: string,
         options?: RequestOptions
     ) =>
         this.baseClient.get<AssetGroupTagMembersResponse>(
@@ -209,6 +210,7 @@ class BHEAPIClient {
                     params: {
                         skip,
                         limit,
+                        sort_by,
                     },
                 },
                 options
@@ -220,6 +222,7 @@ class BHEAPIClient {
         selectorId: number | string,
         skip: number,
         limit: number,
+        sort_by: string,
         options?: RequestOptions
     ) =>
         this.baseClient.get<AssetGroupTagMembersResponse>(
@@ -229,6 +232,7 @@ class BHEAPIClient {
                     params: {
                         skip,
                         limit,
+                        sort_by,
                     },
                 },
                 options


### PR DESCRIPTION
closes BED-5855

<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

This makes the sorting button for the objects list reset the list items and make a new API request since this endpoint is paginated.

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-5855

Right now the sorting button only changes the icon display for the list. This change will make the sorting functional.

## How Has This Been Tested?
Checked the network requests being sent out on clicking the sort button.

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)
- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
