### PR TITLE
fix(agt): search bar overlap create buttons fix

### DIFF
--- a/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/Details/Details.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/Details/Details.tsx
@@ -124,11 +124,12 @@ const Details: FC = () => {
     return (
         <div className='h-full'>
             <div className='flex mt-6'>
-                <div className='w-1/3'>{InfoHeader && <InfoHeader />}</div>
-                <div className='w-1/3 flex justify-end'>
+                <div className='flex flex-wrap basis-2/3 justify-between'>
+                    {InfoHeader && <InfoHeader />}
                     <SearchBar />
                 </div>
-                <div className='w-1/3 ml-8'>
+
+                <div className='basis-1/3 ml-8'>
                     {showEditButton && (
                         <Button
                             asChild={showEditButton || !saveLink}

--- a/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/Details/SearchBar.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/Details/SearchBar.tsx
@@ -99,7 +99,7 @@ const SearchBar: React.FC = () => {
         : { Zones: 'tags', Selectors: 'selectors', Members: 'members' };
 
     return (
-        <div {...getComboboxProps()} className='relative w-4/6'>
+        <div {...getComboboxProps()} className='relative w-1/4 self-end'>
             <Popover open={isOpen} onOpenChange={(open) => !open && setIsOpen(false)}>
                 <PopoverTrigger asChild>
                     <div className='flex items-center'>


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Updates styles for the row with buttons and the search input in PZ details page.

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-6496

On small width resolutions the search input element overlaps the create buttons even though not readily apparent. This interferes with clicking the buttons and is confusing.

## How Has This Been Tested?
Manually verified. 

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
