### PR TITLE
BED-6036: Update Go Container Build From 1.23.9 to 1.23.10

### DIFF
--- a/dockerfiles/bloodhound.Dockerfile
+++ b/dockerfiles/bloodhound.Dockerfile
@@ -23,7 +23,7 @@ ARG AZUREHOUND_VERSION=v2.5.0
 ########
 # Golang Image
 ################
-FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.23-alpine3.20 AS godeps
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.23-alpine3.22 AS godeps
 
 ########
 # Builder init


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Upgrade our container building to use Go 1.23.10 in order to address
CVE-2025-22874
CVE-2025-0913
CVE-2025-4673

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves: BED-6036

*Why is this change required? What problem does it solve?*

## How Has This Been Tested?

*Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc.*

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)
- Database Migrations

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
