### PR TITLE
BED-3538: removes enable control into useExploreGraph

### DIFF
--- a/packages/javascript/bh-shared-ui/src/hooks/useExploreGraph/useExploreGraph.tsx
+++ b/packages/javascript/bh-shared-ui/src/hooks/useExploreGraph/useExploreGraph.tsx
@@ -51,7 +51,7 @@ export function exploreGraphQueryFactory(
 }
 
 // Hook for maintaining the top level graph query powering the explore page
-export const useExploreGraph = (enabled = true) => {
+export const useExploreGraph = () => {
     const params = useExploreParams();
 
     const { addNotification } = useNotifications();
@@ -59,8 +59,6 @@ export const useExploreGraph = (enabled = true) => {
     const query = exploreGraphQueryFactory(params);
 
     const queryConfig = query.getQueryConfig(params);
-
-    const shouldFetch = Boolean(enabled && queryConfig?.enabled);
 
     return useQuery({
         ...queryConfig,
@@ -70,6 +68,5 @@ export const useExploreGraph = (enabled = true) => {
                 autoHideDuration: SNACKBAR_DURATION_LONG,
             });
         },
-        enabled: shouldFetch,
     });
 };

--- a/packages/javascript/bh-shared-ui/src/hooks/useExploreTableAutoDisplay/useExploreTableAutoDisplay.tsx
+++ b/packages/javascript/bh-shared-ui/src/hooks/useExploreTableAutoDisplay/useExploreTableAutoDisplay.tsx
@@ -24,7 +24,7 @@ import { useFeatureFlag } from '../useFeatureFlags';
 // Auto display when current search is cypher and returned data contains nodes but not edges.
 // And dont auto display if the auto display has been closed.
 export const useExploreTableAutoDisplay = (enabled: boolean) => {
-    const { data: graphData, isFetching } = useExploreGraph(enabled);
+    const { data: graphData, isFetching } = useExploreGraph();
     const { searchType } = useExploreParams();
     const { data: featureFlag } = useFeatureFlag('explore_table_view');
 


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description
This pulls out the plumbing for enable the useExploreGraph hook as a param. It was only used in one case, and in that case the query will already be executed.

This was causing 2 different issues:
- Other searchTypes are blocked if they didnt specify an enabled field for the queryConfig
- `autoDisplayTable` triggering twice after selecting any explore layout other than table.

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Patches: BED-3538

This plumbing caused other searchTypes to be blocked if they didnt specify an enabled field for the queryConfig. It also resolved the useExploreTableAutoDisplay from executing twice when it goes from enabled =-

## How Has This Been Tested?
Manually tested and confirmed queries execute when expected.

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
