### PR TITLE
[BED-6355] Allow nullable NTLM registry values ingest from SharpHound

### DIFF
--- a/packages/go/ein/ad.go
+++ b/packages/go/ein/ad.go
@@ -106,22 +106,51 @@ func ConvertComputerToNode(item Computer, ingestTime time.Time) IngestibleNode {
 	}
 
 	if item.NTLMRegistryData.Collected {
+		// If a registry value doesn't exist, assign its item prop to nil to clear it from the node
+		itemProps[ad.RestrictOutboundNTLM.String()] = nil
+		itemProps[ad.RestrictReceivingNTLMTraffic.String()] = nil
+		itemProps[ad.RequireSecuritySignature.String()] = nil
+		itemProps[ad.EnableSecuritySignature.String()] = nil
+		itemProps[ad.NTLMMinClientSec.String()] = nil
+		itemProps[ad.NTLMMinServerSec.String()] = nil
+		itemProps[ad.LMCompatibilityLevel.String()] = nil
+		itemProps[ad.UseMachineID.String()] = nil
+		itemProps[ad.ClientAllowedNTLMServers.String()] = nil
+
 		/*
-			RestrictSendingNtlmTraffic is sent to us as an uint
+			RestrictSendingNtlmTraffic is sent to us as an uint if sent at all
 			The possible values are
 				0: Allow All
 				1: Audit All
 				2: Deny All
 		*/
-		itemProps[ad.RestrictOutboundNTLM.String()] = item.NTLMRegistryData.Result.RestrictSendingNtlmTraffic == 2
-		itemProps[ad.RestrictReceivingNTLMTraffic.String()] = item.NTLMRegistryData.Result.RestrictReceivingNTLMTraffic == 2
-		itemProps[ad.RequireSecuritySignature.String()] = item.NTLMRegistryData.Result.RequireSecuritySignature != 0
-		itemProps[ad.EnableSecuritySignature.String()] = item.NTLMRegistryData.Result.EnableSecuritySignature != 0
-		itemProps[ad.NTLMMinClientSec.String()] = item.NTLMRegistryData.Result.NtlmMinClientSec
-		itemProps[ad.NTLMMinServerSec.String()] = item.NTLMRegistryData.Result.NtlmMinServerSec
-		itemProps[ad.LMCompatibilityLevel.String()] = item.NTLMRegistryData.Result.LmCompatibilityLevel
-		itemProps[ad.UseMachineID.String()] = item.NTLMRegistryData.Result.UseMachineId != 0
-		itemProps[ad.ClientAllowedNTLMServers.String()] = item.NTLMRegistryData.Result.ClientAllowedNTLMServers
+		if item.NTLMRegistryData.Result.RestrictSendingNtlmTraffic != nil {
+			itemProps[ad.RestrictOutboundNTLM.String()] = *item.NTLMRegistryData.Result.RestrictSendingNtlmTraffic == 2
+		}
+		if item.NTLMRegistryData.Result.RestrictReceivingNTLMTraffic != nil {
+			itemProps[ad.RestrictReceivingNTLMTraffic.String()] = *item.NTLMRegistryData.Result.RestrictReceivingNTLMTraffic == 2
+		}
+		if item.NTLMRegistryData.Result.RequireSecuritySignature != nil {
+			itemProps[ad.RequireSecuritySignature.String()] = *item.NTLMRegistryData.Result.RequireSecuritySignature != 0
+		}
+		if item.NTLMRegistryData.Result.EnableSecuritySignature != nil {
+			itemProps[ad.EnableSecuritySignature.String()] = *item.NTLMRegistryData.Result.EnableSecuritySignature != 0
+		}
+		if item.NTLMRegistryData.Result.NtlmMinClientSec != nil {
+			itemProps[ad.NTLMMinClientSec.String()] = *item.NTLMRegistryData.Result.NtlmMinClientSec
+		}
+		if item.NTLMRegistryData.Result.NtlmMinServerSec != nil {
+			itemProps[ad.NTLMMinServerSec.String()] = *item.NTLMRegistryData.Result.NtlmMinServerSec
+		}
+		if item.NTLMRegistryData.Result.LmCompatibilityLevel != nil {
+			itemProps[ad.LMCompatibilityLevel.String()] = *item.NTLMRegistryData.Result.LmCompatibilityLevel
+		}
+		if item.NTLMRegistryData.Result.UseMachineId != nil {
+			itemProps[ad.UseMachineID.String()] = *item.NTLMRegistryData.Result.UseMachineId != 0
+		}
+		if item.NTLMRegistryData.Result.ClientAllowedNTLMServers != nil {
+			itemProps[ad.ClientAllowedNTLMServers.String()] = *item.NTLMRegistryData.Result.ClientAllowedNTLMServers
+		}
 	}
 
 	if ldapEnabled, ok := itemProps["ldapenabled"]; ok {

--- a/packages/go/ein/ad_test.go
+++ b/packages/go/ein/ad_test.go
@@ -249,6 +249,8 @@ func TestParseDomainTrusts_TrustAttributes(t *testing.T) {
 }
 
 func TestConvertComputerToNode(t *testing.T) {
+	var restrictSendingNtlmTraffic uint = 2
+
 	computer := ein.Computer{
 		IngestBase: ein.IngestBase{
 			Properties: map[string]any{
@@ -260,7 +262,7 @@ func TestConvertComputerToNode(t *testing.T) {
 				Collected: true,
 			},
 			Result: ein.NTLMRegistryInfo{
-				RestrictSendingNtlmTraffic: 2,
+				RestrictSendingNtlmTraffic: &restrictSendingNtlmTraffic,
 			},
 		},
 		IsWebClientRunning: ein.BoolAPIResult{

--- a/packages/go/ein/incoming_models.go
+++ b/packages/go/ein/incoming_models.go
@@ -309,15 +309,15 @@ type NTLMRegistryDataAPIResult struct {
 }
 
 type NTLMRegistryInfo struct {
-	RestrictSendingNtlmTraffic   uint
-	RequireSecuritySignature     uint
-	EnableSecuritySignature      uint
-	RestrictReceivingNTLMTraffic uint
-	NtlmMinServerSec             uint
-	NtlmMinClientSec             uint
-	LmCompatibilityLevel         uint
-	UseMachineId                 uint
-	ClientAllowedNTLMServers     []string
+	RestrictSendingNtlmTraffic   *uint
+	RequireSecuritySignature     *uint
+	EnableSecuritySignature      *uint
+	RestrictReceivingNTLMTraffic *uint
+	NtlmMinServerSec             *uint
+	NtlmMinClientSec             *uint
+	LmCompatibilityLevel         *uint
+	UseMachineId                 *uint
+	ClientAllowedNTLMServers     *[]string
 }
 
 type Computer struct {


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description
SharpHound sends nullable registry values for NTLM properties, but right now Ingest coerces them into concrete values, causing issues of remediation not reflecting in findings.  This PR aims to remove these values that have been collected but are null, to clear findings that are no longer valid.

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-6355

## How Has This Been Tested?
GOAD collection with manual modification

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * NTLM settings are now shown only when actually provided, preventing misleading defaults and improving accuracy in reports and views.
  * Improves robustness when NTLM registry data is partially available.

* **Refactor**
  * Updated internal data handling to better support optional NTLM values, enabling clearer distinction between “unset” and “zero” states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->