### PR TITLE
BED-5960 feat(AGT): add analysis enabled / disabled actions to AGT history

### DIFF
--- a/cmd/api/src/database/assetgrouptags.go
+++ b/cmd/api/src/database/assetgrouptags.go
@@ -453,8 +453,20 @@ func (s *BloodhoundDB) UpdateAssetGroupTag(ctx context.Context, user model.User,
 					return CheckError(result)
 				}
 			}
+
 			if err := bhdb.CreateAssetGroupHistoryRecord(ctx, user.ID.String(), user.EmailAddress.ValueOrZero(), tag.Name, model.AssetGroupHistoryActionUpdateTag, tag.ID, null.String{}, null.String{}); err != nil {
 				return err
+			}
+
+			// Analysis was updated, create an additional separate history record
+			if !origTag.AnalysisEnabled.Equal(tag.AnalysisEnabled) {
+				action := model.AssetGroupHistoryActionAnalysisDisabledTag
+				if tag.AnalysisEnabled.ValueOrZero() {
+					action = model.AssetGroupHistoryActionAnalysisEnabledTag
+				}
+				if err := bhdb.CreateAssetGroupHistoryRecord(ctx, user.ID.String(), user.EmailAddress.ValueOrZero(), tag.Name, action, tag.ID, null.String{}, null.String{}); err != nil {
+					return err
+				}
 			}
 		}
 

--- a/cmd/api/src/model/assetgrouphistory.go
+++ b/cmd/api/src/model/assetgrouphistory.go
@@ -29,6 +29,9 @@ const (
 	AssetGroupHistoryActionUpdateTag AssetGroupHistoryAction = "UpdateTag"
 	AssetGroupHistoryActionDeleteTag AssetGroupHistoryAction = "DeleteTag"
 
+	AssetGroupHistoryActionAnalysisEnabledTag  AssetGroupHistoryAction = "AnalysisEnabledTag"
+	AssetGroupHistoryActionAnalysisDisabledTag AssetGroupHistoryAction = "AnalysisDisabledTag"
+
 	AssetGroupHistoryActionCreateSelector AssetGroupHistoryAction = "CreateSelector"
 	AssetGroupHistoryActionUpdateSelector AssetGroupHistoryAction = "UpdateSelector"
 	AssetGroupHistoryActionDeleteSelector AssetGroupHistoryAction = "DeleteSelector"


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Added specific analysisEnabledTag / analysisDisabledTag history records when zone analysis is toggled

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Resolves: BED-5960

## How Has This Been Tested?
Locally enabled / disabled analysis through the PATCH `/asset-group-tags` endpoint and inspected the db for the new records. Also added unit test to handler test

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (a change that does not modify the application functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Documentation updates are needed, and have been made accordingly.
- [x] I have added and/or updated tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] My changes include a database migration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved history tracking for asset group tags by recording specific changes when analysis is enabled or disabled.
  * Added clearer action types for analysis status changes in asset group tag history.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->