### PR TITLE
BED-6507--Saved Queries set to public

### DIFF
--- a/packages/javascript/bh-shared-ui/src/views/Explore/ExploreSearch/SavedQueries/SavedQueryPermissions.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/Explore/ExploreSearch/SavedQueries/SavedQueryPermissions.test.tsx
@@ -88,7 +88,7 @@ describe('SavedQueryPermissions', () => {
         expect(screen.getByText(/loading/i)).toBeInTheDocument();
 
         // Table Header Rendered
-        const nestedElement = await waitFor(() => screen.getByText(/name/i));
+        const nestedElement = await waitFor(() => screen.getByText(/set to public/i));
         expect(nestedElement).toBeInTheDocument();
 
         expect(screen.getByRole('checkbox')).toBeInTheDocument();
@@ -107,7 +107,7 @@ describe('SavedQueryPermissions', () => {
                 setIsPublic={testSetIsPublic}
             />
         );
-        const nestedElement = await waitFor(() => screen.getByText(/name/i));
+        const nestedElement = await waitFor(() => screen.getByText(/set to public/i));
         expect(nestedElement).toBeInTheDocument();
         const setPublicCheckbox = screen.getByTestId('public-query');
         expect(setPublicCheckbox).toBeInTheDocument();
@@ -127,7 +127,7 @@ describe('SavedQueryPermissions', () => {
                 setIsPublic={testSetIsPublic}
             />
         );
-        const nestedElement = await waitFor(() => screen.getByText(/name/i));
+        const nestedElement = await waitFor(() => screen.getByText(/set to public/i));
         expect(nestedElement).toBeInTheDocument();
         const setPublicCheckbox = screen.getByTestId('public-query');
         expect(setPublicCheckbox).toBeInTheDocument();

--- a/packages/javascript/bh-shared-ui/src/views/Explore/ExploreSearch/SavedQueries/SavedQueryPermissions.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/Explore/ExploreSearch/SavedQueries/SavedQueryPermissions.tsx
@@ -125,7 +125,7 @@ const SavedQueryPermissions: React.FC<SavedQueryPermissionsProps> = (props: Save
             {
                 accessorKey: 'name',
                 header: () => {
-                    return <span className='dark:text-neutral-light-1'>Name</span>;
+                    return <span className='dark:text-neutral-light-1 font-normal'>Set to Public</span>;
                 },
                 cell: ({ row }) => {
                     const name = row.original.name;
@@ -177,7 +177,7 @@ const SavedQueryPermissions: React.FC<SavedQueryPermissionsProps> = (props: Save
                         {filteredUsers?.length ? (
                             <DataTable
                                 TableHeadProps={{
-                                    className: 'text-s font-bold first:!w-8 pl-3 first:pl-0 first:text-center',
+                                    className: 'text-s first:!w-8 pl-3 first:pl-0 first:text-center',
                                 }}
                                 TableBodyProps={{ className: 'text-s font-roboto' }}
                                 TableCellProps={{ className: 'first:!w-8 pl-3 first:pl-0 first:text-center' }}


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Updated wording for the isPublic checkbox in Saved Query Permissions

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-6507

Updating the checkbox to read 'Set to Public' makes the functionality much more clear to the user.  

## How Has This Been Tested?

Tested manually in local dev environment.  
Unit test updated.
Existing tests passing.  

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- [x] Chore (a change that does not modify the application functionality)
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)
- Database Migrations

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
