### PR TITLE
fix: cancel the scrollbar rave

### DIFF
--- a/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/Details/Details.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/Details/Details.tsx
@@ -134,7 +134,7 @@ const Details: FC = () => {
                 </div>
             </div>
             <div className='flex gap-8 mt-4 h-full'>
-                <div className='flex basis-2/3 bg-neutral-light-2 dark:bg-neutral-dark-2 rounded-lg shadow-outer-1 *:w-1/3 h-fit'>
+                <div className='flex basis-2/3 bg-neutral-2 min-w-0 rounded-lg shadow-outer-1 h-fit'>
                     {isLabelPage ? (
                         <TagList
                             title={'Labels'}

--- a/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/Details/MembersList.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/Details/MembersList.tsx
@@ -38,7 +38,7 @@ const LoadingRow = (index: number, style: React.CSSProperties) => (
     <div
         data-testid={`privilege-zones_members-list_loading-skeleton`}
         style={style}
-        className='border-y border-neutral-light-3 dark:border-neutral-dark-3 relative w-full p-2'>
+        className='border-y border-neutral-3 relative w-full p-2'>
         <Skeleton className={`h-full`} />
     </div>
 );
@@ -62,8 +62,8 @@ export const MembersList: React.FC<MembersListProps> = ({
             <div
                 key={index}
                 role='listitem'
-                className={cn('border-y border-neutral-light-3 dark:border-neutral-dark-3 relative', {
-                    'bg-neutral-light-4 dark:bg-neutral-dark-4': selected === item.id.toString(),
+                className={cn('border-y border-neutral-3 relative', {
+                    'bg-neutral-4': selected === item.id.toString(),
                 })}
                 style={style}>
                 <SelectedHighlight selected={selected} itemId={item.id} title={'Members'} />
@@ -90,12 +90,12 @@ export const MembersList: React.FC<MembersListProps> = ({
                 }}
                 sortOrder={sortOrder}
                 classes={{
-                    container: 'border-b-2 border-neutral-light-5 dark:border-neutral-dark-5',
+                    container: 'border-b-2 border-neutral-5',
                     button: 'pl-6 font-bold text-xl',
                 }}
             />
             <div
-                className={cn(`overflow-y-auto border-neutral-light-5 dark:border-neutral-dark-5`, {
+                className={cn(`border-neutral-5`, {
                     'h-[762px]': getListHeight(window.innerHeight) === 762,
                     'h-[642px]': getListHeight(window.innerHeight) === 642,
                     'h-[438px]': getListHeight(window.innerHeight) === 438,

--- a/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/Details/MembersList.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/Details/MembersList.tsx
@@ -34,7 +34,7 @@ interface MembersListProps {
     onChangeSortOrder: (sort: SortOrder) => void;
 }
 
-const LoadingRow = (index: number, style: React.CSSProperties) => (
+const LoadingRow = (_: number, style: React.CSSProperties) => (
     <div
         data-testid={`privilege-zones_members-list_loading-skeleton`}
         style={style}
@@ -82,7 +82,7 @@ export const MembersList: React.FC<MembersListProps> = ({
     };
 
     return (
-        <div data-testid={`privilege-zones_details_members-list`}>
+        <div className='min-w-0 w-1/3' data-testid={`privilege-zones_details_members-list`}>
             <SortableHeader
                 title={'Members'}
                 onSort={() => {
@@ -96,9 +96,9 @@ export const MembersList: React.FC<MembersListProps> = ({
             />
             <div
                 className={cn(`border-neutral-5`, {
-                    'h-[762px]': getListHeight(window.innerHeight) === 762,
-                    'h-[642px]': getListHeight(window.innerHeight) === 642,
-                    'h-[438px]': getListHeight(window.innerHeight) === 438,
+                    'h-[760px]': getListHeight(window.innerHeight) === 760,
+                    'h-[640px]': getListHeight(window.innerHeight) === 640,
+                    'h-[436px]': getListHeight(window.innerHeight) === 436,
                 })}>
                 <InfiniteQueryFixedList<AssetGroupTagMemberListItem>
                     itemSize={40}

--- a/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/Details/SelectorsList.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/Details/SelectorsList.tsx
@@ -24,11 +24,11 @@ import { SortOrder } from '../../../types';
 import { cn } from '../../../utils';
 import { SelectedHighlight, getListHeight } from './utils';
 
-const LoadingRow = (index: number, style: React.CSSProperties) => (
+const LoadingRow = (_: number, style: React.CSSProperties) => (
     <div
         data-testid={`privilege-zones_selectors-list_loading-skeleton`}
         style={style}
-        className='border-y border-neutral-light-3 dark:border-neutral-dark-3 relative w-full p-2'>
+        className='border-y border-neutral-3 relative w-full p-2'>
         <Skeleton className={`h-full`} />
     </div>
 );
@@ -62,12 +62,12 @@ const SelectorsListWrapper = ({
                 }}
                 sortOrder={sortOrder}
                 classes={{
-                    container: 'border-b-2 border-neutral-light-5 dark:border-neutral-dark-5',
+                    container: 'border-b-2 border-neutral-5',
                     button: 'pl-6 font-bold text-xl',
                 }}
             />
             <div
-                className={cn(`overflow-y-auto border-x-2 border-neutral-light-5 dark:border-neutral-dark-5`, {
+                className={cn(`border-x-2 border-neutral-5`, {
                     'h-[762px]': getListHeight(window.innerHeight) === 762,
                     'h-[642px]': getListHeight(window.innerHeight) === 642,
                     'h-[438px]': getListHeight(window.innerHeight) === 438,
@@ -97,7 +97,7 @@ export const SelectorsList: FC<SelectorsListProps> = ({
         return (
             <SelectorsListWrapper sortOrder={sortOrder} onChangeSortOrder={onChangeSortOrder}>
                 <ul>
-                    <li className='border-y border-neutral-light-3 dark:border-neutral-dark-3 relative h-10 pl-2'>
+                    <li className='border-y border-neutral-3 relative h-10 pl-2'>
                         <span className='text-base'>There was an error fetching this data</span>
                     </li>
                 </ul>
@@ -113,8 +113,8 @@ export const SelectorsList: FC<SelectorsListProps> = ({
                 style={style}
                 role='listitem'
                 key={item.id}
-                className={cn('border-y border-neutral-light-3 dark:border-neutral-dark-3 relative h-10', {
-                    'bg-neutral-light-4 dark:bg-neutral-dark-4': selected === item.id.toString(),
+                className={cn('border-y border-neutral-3 relative h-10', {
+                    'bg-neutral-4': selected === item.id.toString(),
                 })}>
                 <SelectedHighlight selected={selected} itemId={item.id} title={'Selectors'} />
                 <Button
@@ -123,19 +123,14 @@ export const SelectorsList: FC<SelectorsListProps> = ({
                     onClick={() => {
                         onSelect(item.id);
                     }}>
-                    <div className='flex items-center'>
-                        <span
-                            className={cn(
-                                'text-base dark:text-white truncate sm:max-w-[50px] lg:max-w-[100px] xl:max-w-[150px] 2xl:max-w-[300px]',
-                                {
-                                    'text-[#8E8C95] dark:text-[#919191]': isDisabled,
-                                }
-                            )}
-                            title={isDisabled ? `Disabled: ${item.name}` : item.name}>
-                            {item.name}
-                        </span>
-                    </div>
-                    {item.counts && <span className='text-base'>{item.counts.members.toLocaleString()}</span>}
+                    <span
+                        className={cn('text-base dark:text-white truncate', {
+                            'text-[#8E8C95] dark:text-[#919191]': isDisabled,
+                        })}
+                        title={isDisabled ? `Disabled: ${item.name}` : item.name}>
+                        {item.name}
+                    </span>
+                    {item.counts && <span className='text-base pl-2'>{item.counts.members.toLocaleString()}</span>}
                 </Button>
             </div>
         );

--- a/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/Details/SelectorsList.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/Details/SelectorsList.tsx
@@ -54,7 +54,7 @@ const SelectorsListWrapper = ({
     sortOrder: SortOrder;
 }) => {
     return (
-        <div data-testid={`privilege-zones_details_selectors-list`}>
+        <div className='min-w-0 w-1/3' data-testid={`privilege-zones_details_selectors-list`}>
             <SortableHeader
                 title={'Selectors'}
                 onSort={() => {
@@ -68,9 +68,9 @@ const SelectorsListWrapper = ({
             />
             <div
                 className={cn(`border-x-2 border-neutral-5`, {
-                    'h-[762px]': getListHeight(window.innerHeight) === 762,
-                    'h-[642px]': getListHeight(window.innerHeight) === 642,
-                    'h-[438px]': getListHeight(window.innerHeight) === 438,
+                    'h-[760px]': getListHeight(window.innerHeight) === 760,
+                    'h-[640px]': getListHeight(window.innerHeight) === 640,
+                    'h-[436px]': getListHeight(window.innerHeight) === 436,
                 })}>
                 {children}
             </div>

--- a/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/Details/TagList.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/Details/TagList.test.tsx
@@ -175,7 +175,9 @@ describe('List', async () => {
             })
         );
 
-        render(<TagList title='Zones' listQuery={testQuery} selected={'2'} onSelect={() => {}} />);
+        render(<TagList title='Zones' listQuery={testQuery} selected={'2'} onSelect={() => {}} />, {
+            route: '/privilege-zones/zones/2/details',
+        });
 
         const listItem = screen.getByTestId('privilege-zones_details_zones-list_item-2');
         expect(listItem).toBeInTheDocument();
@@ -191,7 +193,9 @@ describe('List', async () => {
             })
         );
 
-        render(<TagList title='Zones' listQuery={testQuery} selected={'2'} onSelect={() => {}} />);
+        render(<TagList title='Zones' listQuery={testQuery} selected={'2'} onSelect={() => {}} />, {
+            route: '/privilege-zones/zones/2/details',
+        });
 
         const listItem1 = screen.getByTestId('privilege-zones_details_zones-list_item-1');
         expect(listItem1).toBeInTheDocument();

--- a/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/Details/TagList.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/Details/TagList.tsx
@@ -44,7 +44,7 @@ type TagListProps = {
 export const TagList: FC<TagListProps> = ({ title, listQuery, selected, onSelect }) => {
     const [sortOrder, setSortOrder] = useState<SortOrder>('asc');
     const { tagId: topTagId } = useHighestPrivilegeTagId();
-    const { hasZoneId, isLabelPage, isZonePage } = usePZPathParams();
+    const { isLabelPage, isZonePage } = usePZPathParams();
 
     return (
         <div data-testid={`privilege-zones_details_${title.toLowerCase()}-list`}>
@@ -56,21 +56,21 @@ export const TagList: FC<TagListProps> = ({ title, listQuery, selected, onSelect
                     }}
                     sortOrder={sortOrder}
                     classes={{
-                        container: 'border-b-2 border-neutral-light-5 dark:border-neutral-dark-5',
+                        container: 'border-b-2 border-neutral-5',
                         button: 'pl-6 font-bold text-xl',
                     }}
                 />
             ) : (
                 <div
                     data-testid={`privilege-zones_details_${title.toLowerCase()}-list_static-order`}
-                    className='p-0 relative w-full border-b-2 border-neutral-light-5 dark:border-neutral-dark-5'>
+                    className='p-0 relative w-full border-b-2 border-neutral-5'>
                     <div className='inline-flex items-center justify-center h-10 transition-colors text-neutral-dark-5 dark:text-neutral-light-5 pl-6 font-bold text-xl'>
                         {title}
                     </div>
                 </div>
             )}
             <div
-                className={cn(`overflow-y-auto`, {
+                className={cn({
                     'h-[762px]': getListHeight(window.innerHeight) === 762,
                     'h-[642px]': getListHeight(window.innerHeight) === 642,
                     'h-[438px]': getListHeight(window.innerHeight) === 438,
@@ -81,14 +81,13 @@ export const TagList: FC<TagListProps> = ({ title, listQuery, selected, onSelect
                             return skeleton(title, index);
                         })
                     ) : listQuery.isError ? (
-                        <li className='border-y border-neutral-light-3 dark:border-neutral-dark-3 relative h-10 pl-2'>
+                        <li className='border-y border-neutral-3 relative h-10 pl-2'>
                             <span className='text-base'>There was an error fetching this data</span>
                         </li>
                     ) : listQuery.isSuccess ? (
                         listQuery.data
                             ?.sort((a, b) => {
                                 if (isTag(a) && isTag(b) && isZonePage) {
-                                    // A tag can be a zone and also have position null it seems
                                     return (a.position || 0) - (b.position || 0);
                                 } else {
                                     switch (sortOrder) {
@@ -106,13 +105,9 @@ export const TagList: FC<TagListProps> = ({ title, listQuery, selected, onSelect
                                     <li
                                         data-testid={`privilege-zones_details_${title.toLowerCase()}-list_item-${listItem.id}`}
                                         key={listItem.id}
-                                        className={cn(
-                                            'border-y border-neutral-light-3 dark:border-neutral-dark-3 relative h-10',
-                                            {
-                                                'bg-neutral-light-4 dark:bg-neutral-dark-4':
-                                                    selected === listItem.id.toString(),
-                                            }
-                                        )}>
+                                        className={cn('border-y border-neutral-3 relative h-10', {
+                                            'bg-neutral-4': selected === listItem.id.toString(),
+                                        })}>
                                         <SelectedHighlight selected={selected} itemId={listItem.id} title={title} />
                                         <Button
                                             variant={'text'}
@@ -121,7 +116,7 @@ export const TagList: FC<TagListProps> = ({ title, listQuery, selected, onSelect
                                                 onSelect(listItem.id);
                                             }}>
                                             <div className='flex items-center'>
-                                                {isTag(listItem) && hasZoneId && listItem.id !== topTagId && (
+                                                {isZonePage && listItem.id !== topTagId && (
                                                     <ZoneAnalysisIcon
                                                         size={18}
                                                         tooltip
@@ -129,9 +124,7 @@ export const TagList: FC<TagListProps> = ({ title, listQuery, selected, onSelect
                                                     />
                                                 )}
                                                 <span
-                                                    className={cn(
-                                                        'text-base dark:text-white truncate sm:max-w-[50px] lg:max-w-[100px] xl:max-w-[150px] 2xl:max-w-[300px]'
-                                                    )}
+                                                    className={cn('text-base dark:text-white truncate')}
                                                     title={listItem.name}>
                                                     {listItem.name}
                                                 </span>

--- a/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/Details/TagList.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/Details/TagList.tsx
@@ -24,7 +24,7 @@ import { SortOrder } from '../../../types';
 import { cn } from '../../../utils';
 import { ZoneAnalysisIcon } from '../ZoneAnalysisIcon';
 import { itemSkeletons } from '../utils';
-import { SelectedHighlight, getListHeight, isTag } from './utils';
+import { SelectedHighlight, isTag } from './utils';
 
 type TagListProps = {
     title: 'Zones' | 'Labels';
@@ -47,7 +47,7 @@ export const TagList: FC<TagListProps> = ({ title, listQuery, selected, onSelect
     const { isLabelPage, isZonePage } = usePZPathParams();
 
     return (
-        <div data-testid={`privilege-zones_details_${title.toLowerCase()}-list`}>
+        <div className='min-w-0 w-1/3' data-testid={`privilege-zones_details_${title.toLowerCase()}-list`}>
             {isLabelPage ? (
                 <SortableHeader
                     title={title}
@@ -64,83 +64,76 @@ export const TagList: FC<TagListProps> = ({ title, listQuery, selected, onSelect
                 <div
                     data-testid={`privilege-zones_details_${title.toLowerCase()}-list_static-order`}
                     className='p-0 relative w-full border-b-2 border-neutral-5'>
-                    <div className='inline-flex items-center justify-center h-10 transition-colors text-neutral-dark-5 dark:text-neutral-light-5 pl-6 font-bold text-xl'>
+                    <div className='inline-flex items-center justify-center h-10 transition-colors pl-6 font-bold text-xl'>
                         {title}
                     </div>
                 </div>
             )}
-            <div
-                className={cn({
-                    'h-[762px]': getListHeight(window.innerHeight) === 762,
-                    'h-[642px]': getListHeight(window.innerHeight) === 642,
-                    'h-[438px]': getListHeight(window.innerHeight) === 438,
-                })}>
-                <ul>
-                    {listQuery.isLoading ? (
-                        itemSkeletons.map((skeleton, index) => {
-                            return skeleton(title, index);
-                        })
-                    ) : listQuery.isError ? (
-                        <li className='border-y border-neutral-3 relative h-10 pl-2'>
-                            <span className='text-base'>There was an error fetching this data</span>
-                        </li>
-                    ) : listQuery.isSuccess ? (
-                        listQuery.data
-                            ?.sort((a, b) => {
-                                if (isTag(a) && isTag(b) && isZonePage) {
-                                    return (a.position || 0) - (b.position || 0);
-                                } else {
-                                    switch (sortOrder) {
-                                        case 'asc':
-                                            return a.name.localeCompare(b.name);
-                                        case 'desc':
-                                            return b.name.localeCompare(a.name);
-                                        default:
-                                            return b.name.localeCompare(a.name);
-                                    }
+            <ul>
+                {listQuery.isLoading ? (
+                    itemSkeletons.map((skeleton, index) => {
+                        return skeleton(title, index);
+                    })
+                ) : listQuery.isError ? (
+                    <li className='border-y border-neutral-3 relative h-10 pl-2'>
+                        <span className='text-base'>There was an error fetching this data</span>
+                    </li>
+                ) : listQuery.isSuccess ? (
+                    listQuery.data
+                        ?.sort((a, b) => {
+                            if (isTag(a) && isTag(b) && isZonePage) {
+                                return (a.position || 0) - (b.position || 0);
+                            } else {
+                                switch (sortOrder) {
+                                    case 'asc':
+                                        return a.name.localeCompare(b.name);
+                                    case 'desc':
+                                        return b.name.localeCompare(a.name);
+                                    default:
+                                        return b.name.localeCompare(a.name);
                                 }
-                            })
-                            .map((listItem) => {
-                                return (
-                                    <li
-                                        data-testid={`privilege-zones_details_${title.toLowerCase()}-list_item-${listItem.id}`}
-                                        key={listItem.id}
-                                        className={cn('border-y border-neutral-3 relative h-10', {
-                                            'bg-neutral-4': selected === listItem.id.toString(),
-                                        })}>
-                                        <SelectedHighlight selected={selected} itemId={listItem.id} title={title} />
-                                        <Button
-                                            variant={'text'}
-                                            className='flex justify-between w-full overflow-hidden'
-                                            onClick={() => {
-                                                onSelect(listItem.id);
-                                            }}>
-                                            <div className='flex items-center'>
-                                                {isZonePage && listItem.id !== topTagId && (
-                                                    <ZoneAnalysisIcon
-                                                        size={18}
-                                                        tooltip
-                                                        analysisEnabled={listItem?.analysis_enabled}
-                                                    />
-                                                )}
-                                                <span
-                                                    className={cn('text-base dark:text-white truncate')}
-                                                    title={listItem.name}>
-                                                    {listItem.name}
-                                                </span>
-                                            </div>
-                                            {listItem.counts && (
-                                                <span className='text-base ml-4'>
-                                                    {listItem.counts.selectors.toLocaleString()}
-                                                </span>
+                            }
+                        })
+                        .map((listItem) => {
+                            return (
+                                <li
+                                    data-testid={`privilege-zones_details_${title.toLowerCase()}-list_item-${listItem.id}`}
+                                    key={listItem.id}
+                                    className={cn('border-y border-neutral-3 relative h-10', {
+                                        'bg-neutral-4': selected === listItem.id.toString(),
+                                    })}>
+                                    <SelectedHighlight selected={selected} itemId={listItem.id} title={title} />
+                                    <Button
+                                        variant={'text'}
+                                        className='flex justify-between w-full'
+                                        onClick={() => {
+                                            onSelect(listItem.id);
+                                        }}>
+                                        <div className='flex items-center overflow-hidden'>
+                                            {isZonePage && listItem.id !== topTagId && (
+                                                <ZoneAnalysisIcon
+                                                    size={18}
+                                                    tooltip
+                                                    analysisEnabled={listItem?.analysis_enabled}
+                                                />
                                             )}
-                                        </Button>
-                                    </li>
-                                );
-                            })
-                    ) : null}
-                </ul>
-            </div>
+                                            <span
+                                                className={cn('text-base dark:text-white truncate')}
+                                                title={listItem.name}>
+                                                {listItem.name}
+                                            </span>
+                                        </div>
+                                        {listItem.counts && (
+                                            <span className='text-base ml-4'>
+                                                {listItem.counts.selectors.toLocaleString()}
+                                            </span>
+                                        )}
+                                    </Button>
+                                </li>
+                            );
+                        })
+                ) : null}
+            </ul>
         </div>
     );
 };

--- a/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/Details/utils.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/Details/utils.tsx
@@ -49,8 +49,8 @@ export const getSelectorSeedType = (selector: AssetGroupTagSelector): SeedTypes 
 };
 
 export const getListHeight = (windoHeight: number) => {
-    if (windoHeight > 1080) return 762;
-    if (1080 >= windoHeight && windoHeight > 900) return 642;
-    if (900 >= windoHeight) return 438;
+    if (windoHeight > 1080) return 760;
+    if (1080 >= windoHeight && windoHeight > 900) return 640;
+    if (900 >= windoHeight) return 436;
     return 438;
 };

--- a/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/Details/utils.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/Details/utils.tsx
@@ -52,5 +52,5 @@ export const getListHeight = (windoHeight: number) => {
     if (windoHeight > 1080) return 760;
     if (1080 >= windoHeight && windoHeight > 900) return 640;
     if (900 >= windoHeight) return 436;
-    return 438;
+    return 436;
 };

--- a/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/Save/TagForm/TagForm.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/Save/TagForm/TagForm.tsx
@@ -244,15 +244,12 @@ export const TagForm: FC = () => {
     const handleDeleteCancel = useCallback(() => setDeleteDialogOpen(false), []);
 
     const handleGlyphCancel = useCallback(() => setGlyphDialogOpen(false), []);
-    const handleGlyphSelect = useCallback(
-        (iconName?: IconName) => {
-            if (iconName) setValue('glyph', iconName, { shouldDirty: true });
-            else setValue('glyph', '', { shouldDirty: true });
+    const handleGlyphSelect = useCallback((iconName?: IconName) => {
+        if (iconName) setValue('glyph', iconName, { shouldDirty: true });
+        else setValue('glyph', '', { shouldDirty: true });
 
-            setGlyphDialogOpen(false);
-        },
-        [form]
-    );
+        setGlyphDialogOpen(false);
+    }, []);
 
     useEffect(() => {
         if (tagQuery.data) {


### PR DESCRIPTION
## Description

Updates styles in the detail view lists of PZ pages so that the scrollbar does not flash in and out repeatedly at a high frequency at particular resolutions and browser zoom levels.

## Motivation and Context

Resolves BED-6437

*Why is this change required? What problem does it solve?*

## How Has This Been Tested?
This was not easily reproducible. I was able to do so a few times and the updates fixed it under those conditions but if someone can reproduce this consistently before this fix it would be good to have them check with these changes applied.

## Screenshots (optional):


https://github.com/user-attachments/assets/f7026280-2cb2-4716-96d4-ebd21842afbe



## Types of changes

<!-- Please remove any items that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)
## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Unified neutral borders and removed dark-variant tokens across lists, headers, loading and error rows; simplified selected-row background to a single neutral style; improved truncation, name/count alignment, and added consistent list container sizing.

* **Bug Fixes**
  * Corrected zone-related icon visibility to respect the details page context.

* **Refactor**
  * Streamlined list item structure, simplified scroll/height behavior, and tightened callback lifecycle for glyph selection.

* **Tests**
  * Updated tests to render components with explicit route context for details pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->