### PR TITLE
fix: selectorId empty check since it defaults to empty string now

### DIFF
--- a/packages/javascript/bh-shared-ui/src/components/AssetGroupManagement/AssetGroupSelectorObjectSelect.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/AssetGroupManagement/AssetGroupSelectorObjectSelect.tsx
@@ -172,7 +172,7 @@ const AssetGroupSelectorObjectSelect: FC<{ seeds: SelectorSeedRequest[] }> = ({ 
                                 }
                             )}
                             onClick={handleRun}>
-                            Run
+                            Update Sample Results
                         </Button>
                     </div>
                     <CardDescription className='pt-3 font-normal'>

--- a/packages/javascript/bh-shared-ui/src/views/TierManagement/Cypher/Cypher.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/TierManagement/Cypher/Cypher.test.tsx
@@ -84,7 +84,7 @@ describe('Cypher Search component for Tier Management', () => {
 
         expect(screen.getByText('Cypher Search')).toBeInTheDocument();
         expect(screen.getByRole('link', { name: 'View in Explore' })).toBeInTheDocument();
-        expect(screen.getByRole('button', { name: 'Run' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Update Sample Results' })).toBeInTheDocument();
     });
 
     it('runs the query and uses the passed in callback to set the node results', async () => {
@@ -100,7 +100,7 @@ describe('Cypher Search component for Tier Management', () => {
             />
         );
 
-        const runButton = screen.getByRole('button', { name: 'Run' });
+        const runButton = screen.getByRole('button', { name: 'Update Sample Results' });
 
         user.click(runButton);
 

--- a/packages/javascript/bh-shared-ui/src/views/TierManagement/Cypher/Cypher.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/TierManagement/Cypher/Cypher.tsx
@@ -113,7 +113,7 @@ export const Cypher: FC<{
                                     }
                                 )}
                                 onClick={handleCypherSearch}>
-                                Run
+                                Update Sample Results
                             </Button>
                         )}
                     </div>

--- a/packages/javascript/bh-shared-ui/src/views/TierManagement/Save/SelectorForm/BasicInfo.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/TierManagement/Save/SelectorForm/BasicInfo.tsx
@@ -124,6 +124,7 @@ const BasicInfo: FC = () => {
                             <Input
                                 id='name'
                                 {...register('name', { required: true, value: selectorQuery.data?.name })}
+                                autoComplete='off'
                                 className={
                                     'pointer-events-auto rounded-none text-base bg-transparent dark:bg-transparent border-t-0 border-x-0 border-b-neutral-dark-5 dark:border-b-neutral-light-5 border-b-[1px] focus-visible:outline-none focus:border-t-0 focus:border-x-0 focus-visible:ring-offset-0 focus-visible:ring-transparent focus-visible:border-secondary focus-visible:border-b-2 focus:border-secondary focus:border-b-2 dark:focus-visible:outline-none dark:focus:border-t-0 dark:focus:border-x-0 dark:focus-visible:ring-offset-0 dark:focus-visible:ring-transparent dark:focus-visible:border-secondary-variant-2 dark:focus-visible:border-b-2 dark:focus:border-secondary-variant-2 dark:focus:border-b-2 hover:border-b-2'
                                 }

--- a/packages/javascript/bh-shared-ui/src/views/TierManagement/Save/SelectorForm/SelectorForm.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/TierManagement/Save/SelectorForm/SelectorForm.tsx
@@ -134,7 +134,7 @@ const SelectorForm: FC = () => {
 
     const onSubmit: SubmitHandler<SelectorFormInputs> = useCallback(
         (data) => {
-            if (selectorId !== undefined) {
+            if (selectorId !== '') {
                 handlePatchSelector(data);
             } else {
                 handleCreateSelector(data);


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

An equality check is updated to account for setting a default value for the selectorId path param within the selector form component.

Updates the run buttons for seed selection to display "Update Sample Results"

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-5894

*Why is this change required? What problem does it solve?*

## How Has This Been Tested?
Unit test is added for creating selector

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)
- 
## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
