### PR TITLE
BED-6211: Migration for users_roles table to support TAC ACL

### DIFF
--- a/cmd/api/src/database/migration/migrations/v8.1.0.sql
+++ b/cmd/api/src/database/migration/migrations/v8.1.0.sql
@@ -13,6 +13,7 @@
 -- limitations under the License.
 --
 -- SPDX-License-Identifier: Apache-2.0
+
 -- Targeted Access Control Feature Flag
 INSERT INTO feature_flags (created_at, updated_at, key, name, description, enabled, user_updatable)
 VALUES (current_timestamp,
@@ -23,3 +24,8 @@ VALUES (current_timestamp,
         false,
         false)
 ON CONFLICT DO NOTHING;
+
+-- Targeted Access Control users_roles column additions and defaults
+ALTER TABLE users_roles 
+        ADD COLUMN IF NOT EXISTS access_control_list text[] default array ['all_environments'],
+        ADD COLUMN IF NOT EXISTS explore_enabled bool DEFAULT true;


### PR DESCRIPTION
## Description

PR to update users_roles table to support TAC ACL

## Motivation and Context

Resolves [BED-6211](https://specterops.atlassian.net/browse/BED-6211)

## How Has This Been Tested?

This has been manually tested

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Database Migrations

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [X] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [X] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [X] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


[BED-6211]: https://specterops.atlassian.net/browse/BED-6211?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced support for targeted access control, allowing more granular management of user permissions.
  * Added new settings for user roles to enable or disable exploration features and specify environment access.

* **Chores**
  * Updated database to support new access control features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->