### PR TITLE
fix (api): pass any type for last seen value

### DIFF
--- a/cmd/api/src/migrations/manifest.go
+++ b/cmd/api/src/migrations/manifest.go
@@ -74,7 +74,7 @@ func Version_740_Migration(ctx context.Context, db graph.Database) error {
 			edgeProperties := graph.NewProperties()
 			edgeProperties.Set(ad.IsACL.String(), false)
 			edgeProperties.Set(ad.TrustType.String(), trustType)
-			edgeProperties.Set(common.LastSeen.String(), rel.Properties.Get(common.LastSeen.String()))
+			edgeProperties.Set(common.LastSeen.String(), rel.Properties.Get(common.LastSeen.String()).Any())
 
 			// Create new edge in opposite direction
 			if err := batch.CreateRelationship(&graph.Relationship{


### PR DESCRIPTION
## Description

Ensures the last_seen property value retuns an actual value instead of the untyped PropertyValue interface.

## Motivation and Context
Resolves: [BED-5940](https://specterops.atlassian.net/browse/BED-5940)

The data migration from v7.3.1 to v7.4.0 causes the following error: "Failed starting the server: failed to start services: graph migration error: migration version v7.4.0 failed: Usage of type '*graph.safePropertyValue' is not supported"

## How Has This Been Tested?

- Checked out v7.3.1, built, ran and uploaded azure and AD test data to the local environment.
- Spun down v7.3.1 and spun up the a docker image containing the change using the just run-bhce-container command
- Observed a successful migration

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


[BED-5940]: https://specterops.atlassian.net/browse/BED-5940?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of relationship properties to ensure correct extraction and assignment of values during migrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->