### PR TITLE
BED-6269: Explore table sort state

### DIFF
--- a/packages/javascript/bh-shared-ui/src/components/ExploreTable/ExploreTable.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/ExploreTable/ExploreTable.test.tsx
@@ -138,28 +138,42 @@ describe('ExploreTable', async () => {
 
         await screen.findByText('10 results');
 
-        // Unsorted first display name cell
-        expect(getFirstCellOfType('label')).toHaveTextContent('CERTMAN@PHANTOM.CORP');
+        // Make sure sort behavior loops through ascending, descending, unsorted
+        for (let i = 0; i < 3; i++) {
+            // Unsorted first display name cell
+            expect(getFirstCellOfType('label')).toHaveTextContent('CERTMAN@PHANTOM.CORP');
 
-        await user.click(screen.getByText('Name'));
+            await user.click(screen.getByText('Name'));
 
-        // Alphabetically sorted first display name cell
-        expect(getFirstCellOfType('label')).toHaveTextContent('ADMINISTRATOR@GHOST.CORP');
+            // Alphabetically sorted first display name cell
+            expect(getFirstCellOfType('label')).toHaveTextContent('ADMINISTRATOR@GHOST.CORP');
 
-        await user.click(screen.getByText('Name'));
+            await user.click(screen.getByText('Name'));
 
-        // Reverse Alphabetically sorted first display name cell
-        expect(getFirstCellOfType('label')).toHaveTextContent('ZZZIGNE@PHANTOM.CORP');
+            // Reverse Alphabetically sorted first display name cell
+            expect(getFirstCellOfType('label')).toHaveTextContent('ZZZIGNE@PHANTOM.CORP');
 
-        await user.click(screen.getByText('Object ID'));
+            // Reset to unsorted
+            await user.click(screen.getByText('Name'));
+        }
 
-        // Descending sorted first object id cell
-        expect(getFirstCellOfType('objectId')).toHaveTextContent('PHANTOM.CORP-S-1-5-20');
+        for (let i = 0; i < 3; i++) {
+            // Unsorted first object id cell
+            expect(getFirstCellOfType('objectId')).toHaveTextContent('S-1-5-21-2697957641-2271029196-387917394-2201');
 
-        await user.click(screen.getByText('Object ID'));
+            await user.click(screen.getByText('Object ID'));
 
-        // Ascending sorted first object id cell
-        expect(getFirstCellOfType('objectId')).toHaveTextContent('S-1-5-21-2845847946-3451170323-4261139666-1106');
+            // Descending sorted first object id cell
+            expect(getFirstCellOfType('objectId')).toHaveTextContent('PHANTOM.CORP-S-1-5-20');
+
+            await user.click(screen.getByText('Object ID'));
+
+            // Ascending sorted first object id cell
+            expect(getFirstCellOfType('objectId')).toHaveTextContent('S-1-5-21-2845847946-3451170323-4261139666-1106');
+
+            // Reset to unsorted
+            await user.click(screen.getByText('Object ID'));
+        }
     });
 
     it('Expand button causes table to expand to full height', async () => {

--- a/packages/javascript/bh-shared-ui/src/components/ExploreTable/useExploreTableRowsAndColumns.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/ExploreTable/useExploreTableRowsAndColumns.tsx
@@ -75,23 +75,17 @@ const useExploreTableRowsAndColumns = ({
 
     const handleSort = useCallback(
         (sortByColumn: keyof MungedTableRowWithId) => {
-            if (sortByColumn) {
-                if (sortBy === sortByColumn) {
-                    switch (sortOrder) {
-                        case 'desc':
-                            setSortOrder('asc');
-                            break;
-                        case 'asc':
-                            setSortOrder('desc');
-                            break;
-                        default:
-                            setSortOrder('desc');
-                            break;
-                    }
-                } else {
-                    setSortBy(sortByColumn);
-                    setSortOrder('asc');
-                }
+            if (!sortByColumn || sortByColumn !== sortBy) {
+                // first sort of a new column
+                setSortBy(sortByColumn);
+                setSortOrder('asc');
+            } else if (sortOrder === 'asc') {
+                // second sort, swap the sort direction
+                setSortOrder('desc');
+            } else {
+                // on third sort, reset the sort state to default
+                setSortBy(undefined);
+                setSortOrder(undefined);
             }
         },
         [sortBy, sortOrder]


### PR DESCRIPTION
## Description
Updates the column sorting functionality in the Explore table to reset the column sorting when the header is clicked for the third time in a row.

## Motivation and Context

Resolves [BED-6269](https://specterops.atlassian.net/browse/BED-6269)

Previously, there was no way to get back to the default "unsorted" state once a sorting direction was selected.

## How Has This Been Tested?
Updated existing explore table tests to cover the changes to column sorting state.

## Screenshots (optional):

## Types of changes
- New feature (non-breaking change which adds functionality)

## Checklist:
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
