### PR TITLE
feat: AdminSDHolder Protected - BED-6286

### DIFF
--- a/cmd/api/src/database/migration/migrations/v8.1.0.sql
+++ b/cmd/api/src/database/migration/migrations/v8.1.0.sql
@@ -1,3 +1,18 @@
+-- Copyright 2025 Specter Ops, Inc.
+--
+-- Licensed under the Apache License, Version 2.0
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- SPDX-License-Identifier: Apache-2.0
 -- Targeted Access Control Feature Flag
 INSERT INTO feature_flags (created_at, updated_at, key, name, description, enabled, user_updatable)
 VALUES (current_timestamp,

--- a/cmd/ui/public/img/BHCE_Vertical_RedField.svg
+++ b/cmd/ui/public/img/BHCE_Vertical_RedField.svg
@@ -1,3 +1,20 @@
+<!--
+    Copyright 2025 Specter Ops, Inc.
+    
+    Licensed under the Apache License, Version 2.0
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    
+        http://www.apache.org/licenses/LICENSE-2.0
+    
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+    
+    SPDX-License-Identifier: Apache-2.0
+-->
 <svg width="500" height="500" viewBox="0 0 500 500" fill="none" xmlns="http://www.w3.org/2000/svg">
 <rect width="500" height="500" rx="10" fill="#E02F35"/>
 <path d="M72.3256 438.227C70.1717 438.227 68.3311 437.796 66.7907 436.922C65.2503 436.047 64.0754 434.82 63.253 433.227C62.4306 431.635 62.0259 429.755 62.0259 427.575C62.0259 425.395 62.4306 423.528 63.253 421.935C64.0754 420.356 65.2503 419.129 66.7907 418.254C68.3311 417.38 70.1717 416.949 72.3256 416.949C73.7094 416.949 75.0279 417.158 76.268 417.588C77.5082 418.019 78.5394 418.633 79.3357 419.442L78.1086 422.431C77.234 421.687 76.3333 421.139 75.4064 420.8C74.4796 420.46 73.5005 420.291 72.4431 420.291C70.3545 420.291 68.7488 420.917 67.6653 422.183C66.5687 423.45 66.0205 425.238 66.0205 427.575C66.0205 429.912 66.5687 431.7 67.6653 432.979C68.7618 434.259 70.3545 434.885 72.4431 434.885C73.5005 434.885 74.4926 434.715 75.4064 434.376C76.3202 434.037 77.221 433.488 78.1086 432.744L79.3357 435.734C78.5394 436.517 77.5082 437.13 76.268 437.574C75.0279 438.018 73.7094 438.24 72.3256 438.24V438.227Z" fill="white"/>

--- a/packages/cue/bh/ad/ad.cue
+++ b/packages/cue/bh/ad/ad.cue
@@ -292,6 +292,13 @@ AdminCount: types.#StringEnum & {
 	representation: "admincount"
 }
 
+AdminSDHolderProtected: types.#StringEnum & {
+	symbol:         "AdminSDHolderProtected"
+	schema:         "ad"
+	name:           "AdminSDHolder Protected"
+	representation: "adminsdholderprotected"
+}
+
 DontRequirePreAuth: types.#StringEnum & {
 	symbol:         "DontRequirePreAuth"
 	schema:         "ad"
@@ -1126,6 +1133,7 @@ Properties: [
 	Transitive,
 	GroupScope,
 	NetBIOS,
+	AdminSDHolderProtected,
 ]
 
 // Kinds

