### PR TITLE
chore: remove paths-ignore for docs

### DIFF
--- a/.github/workflows/build-ui.yml
+++ b/.github/workflows/build-ui.yml
@@ -24,9 +24,6 @@ on:
     types:
       - opened
       - synchronize
-    paths-ignore:
-      - 'docs/**'
-      - 'rfc/**'
 
 jobs:
   build-ui:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,6 @@ on:
     types:
       - opened
       - synchronize
-    paths-ignore:
-      - 'docs/**'
-      - 'rfc/**'
 
 jobs:
   cla-check:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -24,9 +24,6 @@ on:
     types:
       - opened
       - synchronize
-    paths-ignore:
-      - 'docs/**'
-      - 'rfc/**'
 
 jobs:
   run-tests:

--- a/.github/workflows/static-code-analysis.yml
+++ b/.github/workflows/static-code-analysis.yml
@@ -24,9 +24,6 @@ on:
     types:
       - opened
       - synchronize
-    paths-ignore:
-      - 'docs/**'
-      - 'rfc/**'
 
 jobs:
   run-analysis:

--- a/.github/workflows/vuln-scan.yml
+++ b/.github/workflows/vuln-scan.yml
@@ -24,9 +24,6 @@ on:
     types:
       - opened
       - synchronize
-    paths-ignore:
-      - 'docs/**'
-      - 'rfc/**'
 
 jobs:
   run-analysis:


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

The `paths-ignore` configuration was meant to streamline doc-only changes, but it caused conflicts in our configuration and led to doc-only PRs getting held up indefinitely. Removing to streamline while we work on future pipeline improvements.

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-5944

## How Has This Been Tested?

No testing could be done ahead of time, pipeline only change which will require a doc-only PR to validate.

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated workflow configurations so that changes to documentation and RFC files now trigger all automated checks, including build, CI, tests, static code analysis, and vulnerability scans, on pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->