### PR TITLE
fix(FeatureFlags): ensure feature request throws 403s

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+# CODEOWNERS
+# Last matching rule wins. Keep specific exclusions below general rules if needed.
+
+# NPM and Yarn files
+**/package.json              @superlinkx @elikmiller
+**/package-lock.json         @superlinkx @elikmiller
+**/.yarn/**                  @superlinkx @elikmiller
+**/.yarnrc                   @superlinkx @elikmiller
+**/.yarnrc.yml               @superlinkx @elikmiller
+**/yarn.lock                 @superlinkx @elikmiller
+**/yarn-workspaces.json      @superlinkx @elikmiller

--- a/cmd/api/src/api/v2/access_control_list.go
+++ b/cmd/api/src/api/v2/access_control_list.go
@@ -1,0 +1,59 @@
+// Copyright 2025 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package v2
+
+import (
+	"context"
+
+	"github.com/specterops/bloodhound/cmd/api/src/database"
+	"github.com/specterops/bloodhound/cmd/api/src/model"
+)
+
+type UpdateEnvironmentRequest struct {
+	EnvironmentID string `json:"environment_id"`
+}
+
+type UpdateUserEnvironmentAccessControlRequest struct {
+	Environments []UpdateEnvironmentRequest `json:"environments"`
+}
+
+func CheckUserAccessToEnvironments(ctx context.Context, db database.EnvironmentAccessControlData, user model.User, environments ...string) (bool, error) {
+	if user.AllEnvironments {
+		return true, nil
+	}
+
+	allowedList, err := db.GetEnvironmentAccessListForUser(ctx, user)
+
+	if err != nil {
+		return false, err
+	}
+
+	allowedMap := make(map[string]struct{}, len(allowedList))
+	for _, envAccess := range allowedList {
+		allowedMap[envAccess.EnvironmentID] = struct{}{}
+	}
+
+	for _, env := range environments {
+		_, ok := allowedMap[env]
+
+		if !ok {
+			return false, nil
+		}
+	}
+
+	return true, nil
+}

