### PR TITLE
bed-6239: remove v1 error response

### DIFF
--- a/cmd/api/src/api/error.go
+++ b/cmd/api/src/api/error.go
@@ -95,13 +95,7 @@ func IsErrorResponse(response *http.Response) bool {
 	return response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices
 }
 
-// ErrorResponse is the V1 response
-type ErrorResponse struct {
-	HTTPStatus int
-	Error      any
-}
-
-// ErrorWrapper is the V2 response
+// ErrorWrapper is the standard API response structure
 type ErrorWrapper struct {
 	HTTPStatus int            `json:"http_status"`
 	Timestamp  time.Time      `json:"timestamp"`

--- a/cmd/api/src/api/marshalling_test.go
+++ b/cmd/api/src/api/marshalling_test.go
@@ -39,16 +39,6 @@ func TestWriteErrorResponse_InvalidFormat(t *testing.T) {
 	require.Contains(t, response.Body.String(), "internal error")
 }
 
-func TestWriteErrorResponse_V1(t *testing.T) {
-	response := httptest.NewRecorder()
-	api.WriteErrorResponse(context.Background(), &api.ErrorResponse{
-		HTTPStatus: http.StatusTeapot,
-		Error:      json.RawMessage(`{"foo":"bar"}`),
-	}, response)
-	require.Equal(t, response.Code, http.StatusTeapot)
-	require.Contains(t, response.Body.String(), "foo")
-}
-
 func TestWriteErrorResponse_V2(t *testing.T) {
 	response := httptest.NewRecorder()
 	api.WriteErrorResponse(context.Background(), &api.ErrorWrapper{


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Removing V1 error struct
https://specterops.atlassian.net/browse/BED-6239

## How Has This Been Tested?
After the struct was removed, I ran the unit tests and found the V1 tests failing (as expected). I proceeded to remove the V1 tests for a green build.

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified error response handling by consolidating to a single error response format across the API.
  * Removed legacy support for the previous error response structure.

* **Tests**
  * Removed tests related to the deprecated error response format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->