### PR TITLE
Revert "feat: AdminSDHolder Protected - BED-6286 (#1743)"

### DIFF
--- a/cmd/ui/public/img/BHCE_Vertical_RedField.svg
+++ b/cmd/ui/public/img/BHCE_Vertical_RedField.svg
@@ -1,20 +1,3 @@
-<!--
-    Copyright 2025 Specter Ops, Inc.
-    
-    Licensed under the Apache License, Version 2.0
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
-    
-        http://www.apache.org/licenses/LICENSE-2.0
-    
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-    
-    SPDX-License-Identifier: Apache-2.0
--->
 <svg width="500" height="500" viewBox="0 0 500 500" fill="none" xmlns="http://www.w3.org/2000/svg">
 <rect width="500" height="500" rx="10" fill="#E02F35"/>
 <path d="M72.3256 438.227C70.1717 438.227 68.3311 437.796 66.7907 436.922C65.2503 436.047 64.0754 434.82 63.253 433.227C62.4306 431.635 62.0259 429.755 62.0259 427.575C62.0259 425.395 62.4306 423.528 63.253 421.935C64.0754 420.356 65.2503 419.129 66.7907 418.254C68.3311 417.38 70.1717 416.949 72.3256 416.949C73.7094 416.949 75.0279 417.158 76.268 417.588C77.5082 418.019 78.5394 418.633 79.3357 419.442L78.1086 422.431C77.234 421.687 76.3333 421.139 75.4064 420.8C74.4796 420.46 73.5005 420.291 72.4431 420.291C70.3545 420.291 68.7488 420.917 67.6653 422.183C66.5687 423.45 66.0205 425.238 66.0205 427.575C66.0205 429.912 66.5687 431.7 67.6653 432.979C68.7618 434.259 70.3545 434.885 72.4431 434.885C73.5005 434.885 74.4926 434.715 75.4064 434.376C76.3202 434.037 77.221 433.488 78.1086 432.744L79.3357 435.734C78.5394 436.517 77.5082 437.13 76.268 437.574C75.0279 438.018 73.7094 438.24 72.3256 438.24V438.227Z" fill="white"/>

--- a/packages/csharp/graphschema/PropertyNames.cs
+++ b/packages/csharp/graphschema/PropertyNames.cs
@@ -174,7 +174,6 @@ public static readonly string ClientAllowedNTLMServers = "clientallowedntlmserve
 public static readonly string Transitive = "transitive";
 public static readonly string GroupScope = "groupscope";
 public static readonly string NetBIOS = "netbios";
-public static readonly string AdminSDHolderProtected = "adminsdholderprotected";
 
 }
 }

--- a/packages/cue/bh/ad/ad.cue
+++ b/packages/cue/bh/ad/ad.cue
@@ -292,13 +292,6 @@ AdminCount: types.#StringEnum & {
 	representation: "admincount"
 }
 
-AdminSDHolderProtected: types.#StringEnum & {
-	symbol:         "AdminSDHolderProtected"
-	schema:         "ad"
-	name:           "AdminSDHolder Protected"
-	representation: "adminsdholderprotected"
-}
-
 DontRequirePreAuth: types.#StringEnum & {
 	symbol:         "DontRequirePreAuth"
 	schema:         "ad"
@@ -1133,7 +1126,6 @@ Properties: [
 	Transitive,
 	GroupScope,
 	NetBIOS,
-	AdminSDHolderProtected,
 ]
 
 // Kinds

