### PR TITLE
BED-5896: Mark /api/v2/asset-groups/{id}/members as deprecated in OpenAPI docs

### DIFF
--- a/packages/go/openapi/doc/openapi.json
+++ b/packages/go/openapi/doc/openapi.json
@@ -2891,25 +2891,32 @@
                     }
                   }
                 },
-                "example": [
-                  {
-                    "data": [
-                      {
-                          "id": 1,
-                          "kindName": "KindA",
-                          "config": {
-                              "icon": {
-                                  "type": "font-awesome",
-                                  "name": "house",
-                                  "color": "#FFFFFF"
-                              }
-                          }
+                "example": {
+                  "data": [
+                    {
+                      "id": 1,
+                      "kindName": "KindA",
+                      "config": {
+                        "icon": {
+                          "type": "font-awesome",
+                          "name": "house",
+                          "color": "#FFFFFF"
+                        }
                       }
-                    ]
-                  }
-                  
-                  
-                ]
+                    },
+                    {
+                      "id": 2,
+                      "kindName": "KindB",
+                      "config": {
+                        "icon": {
+                          "type": "font-awesome",
+                          "name": "coffee",
+                          "color": "#000000"
+                        }
+                      }
+                    }
+                  ]
+                }
               }
             }
           },
@@ -3054,9 +3061,11 @@
                   "id": 1,
                   "kindName": "KindA",
                   "config": {
-                    "type": "font-awesome",
-                    "name": "house",
-                    "color": "#FFFFFF"
+                    "icon": {
+                      "type": "font-awesome",
+                      "name": "house",
+                      "color": "#FFFFFF"
+                    }
                   }
                 }
               }
@@ -4556,8 +4565,9 @@
       ],
       "get": {
         "operationId": "ListAssetGroupMembers",
+        "deprecated": true,
         "summary": "List all asset isolation group members",
-        "description": "List all members of an asset isolation group.",
+        "description": "**Deprecated**: This endpoint will no longer be supported in a future release. Please use `GET /api/v2/asset-group-tags/{asset_group_tag_id}/members` or `GET /api/v2/asset-group-tags/{asset_group_tag_id}/selectors/{asset_group_tag_selector_id}/members` instead.\n",
         "tags": [
           "Asset Isolation",
           "Community",

--- a/packages/go/openapi/src/paths/asset-isolation.asset-groups.id.members.yaml
+++ b/packages/go/openapi/src/paths/asset-isolation.asset-groups.id.members.yaml
@@ -26,8 +26,11 @@ parameters:
 
 get:
   operationId: ListAssetGroupMembers
+  deprecated: true
   summary: List all asset isolation group members
-  description: List all members of an asset isolation group.
+  description: > 
+    **Deprecated**: This endpoint will no longer be supported in a future release.
+    Please use `GET /api/v2/asset-group-tags/{asset_group_tag_id}/members` or `GET /api/v2/asset-group-tags/{asset_group_tag_id}/selectors/{asset_group_tag_selector_id}/members` instead.
   tags:
     - Asset Isolation
     - Community

--- a/packages/go/openapi/src/paths/custom-nodes.custom-nodes.name.yaml
+++ b/packages/go/openapi/src/paths/custom-nodes.custom-nodes.name.yaml
@@ -43,9 +43,10 @@ get:
             id: 1
             kindName: "KindA"
             config:
-              type: "font-awesome"
-              name: "house"
-              color: "#FFFFFF"
+              icon:
+                type: "font-awesome"
+                name: "house"
+                color: "#FFFFFF"
     401:
       $ref: './../responses/unauthorized.yaml'
     404:

--- a/packages/go/openapi/src/paths/custom-nodes.custom-nodes.yaml
+++ b/packages/go/openapi/src/paths/custom-nodes.custom-nodes.yaml
@@ -39,18 +39,21 @@ get:
                 items:
                   $ref: './../schemas/model.custom-node.yaml'
           example:
-            - id: 1
-              kindName: "KindA"
-              config:
-                type: "font-awesome"
-                name: "house"
-                color: "#FFFFFF"
-            - id: 2
-              kindName: "KindB"
-              config:
-                type: "font-awesome"
-                name: "coffee"
-                color: "#000000"
+            data:
+              - id: 1
+                kindName: "KindA"
+                config:
+                  icon:
+                    type: "font-awesome"
+                    name: "house"
+                    color: "#FFFFFF"
+              - id: 2
+                kindName: "KindB"
+                config:
+                  icon:
+                    type: "font-awesome"
+                    name: "coffee"
+                    color: "#000000"
     401:
       $ref: './../responses/unauthorized.yaml'
     500:


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

- Marked `/api/v2/asset-groups/{id}/members` as deprecated in the OpenAPI docs
- Fixed previous openAPI syntax warnings/errors

## Motivation and Context

This PR addresses:

- BED-5896

*Why is this change required? What problem does it solve?*
- Marking `/api/v2/asset-groups/{id}/members` as deprecated in the OpenAPI docs gives context to users that the endpoint is no longer being supported, and that they should use the endpoints: `GET /api/v2/asset-group-tags/{asset_group_tag_id}/members` or `GET /api/v2/asset-group-tags/{asset_group_tag_id}/selectors/{asset_group_tag_selector_id}/members` instead

## How Has This Been Tested?

- Local testing by confirming the changes made were shown on my OpenAPI Swagger UI preview within vscode

## Screenshots (optional):
<img width="945" alt="Screenshot 2025-06-25 at 2 56 54 PM" src="https://github.com/user-attachments/assets/61c66ba3-af75-46db-b974-7c20723ea7f7" />


## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)
- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated API documentation to mark the asset group members listing endpoint as deprecated and provided guidance on alternative endpoints.
  - Improved example responses for custom node endpoints to better reflect current response structures, including updated nesting for icon properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->