### PR TITLE
chore: bump SharpHound Version

### DIFF
--- a/dockerfiles/bloodhound.Dockerfile
+++ b/dockerfiles/bloodhound.Dockerfile
@@ -19,7 +19,7 @@
 ########
 # Global build args
 ################
-ARG SHARPHOUND_VERSION=v2.7.0
+ARG SHARPHOUND_VERSION=v2.7.1
 ARG AZUREHOUND_VERSION=v2.6.0
 
 ########

--- a/packages/javascript/bh-shared-ui/src/views/ZoneManagement/Details/DetailsList.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/ZoneManagement/Details/DetailsList.test.tsx
@@ -90,7 +90,7 @@ describe('List', async () => {
     it('shows a loading view when data is fetching', async () => {
         const testQuery = { isLoading: true, isError: false, data: [] } as unknown as UseQueryResult<AssetGroupTag[]>;
 
-        render(<DetailsList title='Selectors' listQuery={testQuery} selected={'1'} onSelect={() => { }} />);
+        render(<DetailsList title='Selectors' listQuery={testQuery} selected={'1'} onSelect={() => {}} />);
 
         expect(screen.getAllByTestId('zone-management_selectors-list_loading-skeleton')).toHaveLength(3);
     });
@@ -98,27 +98,27 @@ describe('List', async () => {
     it('handles data fetching errors', async () => {
         const testQuery = { isLoading: false, isError: true, data: [] } as unknown as UseQueryResult<AssetGroupTag[]>;
 
-        render(<DetailsList title='Selectors' listQuery={testQuery} selected={'1'} onSelect={() => { }} />);
+        render(<DetailsList title='Selectors' listQuery={testQuery} selected={'1'} onSelect={() => {}} />);
 
         expect(await screen.findByText('There was an error fetching this data')).toBeInTheDocument();
     });
 
     it('renders a sortable list for Selectors', async () => {
-        render(<DetailsList title='Selectors' listQuery={testQuery} selected={'1'} onSelect={() => { }} />);
+        render(<DetailsList title='Selectors' listQuery={testQuery} selected={'1'} onSelect={() => {}} />);
 
         expect(await screen.findByText('app-icon-sort-asc')).toBeInTheDocument();
         expect(screen.queryByTestId('zone-management_details_selectors-list_static-order')).not.toBeInTheDocument();
     });
 
     it('renders a sortable list for Labels', async () => {
-        render(<DetailsList title='Labels' listQuery={testQuery} selected={'1'} onSelect={() => { }} />);
+        render(<DetailsList title='Labels' listQuery={testQuery} selected={'1'} onSelect={() => {}} />);
 
         expect(await screen.findByText('app-icon-sort-asc')).toBeInTheDocument();
         expect(screen.queryByTestId('zone-management_details_labels-list_static-order')).not.toBeInTheDocument();
     });
 
     it('renders a non sortable list for Tiers', async () => {
-        render(<DetailsList title='Tiers' listQuery={testQuery} selected={'1'} onSelect={() => { }} />);
+        render(<DetailsList title='Tiers' listQuery={testQuery} selected={'1'} onSelect={() => {}} />);
 
         expect(await screen.findByTestId('zone-management_details_tiers-list_static-order')).toBeInTheDocument();
         expect(screen.queryByText('app-icon-sort-empty')).not.toBeInTheDocument();
@@ -140,7 +140,7 @@ describe('List', async () => {
             })
         );
 
-        render(<DetailsList title='Tiers' listQuery={testQuery} selected={'1'} onSelect={() => { }} />);
+        render(<DetailsList title='Tiers' listQuery={testQuery} selected={'1'} onSelect={() => {}} />);
 
         const listItem = await screen.findByTestId('zone-management_details_tiers-list_item-2');
         expect(listItem).toBeInTheDocument();
@@ -156,7 +156,7 @@ describe('List', async () => {
             })
         );
 
-        render(<DetailsList title='Tiers' listQuery={testQuery} selected={'1'} onSelect={() => { }} />);
+        render(<DetailsList title='Tiers' listQuery={testQuery} selected={'1'} onSelect={() => {}} />);
 
         const listItem = screen.getByTestId('zone-management_details_tiers-list_item-2');
         expect(listItem).toBeInTheDocument();
@@ -172,7 +172,7 @@ describe('List', async () => {
             })
         );
 
-        render(<DetailsList title='Tiers' listQuery={testQuery} selected={'1'} onSelect={() => { }} />);
+        render(<DetailsList title='Tiers' listQuery={testQuery} selected={'1'} onSelect={() => {}} />);
 
         const listItem1 = screen.getByTestId('zone-management_details_tiers-list_item-1');
         expect(listItem1).toBeInTheDocument();
@@ -184,7 +184,7 @@ describe('List', async () => {
     });
 
     it('handles rendering a selected item', async () => {
-        render(<DetailsList title='Tiers' listQuery={testQuery} selected={'1'} onSelect={() => { }} />);
+        render(<DetailsList title='Tiers' listQuery={testQuery} selected={'1'} onSelect={() => {}} />);
 
         expect(await screen.findByTestId('zone-management_details_tiers-list_active-tiers-item-1')).toBeInTheDocument();
     });

--- a/tools/docker-compose/api.Dockerfile
+++ b/tools/docker-compose/api.Dockerfile
@@ -17,7 +17,7 @@
 ########
 # Global build args
 ################
-ARG SHARPHOUND_VERSION=v2.7.0
+ARG SHARPHOUND_VERSION=v2.7.1
 ARG AZUREHOUND_VERSION=v2.6.0
 
 ########


### PR DESCRIPTION
## Description

Bumps SharpHound to the Latest Version

## Motivation and Context

Resolves [BED-6302](https://specterops.atlassian.net/browse/BED-6302)

A new patch was released of SharpHound and this change includes this new version. 

## How Has This Been Tested?

This has been tested by building and running locally and ensuring the new version of SharpHound was available.


## Screenshots (optional):

## Types of changes



- Chore (a change that does not modify the application functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


[BED-6302]: https://specterops.atlassian.net/browse/BED-6302?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