--- a/packages/go/graphschema/ad/ad.go
+++ b/packages/go/graphschema/ad/ad.go
@@ -265,11 +265,10 @@ const (
 	Transitive                              Property = "transitive"
 	GroupScope                              Property = "groupscope"
 	NetBIOS                                 Property = "netbios"
-	AdminSDHolderProtected                  Property = "adminsdholderprotected"
 )
 
 func AllProperties() []Property {
-	return []Property{AdminCount, CASecurityCollected, CAName, CertChain, CertName, CertThumbprint, CertThumbprints, HasEnrollmentAgentRestrictions, EnrollmentAgentRestrictionsCollected, IsUserSpecifiesSanEnabled, IsUserSpecifiesSanEnabledCollected, RoleSeparationEnabled, RoleSeparationEnabledCollected, HasBasicConstraints, BasicConstraintPathLength, UnresolvedPublishedTemplates, DNSHostname, CrossCertificatePair, DistinguishedName, DomainFQDN, DomainSID, Sensitive, BlocksInheritance, IsACL, IsACLProtected, InheritanceHash, InheritanceHashes, IsDeleted, Enforced, Department, HasCrossCertificatePair, HasSPN, UnconstrainedDelegation, LastLogon, LastLogonTimestamp, IsPrimaryGroup, HasLAPS, DontRequirePreAuth, LogonType, HasURA, PasswordNeverExpires, PasswordNotRequired, FunctionalLevel, TrustType, SpoofSIDHistoryBlocked, TrustedToAuth, SamAccountName, CertificateMappingMethodsRaw, CertificateMappingMethods, StrongCertificateBindingEnforcementRaw, StrongCertificateBindingEnforcement, EKUs, SubjectAltRequireUPN, SubjectAltRequireDNS, SubjectAltRequireDomainDNS, SubjectAltRequireEmail, SubjectAltRequireSPN, SubjectRequireEmail, AuthorizedSignatures, ApplicationPolicies, IssuancePolicies, SchemaVersion, RequiresManagerApproval, AuthenticationEnabled, SchannelAuthenticationEnabled, EnrolleeSuppliesSubject, CertificateApplicationPolicy, CertificateNameFlag, EffectiveEKUs, EnrollmentFlag, Flags, NoSecurityExtension, RenewalPeriod, ValidityPeriod, OID, HomeDirectory, CertificatePolicy, CertTemplateOID, GroupLinkID, ObjectGUID, ExpirePasswordsOnSmartCardOnlyAccounts, MachineAccountQuota, SupportedKerberosEncryptionTypes, TGTDelegation, PasswordStoredUsingReversibleEncryption, SmartcardRequired, UseDESKeyOnly, LogonScriptEnabled, LockedOut, UserCannotChangePassword, PasswordExpired, DSHeuristics, UserAccountControl, TrustAttributesInbound, TrustAttributesOutbound, MinPwdLength, PwdProperties, PwdHistoryLength, LockoutThreshold, MinPwdAge, MaxPwdAge, LockoutDuration, LockoutObservationWindow, OwnerSid, SMBSigning, WebClientRunning, RestrictOutboundNTLM, GMSA, MSA, DoesAnyAceGrantOwnerRights, DoesAnyInheritedAceGrantOwnerRights, ADCSWebEnrollmentHTTP, ADCSWebEnrollmentHTTPS, ADCSWebEnrollmentHTTPSEPA, LDAPSigning, LDAPAvailable, LDAPSAvailable, LDAPSEPA, IsDC, IsReadOnlyDC, HTTPEnrollmentEndpoints, HTTPSEnrollmentEndpoints, HasVulnerableEndpoint, RequireSecuritySignature, EnableSecuritySignature, RestrictReceivingNTLMTraffic, NTLMMinServerSec, NTLMMinClientSec, LMCompatibilityLevel, UseMachineID, ClientAllowedNTLMServers, Transitive, GroupScope, NetBIOS, AdminSDHolderProtected}
+	return []Property{AdminCount, CASecurityCollected, CAName, CertChain, CertName, CertThumbprint, CertThumbprints, HasEnrollmentAgentRestrictions, EnrollmentAgentRestrictionsCollected, IsUserSpecifiesSanEnabled, IsUserSpecifiesSanEnabledCollected, RoleSeparationEnabled, RoleSeparationEnabledCollected, HasBasicConstraints, BasicConstraintPathLength, UnresolvedPublishedTemplates, DNSHostname, CrossCertificatePair, DistinguishedName, DomainFQDN, DomainSID, Sensitive, BlocksInheritance, IsACL, IsACLProtected, InheritanceHash, InheritanceHashes, IsDeleted, Enforced, Department, HasCrossCertificatePair, HasSPN, UnconstrainedDelegation, LastLogon, LastLogonTimestamp, IsPrimaryGroup, HasLAPS, DontRequirePreAuth, LogonType, HasURA, PasswordNeverExpires, PasswordNotRequired, FunctionalLevel, TrustType, SpoofSIDHistoryBlocked, TrustedToAuth, SamAccountName, CertificateMappingMethodsRaw, CertificateMappingMethods, StrongCertificateBindingEnforcementRaw, StrongCertificateBindingEnforcement, EKUs, SubjectAltRequireUPN, SubjectAltRequireDNS, SubjectAltRequireDomainDNS, SubjectAltRequireEmail, SubjectAltRequireSPN, SubjectRequireEmail, AuthorizedSignatures, ApplicationPolicies, IssuancePolicies, SchemaVersion, RequiresManagerApproval, AuthenticationEnabled, SchannelAuthenticationEnabled, EnrolleeSuppliesSubject, CertificateApplicationPolicy, CertificateNameFlag, EffectiveEKUs, EnrollmentFlag, Flags, NoSecurityExtension, RenewalPeriod, ValidityPeriod, OID, HomeDirectory, CertificatePolicy, CertTemplateOID, GroupLinkID, ObjectGUID, ExpirePasswordsOnSmartCardOnlyAccounts, MachineAccountQuota, SupportedKerberosEncryptionTypes, TGTDelegation, PasswordStoredUsingReversibleEncryption, SmartcardRequired, UseDESKeyOnly, LogonScriptEnabled, LockedOut, UserCannotChangePassword, PasswordExpired, DSHeuristics, UserAccountControl, TrustAttributesInbound, TrustAttributesOutbound, MinPwdLength, PwdProperties, PwdHistoryLength, LockoutThreshold, MinPwdAge, MaxPwdAge, LockoutDuration, LockoutObservationWindow, OwnerSid, SMBSigning, WebClientRunning, RestrictOutboundNTLM, GMSA, MSA, DoesAnyAceGrantOwnerRights, DoesAnyInheritedAceGrantOwnerRights, ADCSWebEnrollmentHTTP, ADCSWebEnrollmentHTTPS, ADCSWebEnrollmentHTTPSEPA, LDAPSigning, LDAPAvailable, LDAPSAvailable, LDAPSEPA, IsDC, IsReadOnlyDC, HTTPEnrollmentEndpoints, HTTPSEnrollmentEndpoints, HasVulnerableEndpoint, RequireSecuritySignature, EnableSecuritySignature, RestrictReceivingNTLMTraffic, NTLMMinServerSec, NTLMMinClientSec, LMCompatibilityLevel, UseMachineID, ClientAllowedNTLMServers, Transitive, GroupScope, NetBIOS}
 }
 func ParseProperty(source string) (Property, error) {
 	switch source {
@@ -541,8 +540,6 @@ func ParseProperty(source string) (Property, error) {
 		return GroupScope, nil
 	case "netbios":
 		return NetBIOS, nil
-	case "adminsdholderprotected":
-		return AdminSDHolderProtected, nil
 	default:
 		return "", errors.New("Invalid enumeration value: " + source)
 	}
@@ -817,8 +814,6 @@ func (s Property) String() string {
 		return string(GroupScope)
 	case NetBIOS:
 		return string(NetBIOS)
-	case AdminSDHolderProtected:
-		return string(AdminSDHolderProtected)
 	default:
 		return "Invalid enumeration case: " + string(s)
 	}
@@ -1093,8 +1088,6 @@ func (s Property) Name() string {
 		return "Group Scope"
 	case NetBIOS:
 		return "NetBIOS"
-	case AdminSDHolderProtected:
-		return "AdminSDHolder Protected"
 	default:
 		return "Invalid enumeration case: " + string(s)
 	}

--- a/packages/go/openapi/doc/openapi.json
+++ b/packages/go/openapi/doc/openapi.json
@@ -2818,7 +2818,7 @@
                     "data": {
                       "type": "array",
                       "items": {
-                        "$ref": "#/components/schemas/model.file-upload-job"
+                        "$ref": "#/components/schemas/model.file-upload-job.completed-tasks"
                       }
                     }
                   }
@@ -17731,6 +17731,33 @@
               },
               "failed_files": {
                 "type": "integer"
+              }
+            }
+          }
+        ]
+      },
+      "model.file-upload-job.completed-tasks": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/model.components.int64.id"
+          },
+          {
+            "$ref": "#/components/schemas/model.components.timestamps"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "file_name": {
+                "type": "string"
+              },
+              "parent_file_name": {
+                "type": "string"
+              },
+              "errors": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
               }
             }
           }

