### PR TITLE
fix (api): Overwrite SharedWithUsers - BED-6388

### DIFF
--- a/cmd/api/src/database/saved_queries_permissions.go
+++ b/cmd/api/src/database/saved_queries_permissions.go
@@ -83,7 +83,7 @@ func (s *BloodhoundDB) CreateSavedQueryPermissionsToUsers(ctx context.Context, q
 	err := s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		if err := CheckError(tx.Table("saved_queries_permissions").Where("query_id = ? AND public = false", queryID).Delete(&model.SavedQueriesPermissions{})); err != nil {
 			return err
-		} else if err = CheckError(tx.WithContext(ctx).Clauses(clause.OnConflict{DoNothing: true}).CreateInBatches(&newPermissions, 100)); err != nil {
+		} else if err = CheckError(tx.Clauses(clause.OnConflict{DoNothing: true}).CreateInBatches(&newPermissions, 100)); err != nil {
 			return err
 		}
 		return nil

--- a/cmd/api/src/database/saved_queries_permissions.go
+++ b/cmd/api/src/database/saved_queries_permissions.go
@@ -68,7 +68,8 @@ func (s *BloodhoundDB) CreateSavedQueryPermissionToPublic(ctx context.Context, q
 	return permission, err
 }
 
-// CreateSavedQueryPermissionsToUsers - attempts to save the given saved query permissions in batches of 100 in a transaction
+// CreateSavedQueryPermissionsToUsers - attempts to save the given saved query permissions in batches of 100 in a transaction.
+// This will remove previously shared with users and replace it with the incoming user ids.
 func (s *BloodhoundDB) CreateSavedQueryPermissionsToUsers(ctx context.Context, queryID int64, userIDs ...uuid.UUID) ([]model.SavedQueriesPermissions, error) {
 	var newPermissions []model.SavedQueriesPermissions
 	for _, sharedUserID := range userIDs {
@@ -79,11 +80,15 @@ func (s *BloodhoundDB) CreateSavedQueryPermissionsToUsers(ctx context.Context, q
 		})
 	}
 
-	result := s.db.WithContext(ctx).Clauses(clause.OnConflict{
-		DoNothing: true,
-	}).CreateInBatches(&newPermissions, 100)
-
-	return newPermissions, CheckError(result)
+	err := s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := CheckError(tx.Table("saved_queries_permissions").Where("query_id = ? AND public = false", queryID).Delete(&model.SavedQueriesPermissions{})); err != nil {
+			return err
+		} else if err = CheckError(s.db.WithContext(ctx).Clauses(clause.OnConflict{DoNothing: true}).CreateInBatches(&newPermissions, 100)); err != nil {
+			return err
+		}
+		return nil
+	})
+	return newPermissions, err
 }
 
 // DeleteSavedQueryPermissionsForUsers batch deletes permissions associated with a query id and a list of users

--- a/cmd/api/src/database/saved_queries_permissions.go
+++ b/cmd/api/src/database/saved_queries_permissions.go
@@ -81,7 +81,7 @@ func (s *BloodhoundDB) CreateSavedQueryPermissionsToUsers(ctx context.Context, q
 	}
 
 	err := s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		if err := CheckError(tx.Table("saved_queries_permissions").Where("query_id = ? AND public = false", queryID).Delete(&model.SavedQueriesPermissions{})); err != nil {
+		if err := CheckError(tx.Exec("DELETE FROM saved_queries_permissions WHERE query_id = ? AND public = FALSE", queryID)); err != nil {
 			return err
 		} else if err = CheckError(tx.Clauses(clause.OnConflict{DoNothing: true}).CreateInBatches(&newPermissions, 100)); err != nil {
 			return err

--- a/cmd/api/src/database/saved_queries_permissions.go
+++ b/cmd/api/src/database/saved_queries_permissions.go
@@ -83,7 +83,7 @@ func (s *BloodhoundDB) CreateSavedQueryPermissionsToUsers(ctx context.Context, q
 	err := s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		if err := CheckError(tx.Table("saved_queries_permissions").Where("query_id = ? AND public = false", queryID).Delete(&model.SavedQueriesPermissions{})); err != nil {
 			return err
-		} else if err = CheckError(s.db.WithContext(ctx).Clauses(clause.OnConflict{DoNothing: true}).CreateInBatches(&newPermissions, 100)); err != nil {
+		} else if err = CheckError(tx.WithContext(ctx).Clauses(clause.OnConflict{DoNothing: true}).CreateInBatches(&newPermissions, 100)); err != nil {
 			return err
 		}
 		return nil


### PR DESCRIPTION
## Description

Update the CreateSavedQueryPermissionsToUsers DB method to run in a transaction and remove existing shared_with_id records prior to inserting new records. 

## Motivation and Context
Resolves: BED-6388

The ShareSavedQueries endpoint (/api/v2/saved-queries/{%s}/permissions) currently is set as a PUT endpoint. New requests just append the data like a PATCH endpoint would instead of overwriting the data like a PUT endpoint should. 

## How Has This Been Tested?

Tested locally:

- Create 2 additional users on top of base admin user
- Create saved query under User 1
- Share saved query with User 2
- Check saved query permissions and ensure query is shared with user 2
- Share saved query with User 3
- Check saved query permissions and ensure query is shared with only user 3


## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updating who a saved query is shared with now fully replaces previous private shares, preventing lingering or duplicate access.
  * Share updates are applied atomically (remove-then-add in a single operation), ensuring consistent permissions and avoiding partial updates.

* **Tests**
  * Integration tests updated to reflect and verify the new replace-rather-than-append sharing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->