### PR TITLE
fix: remove timezone setting in the configuration file due to the image no longer supporting it

### DIFF
--- a/.github/config/postgresql.conf
+++ b/.github/config/postgresql.conf
@@ -617,7 +617,7 @@ log_statement = 'ddl'			# none, ddl, mod, all
 #log_temp_files = -1			# log temporary files equal or larger
 					# than the specified size in kilobytes;
 					# -1 disables, 0 logs all temp files
-log_timezone = 'US/Pacific'
+# log_# timezone = 'US/Pacific'
 
 # - Process Title -
 
@@ -733,7 +733,7 @@ log_timezone = 'US/Pacific'
 
 datestyle = 'iso, mdy'
 #intervalstyle = 'postgres'
-timezone = 'US/Pacific'
+# timezone = 'US/Pacific'
 #timezone_abbreviations = 'Default'	# Select the set of available time zone
 					# abbreviations.  Currently, there are
 					#   Default

--- a/local-harnesses/postgresql.conf.template
+++ b/local-harnesses/postgresql.conf.template
@@ -617,7 +617,7 @@ log_statement = 'ddl'			# none, ddl, mod, all
 #log_temp_files = -1			# log temporary files equal or larger
 					# than the specified size in kilobytes;
 					# -1 disables, 0 logs all temp files
-log_timezone = 'US/Pacific'
+# log_# timezone = 'US/Pacific'
 
 # - Process Title -
 
@@ -733,7 +733,7 @@ log_timezone = 'US/Pacific'
 
 datestyle = 'iso, mdy'
 #intervalstyle = 'postgres'
-timezone = 'US/Pacific'
+# timezone = 'US/Pacific'
 #timezone_abbreviations = 'Default'	# Select the set of available time zone
 					# abbreviations.  Currently, there are
 					#   Default


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Removes timezone parameters from the config file as they don't work properly with the latest postgres:16 image

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-6350

All CI is blocked on this

## How Has This Been Tested?

Ran with the latest image pulled locally. Prior to patch I get the same errors as CI, with the patch the container starts properly.

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)
- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed explicit time zone settings in database configuration by commenting them out. Log and session time zones will now follow the environment or database defaults instead of being forced to a specific region.
  * No application logic changed; this only affects how timestamps appear in database logs and sessions, potentially varying by deployment environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->