### PR TITLE
feat(utils): add isDeepEqual

### DIFF
--- a/cmd/api/src/daemons/changelog/cache_internal_test.go
+++ b/cmd/api/src/daemons/changelog/cache_internal_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/cmd/api/src/daemons/changelog/changelog_integration_test.go
+++ b/cmd/api/src/daemons/changelog/changelog_integration_test.go
@@ -55,11 +55,7 @@ type changelogHarness struct {
 func setupChangelogTest(t *testing.T, config testChangelogConfig) *changelogHarness {
 	suite := setupIntegrationTest(t)
 
-	changelog := NewChangelog(suite.GraphDB, suite.BloodhoundDB, Options{
-		BatchSize:     config.BatchSize,
-		FlushInterval: config.FlushInterval,
-		PollInterval:  config.PollInterval,
-	})
+	changelog := NewChangelog(suite.GraphDB, suite.BloodhoundDB, Options(config))
 
 	return &changelogHarness{
 		suite:     &suite,

--- a/packages/javascript/bh-shared-ui/src/components/DetailsAccordion/DetailsAccordion.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/DetailsAccordion/DetailsAccordion.test.tsx
@@ -1,3 +1,19 @@
+// Copyright 2025 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import userEvent from '@testing-library/user-event';
 
 import { render, screen } from '../../test-utils';

--- a/packages/javascript/bh-shared-ui/src/components/DetailsAccordion/DetailsAccordion.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/DetailsAccordion/DetailsAccordion.test.tsx
@@ -1,0 +1,187 @@
+import userEvent from '@testing-library/user-event';
+
+import { render, screen } from '../../test-utils';
+import { DetailsAccordion } from './DetailsAccordion';
+
+// Need test ID for icon
+vi.mock('@fortawesome/react-fontawesome', () => ({
+    FontAwesomeIcon: (props: any) => <span data-testid='fa' {...props} />,
+}));
+
+vi.mock('@fortawesome/free-solid-svg-icons', () => ({ faAngleDown: {} }));
+
+type Item = { title: string; description: string; disabled?: boolean };
+
+const Header: React.FC<Item> = (item) => <h3>{item.title}</h3>;
+const Content: React.FC<Item> = (item) => <p>{item.description}</p>;
+const Empty: React.FC = () => <div role='status'>No items</div>;
+
+describe('<DetailsAccordion />', () => {
+    it('renders Empty when items is undefined and Empty is provided', () => {
+        render(<DetailsAccordion<Item> Header={Header} Content={Content} Empty={Empty} />);
+        expect(screen.getByRole('status')).toHaveTextContent('No items');
+    });
+
+    it('renders a single item when items is an object', () => {
+        render(
+            <DetailsAccordion<Item>
+                Header={Header}
+                Content={Content}
+                items={{ title: 'One', description: 'Only child' }}
+            />
+        );
+        expect(screen.getByRole('button')).toHaveTextContent('One');
+    });
+
+    it('passes item props to Header and Content', async () => {
+        const user = userEvent.setup();
+        render(
+            <DetailsAccordion<Item>
+                Header={Header}
+                Content={Content}
+                items={[
+                    { title: 'A', description: 'Alpha' },
+                    { title: 'B', description: 'Beta' },
+                ]}
+                openIndex={0}
+            />
+        );
+
+        // default open is index 0 -> content "Alpha" should be visible
+        expect(screen.getByText('Alpha')).toBeInTheDocument();
+
+        // Click header B, then "Beta" should appear
+        await user.click(screen.getAllByRole('button').find((el) => el.textContent?.includes('B'))!);
+        expect(screen.getByText('Beta')).toBeInTheDocument();
+    });
+
+    it('calls getKey for each item (stable keys hook)', () => {
+        const items = [
+            { title: 'A', description: 'Alpha' },
+            { title: 'B', description: 'Beta' },
+        ];
+        const getKey = vi.fn((i: Item) => i.title);
+
+        render(<DetailsAccordion<Item> Header={Header} Content={Content} items={items} getKey={getKey} />);
+
+        expect(getKey).toHaveBeenCalledTimes(2);
+        expect(getKey).toHaveBeenNthCalledWith(1, items[0], 0);
+        expect(getKey).toHaveBeenNthCalledWith(2, items[1], 1);
+    });
+
+    it('skips undefined items gracefully', () => {
+        render(
+            <DetailsAccordion<any>
+                Header={({ label }: any) => <div>{label}</div>}
+                Content={() => <div>ok</div>}
+                // an undefined item
+                items={[{ label: 'Valid' }, undefined]}
+            />
+        );
+        expect(screen.getByRole('button')).toHaveTextContent('Valid');
+        // only one header rendered
+        expect(screen.getAllByRole('button')).toHaveLength(1);
+    });
+
+    it('applies accent styling to headers when accent is true', () => {
+        render(
+            <DetailsAccordion<Item>
+                Header={Header}
+                Content={Content}
+                items={[{ title: 'Fancy', description: 'With accent' }]}
+                accent
+            />
+        );
+
+        const header = screen.getByRole('button');
+        // spot-check a couple of classes from implementation
+        expect(header).toHaveClass('bg-[#e0e0e0]');
+        expect(header).toHaveClass('border-l-8');
+        expect(header).toHaveClass('border-primary');
+    });
+
+    it('disables items via itemDisabled and hides the chevron icon visually', () => {
+        render(
+            <DetailsAccordion<Item>
+                Header={Header}
+                Content={Content}
+                items={[
+                    { title: 'Disabled', description: 'Nope', disabled: true },
+                    { title: 'Enabled', description: 'Yep', disabled: false },
+                ]}
+                itemDisabled={(i) => !!i.disabled}
+            />
+        );
+
+        const [disabledHeader, enabledHeader] = screen.getAllByRole('button');
+
+        // Icon for disabled row should have opacity-0
+        const disabledIcon = disabledHeader.querySelector('[data-testid="fa"]');
+        expect(disabledIcon).toHaveClass('opacity-0');
+
+        const enabledIcon = enabledHeader.querySelector('[data-testid="fa"]');
+        expect(enabledIcon).not.toHaveClass('opacity-0');
+    });
+
+    it('respects openIndex (default opened panel)', () => {
+        render(
+            <DetailsAccordion<Item>
+                Header={Header}
+                Content={Content}
+                items={[
+                    { title: 'First', description: 'one' },
+                    { title: 'Second', description: 'two' },
+                ]}
+                openIndex={1}
+            />
+        );
+        // only 'two' should be visible initially
+        expect(screen.queryByText('one')).not.toBeInTheDocument();
+        expect(screen.getByText('two')).toBeInTheDocument();
+    });
+
+    it('clicking a disabled header does not toggle content', async () => {
+        const user = userEvent.setup();
+        render(
+            <DetailsAccordion<Item>
+                Header={Header}
+                Content={Content}
+                items={[{ title: 'Locked', description: 'hidden', disabled: true }]}
+                itemDisabled={(i) => !!i.disabled}
+            />
+        );
+
+        const header = screen.getByRole('button', { name: /Locked/i });
+        await user.click(header);
+
+        // never opens
+        expect(screen.queryByText('hidden')).not.toBeInTheDocument();
+    });
+
+    it('clicking an enabled header toggles content (single mode)', async () => {
+        const user = userEvent.setup();
+        render(
+            <DetailsAccordion<Item>
+                Header={Header}
+                Content={Content}
+                items={[
+                    { title: 'A', description: 'Alpha' },
+                    { title: 'B', description: 'Beta' },
+                ]}
+            />
+        );
+
+        // Initially nothing is open (no openIndex)
+        expect(screen.queryByText('Alpha')).not.toBeInTheDocument();
+        expect(screen.queryByText('Beta')).not.toBeInTheDocument();
+
+        // Open A
+        await user.click(screen.getByRole('button', { name: /A/i }));
+        expect(screen.getByText('Alpha')).toBeInTheDocument();
+
+        // Open B (single mode should close A)
+        await user.click(screen.getByRole('button', { name: /B/i }));
+        expect(screen.queryByText('Alpha')).not.toBeInTheDocument();
+        expect(screen.getByText('Beta')).toBeInTheDocument();
+    });
+});

--- a/packages/javascript/bh-shared-ui/src/components/DetailsAccordion/DetailsAccordion.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/DetailsAccordion/DetailsAccordion.tsx
@@ -2,11 +2,10 @@ import { Accordion, AccordionContent, AccordionHeader, AccordionItem } from '@bl
 import { faAngleDown } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import clsx from 'clsx';
-import { stubFalse } from 'lodash';
 
 import React, { ComponentType } from 'react';
 
-type DetailsAccordionProps<T extends Record<string, unknown>> = {
+export type DetailsAccordionProps<T extends Record<string, unknown>> = {
     /** If `true`, applies an accent style to the selected item’s header  */
     accent?: boolean;
 
@@ -28,7 +27,7 @@ type DetailsAccordionProps<T extends Record<string, unknown>> = {
     /** A single item or array of items to render */
     items?: T | T[];
 
-    /** Index of the item that should start open (`null` = none) */
+    /** Index of the item that should start open (`undefined` = none) */
     openIndex?: number;
 };
 
@@ -63,7 +62,7 @@ export const DetailsAccordion = <T extends Record<string, unknown>>({
     Empty,
     getKey,
     items,
-    itemDisabled = stubFalse,
+    itemDisabled = () => false,
     Header,
     openIndex,
 }: DetailsAccordionProps<T>) => {
@@ -73,8 +72,11 @@ export const DetailsAccordion = <T extends Record<string, unknown>>({
 
     const itemArray = Array.isArray(items) ? items : [items];
 
+    const defaultValue =
+        typeof openIndex === 'number' && openIndex >= 0 && openIndex < itemArray.length ? String(openIndex) : undefined;
+
     return (
-        <Accordion collapsible defaultValue={String(openIndex)} type='single'>
+        <Accordion collapsible defaultValue={defaultValue} type='single'>
             {itemArray.map((item, idx) => {
                 if (item === undefined) {
                     return null;
@@ -96,7 +98,11 @@ export const DetailsAccordion = <T extends Record<string, unknown>>({
                                 isDisabled && 'hover:no-underline',
                                 accent && 'bg-[#e0e0e0] dark:bg-[#202020] border-l-8 border-primary'
                             )}>
-                            <FontAwesomeIcon icon={faAngleDown} className={clsx(isDisabled && 'opacity-0')} />
+                            <FontAwesomeIcon
+                                aria-hidden
+                                className={clsx(isDisabled && 'opacity-0')}
+                                icon={faAngleDown}
+                            />
                             <Header {...item} />
                         </AccordionHeader>
 

--- a/packages/javascript/bh-shared-ui/src/components/DetailsAccordion/DetailsAccordion.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/DetailsAccordion/DetailsAccordion.tsx
@@ -1,0 +1,111 @@
+import { Accordion, AccordionContent, AccordionHeader, AccordionItem } from '@bloodhoundenterprise/doodleui';
+import { faAngleDown } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import clsx from 'clsx';
+import { stubFalse } from 'lodash';
+
+import React, { ComponentType } from 'react';
+
+type DetailsAccordionProps<T extends Record<string, unknown>> = {
+    /** If `true`, applies an accent style to the selected item’s header  */
+    accent?: boolean;
+
+    /** Component to render the content area of each item */
+    Content: ComponentType<T>;
+
+    /** Optional component to render when `items` is `undefined` */
+    Empty?: ComponentType;
+
+    /** Function to provide a stable key for each row (defaults to index) */
+    getKey?: (item: T, index: number) => React.Key;
+
+    /** Predicate to determine if an item is disabled (default: always `false`) */
+    itemDisabled?: (item: T) => boolean;
+
+    /** Component to render the header of each item */
+    Header: ComponentType<T>;
+
+    /** A single item or array of items to render */
+    items?: T | T[];
+
+    /** Index of the item that should start open (`null` = none) */
+    openIndex?: number;
+};
+
+/**
+ * A generic accordion component for displaying a list of items, where each
+ * item has a header and expandable content.
+ *
+ * @typeParam T - Shape of a rendered item. Extends `Record<string, unknown>`.
+ *
+ * @remarks
+ * - Renders each item inside a single-select accordion panel.
+ * - If `items` is `undefined` and an `Empty` component is provided, the `Empty` component will render instead.
+ * - Each item is passed as props to the `Header` and `Content` components.
+ * - Supports disabling items, custom keys, and optionally applying an accent style.
+ *
+ * @example
+ * ```tsx
+ * <DetailsAccordion
+ *   Header={({ title }) => <div>{title}</div>}
+ *   Content={({ description }) => <p>{description}</p>}
+ *   items={[
+ *     { title: "First", description: "First item description" },
+ *     { title: "Second", description: "Second item description" },
+ *   ]}
+ *   openIndex={0}
+ * />
+ * ```
+ */
+export const DetailsAccordion = <T extends Record<string, unknown>>({
+    accent = false,
+    Content,
+    Empty,
+    getKey,
+    items,
+    itemDisabled = stubFalse,
+    Header,
+    openIndex,
+}: DetailsAccordionProps<T>) => {
+    if (items === undefined && Empty) {
+        return <Empty />;
+    }
+
+    const itemArray = Array.isArray(items) ? items : [items];
+
+    return (
+        <Accordion collapsible defaultValue={String(openIndex)} type='single'>
+            {itemArray.map((item, idx) => {
+                if (item === undefined) {
+                    return null;
+                }
+
+                const key = getKey ? getKey(item, idx) : idx;
+                const isDisabled = itemDisabled(item);
+
+                return (
+                    <AccordionItem
+                        className='bg-neutral-light-2 dark:bg-neutral-dark-2 border-t dark:border-neutral-dark-4 first:border-none'
+                        disabled={isDisabled}
+                        key={key}
+                        value={String(idx)}>
+                        <AccordionHeader
+                            className={clsx(
+                                'h-16',
+                                !isDisabled && 'cursor-pointer',
+                                isDisabled && 'hover:no-underline',
+                                accent && 'bg-[#e0e0e0] dark:bg-[#202020] border-l-8 border-primary'
+                            )}>
+                            <FontAwesomeIcon icon={faAngleDown} className={clsx(isDisabled && 'opacity-0')} />
+                            <Header {...item} />
+                        </AccordionHeader>
+
+                        <AccordionContent className='pr-6 text-base justify-between border-t dark:border-neutral-dark-4'>
+                            <Content {...item} />
+                        </AccordionContent>
+                    </AccordionItem>
+                );
+            })}
+        </Accordion>
+    );
+};

--- a/packages/javascript/bh-shared-ui/src/components/DetailsAccordion/DetailsAccordion.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/DetailsAccordion/DetailsAccordion.tsx
@@ -22,7 +22,7 @@ import clsx from 'clsx';
 import React, { ComponentType } from 'react';
 
 export type DetailsAccordionProps<T extends Record<string, unknown>> = {
-    /** If `true`, applies an accent style to the selected item’s header  */
+    /** If `true`, applies an accent style to item headers  */
     accent?: boolean;
 
     /** Component to render the content area of each item */
@@ -122,7 +122,7 @@ export const DetailsAccordion = <T extends Record<string, unknown>>({
                             <Header {...item} />
                         </AccordionHeader>
 
-                        <AccordionContent className='pr-6 text-base justify-between border-t dark:border-neutral-dark-4'>
+                        <AccordionContent className='pr-6 text-base border-t dark:border-neutral-dark-4'>
                             <Content {...item} />
                         </AccordionContent>
                     </AccordionItem>

--- a/packages/javascript/bh-shared-ui/src/components/DetailsAccordion/DetailsAccordion.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/DetailsAccordion/DetailsAccordion.tsx
@@ -1,3 +1,19 @@
+// Copyright 2025 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { Accordion, AccordionContent, AccordionHeader, AccordionItem } from '@bloodhoundenterprise/doodleui';
 import { faAngleDown } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';

--- a/packages/javascript/bh-shared-ui/src/components/DetailsAccordion/index.ts
+++ b/packages/javascript/bh-shared-ui/src/components/DetailsAccordion/index.ts
@@ -1,0 +1,1 @@
+export * from './DetailsAccordion';

--- a/packages/javascript/bh-shared-ui/src/components/DetailsAccordion/index.ts
+++ b/packages/javascript/bh-shared-ui/src/components/DetailsAccordion/index.ts
@@ -1,1 +1,17 @@
+// Copyright 2025 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 export * from './DetailsAccordion';

--- a/packages/javascript/bh-shared-ui/src/components/index.ts
+++ b/packages/javascript/bh-shared-ui/src/components/index.ts
@@ -62,6 +62,8 @@ export { default as DataTable } from './DataTable';
 export * from './DeleteConfirmationDialog';
 export { default as DeleteConfirmationDialog } from './DeleteConfirmationDialog';
 
+export * from './DetailsAccordion';
+
 export * from './Disable2FADialog';
 export { default as Disable2FADialog } from './Disable2FADialog';
 

--- a/packages/javascript/bh-shared-ui/src/utils/object.test.ts
+++ b/packages/javascript/bh-shared-ui/src/utils/object.test.ts
@@ -1,0 +1,82 @@
+// Copyright 2025 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { isDeepEqual } from './object';
+
+describe('isDeepEqual', () => {
+    it('returns true when objects have the same recursive value', () => {
+        const objA = { a: 1, b: { c: false, d: 'true' } };
+        const objB = { b: { d: 'true', c: false }, a: 1 };
+
+        expect(isDeepEqual(objA, objB)).toBeTruthy();
+    });
+
+    it('returns false if objects do not have the same recursive value', () => {
+        const objA = { a: 1, b: { c: false, d: 'true' } };
+        const objB = { b: { d: 'true', c: false }, a: 2 };
+
+        expect(isDeepEqual(objA, objB)).toBeFalsy();
+    });
+
+    it('returns false if objects do not have the same number of keys', () => {
+        const objA = { a: 1, b: 2 };
+        const objB = { a: 1 };
+
+        expect(isDeepEqual(objA, objB)).toBeFalsy();
+    });
+
+    it('returns false if objects do not have the same keys', () => {
+        const objA = { a: 1, b: 2 };
+        const objB = { a: 1, c: 2 };
+
+        expect(isDeepEqual(objA, objB)).toBeFalsy();
+    });
+
+    it('returns true if arrays have the same values in the same order', () => {
+        const objA = ['a', 'b'];
+        const objB = ['a', 'b'];
+
+        expect(isDeepEqual(objA, objB)).toBeTruthy();
+    });
+
+    it('returns false if arrays have different lengths', () => {
+        const objA = ['a', 'b'];
+        const objB = ['a'];
+
+        expect(isDeepEqual(objA, objB)).toBeFalsy();
+    });
+
+    it('returns false if arrays have the same values in a different order', () => {
+        const objA = ['a', 'b'];
+        const objB = ['b', 'a'];
+
+        expect(isDeepEqual(objA, objB)).toBeFalsy();
+    });
+
+    it('returns false if objects are not the same type', () => {
+        const objA = { '0': 'a' };
+        const objB = ['a'];
+
+        expect(isDeepEqual(objA, objB)).toBeFalsy();
+    });
+
+    it('returns true if primatives have the same value', () => {
+        expect(isDeepEqual('a', 'a')).toBeTruthy();
+        expect(isDeepEqual(1, 1)).toBeTruthy();
+        expect(isDeepEqual(true, true)).toBeTruthy();
+        expect(isDeepEqual(undefined, undefined)).toBeTruthy();
+    });
+});

--- a/packages/javascript/bh-shared-ui/src/utils/object.ts
+++ b/packages/javascript/bh-shared-ui/src/utils/object.ts
@@ -16,3 +16,41 @@
 
 /** Returns Object.entries with results retaining their types */
 export const typedEntries = <T extends object>(obj: T): [keyof T, T[keyof T]][] => Object.entries(obj) as any;
+
+/** Returns true if both objects are deeply equal, by value */
+export const isDeepEqual = (a: unknown, b: unknown): boolean => {
+    if (a === b) {
+        return true;
+    }
+
+    if (a && b && typeof a === 'object' && typeof b === 'object') {
+        // Handle Array case
+        if (Array.isArray(a) && Array.isArray(b)) {
+            if (a.length !== b.length) return false;
+            return a.every((val, i) => isDeepEqual(val, b[i]));
+        }
+
+        // If one is array and the other isn't
+        if (Array.isArray(a) !== Array.isArray(b)) {
+            return false;
+        }
+
+        // Handle plain objects
+        const keysA = Object.keys(a as object);
+        const keysB = Object.keys(b as object);
+
+        if (keysA.length !== keysB.length) {
+            return false;
+        }
+
+        return keysA.every((key) => {
+            if (!(key in (b as object))) {
+                return false;
+            }
+            return isDeepEqual((a as Record<string, unknown>)[key], (b as Record<string, unknown>)[key]);
+        });
+    }
+
+    // For primitives (number, string, boolean, null, undefined, symbol)
+    return false;
+};


### PR DESCRIPTION
## Description

Adds a `isDeepEqual` method that checks two given objects for equivalency by value

## Motivation and Context

Resolves BED-6493

This method will be used to implement dirty checking in the Finished Jobs Filter Dialog

## How Has This Been Tested?

Added unit tests

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
