### PR TITLE
BED-5918: Database Error occurring when timing out user sessions

### DIFF
--- a/cmd/api/src/database/auth.go
+++ b/cmd/api/src/database/auth.go
@@ -520,7 +520,7 @@ func (s *BloodhoundDB) CreateUserSession(ctx context.Context, userSession model.
 // EndUserSession terminates the provided session
 // UPDATE user_sessions SET expires_at = <now> WHERE user_id = ...
 func (s *BloodhoundDB) EndUserSession(ctx context.Context, userSession model.UserSession) {
-	s.db.Model(&userSession).WithContext(ctx).Update("expires_at", gorm.Expr("NOW()"))
+	s.db.WithContext(ctx).Exec(`UPDATE user_sessions SET expires_at = NOW() WHERE user_id = ?`, userSession.UserID)
 }
 
 // corresponding retrival function is model.UserSession.GetFlag()

--- a/cmd/api/src/database/auth.go
+++ b/cmd/api/src/database/auth.go
@@ -520,7 +520,7 @@ func (s *BloodhoundDB) CreateUserSession(ctx context.Context, userSession model.
 // EndUserSession terminates the provided session
 // UPDATE user_sessions SET expires_at = <now> WHERE user_id = ...
 func (s *BloodhoundDB) EndUserSession(ctx context.Context, userSession model.UserSession) {
-	s.db.WithContext(ctx).Exec(`UPDATE user_sessions SET expires_at = NOW() WHERE user_id = ?`, userSession.UserID)
+	s.db.WithContext(ctx).Exec(`UPDATE user_sessions SET expires_at = NOW(), updated_at = NOW() WHERE user_id = ?`, userSession.UserID)
 }
 
 // corresponding retrival function is model.UserSession.GetFlag()


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

- Updated the EndUserSession method to execute raw SQL instead.

## Motivation and Context

This PR addresses:
- BED-5918

*Why is this change required? What problem does it solve?*
- This fixes a gorm database bug to no longer receive these log message when using the app below:

    ```
    error message="database error" query="update \"user_sessions\" set \"expires_at\"=now(),\"updated_at\"='2025-08-27 01:40:53.759'" err="where conditions required"
    ```

## How Has This Been Tested?

*Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc.*
- Locally

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [ ] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [ ] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [ ] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Ending a user session now immediately expires all of the user’s active sessions, signing the user out across all devices at once.
  - Session expiration is applied consistently and takes effect instantly, reducing lingering active sessions after logout or security actions.
  - Improves reliability of session termination for multi-device users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->