### PR TITLE
BED-6264 - Add x to entity panel header to remove selected item

### DIFF
--- a/packages/javascript/bh-shared-ui/src/components/EntityInfo/EntityInfoHeader.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/EntityInfo/EntityInfoHeader.test.tsx
@@ -22,6 +22,19 @@ import { AzureNodeKind } from '../../graphSchema';
 import { ObjectInfoPanelContext } from '../../views';
 import EntityInfoHeader, { HeaderProps } from './EntityInfoHeader';
 
+const mockClearSelectedItem = vi.fn();
+
+vi.mock('../../hooks', async () => {
+    const actual = await vi.importActual('../../hooks');
+
+    return {
+        ...actual,
+        useExploreSelectedItem: () => ({
+            clearSelectedItem: mockClearSelectedItem,
+        }),
+    };
+});
+
 const testProps: HeaderProps = {
     name: 'testName',
     nodeType: AzureNodeKind.Group,
@@ -71,7 +84,7 @@ describe('EntityInfoHeader', async () => {
     it('should render', async () => {
         const { screen } = await setup();
 
-        const collapsePanelButton = screen.getByRole('button', { name: /remove/i });
+        const collapsePanelButton = screen.getByRole('button', { name: /xmark/i });
         const nodeIcon = screen.getByTitle(testProps.nodeType!);
         const nodeTitle = screen.getByRole('heading');
         const collapseAllButton = screen.getByRole('button', { name: /collapse all/i });
@@ -90,5 +103,13 @@ describe('EntityInfoHeader', async () => {
 
         expect(window.location.search).not.toContain('expandedPanelSections');
         expect(mockContextValue.isObjectInfoPanelOpen).toBe(false);
+    });
+    it('should on clicking remove call clearSelectedItem', async () => {
+        const { screen, user } = await setup();
+        const removeButton = screen.getByRole('button', { name: /xmark/i });
+
+        await user.click(removeButton);
+
+        expect(mockClearSelectedItem).toBeCalled();
     });
 });

--- a/packages/javascript/bh-shared-ui/src/components/EntityInfo/EntityInfoHeader.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/EntityInfo/EntityInfoHeader.test.tsx
@@ -85,7 +85,7 @@ describe('EntityInfoHeader', async () => {
     it('should render', async () => {
         const { screen } = await setup();
 
-        const collapsePanelButton = screen.getByRole('button', { name: /xmark/i });
+        const collapsePanelButton = screen.getByRole('button', { name: /Clear selected item/i });
         const nodeIcon = screen.getByTitle(testProps.nodeType!);
         const nodeTitle = screen.getByRole('heading');
         const collapseAllButton = screen.getByRole('button', { name: /collapse all/i });
@@ -107,7 +107,7 @@ describe('EntityInfoHeader', async () => {
     });
     it('should on clicking remove call clearSelectedItem', async () => {
         const { screen, user } = await setup();
-        const removeButton = screen.getByRole('button', { name: /xmark/i });
+        const removeButton = screen.getByRole('button', { name: /Clear selected item/i });
 
         await user.click(removeButton);
 

--- a/packages/javascript/bh-shared-ui/src/components/EntityInfo/EntityInfoHeader.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/EntityInfo/EntityInfoHeader.test.tsx
@@ -71,7 +71,7 @@ describe('EntityInfoHeader', async () => {
     it('should render', async () => {
         const { screen } = await setup();
 
-        const collapsePanelButton = screen.getByRole('button', { name: /minus/i });
+        const collapsePanelButton = screen.getByRole('button', { name: /remove/i });
         const nodeIcon = screen.getByTitle(testProps.nodeType!);
         const nodeTitle = screen.getByRole('heading');
         const collapseAllButton = screen.getByRole('button', { name: /collapse all/i });

--- a/packages/javascript/bh-shared-ui/src/components/EntityInfo/EntityInfoHeader.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/EntityInfo/EntityInfoHeader.test.tsx
@@ -23,9 +23,7 @@ import { ObjectInfoPanelContext } from '../../views';
 import EntityInfoHeader, { HeaderProps } from './EntityInfoHeader';
 
 const testProps: HeaderProps = {
-    expanded: true,
     name: 'testName',
-    onToggleExpanded: vi.fn(),
     nodeType: AzureNodeKind.Group,
 };
 

--- a/packages/javascript/bh-shared-ui/src/components/EntityInfo/EntityInfoHeader.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/EntityInfo/EntityInfoHeader.test.tsx
@@ -31,6 +31,7 @@ vi.mock('../../hooks', async () => {
         ...actual,
         useExploreSelectedItem: () => ({
             clearSelectedItem: mockClearSelectedItem,
+            selectedItem: '123',
         }),
     };
 });

--- a/packages/javascript/bh-shared-ui/src/components/EntityInfo/EntityInfoHeader.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/EntityInfo/EntityInfoHeader.tsx
@@ -47,10 +47,12 @@ const Header: React.FC<HeaderProps> = ({ name, nodeType }) => {
 
     return (
         <Box className={styles.header}>
-            {!!selectedItem && (
+            {selectedItem ? (
                 <Icon className={styles.icon} click={clearSelectedItem}>
                     <FontAwesomeIcon icon={faRemove} />
                 </Icon>
+            ) : (
+                <div className='w-3' />
             )}
 
             {nodeType && <NodeIcon nodeType={nodeType} />}

--- a/packages/javascript/bh-shared-ui/src/components/EntityInfo/EntityInfoHeader.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/EntityInfo/EntityInfoHeader.tsx
@@ -33,7 +33,7 @@ const Header: React.FC<HeaderProps> = ({ name, nodeType }) => {
     const styles = useHeaderStyles();
     const { setIsObjectInfoPanelOpen } = useObjectInfoPanelContext();
     const { setExploreParams, expandedPanelSections } = useExploreParams();
-    const { clearSelectedItem } = useExploreSelectedItem();
+    const { clearSelectedItem, selectedItem } = useExploreSelectedItem();
 
     const handleCollapseAll = () => {
         setIsObjectInfoPanelOpen(false);
@@ -47,9 +47,11 @@ const Header: React.FC<HeaderProps> = ({ name, nodeType }) => {
 
     return (
         <Box className={styles.header}>
-            <Icon className={styles.icon} click={clearSelectedItem}>
-                <FontAwesomeIcon icon={faRemove} />
-            </Icon>
+            {!!selectedItem && (
+                <Icon className={styles.icon} click={clearSelectedItem}>
+                    <FontAwesomeIcon icon={faRemove} />
+                </Icon>
+            )}
 
             {nodeType && <NodeIcon nodeType={nodeType} />}
 

--- a/packages/javascript/bh-shared-ui/src/components/EntityInfo/EntityInfoHeader.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/EntityInfo/EntityInfoHeader.tsx
@@ -48,7 +48,7 @@ const Header: React.FC<HeaderProps> = ({ name, nodeType }) => {
     return (
         <Box className={styles.header}>
             {selectedItem ? (
-                <Icon className={styles.icon} click={clearSelectedItem}>
+                <Icon className={styles.icon} click={clearSelectedItem} tip='Clear selected item'>
                     <FontAwesomeIcon icon={faRemove} />
                 </Icon>
             ) : (

--- a/packages/javascript/bh-shared-ui/src/components/EntityInfo/EntityInfoHeader.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/EntityInfo/EntityInfoHeader.tsx
@@ -13,28 +13,27 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
-import { faAngleDoubleUp, faMinus, faPlus } from '@fortawesome/free-solid-svg-icons';
+import { faAngleDoubleUp, faRemove } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Box, Typography } from '@mui/material';
 import React from 'react';
 import Icon from '../../components/Icon';
 import NodeIcon from '../../components/NodeIcon/NodeIcon';
-import { useExploreParams } from '../../hooks';
+import { useExploreParams, useExploreSelectedItem } from '../../hooks';
 import { EntityKinds } from '../../utils/content';
 import { useHeaderStyles } from '../../views/Explore/InfoStyles';
 import { useObjectInfoPanelContext } from '../../views/Explore/providers';
 
 export interface HeaderProps {
-    expanded: boolean;
     name: string;
-    onToggleExpanded: (expanded: boolean) => void;
     nodeType?: EntityKinds;
 }
 
-const Header: React.FC<HeaderProps> = ({ name, nodeType, onToggleExpanded, expanded }) => {
+const Header: React.FC<HeaderProps> = ({ name, nodeType }) => {
     const styles = useHeaderStyles();
     const { setIsObjectInfoPanelOpen } = useObjectInfoPanelContext();
     const { setExploreParams, expandedPanelSections } = useExploreParams();
+    const { clearSelectedItem } = useExploreSelectedItem();
 
     const handleCollapseAll = () => {
         setIsObjectInfoPanelOpen(false);
@@ -48,12 +47,8 @@ const Header: React.FC<HeaderProps> = ({ name, nodeType, onToggleExpanded, expan
 
     return (
         <Box className={styles.header}>
-            <Icon
-                className={styles.icon}
-                click={() => {
-                    onToggleExpanded(!expanded);
-                }}>
-                <FontAwesomeIcon icon={expanded ? faMinus : faPlus} />
+            <Icon className={styles.icon} click={clearSelectedItem}>
+                <FontAwesomeIcon icon={faRemove} />
             </Icon>
 
             {nodeType && <NodeIcon nodeType={nodeType} />}

--- a/packages/javascript/bh-shared-ui/src/components/EntityInfo/EntityInfoPanel.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/EntityInfo/EntityInfoPanel.tsx
@@ -14,7 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import { Box, Paper, SxProps, Typography } from '@mui/material';
-import React, { useState } from 'react';
+import React from 'react';
 import { SelectedNode } from '../../types';
 import { EntityInfoDataTableProps, NoEntitySelectedHeader, NoEntitySelectedMessage } from '../../utils';
 import { ObjectInfoPanelContextProvider, usePaneStyles } from '../../views/Explore';
@@ -33,26 +33,13 @@ interface EntityInfoPanelProps {
 
 const EntityInfoPanel: React.FC<EntityInfoPanelProps> = ({ selectedNode, sx, additionalTables, DataTable }) => {
     const styles = usePaneStyles();
-    const [expanded, setExpanded] = useState(true);
 
     return (
         <Box sx={sx} className={styles.container} data-testid='explore_entity-information-panel'>
             <Paper elevation={0} classes={{ root: styles.headerPaperRoot }}>
-                <Header
-                    name={selectedNode?.name || NoEntitySelectedHeader}
-                    nodeType={selectedNode?.type}
-                    expanded={expanded}
-                    onToggleExpanded={(expanded) => {
-                        setExpanded(expanded);
-                    }}
-                />
+                <Header name={selectedNode?.name || NoEntitySelectedHeader} nodeType={selectedNode?.type} />
             </Paper>
-            <Paper
-                elevation={0}
-                classes={{ root: styles.contentPaperRoot }}
-                style={{
-                    display: expanded ? 'initial' : 'none',
-                }}>
+            <Paper elevation={0} classes={{ root: styles.contentPaperRoot }}>
                 {selectedNode ? (
                     <EntityInfoContent
                         DataTable={DataTable}

--- a/packages/javascript/bh-shared-ui/src/hooks/useExploreSelectedItem.tsx
+++ b/packages/javascript/bh-shared-ui/src/hooks/useExploreSelectedItem.tsx
@@ -38,11 +38,13 @@ export const useExploreSelectedItem = () => {
     );
 
     const clearSelectedItem = useCallback(() => {
-        setExploreParams({
-            expandedPanelSections: null,
-            selectedItem: null,
-        });
-    }, [setExploreParams]);
+        if (selectedItem) {
+            setExploreParams({
+                expandedPanelSections: null,
+                selectedItem: null,
+            });
+        }
+    }, [setExploreParams, selectedItem]);
 
     const selectedItemType = useMemo(
         () => (selectedItem ? parseItemId(selectedItem).itemType : undefined),

--- a/packages/javascript/bh-shared-ui/src/views/Explore/EdgeInfo/EdgeInfoHeader.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/Explore/EdgeInfo/EdgeInfoHeader.test.tsx
@@ -53,7 +53,7 @@ describe('EdgeInfoHeader', async () => {
     it('should render', async () => {
         const { screen } = await setup();
 
-        const collapsePanelButton = screen.getByRole('button', { name: /minus/i });
+        const collapsePanelButton = screen.getByRole('button', { name: /remove/i });
         const edgeTitle = screen.getByRole('heading');
         const collapseAllButton = screen.getByRole('button', { name: /collapse all/i });
 

--- a/packages/javascript/bh-shared-ui/src/views/Explore/EdgeInfo/EdgeInfoHeader.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/Explore/EdgeInfo/EdgeInfoHeader.test.tsx
@@ -20,9 +20,7 @@ import { ObjectInfoPanelContext } from '../providers';
 import EdgeInfoHeader, { HeaderProps } from './EdgeInfoHeader';
 
 const testProps: HeaderProps = {
-    expanded: true,
     name: 'testName',
-    onToggleExpanded: vi.fn(),
 };
 
 const setIsObjectInfoPanelOpen = (newValue: boolean) => {

--- a/packages/javascript/bh-shared-ui/src/views/Explore/EdgeInfo/EdgeInfoHeader.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/Explore/EdgeInfo/EdgeInfoHeader.test.tsx
@@ -19,6 +19,18 @@ import { act, render } from '../../../test-utils';
 import { ObjectInfoPanelContext } from '../providers';
 import EdgeInfoHeader, { HeaderProps } from './EdgeInfoHeader';
 
+const mockClearSelectedItem = vi.fn();
+
+vi.mock('../../../hooks', async () => {
+    const actual = await vi.importActual('../../../hooks');
+
+    return {
+        ...actual,
+        useExploreSelectedItem: () => ({
+            clearSelectedItem: mockClearSelectedItem,
+        }),
+    };
+});
 const testProps: HeaderProps = {
     name: 'testName',
 };
@@ -53,7 +65,7 @@ describe('EdgeInfoHeader', async () => {
     it('should render', async () => {
         const { screen } = await setup();
 
-        const collapsePanelButton = screen.getByRole('button', { name: /remove/i });
+        const collapsePanelButton = screen.getByRole('button', { name: /xmark/i });
         const edgeTitle = screen.getByRole('heading');
         const collapseAllButton = screen.getByRole('button', { name: /collapse all/i });
 
@@ -70,5 +82,13 @@ describe('EdgeInfoHeader', async () => {
 
         expect(window.location.search).not.toContain('expandedPanelSections');
         expect(mockContextValue.isObjectInfoPanelOpen).toBe(false);
+    });
+    it('should on clicking remove call clearSelectedItem', async () => {
+        const { screen, user } = await setup();
+        const removeButton = screen.getByRole('button', { name: /xmark/i });
+
+        await user.click(removeButton);
+
+        expect(mockClearSelectedItem).toBeCalled();
     });
 });

--- a/packages/javascript/bh-shared-ui/src/views/Explore/EdgeInfo/EdgeInfoHeader.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/Explore/EdgeInfo/EdgeInfoHeader.test.tsx
@@ -66,7 +66,7 @@ describe('EdgeInfoHeader', async () => {
     it('should render', async () => {
         const { screen } = await setup();
 
-        const collapsePanelButton = screen.getByRole('button', { name: /xmark/i });
+        const collapsePanelButton = screen.getByRole('button', { name: /Clear selected item/i });
         const edgeTitle = screen.getByRole('heading');
         const collapseAllButton = screen.getByRole('button', { name: /collapse all/i });
 
@@ -86,7 +86,7 @@ describe('EdgeInfoHeader', async () => {
     });
     it('should on clicking remove call clearSelectedItem', async () => {
         const { screen, user } = await setup();
-        const removeButton = screen.getByRole('button', { name: /xmark/i });
+        const removeButton = screen.getByRole('button', { name: /Clear selected item/i });
 
         await user.click(removeButton);
 

--- a/packages/javascript/bh-shared-ui/src/views/Explore/EdgeInfo/EdgeInfoHeader.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/Explore/EdgeInfo/EdgeInfoHeader.test.tsx
@@ -28,6 +28,7 @@ vi.mock('../../../hooks', async () => {
         ...actual,
         useExploreSelectedItem: () => ({
             clearSelectedItem: mockClearSelectedItem,
+            selectedItem: '123',
         }),
     };
 });

--- a/packages/javascript/bh-shared-ui/src/views/Explore/EdgeInfo/EdgeInfoHeader.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/Explore/EdgeInfo/EdgeInfoHeader.tsx
@@ -42,7 +42,7 @@ const Header: React.FC<HeaderProps> = ({ name = 'None Selected' }) => {
     return (
         <div className={styles.header}>
             {selectedItem ? (
-                <Icon className={styles.icon} click={clearSelectedItem}>
+                <Icon className={styles.icon} click={clearSelectedItem} tip='Clear selected item'>
                     <FontAwesomeIcon icon={faRemove} />
                 </Icon>
             ) : (

--- a/packages/javascript/bh-shared-ui/src/views/Explore/EdgeInfo/EdgeInfoHeader.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/Explore/EdgeInfo/EdgeInfoHeader.tsx
@@ -30,7 +30,7 @@ const Header: React.FC<HeaderProps> = ({ name = 'None Selected' }) => {
     const styles = useHeaderStyles();
     const { setIsObjectInfoPanelOpen } = useObjectInfoPanelContext();
     const { setExploreParams } = useExploreParams();
-    const { clearSelectedItem } = useExploreSelectedItem();
+    const { clearSelectedItem, selectedItem } = useExploreSelectedItem();
 
     const handleCollapseAll = () => {
         setIsObjectInfoPanelOpen(false);
@@ -41,9 +41,11 @@ const Header: React.FC<HeaderProps> = ({ name = 'None Selected' }) => {
 
     return (
         <div className={styles.header}>
-            <Icon className={styles.icon} click={clearSelectedItem}>
-                <FontAwesomeIcon icon={faRemove} />
-            </Icon>
+            {!!selectedItem && (
+                <Icon className={styles.icon} click={clearSelectedItem}>
+                    <FontAwesomeIcon icon={faRemove} />
+                </Icon>
+            )}
 
             <Typography
                 data-testid='explore_edge-information-pane_header-text'

--- a/packages/javascript/bh-shared-ui/src/views/Explore/EdgeInfo/EdgeInfoHeader.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/Explore/EdgeInfo/EdgeInfoHeader.tsx
@@ -41,10 +41,12 @@ const Header: React.FC<HeaderProps> = ({ name = 'None Selected' }) => {
 
     return (
         <div className={styles.header}>
-            {!!selectedItem && (
+            {selectedItem ? (
                 <Icon className={styles.icon} click={clearSelectedItem}>
                     <FontAwesomeIcon icon={faRemove} />
                 </Icon>
+            ) : (
+                <div className='w-3' />
             )}
 
             <Typography

--- a/packages/javascript/bh-shared-ui/src/views/Explore/EdgeInfo/EdgeInfoHeader.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/Explore/EdgeInfo/EdgeInfoHeader.tsx
@@ -13,25 +13,24 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
-import { faAngleDoubleUp, faMinus, faPlus } from '@fortawesome/free-solid-svg-icons';
+import { faAngleDoubleUp, faRemove } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Typography } from '@mui/material';
 import React from 'react';
 import Icon from '../../../components/Icon';
-import { useExploreParams } from '../../../hooks';
+import { useExploreParams, useExploreSelectedItem } from '../../../hooks';
 import { useHeaderStyles } from '../InfoStyles';
 import { useObjectInfoPanelContext } from '../providers';
 
 export interface HeaderProps {
     name: string;
-    expanded: boolean;
-    onToggleExpanded: (expanded: boolean) => void;
 }
 
-const Header: React.FC<HeaderProps> = ({ name = 'None Selected', onToggleExpanded, expanded }) => {
+const Header: React.FC<HeaderProps> = ({ name = 'None Selected' }) => {
     const styles = useHeaderStyles();
     const { setIsObjectInfoPanelOpen } = useObjectInfoPanelContext();
     const { setExploreParams } = useExploreParams();
+    const { clearSelectedItem } = useExploreSelectedItem();
 
     const handleCollapseAll = () => {
         setIsObjectInfoPanelOpen(false);
@@ -42,12 +41,8 @@ const Header: React.FC<HeaderProps> = ({ name = 'None Selected', onToggleExpande
 
     return (
         <div className={styles.header}>
-            <Icon
-                className={styles.icon}
-                click={() => {
-                    onToggleExpanded(!expanded);
-                }}>
-                <FontAwesomeIcon icon={expanded ? faMinus : faPlus} />
+            <Icon className={styles.icon} click={clearSelectedItem}>
+                <FontAwesomeIcon icon={faRemove} />
             </Icon>
 
             <Typography

--- a/packages/javascript/bh-shared-ui/src/views/Explore/EdgeInfo/EdgeInfoPane.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/Explore/EdgeInfo/EdgeInfoPane.tsx
@@ -14,7 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import { Box, Paper, SxProps } from '@mui/material';
-import React, { useState } from 'react';
+import React from 'react';
 import { SelectedEdge } from '../../../store';
 import { usePaneStyles } from '../InfoStyles';
 import { ObjectInfoPanelContextProvider } from '../providers';
@@ -28,25 +28,13 @@ interface EdgeInfoPaneProps {
 
 const EdgeInfoPane: React.FC<EdgeInfoPaneProps> = ({ sx, selectedEdge }) => {
     const styles = usePaneStyles();
-    const [expanded, setExpanded] = useState(true);
 
     return (
         <Box sx={sx} className={styles.container} data-testid='explore_edge-information-pane'>
             <Paper elevation={0} classes={{ root: styles.headerPaperRoot }}>
-                <Header
-                    name={selectedEdge?.name || 'None'}
-                    expanded={expanded}
-                    onToggleExpanded={(expanded: boolean) => {
-                        setExpanded(expanded);
-                    }}
-                />
+                <Header name={selectedEdge?.name || 'None'} />
             </Paper>
-            <Paper
-                elevation={0}
-                classes={{ root: styles.contentPaperRoot }}
-                style={{
-                    display: expanded ? 'initial' : 'none',
-                }}>
+            <Paper elevation={0} classes={{ root: styles.contentPaperRoot }}>
                 {selectedEdge === null ? 'No information to display.' : <EdgeInfoContent selectedEdge={selectedEdge} />}
             </Paper>
         </Box>


### PR DESCRIPTION
## Description

This PR removes expanded functionality from entity panel and replaces it with 'close' functionality.

## Motivation and Context

Resolves BED-6264

https://github.com/user-attachments/assets/bf2c7324-f0a4-4dc5-8bf8-f0c99f94beec


## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)
- Database Migrations

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [ ] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [ ] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [ ] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Headers now include a Clear Selected Item action (shown only when an item is selected).

* **Refactor**
  * Removed expand/collapse controls from Entity and Edge info headers and panels; content is always visible.
  * Header props simplified to name-only and iconography changed from plus/minus to remove (xmark).

* **Tests**
  * Tests updated to mock and verify the clear-selection action and adjusted UI assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->