### PR TITLE
Support HasSIDHistroy on Groups

### DIFF
--- a/cmd/api/src/services/graphify/convertors.go
+++ b/cmd/api/src/services/graphify/convertors.go
@@ -145,6 +145,7 @@ func convertGroupData(group ein.Group, converted *ConvertedGroupData, ingestTime
 	groupMembershipData := ein.ParseGroupMembershipData(group)
 	converted.RelProps = append(converted.RelProps, groupMembershipData.RegularMembers...)
 	converted.DistinguishedNameProps = append(converted.DistinguishedNameProps, groupMembershipData.DistinguishedNameMembers...)
+	converted.RelProps = append(converted.RelProps, ein.ParseGroupMiscData(group)...)
 }
 
 func convertDomainData(domain ein.Domain, converted *ConvertedData, ingestTime time.Time) {

--- a/packages/go/ein/ad.go
+++ b/packages/go/ein/ad.go
@@ -311,6 +311,30 @@ func ParsePrimaryGroup(item IngestBase, itemType graph.Kind, primaryGroupSid str
 	return NewIngestibleRelationship(IngestibleEndpoint{}, IngestibleEndpoint{}, IngestibleRel{})
 }
 
+// ParseGroupMiscData parses HasSIDHistory
+func ParseGroupMiscData(group Group) []IngestibleRelationship {
+	data := make([]IngestibleRelationship, 0)
+
+	for _, target := range group.HasSIDHistory {
+		data = append(data, NewIngestibleRelationship(
+			IngestibleEndpoint{
+				Value: group.ObjectIdentifier,
+				Kind:  ad.Group,
+			},
+			IngestibleEndpoint{
+				Value: target.ObjectIdentifier,
+				Kind:  target.Kind(),
+			},
+			IngestibleRel{
+				RelProps: map[string]any{ad.IsACL.String(): false},
+				RelType:  ad.HasSIDHistory,
+			},
+		))
+	}
+
+	return data
+}
+
 func ParseGroupMembershipData(group Group) ParsedGroupMembershipData {
 	result := ParsedGroupMembershipData{}
 	for _, member := range group.Members {

--- a/packages/go/ein/ad_test.go
+++ b/packages/go/ein/ad_test.go
@@ -17,9 +17,10 @@
 package ein_test
 
 import (
-	"github.com/specterops/dawgs/graph"
 	"testing"
 	"time"
+
+	"github.com/specterops/dawgs/graph"
 
 	"github.com/specterops/bloodhound/packages/go/ein"
 	"github.com/specterops/bloodhound/packages/go/graphschema/ad"

--- a/packages/go/ein/incoming_models.go
+++ b/packages/go/ein/incoming_models.go
@@ -209,7 +209,8 @@ type Session struct {
 
 type Group struct {
 	IngestBase
-	Members []TypedPrincipal
+	Members       []TypedPrincipal
+	HasSIDHistory []TypedPrincipal
 }
 
 type User struct {


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

This change adds support for BloodHound to show the HasSIDHistory Edge when collected from groups. 

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves [BED-4881](https://specterops.atlassian.net/browse/BED-4881)

## How Has This Been Tested?

This change has been tested by running BloodHound locally with an updated collection, and ensuring the edge was present for the user. In addition, unit tests were added for the new function. 

## Screenshots (optional):

<img width="1588" height="706" alt="image" src="https://github.com/user-attachments/assets/ad055217-a784-49ff-bcc0-83f3cd0ccc83" />


## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)
- New feature (non-breaking change which adds functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


[BED-4881]: https://specterops.atlassian.net/browse/BED-4881?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced group data to include SID history relationships, providing more comprehensive information about group associations.

* **Tests**
  * Added new tests to ensure correct handling and display of group SID history relationships.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->