### PR TITLE
BED-6424 chore: add start / finished to duration logs

### DIFF
--- a/packages/go/bhlog/measure/measure.go
+++ b/packages/go/bhlog/measure/measure.go
@@ -62,12 +62,12 @@ func ContextLogAndMeasure(ctx context.Context, level slog.Level, msg string, arg
 	)
 
 	args = append(args, FieldMeasurementID, pairID)
-	slog.Log(ctx, level, msg, args...)
+	slog.Log(ctx, level, "Starting "+msg, args...)
 
 	return func() {
 		if elapsed := time.Since(then); elapsed >= measureThreshold {
 			args = append(args, FieldElapsed, elapsed)
-			slog.Log(ctx, level, msg, args...)
+			slog.Log(ctx, level, "Finished "+msg, args...)
 		}
 	}
 }
@@ -79,12 +79,12 @@ func LogAndMeasure(level slog.Level, msg string, args ...any) func() {
 	)
 
 	args = append(args, FieldMeasurementID, pairID)
-	slog.Log(context.TODO(), level, msg, args...)
+	slog.Log(context.TODO(), level, "Starting "+msg, args...)
 
 	return func() {
 		if elapsed := time.Since(then); elapsed >= measureThreshold {
 			args = append(args, FieldElapsed, elapsed)
-			slog.Log(context.TODO(), level, msg, args...)
+			slog.Log(context.TODO(), level, "Finished "+msg, args...)
 		}
 	}
 }


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

*Describe your changes in detail*
Adds start and finish to duration logs for quick parsing between the pairs

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-6424

*Why is this change required? What problem does it solve?*

## How Has This Been Tested?
Locally ran 
*Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc.*

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)


## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
