### PR TITLE
BED-6127: Added KindAZRoleEligibilityScheduleInstance To The Azure Converters

### DIFF
--- a/cmd/api/src/services/graphify/azure_convertors.go
+++ b/cmd/api/src/services/graphify/azure_convertors.go
@@ -144,6 +144,8 @@ func getKindConverter(kind enums.Kind) func(json.RawMessage, *ConvertedAzureData
 		return convertAzureAutomationAccountRoleAssignment
 	case enums.KindAZRoleManagementPolicyAssignment:
 		return convertAzureRoleManagementPolicyAssignment
+	case enums.KindAZRoleEligibilityScheduleInstance:
+		return convertAzureRoleEligibilityScheduleInstance
 	default:
 		// TODO: we should probably have a hook or something to log the unknown type
 		return func(rm json.RawMessage, cd *ConvertedAzureData, now time.Time) {}
@@ -725,5 +727,16 @@ func convertAzureRoleManagementPolicyAssignment(raw json.RawMessage, converted *
 		nodes, relationships := ein.ConvertAzureRoleManagementPolicyAssignment(data)
 		converted.NodeProps = append(converted.NodeProps, nodes)
 		converted.RelProps = append(converted.RelProps, relationships...)
+	}
+}
+
+func convertAzureRoleEligibilityScheduleInstance(raw json.RawMessage, converted *ConvertedAzureData, ingestTime time.Time) {
+	var data models.RoleEligibilityScheduleInstance
+
+	if err := json.Unmarshal(raw, &data); err != nil {
+		slog.Error(fmt.Sprintf(SerialError, "azure role eligibility schedule instance", err))
+	} else {
+		relProps := ein.ConvertAzureRoleEligibilityScheduleInstanceToRel(data)
+		converted.RelProps = append(converted.RelProps, relProps...)
 	}
 }


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

This takes the function defined in BHE used for `KindAZRoleEligibilityScheduleInstance` ingestion, removes the BHE specific code, and allows BHE to create `AZRoleEligible` edges

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-6127


## How Has This Been Tested?

I ingested a sample AzureHound dataset and searched for the nodes using
```
MATCH p = (:AZBase)-[:AZRoleEligible]-(:AZBase)
RETURN p
```

## Screenshots (optional):
<img width="1898" alt="image" src="https://github.com/user-attachments/assets/fa8b08ab-85f3-4791-bbae-a32b1a1c1b5c" />


## Types of changes

<!-- Please remove any items that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