--- a/packages/javascript/bh-shared-ui/src/commonSearchesAGI.ts
+++ b/packages/javascript/bh-shared-ui/src/commonSearchesAGI.ts
@@ -271,10 +271,6 @@ export const CommonSearches: CommonSearchType[] = [
                 description: 'Tier Zero / High Value users with non-expiring passwords',
                 cypher: `MATCH (u:User)\nWHERE u.enabled = true\nAND u.pwdneverexpires = true\nand COALESCE(u.system_tags, '') CONTAINS '${TIER_ZERO_TAG}'\nRETURN u\nLIMIT 100`,
             },
-            {
-                description: 'Tier Zero principals without AdminSDHolder protection',
-                cypher: `MATCH (n:Base)\nWHERE COALESCE(n.system_tags, '') CONTAINS '${TIER_ZERO_TAG}'\nAND n.adminsdholderprotected = false\nRETURN n\nLIMIT 500`,
-            },
         ],
     },
     {

--- a/packages/javascript/bh-shared-ui/src/commonSearchesAGT.ts
+++ b/packages/javascript/bh-shared-ui/src/commonSearchesAGT.ts
@@ -271,10 +271,6 @@ export const CommonSearches: CommonSearchType[] = [
                 description: 'Tier Zero / High Value users with non-expiring passwords',
                 cypher: `MATCH (u:User)\nWHERE (u:${TAG_TIER_ZERO_AGT}) AND u.enabled = true\nAND u.pwdneverexpires = true\nRETURN u\nLIMIT 100`,
             },
-            {
-                description: 'Tier Zero principals without AdminSDHolder protection',
-                cypher: `MATCH (n:Base)\nWHERE (n:${TAG_TIER_ZERO_AGT})\nAND n.adminsdholderprotected = false\nRETURN n\nLIMIT 500`,
-            },
         ],
     },
     {

--- a/packages/javascript/bh-shared-ui/src/graphSchema.ts
+++ b/packages/javascript/bh-shared-ui/src/graphSchema.ts
@@ -487,7 +487,6 @@ export enum ActiveDirectoryKindProperties {
     Transitive = 'transitive',
     GroupScope = 'groupscope',
     NetBIOS = 'netbios',
-    AdminSDHolderProtected = 'adminsdholderprotected',
 }
 export function ActiveDirectoryKindPropertiesToDisplay(value: ActiveDirectoryKindProperties): string | undefined {
     switch (value) {
@@ -759,8 +758,6 @@ export function ActiveDirectoryKindPropertiesToDisplay(value: ActiveDirectoryKin
             return 'Group Scope';
         case ActiveDirectoryKindProperties.NetBIOS:
             return 'NetBIOS';
-        case ActiveDirectoryKindProperties.AdminSDHolderProtected:
-            return 'AdminSDHolder Protected';
         default:
             return undefined;
     }


### PR DESCRIPTION
This reverts commit 5dce78f7f8ea34a6c012e67c410d12407ef27b30.

## Description
This feature depends on some collector work that will not be completed in time for this release cycle, so we are pulling it out of the staging branch and it will get pulled in during 8.2.0

## Motivation and Context

Removes [BED-6286](https://specterops.atlassian.net/browse/BED-6286)

The pre-built cypher queries added in this PR currently will not return any results since we are not collecting the required properties yet, which could lead to a poor user experience.

## How Has This Been Tested?

## Screenshots (optional):

## Types of changes
- Chore (a change that does not modify the application functionality)

## Checklist:
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


[BED-6286]: https://specterops.atlassian.net/browse/BED-6286?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