### PR TITLE
update db pooling to handle iam rds auth [DRAFT]

### DIFF
--- a/cmd/api/src/api/tools/pg.go
+++ b/cmd/api/src/api/tools/pg.go
@@ -448,7 +448,7 @@ func (s *PGMigrator) MigrationStatus(response http.ResponseWriter, request *http
 }
 
 func (s *PGMigrator) OpenPostgresGraphConnection() (graph.Database, error) {
-	if pool, err := pg.NewPool(s.Cfg.Database.PostgreSQLConnectionString()); err != nil {
+	if pool, err := pg.NewPool(s.Cfg.Database); err != nil {
 		return nil, err
 	} else {
 		return dawgs.Open(s.ServerCtx, pg.DriverName, dawgs.Config{

--- a/cmd/api/src/bootstrap/util.go
+++ b/cmd/api/src/bootstrap/util.go
@@ -96,7 +96,7 @@ func ConnectGraph(ctx context.Context, cfg config.Configuration) (*graph.Databas
 		slog.InfoContext(ctx, "Connecting to graph using PostgreSQL")
 		connectionString = cfg.Database.PostgreSQLConnectionString()
 
-		pool, err = pg.NewPool(connectionString)
+		pool, err = pg.NewPool(cfg.Database)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/api/src/cmd/dawgs-harness/main.go
+++ b/cmd/api/src/cmd/dawgs-harness/main.go
@@ -37,7 +37,7 @@ import (
 	"github.com/specterops/dawgs/drivers/pg"
 	"github.com/specterops/dawgs/graph"
 	"github.com/specterops/dawgs/util/size"
-	"github.com/specterops/bloodhound/src/config"
+	"github.com/specterops/bloodhound/cmd/api/src/config"
 )
 
 func fatalf(format string, args ...any) {

--- a/cmd/api/src/cmd/dawgs-harness/main.go
+++ b/cmd/api/src/cmd/dawgs-harness/main.go
@@ -37,6 +37,7 @@ import (
 	"github.com/specterops/dawgs/drivers/pg"
 	"github.com/specterops/dawgs/graph"
 	"github.com/specterops/dawgs/util/size"
+	"github.com/specterops/bloodhound/src/config"
 )
 
 func fatalf(format string, args ...any) {
@@ -44,14 +45,14 @@ func fatalf(format string, args ...any) {
 	os.Exit(1)
 }
 
-func RunTestSuite(ctx context.Context, connectionStr, driverName string) tests.TestSuite {
+func RunTestSuite(ctx context.Context, connectionStr, driverName string, cfg config.DatabaseConfiguration) tests.TestSuite {
 	var (
 		pool *pgxpool.Pool
 		err  error
 	)
 
 	if driverName == pg.DriverName {
-		pool, err = pg.NewPool(connectionStr)
+		pool, err = pg.NewPool(cfg)
 		if err != nil {
 			fatalf("Failed creating a new pgxpool: %s", err)
 		}
@@ -141,10 +142,14 @@ func main() {
 
 	bhlog.ConfigureDefaultText(os.Stdout)
 
+	cfg := config.NewDefaultConfiguration(); err != nil {
+		return configuration, fmt.Errorf("failed to create default configuration: %w", err)
+	}
+
 	switch testType {
 	case "both":
 		n4jTestSuite := execSuite(neo4j.DriverName, func() tests.TestSuite {
-			return RunTestSuite(ctx, neo4jConnectionStr, neo4j.DriverName)
+			return RunTestSuite(ctx, neo4jConnectionStr, neo4j.DriverName, cfg)
 		})
 
 		fmt.Println()
@@ -153,7 +158,7 @@ func main() {
 		time.Sleep(time.Second * 3)
 
 		pgTestSuite := execSuite(pg.DriverName, func() tests.TestSuite {
-			return RunTestSuite(ctx, pgConnectionStr, pg.DriverName)
+			return RunTestSuite(ctx, pgConnectionStr, pg.DriverName, cfg)
 		})
 		fmt.Println()
 
@@ -161,12 +166,12 @@ func main() {
 
 	case "postgres":
 		execSuite(pg.DriverName, func() tests.TestSuite {
-			return RunTestSuite(ctx, pgConnectionStr, pg.DriverName)
+			return RunTestSuite(ctx, pgConnectionStr, pg.DriverName, cfg)
 		})
 
 	case "neo4j":
 		execSuite(neo4j.DriverName, func() tests.TestSuite {
-			return RunTestSuite(ctx, neo4jConnectionStr, neo4j.DriverName)
+			return RunTestSuite(ctx, neo4jConnectionStr, neo4j.DriverName, cfg)
 		})
 	}
 }

--- a/cmd/api/src/config/config.go
+++ b/cmd/api/src/config/config.go
@@ -17,11 +17,13 @@
 package config
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
+	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -30,6 +32,9 @@ import (
 
 	"github.com/specterops/bloodhound/cmd/api/src/serde"
 	"github.com/specterops/bloodhound/packages/go/crypto"
+
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/feature/rds/auth"
 )
 
 const (
@@ -72,11 +77,22 @@ type CollectorVersion struct {
 type CollectorManifests map[string]CollectorManifest
 
 func (s DatabaseConfiguration) PostgreSQLConnectionString() string {
-	if s.Connection == "" {
-		return fmt.Sprintf("postgresql://%s:%s@%s/%s", s.Username, s.Secret, s.Address, s.Database)
+	slog.Info("loading default config for rds auth")
+	cfg, err := config.LoadDefaultConfig(context.TODO())
+	if err != nil {
+		panic("configuration error: " + err.Error())
 	}
 
-	return s.Connection
+	dbinput := s.Address + ":5432"
+	slog.Info("requesting auth token")
+	authenticationToken, err := auth.BuildAuthToken(context.TODO(), dbinput, "us-east-1", s.Username, cfg.Credentials)
+	if err != nil {
+		panic("failed to create authentication token: " + err.Error())
+	}
+	slog.Info("auth token successfully created")
+	encodedToken := url.QueryEscape(authenticationToken)
+
+	return fmt.Sprintf("postgresql://%s:%s@%s/%s", s.Username, encodedToken, s.Address, s.Database)
 }
 
 func (s DatabaseConfiguration) Neo4jConnectionString() string {

--- a/cmd/api/src/database/db.go
+++ b/cmd/api/src/database/db.go
@@ -26,13 +26,16 @@ import (
 	"time"
 
 	"github.com/gofrs/uuid"
+	"github.com/jackc/pgx/v5/stdlib"
 	"github.com/specterops/bloodhound/cmd/api/src/auth"
+	"github.com/specterops/bloodhound/cmd/api/src/config"
 	"github.com/specterops/bloodhound/cmd/api/src/database/migration"
 	"github.com/specterops/bloodhound/cmd/api/src/model"
 	"github.com/specterops/bloodhound/cmd/api/src/model/appcfg"
 	"github.com/specterops/bloodhound/cmd/api/src/services/agi"
 	"github.com/specterops/bloodhound/cmd/api/src/services/dataquality"
 	"github.com/specterops/bloodhound/cmd/api/src/services/upload"
+	"github.com/specterops/dawgs/drivers/pg"
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 )
@@ -215,7 +218,7 @@ func NewBloodhoundDB(db *gorm.DB, idResolver auth.IdentityResolver) *BloodhoundD
 	return &BloodhoundDB{db: db, idResolver: idResolver}
 }
 
-func OpenDatabase(connection string) (*gorm.DB, error) {
+func OpenDatabase(cfg config.Configuration) (*gorm.DB, error) {
 	gormConfig := &gorm.Config{
 		Logger: &GormLogAdapter{
 			SlowQueryErrorThreshold: time.Second * 10,
@@ -223,7 +226,14 @@ func OpenDatabase(connection string) (*gorm.DB, error) {
 		},
 	}
 
-	if db, err := gorm.Open(postgres.Open(connection), gormConfig); err != nil {
+	pool, err := pg.NewPool(cfg.Database)
+	if err != nil {
+		return nil, err
+	}
+
+	dbPool := stdlib.OpenDBFromPool(pool)
+
+	if db, err := gorm.Open(postgres.New(postgres.Config{Conn: dbPool}), gormConfig); err != nil {
 		return nil, err
 	} else {
 		return db, nil

--- a/cmd/api/src/services/entrypoint.go
+++ b/cmd/api/src/services/entrypoint.go
@@ -44,7 +44,7 @@ import (
 
 // ConnectPostgres initializes a connection to PG, and returns errors if any
 func ConnectPostgres(cfg config.Configuration) (*database.BloodhoundDB, error) {
-	if db, err := database.OpenDatabase(cfg.Database.PostgreSQLConnectionString()); err != nil {
+	if db, err := database.OpenDatabase(cfg); err != nil {
 		return nil, fmt.Errorf("error while attempting to create database connection: %w", err)
 	} else {
 		return database.NewBloodhoundDB(db, auth.NewIdentityResolver()), nil


### PR DESCRIPTION
Proof of concept for introducing RDS iam auth capabilities for PG. This is intended to be used to test IAM rds auth functionality.

Updates PostgresConnectionString() to fetch an IAM auth token and encode it before adding it to the password of the return postgres connection string.

Updates NewPool() calls coinciding with DAWGs newpool change

Updates OpenDatabase() to pass pgxpool to Gorm.