### PR TITLE
BED-6148 chore: remove app config perms from power users

### DIFF
--- a/cmd/api/src/auth/role.go
+++ b/cmd/api/src/auth/role.go
@@ -77,8 +77,6 @@ func Roles() map[string]RoleTemplate {
 			Name:        RolePowerUser,
 			Description: "Can upload data, manage clients, and perform any action a User can",
 			Permissions: model.Permissions{
-				permissions.AppReadApplicationConfiguration,
-				permissions.AppWriteApplicationConfiguration,
 				permissions.APsGenerateReport,
 				permissions.APsManageAPs,
 				permissions.AuthCreateToken,

--- a/cmd/api/src/database/migration/migrations/v8.0.0.sql
+++ b/cmd/api/src/database/migration/migrations/v8.0.0.sql
@@ -1,0 +1,20 @@
+-- Copyright 2025 Specter Ops, Inc.
+--
+-- Licensed under the Apache License, Version 2.0
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- SPDX-License-Identifier: Apache-2.0
+
+-- Remove the ReadAppConfig / WriteAppConfig from power users role
+DELETE FROM roles_permissions
+WHERE role_id = (SELECT id FROM roles WHERE roles.name = 'Power User')
+  AND permission_id IN (SELECT id FROM permissions WHERE permissions.authority = 'app' AND permissions.name IN ('ReadAppConfig', 'WriteAppConfig'));


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Removed WriteAppConfig and ReadAppConfig from power user

*Describe your changes in detail*

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-6148

*Why is this change required? What problem does it solve?*

## How Has This Been Tested?
integration tests auto updated and passed

*Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc.*

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)
- Database Migrations

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed the ability for Power Users to read or modify application configuration settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->