### PR TITLE
feat (api): Add Get SavedQuery and Get SavedQueryPermissions Endpoints - BED-6220 and BED-6219

### DIFF
--- a/cmd/api/src/api/registration/v2.go
+++ b/cmd/api/src/api/registration/v2.go
@@ -208,6 +208,7 @@ func NewV2API(resources v2.Resources, routerInst *router.Router) {
 		routerInst.POST("/api/v2/graphs/cypher", resources.CypherQuery).RequirePermissions(permissions.GraphDBRead),
 		routerInst.GET("/api/v2/saved-queries", resources.ListSavedQueries).RequirePermissions(permissions.SavedQueriesRead),
 		routerInst.POST("/api/v2/saved-queries", resources.CreateSavedQuery).RequirePermissions(permissions.SavedQueriesWrite),
+		routerInst.GET(fmt.Sprintf("/api/v2/saved-queries/{%s}", api.URIPathVariableSavedQueryID), resources.GetSavedQuery).RequirePermissions(permissions.SavedQueriesRead),
 		routerInst.PUT(fmt.Sprintf("/api/v2/saved-queries/{%s}", api.URIPathVariableSavedQueryID), resources.UpdateSavedQuery).RequirePermissions(permissions.SavedQueriesWrite),
 		routerInst.DELETE(fmt.Sprintf("/api/v2/saved-queries/{%s}", api.URIPathVariableSavedQueryID), resources.DeleteSavedQuery).RequirePermissions(permissions.SavedQueriesWrite),
 		routerInst.GET(fmt.Sprintf("/api/v2/saved-queries/{%s}/permissions", api.URIPathVariableSavedQueryID), resources.GetSavedQueryPermissions).RequirePermissions(permissions.SavedQueriesRead),

--- a/cmd/api/src/api/registration/v2.go
+++ b/cmd/api/src/api/registration/v2.go
@@ -210,6 +210,7 @@ func NewV2API(resources v2.Resources, routerInst *router.Router) {
 		routerInst.POST("/api/v2/saved-queries", resources.CreateSavedQuery).RequirePermissions(permissions.SavedQueriesWrite),
 		routerInst.PUT(fmt.Sprintf("/api/v2/saved-queries/{%s}", api.URIPathVariableSavedQueryID), resources.UpdateSavedQuery).RequirePermissions(permissions.SavedQueriesWrite),
 		routerInst.DELETE(fmt.Sprintf("/api/v2/saved-queries/{%s}", api.URIPathVariableSavedQueryID), resources.DeleteSavedQuery).RequirePermissions(permissions.SavedQueriesWrite),
+		routerInst.GET(fmt.Sprintf("/api/v2/saved-queries/{%s}/permissions", api.URIPathVariableSavedQueryID), resources.GetSavedQueryPermissions).RequirePermissions(permissions.SavedQueriesRead),
 		routerInst.DELETE(fmt.Sprintf("/api/v2/saved-queries/{%s}/permissions", api.URIPathVariableSavedQueryID), resources.DeleteSavedQueryPermissions).RequirePermissions(permissions.SavedQueriesWrite),
 		routerInst.PUT(fmt.Sprintf("/api/v2/saved-queries/{%s}/permissions", api.URIPathVariableSavedQueryID), resources.ShareSavedQueries).RequirePermissions(permissions.SavedQueriesWrite),
 		routerInst.GET(fmt.Sprintf("/api/v2/saved-queries/{%s}/export", api.URIPathVariableSavedQueryID), resources.ExportSavedQuery).RequirePermissions(permissions.SavedQueriesRead),

--- a/cmd/api/src/api/v2/saved_queries.go
+++ b/cmd/api/src/api/v2/saved_queries.go
@@ -46,6 +46,30 @@ import (
 	"github.com/specterops/bloodhound/packages/go/mediatypes"
 )
 
+func (s Resources) GetSavedQuery(response http.ResponseWriter, request *http.Request) {
+	var (
+		rawSavedQueryID = mux.Vars(request)[api.URIPathVariableSavedQueryID]
+	)
+
+	if user, isUser := auth.GetUserFromAuthCtx(ctx2.FromRequest(request).AuthCtx); !isUser {
+		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, "No associated user found", request), response)
+	} else if savedQueryID, err := strconv.ParseInt(rawSavedQueryID, 10, 64); err != nil {
+		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, api.ErrorResponseDetailsIDMalformed, request), response)
+	} else if savedQuery, err := s.DB.GetSavedQuery(request.Context(), savedQueryID); err != nil {
+		if errors.Is(err, database.ErrNotFound) {
+			api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusNotFound, "query not found", request), response)
+		} else {
+			api.HandleDatabaseError(request, response, err)
+		}
+	} else if isAccessibleToUser, err := s.canUserAccessQuery(request.Context(), savedQuery, user); err != nil {
+		api.HandleDatabaseError(request, response, err)
+	} else if !isAccessibleToUser {
+		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusNotFound, "query not found", request), response)
+	} else {
+		api.WriteBasicResponse(request.Context(), savedQuery, http.StatusOK, response)
+	}
+}
+
 func (s Resources) ListSavedQueries(response http.ResponseWriter, request *http.Request) {
 	var (
 		order         []string

--- a/cmd/api/src/api/v2/saved_queries_permissions.go
+++ b/cmd/api/src/api/v2/saved_queries_permissions.go
@@ -122,7 +122,7 @@ func (s Resources) GetSavedQueryPermissions(response http.ResponseWriter, reques
 				savedQueryPermissionResponse.AppendUserId(savedQueryPermission.SharedToUserID)
 			}
 		}
-		api.WriteJSONResponse(request.Context(), savedQueryPermissionResponse, http.StatusOK, response)
+		api.WriteBasicResponse(request.Context(), savedQueryPermissionResponse, http.StatusOK, response)
 	}
 }
 

