### PR TITLE
BED-5266 fix(AGT): missing pathwalk step in selector engine

### DIFF
--- a/cmd/api/src/daemons/datapipe/agt.go
+++ b/cmd/api/src/daemons/datapipe/agt.go
@@ -292,11 +292,9 @@ func fetchADParentNodes(ctx context.Context, tx traversal.Traversal, node *graph
 				query.Kind(query.Relationship(), ad.GPLink),
 				query.Kind(query.Start(), ad.GPO),
 			)).Do(func(path *graph.PathSegment) error {
-			if path.Trunk != nil {
-				channels.Submit(ctx, ch, &nodeWithSource{Source: model.AssetGroupSelectorNodeSourceParent, Node: path.Trunk.Node})
-			}
-			channels.Submit(ctx, ch, &nodeWithSource{Source: model.AssetGroupSelectorNodeSourceParent, Node: path.Node})
-
+			path.WalkReverse(func(nextSegment *graph.PathSegment) bool {
+				return channels.Submit(ctx, ch, &nodeWithSource{Source: model.AssetGroupSelectorNodeSourceParent, Node: nextSegment.Node})
+			})
 			return nil
 		})}); err != nil {
 		return err
@@ -310,10 +308,9 @@ func fetchADParentNodes(ctx context.Context, tx traversal.Traversal, node *graph
 				query.Kind(query.Relationship(), ad.Contains),
 				query.Kind(query.Start(), ad.Container),
 			)).Do(func(path *graph.PathSegment) error {
-				if path.Trunk != nil {
-					channels.Submit(ctx, ch, &nodeWithSource{Source: model.AssetGroupSelectorNodeSourceParent, Node: path.Trunk.Node})
-				}
-				channels.Submit(ctx, ch, &nodeWithSource{Source: model.AssetGroupSelectorNodeSourceParent, Node: path.Node})
+				path.WalkReverse(func(nextSegment *graph.PathSegment) bool {
+					return channels.Submit(ctx, ch, &nodeWithSource{Source: model.AssetGroupSelectorNodeSourceParent, Node: nextSegment.Node})
+				})
 				return nil
 			})}); err != nil {
 			return err
@@ -331,12 +328,12 @@ func fetchAzureParentNodes(ctx context.Context, tx traversal.Traversal, node *gr
 			query.KindIn(query.Relationship(), azure.Contains),
 			query.KindIn(query.Start(), azure.Entity),
 		)).Do(func(path *graph.PathSegment) error {
-			if path.Trunk != nil && path.Trunk.Node.Kinds.ContainsOneOf(azure.Subscription, azure.ResourceGroup, azure.ManagementGroup) {
-				channels.Submit(ctx, ch, &nodeWithSource{Source: model.AssetGroupSelectorNodeSourceParent, Node: path.Trunk.Node})
-			}
-			if path.Node.Kinds.ContainsOneOf(azure.Subscription, azure.ResourceGroup, azure.ManagementGroup) {
-				channels.Submit(ctx, ch, &nodeWithSource{Source: model.AssetGroupSelectorNodeSourceParent, Node: path.Node})
-			}
+			path.WalkReverse(func(nextSegment *graph.PathSegment) bool {
+				if nextSegment.Node.Kinds.ContainsOneOf(azure.Subscription, azure.ResourceGroup, azure.ManagementGroup) {
+					return channels.Submit(ctx, ch, &nodeWithSource{Source: model.AssetGroupSelectorNodeSourceParent, Node: nextSegment.Node})
+				}
+				return true
+			})
 			return nil
 		})}); err != nil {
 		return err
@@ -350,10 +347,9 @@ func fetchAzureParentNodes(ctx context.Context, tx traversal.Traversal, node *gr
 				query.Kind(query.Relationship(), azure.RunsAs),
 				query.Kind(query.Start(), azure.App),
 			)).Do(func(path *graph.PathSegment) error {
-				if path.Trunk != nil {
-					channels.Submit(ctx, ch, &nodeWithSource{Source: model.AssetGroupSelectorNodeSourceParent, Node: path.Trunk.Node})
-				}
-				channels.Submit(ctx, ch, &nodeWithSource{Source: model.AssetGroupSelectorNodeSourceParent, Node: path.Node})
+				path.WalkReverse(func(nextSegment *graph.PathSegment) bool {
+					return channels.Submit(ctx, ch, &nodeWithSource{Source: model.AssetGroupSelectorNodeSourceParent, Node: nextSegment.Node})
+				})
 				return nil
 			})}); err != nil {
 			return err


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

*Describe your changes in detail*
- Adds reverse walkway to selector engine to tag any interstitial nodes that were part of the criteria

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-5266

*Why is this change required? What problem does it solve?*

## How Has This Been Tested?

*Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc.*

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->
- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
