### PR TITLE
BED-6487--Saved Query Filters Persist

### DIFF
--- a/cmd/api/src/api/registration/v2.go
+++ b/cmd/api/src/api/registration/v2.go
@@ -91,6 +91,7 @@ func registerV2Auth(resources v2.Resources, routerInst *router.Router, permissio
 		// User management for all BloodHound users
 		routerInst.GET("/api/v2/bloodhound-users", managementResource.ListUsers).RequirePermissions(permissions.AuthManageUsers),
 		routerInst.POST("/api/v2/bloodhound-users", managementResource.CreateUser).RequirePermissions(permissions.AuthManageUsers),
+		routerInst.GET("/api/v2/bloodhound-users-minimal", managementResource.ListActiveUsersMinimal).RequirePermissions(permissions.AuthReadUsers), // returns user data without any sensitive information.
 
 		routerInst.GET(fmt.Sprintf("/api/v2/bloodhound-users/{%s}", api.URIPathVariableUserID), managementResource.GetUser).RequirePermissions(permissions.AuthManageUsers),
 		routerInst.PATCH(fmt.Sprintf("/api/v2/bloodhound-users/{%s}", api.URIPathVariableUserID), managementResource.UpdateUser).RequirePermissions(permissions.AuthManageUsers),

--- a/cmd/api/src/api/v2/auth/users.go
+++ b/cmd/api/src/api/v2/auth/users.go
@@ -1,0 +1,134 @@
+// Copyright 2025 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package auth
+
+import (
+	"fmt"
+	"net/http"
+	"slices"
+	"strings"
+
+	"github.com/gofrs/uuid"
+
+	"github.com/specterops/bloodhound/cmd/api/src/api"
+	"github.com/specterops/bloodhound/cmd/api/src/model"
+)
+
+type UsersMinimalResponse struct {
+	Users []UserMinimal `json:"users"`
+}
+
+type UserMinimal struct {
+	ID           uuid.UUID `json:"id"`
+	EmailAddress string    `json:"email_address"`
+	FirstName    string    `json:"first_name"`
+	LastName     string    `json:"last_name"`
+}
+
+// ListActiveUsersMinimal - Returns a list of Users without any sensitive data. At the time, this is used in the saved queries
+// workflow to return a list of users with whom a query can be shared with.
+func (s ManagementResource) ListActiveUsersMinimal(response http.ResponseWriter, request *http.Request) {
+	var (
+		usersFilter                UserMinimal
+		queryParams                = request.URL.Query()
+		queryParameterFilterParser = model.NewQueryParameterFilterParser()
+	)
+
+	if orderBy, err := api.ParseSortParameters(UserMinimal{}, queryParams); err != nil {
+		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, err.Error(), request), response)
+	} else if order, err := api.BuildSQLSort(orderBy, model.SortItem{Column: "email_address", Direction: model.AscendingSortDirection}); err != nil {
+		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, err.Error(), request), response)
+	} else if queryFilters, err := queryParameterFilterParser.ParseQueryParameterFilters(request); err != nil {
+		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, api.ErrorResponseDetailsBadQueryParameterFilters, request), response)
+	} else {
+		for name, filters := range queryFilters {
+			if valid := slices.Contains(api.GetFilterableColumns(usersFilter), name); !valid {
+				api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, fmt.Sprintf("%s: %s", api.ErrorResponseDetailsColumnNotFilterable, name), request), response)
+				return
+			}
+
+			if validPredicates, err := api.GetValidFilterPredicatesAsStrings(usersFilter, name); err != nil {
+				api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, fmt.Sprintf("%s: %s", api.ErrorResponseDetailsColumnNotFilterable, name), request), response)
+				return
+			} else {
+				for i, filter := range filters {
+					if !slices.Contains(validPredicates, string(filter.Operator)) {
+						api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, fmt.Sprintf("%s: %s %s", api.ErrorResponseDetailsFilterPredicateNotSupported, filter.Name, filter.Operator), request), response)
+						return
+					}
+					queryFilters[name][i].IsStringData = usersFilter.IsStringColumn(filter.Name)
+				}
+			}
+		}
+		if sqlFilter, err := queryFilters.BuildSQLFilter(); err != nil {
+			api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, api.ErrorResponseDetailsBadQueryParameterFilters, request), response)
+		} else if activeUsers, err := s.db.GetAllUsers(request.Context(), strings.Join(order, ", "), sqlFilter); err != nil {
+			api.HandleDatabaseError(request, response, err)
+		} else {
+			usersMinimal := make([]UserMinimal, 0)
+			for _, user := range activeUsers {
+				if !user.IsDisabled {
+					usersMinimal = append(usersMinimal, UserMinimal{
+						ID:           user.ID,
+						EmailAddress: user.EmailAddress.String,
+						FirstName:    user.FirstName.String,
+						LastName:     user.LastName.String,
+					})
+				}
+			}
+			api.WriteBasicResponse(request.Context(), UsersMinimalResponse{Users: usersMinimal}, http.StatusOK, response)
+		}
+	}
+}
+
+// Below is needed to allow sorting and filtering on the ListActiveUsersMinimal endpoint.
+// Using the same filter as model.User is not ideal as that would allow users to filter/sort on columns they may not have access to.
+
+// IsSortable - determines if the passed column can be sorted on or not
+func (s UserMinimal) IsSortable(column string) bool {
+	switch column {
+	case "first_name",
+		"last_name",
+		"email_address",
+		"id":
+		return true
+	default:
+		return false
+	}
+}
+
+// ValidFilters - returns a map of columns and their valid filters
+func (s UserMinimal) ValidFilters() map[string][]model.FilterOperator {
+	return map[string][]model.FilterOperator{
+		"first_name":    {model.Equals, model.NotEquals, model.ApproximatelyEquals},
+		"last_name":     {model.Equals, model.NotEquals, model.ApproximatelyEquals},
+		"email_address": {model.Equals, model.NotEquals, model.ApproximatelyEquals},
+		"id":            {model.Equals, model.NotEquals},
+	}
+}
+
+// IsStringColumn - determines if the passed column is a string or not
+func (s UserMinimal) IsStringColumn(column string) bool {
+	switch column {
+	case "first_name",
+		"last_name",
+		"email_address":
+		return true
+	default:
+		return false
+	}
+}

