### PR TITLE
feat(Entity Panel): add node type

### DIFF
--- a/cmd/ui/src/views/Explore/EntityInfo/EntityObjectInformation.tsx
+++ b/cmd/ui/src/views/Explore/EntityInfo/EntityObjectInformation.tsx
@@ -86,7 +86,11 @@ const EntityObjectInformation: React.FC<EntityInfoContentProps> = ({ id, nodeTyp
     return (
         <EntityInfoCollapsibleSection onChange={handleOnChange} isExpanded={isObjectInfoPanelOpen} label={sectionLabel}>
             <FieldsContainer>
-                <BasicObjectInfoFields handleSourceNodeSelected={handleSourceNodeSelected} {...entityProperties} />
+                <BasicObjectInfoFields
+                    nodeType={nodeType}
+                    handleSourceNodeSelected={handleSourceNodeSelected}
+                    {...entityProperties}
+                />
                 <ObjectInfoFields fields={formattedObjectFields} />
             </FieldsContainer>
         </EntityInfoCollapsibleSection>

--- a/packages/javascript/bh-shared-ui/src/views/Explore/BasicObjectInfoFields.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/Explore/BasicObjectInfoFields.tsx
@@ -22,15 +22,16 @@ import { EntityKinds } from '../../utils';
 import { Field } from './fragments';
 
 interface BasicObjectInfoFieldsProps {
-    handleSourceNodeSelected?: (sourceNode: SearchValue) => void;
-    objectid: string;
     displayname?: string;
-    isTierZero?: boolean;
-    isOwned?: boolean;
-    service_principal_id?: string;
-    noderesourcegroupid?: string;
     grouplinkid?: string;
+    handleSourceNodeSelected?: (sourceNode: SearchValue) => void;
+    isOwned?: boolean;
+    isTierZero?: boolean;
     name?: string;
+    noderesourcegroupid?: string;
+    nodeType?: string;
+    objectid: string;
+    service_principal_id?: string;
 }
 
 const RelatedKindField = (
@@ -64,6 +65,7 @@ const RelatedKindField = (
 export const BasicObjectInfoFields: React.FC<BasicObjectInfoFieldsProps> = (props): JSX.Element => {
     return (
         <>
+            {props.nodeType && <Field label='Node Type' value={props.nodeType} />}
             {props.isTierZero && <Field label='Tier Zero:' value={true} />}
             {props.isOwned && <Field label='Owned Object:' value={true} />}
             {props.displayname && <Field label='Display Name:' value={props.displayname} />}

--- a/packages/javascript/bh-shared-ui/src/views/TierManagement/Details/EntityInfo/EntityObjectInformation.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/TierManagement/Details/EntityInfo/EntityObjectInformation.tsx
@@ -23,7 +23,9 @@ import { EntityInfoContentProps } from './EntityInfoContent';
 
 const EntityObjectInformation: React.FC<EntityInfoContentProps> = ({ properties }) => {
     const formattedObjectFields: EntityField[] = formatObjectInfoFields(properties);
-    const nodeProperties = { ...properties, objectid: properties.objectid || '' };
+    const nodeType = properties.nodeType || '';
+    const objectid = properties.objectid || '';
+    const nodeProperties = { ...properties, nodeType, objectid };
 
     return (
         <EntityInfoCollapsibleSection label='Object Information'>


### PR DESCRIPTION
## Description

Adds node type to Entity Panel

## Motivation and Context

Shows the node type on the Entity Panel.

Resolves BED-5052

## How Has This Been Tested?

Manually tested by clicking on a node and seeing the new info.

## Screenshots (optional):

Before:
![image](https://github.com/user-attachments/assets/0987e1af-32b4-419f-9307-613002dc38b6)

After:
![image](https://github.com/user-attachments/assets/9a85b9bc-52e4-4e45-b3eb-b2b6759649d6)

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
