### PR TITLE
stbernard: Improve detection and adjustability of tooling executables

### DIFF
--- a/packages/go/stbernard/analyzers/golang/golang.go
+++ b/packages/go/stbernard/analyzers/golang/golang.go
@@ -35,7 +35,7 @@ func Run(cwd string, modPath string, env environment.Environment) (codeclimate.S
 	var (
 		lintEntries []codeclimate.Entry
 		output      *bytes.Buffer
-		command     = "go"
+		command     = environment.GoCommand()
 		args        = []string{"tool", "golangci-lint", "run", "--fix", "--config", ".golangci.json", "--output.code-climate.path", "stdout", "--"}
 	)
 

--- a/packages/go/stbernard/analyzers/js/js.go
+++ b/packages/go/stbernard/analyzers/js/js.go
@@ -69,7 +69,7 @@ func runEslint(path string, env environment.Environment) ([]codeclimate.Entry, e
 		esLintEntries []esLintEntry
 		output        *bytes.Buffer
 
-		command = "yarn"
+		command = environment.YarnCommand()
 		args    = []string{"run", "lint", "--quiet", "--format", "json"}
 	)
 

--- a/packages/go/stbernard/environment/commands.go
+++ b/packages/go/stbernard/environment/commands.go
@@ -1,0 +1,50 @@
+package environment
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+
+// GoCommand will attempt to locate the preferred go binary
+func GoCommand() string {
+	// Allow users to override go root location
+	goRoot := os.Getenv("GOROOT")
+	if len(goRoot) != 0 {
+		goCmd := fmt.Sprintf("%s/bin/go", goRoot)
+		_, err := exec.LookPath(goCmd)
+		if err == nil {
+			return goCmd
+		}
+	}
+	_, err := exec.LookPath("go")
+	if err == nil {
+		return "go"
+	}
+	panic("go does not seem to be installed!")
+}
+
+
+// YarnCommand checks which yarn executable is in the path
+func YarnCommand() string {
+	// Allow users to override YARN command location
+	yarnCmd := os.Getenv("ST_YARNCMD")
+	if len(yarnCmd) != 0 {
+		_, err := exec.LookPath(yarnCmd)
+		if err == nil {
+			return yarnCmd
+		}
+	}
+	// Arch, etc.
+	_, err := exec.LookPath("yarn")
+	if err == nil {
+		return "yarn"
+	}
+	// Debian, etc. (yarn conflicts with other software)
+	_, err = exec.LookPath("yarnpkg")
+	if err == nil {
+		return "yarnpkg"
+	}
+	panic("yarn does not seem to be installed!")
+}

--- a/packages/go/stbernard/workspace/golang/build.go
+++ b/packages/go/stbernard/workspace/golang/build.go
@@ -62,7 +62,7 @@ func buildModuleMainPackages(buildDir string, modPath string, version semver.Ver
 		errs []error
 		mu   sync.Mutex
 
-		command             = "go"
+		command             = environment.GoCommand()
 		majorString         = fmt.Sprintf("-X 'github.com/specterops/bloodhound/cmd/api/src/version.majorVersion=%d'", version.Major())
 		minorString         = fmt.Sprintf("-X 'github.com/specterops/bloodhound/cmd/api/src/version.minorVersion=%d'", version.Minor())
 		patchString         = fmt.Sprintf("-X 'github.com/specterops/bloodhound/cmd/api/src/version.patchVersion=%d'", version.Patch())

--- a/packages/go/stbernard/workspace/golang/generate.go
+++ b/packages/go/stbernard/workspace/golang/generate.go
@@ -105,7 +105,7 @@ func parallelGenerateModulePackages(jobC <-chan GoPackage, waitGroup *sync.WaitG
 					addErr(err)
 				} else if hasGenerationDirectives {
 					var (
-						command = "go"
+						command = environment.GoCommand()
 						args    = []string{"generate", nextPackage.Dir}
 					)
 

--- a/packages/go/stbernard/workspace/golang/goimports.go
+++ b/packages/go/stbernard/workspace/golang/goimports.go
@@ -29,7 +29,7 @@ func RunGoImports(env environment.Environment) error {
 	if err != nil {
 		return err
 	}
-	cmd := "go"
+	cmd := environment.GoCommand()
 	args := []string{"tool", "goimports", "-w", rootDir}
 
 	if _, err := cmdrunner.Run(cmd, args, rootDir, env); err != nil {

--- a/packages/go/stbernard/workspace/golang/mod.go
+++ b/packages/go/stbernard/workspace/golang/mod.go
@@ -61,7 +61,8 @@ func ParseModulesAbsPaths(cwd string) ([]string, error) {
 }
 
 func moduleListPackages(modPath string) ([]GoPackage, error) {
-	if result, err := cmdrunner.Run("go", []string{"list", "-json", "./..."}, modPath, environment.NewEnvironment()); err != nil {
+	if result, err := cmdrunner.Run(environment.GoCommand(),
+			[]string{"list", "-json", "./..."}, modPath, environment.NewEnvironment()); err != nil {
 		return nil, fmt.Errorf("running go mod list: %w", err)
 	} else {
 		var (

--- a/packages/go/stbernard/workspace/golang/sync.go
+++ b/packages/go/stbernard/workspace/golang/sync.go
@@ -29,7 +29,7 @@ import (
 // TidyModules runs go mod tidy for all module paths passed
 func TidyModules(modPath string, env environment.Environment) error {
 	var (
-		command = "go"
+		command = environment.GoCommand()
 		args    = []string{"mod", "tidy"}
 	)
 
@@ -44,7 +44,7 @@ func TidyModules(modPath string, env environment.Environment) error {
 // variables
 func SyncWorkspace(cwd string, env environment.Environment) error {
 	var (
-		command = "go"
+		command = environment.GoCommand()
 		args    = []string{"work", "sync"}
 	)
 

--- a/packages/go/stbernard/workspace/golang/tester.go
+++ b/packages/go/stbernard/workspace/golang/tester.go
@@ -54,7 +54,7 @@ var (
 func TestWorkspace(cwd string, modPath string, profileDir string, env environment.Environment, integration bool, tags string) error {
 	var (
 		manifest = make(map[string]string, len(modPath))
-		command  = "go"
+		command  = environment.GoCommand()
 		args     = []string{"test"}
 	)
 
@@ -111,7 +111,7 @@ func GetCombinedCoverage(coverFile string, env environment.Environment) (string,
 		args = []string{"tool", "cover", "-func", filepath.Base(coverFile)}
 	)
 
-	if result, err := cmdrunner.Run("go", args, filepath.Dir(coverFile), env); err != nil {
+	if result, err := cmdrunner.Run(environment.GoCommand(), args, filepath.Dir(coverFile), env); err != nil {
 		return "", fmt.Errorf("combined coverage: %w", err)
 	} else {
 		matches := combinedCoverageRegex.FindStringSubmatch(result.StandardOutput.String())

--- a/packages/go/stbernard/workspace/workspace.go
+++ b/packages/go/stbernard/workspace/workspace.go
@@ -99,7 +99,7 @@ func FindPaths(env environment.Environment) (WorkspacePaths, error) {
 // GenerateSchema runs schemagen for the current workspace
 func GenerateSchema(cwd string, env environment.Environment) error {
 	var (
-		command = "go"
+		command = environment.GoCommand()
 		args    = []string{"run"}
 	)
 

--- a/packages/go/stbernard/workspace/yarn/yarn.go
+++ b/packages/go/stbernard/workspace/yarn/yarn.go
@@ -58,7 +58,7 @@ type Workspace struct {
 // InstallWorkspaceDeps runs yarn install for a given list of jsPaths
 func InstallWorkspaceDeps(cwd string, jsPaths []string, env environment.Environment) error {
 	var (
-		command = "yarn"
+		command = environment.YarnCommand()
 		args    = []string{"install"}
 	)
 
@@ -74,7 +74,7 @@ func InstallWorkspaceDeps(cwd string, jsPaths []string, env environment.Environm
 // Format runs yarn format on current workspace
 func Format(cwd string, env environment.Environment) error {
 	var (
-		command = "yarn"
+		command = environment.YarnCommand()
 		args    = []string{"format"}
 	)
 
@@ -88,7 +88,7 @@ func Format(cwd string, env environment.Environment) error {
 // BuildWorkspace runs yarn build for the current working directory
 func BuildWorkspace(cwd string, env environment.Environment) error {
 	var (
-		command = "yarn"
+		command = environment.YarnCommand()
 		args    = []string{"build"}
 	)
 
@@ -102,7 +102,7 @@ func BuildWorkspace(cwd string, env environment.Environment) error {
 // TestWorkspace runs yarn tests for all yarn workspaces
 func TestWorkspace(cwd string, env environment.Environment) error {
 	var (
-		command = "yarn"
+		command = environment.YarnCommand()
 		args    = []string{"test", "--coverage", "--run"}
 	)
 


### PR DESCRIPTION

## Description

Support alternative naming for the yarn binary on distributions like Debian in stbernard.

## Motivation and Context

Resolves #1738 .  Search for yarn, then yarnpkg to support cleaner building of Bloodhound on Debian

## How Has This Been Tested?

stbernard used on Debian, and Arch.


## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [X] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [X] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [X] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The application now dynamically detects and uses the appropriate Go and Yarn executables based on your environment, enhancing compatibility and flexibility.

* **Bug Fixes**
  * Fixed issues caused by hardcoded Go and Yarn command usage, improving reliability across diverse system configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->