### PR TITLE
fix: BED-5881 Add TrustedBy rework logic into AGT common searches

### DIFF
--- a/packages/javascript/bh-shared-ui/src/commonSearchesAGT.ts
+++ b/packages/javascript/bh-shared-ui/src/commonSearchesAGT.ts
@@ -38,7 +38,7 @@ export const CommonSearches: CommonSearchType[] = [
             },
             {
                 description: 'Map domain trusts',
-                cypher: `MATCH p = (:Domain)-[:TrustedBy]->(:Domain)\nRETURN p\nLIMIT 1000`,
+                cypher: `MATCH p = (:Domain)-[:SameForestTrust|CrossForestTrust]->(:Domain)\nRETURN p\nLIMIT 1000`,
             },
             {
                 description: 'Locations of Tier Zero / High Value objects',
@@ -228,8 +228,8 @@ export const CommonSearches: CommonSearchType[] = [
                 cypher: `MATCH (s:Domain)-[:Contains*1..]->(t:Base)\nWHERE s.expirepasswordsonsmartcardonlyaccounts = false\nAND t.enabled = true\nAND t.smartcardrequired = true\nRETURN s`,
             },
             {
-                description: 'Two-way forest trusts enabled for delegation',
-                cypher: `MATCH p=(n:Domain)-[r:TrustedBy]->(m:Domain)\nWHERE (m)-[:TrustedBy]->(n)\nAND r.trusttype = 'Forest'\nAND r.tgtdelegationenabled = true\nRETURN p`,
+                description: 'Cross-forest trusts with abusable configuration',
+                cypher: `MATCH p=(n:Domain)-[:CrossForestTrust|SpoofSIDHistory|AbuseTGTDelegation]-(m:Domain)\nWHERE (n)-[:SpoofSIDHistory|AbuseTGTDelegation]-(m)\nRETURN p`,
             },
             {
                 description: 'Computers with unsupported operating systems',


### PR DESCRIPTION
## Description

https://github.com/SpecterOps/BloodHound/pull/1358 replaced TrustedBy with more accurate, consistent edges. These were not known by the Tiering team when the FFed version of the commonSearches was created. This PR pulls those fixes in for consistency

## Motivation and Context

Resolves BED-5881

## How Has This Been Tested?
Validated locally

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [X] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [X] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [X] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
