### PR TITLE
Fix: BED-6098 Fixing test to match new item name 

### DIFF
--- a/cmd/ui/src/views/Explore/ContextMenu/ContextMenuZoneManagementEnabled.test.tsx
+++ b/cmd/ui/src/views/Explore/ContextMenu/ContextMenuZoneManagementEnabled.test.tsx
@@ -176,8 +176,8 @@ describe('ContextMenu', () => {
         const tip = await screen.findByRole('tooltip');
         expect(tip).toBeInTheDocument();
 
-        const displayNameOption = screen.getByLabelText(/display name/i);
-        expect(displayNameOption).toBeInTheDocument();
+        const NameOption = screen.getByLabelText(/name/i);
+        expect(NameOption).toBeInTheDocument();
 
         const objectIdOption = screen.getByLabelText(/object id/i);
         expect(objectIdOption).toBeInTheDocument();
@@ -189,7 +189,7 @@ describe('ContextMenu', () => {
         await userEvent.unhover(copyOption);
 
         await waitFor(() => {
-            expect(screen.queryByText(/display name/i)).not.toBeInTheDocument();
+            expect(screen.queryByText(/name/i)).not.toBeInTheDocument();
             expect(screen.queryByText(/object id/i)).not.toBeInTheDocument();
             expect(screen.queryByText(/cypher/i)).not.toBeInTheDocument();
         });

--- a/cmd/ui/src/views/Explore/ContextMenu/ContextMenuZoneManagementEnabled.test.tsx
+++ b/cmd/ui/src/views/Explore/ContextMenu/ContextMenuZoneManagementEnabled.test.tsx
@@ -177,7 +177,7 @@ describe('ContextMenu', () => {
         expect(tip).toBeInTheDocument();
 
         const NameOption = screen.getByLabelText(/name/i);
-        expect(NameOption).toBeInTheDocument();
+        expect(NameOption).toBeInTheDocument(); 
 
         const objectIdOption = screen.getByLabelText(/object id/i);
         expect(objectIdOption).toBeInTheDocument();


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Fixing test to match new item `name` instead of `display name`

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-6098

*Why is this change required? What problem does it solve?*

## How Has This Been Tested?

*Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc.*

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)
- Database Migrations

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test assertions to use "name" instead of "display name" when verifying submenu options in the context menu.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->