### PR TITLE
Add cli option to clear quarantine on MacOS

### DIFF
--- a/docs/get-started/quickstart/community-edition-quickstart.mdx
+++ b/docs/get-started/quickstart/community-edition-quickstart.mdx
@@ -77,6 +77,12 @@ BloodHound CE deploys in a traditional multi-tier container architecture consist
   <Note>
     **If you encounter Mac Error: “bloodhound-cli” Not Opened. Apple could not verify “bloodhound-cli” is free of malware that may harm your mac or compromise your privacy.**
     In case you get this error message, you need to allow bloodhound-cli to be executed.
+
+    Option 1: In the terminal
+      1. Type the following command: `xattr -d com.apple.quarantine ./bloodhound-cli`
+      2. Repeat the CLI command `./bloodhound-cli install`
+
+    Option 2: In the GUI
       1.	Go to **System Settings** (or System Preferences on older macOS versions)
       2. Navigate to **Privacy & Security**
       3. Scroll down to the **Security** section

--- a/docs/get-started/quickstart/community-edition-quickstart.mdx
+++ b/docs/get-started/quickstart/community-edition-quickstart.mdx
@@ -79,7 +79,7 @@ BloodHound CE deploys in a traditional multi-tier container architecture consist
     In case you get this error message, you need to allow bloodhound-cli to be executed.
 
     Option 1: In the terminal
-      1. Type the following command: `xattr -d com.apple.quarantine ./bloodhound-cli`
+      1. Clear the quarantine flag by typing `xattr -d com.apple.quarantine ./bloodhound-cli` in the CLI
       2. Repeat the CLI command `./bloodhound-cli install`
 
     Option 2: In the GUI


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Updated instructions to help users resolve MacOS security errors when running the bloodhound-cli executable, including a new command-line method alongside the existing GUI solution.

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-5930

*Why is this change required? What problem does it solve?*

## How Has This Been Tested?

1. Ran the command in MacOS terminal 
2. Looked at the new version of the text in mintlify

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated instructions to help users resolve macOS security errors when running the `bloodhound-cli` executable, including a new command-line method alongside the existing GUI solution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->