### PR TITLE
fix: readd necessary identity kinds to fix indexed lookups for ingest

### DIFF
--- a/cmd/api/src/daemons/datapipe/datapipe.go
+++ b/cmd/api/src/daemons/datapipe/datapipe.go
@@ -73,6 +73,7 @@ func NewDaemon(ctx context.Context, cfg config.Configuration, connections bootst
 }
 
 func (s *Daemon) analyze() {
+	defer measure.LogAndMeasure(slog.LevelDebug, "Analysis")()
 	// Ensure that the user-requested analysis switch is deleted. This is done at the beginning of the
 	// function so that any re-analysis requests are caught while analysis is in-progress.
 	if err := s.db.DeleteAnalysisRequest(s.ctx); err != nil {

--- a/cmd/api/src/services/graphify/ingest.go
+++ b/cmd/api/src/services/graphify/ingest.go
@@ -17,6 +17,7 @@
 package graphify
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -25,6 +26,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/specterops/bloodhound/bhlog/measure"
 	"github.com/specterops/bloodhound/dawgs/graph"
 	"github.com/specterops/bloodhound/dawgs/util"
 	"github.com/specterops/bloodhound/ein"
@@ -151,6 +153,7 @@ func IngestGroupData(batch *TimestampedBatch, converted ConvertedGroupData) erro
 }
 
 func IngestAzureData(batch *TimestampedBatch, converted ConvertedAzureData) error {
+	defer measure.ContextLogAndMeasure(context.TODO(), slog.LevelDebug, "ingest azure data")()
 	errs := util.NewErrorCollector()
 
 	if err := IngestNodes(batch, azure.Entity, converted.NodeProps); err != nil {
@@ -303,7 +306,8 @@ func IngestNode(batch *TimestampedBatch, baseKind graph.Kind, nextNode ein.Inges
 		nodeKinds            = mergeBaseKind(baseKind, nextNode.Labels...)
 		normalizedProperties = NormalizeEinNodeProperties(nextNode.PropertyMap, nextNode.ObjectID, batch.IngestTime)
 		nodeUpdate           = graph.NodeUpdate{
-			Node: graph.PrepareNode(graph.AsProperties(normalizedProperties), nodeKinds...),
+			Node:         graph.PrepareNode(graph.AsProperties(normalizedProperties), nodeKinds...),
+			IdentityKind: baseKind,
 			IdentityProperties: []string{
 				common.ObjectID.String(),
 			},
@@ -344,7 +348,7 @@ func IngestRelationships(batch *TimestampedBatch, baseKind graph.Kind, relations
 	}
 
 	for _, update := range updates {
-		if err := batch.Batch.UpdateRelationshipBy(*update); err != nil {
+		if err := batch.Batch.UpdateRelationshipBy(update); err != nil {
 			errs.Add(err)
 		}
 	}

--- a/cmd/api/src/services/graphify/tasks.go
+++ b/cmd/api/src/services/graphify/tasks.go
@@ -27,6 +27,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/specterops/bloodhound/bhlog/measure"
 	"github.com/specterops/bloodhound/bomenc"
 	"github.com/specterops/bloodhound/dawgs/graph"
 	"github.com/specterops/bloodhound/dawgs/util"
@@ -163,6 +164,8 @@ func (s *GraphifyService) processIngestFile(ctx context.Context, task model.Inge
 }
 
 func processSingleFile(ctx context.Context, filePath string, batch *TimestampedBatch, readOpts ReadOptions) error {
+	defer measure.ContextLogAndMeasure(ctx, slog.LevelDebug, "processing single file for ingest", slog.String("filepath", filePath))()
+
 	file, err := os.Open(filePath)
 	if err != nil {
 		slog.ErrorContext(ctx, fmt.Sprintf("Error opening ingest file %s: %v", filePath, err))

--- a/packages/go/dawgs/drivers/neo4j/batch.go
+++ b/packages/go/dawgs/drivers/neo4j/batch.go
@@ -18,9 +18,12 @@ package neo4j
 
 import (
 	"context"
+	"fmt"
+	"log/slog"
 	"strings"
 
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
+	"github.com/specterops/bloodhound/bhlog/measure"
 	"github.com/specterops/bloodhound/dawgs/graph"
 	"github.com/specterops/bloodhound/dawgs/util/size"
 )
@@ -72,6 +75,7 @@ func (s *batchTransaction) UpdateNodeBy(update graph.NodeUpdate) error {
 }
 
 func (s *batchTransaction) UpdateRelationshipBy(update graph.RelationshipUpdate) error {
+	defer measure.ContextMeasure(s.innerTx.ctx, slog.LevelDebug, "update relationship by", slog.String("pattern", fmt.Sprintf("(%d)-[%s]->(%d)", update.Start.ID, update.Relationship.Kind, update.End.ID)))()
 	if s.relationshipUpdateByBuffer = append(s.relationshipUpdateByBuffer, update); len(s.relationshipUpdateByBuffer) >= s.batchWriteSize {
 		return s.flushRelationshipUpdates()
 	}

--- a/packages/go/dawgs/drivers/neo4j/cypher.go
+++ b/packages/go/dawgs/drivers/neo4j/cypher.go
@@ -32,7 +32,7 @@ func newUpdateKey(identityKind graph.Kind, identityProperties []string, updateKi
 	var keys []string
 
 	// Defensive check: identityKind may be nil or zero value
-	if identityKind != nil {
+	if identityKind != nil && !identityKind.Is(graph.EmptyKind) {
 		keys = append(keys, identityKind.String())
 	}
 
@@ -113,7 +113,7 @@ func cypherBuildRelationshipUpdateQueryBatch(updates []graph.RelationshipUpdate)
 	for _, batch := range batchedUpdates {
 		output.WriteString("unwind $p as p merge (s")
 
-		if batch.startIdentityKind != nil {
+		if batch.startIdentityKind != nil && !batch.startIdentityKind.Is(graph.EmptyKind) {
 			output.WriteString(fmt.Sprintf(":%s", batch.startIdentityKind.String()))
 		}
 
@@ -137,7 +137,7 @@ func cypherBuildRelationshipUpdateQueryBatch(updates []graph.RelationshipUpdate)
 		}
 
 		output.WriteString(") merge (e")
-		if batch.endIdentityKind != nil {
+		if batch.endIdentityKind != nil && !batch.endIdentityKind.Is(graph.EmptyKind) {
 			output.WriteString(fmt.Sprintf(":%s", batch.endIdentityKind.String()))
 		}
 
@@ -260,7 +260,7 @@ func cypherBuildNodeUpdateQueryBatch(updates []graph.NodeUpdate) ([]string, []ma
 	for _, batch := range batchedUpdates {
 		output.WriteString("unwind $p as p merge (n")
 
-		if batch.identityKind != nil {
+		if batch.identityKind != nil && !batch.identityKind.Is(graph.EmptyKind) {
 			output.WriteString(fmt.Sprintf(":%s", batch.identityKind.String()))
 		}
 


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Fixes non-indexed lookups for ingest queries regression introduced in #1404 

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-6059

A performance regression that only affected Neo4j was introduced with the mentioned PR that was expanding ingest functionality. Postgres was not affected since the way indexing works for our Postgres graphs does not rely on a Kind label to be explicitly added.

This fix patches the hole, while adding some guards to keep the newer ingest work functional.

## How Has This Been Tested?

Ran through both our example azure dataset (this was a reliable way to trigger the performance issues) and a generic ingest payload through both BloodHound and BHE with this set of fixes without errors and with expected performance and results.

## Types of changes

<!-- Please remove any items that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