--- a/cmd/api/src/api/v2/auth/users_test.go
+++ b/cmd/api/src/api/v2/auth/users_test.go
@@ -1,0 +1,268 @@
+// Copyright 2025 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+package auth_test
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gofrs/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/specterops/bloodhound/cmd/api/src/api/v2/apitest"
+	"github.com/specterops/bloodhound/cmd/api/src/database/mocks"
+	"github.com/specterops/bloodhound/cmd/api/src/database/types/null"
+	"github.com/specterops/bloodhound/cmd/api/src/model"
+	"github.com/specterops/bloodhound/cmd/api/src/utils/test"
+)
+
+func TestResources_ListUsersMinimal(t *testing.T) {
+	t.Parallel()
+
+	user1Id, err := uuid.NewV4()
+	require.NoError(t, err)
+	user2Id, err := uuid.NewV4()
+	require.NoError(t, err)
+
+	type mock struct {
+		mockDatabase *mocks.MockDatabase
+	}
+
+	type expected struct {
+		responseCode   int
+		responseBody   string
+		responseHeader http.Header
+	}
+
+	type fields struct {
+		setupMocks func(t *testing.T, mock *mock)
+	}
+
+	type args struct {
+		buildRequest func() *http.Request
+	}
+
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		expect expected
+	}{
+		{
+			name: "fail - empty sort column",
+			args: args{
+				func() *http.Request {
+					req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "/api/v2/bloodhound-users-minimal", nil)
+					require.NoError(t, err)
+					query := req.URL.Query()
+					query.Add("sort_by", "")
+					req.URL.RawQuery = query.Encode()
+					return req
+				},
+			},
+			expect: expected{
+				responseCode:   http.StatusBadRequest,
+				responseBody:   `{"errors":[{"context":"","message":"the specified column cannot be sorted because it is empty: "}],"http_status":400,"request_id":"","timestamp":"0001-01-01T00:00:00Z"}`,
+				responseHeader: http.Header{"Content-Type": []string{"application/json"}},
+			},
+		},
+		{
+			name: "fail - invalid sort column",
+			args: args{
+				func() *http.Request {
+					req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "/api/v2/bloodhound-users-minimal", nil)
+					require.NoError(t, err)
+					query := req.URL.Query()
+					query.Add("sort_by", "awfawf")
+					req.URL.RawQuery = query.Encode()
+					return req
+				},
+			},
+			expect: expected{
+				responseCode:   http.StatusBadRequest,
+				responseBody:   `{"errors":[{"context":"","message":"the specified column cannot be sorted: awfawf"}],"http_status":400,"request_id":"","timestamp":"0001-01-01T00:00:00Z"}`,
+				responseHeader: http.Header{"Content-Type": []string{"application/json"}},
+			},
+		},
+		{
+			name: "fail - parse query parameter filter error",
+			args: args{
+				func() *http.Request {
+					req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "/api/v2/bloodhound-users-minimal", nil)
+					require.NoError(t, err)
+					query := req.URL.Query()
+					query.Add("id", "afwa:3")
+					req.URL.RawQuery = query.Encode()
+					return req
+				},
+			},
+			expect: expected{
+				responseCode:   http.StatusBadRequest,
+				responseBody:   `{"errors":[{"context":"","message":"there are errors in the query parameter filters specified"}],"http_status":400,"request_id":"","timestamp":"0001-01-01T00:00:00Z"}`,
+				responseHeader: http.Header{"Content-Type": []string{"application/json"}},
+			},
+		},
+		{
+			name: "fail - filter not supported for column",
+			args: args{
+				func() *http.Request {
+					req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "/api/v2/bloodhound-users-minimal", nil)
+					require.NoError(t, err)
+					query := req.URL.Query()
+					query.Add("awfaw", "eq:3")
+					req.URL.RawQuery = query.Encode()
+					return req
+				},
+			},
+			expect: expected{
+				responseCode:   http.StatusBadRequest,
+				responseBody:   `{"errors":[{"context":"","message":"the specified column cannot be filtered: awfaw"}],"http_status":400,"request_id":"","timestamp":"0001-01-01T00:00:00Z"}`,
+				responseHeader: http.Header{"Content-Type": []string{"application/json"}},
+			},
+		},
+		{
+			name: "fail - filter predicate not supported for specified column",
+			args: args{
+				func() *http.Request {
+					req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "/api/v2/bloodhound-users-minimal", nil)
+					require.NoError(t, err)
+					query := req.URL.Query()
+					query.Add("id", "lte:3")
+					req.URL.RawQuery = query.Encode()
+					return req
+				},
+			},
+			expect: expected{
+				responseCode:   http.StatusBadRequest,
+				responseBody:   `{"errors":[{"context":"","message":"the specified filter predicate is not supported for this column: id lte"}],"http_status":400,"request_id":"","timestamp":"0001-01-01T00:00:00Z"}`,
+				responseHeader: http.Header{"Content-Type": []string{"application/json"}},
+			},
+		},
+		{
+			name: "fail - DB error",
+			fields: fields{
+				setupMocks: func(t *testing.T, mock *mock) {
+					mock.mockDatabase.EXPECT().GetAllUsers(gomock.Any(), "email_address", model.SQLFilter{}).Return(nil, fmt.Errorf("db error"))
+				},
+			},
+			args: args{
+				func() *http.Request {
+					req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "/api/v2/bloodhound-users-minimal", nil)
+					require.NoError(t, err)
+					return req
+				},
+			},
+			expect: expected{
+				responseCode:   http.StatusInternalServerError,
+				responseBody:   `{"errors":[{"context":"","message":"an internal error has occurred that is preventing the service from servicing this request"}],"http_status":500,"request_id":"","timestamp":"0001-01-01T00:00:00Z"}`,
+				responseHeader: http.Header{"Content-Type": []string{"application/json"}},
+			},
+		},
+		{
+			name: "success",
+			fields: fields{
+				setupMocks: func(t *testing.T, mock *mock) {
+					mock.mockDatabase.EXPECT().GetAllUsers(gomock.Any(), "email_address", model.SQLFilter{}).Return(model.Users{
+						{
+							FirstName: null.String{
+								NullString: sql.NullString{
+									String: "Test",
+									Valid:  true,
+								},
+							},
+							LastName: null.String{
+								NullString: sql.NullString{
+									String: "User1",
+									Valid:  true,
+								},
+							},
+							EmailAddress: null.String{
+								NullString: sql.NullString{
+									String: "testuser1@email.com",
+									Valid:  true,
+								},
+							},
+							Unique: model.Unique{
+								ID: user1Id,
+							},
+						},
+						{
+							FirstName: null.String{
+								NullString: sql.NullString{
+									String: "Test",
+									Valid:  true,
+								},
+							},
+							LastName: null.String{
+								NullString: sql.NullString{
+									String: "User2",
+									Valid:  true,
+								},
+							},
+							EmailAddress: null.String{
+								NullString: sql.NullString{
+									String: "testuser2@email.com",
+									Valid:  true,
+								},
+							},
+							Unique: model.Unique{
+								ID: user2Id,
+							},
+						},
+					}, nil)
+				},
+			},
+			args: args{
+				func() *http.Request {
+					req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "/api/v2/bloodhound-users/minimal", nil)
+					require.NoError(t, err)
+					return req
+				},
+			},
+			expect: expected{
+				responseCode:   http.StatusOK,
+				responseBody:   fmt.Sprintf(`{"data":{"users":[{"first_name":"Test", "id":"%s", "last_name":"User1", "email_address":"testuser1@email.com"}, {"first_name":"Test", "id":"%s", "last_name":"User2", "email_address":"testuser2@email.com"}]}}`, user1Id, user2Id),
+				responseHeader: http.Header{"Content-Type": []string{"application/json"}},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			mockCtrl := gomock.NewController(t)
+			resource, mockDB := apitest.NewAuthManagementResource(mockCtrl)
+
+			defer mockCtrl.Finish()
+
+			if tt.fields.setupMocks != nil {
+				tt.fields.setupMocks(t, &mock{mockDB})
+			}
+			response := httptest.NewRecorder()
+			request := tt.args.buildRequest()
+			resource.ListActiveUsersMinimal(response, request)
+			statusCode, header, body := test.ProcessResponse(t, response)
+			assert.Equal(t, tt.expect.responseCode, statusCode)
+			assert.Equal(t, tt.expect.responseHeader, header)
+			assert.JSONEq(t, tt.expect.responseBody, body)
+		})
+	}
+}

