### PR TITLE
docs(install-azurehound): BED-5965 Fixes file downloads

### DIFF
--- a/docs/install-data-collector/install-azurehound/create-configuration.mdx
+++ b/docs/install-data-collector/install-azurehound/create-configuration.mdx
@@ -3,10 +3,10 @@ title: Create an AzureHound Configuration
 ---
 
 <img noZoom src="/assets/enterprise-edition-pill-tag.svg"/>
-_
+
+
 You will need your Tenant ID and Application ID from completing [AzureHound Enterprise Azure Configuration](/install-data-collector/install-azurehound/azure-configuration) prior to beginning this process.
 
-_
 
 1.  Log into your BloodHound Enterprise tenant.
 

--- a/docs/install-data-collector/install-azurehound/installation-options.mdx
+++ b/docs/install-data-collector/install-azurehound/installation-options.mdx
@@ -106,7 +106,7 @@ Instead of installing AzureHound as a service, it is also possible to run AzureH
 
 ### Run AzureHound Enterprise on Docker
 
-1.  Use the attached sample file: [docker-compose.yaml](/assets/docker-compose.yaml) 397 Bytes
+1.  Use the attached sample file: [docker-compose.yaml](https://github.com/SpecterOps/BloodHound/blob/main/docs/assets/docker-compose.yaml) 397 Bytes
 2.  Integrate the appropriate structure into your existing configuration or utilize it as a new configuration in Docker, moving the associated config.json, cert.pem, and key.pem files to the appropriate location, and updating config.json according to your assigned values.
 3.  In your docker directory, run:
 ```
@@ -140,7 +140,7 @@ Instead of installing AzureHound as a service, it is also possible to run AzureH
 ```
     kubectl create secret generic azurehound-secret --from-literal tokenId=&lt;bloodhound enterprise token id&gt; --from-literal token=&lt;bloodhound enterprise token&gt; --from-literal keypass=&lt;private key passphrase&gt;
 ```
-3.  A sample deployment.yaml file is attached to this article ([here](/assets/deployment.yaml)).
+3.  A sample deployment.yaml file is attached to this article ([here](https://github.com/SpecterOps/BloodHound/blob/main/docs/assets/deployment.yaml)).
 4.  Edit the provided deployment.yaml file. Read comments and replace instances of \[ INSERT HERE \] with appropriate values
 5.  Deploy AzureHound on k8s:
 ```
@@ -156,6 +156,6 @@ Instead of installing AzureHound as a service, it is also possible to run AzureH
 
 2.  Review the container logs and BloodHound Enterprise user interface to verify that AzureHound has successfully connected.
 
-* [docker-compose.yaml](/assets/docker-compose.yaml) 397 Bytes
-* [deployment.yaml](/assets/deployment.yaml) 2 KB
+* [docker-compose.yaml](https://github.com/SpecterOps/BloodHound/blob/main/docs/assets/docker-compose.yaml) 397 Bytes
+* [deployment.yaml](https://github.com/SpecterOps/BloodHound/blob/main/docs/assets/deployment.yaml) 2 KB
 

--- a/docs/install-data-collector/install-azurehound/installation-options.mdx
+++ b/docs/install-data-collector/install-azurehound/installation-options.mdx
@@ -4,7 +4,7 @@ title: Install and Upgrade AzureHound (Windows, Docker, or Kubernetes)
 
 <img noZoom src="/assets/enterprise-edition-pill-tag.svg"/>
 
-_You will need your AzureHound Enterprise configuration file from [Create an AzureHound Configuration](/install-data-collector/install-azurehound/create-configuration) prior to beginning this process.
+You will need your AzureHound Enterprise configuration file from [Create an AzureHound Configuration](/install-data-collector/install-azurehound/create-configuration) prior to beginning this process.
 
 
 ## Windows
@@ -106,7 +106,7 @@ Instead of installing AzureHound as a service, it is also possible to run AzureH
 
 ### Run AzureHound Enterprise on Docker
 
-1.  Use the attached sample file: [docker-compose.yaml](https://github.com/SpecterOps/BloodHound/blob/main/docs/assets/docker-compose.yaml) 397 Bytes
+1.  Use the attached sample file: [docker-compose.yaml](https://raw.githubusercontent.com/SpecterOps/BloodHound/main/docs/assets/docker-compose.yaml) (397 Bytes)
 2.  Integrate the appropriate structure into your existing configuration or utilize it as a new configuration in Docker, moving the associated config.json, cert.pem, and key.pem files to the appropriate location, and updating config.json according to your assigned values.
 3.  In your docker directory, run:
 ```
@@ -140,7 +140,7 @@ Instead of installing AzureHound as a service, it is also possible to run AzureH
 ```
     kubectl create secret generic azurehound-secret --from-literal tokenId=&lt;bloodhound enterprise token id&gt; --from-literal token=&lt;bloodhound enterprise token&gt; --from-literal keypass=&lt;private key passphrase&gt;
 ```
-3.  A sample deployment.yaml file is attached to this article ([here](https://github.com/SpecterOps/BloodHound/blob/main/docs/assets/deployment.yaml)).
+3.  A sample [deployment.yaml](https://raw.githubusercontent.com/SpecterOps/BloodHound/main/docs/assets/deployment.yaml) file is attached to this article.
 4.  Edit the provided deployment.yaml file. Read comments and replace instances of \[ INSERT HERE \] with appropriate values
 5.  Deploy AzureHound on k8s:
 ```
@@ -156,6 +156,6 @@ Instead of installing AzureHound as a service, it is also possible to run AzureH
 
 2.  Review the container logs and BloodHound Enterprise user interface to verify that AzureHound has successfully connected.
 
-* [docker-compose.yaml](https://github.com/SpecterOps/BloodHound/blob/main/docs/assets/docker-compose.yaml) 397 Bytes
-* [deployment.yaml](https://github.com/SpecterOps/BloodHound/blob/main/docs/assets/deployment.yaml) 2 KB
+* [docker-compose.yaml](https://raw.githubusercontent.com/SpecterOps/BloodHound/main/docs/assets/docker-compose.yaml) (397 Bytes)
+* [deployment.yaml](https://raw.githubusercontent.com/SpecterOps/BloodHound/main/docs/assets/deployment.yaml) (2 KB)
 


### PR DESCRIPTION
## Description

- Directs docker-compose.yaml and deployment.yaml links to GitHub locations for direct download

## Motivation and Context

Resolves BED-5965

With switch to Mintlify, links were redirecting to home page as linking to files in-page is no longer supported.

## How Has This Been Tested?

Local validation

## Screenshots (optional):

## Types of changes

- Chore (a change that does not modify the application functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated installation instructions to use direct GitHub links for Docker and Kubernetes sample files, ensuring users access the latest versions.
  - Improved formatting by removing extraneous underscores for clearer readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->