--- a/packages/go/graphschema/ad/ad.go
+++ b/packages/go/graphschema/ad/ad.go
@@ -265,10 +265,11 @@ const (
 	Transitive                              Property = "transitive"
 	GroupScope                              Property = "groupscope"
 	NetBIOS                                 Property = "netbios"
+	AdminSDHolderProtected                  Property = "adminsdholderprotected"
 )
 
 func AllProperties() []Property {
-	return []Property{AdminCount, CASecurityCollected, CAName, CertChain, CertName, CertThumbprint, CertThumbprints, HasEnrollmentAgentRestrictions, EnrollmentAgentRestrictionsCollected, IsUserSpecifiesSanEnabled, IsUserSpecifiesSanEnabledCollected, RoleSeparationEnabled, RoleSeparationEnabledCollected, HasBasicConstraints, BasicConstraintPathLength, UnresolvedPublishedTemplates, DNSHostname, CrossCertificatePair, DistinguishedName, DomainFQDN, DomainSID, Sensitive, BlocksInheritance, IsACL, IsACLProtected, InheritanceHash, InheritanceHashes, IsDeleted, Enforced, Department, HasCrossCertificatePair, HasSPN, UnconstrainedDelegation, LastLogon, LastLogonTimestamp, IsPrimaryGroup, HasLAPS, DontRequirePreAuth, LogonType, HasURA, PasswordNeverExpires, PasswordNotRequired, FunctionalLevel, TrustType, SpoofSIDHistoryBlocked, TrustedToAuth, SamAccountName, CertificateMappingMethodsRaw, CertificateMappingMethods, StrongCertificateBindingEnforcementRaw, StrongCertificateBindingEnforcement, EKUs, SubjectAltRequireUPN, SubjectAltRequireDNS, SubjectAltRequireDomainDNS, SubjectAltRequireEmail, SubjectAltRequireSPN, SubjectRequireEmail, AuthorizedSignatures, ApplicationPolicies, IssuancePolicies, SchemaVersion, RequiresManagerApproval, AuthenticationEnabled, SchannelAuthenticationEnabled, EnrolleeSuppliesSubject, CertificateApplicationPolicy, CertificateNameFlag, EffectiveEKUs, EnrollmentFlag, Flags, NoSecurityExtension, RenewalPeriod, ValidityPeriod, OID, HomeDirectory, CertificatePolicy, CertTemplateOID, GroupLinkID, ObjectGUID, ExpirePasswordsOnSmartCardOnlyAccounts, MachineAccountQuota, SupportedKerberosEncryptionTypes, TGTDelegation, PasswordStoredUsingReversibleEncryption, SmartcardRequired, UseDESKeyOnly, LogonScriptEnabled, LockedOut, UserCannotChangePassword, PasswordExpired, DSHeuristics, UserAccountControl, TrustAttributesInbound, TrustAttributesOutbound, MinPwdLength, PwdProperties, PwdHistoryLength, LockoutThreshold, MinPwdAge, MaxPwdAge, LockoutDuration, LockoutObservationWindow, OwnerSid, SMBSigning, WebClientRunning, RestrictOutboundNTLM, GMSA, MSA, DoesAnyAceGrantOwnerRights, DoesAnyInheritedAceGrantOwnerRights, ADCSWebEnrollmentHTTP, ADCSWebEnrollmentHTTPS, ADCSWebEnrollmentHTTPSEPA, LDAPSigning, LDAPAvailable, LDAPSAvailable, LDAPSEPA, IsDC, IsReadOnlyDC, HTTPEnrollmentEndpoints, HTTPSEnrollmentEndpoints, HasVulnerableEndpoint, RequireSecuritySignature, EnableSecuritySignature, RestrictReceivingNTLMTraffic, NTLMMinServerSec, NTLMMinClientSec, LMCompatibilityLevel, UseMachineID, ClientAllowedNTLMServers, Transitive, GroupScope, NetBIOS}
+	return []Property{AdminCount, CASecurityCollected, CAName, CertChain, CertName, CertThumbprint, CertThumbprints, HasEnrollmentAgentRestrictions, EnrollmentAgentRestrictionsCollected, IsUserSpecifiesSanEnabled, IsUserSpecifiesSanEnabledCollected, RoleSeparationEnabled, RoleSeparationEnabledCollected, HasBasicConstraints, BasicConstraintPathLength, UnresolvedPublishedTemplates, DNSHostname, CrossCertificatePair, DistinguishedName, DomainFQDN, DomainSID, Sensitive, BlocksInheritance, IsACL, IsACLProtected, InheritanceHash, InheritanceHashes, IsDeleted, Enforced, Department, HasCrossCertificatePair, HasSPN, UnconstrainedDelegation, LastLogon, LastLogonTimestamp, IsPrimaryGroup, HasLAPS, DontRequirePreAuth, LogonType, HasURA, PasswordNeverExpires, PasswordNotRequired, FunctionalLevel, TrustType, SpoofSIDHistoryBlocked, TrustedToAuth, SamAccountName, CertificateMappingMethodsRaw, CertificateMappingMethods, StrongCertificateBindingEnforcementRaw, StrongCertificateBindingEnforcement, EKUs, SubjectAltRequireUPN, SubjectAltRequireDNS, SubjectAltRequireDomainDNS, SubjectAltRequireEmail, SubjectAltRequireSPN, SubjectRequireEmail, AuthorizedSignatures, ApplicationPolicies, IssuancePolicies, SchemaVersion, RequiresManagerApproval, AuthenticationEnabled, SchannelAuthenticationEnabled, EnrolleeSuppliesSubject, CertificateApplicationPolicy, CertificateNameFlag, EffectiveEKUs, EnrollmentFlag, Flags, NoSecurityExtension, RenewalPeriod, ValidityPeriod, OID, HomeDirectory, CertificatePolicy, CertTemplateOID, GroupLinkID, ObjectGUID, ExpirePasswordsOnSmartCardOnlyAccounts, MachineAccountQuota, SupportedKerberosEncryptionTypes, TGTDelegation, PasswordStoredUsingReversibleEncryption, SmartcardRequired, UseDESKeyOnly, LogonScriptEnabled, LockedOut, UserCannotChangePassword, PasswordExpired, DSHeuristics, UserAccountControl, TrustAttributesInbound, TrustAttributesOutbound, MinPwdLength, PwdProperties, PwdHistoryLength, LockoutThreshold, MinPwdAge, MaxPwdAge, LockoutDuration, LockoutObservationWindow, OwnerSid, SMBSigning, WebClientRunning, RestrictOutboundNTLM, GMSA, MSA, DoesAnyAceGrantOwnerRights, DoesAnyInheritedAceGrantOwnerRights, ADCSWebEnrollmentHTTP, ADCSWebEnrollmentHTTPS, ADCSWebEnrollmentHTTPSEPA, LDAPSigning, LDAPAvailable, LDAPSAvailable, LDAPSEPA, IsDC, IsReadOnlyDC, HTTPEnrollmentEndpoints, HTTPSEnrollmentEndpoints, HasVulnerableEndpoint, RequireSecuritySignature, EnableSecuritySignature, RestrictReceivingNTLMTraffic, NTLMMinServerSec, NTLMMinClientSec, LMCompatibilityLevel, UseMachineID, ClientAllowedNTLMServers, Transitive, GroupScope, NetBIOS, AdminSDHolderProtected}
 }
 func ParseProperty(source string) (Property, error) {
 	switch source {
@@ -540,6 +541,8 @@ func ParseProperty(source string) (Property, error) {
 		return GroupScope, nil
 	case "netbios":
 		return NetBIOS, nil
+	case "adminsdholderprotected":
+		return AdminSDHolderProtected, nil
 	default:
 		return "", errors.New("Invalid enumeration value: " + source)
 	}
@@ -814,6 +817,8 @@ func (s Property) String() string {
 		return string(GroupScope)
 	case NetBIOS:
 		return string(NetBIOS)
+	case AdminSDHolderProtected:
+		return string(AdminSDHolderProtected)
 	default:
 		return "Invalid enumeration case: " + string(s)
 	}
@@ -1088,6 +1093,8 @@ func (s Property) Name() string {
 		return "Group Scope"
 	case NetBIOS:
 		return "NetBIOS"
+	case AdminSDHolderProtected:
+		return "AdminSDHolder Protected"
 	default:
 		return "Invalid enumeration case: " + string(s)
 	}

--- a/packages/javascript/bh-shared-ui/src/commonSearchesAGI.ts
+++ b/packages/javascript/bh-shared-ui/src/commonSearchesAGI.ts
@@ -273,7 +273,7 @@ export const CommonSearches: CommonSearchType[] = [
             },
             {
                 description: 'Tier Zero principals without AdminSDHolder protection',
-                cypher: `MATCH (n:Base)\nWHERE (n:Tag_Tier_Zero)\nAND n.adminsdholderprotected = false\nRETURN n\nLIMIT 500`,
+                cypher: `MATCH (n:Base)\nWHERE ((n:Tag_Tier_Zero) OR COALESCE(n.system_tags, '') CONTAINS 'admin_tier_0')\nAND n.adminsdholderprotected = false\nRETURN n\nLIMIT 500`,
             },
         ],
     },

