### PR TITLE
fix(stbernard): misbehaving goroutines

### DIFF
--- a/packages/go/stbernard/workspace/golang/generate.go
+++ b/packages/go/stbernard/workspace/golang/generate.go
@@ -148,5 +148,9 @@ func WorkspaceGenerate(modPaths []string, env environment.Environment) error {
 		}
 	}
 
+	close(jobC)
+
+	waitGroup.Wait()
+
 	return errors.Join(errs...)
 }


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Fixes an issue where goroutines could still be running code generation after `stbernard generate` exits. This was causing inconsistency when running `just prepare-for-codereview` under certain conditions.

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-5925

## How Has This Been Tested?

Confirmed fix by running multiple times with improperly generated code as a starting point

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)
- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of workspace generation by ensuring all background tasks complete before finishing the operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->