### PR TITLE
fix: update tag id usage for object return value

### DIFF
--- a/cmd/ui/src/views/ZoneManagement/InfoHeader.tsx
+++ b/cmd/ui/src/views/ZoneManagement/InfoHeader.tsx
@@ -19,8 +19,8 @@ import { FC } from 'react';
 import { useParams } from 'react-router-dom';
 
 const InfoHeader: FC = () => {
-    const topTagId = useHighestPrivilegeTagId();
-    const { tierId = topTagId, labelId } = useParams();
+    const { tagId: topTagId } = useHighestPrivilegeTagId();
+    const { tierId = topTagId?.toString(), labelId } = useParams();
     const tagId = labelId === undefined ? tierId : labelId;
 
     return (

--- a/packages/javascript/bh-shared-ui/src/views/ZoneManagement/Details/Details.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/ZoneManagement/Details/Details.tsx
@@ -76,8 +76,8 @@ export const getEditButtonState = (memberId?: string, selectorsQuery?: UseQueryR
 const Details: FC = () => {
     const navigate = useAppNavigate();
     const location = useLocation();
-    const topTagId = useHighestPrivilegeTagId()?.toString();
-    const { tierId = topTagId, labelId, selectorId, memberId } = useParams();
+    const { tagId: topTagId } = useHighestPrivilegeTagId();
+    const { tierId = topTagId?.toString(), labelId, selectorId, memberId } = useParams();
     const tagId = labelId === undefined ? tierId : labelId;
 
     const context = useContext(ZoneManagementContext);

--- a/packages/javascript/bh-shared-ui/src/views/ZoneManagement/Details/DynamicDetails.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/ZoneManagement/Details/DynamicDetails.tsx
@@ -54,7 +54,7 @@ const TagDetails: FC<{ data: AssetGroupTag }> = ({ data }) => {
     const { SalesMessage } = useContext(ZoneManagementContext);
     const { tierId = '', labelId } = useParams();
     const tagId = labelId === undefined ? tierId : labelId;
-    const topTagId = useHighestPrivilegeTagId();
+    const { tagId: topTagId } = useHighestPrivilegeTagId();
     const ownedId = useOwnedTagId();
 
     return (

--- a/packages/javascript/bh-shared-ui/src/views/ZoneManagement/Save/Save.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/ZoneManagement/Save/Save.test.tsx
@@ -1,0 +1,88 @@
+// Copyright 2025 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { AssetGroupTagTypeTier } from 'js-client-library';
+import { rest } from 'msw';
+import { setupServer } from 'msw/node';
+import { useParams } from 'react-router-dom';
+import Save from '.';
+import { render, screen, waitFor } from '../../../test-utils';
+
+const handlers = [
+    rest.get('/api/v2/asset-group-tags', async (_, res, ctx) => {
+        return res(
+            ctx.json({
+                data: {
+                    tags: [
+                        { position: 1, id: 42, type: AssetGroupTagTypeTier },
+                        { position: 2, id: 23, type: AssetGroupTagTypeTier },
+                        { position: 7, id: 1, type: AssetGroupTagTypeTier },
+                        { position: 3, id: 2, type: AssetGroupTagTypeTier },
+                        { position: 777, id: 3, type: AssetGroupTagTypeTier },
+                    ],
+                },
+            })
+        );
+    }),
+    rest.get('/api/v2/asset-group-tags/1', async (_, res, ctx) => {
+        return res(ctx.status(200));
+    }),
+    rest.get('/api/v2/features', async (_req, res, ctx) => {
+        return res(
+            ctx.json({
+                data: [
+                    {
+                        key: 'tier_management_engine',
+                        enabled: true,
+                    },
+                ],
+            })
+        );
+    }),
+    rest.get('api/v2/config', async (req, rest, ctx) => {
+        return rest(ctx.status(200));
+    }),
+];
+
+const server = setupServer(...handlers);
+
+beforeAll(() => server.listen());
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+vi.mock('react-router-dom', async () => {
+    const actual = await vi.importActual('react-router-dom');
+    return {
+        ...actual,
+        useParams: vi.fn(),
+    };
+});
+
+describe('Create Update pages', () => {
+    it('has the correct value for the links in the breadcrumbs', async () => {
+        vi.mocked(useParams).mockReturnValue({ tierId: '1', labelId: undefined });
+        render(<Save />);
+
+        await screen.findByTestId('zone-management_save_details-breadcrumb');
+
+        waitFor(async () => {
+            expect(screen.getByTestId('zone-management_save_details-breadcrumb')).toHaveAttribute(
+                'href',
+                '/zone-management/details/tier/42`'
+            );
+        });
+    });
+});

--- a/packages/javascript/bh-shared-ui/src/views/ZoneManagement/Save/Save.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/ZoneManagement/Save/Save.tsx
@@ -38,7 +38,7 @@ const Save: FC = () => {
     const tagValue = location.pathname.includes('label') ? 'label' : 'tier';
     const capitalizedTagValue = capitalize(tagValue);
     const captitalizedPluralTagValue = capitalizedTagValue + 's';
-    const topTagId = useHighestPrivilegeTagId();
+    const { tagId: topTagId } = useHighestPrivilegeTagId();
     const ownedId = useOwnedTagId();
     return (
         <div>

--- a/packages/javascript/bh-shared-ui/src/views/ZoneManagement/Save/Save.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/ZoneManagement/Save/Save.tsx
@@ -47,6 +47,7 @@ const Save: FC = () => {
                     <BreadcrumbItem>
                         <BreadcrumbLink asChild>
                             <AppLink
+                                data-testid='zone-management_save_details-breadcrumb'
                                 to={`/zone-management/details/${tagValue}/${tagValue === 'tier' ? topTagId : ownedId}`}>
                                 {captitalizedPluralTagValue}
                             </AppLink>
@@ -57,7 +58,9 @@ const Save: FC = () => {
                         <>
                             <BreadcrumbItem>
                                 <BreadcrumbLink asChild>
-                                    <AppLink to={`/zone-management/save/${tagValue}/${tagId}`}>
+                                    <AppLink
+                                        data-testid='zone-management_save_tag-breadcrumb'
+                                        to={`/zone-management/save/${tagValue}/${tagId}`}>
                                         {`${capitalizedTagValue} Details`}
                                     </AppLink>
                                 </BreadcrumbLink>

--- a/packages/javascript/bh-shared-ui/src/views/ZoneManagement/Save/TagForm/TagForm.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/ZoneManagement/Save/TagForm/TagForm.tsx
@@ -108,7 +108,7 @@ export const TagForm: FC = () => {
     const { data } = useGetConfiguration();
     const tieringConfig = parseTieringConfiguration(data);
 
-    const topTagId = useHighestPrivilegeTagId();
+    const { tagId: topTagId } = useHighestPrivilegeTagId();
     const ownedId = useOwnedTagId();
 
     const showAnalysisToggle =

--- a/packages/javascript/bh-shared-ui/src/views/ZoneManagement/Summary/Summary.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/ZoneManagement/Summary/Summary.tsx
@@ -37,8 +37,8 @@ export const getEditButtonState = (memberId?: string, selectorsQuery?: UseQueryR
 
 const Summary: FC = () => {
     const navigate = useAppNavigate();
-    const topTagId = useHighestPrivilegeTagId()?.toString();
-    const { tierId = topTagId, labelId, selectorId, memberId } = useParams();
+    const { tagId: topTagId } = useHighestPrivilegeTagId();
+    const { tierId = topTagId?.toString(), labelId, selectorId, memberId } = useParams();
     const tagId = labelId === undefined ? tierId : labelId;
 
     const context = useContext(ZoneManagementContext);


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Updates the use of the id value returned from the useHighestPrivilegeTagId hook to destructure the ID now that it is returning the loading and error states and not just a primitive value. 

## Motivation and Context

Resolves BED-6189

Some of the routing was broken when this hook was updated. This changeset rectifies the behavior.

## How Has This Been Tested?

*Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc.*

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
