### PR TITLE
BED-5983: Retire "Automatically add parent OUs and containers of Tier Zero AD objects to Tier Zero" EA setting

### DIFF
--- a/cmd/api/src/database/migration/migrations/v7.6.0.sql
+++ b/cmd/api/src/database/migration/migrations/v7.6.0.sql
@@ -26,8 +26,5 @@ INSERT INTO parameters (key, name, description, value, created_at, updated_at) V
 -- Add Auth Session TTL Hours
 INSERT INTO parameters (key, name, description, value, created_at, updated_at) VALUES ('auth.session_ttl_hours', 'Auth Session TTL Hours', 'This configuration parameter determines the length of time in hours a logged in session stays active before expiration.', '{"hours": 8}', current_timestamp, current_timestamp) ON CONFLICT DO NOTHING;
 
--- Set the `auto_tag_t0_parent_objects` feature flag to true
-UPDATE feature_flags SET enabled = true WHERE key = 'auto_tag_t0_parent_objects';
-
--- Retire auto_tag_t0_parent_objects EA setting
-UPDATE feature_flags SET user_updatable = false WHERE key = 'auto_tag_t0_parent_objects';
+-- Retire the `auto_tag_t0_parent_objects` feature flag
+UPDATE feature_flags SET enabled = true, user_updatable = false WHERE key = 'auto_tag_t0_parent_objects';


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

- Altered migration file in order to retire auto_tag_t0_parent_objects EA setting

## Motivation and Context

This PR addresses:

- BED-5983

*Why is this change required? What problem does it solve?*

- With the addition of Privilege Zone Management, there is no longer a need for this flag/setting

## How Has This Been Tested?

- Locally

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)
- Database Migrations

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated feature flag settings to enable `auto_tag_t0_parent_objects` and prevent users from modifying it.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->