### PR TITLE
feat (api): Extract enable_user_analytics and Introduce a Dyanamic CSP - BED-6449

### DIFF
--- a/cmd/api/src/api/middleware/middleware.go
+++ b/cmd/api/src/api/middleware/middleware.go
@@ -31,6 +31,8 @@ import (
 	"github.com/gofrs/uuid"
 	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
+	"github.com/unrolled/secure"
+
 	"github.com/specterops/bloodhound/cmd/api/src/api"
 	"github.com/specterops/bloodhound/cmd/api/src/config"
 	"github.com/specterops/bloodhound/cmd/api/src/ctx"
@@ -38,7 +40,6 @@ import (
 	"github.com/specterops/bloodhound/cmd/api/src/model"
 	"github.com/specterops/bloodhound/cmd/api/src/utils"
 	"github.com/specterops/bloodhound/packages/go/headers"
-	"github.com/unrolled/secure"
 )
 
 // Wrapper is an iterator for middleware function application that wraps around a http.Handler.
@@ -246,7 +247,7 @@ func SecureHandlerMiddleware(cfg config.Configuration, contentSecurityPolicy str
 		STSPreload:           true,
 		STSIncludeSubdomains: true,
 
-		//Referrer-Policy
+		// Referrer-Policy
 		ReferrerPolicy: referrerPolicy,
 
 		// Permissions Policy

--- a/cmd/api/src/api/static/static.go
+++ b/cmd/api/src/api/static/static.go
@@ -70,12 +70,12 @@ func serve(cfg AssetConfig, response http.ResponseWriter, request *http.Request)
 		assetPath = cfg.IndexPath
 	}
 
-	if fin, err := fetchAsset(cfg, assetPath); err != nil {
+	if assetFile, err := fetchAsset(cfg, assetPath); err != nil {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusNotFound, api.ErrorResponseDetailsResourceNotFound, request), response)
-	} else if fileInfo, err := fin.Stat(); err != nil || fileInfo == nil {
+	} else if fileInfo, err := assetFile.Stat(); err != nil || fileInfo == nil {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusInternalServerError, api.ErrorResponseDetailsInternalServerError, request), response)
 	} else {
-		defer fin.Close()
+		defer assetFile.Close()
 
 		var (
 			assetExtension = filepath.Ext(fileInfo.Name())
@@ -90,7 +90,7 @@ func serve(cfg AssetConfig, response http.ResponseWriter, request *http.Request)
 		response.Header().Set(headers.ContentType.String(), contentType)
 		response.Header().Set(headers.StrictTransportSecurity.String(), utils.HSTSSetting)
 
-		if _, err := io.Copy(response, fin); err != nil {
+		if _, err := io.Copy(response, assetFile); err != nil {
 			slog.ErrorContext(request.Context(), fmt.Sprintf("Failed flushing static file content for asset %s to client: %v", assetPath, err))
 		}
 	}

--- a/cmd/api/src/bootstrap/server.go
+++ b/cmd/api/src/bootstrap/server.go
@@ -27,6 +27,8 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/specterops/dawgs/graph"
+
 	"github.com/specterops/bloodhound/cmd/api/src/auth"
 	"github.com/specterops/bloodhound/cmd/api/src/config"
 	"github.com/specterops/bloodhound/cmd/api/src/database"
@@ -34,12 +36,11 @@ import (
 	"github.com/specterops/bloodhound/cmd/api/src/migrations"
 	"github.com/specterops/bloodhound/cmd/api/src/model"
 	"github.com/specterops/bloodhound/cmd/api/src/model/appcfg"
-	"github.com/specterops/dawgs/graph"
 )
 
 const (
 	DefaultServerShutdownTimeout = time.Minute
-	ContentSecurityPolicy        = "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:;"
+	ContentSecurityPolicy        = "default-src 'self'; script-src 'self' %s 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' %s data: blob:; font-src 'self' data:;"
 )
 
 func NewDaemonContext(parentCtx context.Context) context.Context {

--- a/cmd/api/src/config/config.go
+++ b/cmd/api/src/config/config.go
@@ -124,10 +124,6 @@ type SAMLConfiguration struct {
 	ServiceProviderCertificateCAChain string `json:"sp_ca_chain"`
 }
 
-type UIConfiguration struct {
-	EnableUserAnalytics bool `json:"enable_user_analytics"`
-}
-
 type DefaultAdminConfiguration struct {
 	PrincipalName string `json:"principal_name"`
 	Password      string `json:"password"`
@@ -168,7 +164,7 @@ type Configuration struct {
 	GraphQueryMemoryLimit        uint16                    `json:"graph_query_memory_limit"`
 	EnableTextLogger             bool                      `json:"enable_text_logger"`
 	RecreateDefaultAdmin         bool                      `json:"recreate_default_admin"`
-	UI                           UIConfiguration           `json:"ui"`
+	EnableUserAnalytics          bool                      `json:"enable_user_analytics"`
 }
 
 func (s Configuration) TempDirectory() string {

--- a/cmd/api/src/config/default.go
+++ b/cmd/api/src/config/default.go
@@ -19,8 +19,9 @@ package config
 import (
 	"fmt"
 
-	"github.com/specterops/bloodhound/cmd/api/src/serde"
 	"github.com/specterops/dawgs/drivers/neo4j"
+
+	"github.com/specterops/bloodhound/cmd/api/src/serde"
 )
 
 // NewDefaultConfiguration returns a new Configuration struct containing all documented
@@ -82,9 +83,7 @@ func NewDefaultConfiguration() (Configuration, error) {
 				LastName:      "User",
 				ExpireNow:     true,
 			},
-			UI: UIConfiguration{
-				EnableUserAnalytics: false,
-			},
+			EnableUserAnalytics: false,
 		}, nil
 	}
 }

--- a/cmd/api/src/services/entrypoint.go
+++ b/cmd/api/src/services/entrypoint.go
@@ -22,6 +22,8 @@ import (
 	"log/slog"
 	"time"
 
+	"github.com/specterops/dawgs/graph"
+
 	"github.com/specterops/bloodhound/cmd/api/src/api"
 	"github.com/specterops/bloodhound/cmd/api/src/api/registration"
 	"github.com/specterops/bloodhound/cmd/api/src/api/router"
@@ -39,7 +41,6 @@ import (
 	"github.com/specterops/bloodhound/cmd/api/src/services/upload"
 	"github.com/specterops/bloodhound/packages/go/cache"
 	schema "github.com/specterops/bloodhound/packages/go/graphschema"
-	"github.com/specterops/dawgs/graph"
 )
 
 // ConnectPostgres initializes a connection to PG, and returns errors if any
@@ -111,7 +112,7 @@ func Entrypoint(ctx context.Context, cfg config.Configuration, connections boots
 			graphQuery     = queries.NewGraphQuery(connections.Graph, graphQueryCache, cfg)
 			authorizer     = auth.NewAuthorizer(connections.RDMS)
 			datapipeDaemon = datapipe.NewDaemon(pipeline, startDelay, time.Duration(cfg.DatapipeInterval)*time.Second, connections.RDMS)
-			routerInst     = router.NewRouter(cfg, authorizer, bootstrap.ContentSecurityPolicy)
+			routerInst     = router.NewRouter(cfg, authorizer, fmt.Sprintf(bootstrap.ContentSecurityPolicy, "", ""))
 			ctxInitializer = database.NewContextInitializer(connections.RDMS)
 			authenticator  = api.NewAuthenticator(cfg, connections.RDMS, ctxInitializer)
 		)

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/HasSIDHistory/General.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/HasSIDHistory/General.tsx
@@ -27,7 +27,8 @@ const General: FC<EdgeInfoProps> = ({ sourceName, sourceType, targetName, target
                 {typeFormat(targetType)} {targetName}.
             </Typography>
             <Typography variant='body2'>
-                When a Kerberos ticket is created for {sourceName}, it will include the SID for {targetName} and therefore grant {sourceName} the same privileges and permissions as {targetName}.
+                When a Kerberos ticket is created for {sourceName}, it will include the SID for {targetName} and
+                therefore grant {sourceName} the same privileges and permissions as {targetName}.
             </Typography>
         </>
     );


### PR DESCRIPTION
## Description

Extract config flag enable_user_analytics up a level as it no longer affects just UI components. Introduce placeholders for injecting a domain into the CSP. This is not utilized in BHCE so they are replaced with empty strings. 

## Motivation and Context
Resolves: BED-6449

## How Has This Been Tested?

- Tested locally with the distroless image found in examples, please see enterprise PR or ticket for additional testing instructions. 

## Types of changes
- New feature (non-breaking change which adds functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
