### PR TITLE
fix: power user app config read

### DIFF
--- a/cmd/api/src/auth/role.go
+++ b/cmd/api/src/auth/role.go
@@ -77,6 +77,7 @@ func Roles() map[string]RoleTemplate {
 			Name:        RolePowerUser,
 			Description: "Can upload data, manage clients, and perform any action a User can",
 			Permissions: model.Permissions{
+				permissions.AppReadApplicationConfiguration,
 				permissions.APsGenerateReport,
 				permissions.APsManageAPs,
 				permissions.AuthCreateToken,

--- a/cmd/api/src/database/migration/migrations/v8.0.0.sql
+++ b/cmd/api/src/database/migration/migrations/v8.0.0.sql
@@ -37,7 +37,7 @@ WHERE role_id = (
     SELECT id
     FROM permissions
     WHERE permissions.authority = 'app'
-      AND permissions.name IN ('ReadAppConfig', 'WriteAppConfig')
+      AND permissions.name IN ('WriteAppConfig')
   );
 -- Add name index to asset_group_tag_selectors table for search
 CREATE INDEX IF NOT EXISTS idx_asset_group_tag_selectors_name ON asset_group_tag_selectors USING btree (name);


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Brings back app config read for power users.

## Motivation and Context

closes BED-6250

Calling the feature flag endpoint results in a 403 without this permission. This means that conditional rendering in the UI based on feature flags for power users would not function as intended. Power Users will still be limited in changing app config.

## How Has This Been Tested?

*Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc.*

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
