### PR TITLE
BED-6547--Safari Select Label z-index

### DIFF
--- a/packages/javascript/bh-shared-ui/src/views/Explore/ExploreSearch/SavedQueries/QuerySearchFilter.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/Explore/ExploreSearch/SavedQueries/QuerySearchFilter.tsx
@@ -118,11 +118,12 @@ const QuerySearchFilter = (props: QuerySearchProps) => {
                     </div>
                 </div>
                 <div className='flex w-full items-center justify-between flex-row'>
-                    <FormControl size='small' className='w-full'>
+                    <FormControl size='small' className='w-full z-10'>
                         <InputLabel id='platforms-label'>Platforms</InputLabel>
                         <Select
                             labelId='platforms-label'
                             id='demo-simple-select-helper'
+                            className='z-10'
                             value={platform}
                             label='Platforms'
                             onChange={(e) => handlePlatformFilter(e.target.value)}>
@@ -132,11 +133,12 @@ const QuerySearchFilter = (props: QuerySearchProps) => {
                             <MenuItem value='Saved Queries'>Saved Queries</MenuItem>
                         </Select>
                     </FormControl>
-                    <FormControl size='small' className='w-full ml-2'>
+                    <FormControl size='small' className='w-full ml-2 z-10'>
                         <InputLabel id='category-filter-label'>Categories</InputLabel>
                         <Select
                             labelId='category-filter-label'
                             id='category-filter'
+                            className='z-10'
                             value={categoryFilter}
                             label='categories'
                             open={categoriesOpen}
@@ -152,11 +154,12 @@ const QuerySearchFilter = (props: QuerySearchProps) => {
                             ))}
                         </Select>
                     </FormControl>
-                    <FormControl size='small' className='w-full ml-2'>
+                    <FormControl size='small' className='w-full ml-2 z-10'>
                         <InputLabel id='source-filter-label'>Source</InputLabel>
                         <Select
                             labelId='source-filter-label'
                             id='source-filter'
+                            className='z-10'
                             value={source || ''}
                             label='source'
                             open={sourcesOpen}


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

*Describe your changes in detail*
Updated z-index for Saved Query filter dropdowns.  

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-6547

*Why is this change required? What problem does it solve?*

This issue affects Safari.
The MUI Select component we are using for the filter drop-downs was rendering inconsistently in Safari.  Specifically, when focusing and un-focusing, the label text animates up and covers the drop-down border.  In Safari, the border was positioned above the text causing a strikethrough effect.  Explicitly setting z-index on the select components and their parents mitigates the issue.  


## How Has This Been Tested?

*Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc.*

- Manually tested in local dev environment.
- All existing unit tests passing

## Screenshots (optional):

#### Before

<img width="763" height="887" alt="Safari-Select-Before" src="https://github.com/user-attachments/assets/917da406-03ff-4c6d-894a-6621fcebc252" />

___

#### After

<img width="841" height="885" alt="Safari-Select-After" src="https://github.com/user-attachments/assets/74e993a8-258d-4267-aa6d-c1a393783840" />


## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)
- Database Migrations

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Resolved visual overlap issues in Explore > Saved Queries filters.
  - Platforms, Categories, and Source dropdowns now reliably appear above surrounding UI.
  - Improved interaction by preventing dropdowns from being obscured by other elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->