### PR TITLE
BED-5769: Fix user form test performance issues

### DIFF
--- a/packages/javascript/bh-shared-ui/src/components/CreateUserForm/CreateUserForm.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/CreateUserForm/CreateUserForm.test.tsx
@@ -110,10 +110,10 @@ describe('CreateUserForm', () => {
         await user.click(button);
 
         expect(await screen.findByText(`Principal Name must be ${MIN_NAME_LENGTH} characters or more`))
-            .toBeInTheDocument;
-        expect(await screen.findByText(`First Name must be ${MIN_NAME_LENGTH} characters or more`)).toBeInTheDocument;
-        expect(await screen.findByText(`Last Name must be ${MIN_NAME_LENGTH} characters or more`)).toBeInTheDocument;
-        expect(await screen.findByText('Password must be at least 12 characters long')).toBeInTheDocument;
+            .toBeInTheDocument();
+        expect(await screen.findByText(`First Name must be ${MIN_NAME_LENGTH} characters or more`)).toBeInTheDocument();
+        expect(await screen.findByText(`Last Name must be ${MIN_NAME_LENGTH} characters or more`)).toBeInTheDocument();
+        expect(await screen.findByText('Password must be at least 12 characters long')).toBeInTheDocument();
     });
 
     it('should not allow the input to exceed the allowed length', async () => {
@@ -130,20 +130,31 @@ describe('CreateUserForm', () => {
 
         const user = userEvent.setup();
         const button = screen.getByRole('button', { name: 'Save' });
-        await user.type(screen.getByLabelText(/email/i), 'a'.repeat(309) + '@domain.com');
-        await user.type(screen.getByLabelText(/principal/i), 'a'.repeat(1001));
-        await user.type(screen.getByLabelText(/first/i), 'a'.repeat(1001));
-        await user.type(screen.getByLabelText(/last/i), 'a'.repeat(1001));
-        await user.type(screen.getByLabelText(/Initial password/i), 'a'.repeat(1001));
+
+        await user.click(screen.getByLabelText(/email/i));
+        await user.paste('a'.repeat(309) + '@domain.com');
+
+        await user.click(screen.getByLabelText(/principal/i));
+        await user.paste('a'.repeat(1001));
+
+        await user.click(screen.getByLabelText(/first/i));
+        await user.paste('a'.repeat(1001));
+
+        await user.click(screen.getByLabelText(/last/i));
+        await user.paste('a'.repeat(1001));
+
+        await user.click(screen.getByLabelText(/Initial password/i));
+        await user.paste('a'.repeat(1001));
+
         await user.click(button);
 
         expect(await screen.findByText(`Email address must be less than ${MAX_EMAIL_LENGTH} characters`))
-            .toBeInTheDocument;
+            .toBeInTheDocument();
         expect(await screen.findByText(`Principal Name must be less than ${MAX_NAME_LENGTH} characters`))
-            .toBeInTheDocument;
-        expect(await screen.findByText(`First Name must be less than ${MAX_NAME_LENGTH} characters`)).toBeInTheDocument;
-        expect(await screen.findByText(`Last Name must be less than ${MAX_NAME_LENGTH} characters`)).toBeInTheDocument;
-        expect(await screen.findByText('Password must be less than 1000 characters')).toBeInTheDocument;
+            .toBeInTheDocument();
+        expect(await screen.findByText(`First Name must be less than ${MAX_NAME_LENGTH} characters`)).toBeInTheDocument();
+        expect(await screen.findByText(`Last Name must be less than ${MAX_NAME_LENGTH} characters`)).toBeInTheDocument();
+        expect(await screen.findByText('Password must be less than 1000 characters')).toBeInTheDocument();
     });
 
     it('should not allow leading or trailing empty spaces', async () => {
@@ -165,8 +176,8 @@ describe('CreateUserForm', () => {
         await user.type(screen.getByLabelText(/last/i), 'asdfw ');
         await user.click(button);
 
-        expect(await screen.findByText('Principal Name does not allow leading or trailing spaces')).toBeInTheDocument;
-        expect(await screen.findByText('First Name does not allow leading or trailing spaces')).toBeInTheDocument;
-        expect(await screen.findByText('Last Name does not allow leading or trailing spaces')).toBeInTheDocument;
+        expect(await screen.findByText('Principal Name does not allow leading or trailing spaces')).toBeInTheDocument();
+        expect(await screen.findByText('First Name does not allow leading or trailing spaces')).toBeInTheDocument();
+        expect(await screen.findByText('Last Name does not allow leading or trailing spaces')).toBeInTheDocument();
     });
 });

--- a/packages/javascript/bh-shared-ui/src/components/UpdateUserForm/UpdateUserForm.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/UpdateUserForm/UpdateUserForm.test.tsx
@@ -390,15 +390,15 @@ describe('UpdateUserForm', () => {
 
         await user.click(screen.getByLabelText(/last/i));
         await user.paste('a'.repeat(1001));
-        
+
         await user.click(button);
 
         expect(await screen.findByText(`Email address must be less than ${MAX_EMAIL_LENGTH} characters`))
-            .toBeInTheDocument;
+            .toBeInTheDocument();
         expect(await screen.findByText(`Principal Name must be less than ${MAX_NAME_LENGTH} characters`))
-            .toBeInTheDocument;
-        expect(await screen.findByText(`First Name must be less than ${MAX_NAME_LENGTH} characters`)).toBeInTheDocument;
-        expect(await screen.findByText(`Last Name must be less than ${MAX_NAME_LENGTH} characters`)).toBeInTheDocument;
+            .toBeInTheDocument();
+        expect(await screen.findByText(`First Name must be less than ${MAX_NAME_LENGTH} characters`)).toBeInTheDocument();
+        expect(await screen.findByText(`Last Name must be less than ${MAX_NAME_LENGTH} characters`)).toBeInTheDocument();
     });
 
     it('should not have less characters than the minimum requirement', async () => {
@@ -426,9 +426,9 @@ describe('UpdateUserForm', () => {
         await user.click(button);
 
         expect(await screen.findByText(`Principal Name must be ${MIN_NAME_LENGTH} characters or more`))
-            .toBeInTheDocument;
-        expect(await screen.findByText(`First Name must be ${MIN_NAME_LENGTH} characters or more`)).toBeInTheDocument;
-        expect(await screen.findByText(`Last Name must be ${MIN_NAME_LENGTH} characters or more`)).toBeInTheDocument;
+            .toBeInTheDocument();
+        expect(await screen.findByText(`First Name must be ${MIN_NAME_LENGTH} characters or more`)).toBeInTheDocument();
+        expect(await screen.findByText(`Last Name must be ${MIN_NAME_LENGTH} characters or more`)).toBeInTheDocument();
     });
 
     it('should not allow leading or trailing empty spaces', async () => {
@@ -455,8 +455,8 @@ describe('UpdateUserForm', () => {
         await user.type(screen.getByLabelText(/last/i), 'asdfw ');
         await user.click(button);
 
-        expect(await screen.findByText('Principal Name does not allow leading or trailing spaces')).toBeInTheDocument;
-        expect(await screen.findByText('First Name does not allow leading or trailing spaces')).toBeInTheDocument;
-        expect(await screen.findByText('Last Name does not allow leading or trailing spaces')).toBeInTheDocument;
+        expect(await screen.findByText('Principal Name does not allow leading or trailing spaces')).toBeInTheDocument();
+        expect(await screen.findByText('First Name does not allow leading or trailing spaces')).toBeInTheDocument();
+        expect(await screen.findByText('Last Name does not allow leading or trailing spaces')).toBeInTheDocument();
     });
 });

--- a/packages/javascript/bh-shared-ui/src/components/UpdateUserForm/UpdateUserForm.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/UpdateUserForm/UpdateUserForm.test.tsx
@@ -379,10 +379,18 @@ describe('UpdateUserForm', () => {
         const user = userEvent.setup();
         const button = screen.getByRole('button', { name: 'Save' });
 
-        await user.type(screen.getByLabelText(/email/i), 'a'.repeat(309) + '@domain.com');
-        await user.type(screen.getByLabelText(/principal/i), 'a'.repeat(1001));
-        await user.type(screen.getByLabelText(/first/i), 'a'.repeat(1001));
-        await user.type(screen.getByLabelText(/last/i), 'a'.repeat(1001));
+        await user.click(screen.getByLabelText(/email/i));
+        await user.paste('a'.repeat(309) + '@domain.com');
+
+        await user.click(screen.getByLabelText(/principal/i));
+        await user.paste('a'.repeat(1001));
+
+        await user.click(screen.getByLabelText(/first/i));
+        await user.paste('a'.repeat(1001));
+
+        await user.click(screen.getByLabelText(/last/i));
+        await user.paste('a'.repeat(1001));
+        
         await user.click(button);
 
         expect(await screen.findByText(`Email address must be less than ${MAX_EMAIL_LENGTH} characters`))


### PR DESCRIPTION
## Description
Updates tests for our "Create/Update User" forms to use `userEvent.paste()` instead of `userEvent.type()` for testing our max input length field validation.

## Motivation and Context
Due to the number of user events being simulated when "typing" very long strings, these tests were very long-running and were causing CI failures due to timeouts.

## How Has This Been Tested?

## Screenshots (optional):

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
