### PR TITLE
Revert "Bed 5737"

### DIFF
--- a/cmd/api/src/api/v2/assetgrouptags.go
+++ b/cmd/api/src/api/v2/assetgrouptags.go
@@ -68,7 +68,7 @@ func (s Resources) GetAssetGroupTags(response http.ResponseWriter, request *http
 	var rCtx = request.Context()
 
 	if paramIncludeCounts, err := api.ParseOptionalBool(request.URL.Query().Get(api.QueryParameterIncludeCounts), false); err != nil {
-		api.WriteErrorResponse(rCtx, api.BuildErrorResponse(http.StatusBadRequest, "Invalid value specified for include counts", request), response)
+		api.WriteErrorResponse(rCtx, api.BuildErrorResponse(http.StatusBadRequest, "Invalid value specifed for include counts", request), response)
 	} else if queryFilters, err := model.NewQueryParameterFilterParser().ParseQueryParameterFilters(request); err != nil {
 		api.WriteErrorResponse(rCtx, api.BuildErrorResponse(http.StatusBadRequest, api.ErrorResponseDetailsBadQueryParameterFilters, request), response)
 	} else {

--- a/cmd/api/src/model/filter_internal_test.go
+++ b/cmd/api/src/model/filter_internal_test.go
@@ -19,117 +19,42 @@ package model
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestQueryParameterFilterParser_ParseQueryParameterFilter(t *testing.T) {
-	t.Parallel()
-
 	parser := NewQueryParameterFilterParser()
 
-	type args struct {
-		name  string
-		value string
-	}
+	t.Run("parser should parse a parameter filter", func(t *testing.T) {
+		if filter, err := parser.ParseQueryParameterFilter("parameter", "eq:auth.value"); err != nil {
+			t.Fatalf("Failed parsing query parameter: %v", err)
+		} else {
+			require.Equal(t, filter.Name, "parameter")
+			require.Equal(t, "auth.value", filter.Value)
+		}
+	})
 
-	type expected struct {
-		name     string
-		value    string
-		operator FilterOperator
-	}
+	t.Run("parser should parse a parameter with ~", func(t *testing.T) {
+		if filter, err := parser.ParseQueryParameterFilter("parameter", "~eq:auth.value"); err != nil {
+			t.Fatalf("Failed parsing query parameter: %v", err)
+		} else {
+			require.Equal(t, filter.Name, "parameter")
+			require.Equal(t, "auth.value", filter.Value)
+		}
+	})
 
-	tests := []struct {
-		name     string
-		args     args
-		expected expected
-		wantErr  assert.ErrorAssertionFunc
-	}{
-		{
-			name: "success - parser should parse a parameter filter",
-			args: args{
-				name:  "parameter",
-				value: "eq:auth.value",
-			},
-			expected: expected{
-				name:     "parameter",
-				value:    "auth.value",
-				operator: Equals,
-			},
-			wantErr: assert.NoError,
-		},
-		{
-			name: "success - parser should parse a parameter with ~ filter",
-			args: args{
-				name:  "parameter",
-				value: "~eq:auth.value",
-			},
-			expected: expected{
-				name:     "parameter",
-				value:    "auth.value",
-				operator: ApproximatelyEquals,
-			},
-			wantErr: assert.NoError,
-		},
-		{
-			name: "success - parser should parse a parameter filter with spacing",
-			args: args{
-				name:  "parameter",
-				value: "eq:hello world",
-			},
-			expected: expected{
-				name:     "parameter",
-				value:    "hello world",
-				operator: Equals,
-			},
-			wantErr: assert.NoError,
-		},
-		{
-			name: "success - default to eq when parsing a non predicate parameter",
-			args: args{
-				name:  "parameter",
-				value: "hello world",
-			},
-			expected: expected{
-				name:     "parameter",
-				value:    "hello world",
-				operator: Equals,
-			},
-			wantErr: assert.NoError,
-		},
-		{
-			name: "success - colon is included in value if predicate is omitted",
-			args: args{
-				name:  "parameter",
-				value: ":hello_world",
-			},
-			expected: expected{
-				name:     "parameter",
-				value:    ":hello_world",
-				operator: Equals,
-			},
-			wantErr: assert.NoError,
-		},
-		{
-			name: "fail - unknown operator",
-			args: args{
-				name:  "parameter",
-				value: "foo:hello world",
-			},
-			wantErr: assert.Error,
-		},
-	}
+	t.Run("parser should parse a parameter filter with spacing", func(t *testing.T) {
+		if filter, err := parser.ParseQueryParameterFilter("parameter", "eq:hello world"); err != nil {
+			t.Fatalf("Failed parsing query parameter: %v", err)
+		} else {
+			require.Equal(t, filter.Name, "parameter")
+			require.Equal(t, "hello world", filter.Value)
+		}
+	})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
+	t.Run("error when parsing an invalid parameter", func(t *testing.T) {
+		_, err := parser.ParseQueryParameterFilter("parameter", "eq : hello world")
+		require.Error(t, err)
+	})
 
-			if res, err := parser.ParseQueryParameterFilter(tt.args.name, tt.args.value); !tt.wantErr(t, err) {
-				t.Errorf("ParseQueryParameterFilter() returned an unexpected error = %v", err)
-			} else {
-				assert.Equal(t, tt.expected.name, res.Name)
-				assert.Equal(t, tt.expected.value, res.Value)
-				assert.Equal(t, tt.expected.operator, res.Operator)
-			}
-		})
-	}
 }

--- a/cmd/api/src/model/saved_queries.go
+++ b/cmd/api/src/model/saved_queries.go
@@ -62,7 +62,6 @@ func (s SavedQueries) ValidFilters() map[string][]FilterOperator {
 func IgnoreFilters() []string {
 	return []string{
 		"scope",
-		"counts",
 	}
 }
 


### PR DESCRIPTION
BED-5737 was flawed in its assumptions and this work will break several endpoints due to the way filtering works. Reverting for now and putting ticket back into queue

Reverts SpecterOps/BloodHound#1418