### PR TITLE
feat: BED-5246 certification action buttons

### DIFF
--- a/packages/javascript/bh-shared-ui/src/views/ZoneManagement/Certification/Certification.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/ZoneManagement/Certification/Certification.test.tsx
@@ -1,0 +1,152 @@
+import userEvent from '@testing-library/user-event';
+import { CertificationManual, CertificationRevoked } from 'js-client-library';
+import { rest } from 'msw';
+import { setupServer } from 'msw/node';
+import { render, screen } from '../../../test-utils';
+import { apiClient } from '../../../utils';
+import Certification from './Certification';
+
+//TODO -- add selection to test once it's no longer mocked in the component
+const certifyMembersSpy = vi.spyOn(apiClient, 'updateAssetGroupTagCertification');
+
+const addNotificationMock = vi.fn();
+
+vi.mock('../../../providers', async () => {
+    const actual = await vi.importActual('../../../providers');
+    return {
+        ...actual,
+        useNotifications: () => {
+            return { addNotification: addNotificationMock };
+        },
+    };
+});
+
+const server = setupServer(
+    rest.post(`/api/v2/asset-group-tags/certifications`, async (_, res, ctx) => {
+        return res(ctx.status(200));
+    })
+);
+
+const user = userEvent.setup();
+
+beforeAll(() => server.listen());
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+describe('Certification', () => {
+    it('submits the selected items for certification with a note', async () => {
+        const { container } = render(<Certification></Certification>);
+        const textNote = 'a note';
+        const certifyButton = await screen.findByText('Certify');
+        expect(certifyButton).toBeInTheDocument();
+
+        await user.click(certifyButton);
+        const noteDialog = await screen.findByRole('dialog');
+        expect(noteDialog).toBeInTheDocument();
+
+        const input = container.querySelector('#textNote');
+        await user.type(input!, textNote);
+        expect(input).toHaveValue(textNote);
+        const saveNote = await screen.findByText('Save Note');
+        await user.click(saveNote);
+
+        expect(certifyMembersSpy).toHaveBeenCalledTimes(1);
+
+        expect(certifyMembersSpy).toHaveBeenCalledWith({
+            member_ids: [777, 290, 91],
+            action: CertificationManual,
+            note: textNote,
+        });
+        expect(addNotificationMock).toBeCalledWith(
+            'Selected Certification Successful',
+            'zone-management_update-certification_success',
+            {
+                anchorOrigin: { vertical: 'top', horizontal: 'right' },
+            }
+        );
+    });
+    it('submits the selected items for certification without a note', async () => {
+        render(<Certification></Certification>);
+        const certifyButton = await screen.findByText('Certify');
+        expect(certifyButton).toBeInTheDocument();
+
+        await user.click(certifyButton);
+        const noteDialog = await screen.findByRole('dialog');
+        expect(noteDialog).toBeInTheDocument();
+
+        const skipNote = await screen.findByText('Skip Note');
+        await user.click(skipNote);
+
+        expect(certifyMembersSpy).toHaveBeenCalledTimes(1);
+        expect(certifyMembersSpy).toHaveBeenCalledWith({
+            member_ids: [777, 290, 91],
+            action: CertificationManual,
+        });
+        expect(addNotificationMock).toBeCalledWith(
+            'Selected Certification Successful',
+            'zone-management_update-certification_success',
+            {
+                anchorOrigin: { vertical: 'top', horizontal: 'right' },
+            }
+        );
+    });
+    it('submits the selected items for revocation', async () => {
+        render(<Certification></Certification>);
+        const revokeButton = await screen.findByText('Revoke');
+        expect(revokeButton).toBeInTheDocument();
+
+        await user.click(revokeButton);
+        const noteDialog = await screen.findByRole('dialog');
+        expect(noteDialog).toBeInTheDocument();
+
+        const skipNote = await screen.findByText('Skip Note');
+        await user.click(skipNote);
+
+        expect(certifyMembersSpy).toHaveBeenCalledTimes(1);
+        expect(certifyMembersSpy).toHaveBeenCalledWith({
+            member_ids: [777, 290, 91],
+            action: CertificationRevoked,
+        });
+        expect(addNotificationMock).toBeCalledWith(
+            'Selected Revocation Successful',
+            'zone-management_update-certification_success',
+            {
+                anchorOrigin: { vertical: 'top', horizontal: 'right' },
+            }
+        );
+    });
+    it('does not call the API if no items are selected', async () => {
+        // TODO once no longer mocked
+    });
+    it('displays an error notification if the certification was unsuccessful', async () => {
+        server.use(
+            rest.post(`/api/v2/asset-group-tags/certifications`, async (_, res, ctx) => {
+                return res(ctx.status(500));
+            })
+        );
+
+        render(<Certification></Certification>);
+        const certifyButton = await screen.findByText('Certify');
+        expect(certifyButton).toBeInTheDocument();
+
+        await user.click(certifyButton);
+        const noteDialog = await screen.findByRole('dialog');
+        expect(noteDialog).toBeInTheDocument();
+
+        const skipNote = await screen.findByText('Skip Note');
+        await user.click(skipNote);
+
+        expect(certifyMembersSpy).toHaveBeenCalledTimes(1);
+        expect(certifyMembersSpy).toHaveBeenCalledWith({
+            member_ids: [777, 290, 91],
+            action: CertificationManual,
+        });
+        expect(addNotificationMock).toBeCalledWith(
+            'There was an error updating certification',
+            `zone-management_update-certification_error`,
+            {
+                anchorOrigin: { vertical: 'top', horizontal: 'right' },
+            }
+        );
+    });
+});

