### PR TITLE
feat(Client API): add client type

### DIFF
--- a/packages/javascript/bh-shared-ui/src/utils/jobs.ts
+++ b/packages/javascript/bh-shared-ui/src/utils/jobs.ts
@@ -31,7 +31,7 @@ type JobCollectionKey = (typeof jobCollectionKeys)[number];
 
 export type EnabledCollections = Partial<Record<JobCollectionKey, boolean>>;
 
-type JobsParamsKey = 'client_name' | 'end_time' | 'start_time' | 'status';
+type JobsParamsKey = 'client_id' | 'end_time' | 'start_time' | 'status';
 
 type JobsFilterParams = Partial<Record<JobsParamsKey, string>>;
 

--- a/packages/javascript/js-client-library/src/client.ts
+++ b/packages/javascript/js-client-library/src/client.ts
@@ -67,6 +67,7 @@ import {
     DatapipeStatusResponse,
     EndFileIngestResponse,
     Environment,
+    GetClientResponse,
     GetCollectorsResponse,
     GetCommunityCollectorsResponse,
     GetConfigurationResponse,
@@ -691,7 +692,7 @@ class BHEAPIClient {
         hydrateOUs?: boolean,
         options?: RequestOptions
     ) =>
-        this.baseClient.get(
+        this.baseClient.get<GetClientResponse>(
             '/api/v2/clients',
             Object.assign(
                 {

--- a/packages/javascript/js-client-library/src/responses.ts
+++ b/packages/javascript/js-client-library/src/responses.ts
@@ -368,3 +368,39 @@ export type ScheduledJobDisplay = {
 export type GetScheduledJobDisplayResponse = PaginatedResponse<ScheduledJobDisplay[]>;
 
 export type GetExportQueryResponse = AxiosResponse<Blob>;
+
+export type Client = {
+    configured_user: string;
+    events: {
+        id: number;
+        client_id: string;
+        session_collection: boolean;
+        local_group_collection: boolean;
+        ad_structure_collection: boolean;
+        cert_services_collection: boolean;
+        ca_registry_collection: boolean;
+        dc_registry_collection: boolean;
+        all_trusted_domains: boolean;
+        ous: OuDetails[];
+        domains: DomainDetails[];
+        rrule: string;
+    }[];
+    hostname: string;
+    id: string;
+    ip_address: string;
+    last_checkin: string;
+    name: string;
+    token: unknown;
+    current_job_id: null | number;
+    current_task_id: null | number;
+    current_job: ScheduledJobDisplay;
+    current_task: ScheduledJobDisplay;
+    completed_job_count: number;
+    completed_task_count: number;
+    domain_controller: null;
+    version: string;
+    user_sid: string;
+    type: string;
+};
+
+export type GetClientResponse = PaginatedResponse<Client[]>;


### PR DESCRIPTION
## Description

Add Client type to call and update finished jobs params

## Motivation and Context

Prereq for BED-6406

Needed for BHE story to add Client Select to Finished Job filter

## How Has This Been Tested?

Manually tested

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
