### PR TITLE
chore: designate code owners for all npm and yarn related files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+# CODEOWNERS
+# Last matching rule wins. Keep specific exclusions below general rules if needed.
+
+# NPM and Yarn files
+**/package.json              @superlinkx @elikmiller
+**/package-lock.json         @superlinkx @elikmiller
+**/.yarn/**                  @superlinkx @elikmiller
+**/.yarnrc                   @superlinkx @elikmiller
+**/.yarnrc.yml               @superlinkx @elikmiller
+**/yarn.lock                 @superlinkx @elikmiller
+**/yarn-workspaces.json      @superlinkx @elikmiller


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Designates codeowners for all NPM/Yarn related dependency management files

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-6491

This is a proactive and preventative measure against the recently reported "Shai-Hulud" malware campaign.
See https://www.koi.security/blog/shai-hulud-npm-supply-chain-attack-crowdstrike-tinycolor for more details.
