### PR TITLE
fix:BED-5898 fixed width issue

### DIFF
--- a/packages/javascript/bh-shared-ui/src/views/TierManagement/Details/EntityInfo/EntityInfoPanel.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/TierManagement/Details/EntityInfo/EntityInfoPanel.tsx
@@ -42,34 +42,36 @@ const EntityInfoPanel: React.FC<EntityInfoPanelProps> = ({ selectedNode }) => {
     }, [setExpandedSections, previousSelectedNode, selectedNode]);
 
     return (
-        <Box className={styles.container} data-testid='explore_entity-information-panel'>
-            <Paper elevation={0} classes={{ root: styles.headerPaperRoot }}>
-                <Header
-                    name={selectedNode?.properties?.name || NoEntitySelectedHeader}
-                    nodeType={selectedNode?.primary_kind}
-                    expanded={expanded}
-                    onToggleExpanded={(expanded) => {
-                        setExpanded(expanded);
-                    }}
-                />
-            </Paper>
-            <Paper
-                elevation={0}
-                classes={{ root: styles.contentPaperRoot }}
-                style={{
-                    display: expanded ? 'initial' : 'none',
-                }}>
-                {selectedNode ? (
-                    <EntityInfoContent
-                        id={selectedNode.id}
-                        nodeType={selectedNode.primary_kind}
-                        properties={selectedNode.properties}
+        <div className='max-w-[400px]'>
+            <Box className={styles.container} data-testid='explore_entity-information-panel'>
+                <Paper elevation={0} classes={{ root: styles.headerPaperRoot }}>
+                    <Header
+                        name={selectedNode?.properties?.name || NoEntitySelectedHeader}
+                        nodeType={selectedNode?.primary_kind}
+                        expanded={expanded}
+                        onToggleExpanded={(expanded) => {
+                            setExpanded(expanded);
+                        }}
                     />
-                ) : (
-                    <Typography variant='body2'>{NoEntitySelectedMessage}</Typography>
-                )}
-            </Paper>
-        </Box>
+                </Paper>
+                <Paper
+                    elevation={0}
+                    classes={{ root: styles.contentPaperRoot }}
+                    style={{
+                        display: expanded ? 'initial' : 'none',
+                    }}>
+                    {selectedNode ? (
+                        <EntityInfoContent
+                            id={selectedNode.id}
+                            nodeType={selectedNode.primary_kind}
+                            properties={selectedNode.properties}
+                        />
+                    ) : (
+                        <Typography variant='body2'>{NoEntitySelectedMessage}</Typography>
+                    )}
+                </Paper>
+            </Box>
+        </div>
     );
 };
 

--- a/packages/javascript/bh-shared-ui/src/views/TierManagement/Details/EntityInfo/SelectorList.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/TierManagement/Details/EntityInfo/SelectorList.tsx
@@ -80,7 +80,7 @@ const SelectorList: React.FC<SelectorListProps> = ({ tagId, memberId }) => {
                 {memberInfoQuery.data.selectors?.map((selector, index) => {
                     return (
                         <div
-                            className={cn('flex items-center gap-2 p-2', {
+                            className={cn('flex items-center gap-2 p-2 overflow-hidden', {
                                 'bg-neutral-light-4 dark:bg-neutral-dark-4': index % 2 === 0,
                             })}
                             key={index}>
@@ -110,7 +110,9 @@ const SelectorList: React.FC<SelectorListProps> = ({ tagId, memberId }) => {
                                     </div>
                                 </PopoverContent>
                             </Popover>
-                            {selector.name}
+                            <div className='truncate max-w-[350px]' title={selector.name}>
+                                {selector.name}
+                            </div>
                         </div>
                     );
                 })}


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Fixes object info panel width issue by setting max width to match entity panels throughout the app.

## Motivation and Context

Resolves [BED-5898](https://specterops.atlassian.net/browse/BED-5898)

Fixes width issue.

## How Has This Been Tested?

Manually

## Screenshots (optional):

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


[BED-5898]: https://specterops.atlassian.net/browse/BED-5898?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