### PR TITLE
chore: bump sharphound to v2.7.0

### DIFF
--- a/dockerfiles/bloodhound.Dockerfile
+++ b/dockerfiles/bloodhound.Dockerfile
@@ -19,7 +19,7 @@
 ########
 # Global build args
 ################
-ARG SHARPHOUND_VERSION=v2.6.7
+ARG SHARPHOUND_VERSION=v2.7.0
 ARG AZUREHOUND_VERSION=v2.6.0
 
 ########

--- a/tools/docker-compose/api.Dockerfile
+++ b/tools/docker-compose/api.Dockerfile
@@ -17,7 +17,7 @@
 ########
 # Global build args
 ################
-ARG SHARPHOUND_VERSION=v2.6.7
+ARG SHARPHOUND_VERSION=v2.7.0
 ARG AZUREHOUND_VERSION=v2.6.0
 
 ########


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Bumps sharphound to latest version

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
BED-6227 - Prepare for Release v8.0.0

SharpHound v2.7.0 is now released and should be included as our baseline version

## How Has This Been Tested?

Tested that building local dockerfiles works and that the correct version is now included

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
