### PR TITLE
feat(FinishedJobs): feature flag; fix circular deps; faker locales

### DIFF
--- a/cmd/api/src/database/migration/migrations/v8.1.0.sql
+++ b/cmd/api/src/database/migration/migrations/v8.1.0.sql
@@ -67,3 +67,16 @@ CREATE TABLE IF NOT EXISTS completed_tasks (
     updated_at timestamp with time zone
 );
 CREATE INDEX IF NOT EXISTS idx_completed_tasks_ingest_job_id ON completed_tasks USING btree (ingest_job_id);
+
+-- Add FinishedJobsLog rework feature flag
+INSERT INTO feature_flags (created_at, updated_at, key, name, description, enabled, user_updatable)
+VALUES (
+  current_timestamp,
+  current_timestamp,
+  'finished_jobs_log_v2',
+  'Finished Jobs Log Update',
+  'An updated Finished Jobs Log with filtering and more info.',
+  false,
+  false
+)
+ON CONFLICT DO NOTHING;

--- a/cmd/ui/src/mocks/factories/initial.ts
+++ b/cmd/ui/src/mocks/factories/initial.ts
@@ -14,7 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { faker } from '@faker-js/faker';
+import { faker } from '@faker-js/faker/locale/en';
 import { ActiveDirectoryNodeKind } from 'bh-shared-ui';
 
 export const createDatapipeStatus = (updated_at?: Date) => {

--- a/packages/javascript/bh-shared-ui/rollup.config.js
+++ b/packages/javascript/bh-shared-ui/rollup.config.js
@@ -37,6 +37,7 @@ export default {
         '@date-io/luxon',
         '@emotion/react',
         '@emotion/styled',
+        '@faker-js/faker',
         '@faker-js/faker/locale/en',
         '@fortawesome/fontawesome-svg-core',
         '@fortawesome/free-regular-svg-icons',

--- a/packages/javascript/bh-shared-ui/rollup.config.js
+++ b/packages/javascript/bh-shared-ui/rollup.config.js
@@ -37,7 +37,7 @@ export default {
         '@date-io/luxon',
         '@emotion/react',
         '@emotion/styled',
-        '@faker-js/faker',
+        '@faker-js/faker/locale/en',
         '@fortawesome/fontawesome-svg-core',
         '@fortawesome/free-regular-svg-icons',
         '@fortawesome/free-solid-svg-icons',

--- a/packages/javascript/bh-shared-ui/src/components/FinishedJobsTable/FinishedJobsTable.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/FinishedJobsTable/FinishedJobsTable.test.tsx
@@ -23,11 +23,12 @@ import { FinishedJobsTable } from './FinishedJobsTable';
 const checkPermissionMock = vi.fn();
 
 vi.mock('../../hooks/usePermissions', async () => {
-    const actual = await vi.importActual('../../hooks');
+    const actual = await vi.importActual('../../hooks/usePermissions');
     return {
         ...actual,
         usePermissions: () => ({
             checkPermission: checkPermissionMock,
+            isSuccess: true,
         }),
     };
 });

--- a/packages/javascript/bh-shared-ui/src/components/FinishedJobsTable/FinishedJobsTable.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/FinishedJobsTable/FinishedJobsTable.tsx
@@ -14,7 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { ScheduledJobDisplay } from 'js-client-library';
+import type { ScheduledJobDisplay } from 'js-client-library';
 import { FC, useState } from 'react';
 import { useFinishedJobs } from '../../hooks';
 import { JOB_STATUS_MAP, toCollected, toFormatted, toMins } from '../../utils';
@@ -70,7 +70,7 @@ export const FinishedJobsTable: FC = () => {
                 rowsPerPage,
                 count,
                 onPageChange: (_event, page) => setPage(page),
-                onRowsPerPageChange: (event) => setRowsPerPage(parseInt(event.target.value)),
+                onRowsPerPageChange: (event) => setRowsPerPage(parseInt(event.target.value, 10)),
             }}
             showPaginationControls
         />

--- a/packages/javascript/bh-shared-ui/src/components/FinishedJobsTable/FinishedJobsTable.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/FinishedJobsTable/FinishedJobsTable.tsx
@@ -16,7 +16,8 @@
 
 import { ScheduledJobDisplay } from 'js-client-library';
 import { FC, useState } from 'react';
-import { JOB_STATUS_MAP, toCollected, toFormatted, toMins, useFinishedJobsQuery } from '../../utils';
+import { useFinishedJobs } from '../../hooks';
+import { JOB_STATUS_MAP, toCollected, toFormatted, toMins } from '../../utils';
 import DataTable from '../DataTable';
 import { StatusIndicator } from '../StatusIndicator';
 
@@ -54,7 +55,7 @@ export const FinishedJobsTable: FC = () => {
     const [page, setPage] = useState(0);
     const [rowsPerPage, setRowsPerPage] = useState(10);
 
-    const { data, isLoading } = useFinishedJobsQuery({ page, rowsPerPage });
+    const { data, isLoading } = useFinishedJobs({ page, rowsPerPage });
 
     const finishedJobs = data?.data ?? [];
     const count = data?.count ?? 0;

--- a/packages/javascript/bh-shared-ui/src/hooks/index.ts
+++ b/packages/javascript/bh-shared-ui/src/hooks/index.ts
@@ -14,15 +14,15 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-export { default as useOnClickOutside } from './useOnClickOutside';
-
-export { default as useDebouncedValue } from './useDebouncedValue';
-
-export { default as useToggle } from './useToggle';
-
 export { default as useApiVersion } from './useApiVersion';
 
 export { default as useCreateDisableZoomRef } from './useCreateDisableZoomRef';
+
+export { default as useDebouncedValue } from './useDebouncedValue';
+
+export { default as useOnClickOutside } from './useOnClickOutside';
+
+export { default as useToggle } from './useToggle';
 
 export * from './useAssetGroupTags';
 
@@ -30,7 +30,19 @@ export * from './useAvailableEnvironments';
 
 export * from './useConfiguration';
 
+export * from './useCustomNodeKinds';
+
 export * from './useDataQualityStats';
+
+export * from './useEnvironmentParams';
+
+export * from './useExploreGraph';
+
+export * from './useExploreParams';
+
+export * from './useExploreSelectedItem';
+
+export * from './useExploreTableAutoDisplay';
 
 export * from './useFeatureFlags';
 
@@ -38,40 +50,30 @@ export * from './useFetchEntityProperties';
 
 export * from './useFileIngest';
 
+export * from './useFinishedJobs';
+
+export * from './useGraphHasData';
+
 export * from './useGraphItem';
 
-export * from './useMountEffect';
-
-export * from './usePermissions';
-
-export * from './useSavedQueries';
-
-export * from './useSearch';
-
-export * from './useExploreParams';
-
-export * from './useExploreGraph';
-
-export * from './useExploreSelectedItem';
-
-export * from './useEnvironmentParams';
-
-export * from './useShowNavBar';
+export * from './useInitialEnvironment';
 
 export * from './useIsMouseDragging';
 
 export * from './useMatchingPaths';
 
-export * from './useInitialEnvironment';
+export * from './useMountEffect';
+
+export * from './usePermissions';
 
 export * from './usePreviousValue';
 
-export * from './useCustomNodeKinds';
+export * from './useSavedQueries';
 
-export * from './useExploreTableAutoDisplay';
-
-export * from './useGraphHasData';
+export * from './useSearch';
 
 export * from './useSelectedTagName';
+
+export * from './useShowNavBar';
 
 export * from './useZoneParams';

--- a/packages/javascript/bh-shared-ui/src/hooks/useFinishedJobs/index.ts
+++ b/packages/javascript/bh-shared-ui/src/hooks/useFinishedJobs/index.ts
@@ -1,0 +1,17 @@
+// Copyright 2025 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+export * from './useFinishedJobs';

--- a/packages/javascript/bh-shared-ui/src/hooks/useFinishedJobs/useFinishedJobs.test.ts
+++ b/packages/javascript/bh-shared-ui/src/hooks/useFinishedJobs/useFinishedJobs.test.ts
@@ -31,8 +31,8 @@ const addNotificationMock = vi.fn();
 const dismissNotificationMock = vi.fn();
 const checkPermissionMock = vi.fn();
 
-vi.mock('../providers', async () => {
-    const actual = await vi.importActual('../providers');
+vi.mock('../../providers', async () => {
+    const actual = await vi.importActual('../../providers');
     return {
         ...actual,
         useNotifications: () => ({
@@ -42,8 +42,8 @@ vi.mock('../providers', async () => {
     };
 });
 
-vi.mock('../hooks/usePermissions', async () => {
-    const actual = await vi.importActual('../hooks');
+vi.mock('../usePermissions', async () => {
+    const actual = await vi.importActual('../usePermissions');
     return {
         ...actual,
         usePermissions: () => ({

--- a/packages/javascript/bh-shared-ui/src/hooks/useFinishedJobs/useFinishedJobs.test.ts
+++ b/packages/javascript/bh-shared-ui/src/hooks/useFinishedJobs/useFinishedJobs.test.ts
@@ -48,6 +48,8 @@ vi.mock('../usePermissions', async () => {
         ...actual,
         usePermissions: () => ({
             checkPermission: checkPermissionMock,
+            // Treat permissions as loaded in tests unless explicitly overridden
+            isSuccess: true,
         }),
     };
 });

--- a/packages/javascript/bh-shared-ui/src/hooks/useFinishedJobs/useFinishedJobs.test.ts
+++ b/packages/javascript/bh-shared-ui/src/hooks/useFinishedJobs/useFinishedJobs.test.ts
@@ -1,0 +1,135 @@
+// Copyright 2025 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import type { ScheduledJobDisplay } from 'js-client-library';
+import { rest } from 'msw';
+import { setupServer } from 'msw/node';
+import { renderHook, waitFor } from '../../test-utils';
+import {
+    FETCH_ERROR_KEY,
+    FETCH_ERROR_MESSAGE,
+    NO_PERMISSION_KEY,
+    NO_PERMISSION_MESSAGE,
+    PERSIST_NOTIFICATION,
+} from '../../utils/finishedJobs';
+import { useFinishedJobs } from './useFinishedJobs';
+
+const addNotificationMock = vi.fn();
+const dismissNotificationMock = vi.fn();
+const checkPermissionMock = vi.fn();
+
+vi.mock('../providers', async () => {
+    const actual = await vi.importActual('../providers');
+    return {
+        ...actual,
+        useNotifications: () => ({
+            addNotification: addNotificationMock,
+            dismissNotification: dismissNotificationMock,
+        }),
+    };
+});
+
+vi.mock('../hooks/usePermissions', async () => {
+    const actual = await vi.importActual('../hooks');
+    return {
+        ...actual,
+        usePermissions: () => ({
+            checkPermission: checkPermissionMock,
+        }),
+    };
+});
+
+const MOCK_FINISHED_JOB: ScheduledJobDisplay = {
+    id: 22,
+    client_id: '718c9b04-9394-42c0-9d53-c87b689e2d92',
+    client_name: 'GOAD',
+    event_id: 123,
+    execution_time: '2024-08-15T21:24:52.366579Z',
+    start_time: '2024-08-15T21:25:21.990437Z',
+    end_time: '2024-08-15T21:26:43.033448Z',
+    status: 2,
+    status_message: 'The service collected successfully',
+    session_collection: true,
+    local_group_collection: true,
+    ad_structure_collection: true,
+    cert_services_collection: true,
+    ca_registry_collection: true,
+    dc_registry_collection: true,
+    all_trusted_domains: true,
+    domain_controller: '',
+    ous: [],
+    domains: [],
+    domain_results: [],
+};
+
+const MOCK_FINISHED_JOBS_RESPONSE = {
+    count: 20,
+    data: new Array(10).fill(MOCK_FINISHED_JOB).map((item, index) => ({
+        ...item,
+        id: index,
+        status: (index % 10) - 1,
+    })),
+    limit: 10,
+    skip: 10,
+};
+
+const server = setupServer(
+    rest.get('/api/v2/jobs/finished', (req, res, ctx) => {
+        return res(ctx.json(MOCK_FINISHED_JOBS_RESPONSE));
+    })
+);
+
+beforeAll(() => server.listen());
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+describe('useFinishedJobs', () => {
+    it('requests finished jobs', async () => {
+        checkPermissionMock.mockImplementation(() => true);
+        const { result } = renderHook(() => useFinishedJobs({ page: 0, rowsPerPage: 10 }));
+        await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+        expect(result.current.data.data.length).toBe(10);
+    });
+
+    it('shows "no permission" notification if lacking permission', async () => {
+        checkPermissionMock.mockImplementation(() => false);
+        const { result } = renderHook(() => useFinishedJobs({ page: 0, rowsPerPage: 10 }));
+        await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+        expect(addNotificationMock).toHaveBeenCalledWith(
+            NO_PERMISSION_MESSAGE,
+            NO_PERMISSION_KEY,
+            PERSIST_NOTIFICATION
+        );
+    });
+
+    it('does not request finished jobs if lacking permission', async () => {
+        checkPermissionMock.mockImplementation(() => false);
+        const { result } = renderHook(() => useFinishedJobs({ page: 0, rowsPerPage: 10 }));
+        await waitFor(() => expect(result.current.isLoading).toBe(false));
+        expect(result.current.data).toBeUndefined();
+    });
+
+    it('shows an error notification if there is an error fetching', async () => {
+        server.use(rest.get('/api/v2/jobs/finished', (req, res, ctx) => res(ctx.status(400))));
+        checkPermissionMock.mockImplementation(() => true);
+        const { result } = renderHook(() => useFinishedJobs({ page: 0, rowsPerPage: 10 }));
+        await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+        expect(addNotificationMock).toHaveBeenCalledWith(FETCH_ERROR_MESSAGE, FETCH_ERROR_KEY);
+    });
+});

--- a/packages/javascript/bh-shared-ui/src/hooks/useFinishedJobs/useFinishedJobs.ts
+++ b/packages/javascript/bh-shared-ui/src/hooks/useFinishedJobs/useFinishedJobs.ts
@@ -1,3 +1,18 @@
+// Copyright 2025 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 import { GetScheduledJobDisplayResponse } from 'js-client-library';
 import { useEffect } from 'react';
 import { useQuery } from 'react-query';

--- a/packages/javascript/bh-shared-ui/src/hooks/useFinishedJobs/useFinishedJobs.ts
+++ b/packages/javascript/bh-shared-ui/src/hooks/useFinishedJobs/useFinishedJobs.ts
@@ -1,0 +1,39 @@
+import { GetScheduledJobDisplayResponse } from 'js-client-library';
+import { useEffect } from 'react';
+import { useQuery } from 'react-query';
+import { useNotifications } from '../../providers';
+import {
+    FETCH_ERROR_KEY,
+    FETCH_ERROR_MESSAGE,
+    FinishedJobParams,
+    NO_PERMISSION_KEY,
+    NO_PERMISSION_MESSAGE,
+    PERSIST_NOTIFICATION,
+    Permission,
+    apiClient,
+} from '../../utils';
+import { usePermissions } from '../usePermissions';
+
+/** Makes a paginated request for Finished Jobs, returned as a TanStack Query */
+export const useFinishedJobs = ({ page, rowsPerPage }: FinishedJobParams) => {
+    const { checkPermission } = usePermissions();
+    const hasPermission = checkPermission(Permission.CLIENTS_MANAGE);
+
+    const { addNotification, dismissNotification } = useNotifications();
+
+    useEffect(() => {
+        if (!hasPermission) {
+            addNotification(NO_PERMISSION_MESSAGE, NO_PERMISSION_KEY, PERSIST_NOTIFICATION);
+        }
+
+        return () => dismissNotification(NO_PERMISSION_KEY);
+    }, [addNotification, dismissNotification, hasPermission]);
+
+    return useQuery<GetScheduledJobDisplayResponse>({
+        enabled: hasPermission,
+        keepPreviousData: true, // Prevent count from resetting to 0 between page fetches
+        onError: () => addNotification(FETCH_ERROR_MESSAGE, FETCH_ERROR_KEY),
+        queryFn: () => apiClient.getFinishedJobs(rowsPerPage * page, rowsPerPage, false, false).then((res) => res.data),
+        queryKey: ['finished-jobs', { page, rowsPerPage }],
+    });
+};

--- a/packages/javascript/bh-shared-ui/src/mocks/factories/zoneManagement.ts
+++ b/packages/javascript/bh-shared-ui/src/mocks/factories/zoneManagement.ts
@@ -14,7 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { faker } from '@faker-js/faker';
+import { faker } from '@faker-js/faker/locale/en';
 import {
     AssetGroupTag,
     AssetGroupTagMemberInfo,

--- a/packages/javascript/bh-shared-ui/src/utils/datePicker.ts
+++ b/packages/javascript/bh-shared-ui/src/utils/datePicker.ts
@@ -1,3 +1,18 @@
+// Copyright 2025 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 export enum CustomRangeError {
     INVALID_DATE = 'Must be a valid date in yyyy-mm-dd format.',
     INVALID_RANGE_START = 'Start date must be before end date.',

--- a/packages/javascript/bh-shared-ui/src/utils/finishedJobs.test.ts
+++ b/packages/javascript/bh-shared-ui/src/utils/finishedJobs.test.ts
@@ -48,7 +48,7 @@ describe('toCollected', () => {
         );
     });
 
-    it('shows some collection methods for the given job', () => {
+    it('shows no collection methods for the given job', () => {
         const NO_COLLECTIONS_JOB = {
             ...MOCK_FINISHED_JOB,
             session_collection: false,
@@ -61,7 +61,7 @@ describe('toCollected', () => {
         expect(toCollected(NO_COLLECTIONS_JOB)).toBe('');
     });
 
-    it('shows no collection methods for the given job', () => {
+    it('shows some collection methods for the given job', () => {
         const SOME_COLLECTIONS_JOB = {
             ...MOCK_FINISHED_JOB,
             session_collection: false,

--- a/packages/javascript/bh-shared-ui/src/utils/finishedJobs.ts
+++ b/packages/javascript/bh-shared-ui/src/utils/finishedJobs.ts
@@ -14,17 +14,11 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import type { GetScheduledJobDisplayResponse, ScheduledJobDisplay } from 'js-client-library';
+import type { ScheduledJobDisplay } from 'js-client-library';
 import { DateTime, Interval } from 'luxon';
 import type { OptionsObject } from 'notistack';
-import { useEffect } from 'react';
-import { useQuery } from 'react-query';
 import type { StatusType } from '../components';
-import { usePermissions } from '../hooks/usePermissions';
-import { useNotifications } from '../providers';
-import { apiClient } from './api';
 import { LuxonFormat } from './datetime';
-import { Permission } from './permissions';
 
 export interface FinishedJobParams {
     page: number;
@@ -74,30 +68,6 @@ export const NO_PERMISSION_KEY = 'finished-jobs-permission';
 
 export const FETCH_ERROR_MESSAGE = 'Unable to fetch jobs. Please try again.';
 export const FETCH_ERROR_KEY = 'finished-jobs-error';
-
-/** Makes a paginated request for Finished Jobs, returned as a TanStack Query */
-export const useFinishedJobsQuery = ({ page, rowsPerPage }: FinishedJobParams) => {
-    const { checkPermission } = usePermissions();
-    const hasPermission = checkPermission(Permission.CLIENTS_MANAGE);
-
-    const { addNotification, dismissNotification } = useNotifications();
-
-    useEffect(() => {
-        if (!hasPermission) {
-            addNotification(NO_PERMISSION_MESSAGE, NO_PERMISSION_KEY, PERSIST_NOTIFICATION);
-        }
-
-        return () => dismissNotification(NO_PERMISSION_KEY);
-    }, [addNotification, dismissNotification, hasPermission]);
-
-    return useQuery<GetScheduledJobDisplayResponse>({
-        enabled: hasPermission,
-        keepPreviousData: true, // Prevent count from resetting to 0 between page fetches
-        onError: () => addNotification(FETCH_ERROR_MESSAGE, FETCH_ERROR_KEY),
-        queryFn: () => apiClient.getFinishedJobs(rowsPerPage * page, rowsPerPage, false, false).then((res) => res.data),
-        queryKey: ['finished-jobs', { page, rowsPerPage }],
-    });
-};
 
 /** Returns the duration, in mins, between 2 given ISO datetime strings */
 export const toMins = (start: string, end: string) =>


### PR DESCRIPTION
## Description

* Creates a feature flag to toggle between the new and old FinishedJobsLog tables
* Fixes circular dependencies in Finished Jobs libs (query)
* Updates faker imports to specify locale. This reduces the bundle size by ~2MB (No jira, just sneaking this small change in)

## Motivation and Context

Resolves BED-6382

## How Has This Been Tested?

Manually, enabling and disabling the feature flag `finished_jobs_log_v2`

## Types of changes

- New feature (non-breaking change which adds functionality)
- Database Migrations

## Checklist:

- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Finished Jobs table keeps showing permission/error notifications and preserves previous page data for smoother pagination.

- Refactor
  - Finished Jobs data fetching reorganized into shared hooks and hook exports were reshuffled.

- Tests
  - Added and updated tests covering Finished Jobs behavior and formatting helpers.

- Chores
  - Seeded a feature flag for the Finished Jobs Log; standardized faker to English locale and aligned build config.

- Bug Fixes
  - Date picker adds clearer "End date must be after start date." validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->