### PR TITLE
Bed 6063 ha dummy

### DIFF
--- a/cmd/api/src/daemons/changelog/changelog.go
+++ b/cmd/api/src/daemons/changelog/changelog.go
@@ -20,6 +20,7 @@ import (
 	"log/slog"
 	"time"
 
+	"github.com/specterops/bloodhound/cmd/api/src/daemons/ha"
 	"github.com/specterops/bloodhound/cmd/api/src/model/appcfg"
 	"github.com/specterops/dawgs/graph"
 )
@@ -49,7 +50,7 @@ func DefaultOptions() Options {
 
 func NewChangelog(dawgsDB graph.Database, flagProvider appcfg.GetFlagByKeyer, opts Options) *Changelog {
 	// Use dummy HA implementation for BHCE (always primary)
-	flagManager := newFeatureFlagManager(flagGetter(dawgsDB, flagProvider), opts.PollInterval, newDummyHA())
+	flagManager := newFeatureFlagManager(flagGetter(dawgsDB, flagProvider), opts.PollInterval, ha.NewDummyHA())
 	coordinator := newIngestionCoordinator(dawgsDB)
 
 	return &Changelog{
@@ -60,7 +61,7 @@ func NewChangelog(dawgsDB graph.Database, flagProvider appcfg.GetFlagByKeyer, op
 }
 
 // NewChangelogWithHA creates a changelog with a real HA implementation for high-availability deployments.
-func NewChangelogWithHA(dawgsDB graph.Database, flagProvider appcfg.GetFlagByKeyer, opts Options, haMutex HAMutex) *Changelog {
+func NewChangelogWithHA(dawgsDB graph.Database, flagProvider appcfg.GetFlagByKeyer, opts Options, haMutex ha.HAMutex) *Changelog {
 	flagManager := newFeatureFlagManager(flagGetter(dawgsDB, flagProvider), opts.PollInterval, haMutex)
 	coordinator := newIngestionCoordinator(dawgsDB)
 

--- a/cmd/api/src/daemons/changelog/flag_internal_test.go
+++ b/cmd/api/src/daemons/changelog/flag_internal_test.go
@@ -22,13 +22,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/specterops/bloodhound/cmd/api/src/daemons/ha"
 	"github.com/stretchr/testify/require"
 )
 
 func TestFeatureFlagManager(t *testing.T) {
 	t.Run("enable creates cache", func(t *testing.T) {
 		var (
-			manager = newFeatureFlagManager(nil, time.Second, newDummyHA())
+			manager = newFeatureFlagManager(nil, time.Second, ha.NewDummyHA())
 			ctx     = context.Background()
 		)
 
@@ -42,7 +43,7 @@ func TestFeatureFlagManager(t *testing.T) {
 
 	t.Run("disable clears cache", func(t *testing.T) {
 		var (
-			manager = newFeatureFlagManager(nil, time.Second, newDummyHA())
+			manager = newFeatureFlagManager(nil, time.Second, ha.NewDummyHA())
 			ctx     = context.Background()
 		)
 
@@ -57,7 +58,7 @@ func TestFeatureFlagManager(t *testing.T) {
 
 	t.Run("getCache is thread-safe", func(t *testing.T) {
 		var (
-			manager       = newFeatureFlagManager(nil, time.Second, newDummyHA())
+			manager       = newFeatureFlagManager(nil, time.Second, ha.NewDummyHA())
 			ctx           = context.Background()
 			wg            sync.WaitGroup
 			numGoroutines = 10
@@ -99,7 +100,7 @@ func TestFeatureFlagManagerPoller(t *testing.T) {
 			flagGetter  = func(ctx context.Context) (bool, int, error) {
 				return enabled, 10, nil
 			}
-			manager = newFeatureFlagManager(flagGetter, 10*time.Millisecond, newDummyHA())
+			manager = newFeatureFlagManager(flagGetter, 10*time.Millisecond, ha.NewDummyHA())
 		)
 		defer cancel()
 
@@ -129,7 +130,7 @@ func TestFeatureFlagManagerPoller(t *testing.T) {
 			flagGetter  = func(ctx context.Context) (bool, int, error) {
 				return enabled, 1500, nil
 			}
-			manager = newFeatureFlagManager(flagGetter, 10*time.Millisecond, newDummyHA())
+			manager = newFeatureFlagManager(flagGetter, 10*time.Millisecond, ha.NewDummyHA())
 		)
 		defer cancel()
 
@@ -161,7 +162,7 @@ func TestFeatureFlagManagerPoller(t *testing.T) {
 				}
 				return true, 3000, nil
 			}
-			manager = newFeatureFlagManager(flagGetter, 10*time.Millisecond, newDummyHA())
+			manager = newFeatureFlagManager(flagGetter, 10*time.Millisecond, ha.NewDummyHA())
 		)
 		defer cancel()
 
@@ -183,7 +184,7 @@ func TestFeatureFlagManagerPoller(t *testing.T) {
 			flagGetter  = func(ctx context.Context) (bool, int, error) {
 				return enabled, 1000, nil
 			}
-			manager = newFeatureFlagManager(flagGetter, 10*time.Millisecond, newDummyHA())
+			manager = newFeatureFlagManager(flagGetter, 10*time.Millisecond, ha.NewDummyHA())
 		)
 		defer cancel()
 
@@ -209,11 +210,11 @@ type mockHA struct {
 	lockError error
 }
 
-func (m *mockHA) TryLock() (LockResult, error) {
+func (m *mockHA) TryLock() (ha.LockResult, error) {
 	if m.lockError != nil {
-		return LockResult{}, m.lockError
+		return ha.LockResult{}, m.lockError
 	}
-	return LockResult{
+	return ha.LockResult{
 		Context:   context.Background(),
 		IsPrimary: m.isPrimary,
 	}, nil
@@ -354,7 +355,7 @@ func TestClearCache_HA(t *testing.T) {
 }
 
 func TestDummyHA(t *testing.T) {
-	dummy := newDummyHA()
+	dummy := ha.NewDummyHA()
 
 	lockResult, err := dummy.TryLock()
 	require.NoError(t, err)

--- a/cmd/api/src/daemons/ha/ha.go
+++ b/cmd/api/src/daemons/ha/ha.go
@@ -1,0 +1,41 @@
+// Copyright 2025 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+package ha
+
+import "context"
+
+type LockResult struct {
+	Context   context.Context
+	IsPrimary bool
+}
+
+type HAMutex interface {
+	TryLock() (LockResult, error)
+}
+
+// dummyHA is a no-op implementation for BHCE that always reports as primary
+type dummyHA struct{}
+
+func (d *dummyHA) TryLock() (LockResult, error) {
+	return LockResult{
+		Context:   context.Background(),
+		IsPrimary: true,
+	}, nil
+}
+
+func NewDummyHA() HAMutex {
+	return &dummyHA{}
+}


### PR DESCRIPTION
make changelog HA aware. CE implementation always reports as primary

non-primary instances will skip these protected codepaths:
- cache enable/disable
- feature flag polling
- clearCache()