--- a/cmd/api/src/api/v2/saved_queries_permissions.go
+++ b/cmd/api/src/api/v2/saved_queries_permissions.go
@@ -105,7 +105,7 @@ func (s Resources) GetSavedQueryPermissions(response http.ResponseWriter, reques
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, api.ErrorResponseDetailsIDMalformed, request), response)
 	} else if savedQueryPermissions, err := s.DB.GetSavedQueryPermissions(request.Context(), savedQueryID); err != nil {
 		api.HandleDatabaseError(request, response, err)
-	} else if savedQueryPermissions == nil || len(savedQueryPermissions) == 0 {
+	} else if len(savedQueryPermissions) == 0 {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusNotFound, "no query permissions exist for saved query", request), response)
 	} else if isAccessibleToUser, err := s.canUserAccessSavedQueryPermissions(request.Context(), savedQueryPermissions[0], user); err != nil {
 		api.HandleDatabaseError(request, response, err)

--- a/cmd/api/src/api/v2/saved_queries_permissions.go
+++ b/cmd/api/src/api/v2/saved_queries_permissions.go
@@ -94,7 +94,7 @@ func (s *SavedQueryPermissionResponse) AppendUserId(userId uuid.NullUUID) {
 	}
 }
 
-// GetSavedQueryPermissions - users or admins can retrieve who queries
+// GetSavedQueryPermissions - returns the query permissions for users who own the query or admins.
 // Public queries will return for any user with no attached user ids.
 func (s Resources) GetSavedQueryPermissions(response http.ResponseWriter, request *http.Request) {
 	var rawSavedQueryID = mux.Vars(request)[api.URIPathVariableSavedQueryID]

--- a/cmd/api/src/api/v2/saved_queries_permissions.go
+++ b/cmd/api/src/api/v2/saved_queries_permissions.go
@@ -119,7 +119,9 @@ func (s Resources) GetSavedQueryPermissions(response http.ResponseWriter, reques
 		}
 		if !savedQueryPermissionResponse.Public {
 			for _, savedQueryPermission := range savedQueryPermissions {
-				savedQueryPermissionResponse.AppendUserId(savedQueryPermission.SharedToUserID)
+				if savedQueryPermission.SharedToUserID.Valid {
+					savedQueryPermissionResponse.AppendUserId(savedQueryPermission.SharedToUserID)
+				}
 			}
 		}
 		api.WriteBasicResponse(request.Context(), savedQueryPermissionResponse, http.StatusOK, response)

--- a/cmd/api/src/api/v2/saved_queries_permissions_test.go
+++ b/cmd/api/src/api/v2/saved_queries_permissions_test.go
@@ -1822,8 +1822,16 @@ func TestResources_GetPermissionsForSavedQuery(t *testing.T) {
 				require.NoError(t, err)
 				assert.Equal(t, tt.expect.responseError, errWrapper.Error())
 			} else {
-				var actualSavedQueryPermissions v2.SavedQueryPermissionResponse
-				err = json.Unmarshal(response.Body.Bytes(), &actualSavedQueryPermissions)
+				var (
+					actualSavedQueryPermissions v2.SavedQueryPermissionResponse
+					basicResponse               api.BasicResponse
+				)
+				err = json.Unmarshal(response.Body.Bytes(), &basicResponse)
+				require.NoError(t, err)
+				basicResponseDataJson, err := basicResponse.Data.MarshalJSON()
+				require.NoError(t, err)
+				err = json.Unmarshal(basicResponseDataJson, &actualSavedQueryPermissions)
+				require.NoError(t, err)
 				assert.Equal(t, tt.expect.responsePermissions, actualSavedQueryPermissions)
 			}
 		})

