### PR TITLE
fix: corrects an invalid update statement in the v7.4.0 migration file

### DIFF
--- a/cmd/api/src/database/migration/migrations/v7.4.0.sql
+++ b/cmd/api/src/database/migration/migrations/v7.4.0.sql
@@ -170,6 +170,6 @@ SELECT
 FROM inserted_selectors s JOIN src_data d ON d.name = s.name;
 
 -- Enable `back_button_support` feature flag and block users from updating it.
-UPDATE feature_flags SET user_updatable = false and enabled = true WHERE key = 'back_button_support';
+UPDATE feature_flags SET user_updatable = false, enabled = true WHERE key = 'back_button_support';
 
 UPDATE feature_flags SET "user_updatable" = true WHERE "key" = 'tier_management_engine';


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description
This PR sets the `back_button_support` feature flag to be enabled and makes it not user updatable.

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Fixes an issue with the implementation of BED-5620

A malformed update statement in our v7.4.0 migration file caused the `back_button_support` record in the `feature_flags` table to be only partially updated.

## How Has This Been Tested?
Validated against my local DB which has run the latest migration

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
