### PR TITLE
fix: get self query key consistency

### DIFF
--- a/packages/javascript/bh-shared-ui/src/hooks/usePermissions/usePermissions.tsx
+++ b/packages/javascript/bh-shared-ui/src/hooks/usePermissions/usePermissions.tsx
@@ -32,7 +32,7 @@ const formatKey = (p: { authority: string; name: string }) => `${p.authority}-${
 const getSelf = (options?: RequestOptions) => apiClient.getSelf(options).then((res) => res.data.data);
 
 export const usePermissions = () => {
-    const getSelfQuery = useQuery(['getSelf', 'permissions'], ({ signal }) => getSelf({ signal }), {
+    const getSelfQuery = useQuery(['getSelf'], ({ signal }) => getSelf({ signal }), {
         cacheTime: Number.POSITIVE_INFINITY,
         select: (data) => {
             const userPermissions = data?.roles.map((role: any) => role.permissions).flat() || [];


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Removes 'permissions' from the query key for the get self call in the usePermissions hook.

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-6387

*Why is this change required? What problem does it solve?*

## How Has This Been Tested?

*Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc.*

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [ ] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [ ] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
