### PR TITLE
BED-6494 -- Delete Query Confirmation Modal

### DIFF
--- a/packages/javascript/bh-shared-ui/src/components/PrebuiltSearchList/PrebuiltSearchList.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/PrebuiltSearchList/PrebuiltSearchList.tsx
@@ -14,11 +14,12 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import { Button } from '@bloodhoundenterprise/doodleui';
-import { Box, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle, Typography } from '@mui/material';
+import { Box, Typography } from '@mui/material';
 import makeStyles from '@mui/styles/makeStyles';
 import groupBy from 'lodash/groupBy';
 import { FC, useEffect, useRef, useState } from 'react';
 import { QueryListSection } from '../../types';
+import ConfirmDeleteQueryDialog from '../../views/Explore/ExploreSearch/SavedQueries/ConfirmDeleteQueryDialog';
 import { useSavedQueriesContext } from '../../views/Explore/providers/SavedQueriesProvider';
 import ListItemActionMenu from './ListItemActionMenu';
 interface PrebuiltSearchListProps {
@@ -158,27 +159,12 @@ const PrebuiltSearchList: FC<PrebuiltSearchListProps> = ({
                     </Button>
                 </Box>
             )}
-
-            <Dialog open={open} onClose={handleClose} maxWidth={'xs'} fullWidth>
-                <DialogTitle>Delete Query</DialogTitle>
-                <DialogContent>
-                    <DialogContentText>Are you sure you want to delete this query?</DialogContentText>
-                </DialogContent>
-                <DialogActions>
-                    <Button variant='tertiary' onClick={handleClose}>
-                        Cancel
-                    </Button>
-                    <Button
-                        onClick={() => {
-                            if (deleteHandler) deleteHandler(queryId!);
-                            handleClose();
-                        }}
-                        color='primary'
-                        autoFocus>
-                        Confirm
-                    </Button>
-                </DialogActions>
-            </Dialog>
+            <ConfirmDeleteQueryDialog
+                open={open}
+                queryId={queryId}
+                deleteHandler={deleteHandler}
+                handleClose={handleClose}
+            />
         </>
     );
 };

--- a/packages/javascript/bh-shared-ui/src/views/Explore/ExploreSearch/SavedQueries/CommonSearches.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/Explore/ExploreSearch/SavedQueries/CommonSearches.tsx
@@ -26,6 +26,7 @@ import { useNotifications } from '../../../../providers';
 import { QueryLineItem, QueryListSection } from '../../../../types';
 import { cn } from '../../../../utils';
 import { useSavedQueriesContext } from '../../providers';
+import ConfirmDeleteQueryDialog from './ConfirmDeleteQueryDialog';
 import QuerySearchFilter from './QuerySearchFilter';
 
 type CommonSearchesProps = {
@@ -50,6 +51,8 @@ const CommonSearches = ({
     const [searchTerm, setSearchTerm] = useState('');
     const [platform, setPlatform] = useState('');
     const [source, setSource] = useState('');
+    const [open, setOpen] = useState(false);
+    const [queryId, setQueryId] = useState<number>();
 
     const [categoryFilter, setCategoryFilter] = useState<string[]>([]);
 
@@ -83,6 +86,16 @@ const CommonSearches = ({
     };
 
     const handleDeleteQuery = (id: number) => {
+        setQueryId(id);
+        setOpen(true);
+    };
+
+    const handleClose = () => {
+        setOpen(false);
+        setQueryId(undefined);
+    };
+
+    const confirmDeleteQuery = (id: number) => {
         deleteQueryMutation.mutate(id, {
             onSuccess: () => {
                 addNotification(`Query deleted.`, 'userDeleteQuery');
@@ -197,6 +210,13 @@ const CommonSearches = ({
                     showCommonQueries={showCommonQueries}
                 />
             </div>
+
+            <ConfirmDeleteQueryDialog
+                open={open}
+                queryId={queryId}
+                deleteHandler={confirmDeleteQuery}
+                handleClose={handleClose}
+            />
         </div>
     );
 };

--- a/packages/javascript/bh-shared-ui/src/views/Explore/ExploreSearch/SavedQueries/ConfirmDeleteQueryDialog.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/Explore/ExploreSearch/SavedQueries/ConfirmDeleteQueryDialog.tsx
@@ -1,0 +1,37 @@
+import { Button } from '@bloodhoundenterprise/doodleui';
+import { Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle } from '@mui/material';
+import { FC } from 'react';
+
+interface ConfirmDeleteQueryDialogProps {
+    open: boolean;
+    queryId?: number;
+    handleClose: () => void;
+    deleteHandler?: (id: number) => void;
+}
+
+const ConfirmDeleteQueryDialog: FC<ConfirmDeleteQueryDialogProps> = ({ open, queryId, handleClose, deleteHandler }) => {
+    return (
+        <Dialog open={open} onClose={handleClose} maxWidth={'xs'} fullWidth>
+            <DialogTitle>Delete Query</DialogTitle>
+            <DialogContent>
+                <DialogContentText>Are you sure you want to delete this query?</DialogContentText>
+            </DialogContent>
+            <DialogActions>
+                <Button variant='tertiary' onClick={handleClose}>
+                    Cancel
+                </Button>
+                <Button
+                    onClick={() => {
+                        if (deleteHandler) deleteHandler(queryId!);
+                        handleClose();
+                    }}
+                    color='primary'
+                    autoFocus>
+                    Confirm
+                </Button>
+            </DialogActions>
+        </Dialog>
+    );
+};
+
+export default ConfirmDeleteQueryDialog;

--- a/packages/javascript/bh-shared-ui/src/views/Explore/ExploreSearch/SavedQueries/QuerySearchFilter.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/Explore/ExploreSearch/SavedQueries/QuerySearchFilter.tsx
@@ -74,6 +74,7 @@ const QuerySearchFilter = (props: QuerySearchProps) => {
     };
 
     const exportEnabled = selectedQuery?.id ? true : false;
+    const deleteEnabled = selectedQuery?.id && selectedQuery?.canEdit ? true : false;
 
     const importHandler = () => {
         setShowImportDialog(true);
@@ -108,7 +109,7 @@ const QuerySearchFilter = (props: QuerySearchProps) => {
                         </Button>
                         <Button
                             aria-label='delete'
-                            disabled={!exportEnabled}
+                            disabled={!deleteEnabled}
                             className='ml-2'
                             variant='icon'
                             onClick={() => deleteHandler(selectedQuery?.id as number)}>


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

In the saved queries flow, there are two places where the user can delete a saved query.  
1. On the top bar next to export.  
2. In the saved queries list within the ellipsis menu

The delete button in the ellipsis is firing off a confirmation modal as expected.  The delete button on the top bar was not.  So, we have added the confirmation modal to the top bar delete button so that there is consistency across both.  

Additionally, the top bar delete button is now correctly set to be disabled for shared queries.  

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-6494

*Why is this change required? What problem does it solve?*

## How Has This Been Tested?

Manually tested in local environment.  
All test cases passed.


## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)
- Database Migrations

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
