### PR TITLE
feat: Release Audit poc

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -22,7 +22,7 @@
 			"installTools": true,
 			"version": "latest"
 		},
-		"ghcr.io/devcontainers-contrib/features/zsh-plugins:0": {
+		"ghcr.io/devcontainers-extra/features/zsh-plugins:0": {
 			"plugins": "ssh-agent npm",
 			"omzPlugins": "https://github.com/zsh-users/zsh-autosuggestions",
 			"username": "vscode"

--- a/.github/workflows/audit-release.yml
+++ b/.github/workflows/audit-release.yml
@@ -1,0 +1,38 @@
+name: Audit Release
+on:
+  workflow_dispatch:
+    inputs:
+      start:
+        description: Begin with commit SHA/tag/branch name
+        required: true
+        type: string
+      end:
+        description: End with commit SHA/tag/branch name
+        required: true
+        type: string
+      base:
+        description: Base branch
+        required: true
+        default: main
+        type: string
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source code for this repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "~1.24.4"
+          cache: true
+
+      - name: Audit Release Tags with Base
+        run: go tool stbernard audit -start ${{ inputs.start }} -end ${{ inputs.end }} -base ${{ inputs.base }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/audit-release.yml
+++ b/.github/workflows/audit-release.yml
@@ -1,3 +1,18 @@
+# Copyright 2025 Specter Ops, Inc.
+#
+# Licensed under the Apache License, Version 2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
 name: Audit Release
 on:
   workflow_dispatch:
@@ -12,7 +27,6 @@ on:
         type: string
       base:
         description: Base branch
-        required: true
         default: main
         type: string
 
@@ -29,8 +43,9 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: "~1.24.4"
+          go-version-file: go.mod
           cache: true
+          check-latest: true
 
       - name: Audit Release Tags with Base
         run: go tool stbernard audit -start ${{ inputs.start }} -end ${{ inputs.end }} -base ${{ inputs.base }}

--- a/.github/workflows/run-go-tests.yml
+++ b/.github/workflows/run-go-tests.yml
@@ -40,8 +40,9 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: "~1.24.4"
+          go-version-file: go.mod
           cache: true
+          check-latest: true
 
       - name: Run Tests
         run: |

--- a/.github/workflows/run-slow-go-tests.yml
+++ b/.github/workflows/run-slow-go-tests.yml
@@ -37,8 +37,9 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: "~1.24.4"
+          go-version-file: go.mod
           cache: true
+          check-latest: true
 
       - name: Run Tests
         run: |

--- a/.github/workflows/run-ui-tests.yml
+++ b/.github/workflows/run-ui-tests.yml
@@ -35,8 +35,9 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: "~1.24.4"
+          go-version-file: go.mod
           cache: true
+          check-latest: true
 
       # Telling yarn that CI is false because of flap
       - name: Run Tests

--- a/.github/workflows/static-code-analysis.yml
+++ b/.github/workflows/static-code-analysis.yml
@@ -36,7 +36,9 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: "~1.24.4"
+          go-version-file: go.mod
+          cache: true
+          check-latest: true
 
       - name: Install Node
         uses: actions/setup-node@v4

--- a/packages/go/stbernard/command/audit/audit.go
+++ b/packages/go/stbernard/command/audit/audit.go
@@ -86,6 +86,11 @@ func (s *command) Parse(cmdIndex int) error {
 		return fmt.Errorf("parsing %s command: no ending sha given", Name)
 	}
 
+	if s.baseBranch == "" {
+		cmd.Usage()
+		return fmt.Errorf("parsing %s command: no base branch given", Name)
+	}
+
 	return nil
 }
 

--- a/packages/go/stbernard/command/audit/audit.go
+++ b/packages/go/stbernard/command/audit/audit.go
@@ -1,3 +1,18 @@
+// Copyright 2025 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 package audit
 
 import (
@@ -117,7 +132,7 @@ func getTicketAudit(env environment.Environment, cwd, startTimestamp, endTimesta
 
 		tickets    = make([]string, 0, 64)
 		exceptions = make([]string, 0, 64)
-		args       = []string{"pr", "list", "--state", "merged", "--json", "url,body"}
+		args       = []string{"pr", "list", "--state", "merged", "--json", "url,body", "--limit", "1000"}
 	)
 
 	if baseBranch != "" {

--- a/packages/go/stbernard/command/audit/audit.go
+++ b/packages/go/stbernard/command/audit/audit.go
@@ -1,0 +1,160 @@
+package audit
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+
+	"github.com/specterops/bloodhound/packages/go/stbernard/cmdrunner"
+	"github.com/specterops/bloodhound/packages/go/stbernard/environment"
+	"github.com/specterops/bloodhound/packages/go/stbernard/git"
+	"github.com/specterops/bloodhound/packages/go/stbernard/workspace"
+)
+
+type TicketAudit struct {
+	Tickets    []string
+	Exceptions []string
+}
+
+type resultJSON struct {
+	Body string `json:"body"`
+	Url  string `json:"url"`
+}
+
+const (
+	Name  = "audit"
+	Usage = "Audit pull requests for ticket association"
+)
+
+var ticketRegex = regexp.MustCompile(`BED-[0-9]{4,}`)
+
+type command struct {
+	env        environment.Environment
+	start      string
+	end        string
+	baseBranch string
+}
+
+// Create new instance of command to capture given environment
+func Create(env environment.Environment) *command {
+	return &command{
+		env: env,
+	}
+}
+
+// Usage of command
+func (s *command) Usage() string {
+	return Usage
+}
+
+// Name of command
+func (s *command) Name() string {
+	return Name
+}
+
+// Parse command flags
+func (s *command) Parse(cmdIndex int) error {
+	cmd := flag.NewFlagSet(Name, flag.ExitOnError)
+
+	cmd.StringVar(&s.start, "start", "", "SHA or tag name to start from")
+	cmd.StringVar(&s.end, "end", "", "SHA or tag name to end with")
+	cmd.StringVar(&s.baseBranch, "base", "", "branch to use as base filter")
+
+	cmd.Usage = func() {
+		w := flag.CommandLine.Output()
+		fmt.Fprintf(w, "%s\n\nUsage: %s %s [OPTIONS]\n\nOptions:\n", Usage, filepath.Base(os.Args[0]), Name)
+		cmd.PrintDefaults()
+	}
+
+	if err := cmd.Parse(os.Args[cmdIndex+1:]); err != nil {
+		cmd.Usage()
+		return fmt.Errorf("parsing %s command: %w", Name, err)
+	}
+
+	if s.start == "" {
+		cmd.Usage()
+		return fmt.Errorf("parsing %s command: no starting sha given", Name)
+	}
+
+	if s.end == "" {
+		cmd.Usage()
+		return fmt.Errorf("parsing %s command: no ending sha given", Name)
+	}
+
+	return nil
+}
+
+// Run build command
+func (s *command) Run() error {
+	if paths, err := workspace.FindPaths(s.env); err != nil {
+		return fmt.Errorf("finding workspace root: %w", err)
+	} else if start, err := git.ParseTimestampFromSHA(s.env, paths.Root, s.start); err != nil {
+		return fmt.Errorf("parsing timestamp for starting SHA: %w", err)
+	} else if end, err := git.ParseTimestampFromSHA(s.env, paths.Root, s.end); err != nil {
+		return fmt.Errorf("parsing timestamp for ending SHA: %w", err)
+	} else if audit, err := getTicketAudit(s.env, paths.Root, start, end, s.baseBranch); err != nil {
+		return fmt.Errorf("getting ticket audit: %w", err)
+	} else {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "    ")
+		return enc.Encode(audit)
+	}
+}
+
+func getTicketAudit(env environment.Environment, cwd, startTimestamp, endTimestamp, baseBranch string) (TicketAudit, error) {
+	var (
+		jsonBody []resultJSON
+
+		tickets    = make([]string, 0, 64)
+		exceptions = make([]string, 0, 64)
+		args       = []string{"pr", "list", "--state", "merged", "--json", "url,body"}
+	)
+
+	if baseBranch != "" {
+		args = append(args, "--search", fmt.Sprintf("merged:%s..%s base:%s", startTimestamp, endTimestamp, baseBranch))
+	} else {
+		args = append(args, "--search", fmt.Sprintf("merged:%s..%s", startTimestamp, endTimestamp))
+	}
+
+	slog.Info(
+		"Ticket Audit Args",
+		slog.String("startTimestamp", startTimestamp),
+		slog.String("endTimestamp", endTimestamp),
+		slog.String("baseBranch", baseBranch),
+		slog.Any("args", args),
+	)
+
+	result, err := cmdrunner.Run("gh", args, cwd, env)
+	if err != nil {
+		return TicketAudit{}, fmt.Errorf("github cli PR listing: %w", err)
+	}
+
+	err = json.NewDecoder(result.StandardOutput).Decode(&jsonBody)
+	if err != nil {
+		return TicketAudit{}, fmt.Errorf("decoding github cli PR listing JSON: %w", err)
+	}
+
+	for _, pr := range jsonBody {
+		var found bool
+		matches := ticketRegex.FindAllString(pr.Body, -1)
+		for _, match := range matches {
+			found = true
+			tickets = append(tickets, "https://specterops.atlassian.net/browse/"+match)
+		}
+		if !found {
+			exceptions = append(exceptions, pr.Url)
+		}
+	}
+
+	slices.Sort(tickets)
+
+	return TicketAudit{
+		slices.Compact(tickets),
+		exceptions,
+	}, nil
+}

--- a/packages/go/stbernard/command/command.go
+++ b/packages/go/stbernard/command/command.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/specterops/bloodhound/packages/go/bhlog/level"
 	"github.com/specterops/bloodhound/packages/go/stbernard/command/analysis"
+	"github.com/specterops/bloodhound/packages/go/stbernard/command/audit"
 	"github.com/specterops/bloodhound/packages/go/stbernard/command/builder"
 	"github.com/specterops/bloodhound/packages/go/stbernard/command/cover"
 	"github.com/specterops/bloodhound/packages/go/stbernard/command/deps"
@@ -97,6 +98,7 @@ func ParseCLI(env environment.Environment) (CommandRunner, error) {
 			goimports.Create(env),
 			license.Create(env),
 			tag.Create(env),
+			audit.Create(env),
 		}
 	)
 

--- a/packages/go/stbernard/git/git.go
+++ b/packages/go/stbernard/git/git.go
@@ -118,6 +118,16 @@ func ParseLatestVersionFromTags(cwd string, env environment.Environment) (semver
 	}
 }
 