--- a/cmd/api/src/database/mocks/db.go
+++ b/cmd/api/src/database/mocks/db.go
@@ -1629,6 +1629,21 @@ func (mr *MockDatabaseMockRecorder) GetSavedQuery(ctx, savedQueryID any) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSavedQuery", reflect.TypeOf((*MockDatabase)(nil).GetSavedQuery), ctx, savedQueryID)
 }
 
+// GetSavedQueryPermissions mocks base method.
+func (m *MockDatabase) GetSavedQueryPermissions(ctx context.Context, queryID int64) ([]model.SavedQueriesPermissions, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSavedQueryPermissions", ctx, queryID)
+	ret0, _ := ret[0].([]model.SavedQueriesPermissions)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetSavedQueryPermissions indicates an expected call of GetSavedQueryPermissions.
+func (mr *MockDatabaseMockRecorder) GetSavedQueryPermissions(ctx, queryID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSavedQueryPermissions", reflect.TypeOf((*MockDatabase)(nil).GetSavedQueryPermissions), ctx, queryID)
+}
+
 // GetScopeForSavedQuery mocks base method.
 func (m *MockDatabase) GetScopeForSavedQuery(ctx context.Context, queryID int64, userID uuid.UUID) (database.SavedQueryScopeMap, error) {
 	m.ctrl.T.Helper()

--- a/cmd/api/src/database/saved_queries_permissions_test.go
+++ b/cmd/api/src/database/saved_queries_permissions_test.go
@@ -24,11 +24,12 @@ import (
 	"testing"
 
 	"github.com/gofrs/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/specterops/bloodhound/cmd/api/src/database"
 	"github.com/specterops/bloodhound/cmd/api/src/model"
 	"github.com/specterops/bloodhound/cmd/api/src/test/integration"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestSavedQueriesPermissions_CreateSavedQueryPermissionToPublic(t *testing.T) {
@@ -342,4 +343,36 @@ func TestSavedQueriesPermissions_IsSavedQuerySharedToUser(t *testing.T) {
 	isShared, err := dbInst.IsSavedQuerySharedToUser(testCtx, query.ID, user1.ID)
 	require.NoError(t, err)
 	assert.True(t, isShared)
+}
+
+func TestSavedQueriesPermissions_GetSavedQueryPermissions(t *testing.T) {
+	var (
+		testCtx                       = context.Background()
+		dbInst, user1                 = initAndCreateUser(t)
+		user2                         = createUser(t, dbInst, user2Principal)
+		expectedSavedQueryPermissions = []model.SavedQueriesPermissions{{
+			SharedToUserID: uuid.NullUUID{
+				UUID:  user2.ID,
+				Valid: true,
+			},
+			QueryID: 1,
+			Public:  false,
+			BigSerial: model.BigSerial{
+				ID: 1,
+			},
+		}}
+	)
+
+	query, err := dbInst.CreateSavedQuery(testCtx, user1.ID, "Test Query", "TESTING", "Test Description")
+	require.NoError(t, err)
+	_, err = dbInst.CreateSavedQueryPermissionsToUsers(testCtx, query.ID, user2.ID)
+	require.NoError(t, err)
+	actualSavedQueryPermissions, err := dbInst.GetSavedQueryPermissions(testCtx, query.ID)
+	require.NoError(t, err)
+	assert.Equal(t, len(expectedSavedQueryPermissions), len(actualSavedQueryPermissions))
+	for idx, _ := range expectedSavedQueryPermissions {
+		expectedSavedQueryPermissions[idx].CreatedAt = actualSavedQueryPermissions[idx].CreatedAt
+		expectedSavedQueryPermissions[idx].UpdatedAt = actualSavedQueryPermissions[idx].UpdatedAt
+		assert.Equal(t, expectedSavedQueryPermissions[idx], actualSavedQueryPermissions[idx])
+	}
 }

--- a/cmd/api/src/database/saved_queries_permissions_test.go
+++ b/cmd/api/src/database/saved_queries_permissions_test.go
@@ -370,7 +370,7 @@ func TestSavedQueriesPermissions_GetSavedQueryPermissions(t *testing.T) {
 	actualSavedQueryPermissions, err := dbInst.GetSavedQueryPermissions(testCtx, query.ID)
 	require.NoError(t, err)
 	assert.Equal(t, len(expectedSavedQueryPermissions), len(actualSavedQueryPermissions))
-	for idx, _ := range expectedSavedQueryPermissions {
+	for idx := range expectedSavedQueryPermissions {
 		expectedSavedQueryPermissions[idx].CreatedAt = actualSavedQueryPermissions[idx].CreatedAt
 		expectedSavedQueryPermissions[idx].UpdatedAt = actualSavedQueryPermissions[idx].UpdatedAt
 		assert.Equal(t, expectedSavedQueryPermissions[idx], actualSavedQueryPermissions[idx])

--- a/packages/go/openapi/doc/openapi.json
+++ b/packages/go/openapi/doc/openapi.json
@@ -7107,6 +7107,46 @@
           }
         }
       ],
+      "get": {
+        "operationId": "GetSavedQueryPermissions",
+        "summary": "Retrieves saved query permissions for provided query id",
+        "description": "Retrieves saved query permissions for provided query id",
+        "tags": [
+          "Cypher",
+          "Community",
+          "Enterprise"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/model.saved-queries-permissions.response"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/bad-request"
+          },
+          "401": {
+            "$ref": "#/components/responses/unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/not-found"
+          },
+          "429": {
+            "$ref": "#/components/responses/too-many-requests"
+          },
+          "500": {
+            "$ref": "#/components/responses/internal-server-error"
+          }
+        }
+      },
       "delete": {
         "operationId": "DeleteSavedQueryPermissions",
         "summary": "Revokes permission of a saved query from users",
@@ -18442,6 +18482,26 @@
             }
           }
         ]
+      },
+      "model.saved-queries-permissions.response": {
+        "type": "object",
+        "properties": {
+          "shared_to_user_ids": {
+            "type": "array",
+            "items": [
+              {
+                "$ref": "#/components/schemas/model.components.uuid"
+              }
+            ]
+          },
+          "query_id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "public": {
+            "type": "boolean"
+          }
+        }
       },
       "model.saved-queries-permissions": {
         "allOf": [

--- a/packages/go/openapi/doc/openapi.json
+++ b/packages/go/openapi/doc/openapi.json
@@ -7001,6 +7001,51 @@
           }
         }
       ],
