### PR TITLE
BED-6215: add explore_table_view flag if it doesnt already exist

### DIFF
--- a/cmd/api/src/database/migration/migrations/v8.0.0.sql
+++ b/cmd/api/src/database/migration/migrations/v8.0.0.sql
@@ -41,5 +41,17 @@ WHERE role_id = (SELECT id FROM roles WHERE roles.name = 'Power User')
 -- Add name index to asset_group_tag_selectors table for search
 CREATE INDEX IF NOT EXISTS idx_asset_group_tag_selectors_name ON asset_group_tag_selectors USING btree (name);
 
+-- if the explore_table_view flag doesnt exist, create explore_table_view feature flag, disable it, and make it non user-updatable.
+-- this same query exists in 7.5.0, however it was merged after the release was cut so any tenants created before 7.5.0 will be missing this flag.
+INSERT INTO feature_flags (created_at, updated_at, key, name, description, enabled, user_updatable)
+VALUES (current_timestamp,
+        current_timestamp,
+        'explore_table_view',
+        'Explore Table View',
+        'Adds a layout option to the Explore page that will display all nodes in a table view. It also will automatically display the table when a cypher query returned only nodes.',
+        false,
+        false)
+ON CONFLICT DO NOTHING;
+
 -- enable explore_table_view feature flag
 UPDATE feature_flags SET enabled = true WHERE key = 'explore_table_view';


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

The original `explore_table_view` feature flag was added to a migration file after it was included in the release, so this fixes the missing feature flag for all tenants created after v7.5.0

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-6215

*Why is this change required? What problem does it solve?*

## How Has This Been Tested?
Executed the migration locally and confirmed it worked as expected.

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)
- Database Migrations

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