+// ParseTimestampFromSHA gets the timestamp for a given commit SHA
+func ParseTimestampFromSHA(env environment.Environment, cwd, sha string) (string, error) {
+	result, err := cmdrunner.Run("git", []string{"--no-pager", "log", "-n", "1", "--format=%cI", sha}, cwd, env)
+	if err != nil {
+		return "", fmt.Errorf("getting timestamp via git log: %w", err)
+	}
+
+	return strings.TrimSuffix(result.StandardOutput.String(), "\n"), nil
+}
+
 // parseLatestVersion parses a list of found versions and returns the latest from among them
 func parseLatestVersion(versions []string) (semver.Version, error) {
 	if len(versions) == 0 {


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Adds a new `audit` command to St Bernard, allowing us to find associated tickets with PRs that have been merged between two tags
Adds a new GitHub Actions Workflow to allow for more easily running this command and getting output useful for auditing releases

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-6408

*Why is this change required? What problem does it solve?*
Makes it easier to audit exactly what is in a release, improving communication for release notes and keeping our internal ticketing up to date for various internal consumers of ticket statuses.

## How Has This Been Tested?

*Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc.*

Tested locally with the `gh` cli. Actions are unfortunately not testable since they're designed as workflow_dispatch only

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an "audit" CLI command to scan merged PRs between two SHAs (start/end, base) and output JSON of linked tickets and PRs lacking ticket references.
  - Added SHA-to-commit-timestamp resolution used by the audit flow.

- **CI**
  - Added an "Audit Release" GitHub Actions workflow (manual trigger).
  - Updated multiple workflows to derive Go version from go.mod and enable check-latest.

- **Chores**
  - Switched devcontainer zsh-plugins feature source.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->