+      "get": {
+        "operationId": "GetSavedQuery",
+        "summary": "Return a saved query",
+        "description": "Returns an existing saved query by ID",
+        "tags": [
+          "Cypher",
+          "Community",
+          "Enterprise"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/model.saved-query"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/bad-request"
+          },
+          "401": {
+            "$ref": "#/components/responses/unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/not-found"
+          },
+          "429": {
+            "$ref": "#/components/responses/too-many-requests"
+          },
+          "500": {
+            "$ref": "#/components/responses/internal-server-error"
+          }
+        }
+      },
       "delete": {
         "operationId": "DeleteSavedQuery",
         "summary": "Delete a saved query",
@@ -7122,7 +7167,12 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/model.saved-queries-permissions.response"
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/model.saved-queries-permissions.response"
+                    }
+                  }
                 }
               }
             }

--- a/packages/go/openapi/src/paths/cypher.saved-queries.id.permissions.yaml
+++ b/packages/go/openapi/src/paths/cypher.saved-queries.id.permissions.yaml
@@ -23,6 +23,33 @@ parameters:
     schema:
       type: integer
       format: int32
+get:
+  operationId: GetSavedQueryPermissions
+  summary: Retrieves saved query permissions for provided query id
+  description: Retrieves saved query permissions for provided query id
+  tags:
+    - Cypher
+    - Community
+    - Enterprise
+  responses:
+    200:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: './../schemas/model.saved-queries-permissions.response.yaml'
+    400:
+      $ref: './../responses/bad-request.yaml'
+    401:
+      $ref: './../responses/unauthorized.yaml'
+    403:
+      $ref: './../responses/forbidden.yaml'
+    404:
+      $ref: './../responses/not-found.yaml'
+    429:
+      $ref: './../responses/too-many-requests.yaml'
+    500:
+      $ref: './../responses/internal-server-error.yaml'
 delete:
   operationId: DeleteSavedQueryPermissions
   summary: Revokes permission of a saved query from users