--- a/cmd/api/src/api/v2/access_control_list_test.go
+++ b/cmd/api/src/api/v2/access_control_list_test.go
@@ -1,0 +1,208 @@
+// Copyright 2025 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package v2_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gofrs/uuid"
+	v2 "github.com/specterops/bloodhound/cmd/api/src/api/v2"
+	"github.com/specterops/bloodhound/cmd/api/src/database/mocks"
+	"github.com/specterops/bloodhound/cmd/api/src/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func Test_CheckAccessToEnvironments(t *testing.T) {
+	t.Parallel()
+
+	type mock struct {
+		mockDatabase *mocks.MockDatabase
+		mockUser     model.User
+	}
+	type input struct {
+		environments []string
+		user         model.User
+	}
+	type testData struct {
+		name       string
+		setupMocks func(t *testing.T, mock *mock)
+		input      input
+		expected   bool
+	}
+
+	userUuid, err := uuid.NewV4()
+
+	require.NoError(t, err)
+
+	testCases := []testData{
+		{
+			name: "Positive Test - Exact Match",
+			setupMocks: func(t *testing.T, mock *mock) {
+				t.Helper()
+
+				envs := []model.EnvironmentAccess{
+					{
+						UserID:        userUuid.String(),
+						EnvironmentID: "1",
+					},
+					{
+						UserID:        userUuid.String(),
+						EnvironmentID: "2",
+					},
+					{
+						UserID:        userUuid.String(),
+						EnvironmentID: "3",
+					},
+				}
+
+				mock.mockDatabase.EXPECT().GetEnvironmentAccessListForUser(gomock.Any(), mock.mockUser).Return(envs, nil)
+			},
+			input: input{
+				environments: []string{"1", "2", "3"},
+				user: model.User{
+					Unique: model.Unique{
+						ID: userUuid,
+					},
+					AllEnvironments: false,
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "Positive Test - Partial Match",
+			setupMocks: func(t *testing.T, mock *mock) {
+				t.Helper()
+
+				envs := []model.EnvironmentAccess{
+					{
+						UserID:        userUuid.String(),
+						EnvironmentID: "1",
+					},
+					{
+						UserID:        userUuid.String(),
+						EnvironmentID: "2",
+					},
+					{
+						UserID:        userUuid.String(),
+						EnvironmentID: "3",
+					},
+				}
+
+				mock.mockDatabase.EXPECT().GetEnvironmentAccessListForUser(gomock.Any(), mock.mockUser).Return(envs, nil)
+			},
+			input: input{
+				environments: []string{"1", "2"},
+				user: model.User{
+					Unique: model.Unique{
+						ID: userUuid,
+					},
+					AllEnvironments: false,
+				},
+			}, expected: true,
+		},
+		{
+			name: "Negative Test - Extra Environment",
+			setupMocks: func(t *testing.T, mock *mock) {
+				t.Helper()
+
+				envs := []model.EnvironmentAccess{
+					{
+						UserID:        userUuid.String(),
+						EnvironmentID: "1",
+					},
+					{
+						UserID:        userUuid.String(),
+						EnvironmentID: "2",
+					},
+					{
+						UserID:        userUuid.String(),
+						EnvironmentID: "3",
+					},
+				}
+
+				mock.mockDatabase.EXPECT().GetEnvironmentAccessListForUser(gomock.Any(), mock.mockUser).Return(envs, nil)
+			},
+			input: input{
+				environments: []string{"1", "2", "4"},
+				user: model.User{
+					Unique: model.Unique{
+						ID: userUuid,
+					},
+					AllEnvironments: false,
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "Negative Test - No Allowed Environments",
+			setupMocks: func(t *testing.T, mock *mock) {
+				t.Helper()
+
+				envs := []model.EnvironmentAccess{}
+
+				mock.mockDatabase.EXPECT().GetEnvironmentAccessListForUser(gomock.Any(), mock.mockUser).Return(envs, nil)
+			},
+			input: input{
+				environments: []string{"1", "2", "4"},
+				user: model.User{
+					Unique: model.Unique{
+						ID: userUuid,
+					},
+					AllEnvironments: false,
+				},
+			},
+			expected: false,
+		},
+		{
+			name:       "Positive Test - All Environments True",
+			setupMocks: func(t *testing.T, mock *mock) {},
+			input: input{
+				environments: []string{"1", "2", "4"},
+				user: model.User{
+					Unique: model.Unique{
+						ID: userUuid,
+					},
+					AllEnvironments: true,
+				},
+			},
+			expected: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctrl := gomock.NewController(t)
+
+			mocks := &mock{
+				mockDatabase: mocks.NewMockDatabase(ctrl),
+				mockUser:     testCase.input.user,
+			}
+
+			testCase.setupMocks(t, mocks)
+
+			actual, err := v2.CheckUserAccessToEnvironments(context.Background(), mocks.mockDatabase, testCase.input.user, testCase.input.environments...)
+
+			require.NoError(t, err)
+			assert.Equal(t, testCase.expected, actual)
+		})
+	}
+}

--- a/cmd/api/src/api/v2/auth/etac.go
+++ b/cmd/api/src/api/v2/auth/etac.go
@@ -1,0 +1,102 @@
+// Copyright 2025 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package auth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/specterops/bloodhound/cmd/api/src/api"
+	v2 "github.com/specterops/bloodhound/cmd/api/src/api/v2"
+	"github.com/specterops/bloodhound/cmd/api/src/auth"
+	"github.com/specterops/bloodhound/cmd/api/src/model"
+	"github.com/specterops/bloodhound/cmd/api/src/queries"
+	"github.com/specterops/bloodhound/packages/go/graphschema/ad"
+	"github.com/specterops/bloodhound/packages/go/graphschema/azure"
+	"github.com/specterops/bloodhound/packages/go/graphschema/common"
+	"github.com/specterops/dawgs/graph"
+)
+
+// handleETACRequest will modify the user passed in to assign an etac list or grant all environment access
+// and will return an error on bad requests
+// Administrators and Power Users may not have an ETAC list applied to them
+// The user may not request all environments and have an ETAC list applied to them
+func handleETACRequest(ctx context.Context, updateUserRequest v2.UpdateUserRequest, roles model.Roles, user *model.User, graphDB queries.Graph) error {
+	if updateUserRequest.AllEnvironments.Valid || updateUserRequest.EnvironmentAccessControl != nil {
+		// Admin / Power Users can only have all_environments set to true
+		if (roles.Has(model.Role{Name: auth.RoleAdministrator}) || roles.Has(model.Role{Name: auth.RolePowerUser})) &&
+			(!updateUserRequest.AllEnvironments.Bool || (updateUserRequest.EnvironmentAccessControl != nil && len(updateUserRequest.EnvironmentAccessControl.Environments) > 0)) {
+			return errors.New(api.ErrorResponseETACInvalidRoles)
+		}
+		user.AllEnvironments = updateUserRequest.AllEnvironments.Bool
+	}
+
+	if updateUserRequest.EnvironmentAccessControl == nil || len(updateUserRequest.EnvironmentAccessControl.Environments) == 0 {
+		user.EnvironmentAccessControl = make([]model.EnvironmentAccess, 0)
+		return nil
+	}
+
+	// Both all_environments and environment_access_control was set on the request
+	// A user may only have all_environments true or an environment access control list
+	if updateUserRequest.AllEnvironments.Bool {
+		return errors.New(api.ErrorResponseETACBadRequest)
+	}
+
+	// Validate provided environment ids exist in the graph prior to adding ETAC control
+	var envIds []string
+	for _, environment := range updateUserRequest.EnvironmentAccessControl.Environments {
+		envIds = append(envIds, environment.EnvironmentID)
+	}
+
+	if nodes, err := graphDB.FetchNodesByObjectIDsAndKinds(ctx, graph.Kinds{
+		ad.Domain, azure.Tenant,
+	}, envIds...); err != nil {
+		return fmt.Errorf("error fetching environments: %w", err)
+	} else if nodesByObject, err := nodeSetToObjectIDMap(nodes); err != nil {
+		return err
+	} else {
+		for _, envId := range envIds {
+			if _, ok := nodesByObject[envId]; !ok {
+				return fmt.Errorf("domain or tenant not found: %s", envId)
+			} else {
+				user.EnvironmentAccessControl = append(user.EnvironmentAccessControl, model.EnvironmentAccess{
+					UserID:        user.ID.String(),
+					EnvironmentID: envId,
+				})
+			}
+		}
+	}
+
+	return nil
+}
+
+func nodeSetToObjectIDMap(set graph.NodeSet) (map[string]bool, error) {
+	var (
+		objectIDs = make(map[string]bool)
+	)
+
+	for _, node := range set {
+		if objectID, err := node.Properties.Get(common.ObjectID.String()).String(); err != nil {
+			return objectIDs, err
+		} else {
+			objectIDs[objectID] = true
+		}
+	}
+
+	return objectIDs, nil
+}

--- a/cmd/api/src/database/migration/migrations/v8.3.0.sql
+++ b/cmd/api/src/database/migration/migrations/v8.3.0.sql
@@ -1,0 +1,63 @@
+-- Copyright 2025 Specter Ops, Inc.
+--
+-- Licensed under the Apache License, Version 2.0
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- SPDX-License-Identifier: Apache-2.0
+
+
+-- Set all_environments to true for existing users
+UPDATE users SET all_environments = true;
+-- Rename environment to environment_id to prepare for data partitioning, if the column does not exist then we throw away the error for idempotence
+DO
+$$
+    BEGIN
+        ALTER TABLE environment_access_control
+            RENAME COLUMN environment TO environment_id;
+    EXCEPTION
+        WHEN undefined_column THEN
+    END;
+$$;
+
+-- This migration changes the auto_certify column type from a boolean to an integer type
+-- Then it converts the previous boolean values into enum-like integer values of 0, 1, or 2
+DO $$
+	BEGIN
+		IF (
+            SELECT data_type
+            FROM information_schema.columns
+            WHERE table_name = 'asset_group_tag_selectors' AND column_name = 'auto_certify'
+        ) = 'boolean' THEN
+		    ALTER TABLE asset_group_tag_selectors ADD COLUMN auto_certify_int INTEGER NOT NULL DEFAULT 0;
+		
+		    -- 0 means disabled 
+		    -- 1 is enabled for all objects (seeds, children, parents) 
+		    -- 2 is enabled for seeds only
+		    UPDATE asset_group_tag_selectors selectors
+		    SET auto_certify_int = CASE
+		        WHEN selectors.is_default THEN 2                      
+		        WHEN selectors.auto_certify = TRUE THEN 1             
+		        WHEN EXISTS (                                         
+		            SELECT *
+		            FROM asset_group_tag_selector_seeds seeds
+		            WHERE seeds.type = 1 AND seeds.selector_id = selectors.id
+		        ) THEN 2
+		        ELSE 0
+		    END
+		    FROM asset_group_tags tags
+		    WHERE selectors.asset_group_tag_id = tags.id;
+		
+		    ALTER TABLE asset_group_tag_selectors DROP COLUMN auto_certify;
+		    ALTER TABLE asset_group_tag_selectors RENAME COLUMN auto_certify_int TO auto_certify;
+		END IF;
+	END;
+$$;

--- a/cmd/api/src/model/access_control_list.go
+++ b/cmd/api/src/model/access_control_list.go
@@ -1,0 +1,27 @@
+// Copyright 2025 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+package model
+
+// EnvironmentAccess defines the model for a row in the environment_access_control table
+type EnvironmentAccess struct {
+	UserID        string `json:"user_id"`
+	EnvironmentID string `json:"environment_id"`
+	BigSerial
+}
+
+func (EnvironmentAccess) TableName() string {
+	return "environment_access_control"
+}

--- a/packages/go/openapi/src/schemas/model.asset-group-tags-selector-request.yaml
+++ b/packages/go/openapi/src/schemas/model.asset-group-tags-selector-request.yaml
@@ -1,0 +1,29 @@
+# Copyright 2025 Specter Ops, Inc.
+#
+# Licensed under the Apache License, Version 2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+allOf:
+  - $ref: './../schemas/model.asset-group-tags-selector-response.yaml'
+  - type: object
+    properties:
+      auto_certify:
+        type: integer
+        enum: [0,1,2]
+        description: auto_certify must be an input value of 0 (Disabled), 1 (AllMembers), or 2 (SeedsOnly)
+      description:
+        type: string
+      disabled:
+        type: boolean
+

--- a/packages/go/openapi/src/schemas/model.environment-access-control.yaml
+++ b/packages/go/openapi/src/schemas/model.environment-access-control.yaml
@@ -1,0 +1,26 @@
+# Copyright 2025 Specter Ops, Inc.
+#
+# Licensed under the Apache License, Version 2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+type: object
+properties:
+  user_id:
+    type: string
+    format: uuid
+    description: The user UUID that associates the access control to a specific user
+    readOnly: true
+  environment_id:
+    type: string
+    description: The environment id which a user has been granted access to

--- a/packages/javascript/bh-shared-ui/src/components/DetailsAccordion/DetailsAccordion.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/DetailsAccordion/DetailsAccordion.test.tsx
@@ -1,0 +1,224 @@
+// Copyright 2025 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import userEvent from '@testing-library/user-event';
+
+import { render, screen } from '../../test-utils';
+import { DetailsAccordion } from './DetailsAccordion';
+
+// Need test ID for icon
+vi.mock('@fortawesome/react-fontawesome', () => ({
+    FontAwesomeIcon: ({ className }: any) => <span data-testid='fa' className={className} />,
+}));
+
+vi.mock('@fortawesome/free-solid-svg-icons', () => ({ faAngleDown: {} }));
+
+type Item = { title: string; description: string; disabled?: boolean };
+
+const Header: React.FC<Item> = (item) => <h3>{item.title}</h3>;
+const Content: React.FC<Item> = (item) => <p>{item.description}</p>;
+const Empty: React.FC = () => <div role='status'>No items</div>;
+
+describe('<DetailsAccordion />', () => {
+    it('renders Empty when items is undefined and Empty is provided', () => {
+        render(<DetailsAccordion<Item> Header={Header} Content={Content} Empty={Empty} />);
+        expect(screen.getByRole('status')).toHaveTextContent('No items');
+    });
+
+    it('renders a single item when items is an object', () => {
+        render(
+            <DetailsAccordion<Item>
+                Header={Header}
+                Content={Content}
+                items={{ title: 'One', description: 'Only child' }}
+            />
+        );
+        expect(screen.getByRole('button')).toHaveTextContent('One');
+    });
+
+    it('passes item props to Header and Content', async () => {
+        const user = userEvent.setup();
+        render(
+            <DetailsAccordion<Item>
+                Header={Header}
+                Content={Content}
+                items={[
+                    { title: 'A', description: 'Alpha' },
+                    { title: 'B', description: 'Beta' },
+                ]}
+                openIndex={0}
+            />
+        );
+
+        // default open is index 0 -> content "Alpha" should be visible
+        expect(screen.getByText('Alpha')).toBeInTheDocument();
+
+        // Click header B, then "Beta" should appear
+        await user.click(screen.getByRole('button', { name: 'B' }));
+        expect(screen.getByText('Beta')).toBeInTheDocument();
+    });
+
+    it('calls getKey for each item (stable keys hook)', () => {
+        const items = [
+            { title: 'A', description: 'Alpha' },
+            { title: 'B', description: 'Beta' },
+        ];
+        const getKey = vi.fn((i: Item) => i.title);
+
+        render(<DetailsAccordion<Item> Header={Header} Content={Content} items={items} getKey={getKey} />);
+
+        expect(getKey).toHaveBeenCalledTimes(2);
+        expect(getKey).toHaveBeenNthCalledWith(1, items[0], 0);
+        expect(getKey).toHaveBeenNthCalledWith(2, items[1], 1);
+    });
+
+    it('skips undefined items gracefully', () => {
+        render(
+            <DetailsAccordion<any>
+                Header={({ label }: any) => <div>{label}</div>}
+                Content={() => <div>ok</div>}
+                // an undefined item
+                items={[{ label: 'Valid' }, undefined]}
+            />
+        );
+        expect(screen.getByRole('button')).toHaveTextContent('Valid');
+        // only one header rendered
+        expect(screen.getAllByRole('button')).toHaveLength(1);
+    });
+
+    it('applies accent styling to headers when accent is true', () => {
+        render(
+            <DetailsAccordion<Item>
+                Header={Header}
+                Content={Content}
+                items={[{ title: 'Fancy', description: 'With accent' }]}
+                accent
+            />
+        );
+
+        const header = screen.getByRole('button');
+        // spot-check invariant classes from implementation
+        expect(header).toHaveClass('border-l-8');
+        expect(header).toHaveClass('border-primary');
+    });
+
+    it('disables items via itemDisabled and hides the chevron icon visually', () => {
+        render(
+            <DetailsAccordion<Item>
+                Header={Header}
+                Content={Content}
+                items={[
+                    { title: 'Disabled', description: 'Nope', disabled: true },
+                    { title: 'Enabled', description: 'Yep', disabled: false },
+                ]}
+                itemDisabled={(i) => !!i.disabled}
+            />
+        );
+
+        const [disabledHeader, enabledHeader] = screen.getAllByRole('button');
+        expect(disabledHeader).toHaveAttribute('data-disabled');
+
+        // Icon for disabled row should have opacity-0
+        const disabledIcon = disabledHeader.querySelector('[data-testid="fa"]');
+        expect(disabledIcon).toHaveClass('opacity-0');
+
+        const enabledIcon = enabledHeader.querySelector('[data-testid="fa"]');
+        expect(enabledIcon).not.toHaveClass('opacity-0');
+    });
+
+    it('respects openIndex (default opened panel)', () => {
+        render(
+            <DetailsAccordion<Item>
+                Header={Header}
+                Content={Content}
+                items={[
+                    { title: 'First', description: 'one' },
+                    { title: 'Second', description: 'two' },
+                ]}
+                openIndex={1}
+            />
+        );
+        const firstHeader = screen.getByRole('button', { name: /First/i });
+        const secondHeader = screen.getByRole('button', { name: /Second/i });
+        expect(firstHeader).toHaveAttribute('aria-expanded', 'false');
+        expect(secondHeader).toHaveAttribute('aria-expanded', 'true');
+    });
+
+    it('clicking a disabled header does not toggle content', async () => {
+        const user = userEvent.setup();
+        render(
+            <DetailsAccordion<Item>
+                Header={Header}
+                Content={Content}
+                items={[{ title: 'Locked', description: 'hidden', disabled: true }]}
+                itemDisabled={(i) => !!i.disabled}
+            />
+        );
+
+        const header = screen.getByRole('button', { name: /Locked/i });
+        await user.click(header);
+
+        // never opens
+        expect(screen.queryByText('hidden')).not.toBeInTheDocument();
+    });
+
+    it('clicking an enabled header toggles content (single mode)', async () => {
+        const user = userEvent.setup();
+        render(
+            <DetailsAccordion<Item>
+                Header={Header}
+                Content={Content}
+                items={[
+                    { title: 'A', description: 'Alpha' },
+                    { title: 'B', description: 'Beta' },
+                ]}
+            />
+        );
+
+        // Initially nothing is open (no openIndex)
+        expect(screen.queryByText('Alpha')).not.toBeInTheDocument();
+        expect(screen.queryByText('Beta')).not.toBeInTheDocument();
+
+        const a = screen.getByRole('button', { name: /A/i });
+        const b = screen.getByRole('button', { name: /B/i });
+
+        // Open A
+        await user.click(a);
+        expect(a).toHaveAttribute('aria-expanded', 'true');
+
+        // Open B (single mode should close A)
+        await user.click(b);
+        expect(a).toHaveAttribute('aria-expanded', 'false');
+        expect(b).toHaveAttribute('aria-expanded', 'true');
+    });
+
+    it('collapses an open item when its header is clicked again', async () => {
+        const user = userEvent.setup();
+        render(
+            <DetailsAccordion<Item>
+                Header={Header}
+                Content={Content}
+                items={[{ title: 'A', description: 'Alpha' }]}
+                openIndex={0}
+            />
+        );
+        const header = screen.getByRole('button', { name: /A/i });
+        expect(screen.getByText('Alpha')).toBeInTheDocument();
+        await user.click(header);
+        // Prefer visibility or aria-expanded as noted above
+        expect(header).toHaveAttribute('aria-expanded', 'false');
+    });
+});

--- a/packages/javascript/bh-shared-ui/src/components/DetailsAccordion/DetailsAccordion.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/DetailsAccordion/DetailsAccordion.tsx
@@ -1,0 +1,133 @@
+// Copyright 2025 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { Accordion, AccordionContent, AccordionHeader, AccordionItem } from '@bloodhoundenterprise/doodleui';
+import { faAngleDown } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import clsx from 'clsx';
+
+import React, { ComponentType } from 'react';
+
+export type DetailsAccordionProps<T extends Record<string, unknown>> = {
+    /** If `true`, applies an accent style to item headers  */
+    accent?: boolean;
+
+    /** Component to render the content area of each item */
+    Content: ComponentType<T>;
+
+    /** Optional component to render when `items` is `undefined` */
+    Empty?: ComponentType;
+
+    /** Function to provide a stable key for each row (defaults to index) */
+    getKey?: (item: T, index: number) => React.Key;
+
+    /** Predicate to determine if an item is disabled (default: always `false`) */
+    itemDisabled?: (item: T) => boolean;
+
+    /** Component to render the header of each item */
+    Header: ComponentType<T>;
+
+    /** A single item or array of items to render */
+    items?: T | T[];
+
+    /** Index of the item that should start open (`undefined` = none) */
+    openIndex?: number;
+};
+
+/**
+ * A generic accordion component for displaying a list of items, where each
+ * item has a header and expandable content.
+ *
+ * @typeParam T - Shape of a rendered item. Extends `Record<string, unknown>`.
+ *
+ * @remarks
+ * - Renders each item inside a single-select accordion panel.
+ * - If `items` is `undefined` and an `Empty` component is provided, the `Empty` component will render instead.
+ * - Each item is passed as props to the `Header` and `Content` components.
+ * - Supports disabling items, custom keys, and optionally applying an accent style.
+ *
+ * @example
+ * ```tsx
+ * <DetailsAccordion
+ *   Header={({ title }) => <div>{title}</div>}
+ *   Content={({ description }) => <p>{description}</p>}
+ *   items={[
+ *     { title: "First", description: "First item description" },
+ *     { title: "Second", description: "Second item description" },
+ *   ]}
+ *   openIndex={0}
+ * />
+ * ```
+ */
+export const DetailsAccordion = <T extends Record<string, unknown>>({
+    accent = false,
+    Content,
+    Empty,
+    getKey,
+    items,
+    itemDisabled = () => false,
+    Header,
+    openIndex,
+}: DetailsAccordionProps<T>) => {
+    if (items === undefined && Empty) {
+        return <Empty />;
+    }
+
+    const itemArray = Array.isArray(items) ? items : [items];
+
+    const defaultValue =
+        typeof openIndex === 'number' && openIndex >= 0 && openIndex < itemArray.length ? String(openIndex) : undefined;
+
+    return (
+        <Accordion collapsible defaultValue={defaultValue} type='single'>
+            {itemArray.map((item, idx) => {
+                if (item === undefined) {
+                    return null;
+                }
+
+                const key = getKey ? getKey(item, idx) : idx;
+                const isDisabled = itemDisabled(item);
+
+                return (
+                    <AccordionItem
+                        className='bg-neutral-light-2 dark:bg-neutral-dark-2 border-t dark:border-neutral-dark-4 first:border-none'
+                        disabled={isDisabled}
+                        key={key}
+                        value={String(idx)}>
+                        <AccordionHeader
+                            className={clsx(
+                                'h-16',
+                                !isDisabled && 'cursor-pointer',
+                                isDisabled && 'hover:no-underline',
+                                accent && 'bg-[#e0e0e0] dark:bg-[#202020] border-l-8 border-primary'
+                            )}>
+                            <FontAwesomeIcon
+                                aria-hidden
+                                className={clsx(isDisabled && 'opacity-0')}
+                                icon={faAngleDown}
+                            />
+                            <Header {...item} />
+                        </AccordionHeader>
+
+                        <AccordionContent className='pr-6 text-base border-t dark:border-neutral-dark-4'>
+                            <Content {...item} />
+                        </AccordionContent>
+                    </AccordionItem>
+                );
+            })}
+        </Accordion>
+    );
+};

--- a/packages/javascript/bh-shared-ui/src/components/DetailsAccordion/index.ts
+++ b/packages/javascript/bh-shared-ui/src/components/DetailsAccordion/index.ts
@@ -1,0 +1,17 @@
+// Copyright 2025 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+export * from './DetailsAccordion';

--- a/packages/javascript/bh-shared-ui/src/hooks/useFeatureFlags.tsx
+++ b/packages/javascript/bh-shared-ui/src/hooks/useFeatureFlags.tsx
@@ -52,18 +52,7 @@ export function useFeatureFlags<T = Flag[]>(options?: QueryOptions<T>) {
     return useQuery({
         ...rest,
         queryKey: featureFlagKeys.getKey(options?.queryKey),
-        queryFn: async ({ signal }) => {
-            try {
-                return await getFeatureFlags({ signal });
-            } catch (error) {
-                const status = (error as AxiosError).response?.status;
-                // Ignore 403s as any retries will still be 403
-                if (status === FORBIDDEN) {
-                    return [] as Flag[];
-                }
-                throw error;
-            }
-        },
+        queryFn: ({ signal }) => getFeatureFlags({ signal }),
     });
 }
 


### PR DESCRIPTION
## Description

Fixes issue with Upload Only uses not able to interact with feature flagged components

## Motivation and Context

Resolves BED-6513

## How Has This Been Tested?

Manually tested

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Feature flag loading now correctly surfaces access-related errors instead of silently treating them as no flags. Users may see an error state or message when flags cannot be retrieved, improving transparency and troubleshooting.
  * Aligns error and retry behavior with the app’s standard handling, reducing confusing states where features appeared disabled without explanation.
  * No changes to how you use feature flags; only error visibility and handling are improved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->