### PR TITLE
fix(FeatureFlag): fallback to 'disabled' view on 403

### DIFF
--- a/packages/javascript/bh-shared-ui/src/components/FeatureFlag/FeatureFlag.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/FeatureFlag/FeatureFlag.tsx
@@ -14,7 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { useFeatureFlag } from '../../hooks/useFeatureFlags';
+import { FORBIDDEN, useFeatureFlag } from '../../hooks/useFeatureFlags';
 
 type FeatureFlagProps = {
     flagKey: string;
@@ -39,7 +39,10 @@ const FeatureFlag = ({
 
     if (isError) {
         console.error(error);
-        return errorFallback;
+
+        // Forbidden status means user can't fetch features;
+        // Treat forbidden like disabled
+        return error.status === FORBIDDEN ? disabled : errorFallback;
     }
 
     if (flag === undefined) {


### PR DESCRIPTION
## Description

* Updates `<FeatureFlag>` component to use `disabled` view if features call returns a 403

## Motivation and Context

Resolves BED-6426

No all users have access to the features endpoint, ex. Upload-only. If any of these users visit a feature-flagged page, the component would error. Instead, it will fallback to the disabled view.

## How Has This Been Tested?

Manually tested

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - 403 (forbidden) responses for feature flags are now treated as the flag being disabled, avoiding error fallbacks.

- Improvements
  - More consistent loading and error handling for feature flags, reducing UI errors and unnecessary retries.

- Chores
  - Updated feature-flag metadata and typing to improve reliability and observability of flag data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->