--- a/packages/go/openapi/src/paths/cypher.saved-queries.id.permissions.yaml
+++ b/packages/go/openapi/src/paths/cypher.saved-queries.id.permissions.yaml
@@ -37,7 +37,10 @@ get:
       content:
         application/json:
           schema:
-            $ref: './../schemas/model.saved-queries-permissions.response.yaml'
+            type: object
+            properties:
+              data:
+                $ref: './../schemas/model.saved-queries-permissions.response.yaml'
     400:
       $ref: './../responses/bad-request.yaml'
     401:

--- a/packages/go/openapi/src/paths/cypher.saved-queries.id.yaml
+++ b/packages/go/openapi/src/paths/cypher.saved-queries.id.yaml
@@ -23,6 +23,36 @@ parameters:
     schema:
       type: integer
       format: int32
+get:
+  operationId: GetSavedQuery
+  summary: Return a saved query
+  description: Returns an existing saved query by ID
+  tags:
+    - Cypher
+    - Community
+    - Enterprise
+  responses:
+    200:
+      description: OK
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              data:
+                $ref: './../schemas/model.saved-query.yaml'
+    400:
+      $ref: './../responses/bad-request.yaml'
+    401:
+      $ref: './../responses/unauthorized.yaml'
+    403:
+      $ref: './../responses/forbidden.yaml'
+    404:
+      $ref: './../responses/not-found.yaml'
+    429:
+      $ref: './../responses/too-many-requests.yaml'
+    500:
+      $ref: './../responses/internal-server-error.yaml'
 delete:
   operationId: DeleteSavedQuery
   summary: Delete a saved query

--- a/packages/go/openapi/src/schemas/model.saved-queries-permissions.response.yaml
+++ b/packages/go/openapi/src/schemas/model.saved-queries-permissions.response.yaml
@@ -1,0 +1,26 @@
+# Copyright 2025 Specter Ops, Inc.
+#
+# Licensed under the Apache License, Version 2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+type: object
+properties:
+  shared_to_user_ids:
+    type: array
+    items:
+      - $ref: './model.components.uuid.yaml'
+  query_id:
+    type: integer
+    format: int64
+  public:
+    type: boolean


### PR DESCRIPTION
## Description

Added two endpoints to support the Saved Queries initiative, one to retrieve a Saved Query by id and a second to retrieve a Saved Query's permissions by id. The bulk of the added code is in testing and documentation. 

## Motivation and Context
Resolves: BED-6219
Resolves: BED-6220

*Why is this change required? What problem does it solve?*

To accomplish the saved queries initiative we need to be able to get a single saved query along with its permissions set. This way, the front end can correctly show which users a query is shared with. 

## How Has This Been Tested?

- Added unit and integration tests for the added functions
- Tested locally against the endpoints. 

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
