### PR TITLE
BED-6331: Added formatting function to display comma separated numbers

### DIFF
--- a/packages/javascript/bh-shared-ui/src/utils/index.ts
+++ b/packages/javascript/bh-shared-ui/src/utils/index.ts
@@ -14,7 +14,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-export * from './abbreviatedNumber';
 export * from './api';
 export * from './array';
 export * from './colors';
@@ -28,6 +27,7 @@ export * from './exportGraphData';
 export * from './icons';
 export * from './jobs';
 export * from './luxon';
+export * from './numberFormatting';
 export * from './object';
 export * from './parseItemId';
 export * from './passwd';

--- a/packages/javascript/bh-shared-ui/src/utils/numberFormatting.test.ts
+++ b/packages/javascript/bh-shared-ui/src/utils/numberFormatting.test.ts
@@ -14,9 +14,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { abbreviatedNumber } from './abbreviatedNumber';
+import { abbreviatedNumber, commaSeparatedNumber } from './numberFormatting';
 
-describe('abbreviatedNumber', () => {
+describe('numberFormatting', () => {
     it('returns numbers as strings', () => {
         const result = abbreviatedNumber(1);
         expect(typeof result).toBe('string');
@@ -39,5 +39,14 @@ describe('abbreviatedNumber', () => {
         expect(millions).toBe('31.0M');
         expect(billions).toBe('220.0B');
         expect(trillions).toBe('8.7T');
+    });
+    it('returns a comma separated number when provided with a number > 999', () => {
+        const formattedThousandNumber = commaSeparatedNumber(1842);
+        const formattedMillionNumber = commaSeparatedNumber(1000000);
+        const formattedBillionNumber = commaSeparatedNumber(1000000000);
+
+        expect(formattedThousandNumber).toBe('1,842');
+        expect(formattedMillionNumber).toBe('1,000,000');
+        expect(formattedBillionNumber).toBe('1,000,000,000');
     });
 });

--- a/packages/javascript/bh-shared-ui/src/utils/numberFormatting.ts
+++ b/packages/javascript/bh-shared-ui/src/utils/numberFormatting.ts
@@ -26,3 +26,7 @@ export const abbreviatedNumber = (num: number, fractionDigits: number = 1) => {
     const formattedNumber = (num / Math.pow(1000, log1000)).toFixed(fractionDigits);
     return formattedNumber + abbreviations[log1000];
 };
+
+export const commaSeparatedNumber = (num: number) => {
+    return new Intl.NumberFormat('en-US').format(num);
+};

--- a/packages/javascript/bh-shared-ui/src/views/ZoneManagement/Summary/SummaryCard.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/ZoneManagement/Summary/SummaryCard.tsx
@@ -24,7 +24,7 @@ import LargeRightArrow from '../../../components/AppIcon/Icons/LargeRightArrow';
 import { useHighestPrivilegeTagId } from '../../../hooks';
 import { ROUTE_ZONE_MANAGEMENT_DETAILS } from '../../../routes';
 import { useAppNavigate } from '../../../utils';
-import { abbreviatedNumber } from '../../../utils/abbreviatedNumber';
+import { abbreviatedNumber } from '../../../utils/numberFormatting';
 import { ZoneAnalysisIcon } from '../ZoneAnalysisIcon';
 
 type SummaryCardProps = {


### PR DESCRIPTION
## Description

Changed the abbreviatedNumbers utils file to be a generic numbers formatting file and added a comma separating function for numbers greater than 999.

**Note:** There were two options to achieve this, localeString() vs Intl.NumberFormat. Opted for Intl.NumberFormat as it felt more descriptive/relevant.

Also decided to hardcode the 'en-US' param to ensure that it would always add commas instead of other formatting that can be available in other countries to keep it consistent. But if at any point we want to make in locale specific we can evaluate to change that and make it flexible.

## Motivation and Context

This addresses: [BED-6331](https://specterops.atlassian.net/browse/BED-6331)

## How Has This Been Tested?

Manually tested numbers being formatted, added new tests and existing ones passed.

## Screenshots (optional):


<img width="776" height="453" alt="Screenshot 2025-09-09 at 4 31 46 PM" src="https://github.com/user-attachments/assets/80b1fda2-bf75-4a4e-951d-957340a877cd" />
<img width="833" height="570" alt="Screenshot 2025-09-09 at 4 31 00 PM" src="https://github.com/user-attachments/assets/db85fd50-b4f9-479e-b98c-c6048ca78471" />
<img width="1080" height="499" alt="Screenshot 2025-09-09 at 4 30 26 PM" src="https://github.com/user-attachments/assets/fa7539e5-5d9d-44a6-a994-1bc319f29a49" />
<img width="1100" height="738" alt="Screenshot 2025-09-09 at 4 29 42 PM" src="https://github.com/user-attachments/assets/609b7327-a1b3-4fb7-9764-3f55abb74ff3" />
<img width="1581" height="840" alt="Screenshot 2025-09-09 at 4 29 33 PM" src="https://github.com/user-attachments/assets/1d696821-9776-4e67-8013-428750f6724d" />
<img width="1355" height="813" alt="Screenshot 2025-09-10 at 2 18 49 PM" src="https://github.com/user-attachments/assets/57bd34fc-68e8-4890-b8d2-93f12314706c" />

## Types of changes

- New feature (non-breaking change which adds functionality)


## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


[BED-6331]: https://specterops.atlassian.net/browse/BED-6331?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Numbers are now displayed with thousands separators (e.g., 1,842; 1,000,000) for improved readability across relevant views.
* **Refactor**
  * Consolidated number formatting utilities to a single module for consistency and easier maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->