### PR TITLE
Bed 5937: Fix "undefined%" exposure percentage in both Attack Paths graph and environment Selector

### DIFF
--- a/cmd/api/src/model/search.go
+++ b/cmd/api/src/model/search.go
@@ -39,7 +39,7 @@ type DomainSelector struct {
 	Name        string `json:"name"`
 	ObjectID    string `json:"id"`
 	Collected   bool   `json:"collected"`
-	ImpactValue int    `json:"impactValue,omitempty"`
+	ImpactValue *int   `json:"impactValue,omitempty"`
 }
 
 type DomainSelectors []DomainSelector


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description
- Changed the `ImpactValue` type to `*int`

## Motivation and Context

- Resolves BED-5937

*Why is this change required? What problem does it solve?*
- Some environments were being displayed with “undefined%” exposure in the attack paths page graph and within the environment selector menu. This change makes it so that the ImpactValue no longer shows "undefined%" and instead shows 0% now

## How Has This Been Tested?
- Locally within my BHE env

## Screenshots (optional):
<img width="613" alt="Screenshot 2025-05-29 at 3 09 31 PM" src="https://github.com/user-attachments/assets/ac122247-051c-480e-bbfd-84a1497c67f8" />

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)
- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [ ] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [ ] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [ ] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
