### PR TITLE
BED-6451:  Duplicate edge issue

### DIFF
--- a/cmd/ui/src/views/Explore/utils.test.ts
+++ b/cmd/ui/src/views/Explore/utils.test.ts
@@ -20,6 +20,51 @@ import { initGraph } from './utils';
 
 const layoutDagreSpy = vi.spyOn(layoutDagre, 'layoutDagre');
 
+const testNodes = {
+    '1': {
+        label: 'User 1',
+        kind: 'User',
+        kinds: ['User'],
+        objectId: 'test-user-1',
+        lastSeen: '',
+        isTierZero: false,
+        isOwnedObject: false,
+    },
+    '2': {
+        label: 'Group 1',
+        kind: 'Group',
+        kinds: ['Group'],
+        objectId: 'test-group-1',
+        lastSeen: '',
+        isTierZero: false,
+        isOwnedObject: false,
+    },
+};
+
+const testEdgesWithDuplicate = [
+    {
+        source: '1',
+        target: '2',
+        label: 'MemberOf',
+        kind: 'MemberOf',
+        lastSeen: '',
+    },
+    {
+        source: '1',
+        target: '2',
+        label: 'MemberOf',
+        kind: 'MemberOf',
+        lastSeen: '',
+    },
+    {
+        source: '1',
+        target: '2',
+        label: 'GetChangesAll',
+        kind: 'GetChangesAll',
+        lastSeen: '',
+    },
+];
+
 describe('Explore utils', () => {
     describe('initGraph', () => {
         const mockTheme = {
@@ -36,6 +81,16 @@ describe('Explore utils', () => {
             );
 
             expect(layoutDagreSpy).toBeCalled();
+        });
+        it('dedupes edges before adding them to the graph', () => {
+            const graph = initGraph(
+                { nodes: testNodes, edges: testEdgesWithDuplicate },
+                { theme: mockTheme as Theme, hideNodes: false, customIcons: {}, darkMode: false, tagGlyphMap: {} }
+            );
+
+            expect(graph.edges.length).toEqual(2);
+            expect(graph.hasEdge('1_MemberOf_2')).toBeTruthy();
+            expect(graph.hasEdge('1_GetChangesAll_2')).toBeTruthy();
         });
     });
 });

--- a/cmd/ui/src/views/Explore/utils.test.ts
+++ b/cmd/ui/src/views/Explore/utils.test.ts
@@ -57,6 +57,13 @@ const testEdgesWithDuplicate = [
         lastSeen: '',
     },
     {
+        source: '2',
+        target: '1',
+        label: 'MemberOf',
+        kind: 'MemberOf',
+        lastSeen: '',
+    },
+    {
         source: '1',
         target: '2',
         label: 'GetChangesAll',
@@ -88,8 +95,9 @@ describe('Explore utils', () => {
                 { theme: mockTheme as Theme, hideNodes: false, customIcons: {}, darkMode: false, tagGlyphMap: {} }
             );
 
-            expect(graph.edges.length).toEqual(2);
+            expect(graph.edges().length).toEqual(3);
             expect(graph.hasEdge('1_MemberOf_2')).toBeTruthy();
+            expect(graph.hasEdge('2_MemberOf_1')).toBeTruthy();
             expect(graph.hasEdge('1_GetChangesAll_2')).toBeTruthy();
         });
     });

--- a/cmd/ui/src/views/Explore/utils.ts
+++ b/cmd/ui/src/views/Explore/utils.ts
@@ -19,7 +19,7 @@ import { GLYPHS, GetIconInfo, GlyphKind, IconDictionary, getGlyphFromKinds } fro
 import { MultiDirectedGraph } from 'graphology';
 import { random } from 'graphology-layout';
 import forceAtlas2 from 'graphology-layout-forceatlas2';
-import { GraphData, GraphEdges, GraphNodes } from 'js-client-library';
+import { GraphData, GraphEdge, GraphEdges, GraphNodes } from 'js-client-library';
 import { RankDirection, layoutDagre } from 'src/hooks/useLayoutDagre/useLayoutDagre';
 import { GlyphLocation } from 'src/rendering/programs/node.glyphs';
 import { EdgeDirection, EdgeParams, NodeParams, ThemedOptions } from 'src/utils';

--- a/cmd/ui/src/views/Explore/utils.ts
+++ b/cmd/ui/src/views/Explore/utils.ts
@@ -154,14 +154,20 @@ const initGraphNodes = (
 
 const initGraphEdges = (graph: MultiDirectedGraph, edges: GraphEdges, themedOptions: ThemedOptions) => {
     // Group edges with the same start and end nodes into arrays. Should be grouped regardless of direction
+    const lookupSet = new Set<string>();
     const groupedEdges = edges.reduce<Record<string, GraphEdges>>((groups, edge) => {
-        const identifiers = [edge.source, edge.target].sort();
-        const id = `${identifiers[0]}_${identifiers[1]}`;
+        const groupKey = getEdgeGroupKey(edge);
+        const edgeKey = getEdgeKey(edge);
 
-        if (!groups[id]) {
-            groups[id] = [];
+        if (!groups[groupKey]) {
+            groups[groupKey] = [];
         }
-        groups[id].push(edge);
+
+        // Dedupe edges before they are added to groups so that curved edges get counted and rendered correctly
+        if (!lookupSet.has(edgeKey)) {
+            lookupSet.add(edgeKey);
+            groups[groupKey].push(edge);
+        }
 
         return groups;
     }, {});
@@ -171,7 +177,7 @@ const initGraphEdges = (graph: MultiDirectedGraph, edges: GraphEdges, themedOpti
         const groupSize = groupedEdges[group].length;
 
         for (const [i, edge] of groupedEdges[group].entries()) {
-            const key = `${edge.source}_${edge.kind}_${edge.target}`;
+            const key = getEdgeKey(edge);
 
             // Set default values for single edges
             const edgeParams: Partial<EdgeParams> = {
@@ -209,4 +215,13 @@ const initGraphEdges = (graph: MultiDirectedGraph, edges: GraphEdges, themedOpti
             graph.addEdgeWithKey(key, edge.source, edge.target, edgeParams);
         }
     }
+};
+
+const getEdgeKey = (edge: GraphEdge) => {
+    return `${edge.source}_${edge.kind}_${edge.target}`;
+};
+
+const getEdgeGroupKey = (edge: GraphEdge) => {
+    const identifiers = [edge.source, edge.target].sort();
+    return `${identifiers[0]}_${identifiers[1]}`;
 };


### PR DESCRIPTION
## Description
Updates our graph data transformation logic to remove duplicate edges before handing them off to graphology.

## Motivation and Context

Resolves BED-6451

Duplicate edges from cypher queries were causing graphology to throw an unhandled exception after a recent refactor to our graph data transformations. 

## How Has This Been Tested?

Added a new test to check that edges are correctly deduped and do not cause an error.

## Screenshots (optional):

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
