### PR TITLE
BED-5922 Update CLA Assistant

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -17,23 +17,24 @@
 name: "CLA Assistant"
 on:
   issue_comment:
-    types: [created]
-  pull_request_target:
-    types: [opened, closed, synchronize]
+    types: [created, edited]
 
 jobs:
   CLAssistant:
     runs-on: ubuntu-latest
     steps:
+      # Trigger the CLA assistant check when someone comments the specified text.
+      # The intent is to comment `@cla-pls` on PRs from external contributors to initiate the CLA check.
+      # The other strings that trigger the action are used in normal operation of the `contributor-assistant` action.
       - name: "CLA Assistant"
-        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        if: github.event.issue.pull_request && (github.event.comment.body == '@cla-pls' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA' || github.event.comment.body == 'recheck')
         uses: contributor-assistant/github-action@v2.2.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PERSONAL_ACCESS_TOKEN: ${{ secrets.REPO_SCOPE }}
         with:
           path-to-signatures: "signatures.json"
-          path-to-document: "https://github.com/BloodHoundAD/CLA/blob/main/ICLA.md"
+          path-to-document: "https://github.com/SpecterOps/CLA/blob/main/ICLA.md"
           branch: "main"
-          remote-organization-name: BloodHoundAD
+          remote-organization-name: SpecterOps
           remote-repository-name: CLA


### PR DESCRIPTION
## Description

This PR updates the CLA assistant GitHub Action with a couple changes:

- Update the location of the CLA and signatures list to point to a repo under the `SpecterOps` org
- Change the trigger event to be on comments only, looking for specific text

The CLA check is now intended to be run only for contributors outside of the `SpecterOps` organization. This will be initiated by a comment containing the text `@cla-pls` on all PRs from external contributors. From there the CLA Assistant will function as it had previously. 

## Motivation and Context

Resolves BED-5922

*Why is this change required? What problem does it solve?*

The CLA repo is moving under the `SpecterOps` organization instead of the legacy `BloodHoundAD` org.

## How Has This Been Tested?

* Tested the action functions as expected on a separate test repo

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
