### PR TITLE
BED-6290: Add AGT id to members

### DIFF
--- a/cmd/api/src/model/assetgrouptags.go
+++ b/cmd/api/src/model/assetgrouptags.go
@@ -121,15 +121,6 @@ func (s AssetGroupTag) KindName() string {
 	return fmt.Sprintf("Tag_%s", strings.ReplaceAll(s.Name, " ", "_"))
 }
 
-func KindsToAgtKind(kinds graph.Kinds) (graph.Kind, bool) {
-	for _, kind := range kinds {
-		if strings.HasPrefix(kind.String(), "Tag_") {
-			return kind, true
-		}
-	}
-	return nil, false
-}
-
 func (s AssetGroupTag) IsStringColumn(filter string) bool {
 	return filter == "name" || filter == "description"
 }


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Add asset group tag ID to the members structure returned by TBD endpoints. 

## Motivation and Context

Resolves https://specterops.atlassian.net/browse/BED-6290

## How Has This Been Tested?

*Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc.*

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- New feature (non-breaking change which adds functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [ ] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [ ] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API responses for asset group members now include the associated asset group tag ID, making member-to-tag relationships explicit across member detail, list-by-tag, and search endpoints.
  * Additive and backward compatible: existing fields remain unchanged.

* **Tests**
  * Updated tests to expect and validate the new tag ID in member responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->