--- a/packages/javascript/bh-shared-ui/src/commonSearchesAGI.ts
+++ b/packages/javascript/bh-shared-ui/src/commonSearchesAGI.ts
@@ -271,6 +271,10 @@ export const CommonSearches: CommonSearchType[] = [
                 description: 'Tier Zero / High Value users with non-expiring passwords',
                 cypher: `MATCH (u:User)\nWHERE u.enabled = true\nAND u.pwdneverexpires = true\nand COALESCE(u.system_tags, '') CONTAINS '${TIER_ZERO_TAG}'\nRETURN u\nLIMIT 100`,
             },
+            {
+                description: 'Tier Zero principals without AdminSDHolder protection',
+                cypher: `MATCH (n:Base)\nWHERE (n:Tag_Tier_Zero)\nAND n.adminsdholderprotected = false\nRETURN n\nLIMIT 500`,
+            },
         ],
     },
     {

--- a/packages/javascript/bh-shared-ui/src/commonSearchesAGI.ts
+++ b/packages/javascript/bh-shared-ui/src/commonSearchesAGI.ts
@@ -273,7 +273,7 @@ export const CommonSearches: CommonSearchType[] = [
             },
             {
                 description: 'Tier Zero principals without AdminSDHolder protection',
-                cypher: `MATCH (n:Base)\nWHERE ((n:Tag_Tier_Zero) OR COALESCE(n.system_tags, '') CONTAINS 'admin_tier_0')\nAND n.adminsdholderprotected = false\nRETURN n\nLIMIT 500`,
+                cypher: `MATCH (n:Base)\nWHERE COALESCE(n.system_tags, '') CONTAINS '${TIER_ZERO_TAG}'\nAND n.adminsdholderprotected = false\nRETURN n\nLIMIT 500`,
             },
         ],
     },

