### PR TITLE
BED-6171 - Remove Verbosity Filter for StBernard Interactive Commands

### DIFF
--- a/packages/go/stbernard/cmdrunner/cmdrunner.go
+++ b/packages/go/stbernard/cmdrunner/cmdrunner.go
@@ -18,7 +18,6 @@ package cmdrunner
 
 import (
 	"bytes"
-	"context"
 	"errors"
 	"io"
 	"log/slog"
@@ -152,12 +151,8 @@ func Run(command string, args []string, path string, env environment.Environment
 // to stdout and stderr as they are written to by the executed application.
 func RunInteractive(command string, args []string, path string, env environment.Environment) (*ExecutionResult, error) {
 	cmd, result := prepareCommand(command, args, path, env)
-
-	// Interactive output should only emit if the log level is verbose enough
-	if slog.Default().Enabled(context.Background(), slog.LevelInfo) {
-		cmd.Stdout = io.MultiWriter(cmd.Stdout, os.Stdout)
-		cmd.Stderr = io.MultiWriter(cmd.Stderr, os.Stderr)
-	}
+	cmd.Stdout = io.MultiWriter(cmd.Stdout, os.Stdout)
+	cmd.Stderr = io.MultiWriter(cmd.Stderr, os.Stderr)
 
 	return result, run(cmd, result)
 }


### PR DESCRIPTION
## Description

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-6171

## How Has This Been Tested?

Local test.

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated command output behavior to always display output in the console, regardless of log level settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->