### PR TITLE
BED-6088: AzureHound Collector Bump

### DIFF
--- a/dockerfiles/bloodhound.Dockerfile
+++ b/dockerfiles/bloodhound.Dockerfile
@@ -20,7 +20,7 @@
 # Global build args
 ################
 ARG SHARPHOUND_VERSION=v2.6.7
-ARG AZUREHOUND_VERSION=v2.5.0
+ARG AZUREHOUND_VERSION=v2.6.0
 
 ########
 # Package remote assets

--- a/tools/docker-compose/api.Dockerfile
+++ b/tools/docker-compose/api.Dockerfile
@@ -18,7 +18,7 @@
 # Global build args
 ################
 ARG SHARPHOUND_VERSION=v2.6.7
-ARG AZUREHOUND_VERSION=v2.5.0
+ARG AZUREHOUND_VERSION=v2.6.0
 
 ########
 # Package other assets


### PR DESCRIPTION
## Description

Updates the AzureHound collector to 2.6.0
## Motivation and Context

https://specterops.atlassian.net/browse/BED-6088

## How Has This Been Tested?

Locally checked new version

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [ ] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
