### PR TITLE
BED-5266 fix(AGT): missing pathwalk step in selector engine child expansion

### DIFF
--- a/cmd/api/src/daemons/datapipe/agt.go
+++ b/cmd/api/src/daemons/datapipe/agt.go
@@ -179,12 +179,9 @@ func fetchChildNodes(ctx context.Context, tx traversal.Traversal, node *graph.No
 	if err := tx.BreadthFirst(ctx, traversal.Plan{
 		Root: node,
 		Driver: pattern.Do(func(path *graph.PathSegment) error {
-			if path.Trunk != nil {
-				channels.Submit(ctx, ch, &nodeWithSource{Source: model.AssetGroupSelectorNodeSourceChild, Node: path.Trunk.Node})
-			}
-
-			channels.Submit(ctx, ch, &nodeWithSource{Source: model.AssetGroupSelectorNodeSourceChild, Node: path.Node})
-
+			path.WalkReverse(func(nextSegment *graph.PathSegment) bool {
+				return channels.Submit(ctx, ch, &nodeWithSource{Source: model.AssetGroupSelectorNodeSourceChild, Node: nextSegment.Node})
+			})
 			return nil
 		})}); err != nil {
 


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

*Describe your changes in detail*
Implemented the same fix from https://github.com/SpecterOps/BloodHound/pull/1485 but on the child expansion logic

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-5266

*Why is this change required? What problem does it solve?*
Failing to tag interstitial nodes during traversal for child expansion step

## How Has This Been Tested?

*Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc.*

## Screenshots (optional):
Before:
![image](https://github.com/user-attachments/assets/bded9e7d-b34a-43d3-afc4-0ec46c4e4a0b)

After:
![image](https://github.com/user-attachments/assets/4523c52a-c261-47d4-a5df-a3f42c34fefc)

![image](https://media1.tenor.com/m/eaXeBglrEIoAAAAC/jon-snow-my-queen.gif)
## Types of changes

<!-- Please remove any items that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
