### PR TITLE
Fix Issue #1842: Included other principal types in AZAddMembers logic

### DIFF
--- a/packages/go/analysis/azure/post.go
+++ b/packages/go/analysis/azure/post.go
@@ -858,7 +858,7 @@ func addMembers(roleAssignments RoleAssignments, operation analysis.StatTrackedO
 		)
 
 		if err := operation.Operation.SubmitReader(func(ctx context.Context, tx graph.Transaction, outC chan<- analysis.CreatePostRelationshipJob) error {
-			roleAssignments.UsersWithRole(AddMemberAllGroupsTargetRoles()...).Each(func(nextID uint64) bool {
+			roleAssignments.PrincipalsWithRole(AddMemberAllGroupsTargetRoles()...).Each(func(nextID uint64) bool {
 				nextJob := analysis.CreatePostRelationshipJob{
 					FromID: graph.ID(nextID),
 					ToID:   innerGroupID,
@@ -881,7 +881,7 @@ func addMembers(roleAssignments RoleAssignments, operation analysis.StatTrackedO
 					return err
 				}
 			} else if !isRoleAssignable {
-				roleAssignments.UsersWithRole(AddMemberGroupNotRoleAssignableTargetRoles()...).Each(func(nextID uint64) bool {
+				roleAssignments.PrincipalsWithRole(AddMemberGroupNotRoleAssignableTargetRoles()...).Each(func(nextID uint64) bool {
 					nextJob := analysis.CreatePostRelationshipJob{
 						FromID: graph.ID(nextID),
 						ToID:   innerGroupID,


### PR DESCRIPTION
[(https://github.com/SpecterOps/BloodHound/issues/1842)](https://github.com/SpecterOps/BloodHound/issues/1842)

## Description

Modified Azure post-processing logic for creation of the AZAddMembers edge to evaluate all role assignments, not just user role assignments, so that the edge is created from service principals with roles that allow group membership additions.

## Motivation and Context

Resolves 1842

*Why is this change required? What problem does it solve?*

## How Has This Been Tested?

Tested in BHCE 8.1.0

## Screenshots (optional):

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/1842
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
