### PR TITLE
chore: fix file drifts in schemagen packages

### DIFF
--- a/justfile
+++ b/justfile
@@ -29,11 +29,6 @@ generate *FLAGS:
   @just stbernard generate {{FLAGS}}
   @just check-license
 
-# run the code generation from the cue schema
-schemagen: yarn-local && check-license (yarn "format") goimports
-  go run github.com/specterops/bloodhound/schemagen
-
-
 # Show repository status
 show *FLAGS:
   @just stbernard show {{FLAGS}}
@@ -61,13 +56,8 @@ _prep-steps:
   @just ensure-deps
   @just modsync
   @just generate
-  @just goimports
   @just show > tmp/repo-status.txt
   @just analyze > tmp/analysis-report.txt
-
-goimports:
-  @ echo "Running goimports, check for file drift"
-  @ find . -name \*.go -exec goimports -w {} \;
 
 # check license is applied to source files
 check-license:

--- a/packages/go/stbernard/command/command.go
+++ b/packages/go/stbernard/command/command.go
@@ -31,6 +31,7 @@ import (
 	"github.com/specterops/bloodhound/packages/go/stbernard/command/deps"
 	"github.com/specterops/bloodhound/packages/go/stbernard/command/envdump"
 	"github.com/specterops/bloodhound/packages/go/stbernard/command/generate"
+	"github.com/specterops/bloodhound/packages/go/stbernard/command/goimports"
 	"github.com/specterops/bloodhound/packages/go/stbernard/command/modsync"
 	"github.com/specterops/bloodhound/packages/go/stbernard/command/show"
 	"github.com/specterops/bloodhound/packages/go/stbernard/command/tester"
@@ -91,6 +92,7 @@ func ParseCLI(env environment.Environment) (CommandRunner, error) {
 			tester.Create(env),
 			builder.Create(env),
 			cover.Create(env),
+			goimports.Create(env),
 		}
 	)
 

