### PR TITLE
chore: prelim work for pathfinding edge filter context menu

### DIFF
--- a/cmd/ui/src/components/SigmaChart/GraphEvents.tsx
+++ b/cmd/ui/src/components/SigmaChart/GraphEvents.tsx
@@ -30,8 +30,9 @@ import {
     resetCamera,
 } from 'src/ducks/graph/utils';
 import { bezier } from 'src/rendering/utils/bezier';
-import { getNodeRadius, preventAllDefaults } from 'src/rendering/utils/utils';
+import { getNodeRadius } from 'src/rendering/utils/utils';
 import { useAppSelector } from 'src/store';
+import { preventAllDefaults } from 'src/utils';
 import { sequentialLayout, standardLayout } from 'src/views/Explore/utils';
 
 interface SigmaChartRef {

--- a/cmd/ui/src/rendering/utils/utils.test.ts
+++ b/cmd/ui/src/rendering/utils/utils.test.ts
@@ -14,14 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import type { SigmaNodeEventPayload } from 'sigma/sigma';
-import { MouseCoords } from 'sigma/types';
-import {
-    getLabelBoundsFromContext,
-    getNodeRadius,
-    LabelBoundsParams,
-    preventAllDefaults,
-} from 'src/rendering/utils/utils';
+import { getLabelBoundsFromContext, getNodeRadius, LabelBoundsParams } from 'src/rendering/utils/utils';
 
 describe('getLabelBoundsFromContext', () => {
     it('returns bounds for text rendered to canvas', () => {
@@ -66,36 +59,5 @@ describe('getNodeRadius', () => {
 
         expect(getNodeRadius(true, 1, nodeSize)).not.toEqual(getNodeRadius(true, 0.5, nodeSize));
         expect(getNodeRadius(false, 1, nodeSize)).not.toEqual(getNodeRadius(false, 0.5, nodeSize));
-    });
-});
-
-describe('preventAllDefaults', () => {
-    it('prevents Sigma defaults events', () => {
-        const mockEvent: SigmaNodeEventPayload = {
-            event: { x: 10, y: 20 } as MouseCoords,
-            preventSigmaDefault: vi.fn(),
-            node: 'node-id',
-        };
-
-        preventAllDefaults(mockEvent);
-        expect(mockEvent.preventSigmaDefault).toHaveBeenCalled();
-    });
-
-    it('prevents MouseCoords events', () => {
-        const mockEvent = new MouseEvent('click');
-        mockEvent.preventDefault = vi.fn();
-        mockEvent.stopPropagation = vi.fn();
-        const mockMouseCoords: MouseCoords = {
-            sigmaDefaultPrevented: false,
-            preventSigmaDefault: vi.fn(),
-            original: mockEvent,
-            x: 10,
-            y: 20,
-        };
-
-        preventAllDefaults(mockMouseCoords);
-        expect(mockMouseCoords.preventSigmaDefault).toHaveBeenCalled();
-        expect(mockMouseCoords.original.preventDefault).toHaveBeenCalled();
-        expect(mockMouseCoords.original.stopPropagation).toHaveBeenCalled();
     });
 });

--- a/cmd/ui/src/rendering/utils/utils.ts
+++ b/cmd/ui/src/rendering/utils/utils.ts
@@ -14,8 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { SigmaNodeEventPayload } from 'sigma/sigma';
-import { MouseCoords, NodeDisplayData, PartialButFor } from 'sigma/types';
+import { NodeDisplayData, PartialButFor } from 'sigma/types';
 
 /** Threshold of graph zoom before labels fade out */
 export const STARTING_ZOOM_FADE_RATIO = 0.65;
@@ -129,21 +128,4 @@ export const getNodeRadius = (highlighted: boolean, inverseSqrtZoomRatio: number
     else radius = size * inverseSqrtZoomRatio;
 
     return radius;
-};
-
-/**
- * Reusable method to prevent defaults for mouse move, right click, and double click
- *
- * @param event Sigma or mouse event object used to cancel defaults
- */
-export const preventAllDefaults = (event: SigmaNodeEventPayload | MouseCoords) => {
-    if ('preventSigmaDefault' in event && typeof event.preventSigmaDefault === 'function') {
-        event.preventSigmaDefault();
-    }
-
-    // Prevent events for MouseCoords type
-    if ('original' in event && event.original instanceof MouseEvent) {
-        event.original.preventDefault();
-        event.original.stopPropagation();
-    }
 };

--- a/cmd/ui/src/utils.test.ts
+++ b/cmd/ui/src/utils.test.ts
@@ -1,0 +1,50 @@
+// Copyright 2023 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import type { SigmaNodeEventPayload } from 'sigma/sigma';
+import type { MouseCoords } from 'sigma/types';
+import { preventAllDefaults } from './utils';
+
+describe('preventAllDefaults', () => {
+    it('prevents Sigma defaults events', () => {
+        const mockEvent: SigmaNodeEventPayload = {
+            event: { x: 10, y: 20 } as MouseCoords,
+            preventSigmaDefault: vi.fn(),
+            node: 'node-id',
+        };
+
+        preventAllDefaults(mockEvent);
+        expect(mockEvent.preventSigmaDefault).toHaveBeenCalled();
+    });
+
+    it('prevents MouseCoords events', () => {
+        const mockEvent = new MouseEvent('click');
+        mockEvent.preventDefault = vi.fn();
+        mockEvent.stopPropagation = vi.fn();
+        const mockMouseCoords: MouseCoords = {
+            sigmaDefaultPrevented: false,
+            preventSigmaDefault: vi.fn(),
+            original: mockEvent,
+            x: 10,
+            y: 20,
+        };
+
+        preventAllDefaults(mockMouseCoords);
+        expect(mockMouseCoords.preventSigmaDefault).toHaveBeenCalled();
+        expect(mockMouseCoords.original.preventDefault).toHaveBeenCalled();
+        expect(mockMouseCoords.original.stopPropagation).toHaveBeenCalled();
+    });
+});

--- a/cmd/ui/src/utils.ts
+++ b/cmd/ui/src/utils.ts
@@ -17,7 +17,8 @@
 import { GlyphIconInfo, apiClient } from 'bh-shared-ui';
 import identity from 'lodash/identity';
 import throttle from 'lodash/throttle';
-import { Coordinates } from 'sigma/types';
+import type { SigmaNodeEventPayload } from 'sigma/sigma';
+import type { Coordinates, MouseCoords } from 'sigma/types';
 import { logout } from 'src/ducks/auth/authSlice';
 import { addSnackbar } from 'src/ducks/global/actions';
 import { Glyph } from 'src/rendering/programs/node.glyphs';
@@ -49,6 +50,23 @@ export const getUsername = (user: any): string | undefined => {
         return user.principal_name;
     }
     return undefined;
+};
+
+/**
+ * Reusable method to prevent defaults for mouse move, right click, and double click
+ *
+ * @param event Sigma or mouse event object used to cancel defaults
+ */
+export const preventAllDefaults = (event: SigmaNodeEventPayload | MouseCoords) => {
+    if ('preventSigmaDefault' in event && typeof event.preventSigmaDefault === 'function') {
+        event.preventSigmaDefault();
+    }
+
+    // Prevent events for MouseCoords type
+    if ('original' in event && event.original instanceof MouseEvent) {
+        event.original.preventDefault();
+        event.original.stopPropagation();
+    }
 };
 
 const throttledLogout = throttle(() => {

--- a/packages/javascript/bh-shared-ui/src/hooks/useExploreGraph/usePathfindingFilters.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/hooks/useExploreGraph/usePathfindingFilters.test.tsx
@@ -57,7 +57,7 @@ describe('usePathfindingFilters', () => {
         const hook = renderHook(() => usePathfindingFilters());
 
         await act(() => hook.result.current.handleUpdateFilters([TEST_FILTER]));
-        await act(() => hook.result.current.handleCancelFilters());
+        await act(() => hook.result.current.initialize());
 
         expect(hook.result.current.selectedFilters).toEqual(INITIAL_FILTERS);
         expect(window.location.search).toEqual('');

--- a/packages/javascript/bh-shared-ui/src/hooks/useExploreGraph/usePathfindingFilters.ts
+++ b/packages/javascript/bh-shared-ui/src/hooks/useExploreGraph/usePathfindingFilters.ts
@@ -16,9 +16,10 @@
 
 import { useState } from 'react';
 import { EdgeCheckboxType } from '../../edgeTypes';
+import { areArraysSimilar } from '../../utils';
 import { useExploreParams } from '../useExploreParams';
 import { EMPTY_FILTER_VALUE, INITIAL_FILTERS, INITIAL_FILTER_TYPES } from './queries';
-import { compareEdgeTypes, extractEdgeTypes, mapParamsToFilters } from './utils';
+import { extractEdgeTypes, mapParamsToFilters } from './utils';
 
 export const usePathfindingFilters = () => {
     const [selectedFilters, updateSelectedFilters] = useState<EdgeCheckboxType[]>(INITIAL_FILTERS);
@@ -46,7 +47,7 @@ export const usePathfindingFilters = () => {
         if (selectedEdgeTypes.length === 0) {
             // query string stores a value indicating an empty set if every option is unselected
             setExploreParams({ pathFilters: [EMPTY_FILTER_VALUE] });
-        } else if (compareEdgeTypes(INITIAL_FILTER_TYPES, selectedEdgeTypes)) {
+        } else if (areArraysSimilar(INITIAL_FILTER_TYPES, selectedEdgeTypes)) {
             // query string is not set if user selects the default
             setExploreParams({ pathFilters: null });
         } else {
@@ -54,15 +55,10 @@ export const usePathfindingFilters = () => {
         }
     };
 
-    // In our new implementation, these two functions are equivalent. Once we no longer need to support the old approach,
-    // we can consider removing this.
-    const handleCancelFilters = () => initialize();
-
     return {
         selectedFilters,
         initialize,
         handleApplyFilters,
         handleUpdateFilters,
-        handleCancelFilters,
     };
 };

--- a/packages/javascript/bh-shared-ui/src/hooks/useExploreGraph/utils.ts
+++ b/packages/javascript/bh-shared-ui/src/hooks/useExploreGraph/utils.ts
@@ -27,13 +27,6 @@ export const mapParamsToFilters = (params: string[], initial: EdgeCheckboxType[]
     }));
 };
 
-export const compareEdgeTypes = (initial: string[], comparison: string[]): boolean => {
-    const a = initial.slice(0).sort();
-    const b = comparison.slice(0).sort();
-
-    return a.length === b.length && a.every((item, index) => item === b[index]);
-};
-
 // Create a list of all edge types to initialize pathfinding filter state
 export const getInitialPathFilters = (): EdgeCheckboxType[] => {
     const initialPathFilters: EdgeCheckboxType[] = [];

--- a/packages/javascript/bh-shared-ui/src/utils/array.test.ts
+++ b/packages/javascript/bh-shared-ui/src/utils/array.test.ts
@@ -1,0 +1,69 @@
+// Copyright 2025 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { areArraysSimilar } from './array';
+
+describe('areArraysSimilar', () => {
+    const primeArray = [1, 2, 3, 3, 4];
+    const equalArray = [1, 2, 3, 3, 4];
+    const reorderedArray = [3, 2, 3, 4, 1];
+    const shorterArray = [1, 2, 3, 4];
+    const differentArray = ['a', 'b', 'c', 'd'];
+
+    it('returns true if arrays are referentially equal', () => {
+        expect(areArraysSimilar(primeArray, primeArray)).toEqual(true);
+    });
+
+    it('returns true if arrays are equal', () => {
+        expect(areArraysSimilar(primeArray, equalArray)).toEqual(true);
+    });
+
+    it('returns true if both arrays are empty', () => {
+        expect(areArraysSimilar([], [])).toEqual(true);
+    });
+
+    it('returns true if arrays have same content in different order', () => {
+        expect(areArraysSimilar(primeArray, reorderedArray)).toEqual(true);
+    });
+
+    it('returns false if arrays have different length', () => {
+        expect(areArraysSimilar(primeArray, shorterArray)).toEqual(false);
+    });
+
+    it('returns false if arrays have different elements', () => {
+        // @ts-expect-error: types differ to test negative case
+        expect(areArraysSimilar(primeArray, differentArray)).toEqual(false);
+    });
+
+    it('returns false for arrays with different object references', () => {
+        const objArray1 = [{ id: 1 }, { id: 2 }];
+        const objArray2 = [{ id: 1 }, { id: 2 }];
+        expect(areArraysSimilar(objArray1, objArray2)).toEqual(false);
+    });
+
+    it('accepts a sort and compare function', () => {
+        const objArray1 = [{ id: 1 }, { id: 2 }];
+        const objArray2 = [{ id: 1 }, { id: 2 }];
+        expect(
+            areArraysSimilar(
+                objArray1,
+                objArray2,
+                (i, j) => i.id - j.id,
+                (i, j) => i.id === j.id
+            )
+        ).toEqual(true);
+    });
+});

--- a/packages/javascript/bh-shared-ui/src/utils/array.ts
+++ b/packages/javascript/bh-shared-ui/src/utils/array.ts
@@ -1,0 +1,36 @@
+// Copyright 2025 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Returns true if array `a` and `b` contain the same elements in any order
+ *
+ * Uses referential comparison; provide a sort and compare function for non-primitive array elements.
+ */
+export const areArraysSimilar = <T>(
+    a: T[],
+    b: T[],
+    sortFn?: (i: T, j: T) => number,
+    compareFn?: (i: T, j: T) => boolean
+) => {
+    if (a.length !== b.length) {
+        return false;
+    }
+
+    const sortedA = sortFn ? [...a].sort(sortFn) : [...a].sort();
+    const sortedB = sortFn ? [...b].sort(sortFn) : [...b].sort();
+
+    return sortedA.every((item, index) => (compareFn ? compareFn(item, sortedB[index]) : item === sortedB[index]));
+};

--- a/packages/javascript/bh-shared-ui/src/utils/index.ts
+++ b/packages/javascript/bh-shared-ui/src/utils/index.ts
@@ -16,6 +16,7 @@
 
 export * from './abbreviatedNumber';
 export * from './api';
+export * from './array';
 export * from './colors';
 export * from './compatibility';
 export * from './content';

--- a/packages/javascript/bh-shared-ui/src/views/Explore/ExploreSearch/EdgeFilter.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/Explore/ExploreSearch/EdgeFilter.tsx
@@ -26,14 +26,12 @@ export type PathfindingFilterState = {
     initialize: () => void;
     handleApplyFilters: () => void;
     handleUpdateFilters: (checked: EdgeCheckboxType[]) => void;
-    handleCancelFilters: () => void;
 };
 
 export const EdgeFilter = ({ pathfindingFilterState }: { pathfindingFilterState: PathfindingFilterState }) => {
     const [isOpenDialog, setIsOpenDialog] = useState(false);
 
-    const { selectedFilters, initialize, handleApplyFilters, handleUpdateFilters, handleCancelFilters } =
-        pathfindingFilterState;
+    const { selectedFilters, handleApplyFilters, handleUpdateFilters, initialize } = pathfindingFilterState;
 
     return (
         <>
@@ -41,7 +39,7 @@ export const EdgeFilter = ({ pathfindingFilterState }: { pathfindingFilterState:
                 className={'h-7 w-7 min-w-7 p-0 rounded-[4px] border-black/25 text-white'}
                 onClick={() => {
                     setIsOpenDialog(true);
-                    // what is the initial state of edge filters?  save it
+                    // Save the initial edge filter state
                     initialize();
                 }}>
                 <FontAwesomeIcon icon={faFilter} />
@@ -56,7 +54,7 @@ export const EdgeFilter = ({ pathfindingFilterState }: { pathfindingFilterState:
                 handleUpdate={handleUpdateFilters}
                 handleCancel={() => {
                     setIsOpenDialog(false);
-                    handleCancelFilters();
+                    initialize();
                 }}
             />
         </>


### PR DESCRIPTION
## Description

* Moved preventAllDefaults method from render utils to general utils
* Removed deprecated usePathfindingFilter method
* Converted compareEdgeTypes into more generalized areArraysSimilar with tests

## Motivation and Context

This PR addresses some preliminary house keeping in prep for BED-5180.

Relates to BED-5180

## How Has This Been Tested?

Updated unit tests.

## Types of changes

- Chore (a change that does not modify the application functionality)

## Checklist:

- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * None visible to end users.

* **Bug Fixes**
  * Edge filter cancel/reset now reliably restores initial filters and clears the URL when dismissed.

* **Refactor**
  * Smoother label fading and improved node sizing during zoom for clearer graph visuals.
  * Consolidated event-default cancellation handling (no change to user workflows).

* **Tests**
  * Expanded unit tests for array comparison utilities and event cancellation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->