--- a/packages/javascript/bh-shared-ui/src/commonSearchesAGT.ts
+++ b/packages/javascript/bh-shared-ui/src/commonSearchesAGT.ts
@@ -273,7 +273,7 @@ export const CommonSearches: CommonSearchType[] = [
             },
             {
                 description: 'Tier Zero principals without AdminSDHolder protection',
-                cypher: `MATCH (n:Base)\nWHERE ((n:Tag_Tier_Zero) OR COALESCE(n.system_tags, '') CONTAINS 'admin_tier_0')\nAND n.adminsdholderprotected = false\nRETURN n\nLIMIT 500`,
+                cypher: `MATCH (n:Base)\nWHERE (n:${TAG_TIER_ZERO_AGT})\nAND n.adminsdholderprotected = false\nRETURN n\nLIMIT 500`,
             },
         ],
     },

--- a/packages/javascript/bh-shared-ui/src/commonSearchesAGT.ts
+++ b/packages/javascript/bh-shared-ui/src/commonSearchesAGT.ts
@@ -271,6 +271,10 @@ export const CommonSearches: CommonSearchType[] = [
                 description: 'Tier Zero / High Value users with non-expiring passwords',
                 cypher: `MATCH (u:User)\nWHERE (u:${TAG_TIER_ZERO_AGT}) AND u.enabled = true\nAND u.pwdneverexpires = true\nRETURN u\nLIMIT 100`,
             },
+            {
+                description: 'Tier Zero principals without AdminSDHolder protection',
+                cypher: `MATCH (n:Base)\nWHERE (n:Tag_Tier_Zero)\nAND n.adminsdholderprotected = false\nRETURN n\nLIMIT 500`,
+            },
         ],
     },
     {

--- a/packages/javascript/bh-shared-ui/src/commonSearchesAGT.ts
+++ b/packages/javascript/bh-shared-ui/src/commonSearchesAGT.ts
@@ -273,7 +273,7 @@ export const CommonSearches: CommonSearchType[] = [
             },
             {
                 description: 'Tier Zero principals without AdminSDHolder protection',
-                cypher: `MATCH (n:Base)\nWHERE (n:Tag_Tier_Zero)\nAND n.adminsdholderprotected = false\nRETURN n\nLIMIT 500`,
+                cypher: `MATCH (n:Base)\nWHERE ((n:Tag_Tier_Zero) OR COALESCE(n.system_tags, '') CONTAINS 'admin_tier_0')\nAND n.adminsdholderprotected = false\nRETURN n\nLIMIT 500`,
             },
         ],
     },

