### PR TITLE
BED-5620: GA deep linking feature flag

### DIFF
--- a/cmd/api/src/database/migration/migrations/v7.4.0.sql
+++ b/cmd/api/src/database/migration/migrations/v7.4.0.sql
@@ -168,3 +168,6 @@ SELECT
 	2,
 	d.cypher
 FROM inserted_selectors s JOIN src_data d ON d.name = s.name;
+
+-- Enable `back_button_support` feature flag and block users from updating it.
+UPDATE feature_flags SET user_updatable = false and enabled = true WHERE key = 'back_button_support';


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description
This PR sets the `back_button_support` feature flag to be enabled and makes it not user updatable.

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Partially implements BED-5620

This will effectively make the deep linking feature GA. While there is more work to complete BED-5620, this is all that is required to go GA. We have a fast follow up PR that will remove all feature flag code flows and updates tests to expect the deep linking state management

## How Has This Been Tested?
Validated against my local DB which has run the latest migration

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
