### PR TITLE
BED-5981 fix(AGT): not clearing all asset group tags

### DIFF
--- a/cmd/api/src/daemons/datapipe/agt.go
+++ b/cmd/api/src/daemons/datapipe/agt.go
@@ -676,7 +676,7 @@ func clearAssetGroupTags(ctx context.Context, db database.Database, graphDb grap
 					for _, node := range taggedNodeSet {
 						node.DeleteKinds(tagKind)
 						if err := tx.UpdateNode(node); err != nil {
-							return err
+							slog.WarnContext(ctx, "AGT: Error cleaning node", slog.String("nodeId", node.ID.String()), slog.String("err", err.Error()))
 						}
 					}
 				}


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

*Describe your changes in detail*
Fix early return on clearing asset group tags when tiering flag is disabled

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-5981

*Why is this change required? What problem does it solve?*

## How Has This Been Tested?
Locally

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->
- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling to ensure all relevant tags are cleared from nodes, rather than stopping after the first update. This results in more reliable processing when removing tag kinds from multiple nodes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->