--- a/packages/go/stbernard/command/generate/generate.go
+++ b/packages/go/stbernard/command/generate/generate.go
@@ -81,7 +81,7 @@ func (s *command) Run() error {
 		return fmt.Errorf("generating code for workspace: %w", err)
 	} else if err := workspace.GenerateSchema(paths.Root, s.env); err != nil {
 		return fmt.Errorf("generating schema for workspace: %w", err)
-	} else if err := golang.RunGoImports(paths.GoModules, s.env); err != nil {
+	} else if err := golang.RunGoImports(s.env); err != nil {
 		return fmt.Errorf("running goimports cmd: %w", err)
 	} else if err := yarn.Format(paths.Root, s.env); err != nil {
 		return fmt.Errorf("formatting javascript: %w", err)

--- a/packages/go/stbernard/command/generate/generate.go
+++ b/packages/go/stbernard/command/generate/generate.go
@@ -77,10 +77,10 @@ func (s *command) Parse(cmdIndex int) error {
 func (s *command) Run() error {
 	if paths, err := workspace.FindPaths(s.env); err != nil {
 		return fmt.Errorf("finding workspace root: %w", err)
-	} else if err := golang.WorkspaceGenerate(paths.GoModules, s.env); err != nil {
-		return fmt.Errorf("generating code for workspace: %w", err)
 	} else if err := workspace.GenerateSchema(paths.Root, s.env); err != nil {
 		return fmt.Errorf("generating schema for workspace: %w", err)
+	} else if err := golang.WorkspaceGenerate(paths.GoModules, s.env); err != nil {
+		return fmt.Errorf("generating code for workspace: %w", err)
 	} else if err := golang.RunGoImports(s.env); err != nil {
 		return fmt.Errorf("running goimports cmd: %w", err)
 	} else if err := yarn.Format(paths.Root, s.env); err != nil {

--- a/packages/go/stbernard/command/generate/generate.go
+++ b/packages/go/stbernard/command/generate/generate.go
@@ -81,6 +81,8 @@ func (s *command) Run() error {
 		return fmt.Errorf("generating code for workspace: %w", err)
 	} else if err := workspace.GenerateSchema(paths.Root, s.env); err != nil {
 		return fmt.Errorf("generating schema for workspace: %w", err)
+	} else if err := golang.RunGoImports(paths.GoModules, s.env); err != nil {
+		return fmt.Errorf("running goimports cmd: %w", err)
 	} else if err := yarn.Format(paths.Root, s.env); err != nil {
 		return fmt.Errorf("formatting javascript: %w", err)
 	} else if err := redoc.GenerateOpenAPIDoc(paths.Root, paths.Submodules, s.env); err != nil {

--- a/packages/go/stbernard/command/goimports/goimports.go
+++ b/packages/go/stbernard/command/goimports/goimports.go
@@ -1,0 +1,79 @@
+// Copyright 2025 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package goimports
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/specterops/bloodhound/packages/go/stbernard/environment"
+	"github.com/specterops/bloodhound/packages/go/stbernard/workspace/golang"
+)
+
+const (
+	Name  = "goimports"
+	Usage = "Run goimports to format .go files in the current directory"
+)
+
+type command struct {
+	env environment.Environment
+}
+
+// Create a new instance of goimports command within the current environment
+func Create(env environment.Environment) *command {
+	return &command{
+		env: env,
+	}
+}
+
+// Usage of the command
+func (s *command) Usage() string {
+	return Usage
+}
+
+// Name of the command
+func (s *command) Name() string {
+	return Name
+}
+
+// Parse command flags
+func (s *command) Parse(cmdIndex int) error {
+	cmd := flag.NewFlagSet(Name, flag.ExitOnError)
+
+	cmd.Usage = func() {
+		w := flag.CommandLine.Output()
+		fmt.Fprintf(w, "%s\n\nUsage: %s %s\n", Usage, filepath.Base(os.Args[0]), Name)
+		cmd.PrintDefaults()
+	}
+
+	if err := cmd.Parse(os.Args[cmdIndex+1:]); err != nil {
+		cmd.Usage()
+		return fmt.Errorf("parsing %s command: %w", Name, err)
+	}
+
+	return nil
+}
+
+// Run goimports command
+func (s *command) Run() error {
+	if err := golang.RunGoImports(s.env); err != nil {
+		return fmt.Errorf("running goimports cmd: %w", err)
+	}
+	return nil
+}

--- a/packages/go/stbernard/workspace/golang/goimports.go
+++ b/packages/go/stbernard/workspace/golang/goimports.go
@@ -17,19 +17,24 @@
 package golang
 
 import (
+	"os"
+
 	"github.com/specterops/bloodhound/packages/go/stbernard/cmdrunner"
 	"github.com/specterops/bloodhound/packages/go/stbernard/environment"
 )
 
 // Running checks for unused go imports and formatting .go files
-func RunGoImports(gomodules []string, env environment.Environment) error {
-	for _, gomodule := range gomodules {
-		cmd := "goimports"
-		args := []string{"-w", gomodule}
-
-		if err := cmdrunner.Run(cmd, args, gomodule, env); err != nil {
-			return err
-		}
+func RunGoImports(env environment.Environment) error {
+	rootDir, err := os.Getwd()
+	if err != nil {
+		return err
 	}
+	cmd := "goimports"
+	args := []string{"-w", rootDir}
+
+	if err := cmdrunner.Run(cmd, args, rootDir, env); err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/packages/go/stbernard/workspace/golang/goimports.go
+++ b/packages/go/stbernard/workspace/golang/goimports.go
@@ -1,0 +1,35 @@
+// Copyright 2025 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package golang
+
+import (
+	"github.com/specterops/bloodhound/packages/go/stbernard/cmdrunner"
+	"github.com/specterops/bloodhound/packages/go/stbernard/environment"
+)
+
+// Running checks for unused go imports and formatting .go files
+func RunGoImports(gomodules []string, env environment.Environment) error {
+	for _, gomodule := range gomodules {
+		cmd := "goimports"
+		args := []string{"-w", gomodule}
+
+		if err := cmdrunner.Run(cmd, args, gomodule, env); err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Fixes: BED-5760

<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

The PR addresses Golang formatting issues when generating schemas files at runtime

## Motivation and Context

Fixes: BED-5760

*Why is this change required? What problem does it solve?*

## How Has This Been Tested?

- Run `just generate` command and observe the command does not introduces no file changes

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)
- Database Migrations

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