--- a/cmd/api/src/auth/permission.go
+++ b/cmd/api/src/auth/permission.go
@@ -33,6 +33,7 @@ type PermissionSet struct {
 	AuthManageProviders                 model.Permission
 	AuthManageSelf                      model.Permission
 	AuthManageUsers                     model.Permission
+	AuthReadUsers                       model.Permission
 
 	ClientsManage  model.Permission
 	ClientsRead    model.Permission
@@ -72,6 +73,7 @@ func (s PermissionSet) All() model.Permissions {
 		s.GraphDBWrite,
 		s.SavedQueriesRead,
 		s.SavedQueriesWrite,
+		s.AuthReadUsers,
 		s.WipeDB,
 	}
 }
@@ -91,6 +93,7 @@ func Permissions() PermissionSet {
 		AuthManageProviders:                 model.NewPermission("auth", "ManageProviders"),
 		AuthManageSelf:                      model.NewPermission("auth", "ManageSelf"),
 		AuthManageUsers:                     model.NewPermission("auth", "ManageUsers"),
+		AuthReadUsers:                       model.NewPermission("auth", "ReadUsers"),
 
 		ClientsManage:  model.NewPermission("clients", "Manage"),
 		ClientsRead:    model.NewPermission("clients", "Read"),

--- a/cmd/api/src/database/auth.go
+++ b/cmd/api/src/database/auth.go
@@ -28,11 +28,12 @@ import (
 	"time"
 
 	"github.com/gofrs/uuid"
+	"gorm.io/gorm"
+
 	"github.com/specterops/bloodhound/cmd/api/src/auth"
 	"github.com/specterops/bloodhound/cmd/api/src/database/types"
 	"github.com/specterops/bloodhound/cmd/api/src/database/types/null"
 	"github.com/specterops/bloodhound/cmd/api/src/model"
-	"gorm.io/gorm"
 )
 
 // NewClientAuthToken creates a new Client AuthToken row using the details provided

--- a/cmd/api/src/database/db.go
+++ b/cmd/api/src/database/db.go
@@ -238,12 +238,12 @@ func (s *BloodhoundDB) Wipe(ctx context.Context) error {
 	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		var tables []string
 
-		if result := tx.Raw("select table_name from information_schema.tables where table_schema = current_schema() and not table_name ilike '%pg_stat%'").Scan(&tables); result.Error != nil {
+		if result := tx.Raw("SELECT table_name FROM information_schema.tables WHERE table_schema = CURRENT_SCHEMA() AND NOT table_name ILIKE '%pg_stat%'").Scan(&tables); result.Error != nil {
 			return result.Error
 		}
 
 		for _, table := range tables {
-			stmt := fmt.Sprintf(`drop table if exists "%s" cascade`, table)
+			stmt := fmt.Sprintf(`DROP TABLE IF EXISTS "%s" CASCADE`, table)
 
 			if err := tx.Exec(stmt).Error; err != nil {
 				return err

--- a/cmd/api/src/database/migration/migrations/v8.2.0.sql
+++ b/cmd/api/src/database/migration/migrations/v8.2.0.sql
@@ -25,3 +25,20 @@ VALUES (
            false
        )
 ON CONFLICT DO NOTHING;
+
+INSERT INTO permissions(created_at, updated_at, authority, name)
+VALUES (
+        current_timestamp,
+        current_timestamp,
+        'auth',
+        'ReadUsers'
+       )
+ON CONFLICT DO NOTHING;
+
+INSERT INTO roles_permissions (role_id, permission_id)
+SELECT r.id, p.id
+FROM roles r
+JOIN permissions p
+ON (p.authority, p.name) = ('auth', 'ReadUsers')
+WHERE r.name IN ('Administrator', 'User', 'Read-Only', 'Power User')
+ON CONFLICT DO NOTHING;

--- a/packages/go/openapi/doc/openapi.json
+++ b/packages/go/openapi/doc/openapi.json
@@ -1736,6 +1736,101 @@
         }
       }
     },
+    "/api/v2/bloodhound-users-minimal": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/header.prefer"
+        }
+      ],
+      "get": {
+        "operationId": "ListUsersMinimal",
+        "summary": "List Users Minimal",
+        "description": "Returns all BloodHound user details without any sensitive data.",
+        "tags": [
+          "BloodHound Users",
+          "Community",
+          "Enterprise"
+        ],
+        "parameters": [
+          {
+            "name": "sort_by",
+            "description": "Sortable columns are id, first_name, last_name and email_address.",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/api.params.query.sort-by"
+            }
+          },
+          {
+            "name": "first_name",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/api.params.predicate.filter.string"
+            }
+          },
+          {
+            "name": "last_name",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/api.params.predicate.filter.string"
+            }
+          },
+          {
+            "name": "email_address",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/api.params.predicate.filter.string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/api.params.predicate.filter.uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "users": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/model.users-minimal"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/bad-request"
+          },
+          "401": {
+            "$ref": "#/components/responses/unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/too-many-requests"
+          },
+          "500": {
+            "$ref": "#/components/responses/internal-server-error"
+          }
+        }
+      }
+    },
     "/api/v2/bloodhound-users/{user_id}": {
       "parameters": [
         {
@@ -18431,6 +18526,33 @@
             "type": "boolean"
           }
         }
+      },
+      "model.users-minimal": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/model.components.uuid"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "first_name": {
+                "readOnly": true,
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/null.string"
+                  }
+                ]
+              },
+              "last_name": {
+                "$ref": "#/components/schemas/null.string"
+              },
+              "email": {
+                "type": "string",
+                "readOnly": true
+              }
+            }
+          }
+        ]
       },
       "enum.mfa-activation-status": {
         "type": "string",

--- a/packages/go/openapi/src/openapi.yaml
+++ b/packages/go/openapi/src/openapi.yaml
@@ -251,6 +251,8 @@ paths:
   # user management
   /api/v2/bloodhound-users:
     $ref: './paths/bh-users.bloodhound-users.yaml'
+  /api/v2/bloodhound-users-minimal:
+    $ref: './paths/bh-users.bloodhound-users-minimal.yaml'
   /api/v2/bloodhound-users/{user_id}:
     $ref: './paths/bh-users.bloodhound-users.id.yaml'
   /api/v2/bloodhound-users/{user_id}/secret:

--- a/packages/go/openapi/src/paths/bh-users.bloodhound-users-minimal.yaml
+++ b/packages/go/openapi/src/paths/bh-users.bloodhound-users-minimal.yaml
@@ -1,0 +1,72 @@
+# Copyright 2025 Specter Ops, Inc.
+#
+# Licensed under the Apache License, Version 2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+parameters:
+  - $ref: './../parameters/header.prefer.yaml'
+get:
+  operationId: ListUsersMinimal
+  summary: List Users Minimal
+  description: Returns all BloodHound user details without any sensitive data.
+  tags:
+    - BloodHound Users
+    - Community
+    - Enterprise
+  parameters:
+    - name: sort_by
+      description: Sortable columns are id, first_name, last_name and email_address.
+      in: query
+      schema:
+        $ref: './../schemas/api.params.query.sort-by.yaml'
+    - name: first_name
+      in: query
+      schema:
+        $ref: './../schemas/api.params.predicate.filter.string.yaml'
+    - name: last_name
+      in: query
+      schema:
+        $ref: './../schemas/api.params.predicate.filter.string.yaml'
+    - name: email_address
+      in: query
+      schema:
+        $ref: './../schemas/api.params.predicate.filter.string.yaml'
+    - name: id
+      in: query
+      schema:
+        $ref: './../schemas/api.params.predicate.filter.uuid.yaml'
+  responses:
+    200:
+      description: OK
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              data:
+                type: object
+                properties:
+                  users:
+                    type: array
+                    items:
+                      $ref: './../schemas/model.users-minimal.yaml'
+    400:
+      $ref: './../responses/bad-request.yaml'
+    401:
+      $ref: './../responses/unauthorized.yaml'
+    403:
+      $ref: './../responses/forbidden.yaml'
+    429:
+      $ref: './../responses/too-many-requests.yaml'
+    500:
+      $ref: './../responses/internal-server-error.yaml'

--- a/packages/go/openapi/src/schemas/model.users-minimal.yaml
+++ b/packages/go/openapi/src/schemas/model.users-minimal.yaml
@@ -1,0 +1,28 @@
+# Copyright 2025 Specter Ops, Inc.
+#
+# Licensed under the Apache License, Version 2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+allOf:
+  - $ref: './model.components.uuid.yaml'
+  - type: object
+    properties:
+      first_name:
+        readOnly: true
+        allOf:
+          - $ref: './null.string.yaml'
+      last_name:
+        $ref: './null.string.yaml'
+      email:
+        type: string
+        readOnly: true

--- a/packages/javascript/bh-shared-ui/src/views/Explore/ExploreSearch/SavedQueries/CommonSearches.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/Explore/ExploreSearch/SavedQueries/CommonSearches.tsx
@@ -66,6 +66,7 @@ const CommonSearches = ({
 
     useEffect(() => {
         setFilteredList(queryList);
+        handleFilter(searchTerm, platform, categoryFilter, source);
     }, [userQueries.data]);
 
     const handleClick = (query: string, id: number | undefined) => {


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Updated the UI to run the filtering function when the incoming data is changed.  This way the filters persist on user interaction.  

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-6487

*Why is this change required? What problem does it solve?*
Filters were not persisting in the new saved query flow when the user deletes a query.  

## How Has This Been Tested?

*Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc.*

Tested manually in local environment

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)
- Database Migrations

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
