### PR TITLE
BED-5803:  Edge Info Panel Node List Fix

### DIFF
--- a/packages/javascript/bh-shared-ui/src/hooks/useExploreGraph/useEdgeInfoItems.ts
+++ b/packages/javascript/bh-shared-ui/src/hooks/useExploreGraph/useEdgeInfoItems.ts
@@ -54,6 +54,10 @@ const queryConfig = {
     },
 };
 
+// These incoming ids can be strings sometimes, despite the parameter type (see composition dropdown). This helper function
+// provides more flexible validation
+const validateId = (id: any) => (typeof id === 'number' ? Number.isInteger(id) : !!id);
+
 export const useEdgeInfoItems = (
     { sourceDBId, targetDBId, edgeName, type }: EdgeInfoItemsProps,
     opts?: EdgeInfoItemOpts
@@ -62,14 +66,12 @@ export const useEdgeInfoItems = (
     const { data, isLoading, isError } = useQuery(
         [type, sourceDBId, targetDBId, edgeName],
         () => queryConfig[type].endpoint({ sourceDBId, targetDBId, edgeName }),
-        { enabled: !!(Number.isInteger(sourceDBId) && Number.isInteger(targetDBId) && edgeName) }
+        { enabled: validateId(sourceDBId) && validateId(targetDBId) && !!edgeName }
     );
 
-    const handleNodeClick = (item: number) => {
-        const node = nodesArray[item];
-
+    const handleNodeClick = (objectId: string) => {
         setExploreParams({
-            primarySearch: node.objectId,
+            primarySearch: objectId,
             searchType: 'node',
             exploreSearchTab: 'node',
         });
@@ -81,7 +83,8 @@ export const useEdgeInfoItems = (
         graphId,
         kind: node.kind,
         ...(opts?.withProperties && { properties: node.properties }),
-        onClick: handleNodeClick,
+        onClick: () => handleNodeClick(node.objectId),
     }));
+
     return { isLoading, isError, nodesArray };
 };


### PR DESCRIPTION
## Description
We discovered a few issues during RC testing related to the node lists that display in the Edge Info Panel:
- If an ACE inheritance path had more than one source node, click handlers were breaking
- There was a regression with the composition dropdown that prevented the node list from populating

## Motivation and Context

- Followup for BED-5803

## How Has This Been Tested?
- Manual testing against my local environment and the test API to make sure we are seeing the correct results.

## Screenshots (optional):

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
