### PR TITLE
Bed 6050

### DIFF
--- a/cmd/ui/src/views/Administration/Administration.tsx
+++ b/cmd/ui/src/views/Administration/Administration.tsx
@@ -17,6 +17,7 @@
 import { Box, CircularProgress, Container } from '@mui/material';
 import {
     AdministrationSection,
+    AppNavigate,
     GenericErrorBoundaryFallback,
     Permission,
     SubNav,
@@ -25,7 +26,7 @@ import {
 } from 'bh-shared-ui';
 import React, { Suspense } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
-import { Navigate, Route, Routes } from 'react-router-dom';
+import { Route, Routes } from 'react-router-dom';
 import {
     DEFAULT_ADMINISTRATION_ROUTE,
     ROUTE_ADMINISTRATION,
@@ -179,7 +180,7 @@ const Administration: React.FC = () => {
                                     <Route
                                         path='*'
                                         element={
-                                            <Navigate
+                                            <AppNavigate
                                                 to={getSubRoute(ROUTE_ADMINISTRATION, DEFAULT_ADMINISTRATION_ROUTE)}
                                                 replace
                                             />

--- a/packages/javascript/bh-shared-ui/src/components/Navigation/MainNav.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/Navigation/MainNav.test.tsx
@@ -18,7 +18,6 @@ import userEvent from '@testing-library/user-event';
 import { rest } from 'msw';
 import { setupServer } from 'msw/node';
 import { render, screen, within } from '../../test-utils';
-import { GloballySupportedSearchParams } from '../../utils/searchParams';
 import { AppIcon } from '../AppIcon';
 import MainNav from './MainNav';
 import { MainNavData, MainNavDataListItem, MainNavLogoDataObject } from './types';
@@ -42,7 +41,6 @@ const MainNavLogoData: MainNavLogoDataObject = {
             altText: 'BHE Text Logo',
         },
     },
-    supportedSearchParams: GloballySupportedSearchParams,
 };
 const MainNavPrimaryListData: MainNavDataListItem[] = [
     {
@@ -50,14 +48,12 @@ const MainNavPrimaryListData: MainNavDataListItem[] = [
         icon: <AppIcon.LineChart size={24} />,
         route: '/test',
         testId: 'global_nav-test-link',
-        supportedSearchParams: GloballySupportedSearchParams,
     },
     {
         label: 'Link Item 2',
         icon: <AppIcon.LineChart size={24} />,
         route: '/secondroute',
         testId: 'global_nav-test-link-2',
-        supportedSearchParams: GloballySupportedSearchParams,
     },
 ];
 
@@ -69,7 +65,6 @@ const MainNavSecondaryListData: MainNavDataListItem[] = [
         icon: <AppIcon.LineChart size={24} />,
         functionHandler: handleClick,
         testId: 'global_nav-test-action',
-        supportedSearchParams: GloballySupportedSearchParams,
     },
 ];
 

--- a/packages/javascript/bh-shared-ui/src/components/Navigation/MainNav.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/Navigation/MainNav.tsx
@@ -15,10 +15,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { FC, ReactNode } from 'react';
-import { Link as RouterLink, useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 import { useApiVersion, useIsMouseDragging } from '../../hooks';
-import { cn } from '../../utils';
-import { persistSearchParams } from '../../utils/searchParams/searchParams';
+import { AppLink, cn } from '../../utils';
 import { MainNavData, MainNavDataListItem, MainNavLogoDataObject } from './types';
 
 const MainNavLogoTextImage: FC<{
@@ -86,20 +85,17 @@ const MainNavItemLink: FC<{
     children: ReactNode;
     hoverActive: boolean;
     testId: string;
-    supportedSearchParams: MainNavDataListItem['supportedSearchParams'];
-}> = ({ route, children, hoverActive, testId, supportedSearchParams }) => {
-    const search = supportedSearchParams ? persistSearchParams(supportedSearchParams).toString() : undefined;
-
+}> = ({ route, children, hoverActive, testId }) => {
     return (
         // Note: The w-full is to avoid the hover area to overflow out of the nav when its collapsed
-        <RouterLink
-            to={{ pathname: route, search }}
+        <AppLink
+            to={{ pathname: route }}
             className={cn('h-10 w-auto absolute left-4 flex items-center gap-x-2 hover:underline cursor-default', {
                 'group-hover:w-full cursor-pointer': hoverActive,
             })}
             data-testid={testId}>
             {children}
-        </RouterLink>
+        </AppLink>
     );
 };
 
@@ -192,7 +188,6 @@ const MainNav: FC<{ mainNavData: MainNavData }> = ({ mainNavData }) => {
             )}>
             <MainNavItemLink
                 route={mainNavData.logo.project.route}
-                supportedSearchParams={mainNavData.logo.supportedSearchParams}
                 testId='global_nav-home'
                 hoverActive={!isMouseDragging}>
                 <MainNavItemLabel
@@ -212,8 +207,7 @@ const MainNav: FC<{ mainNavData: MainNavData }> = ({ mainNavData }) => {
                             <MainNavItemLink
                                 route={listDataItem.route as string}
                                 hoverActive={!isMouseDragging}
-                                testId={listDataItem.testId}
-                                supportedSearchParams={listDataItem.supportedSearchParams}>
+                                testId={listDataItem.testId}>
                                 <MainNavItemLabel
                                     icon={listDataItem.icon}
                                     label={listDataItem.label}
@@ -233,8 +227,7 @@ const MainNav: FC<{ mainNavData: MainNavData }> = ({ mainNavData }) => {
                                 <MainNavItemLink
                                     route={listDataItem.route as string}
                                     hoverActive={!isMouseDragging}
-                                    testId={listDataItem.testId}
-                                    supportedSearchParams={listDataItem.supportedSearchParams}>
+                                    testId={listDataItem.testId}>
                                     <MainNavItemLabel
                                         icon={listDataItem.icon}
                                         label={listDataItem.label}

--- a/packages/javascript/bh-shared-ui/src/components/Navigation/SubNav.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/Navigation/SubNav.tsx
@@ -14,9 +14,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import { FC, ReactNode } from 'react';
-import { Link as RouterLink, useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 import { AdministrationSection } from '../..';
-import { cn, persistSearchParams } from '../../utils';
+import { AppLink, cn } from '../../utils';
 
 const SubNavListTitle: FC<{ children: ReactNode }> = ({ children }) => {
     return (
@@ -42,23 +42,18 @@ const SubNavListItem: FC<{ children: ReactNode; route?: string }> = ({ children,
     );
 };
 
-const SubNavListItemLink: FC<{ route: string; supportedSearchParams?: string[]; children: ReactNode }> = ({
-    route,
-    children,
-    supportedSearchParams,
-}) => {
-    const search = supportedSearchParams ? persistSearchParams(supportedSearchParams).toString() : undefined;
+const SubNavListItemLink: FC<{ route: string; children: ReactNode }> = ({ route, children }) => {
     return (
-        <RouterLink
-            to={{ pathname: route, search }}
+        <AppLink
+            to={{ pathname: route }}
             className={`h-7 min-h-7 w-full flex items-center gap-x-2 text-sm whitespace-nowrap`}>
             {children}
-        </RouterLink>
+        </AppLink>
     );
 };
 
 type SubNavSections = Omit<AdministrationSection, 'order' | 'items'> & {
-    items: Pick<AdministrationSection['items'][number], 'label' | 'path' | 'supportedSearchParams'>[];
+    items: Pick<AdministrationSection['items'][number], 'label' | 'path'>[];
 };
 interface SubNavProps {
     sections: SubNavSections[];
@@ -74,7 +69,7 @@ const SubNav: React.FC<SubNavProps> = ({ sections }) => {
                     </SubNavListTitle>
                     {section.items.map((item, itemIndex) => (
                         <SubNavListItem key={itemIndex} route={item.path}>
-                            <SubNavListItemLink route={item.path} supportedSearchParams={item.supportedSearchParams}>
+                            <SubNavListItemLink route={item.path}>
                                 <span>{item.label}</span>
                             </SubNavListItemLink>
                         </SubNavListItem>

--- a/packages/javascript/bh-shared-ui/src/components/Navigation/types.ts
+++ b/packages/javascript/bh-shared-ui/src/components/Navigation/types.ts
@@ -32,14 +32,12 @@ export type MainNavLogoDataObject = {
     specterOps: {
         image: MainNavLogoImage;
     };
-    supportedSearchParams?: string[];
 };
 
 export type MainNavDataListItem = {
     label: string | ReactNode;
     icon: ReactNode;
     route?: string;
-    supportedSearchParams?: string[];
     functionHandler?: () => void;
     testId: string;
 };

--- a/packages/javascript/bh-shared-ui/src/types.ts
+++ b/packages/javascript/bh-shared-ui/src/types.ts
@@ -38,7 +38,6 @@ type AdministrationItem = {
     path: string;
     component: React.LazyExoticComponent<React.FC>;
     adminOnly: boolean;
-    supportedSearchParams?: string[];
 };
 
 export type AdministrationSection = {

--- a/packages/javascript/bh-shared-ui/src/utils/searchParams/AppNavigate.tsx
+++ b/packages/javascript/bh-shared-ui/src/utils/searchParams/AppNavigate.tsx
@@ -1,0 +1,36 @@
+// Copyright 2025 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import { Navigate, NavigateProps } from 'react-router-dom';
+import {
+    AppNavigateProps,
+    GloballySupportedSearchParams,
+    applyPreservedParams,
+    persistSearchParams,
+} from './searchParams';
+
+export const AppNavigate: React.FC<NavigateProps & AppNavigateProps> = (props) => {
+    const { discardQueryParams, to, ...rest } = props;
+
+    if (discardQueryParams) {
+        return <Navigate to={to} {...rest} />;
+    }
+
+    const search = persistSearchParams(GloballySupportedSearchParams);
+    const toWithParams = applyPreservedParams(to, search);
+
+    return <Navigate to={toWithParams} {...rest} />;
+};

--- a/packages/javascript/bh-shared-ui/src/utils/searchParams/index.ts
+++ b/packages/javascript/bh-shared-ui/src/utils/searchParams/index.ts
@@ -15,5 +15,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 export * from './AppLink';
+export * from './AppNavigate';
 export * from './searchParams';
 export * from './useAppNavigate';

--- a/packages/javascript/bh-shared-ui/src/views/ZoneManagement/ZoneManagement.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/ZoneManagement/ZoneManagement.tsx
@@ -17,7 +17,7 @@
 import { Tabs, TabsList, TabsTrigger } from '@bloodhoundenterprise/doodleui';
 import { CircularProgress } from '@mui/material';
 import React, { FC, Suspense, useContext, useMemo } from 'react';
-import { Navigate, Route, Routes, useLocation } from 'react-router-dom';
+import { Route, Routes, useLocation } from 'react-router-dom';
 import {
     DEFAULT_ZONE_MANAGEMENT_ROUTE,
     ROUTE_ZONE_MANAGEMENT_LABEL_DETAILS,
@@ -30,7 +30,7 @@ import {
     ROUTE_ZONE_MANAGEMENT_TIER_SELECTOR_OBJECT_DETAILS,
     Routable,
 } from '../../routes';
-import { cn, useAppNavigate } from '../../utils';
+import { AppNavigate, cn, useAppNavigate } from '../../utils';
 import { ZoneManagementContext } from './ZoneManagementContext';
 import { OWNED_ID, TIER_ZERO_ID } from './utils';
 
@@ -113,7 +113,7 @@ const ZoneManagement: FC = () => {
                             {childRoutes.map((route) => {
                                 return <Route path={route.path} element={<route.component />} key={route.path} />;
                             })}
-                            <Route path='*' element={<Navigate to={DEFAULT_ZONE_MANAGEMENT_ROUTE} replace />} />
+                            <Route path='*' element={<AppNavigate to={DEFAULT_ZONE_MANAGEMENT_ROUTE} replace />} />
                         </Routes>
                     </Suspense>
                 </div>


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description
Fixes global search params being lost when navigating to splat routes. Also cleans up the previous implementation of globally support search params in lieu of App navigation components.

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-6050

Navigating to `/admistration/*` or `/zone-management/*` results in the environmentId param being lost

## How Has This Been Tested?
added unit test for AppLink and AppNavigate components

## Screenshots (optional):

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
