### PR TITLE
fix: failing unit test

### DIFF
--- a/cmd/ui/src/views/Explore/ContextMenu/ContextMenuZoneManagementEnabled.test.tsx
+++ b/cmd/ui/src/views/Explore/ContextMenu/ContextMenuZoneManagementEnabled.test.tsx
@@ -176,8 +176,8 @@ describe('ContextMenu', () => {
         const tip = await screen.findByRole('tooltip');
         expect(tip).toBeInTheDocument();
 
-        const displayNameOption = screen.getByLabelText(/display name/i);
-        expect(displayNameOption).toBeInTheDocument();
+        const nameOption = screen.getByLabelText(/name/i);
+        expect(nameOption).toBeInTheDocument();
 
         const objectIdOption = screen.getByLabelText(/object id/i);
         expect(objectIdOption).toBeInTheDocument();
@@ -189,7 +189,7 @@ describe('ContextMenu', () => {
         await userEvent.unhover(copyOption);
 
         await waitFor(() => {
-            expect(screen.queryByText(/display name/i)).not.toBeInTheDocument();
+            expect(screen.queryByText(/name/i)).not.toBeInTheDocument();
             expect(screen.queryByText(/object id/i)).not.toBeInTheDocument();
             expect(screen.queryByText(/cypher/i)).not.toBeInTheDocument();
         });


### PR DESCRIPTION
closes BED-6173

<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Unit test is updated to match changes that were made recently.

## Motivation and Context

Resolves BED-6173

unit tests are failing in main currently so this fixes the issue.

## How Has This Been Tested?
tests were run locally and they all pass now

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test to check for the "name" label instead of "display name" in the submenu when hovering over the "Copy" menu item.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->