### PR TITLE
BED-6041 etac available domains

### DIFF
--- a/cmd/api/src/api/v2/access_control_list.go
+++ b/cmd/api/src/api/v2/access_control_list.go
@@ -57,3 +57,13 @@ func CheckUserAccessToEnvironments(ctx context.Context, db database.EnvironmentA
 
 	return true, nil
 }
+
+func GetUserEnvironmentAccessList(ctx context.Context, user model.User) []string {
+	list := make([]string, 0, len(user.EnvironmentAccessControl))
+
+	for _, envAccess := range user.EnvironmentAccessControl {
+		list = append(list, envAccess.EnvironmentID)
+	}
+
+	return list
+}

--- a/cmd/api/src/api/v2/access_control_list.go
+++ b/cmd/api/src/api/v2/access_control_list.go
@@ -58,7 +58,8 @@ func CheckUserAccessToEnvironments(ctx context.Context, db database.EnvironmentA
 	return true, nil
 }
 
-func GetUserEnvironmentAccessList(ctx context.Context, user model.User) []string {
+// Helper function to extract a user's environments from their model as a list of strings
+func UserEnvironments(user *model.User) []string {
 	list := make([]string, 0, len(user.EnvironmentAccessControl))
 
 	for _, envAccess := range user.EnvironmentAccessControl {

--- a/cmd/api/src/api/v2/access_control_list.go
+++ b/cmd/api/src/api/v2/access_control_list.go
@@ -58,8 +58,9 @@ func CheckUserAccessToEnvironments(ctx context.Context, db database.EnvironmentA
 	return true, nil
 }
 
-// Helper function to extract a user's environments from their model as a list of strings
-func UserEnvironments(user *model.User) []string {
+// ExtractEnvironmentIDsFromUser is a helper function
+// to extract a user's environments from their model as a list of strings
+func ExtractEnvironmentIDsFromUser(user *model.User) []string {
 	list := make([]string, 0, len(user.EnvironmentAccessControl))
 
 	for _, envAccess := range user.EnvironmentAccessControl {

--- a/packages/go/ein/ad.go
+++ b/packages/go/ein/ad.go
@@ -885,7 +885,7 @@ func ParseDomainTrusts(domain Domain) ParsedDomainTrustData {
 		}
 
 		parsedData.ExtraNodeProps = append(parsedData.ExtraNodeProps, IngestibleNode{
-			PropertyMap: map[string]any{"name": trust.TargetDomainName},
+			PropertyMap: map[string]any{"name": trust.TargetDomainName, ad.DomainSID.String(): trust.TargetDomainSid},
 			ObjectID:    trust.TargetDomainSid,
 			Labels:      []graph.Kind{ad.Domain},
 		})


### PR DESCRIPTION
## Description

This PR contains a helper function and fixes `domainsid` not being set for domain nodes ingested through trusts.

## Motivation and Context

[BED-6041](https://specterops.atlassian.net/browse/BED-6041)

## How Has This Been Tested?
Go unit tests have been adjusted and pass locally. Houndstrike tests have been written and pass locally.  

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [X] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [X] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [X] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Active Directory domain trust metadata now includes the domain SID, improving visibility and filtering in related views.
* **Chores**
  * Added an internal utility to retrieve environment IDs associated with a user.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[BED-6041]: https://specterops.atlassian.net/browse/BED-6041?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