--- a/packages/javascript/bh-shared-ui/src/graphSchema.ts
+++ b/packages/javascript/bh-shared-ui/src/graphSchema.ts
@@ -487,6 +487,7 @@ export enum ActiveDirectoryKindProperties {
     Transitive = 'transitive',
     GroupScope = 'groupscope',
     NetBIOS = 'netbios',
+    AdminSDHolderProtected = 'adminsdholderprotected',
 }
 export function ActiveDirectoryKindPropertiesToDisplay(value: ActiveDirectoryKindProperties): string | undefined {
     switch (value) {
@@ -758,6 +759,8 @@ export function ActiveDirectoryKindPropertiesToDisplay(value: ActiveDirectoryKin
             return 'Group Scope';
         case ActiveDirectoryKindProperties.NetBIOS:
             return 'NetBIOS';
+        case ActiveDirectoryKindProperties.AdminSDHolderProtected:
+            return 'AdminSDHolder Protected';
         default:
             return undefined;
     }

--- a/packages/javascript/bh-shared-ui/src/views/ZoneManagement/Details/DetailsList.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/ZoneManagement/Details/DetailsList.test.tsx
@@ -106,14 +106,14 @@ describe('List', async () => {
     });
 
     it('renders a sortable list for Labels', async () => {
-        render(<DetailsList title='Labels' listQuery={testQuery} selected={'1'} onSelect={() => { }} />);
+        render(<DetailsList title='Labels' listQuery={testQuery} selected={'1'} onSelect={() => {}} />);
 
         expect(await screen.findByText('app-icon-sort-asc')).toBeInTheDocument();
         expect(screen.queryByTestId('zone-management_details_labels-list_static-order')).not.toBeInTheDocument();
     });
 
     it('renders a non sortable list for Tiers', async () => {
-        render(<DetailsList title='Tiers' listQuery={testQuery} selected={'1'} onSelect={() => { }} />);
+        render(<DetailsList title='Tiers' listQuery={testQuery} selected={'1'} onSelect={() => {}} />);
 
         expect(await screen.findByTestId('zone-management_details_tiers-list_static-order')).toBeInTheDocument();
         expect(screen.queryByText('app-icon-sort-empty')).not.toBeInTheDocument();
@@ -179,7 +179,7 @@ describe('List', async () => {
     });
 
     it('handles rendering a selected item', async () => {
-        render(<DetailsList title='Tiers' listQuery={testQuery} selected={'1'} onSelect={() => { }} />);
+        render(<DetailsList title='Tiers' listQuery={testQuery} selected={'1'} onSelect={() => {}} />);
 
         expect(await screen.findByTestId('zone-management_details_tiers-list_active-tiers-item-1')).toBeInTheDocument();
     });


### PR DESCRIPTION
## Description

Adds bool AdminSDHolder Protected to entity panel for user, group, and computer nodes based on adminsdholderprotected JSON property from SharpHound & SharpHound Enterprise (with PRs 165 & 57 merged).

Add pre-defined cypher query to display Tier Zero nodes that are not AdminSDHolder Protected.

## Motivation and Context

Resolves BED-6286

This change is part of my AdminSDHolder redesign, which is captured in BED-6178 and the associated Product Discovery Design Doc.  There are misconceptions about how AdminSDHolder works and I've written a 160+ page whitepaper to clear them up.  All of this is linked in BED-6178.

The purpose of this specific change is to introduce into bhce and bhe the bare-minimum functionality for the AdminSDHolder changes so that the SharpHound and SharpHound Enterprise PRs could be merged into a release-cut along with this and provide the basic functionality.  Then later, the changes which add ProtectAdminGroups non-traversable edge (6223), updated BHE finding remediations (6241) and updated public documentation (6224) can be tackled as appropriate.

## How Has This Been Tested?

*Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc.*

My BH-Dev environment runs in WSL2 on my SO laptop. I have configured an extensive home lab environment for the purposes of testing the AdminSDHolder functionality and writing the whitepaper.  I've been collecting data from that lab environment using the modified shfoss and she versions in the aforementioned PRs for those repos.

I've tested this change in BHCE with data ingested from SharpHound FOSS using the adminsdholderprotected updates in 6221.

I've tested this change with BHE on the current version of main (post v8 mergeback) using this BHCE branch and ingested data from both SharpHound FOSS and SharpHound Enterprise with the adminsdholderprotected updates in 6221.

While working on this feature, and predominately the SharpHound changes, I kept a BHE-Dev instance running on my laptop and kept a SHDelegator instance running in my lab with the latest builds of my SH changes.  This functioned properly.

I also tested ingesting an old SharpHound FOSS collection (2.6.1.0) that does not have the adminsdholderprotected property in the JSON.  This file ingests properly and, as expected, does not display an AdminSDHolder Protected property in the entity panel.

## Screenshots (optional):
<img width="2497" height="1470" alt="image" src="https://github.com/user-attachments/assets/4a56949f-3d45-49b4-87eb-32d3e04eecd4" />

<img width="2502" height="1485" alt="image" src="https://github.com/user-attachments/assets/4595bafc-e842-48ab-a2a6-b0888d5d38e0" />

<img width="3342" height="1476" alt="image" src="https://github.com/user-attachments/assets/4db49fae-b7ca-4432-a66e-a80d50ab4d89" />


## Types of changes
- New feature (non-breaking change which adds functionality)

## Checklist:
- [X] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [X] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [X] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the "AdminSDHolder Protected" property in Active Directory schema and user interface.
  * Introduced new common search queries to identify Tier Zero principals without AdminSDHolder protection in Active Directory Hygiene categories.

* **Style**
  * Minor formatting improvements in test files for consistency.

* **Documentation**
  * Added Apache License 2.0 header to SQL migration file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->