### PR TITLE
BED-5890: fixes VirtualizedNodeList tooltip colors when in darkmode

### DIFF
--- a/packages/javascript/bh-shared-ui/src/components/VirtualizedNodeList.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/VirtualizedNodeList.tsx
@@ -14,7 +14,13 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { Tooltip } from '@bloodhoundenterprise/doodleui';
+import {
+    TooltipContent,
+    TooltipPortal,
+    TooltipProvider,
+    TooltipRoot,
+    TooltipTrigger,
+} from '@bloodhoundenterprise/doodleui';
 import { AssetGroupTagNode, GraphNode } from 'js-client-library';
 import { FixedSizeList, ListChildComponentProps } from 'react-window';
 import { cn } from '../utils';
@@ -92,9 +98,18 @@ const Row = <T,>({ data, index, style }: ListChildComponentProps<NodeList<T>>) =
             onClick={() => normalizedItem.onClick?.(index)}
             data-testid='entity-row'>
             <NodeIcon nodeType={normalizedItem.kind} />
-            <Tooltip tooltip={normalizedItem.name}>
-                <div className='truncate text-ellipsis ml-10'>{normalizedItem.name}</div>
-            </Tooltip>
+            <TooltipProvider>
+                <TooltipRoot>
+                    <TooltipTrigger>
+                        <div className='truncate text-ellipsis ml-10'>{normalizedItem.name}</div>
+                    </TooltipTrigger>
+                    <TooltipPortal>
+                        <TooltipContent className='max-w-80 dark:bg-neutral-dark-5 border-0'>
+                            {normalizedItem.name}
+                        </TooltipContent>
+                    </TooltipPortal>
+                </TooltipRoot>
+            </TooltipProvider>
         </li>
     );
 };


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

This PR fixes the VirtualizedNodeList tooltip coloring when in dark mode. Currently it displays white text on a white background.

## Motivation and Context
Resolves: BED-590

Fixes tooltip text that was essentially hidden because it was white text on a white background.

## How Has This Been Tested?

Manually tested

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