--- a/packages/javascript/bh-shared-ui/src/views/ZoneManagement/Certification/Certification.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/ZoneManagement/Certification/Certification.tsx
@@ -133,12 +133,9 @@ const Certification: FC = () => {
         setCertifyAction(action);
     };
 
-    console.log('selected rows PARENT in not handler', selectedRows);
-
     const handleConfirm = useCallback(
         (withNote: boolean, certifyNote?: string) => {
             setIsDialogOpen(false);
-            console.log('selected rows~ PARENT!', selectedRows);
             const selectedMemberIds = selectedRows;
             if (selectedMemberIds.length === 0) {
                 addNotification(
@@ -154,7 +151,7 @@ const Certification: FC = () => {
             const requestBody = createCertificationRequestBody(certifyAction, selectedMemberIds, withNote, certifyNote);
             certifyMutation.mutate(requestBody);
         },
-        [certifyAction]
+        [addNotification, certifyAction, certifyMutation, selectedRows]
     );
 
     return (

--- a/packages/javascript/bh-shared-ui/src/views/ZoneManagement/Certification/Certification.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/ZoneManagement/Certification/Certification.tsx
@@ -6,6 +6,7 @@ import { EntityInfoDataTable, EntityInfoPanel } from '../../../components';
 import { EntityKinds, apiClient } from '../../../utils';
 import EntitySelectorsInformation from '../Details/EntitySelectorsInformation';
 import CertificationTable from './CertificationTable';
+import CertifyMembersConfirmDialog from './CertifyMembersConfirmDialog';
 
 const Certification: FC = () => {
     const { tierId, labelId } = useParams();
@@ -77,32 +78,58 @@ const Certification: FC = () => {
         type: memberQuery.data?.primary_kind as EntityKinds,
     };
 
+    const showDialog = (choice: string) => {
+        setIsDialogOpen(true);
+        setCertifyOrRevoke(choice);
+    };
+
+    const [isDialogOpen, setIsDialogOpen] = useState(false);
+    // TODO -- make this type safe
+    const [certifyOrRevoke, setCertifyOrRevoke] = useState('');
+
+    const handleConfirm = (withNote: boolean, certifyNote?: string) => {
+        console.log('Confirmed! Note: ', certifyNote);
+        // TODO -- input sanitization?
+        setIsDialogOpen(false);
+        // TODO -- make API call
+    };
+
     return (
-        <div className='flex gap-8 mt-4'>
-            <div className='basis-2/3'>
-                <CertificationTable
-                    data={data}
-                    isLoading={isLoading}
-                    isFetching={isFetching}
-                    isSuccess={isSuccess}
-                    fetchNextPage={fetchNextPage}
-                />
-            </div>
-            <div className='basis-1/3'>
-                <div className='w-[400px] max-w-[400px]'>
-                    <EntityInfoPanel
-                        DataTable={EntityInfoDataTable}
-                        selectedNode={selectedNode}
-                        additionalTables={[
-                            {
-                                sectionProps: { label: 'Selectors', id: memberQuery.data?.object_id },
-                                TableComponent: EntitySelectorsInformation,
-                            },
-                        ]}
+        <>
+            <div className='flex gap-8 mt-4'>
+                <div className='basis-2/3'>
+                    <div className='flex gap-4 mb-4'>
+                        <Button onClick={() => showDialog('certify')}>Certify</Button>
+                        <Button variant='secondary' onClick={() => showDialog('revoke')}>
+                            Revoke
+                        </Button>
+                    </div>
+
+                    <CertificationTable
+                        data={data}
+                        isLoading={isLoading}
+                        isFetching={isFetching}
+                        isSuccess={isSuccess}
+                        fetchNextPage={fetchNextPage}
                     />
                 </div>
+                <div className='basis-1/3'>
+                    <div className='w-[400px] max-w-[400px]'>
+                        <EntityInfoPanel
+                            DataTable={EntityInfoDataTable}
+                            selectedNode={selectedNode}
+                            additionalTables={[
+                                {
+                                    sectionProps: { label: 'Selectors', id: memberQuery.data?.object_id },
+                                    TableComponent: EntitySelectorsInformation,
+                                },
+                            ]}
+                        />
+                    </div>
+                </div>
             </div>
-        </div>
+            {isDialogOpen && <CertifyMembersConfirmDialog open={isDialogOpen} onConfirm={handleConfirm} />}
+        </>
     );
 };
 

--- a/packages/javascript/bh-shared-ui/src/views/ZoneManagement/Certification/CertificationTable.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/ZoneManagement/Certification/CertificationTable.tsx
@@ -7,14 +7,31 @@ import {
     CertificationTypeMap,
 } from 'js-client-library';
 import { DateTime } from 'luxon';
-import { FC, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { FC, useCallback, useEffect, useMemo, useRef } from 'react';
 import { AppIcon, DropdownOption, DropdownSelector } from '../../../components';
 import { useAssetGroupTags, useAvailableEnvironments } from '../../../hooks';
 
-const CertificationTable: FC = ({ data, isLoading, isFetching, isSuccess, fetchNextPage }) => {
+type CertificationTableProps = {
+    data: any;
+    isLoading: boolean;
+    isFetching: boolean;
+    isSuccess: boolean;
+    fetchNextPage: any;
+    selectedRows: number[];
+    setSelectedRows: any;
+};
+
+const CertificationTable: FC<CertificationTableProps> = ({
+    data,
+    isLoading,
+    isFetching,
+    isSuccess,
+    fetchNextPage,
+    selectedRows,
+    setSelectedRows,
+}) => {
     const mockPending = '9';
     const scrollRef = useRef<HTMLDivElement>(null);
-    const [selectedRows, setSelectedRows] = useState<number[]>([]);
 
     const { data: availableEnvironments = [] } = useAvailableEnvironments();
     const { data: assetGroupTags = [] } = useAssetGroupTags();
@@ -163,6 +180,8 @@ const CertificationTable: FC = ({ data, isLoading, isFetching, isSuccess, fetchN
               };
           })
         : [];
+
+    console.log('selected rows in child!!', selectedRows);
 
     return (
         <div className='bg-neutral-light-2 dark:bg-neutral-dark-2'>

--- a/packages/javascript/bh-shared-ui/src/views/ZoneManagement/Certification/CertifyMembersConfirmDialog.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/ZoneManagement/Certification/CertifyMembersConfirmDialog.tsx
@@ -1,0 +1,57 @@
+// Copyright 2025 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { Button, Dialog, DialogActions, DialogContent, DialogTitle } from '@bloodhoundenterprise/doodleui';
+import { TextField } from '@mui/material';
+import { FC, useState } from 'react';
+
+type CertifyMembersConfirmDialogProps = {
+    onConfirm: (withNote: boolean, note?: string) => void;
+    open: boolean;
+};
+
+const CertifyMembersConfirmDialog: FC<CertifyMembersConfirmDialogProps> = ({ onConfirm, open }) => {
+    const [note, setNote] = useState('');
+    const handleChange = (event: any) => {
+        setNote(event.target.value);
+    };
+
+    return (
+        <Dialog open={open} modal={true}>
+            <DialogContent className='' maxWidth='xs' DialogOverlayProps={{ blurBackground: true }}>
+                <DialogTitle className='flex'>Add note</DialogTitle>
+                <TextField
+                    multiline
+                    rows={8}
+                    maxRows={16}
+                    fullWidth
+                    id='textNote'
+                    value={note}
+                    onChange={handleChange}></TextField>
+                <DialogActions>
+                    <Button onClick={() => onConfirm(false)} variant={'text'} className='px-2'>
+                        Skip Note
+                    </Button>
+                    <Button onClick={() => onConfirm(true, note)} variant={'text'} className='px-2'>
+                        Save Note
+                    </Button>
+                </DialogActions>
+            </DialogContent>
+        </Dialog>
+    );
+};
+
+export default CertifyMembersConfirmDialog;

--- a/packages/javascript/bh-shared-ui/src/views/ZoneManagement/Certification/CertifyMembersConfirmDialog.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/ZoneManagement/Certification/CertifyMembersConfirmDialog.tsx
@@ -31,7 +31,11 @@ const CertifyMembersConfirmDialog: FC<CertifyMembersConfirmDialogProps> = ({ onC
 
     return (
         <Dialog open={open} modal={true}>
-            <DialogContent className='' maxWidth='xs' DialogOverlayProps={{ blurBackground: true }}>
+            <DialogContent
+                className=''
+                aria-describedby='textNote'
+                maxWidth='xs'
+                DialogOverlayProps={{ blurBackground: true }}>
                 <DialogTitle className='flex'>Add note</DialogTitle>
                 <TextField
                     multiline

--- a/packages/javascript/js-client-library/src/client.ts
+++ b/packages/javascript/js-client-library/src/client.ts
@@ -40,6 +40,7 @@ import {
     UpdateAssetGroupTagRequest,
     UpdateAzureHoundClientRequest,
     UpdateAzureHoundEventRequest,
+    UpdateCertificationRequest,
     UpdateConfigurationRequest,
     UpdateOIDCProviderRequest,
     UpdateSelectorRequest,
@@ -409,6 +410,10 @@ class BHEAPIClient {
             payload,
             options
         );
+    };
+
+    updateAssetGroupTagCertification = (requestBody: UpdateCertificationRequest) => {
+        return this.baseClient.post('/api/v2/asset-group-tags/certifications', requestBody);
     };
 
     /* asset group isolation (AGI) */

--- a/packages/javascript/js-client-library/src/requests.ts
+++ b/packages/javascript/js-client-library/src/requests.ts
@@ -19,6 +19,8 @@ import {
     AssetGroupTagSelector,
     AssetGroupTagSelectorSeed,
     AssetGroupTagTypes,
+    CertificationManual,
+    CertificationRevoked,
     SeedExpansionMethod,
     SSOProviderConfiguration,
 } from './types';
@@ -44,6 +46,12 @@ export type CreateAssetGroupTagRequest = {
 export type UpdateAssetGroupTagRequest = Partial<
     Partial<CreateAssetGroupTagRequest> & { analysis_enabled?: boolean | undefined }
 >;
+
+export type UpdateCertificationRequest = {
+    member_ids: number[];
+    action: typeof CertificationRevoked | typeof CertificationManual;
+    note?: string;
+};
 
 export type PreviewSelectorsRequest = { seeds: SelectorSeedRequest[]; expansion: SeedExpansionMethod };
 


### PR DESCRIPTION
## Description

*Describe your changes in detail*

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves  BED-5246

This change enables functionality for bulk certifying and decertifying members in the UI via checkboxes in the certification table. 

## How Has This Been Tested?

Unit tests WIP
Tested manually by selecting rows in the table, and then pushing the `Certify` or `Revoke` buttons

## Screenshots (optional):


https://github.com/user-attachments/assets/bf4648a8-5e16-4a2b-ac99-7853bb05377e


## Types of changes

<!-- Please remove any items that do not apply. -->
- New feature (non-breaking change which adds functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [ ] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
