### PR TITLE
Test Ingest start/stopping

### DIFF
--- a/cmd/api/src/api/v2/fileingest_test.go
+++ b/cmd/api/src/api/v2/fileingest_test.go
@@ -29,7 +29,9 @@ import (
 	"net/url"
 	"os"
 	"testing"
+	"time"
 
+	"github.com/gofrs/uuid"
 	"github.com/gorilla/mux"
 	v2 "github.com/specterops/bloodhound/cmd/api/src/api/v2"
 	"github.com/specterops/bloodhound/cmd/api/src/api/v2/apitest"
@@ -110,130 +112,352 @@ func TestResources_ListFileUploadJobs(t *testing.T) {
 
 }
 
-func TestResources_StartFileUploadJob(t *testing.T) {
-	var (
-		mockCtrl  = gomock.NewController(t)
-		mockDB    = dbmocks.NewMockDatabase(mockCtrl)
-		resources = v2.Resources{DB: mockDB}
-		user      = setupUser()
-		userCtx   = setupUserCtx(user)
-	)
-	defer mockCtrl.Finish()
+func TestResources_StartIngestJob(t *testing.T) {
+	t.Parallel()
 
-	apitest.
-		NewHarness(t, resources.StartIngestJob).
-		Run([]apitest.Case{
-			{
-				Name: "Unauthorized",
-				Test: func(output apitest.Output) {
-					apitest.StatusCode(output, http.StatusUnauthorized)
-				},
+	type mock struct {
+		mockDatabase *dbmocks.MockDatabase
+	}
+	type expected struct {
+		responseBody   string
+		responseCode   int
+		responseHeader http.Header
+	}
+	type testData struct {
+		name         string
+		buildRequest func() *http.Request
+		setupMocks   func(t *testing.T, mock *mock)
+		expected     expected
+	}
+
+	tt := []testData{
+		{
+			name: "Error: Database Error - 500",
+			buildRequest: func() *http.Request {
+				request := &http.Request{
+					URL: &url.URL{Path: "/api/v2/file-upload/start"}, Method: http.MethodPost,
+				}
+
+				requestCtx := ctx.Context{
+					RequestID: "id",
+					AuthCtx: auth.Context{
+						Owner:   model.User{},
+						Session: model.UserSession{},
+					},
+				}
+
+				return request.WithContext(context.WithValue(context.Background(), ctx.ValueKey, requestCtx.WithRequestID("id")))
 			},
-			{
-				Name: "DatabaseError",
-				Input: func(input *apitest.Input) {
-					apitest.SetContext(input, userCtx)
-				},
-				Setup: func() {
-					mockDB.EXPECT().CreateIngestJob(gomock.Any(), gomock.Any()).Return(model.IngestJob{}, errors.New("db error"))
-				},
-				Test: func(output apitest.Output) {
-					apitest.StatusCode(output, http.StatusInternalServerError)
-				},
+			setupMocks: func(t *testing.T, mock *mock) {
+				t.Helper()
+				mock.mockDatabase.EXPECT().CreateIngestJob(gomock.Any(), gomock.Any()).Return(model.IngestJob{}, errors.New("db error"))
 			},
-			{
-				Name: "Success",
-				Input: func(input *apitest.Input) {
-					apitest.SetContext(input, userCtx)
-				},
-				Setup: func() {
-					mockDB.EXPECT().CreateIngestJob(gomock.Any(), gomock.Any()).Return(model.IngestJob{}, nil)
-				},
-				Test: func(output apitest.Output) {
-					apitest.StatusCode(output, http.StatusCreated)
-				},
+			expected: expected{
+				responseCode:   http.StatusInternalServerError,
+				responseBody:   `{"errors":[{"context":"", "message":"an internal error has occurred that is preventing the service from servicing this request"}],"http_status":500,"request_id":"id","timestamp":"0001-01-01T00:00:00Z"}`,
+				responseHeader: http.Header{"Content-Type": []string{"application/json"}},
 			},
+		}, {
+			name: "Error: Unauthorized - 401",
+			buildRequest: func() *http.Request {
+				request := &http.Request{
+					URL: &url.URL{Path: "/api/v2/file-upload/start"}, Method: http.MethodPost,
+				}
+
+				requestCtx := ctx.Context{
+					RequestID: "id",
+				}
+
+				return request.WithContext(context.WithValue(context.Background(), ctx.ValueKey, requestCtx.WithRequestID("id")))
+			},
+			setupMocks: func(t *testing.T, mock *mock) {
+				t.Helper()
+			},
+			expected: expected{
+				responseCode:   http.StatusUnauthorized,
+				responseBody:   `{"errors":[{"context":"", "message":"authentication is invalid"}],"http_status":401,"request_id":"id","timestamp":"0001-01-01T00:00:00Z"}`,
+				responseHeader: http.Header{"Content-Type": []string{"application/json"}},
+			},
+		}, {
+			name: "Success: Happy Path - 201",
+			buildRequest: func() *http.Request {
+				request := &http.Request{
+					URL: &url.URL{Path: "/api/v2/file-upload/start"}, Method: http.MethodPost,
+				}
+
+				requestCtx := ctx.Context{
+					RequestID: "id",
+					AuthCtx: auth.Context{
+						Owner:   model.User{},
+						Session: model.UserSession{},
+					},
+				}
+
+				return request.WithContext(context.WithValue(context.Background(), ctx.ValueKey, requestCtx.WithRequestID("id")))
+			},
+			setupMocks: func(t *testing.T, mock *mock) {
+				t.Helper()
+				mock.mockDatabase.EXPECT().CreateIngestJob(gomock.Any(), gomock.Any()).Return(model.IngestJob{
+					UserID:           uuid.FromStringOrNil("id"),
+					UserEmailAddress: null.NewString("email@notreal.com", true),
+					User: model.User{
+						PrincipalName: "name",
+					},
+					Status:        model.JobStatusRunning,
+					StatusMessage: "",
+					StartTime:     time.Time{},
+					EndTime:       time.Time{},
+					LastIngest:    time.Time{},
+					TotalFiles:    0,
+					FailedFiles:   0,
+				}, nil)
+			},
+			expected: expected{
+				responseCode:   http.StatusCreated,
+				responseBody:   `{"data":{"created_at":"0001-01-01T00:00:00Z", "deleted_at":{"Time":"0001-01-01T00:00:00Z", "Valid":false}, "end_time":"0001-01-01T00:00:00Z", "failed_files":0, "id":0, "last_ingest":"0001-01-01T00:00:00Z", "start_time":"0001-01-01T00:00:00Z", "status":1, "status_message":"", "total_files":0, "updated_at":"0001-01-01T00:00:00Z", "user_email_address": "email@notreal.com", "user_id":"00000000-0000-0000-0000-000000000000"}}`,
+				responseHeader: http.Header{"Content-Type": []string{"application/json"}},
+			},
+		},
+	}
+
+	for _, testCase := range tt {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+
+			mocks := &mock{
+				mockDatabase: dbmocks.NewMockDatabase(ctrl),
+			}
+
+			request := testCase.buildRequest()
+			testCase.setupMocks(t, mocks)
+
+			resources := v2.Resources{
+				DB: mocks.mockDatabase,
+			}
+
+			response := httptest.NewRecorder()
+
+			router := mux.NewRouter()
+			router.HandleFunc(request.URL.String(), resources.StartIngestJob).Methods(request.Method)
+
+			router.ServeHTTP(response, request)
+
+			status, header, body := test.ProcessResponse(t, response)
+
+			assert.Equal(t, testCase.expected.responseCode, status)
+			assert.Equal(t, testCase.expected.responseHeader, header)
+			assert.JSONEq(t, testCase.expected.responseBody, body)
 		})
+	}
 }
 
-func TestResources_EndFileUploadJob(t *testing.T) {
-	var (
-		mockCtrl  = gomock.NewController(t)
-		mockDB    = dbmocks.NewMockDatabase(mockCtrl)
-		resources = v2.Resources{DB: mockDB}
-	)
-	defer mockCtrl.Finish()
+func TestResources_EndIngestJob(t *testing.T) {
+	t.Parallel()
 
-	apitest.
-		NewHarness(t, resources.EndIngestJob).
-		Run([]apitest.Case{
-			{
-				Name: "InvalidJobID",
-				Input: func(input *apitest.Input) {
-					apitest.SetURLVar(input, v2.FileUploadJobIdPathParameterName, "invalid")
-				},
-				Test: func(output apitest.Output) {
-					apitest.StatusCode(output, http.StatusBadRequest)
-				},
+	type mock struct {
+		mockDatabase *dbmocks.MockDatabase
+	}
+	type expected struct {
+		responseBody   string
+		responseCode   int
+		responseHeader http.Header
+	}
+	type testData struct {
+		name         string
+		buildRequest func() *http.Request
+		setupMocks   func(t *testing.T, mock *mock)
+		expected     expected
+	}
+
+	tt := []testData{
+		{
+			name: "Error: Invalid Job  - 400",
+			buildRequest: func() *http.Request {
+				request := &http.Request{
+					URL: &url.URL{Path: "/api/v2/file-upload/invalid/end"}, Method: http.MethodPost,
+				}
+
+				requestCtx := ctx.Context{
+					RequestID: "id",
+					AuthCtx: auth.Context{
+						Owner:   model.User{},
+						Session: model.UserSession{},
+					},
+				}
+
+				return request.WithContext(context.WithValue(context.Background(), ctx.ValueKey, requestCtx.WithRequestID("id")))
 			},
-			{
-				Name: "GetIngestJobDatabaseError",
-				Input: func(input *apitest.Input) {
-					apitest.SetURLVar(input, v2.FileUploadJobIdPathParameterName, "123")
-				},
-				Setup: func() {
-					mockDB.EXPECT().GetIngestJob(gomock.Any(), gomock.Any()).Return(model.IngestJob{}, errors.New("db error"))
-				},
-				Test: func(output apitest.Output) {
-					apitest.StatusCode(output, http.StatusInternalServerError)
-				},
+			setupMocks: func(t *testing.T, mock *mock) {
+				t.Helper()
 			},
-			{
-				Name: "InvalidJobStatus",
-				Input: func(input *apitest.Input) {
-					apitest.SetURLVar(input, v2.FileUploadJobIdPathParameterName, "123")
-				},
-				Setup: func() {
-					mockDB.EXPECT().GetIngestJob(gomock.Any(), gomock.Any()).Return(model.IngestJob{
-						Status: model.JobStatusComplete,
-					}, nil)
-				},
-				Test: func(output apitest.Output) {
-					apitest.StatusCode(output, http.StatusBadRequest)
-					apitest.BodyContains(output, "job must be in running status")
-				},
+			expected: expected{
+				responseCode:   http.StatusBadRequest,
+				responseBody:   `{"errors":[{"context":"", "message":"id is malformed."}], "http_status":400, "request_id":"id", "timestamp":"0001-01-01T00:00:00Z"}`,
+				responseHeader: http.Header{"Content-Type": []string{"application/json"}},
 			},
-			{
-				Name: "UpdateIngestJobDatabaseError",
-				Input: func(input *apitest.Input) {
-					apitest.SetURLVar(input, v2.FileUploadJobIdPathParameterName, "123")
-				},
-				Setup: func() {
-					mockDB.EXPECT().GetIngestJob(gomock.Any(), gomock.Any()).Return(model.IngestJob{
-						Status: model.JobStatusRunning,
-					}, nil)
-					mockDB.EXPECT().UpdateIngestJob(gomock.Any(), gomock.Any()).Return(errors.New("database error"))
-				},
-				Test: func(output apitest.Output) {
-					apitest.StatusCode(output, http.StatusInternalServerError)
-				},
+		},
+		{
+			name: "Error: Invalid Job Status - 400",
+			buildRequest: func() *http.Request {
+				request := &http.Request{
+					URL: &url.URL{Path: "/api/v2/file-upload/123/end"}, Method: http.MethodPost,
+				}
+
+				requestCtx := ctx.Context{
+					RequestID: "id",
+					AuthCtx: auth.Context{
+						Owner:   model.User{},
+						Session: model.UserSession{},
+					},
+				}
+
+				return request.WithContext(context.WithValue(context.Background(), ctx.ValueKey, requestCtx.WithRequestID("id")))
 			},
-			{
-				Name: "Success",
-				Input: func(input *apitest.Input) {
-					apitest.SetURLVar(input, v2.FileUploadJobIdPathParameterName, "123")
-				},
-				Setup: func() {
-					mockDB.EXPECT().GetIngestJob(gomock.Any(), gomock.Any()).Return(model.IngestJob{
-						Status: model.JobStatusRunning,
-					}, nil)
-					mockDB.EXPECT().UpdateIngestJob(gomock.Any(), gomock.Any()).Return(nil)
-				},
-				Test: func(output apitest.Output) {
-					apitest.StatusCode(output, http.StatusOK)
-				},
+			setupMocks: func(t *testing.T, mock *mock) {
+				t.Helper()
+				mock.mockDatabase.EXPECT().GetIngestJob(gomock.Any(), gomock.Any()).Return(model.IngestJob{
+					UserID:           uuid.FromStringOrNil("id"),
+					UserEmailAddress: null.NewString("email@notreal.com", true),
+					User:             model.User{PrincipalName: "name"},
+					Status:           model.JobStatusComplete,
+				}, nil)
 			},
+			expected: expected{
+				responseCode:   http.StatusBadRequest,
+				responseBody:   `{"errors":[{"context":"", "message":"job must be in running status to end"}], "http_status":400, "request_id":"id", "timestamp":"0001-01-01T00:00:00Z"}`,
+				responseHeader: http.Header{"Content-Type": []string{"application/json"}},
+			},
+		},
+		{
+			name: "Error: Update Database Error - 500",
+			buildRequest: func() *http.Request {
+				request := &http.Request{
+					URL: &url.URL{Path: "/api/v2/file-upload/123/end"}, Method: http.MethodPost,
+				}
+
+				requestCtx := ctx.Context{
+					RequestID: "id",
+					AuthCtx: auth.Context{
+						Owner:   model.User{},
+						Session: model.UserSession{},
+					},
+				}
+
+				return request.WithContext(context.WithValue(context.Background(), ctx.ValueKey, requestCtx.WithRequestID("id")))
+			},
+			setupMocks: func(t *testing.T, mock *mock) {
+				t.Helper()
+				mock.mockDatabase.EXPECT().GetIngestJob(gomock.Any(), gomock.Any()).Return(model.IngestJob{
+					UserID:           uuid.FromStringOrNil("id"),
+					UserEmailAddress: null.NewString("email@notreal.com", true),
+					User:             model.User{PrincipalName: "name"},
+					Status:           model.JobStatusRunning,
+				}, nil)
+				mock.mockDatabase.EXPECT().UpdateIngestJob(gomock.Any(), gomock.Any()).Return(errors.New("random error"))
+			},
+			expected: expected{
+				responseCode:   http.StatusInternalServerError,
+				responseBody:   `{"errors":[{"context":"","message":"an internal error has occurred that is preventing the service from servicing this request"}],"http_status":500,"request_id":"id","timestamp":"0001-01-01T00:00:00Z"}`,
+				responseHeader: http.Header{"Content-Type": []string{"application/json"}},
+			},
+		},
+		{
+			name: "Error: GetIngestJob Database Error - 500",
+			buildRequest: func() *http.Request {
+				request := &http.Request{
+					URL: &url.URL{Path: "/api/v2/file-upload/123/end"}, Method: http.MethodPost,
+				}
+
+				requestCtx := ctx.Context{
+					RequestID: "id",
+					AuthCtx: auth.Context{
+						Owner:   model.User{},
+						Session: model.UserSession{},
+					},
+				}
+
+				return request.WithContext(context.WithValue(context.Background(), ctx.ValueKey, requestCtx.WithRequestID("id")))
+			},
+			setupMocks: func(t *testing.T, mock *mock) {
+				t.Helper()
+				mock.mockDatabase.EXPECT().GetIngestJob(gomock.Any(), gomock.Any()).Return(model.IngestJob{}, errors.New("db error"))
+			},
+			expected: expected{
+				responseCode:   http.StatusInternalServerError,
+				responseBody:   `{"errors":[{"context":"","message":"an internal error has occurred that is preventing the service from servicing this request"}],"http_status":500,"request_id":"id","timestamp":"0001-01-01T00:00:00Z"}`,
+				responseHeader: http.Header{"Content-Type": []string{"application/json"}},
+			},
+		},
+		{
+			name: "Success: Happy Path - 200",
+			buildRequest: func() *http.Request {
+				request := &http.Request{
+					URL: &url.URL{Path: "/api/v2/file-upload/123/end"}, Method: http.MethodPost,
+				}
+
+				requestCtx := ctx.Context{
+					RequestID: "id",
+					AuthCtx: auth.Context{
+						Owner:   model.User{},
+						Session: model.UserSession{},
+					},
+				}
+
+				return request.WithContext(context.WithValue(context.Background(), ctx.ValueKey, requestCtx.WithRequestID("id")))
+			},
+			setupMocks: func(t *testing.T, mock *mock) {
+				t.Helper()
+				mock.mockDatabase.EXPECT().GetIngestJob(gomock.Any(), gomock.Any()).Return(model.IngestJob{
+					UserID:           uuid.FromStringOrNil("id"),
+					UserEmailAddress: null.NewString("email@notreal.com", true),
+					User:             model.User{PrincipalName: "name"},
+					Status:           model.JobStatusRunning,
+				}, nil)
+				mock.mockDatabase.EXPECT().UpdateIngestJob(gomock.Any(), gomock.Any()).Return(nil)
+			},
+			expected: expected{
+				responseCode:   http.StatusOK,
+				responseBody:   "",
+				responseHeader: http.Header{},
+			},
+		},
+	}
+
+	for _, testCase := range tt {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+
+			mocks := &mock{
+				mockDatabase: dbmocks.NewMockDatabase(ctrl),
+			}
+
+			request := testCase.buildRequest()
+			testCase.setupMocks(t, mocks)
+
+			resources := v2.Resources{
+				DB: mocks.mockDatabase,
+			}
+
+			response := httptest.NewRecorder()
+
+			router := mux.NewRouter()
+			router.HandleFunc(fmt.Sprintf("/api/v2/file-upload/{%s}/end", v2.FileUploadJobIdPathParameterName), resources.EndIngestJob).Methods(request.Method)
+
+			router.ServeHTTP(response, request)
+
+			status, header, body := test.ProcessResponse(t, response)
+
+			assert.Equal(t, testCase.expected.responseCode, status)
+			assert.Equal(t, testCase.expected.responseHeader, header)
+			if body != "" {
+				assert.JSONEq(t, testCase.expected.responseBody, body)
+			} else {
+				assert.Equal(t, testCase.expected.responseBody, body)
+			}
 		})
+	}
 }
 
 func TestResources_ListAcceptedFileUploadTypes(t *testing.T) {


### PR DESCRIPTION
chore(tests): Move old testing framework to the new style for starting/stopping an ingest job

## Description
Moving contract tests to the new way 

## Motivation and Context
Resolves BED-5724

## How Has This Been Tested?
It is a test

## Types of changes
- Chore (a change that does not modify the application functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved and expanded test coverage for file upload job endpoints, ensuring better validation of various scenarios such as unauthorized access, invalid input, database errors, and successful operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->