### PR TITLE
BED-6212:  Tiering history notes

### DIFF
--- a/cmd/api/src/api/constant.go
+++ b/cmd/api/src/api/constant.go
@@ -55,6 +55,7 @@ const (
 	URIPathVariableAssetGroupTagID                   = "asset_group_tag_id"
 	URIPathVariableAssetGroupTagSelectorID           = "asset_group_tag_selector_id"
 	URIPathVariableAssetGroupTagMemberID             = "asset_group_tag_member_id"
+	URIPathVariableAssetGroupHistoryID               = "asset_group_history_id"
 	URIPathVariableAttackPathID                      = "attack_path_id"
 	URIPathVariableClientID                          = "client_id"
 	URIPathVariableDataType                          = "data_type"

--- a/cmd/api/src/api/registration/v2.go
+++ b/cmd/api/src/api/registration/v2.go
@@ -191,7 +191,7 @@ func NewV2API(resources v2.Resources, routerInst *router.Router) {
 
 		// history
 		routerInst.GET("/api/v2/asset-group-tags-history", resources.GetAssetGroupTagHistory).CheckFeatureFlag(resources.DB, appcfg.FeatureTierManagement).RequirePermissions(permissions.GraphDBRead),
-		routerInst.POST(fmt.Sprintf("/api/v2/asset-group-tags-history/{%s}", api.URIPathVariableAssetGroupHistoryID), resources.UpdateAssetGroupTagHistory).CheckFeatureFlag(resources.DB, appcfg.FeatureTierManagement).RequirePermissions(permissions.GraphDBRead),
+		routerInst.POST(fmt.Sprintf("/api/v2/asset-group-tags-history/{%s}", api.URIPathVariableAssetGroupHistoryID), resources.UpdateAssetGroupTagHistory).CheckFeatureFlag(resources.DB, appcfg.FeatureTierManagement).RequirePermissions(permissions.GraphDBWrite),
 
 		// QA API
 		routerInst.GET("/api/v2/completeness", resources.GetDatabaseCompleteness).RequirePermissions(permissions.GraphDBRead),

--- a/cmd/api/src/api/registration/v2.go
+++ b/cmd/api/src/api/registration/v2.go
@@ -175,6 +175,7 @@ func NewV2API(resources v2.Resources, routerInst *router.Router) {
 		// tags
 		routerInst.GET("/api/v2/asset-group-tags", resources.GetAssetGroupTags).CheckFeatureFlag(resources.DB, appcfg.FeatureTierManagement).RequirePermissions(permissions.GraphDBRead),
 		routerInst.POST("/api/v2/asset-group-tags/search", resources.SearchAssetGroupTags).CheckFeatureFlag(resources.DB, appcfg.FeatureTierManagement).RequirePermissions(permissions.GraphDBRead),
+		routerInst.POST(fmt.Sprintf("/api/v2/asset-group-tags/history/{%s}", api.URIPathVariableAssetGroupHistoryID), resources.UpdateAssetGroupTagHistory).CheckFeatureFlag(resources.DB, appcfg.FeatureTierManagement).RequirePermissions(permissions.GraphDBRead),
 		routerInst.GET(fmt.Sprintf("/api/v2/asset-group-tags/{%s}", api.URIPathVariableAssetGroupTagID), resources.GetAssetGroupTag).CheckFeatureFlag(resources.DB, appcfg.FeatureTierManagement).RequirePermissions(permissions.GraphDBRead),
 		routerInst.GET(fmt.Sprintf("/api/v2/asset-group-tags/{%s}/members", api.URIPathVariableAssetGroupTagID), resources.GetAssetGroupMembersByTag).CheckFeatureFlag(resources.DB, appcfg.FeatureTierManagement).RequirePermissions(permissions.GraphDBRead),
 		routerInst.GET(fmt.Sprintf("/api/v2/asset-group-tags/{%s}/members/counts", api.URIPathVariableAssetGroupTagID), resources.GetAssetGroupTagMemberCountsByKind).CheckFeatureFlag(resources.DB, appcfg.FeatureTierManagement).RequirePermissions(permissions.GraphDBRead),

--- a/cmd/api/src/api/registration/v2.go
+++ b/cmd/api/src/api/registration/v2.go
@@ -175,7 +175,6 @@ func NewV2API(resources v2.Resources, routerInst *router.Router) {
 		// tags
 		routerInst.GET("/api/v2/asset-group-tags", resources.GetAssetGroupTags).CheckFeatureFlag(resources.DB, appcfg.FeatureTierManagement).RequirePermissions(permissions.GraphDBRead),
 		routerInst.POST("/api/v2/asset-group-tags/search", resources.SearchAssetGroupTags).CheckFeatureFlag(resources.DB, appcfg.FeatureTierManagement).RequirePermissions(permissions.GraphDBRead),
-		routerInst.POST(fmt.Sprintf("/api/v2/asset-group-tags/history/{%s}", api.URIPathVariableAssetGroupHistoryID), resources.UpdateAssetGroupTagHistory).CheckFeatureFlag(resources.DB, appcfg.FeatureTierManagement).RequirePermissions(permissions.GraphDBRead),
 		routerInst.GET(fmt.Sprintf("/api/v2/asset-group-tags/{%s}", api.URIPathVariableAssetGroupTagID), resources.GetAssetGroupTag).CheckFeatureFlag(resources.DB, appcfg.FeatureTierManagement).RequirePermissions(permissions.GraphDBRead),
 		routerInst.GET(fmt.Sprintf("/api/v2/asset-group-tags/{%s}/members", api.URIPathVariableAssetGroupTagID), resources.GetAssetGroupMembersByTag).CheckFeatureFlag(resources.DB, appcfg.FeatureTierManagement).RequirePermissions(permissions.GraphDBRead),
 		routerInst.GET(fmt.Sprintf("/api/v2/asset-group-tags/{%s}/members/counts", api.URIPathVariableAssetGroupTagID), resources.GetAssetGroupTagMemberCountsByKind).CheckFeatureFlag(resources.DB, appcfg.FeatureTierManagement).RequirePermissions(permissions.GraphDBRead),
@@ -192,6 +191,7 @@ func NewV2API(resources v2.Resources, routerInst *router.Router) {
 
 		// history
 		routerInst.GET("/api/v2/asset-group-tags-history", resources.GetAssetGroupTagHistory).CheckFeatureFlag(resources.DB, appcfg.FeatureTierManagement).RequirePermissions(permissions.GraphDBRead),
+		routerInst.POST(fmt.Sprintf("/api/v2/asset-group-tags-history/{%s}", api.URIPathVariableAssetGroupHistoryID), resources.UpdateAssetGroupTagHistory).CheckFeatureFlag(resources.DB, appcfg.FeatureTierManagement).RequirePermissions(permissions.GraphDBRead),
 
 		// QA API
 		routerInst.GET("/api/v2/completeness", resources.GetDatabaseCompleteness).RequirePermissions(permissions.GraphDBRead),

--- a/cmd/api/src/api/v2/assetgrouptags.go
+++ b/cmd/api/src/api/v2/assetgrouptags.go
@@ -915,13 +915,13 @@ func (s *Resources) UpdateAssetGroupTagHistory(response http.ResponseWriter, req
 		api.HandleDatabaseError(request, response, err)
 	} else if actor, isUser := auth.GetUserFromAuthCtx(ctx.FromRequest(request).AuthCtx); !isUser {
 		slog.WarnContext(request.Context(), "encountered update asset group tag history for unknown user, this shouldn't happen")
-		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusInternalServerError, "unknown user", request), response)
+		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusInternalServerError, api.ErrorResponseDetailsInternalServerError, request), response)
 	} else if err := api.ReadJSONRequestPayloadLimited(&updateReq, request); err != nil {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, api.ErrorResponsePayloadUnmarshalError, request), response)
 	} else if !updateReq.Note.Valid {
-		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, "string cannot be null", request), response)
+		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, "note cannot be null", request), response)
 	} else {
-		historyRec.Note.String += fmt.Sprintf("%s - %s\n%s\n\n", time.Now().UTC().Format(time.RFC3339), actor.EmailAddress.String, updateReq.Note.String)
+		historyRec.Note.String = fmt.Sprintf("%s%s - %s\n%s\n\n", historyRec.Note.String, time.Now().UTC().Format(time.RFC3339), actor.EmailAddress.String, updateReq.Note.String)
 		historyRec.Note.Valid = true
 
 		if historyRec, err := s.DB.UpdateAssetGroupHistoryRecord(request.Context(), historyRec); err != nil {

--- a/cmd/api/src/api/v2/assetgrouptags_test.go
+++ b/cmd/api/src/api/v2/assetgrouptags_test.go
@@ -2828,7 +2828,7 @@ func TestResources_UpdateAssetGroupHistory(t *testing.T) {
 		user     = setupUser()
 		userCtx  = setupUserCtx(user)
 		handler  = http.HandlerFunc(resources.UpdateAssetGroupTagHistory)
-		endpoint = "/api/v2/asset-group-tags/history/1"
+		endpoint = "/api/v2/asset-group-tags-history/1"
 	)
 
 	type WrappedResponse struct {

--- a/cmd/api/src/database/assetgrouphistory.go
+++ b/cmd/api/src/database/assetgrouphistory.go
@@ -113,17 +113,19 @@ func (s *BloodhoundDB) GetAssetGroupHistoryRecord(ctx context.Context, id int) (
 }
 
 func (s *BloodhoundDB) UpdateAssetGroupHistoryRecord(ctx context.Context, historyRecord model.AssetGroupHistory) (model.AssetGroupHistory, error) {
-	if historyRecord.Note.Valid {
-		sqlStr := fmt.Sprintf(
-			"UPDATE %s SET note = ? WHERE id = ?",
-			(model.AssetGroupHistory{}).TableName(),
-		)
-
-		if result := s.db.WithContext(ctx).Exec(sqlStr, historyRecord.Note, historyRecord.ID); result.Error != nil {
-			return model.AssetGroupHistory{}, CheckError(result)
-		} else {
-			return historyRecord, nil
-		}
+	if historyRecord.ID <= 0 {
+		return model.AssetGroupHistory{}, fmt.Errorf("invalid history record ID: %d", historyRecord.ID)
 	}
-	return model.AssetGroupHistory{}, fmt.Errorf("Note field cannot be null")
+
+	if !historyRecord.Note.Valid {
+		return model.AssetGroupHistory{}, fmt.Errorf("note field is required for update")
+	}
+
+	sqlStr := fmt.Sprintf("UPDATE %s SET note = ? WHERE id = ?", (model.AssetGroupHistory{}).TableName())
+
+	if result := s.db.WithContext(ctx).Exec(sqlStr, historyRecord.Note, historyRecord.ID); result.Error != nil {
+		return model.AssetGroupHistory{}, CheckError(result)
+	}
+
+	return historyRecord, nil
 }

--- a/cmd/api/src/database/assetgrouphistory_test.go
+++ b/cmd/api/src/database/assetgrouphistory_test.go
@@ -148,16 +148,21 @@ func TestDatabase_GetAndUpdateAssetGroupHistoryRecord(t *testing.T) {
 		record, err := dbInst.GetAssetGroupHistoryRecord(testCtx, 1)
 		require.NoError(t, err)
 
+		// change some stuff
 		record.Action = model.AssetGroupHistoryActionDeleteSelector
 		record.Note = null.StringFrom("Test note")
 
+		// update the database
 		record, err = dbInst.UpdateAssetGroupHistoryRecord(testCtx, record)
+		require.NoError(t, err)
 
 		// read the record back in from the database
 		record, err = dbInst.GetAssetGroupHistoryRecord(testCtx, 1)
+		require.NoError(t, err)
 
 		// verify note was added
 		require.Equal(t, null.StringFrom("Test note"), record.Note)
-		require.False(t, record.CreatedAt.IsZero())
+		// verify action is unchanged
+		require.Equal(t, model.AssetGroupHistoryActionCreateSelector, record.Action)
 	})
 }

--- a/cmd/api/src/database/mocks/db.go
+++ b/cmd/api/src/database/mocks/db.go
@@ -1085,6 +1085,21 @@ func (mr *MockDatabaseMockRecorder) GetAssetGroupCollections(ctx, assetGroupID, 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAssetGroupCollections", reflect.TypeOf((*MockDatabase)(nil).GetAssetGroupCollections), ctx, assetGroupID, order, filter)
 }
 
+// GetAssetGroupHistoryRecord mocks base method.
+func (m *MockDatabase) GetAssetGroupHistoryRecord(ctx context.Context, id int) (model.AssetGroupHistory, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAssetGroupHistoryRecord", ctx, id)
+	ret0, _ := ret[0].(model.AssetGroupHistory)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetAssetGroupHistoryRecord indicates an expected call of GetAssetGroupHistoryRecord.
+func (mr *MockDatabaseMockRecorder) GetAssetGroupHistoryRecord(ctx, id any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAssetGroupHistoryRecord", reflect.TypeOf((*MockDatabase)(nil).GetAssetGroupHistoryRecord), ctx, id)
+}
+
 // GetAssetGroupHistoryRecords mocks base method.
 func (m *MockDatabase) GetAssetGroupHistoryRecords(ctx context.Context, sqlFilter model.SQLFilter, sortItems model.Sort, skip, limit int) ([]model.AssetGroupHistory, int, error) {
 	m.ctrl.T.Helper()
@@ -2141,6 +2156,21 @@ func (m *MockDatabase) UpdateAssetGroup(ctx context.Context, assetGroup model.As
 func (mr *MockDatabaseMockRecorder) UpdateAssetGroup(ctx, assetGroup any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAssetGroup", reflect.TypeOf((*MockDatabase)(nil).UpdateAssetGroup), ctx, assetGroup)
+}
+
+// UpdateAssetGroupHistoryRecord mocks base method.
+func (m *MockDatabase) UpdateAssetGroupHistoryRecord(ctx context.Context, historyRecord model.AssetGroupHistory) (model.AssetGroupHistory, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateAssetGroupHistoryRecord", ctx, historyRecord)
+	ret0, _ := ret[0].(model.AssetGroupHistory)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateAssetGroupHistoryRecord indicates an expected call of UpdateAssetGroupHistoryRecord.
+func (mr *MockDatabaseMockRecorder) UpdateAssetGroupHistoryRecord(ctx, historyRecord any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAssetGroupHistoryRecord", reflect.TypeOf((*MockDatabase)(nil).UpdateAssetGroupHistoryRecord), ctx, historyRecord)
 }
 
 // UpdateAssetGroupSelectors mocks base method.

--- a/packages/go/openapi/doc/openapi.json
+++ b/packages/go/openapi/doc/openapi.json
@@ -6354,6 +6354,84 @@
         }
       }
     },
+    "/api/v2/asset-group-tags-history/{asset_group_history_id}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/header.prefer"
+        }
+      ],
+      "post": {
+        "operationId": "UpdateAssetGroupTagHistory",
+        "summary": "Update history records",
+        "description": "Appends notes to a history record.",
+        "tags": [
+          "Asset Isolation",
+          "Enterprise",
+          "Community"
+        ],
+        "parameters": [
+          {
+            "name": "asset_group_history_id",
+            "description": "ID of the history record to modify",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "The request body for modifying a history record.",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "note": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "note"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/model.asset-group-tags-history"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/bad-request"
+          },
+          "401": {
+            "$ref": "#/components/responses/unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/not-found"
+          },
+          "429": {
+            "$ref": "#/components/responses/too-many-requests"
+          },
+          "500": {
+            "$ref": "#/components/responses/internal-server-error"
+          }
+        }
+      }
+    },
     "/api/v2/graphs/kinds": {
       "parameters": [
         {

--- a/packages/go/openapi/src/openapi.yaml
+++ b/packages/go/openapi/src/openapi.yaml
@@ -356,6 +356,8 @@ paths:
     $ref: './paths/asset-isolation.asset-group-tags.search.yaml'
   /api/v2/asset-group-tags-history:
     $ref: './paths/asset-isolation.asset-group-tags-history.yaml'
+  /api/v2/asset-group-tags-history/{asset_group_history_id}:
+    $ref: './paths/asset-isolation.asset-group-tags-history.id.yaml'
 
   # graph
   /api/v2/graphs/kinds:

--- a/packages/go/openapi/src/paths/asset-isolation.asset-group-tags-history.id.yaml
+++ b/packages/go/openapi/src/paths/asset-isolation.asset-group-tags-history.id.yaml
@@ -1,0 +1,66 @@
+# Copyright 2025 Specter Ops, Inc.
+#
+# Licensed under the Apache License, Version 2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+parameters:
+  - $ref: './../parameters/header.prefer.yaml'
+
+post:
+  operationId: UpdateAssetGroupTagHistory
+  summary: Update history records
+  description: Appends notes to a history record. 
+  tags:
+    - Asset Isolation
+    - Enterprise
+    - Community
+  parameters:
+    - name: asset_group_history_id
+      description: ID of the history record to modify
+      in: path
+      required: true
+      schema:
+        type: integer
+        format: int32
+  requestBody:
+    description: The request body for modifying a history record. 
+    required: true
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            note:
+              type: string
+          required:
+            - note
+  responses:
+    200:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: './../schemas/model.asset-group-tags-history.yaml'
+    400:
+      $ref: './../responses/bad-request.yaml'
+    401:
+      $ref: './../responses/unauthorized.yaml'
+    403:
+      $ref: './../responses/forbidden.yaml'
+    404:
+      $ref: './../responses/not-found.yaml'
+    429:
+      $ref: './../responses/too-many-requests.yaml'
+    500:
+      $ref: './../responses/internal-server-error.yaml'


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Add a POST endpoint on /api/v2/asset-group-tags-history/{history-id} where a note can be appended to the history record. 

## Motivation and Context

Resolves https://specterops.atlassian.net/browse/BED-6212

## How Has This Been Tested?

I have added unit tests for the endpoint and the database methods. Also verified locally using bruno. 

<img width="1516" height="904" alt="image" src="https://github.com/user-attachments/assets/c720c536-a531-43c9-b5b5-8c0a43930bf7" />

## Types of changes

<!-- Please remove any items that do not apply. -->

- New feature (non-breaking change which adds functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Introduced a new API endpoint to append notes to existing asset group tag history records.
  * The endpoint is accessible via POST at `/api/v2/asset-group-tags-history/{asset_group_history_id}` and requires a note in the request body.
  * Updated OpenAPI documentation to reflect the new endpoint and its parameters.

* **Bug Fixes**
  * None.

* **Tests**
  * Added comprehensive tests for the new note-appending endpoint, covering success and various error scenarios.
  * Added integration tests for retrieving and updating asset group history records.

* **Documentation**
  * Enhanced API documentation to include the new endpoint, request/response formats, and error codes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->