### PR TITLE
OpenGraph: include error context

### DIFF
--- a/cmd/api/src/services/entrypoint.go
+++ b/cmd/api/src/services/entrypoint.go
@@ -102,7 +102,7 @@ func Entrypoint(ctx context.Context, cfg config.Configuration, connections boots
 	} else if collectorManifests, err := cfg.SaveCollectorManifests(); err != nil {
 		return nil, fmt.Errorf("failed to save collector manifests: %w", err)
 	} else if ingestSchema, err := upload.LoadIngestSchema(); err != nil {
-		return nil, fmt.Errorf("failed to load ingest schema")
+		return nil, fmt.Errorf("failed to load OpenGraph schema: %w", err)
 	} else {
 		var (
 			graphQuery     = queries.NewGraphQuery(connections.Graph, graphQueryCache, cfg)

--- a/cmd/api/src/services/upload/schema.go
+++ b/cmd/api/src/services/upload/schema.go
@@ -36,6 +36,7 @@ type IngestSchema struct {
 	EdgeSchema *jsonschema.Schema
 }
 
+// LoadIngestSchema constructs the JSON schema for OpenGraph ingest payloads
 func LoadIngestSchema() (IngestSchema, error) {
 	var schema IngestSchema
 	if nodeSchema, err := loadSchema("node.json"); err != nil {


### PR DESCRIPTION
## Description
we need to include more error context when ingest schema doesn't load

## Motivation and Context

## How Has This Been Tested?

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)
- Database Migrations

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [ ] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [ ] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [ ] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages when loading the OpenGraph schema, providing more specific details for easier troubleshooting.

* **Documentation**
  * Added a descriptive comment to clarify the purpose of the function responsible for constructing the OpenGraph ingest payload schema.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->