### PR TITLE
chore: St Bernard Avalanche Training

### DIFF
--- a/packages/go/stbernard/analyzers/analyzers.go
+++ b/packages/go/stbernard/analyzers/analyzers.go
@@ -19,6 +19,7 @@ package analyzers
 import (
 	"errors"
 	"fmt"
+	"os"
 
 	"github.com/specterops/bloodhound/packages/go/stbernard/analyzers/codeclimate"
 	"github.com/specterops/bloodhound/packages/go/stbernard/analyzers/golang"
@@ -29,6 +30,7 @@ import (
 
 var (
 	ErrSeverityExit = errors.New("high severity linter result")
+	ErrWarnExit     = errors.New("warning severity linter result")
 )
 
 func outputSeverityMap(results codeclimate.SeverityMap, outputAllSeverity bool) {
@@ -39,7 +41,7 @@ func outputSeverityMap(results codeclimate.SeverityMap, outputAllSeverity bool) 
 			// Issues of this severity should be output directly
 			for _, entries := range fileEntries {
 				for _, entry := range entries {
-					fmt.Printf("%s:%d - %s\n", entry.Location.Path, entry.Location.Lines.Begin, entry.Description)
+					fmt.Fprintf(os.Stdout, "%s:%d - %s\n", entry.Location.Path, entry.Location.Lines.Begin, entry.Description)
 				}
 			}
 		}
@@ -65,8 +67,10 @@ func Run(paths workspace.WorkspacePaths, env environment.Environment, outputAllS
 		// Any finding with a priority greater than Minor is considered a high severity finding
 		if combinedResults.HasGreaterSeverity(codeclimate.SeverityMinor) {
 			return ErrSeverityExit
+		} else if len(combinedResults) > 0 {
+			return ErrWarnExit
+		} else {
+			return nil
 		}
 	}
-
-	return nil
 }

--- a/packages/go/stbernard/cmdrunner/cmdrunner.go
+++ b/packages/go/stbernard/cmdrunner/cmdrunner.go
@@ -140,7 +140,7 @@ func run(cmd *exec.Cmd, result *ExecutionResult) error {
 
 	var (
 		ctx           = context.TODO()
-		quietDisabled = slog.Default().Enabled(ctx, slog.LevelInfo)
+		quietDisabled = slog.Default().Enabled(ctx, slog.LevelDebug)
 	)
 
 	if quietDisabled {

--- a/packages/go/stbernard/cmdrunner/cmdrunner.go
+++ b/packages/go/stbernard/cmdrunner/cmdrunner.go
@@ -27,12 +27,22 @@ import (
 	"os/exec"
 	"strings"
 	"time"
-
-	"github.com/specterops/bloodhound/packages/go/stbernard/environment"
 )
 
-// maxShortArgs is the limit for how many command arguments to print when printing the shorthand of the command
-const maxShortArgs = 2
+const (
+	maxShortArgs = 2
+)
+
+var ErrCmdExecutionFailed = errors.New("command execution failed")
+
+// ExecutionPlan is a configuration struct for Run
+type ExecutionPlan struct {
+	Command        string
+	Args           []string
+	Path           string
+	Env            []string
+	SuppressErrors bool
+}
 
 // ExecutionResult data structure that represents the result of running a command and captures information about
 // an executed command's output.
@@ -49,11 +59,11 @@ type ExecutionResult struct {
 	ReturnCode     int
 }
 
-func newExecutionResult(command string, args []string, path string) *ExecutionResult {
+func newExecutionResult(ep ExecutionPlan) *ExecutionResult {
 	return &ExecutionResult{
-		Command:        command,
-		Arguments:      args,
-		Path:           path,
+		Command:        ep.Command,
+		Arguments:      ep.Args,
+		Path:           ep.Path,
 		StandardOutput: &bytes.Buffer{},
 		ErrorOutput:    &bytes.Buffer{},
 		CombinedOutput: &bytes.Buffer{},
@@ -61,36 +71,36 @@ func newExecutionResult(command string, args []string, path string) *ExecutionRe
 	}
 }
 
-// ExecutionError is a wrapper for an ExecutionResult that satisfies the error interface.
-type ExecutionError struct {
-	ExecutionResult
-}
-
-func newExecutionError(result *ExecutionResult, exitErr *exec.ExitError) error {
-	// Update the return code and wrap the result to return it as an error
-	result.ReturnCode = exitErr.ExitCode()
-
-	return &ExecutionError{
-		ExecutionResult: *result,
-	}
-}
-
-func (s *ExecutionError) Error() string {
-	return "command execution failed"
-}
-
-func prepareCommand(command string, args []string, path string, env environment.Environment) (*exec.Cmd, *ExecutionResult) {
-	var (
-		cmd    = exec.Command(command, args...)
-		result = newExecutionResult(command, args, path)
-	)
-
-	cmd.Dir = path
-	cmd.Env = env.Slice()
+// Run a command with args and environment variables set at a specified path.
+func Run(ctx context.Context, ep ExecutionPlan) (*ExecutionResult, error) {
+	result := newExecutionResult(ep)
+	cmd := exec.Command(ep.Command, ep.Args...)
+	cmd.Dir = ep.Path
+	cmd.Env = ep.Env
 	cmd.Stdout = io.MultiWriter(result.StandardOutput, result.CombinedOutput)
 	cmd.Stderr = io.MultiWriter(result.ErrorOutput, result.CombinedOutput)
 
-	return cmd, result
+	defer logCommand(result, ep.SuppressErrors)()
+
+	debugEnabled := slog.Default().Enabled(ctx, slog.LevelDebug)
+
+	if debugEnabled {
+		cmd.Stdout = io.MultiWriter(cmd.Stdout, os.Stderr)
+		cmd.Stderr = io.MultiWriter(cmd.Stderr, os.Stderr)
+	}
+
+	if err := cmd.Run(); err != nil {
+		if exitErr := new(exec.ExitError); errors.As(err, &exitErr) {
+			result.ReturnCode = exitErr.ExitCode()
+			if !debugEnabled && !ep.SuppressErrors {
+				fmt.Fprint(os.Stderr, result.CombinedOutput)
+			}
+			return result, fmt.Errorf("%w: %w", ErrCmdExecutionFailed, err)
+		}
+		return result, fmt.Errorf("command failed to run: %w", err)
+	}
+
+	return result, nil
 }
 
 func shortCommandString(command string, args []string, limit int) string {
@@ -111,70 +121,27 @@ func shortCommandString(command string, args []string, limit int) string {
 // logCommand outputs command execution intent into the log with a short version of the command and its arguments. The
 // returned closure will emit the result of the executed command along with more detailed information including
 // elapsed run time to debug output.
-func logCommand(result *ExecutionResult) func() {
-	var (
-		commandStr = shortCommandString(result.Command, result.Arguments, maxShortArgs)
-		started    = time.Now()
-	)
+func logCommand(result *ExecutionResult, suppressErrors bool) func() {
+	commandStr := shortCommandString(result.Command, result.Arguments, maxShortArgs)
+	started := time.Now()
 
 	slog.Info("exec", slog.String("command", commandStr))
 
 	return func() {
-		var (
-			formattedArgs = strings.Join(result.Arguments, " ")
-			elapsed       = time.Since(started)
-		)
+		elapsed := time.Since(started)
+		logLevel := slog.LevelDebug
+		timeUnit := elapsed.Milliseconds()
 
-		slog.Debug("exec result",
-			slog.String("command", commandStr),
-			slog.String("args", formattedArgs),
-			slog.String("path", result.Path),
-			slog.Int("return_code", result.ReturnCode),
-			slog.Int64("elapsed_ms", elapsed.Milliseconds()),
-		)
-	}
-}
-
-func run(cmd *exec.Cmd, result *ExecutionResult) error {
-	defer logCommand(result)()
-
-	var (
-		ctx           = context.TODO()
-		quietDisabled = slog.Default().Enabled(ctx, slog.LevelDebug)
-	)
-
-	if quietDisabled {
-		cmd.Stdout = io.MultiWriter(cmd.Stdout, os.Stdout)
-		cmd.Stderr = io.MultiWriter(cmd.Stderr, os.Stderr)
-	}
-
-	// Pull the return code from the error, if possible
-	if err := cmd.Run(); err != nil {
-		var exitErr *exec.ExitError
-
-		if errors.As(err, &exitErr) {
-			// Avoid double logging
-			if !quietDisabled {
-				// Send the command's logs to stderr for the user to know what happened
-				fmt.Fprint(os.Stderr, result.ErrorOutput)
-				// NOTE: it may be better to use context and a custom slog handler to gather this information and allow the caller to
-				// determine how to log. This would also mean that moving these attributes out of this if statement would make sense.
-				// The goal here is to give better context about what the exact command that failed was, but without context and
-				// an slog handler to help write the fields higher up, this is best effort.
-				slog.Error("Command run failed", slog.String("cwd", cmd.Dir), slog.String("command", cmd.String()))
-			}
-			return newExecutionError(result, exitErr)
+		if result.ReturnCode != 0 && !suppressErrors {
+			logLevel = slog.LevelError
 		}
 
-		// Likely a system fault that prevented the command from ever running
-		return err
+		slog.Log(context.TODO(), logLevel, "exec result",
+			slog.String("command", result.Command),
+			slog.String("args", strings.Join(result.Arguments, " ")),
+			slog.String("path", result.Path),
+			slog.Int("return_code", result.ReturnCode),
+			slog.Int64("elapsed_ms", timeUnit),
+		)
 	}
-
-	return nil
-}
-
-// Run a command with args and environment variables set at a specified path.
-func Run(command string, args []string, path string, env environment.Environment) (*ExecutionResult, error) {
-	cmd, result := prepareCommand(command, args, path, env)
-	return result, run(cmd, result)
 }

--- a/packages/go/stbernard/command/audit/audit.go
+++ b/packages/go/stbernard/command/audit/audit.go
@@ -16,6 +16,7 @@
 package audit
 
 import (
+	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -149,7 +150,14 @@ func getTicketAudit(env environment.Environment, cwd, startTimestamp, endTimesta
 		slog.Any("args", args),
 	)
 
-	result, err := cmdrunner.Run("gh", args, cwd, env)
+	executionPlan := cmdrunner.ExecutionPlan{
+		Command: "gh",
+		Args:    args,
+		Path:    cwd,
+		Env:     env.Slice(),
+	}
+
+	result, err := cmdrunner.Run(context.TODO(), executionPlan)
 	if err != nil {
 		return TicketAudit{}, fmt.Errorf("github cli PR listing: %w", err)
 	}

--- a/packages/go/stbernard/workspace/golang/build.go
+++ b/packages/go/stbernard/workspace/golang/build.go
@@ -17,6 +17,7 @@
 package golang
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -84,8 +85,13 @@ func buildModuleMainPackages(buildDir string, modPath string, version semver.Ver
 				wg.Add(1)
 				go func(p GoPackage) {
 					defer wg.Done()
-
-					if _, err := cmdrunner.Run(command, args, p.Dir, env); err != nil {
+					executionPlan := cmdrunner.ExecutionPlan{
+						Command: command,
+						Args:    args,
+						Path:    p.Dir,
+						Env:     env.Slice(),
+					}
+					if _, err := cmdrunner.Run(context.TODO(), executionPlan); err != nil {
 						mu.Lock()
 						errs = append(errs, fmt.Errorf("go build for package %s: %w", p.Import, err))
 						mu.Unlock()

--- a/packages/go/stbernard/workspace/golang/generate.go
+++ b/packages/go/stbernard/workspace/golang/generate.go
@@ -109,7 +109,13 @@ func parallelGenerateModulePackages(jobC <-chan GoPackage, waitGroup *sync.WaitG
 						args    = []string{"generate", nextPackage.Dir}
 					)
 
-					if _, err := cmdrunner.Run(command, args, nextPackage.Dir, env); err != nil {
+					executionPlan := cmdrunner.ExecutionPlan{
+						Command: command,
+						Args:    args,
+						Path:    nextPackage.Dir,
+						Env:     env.Slice(),
+					}
+					if _, err := cmdrunner.Run(context.TODO(), executionPlan); err != nil {
 						addErr(err)
 					}
 				}

--- a/packages/go/stbernard/workspace/golang/goimports.go
+++ b/packages/go/stbernard/workspace/golang/goimports.go
@@ -17,6 +17,7 @@
 package golang
 
 import (
+	"context"
 	"os"
 
 	"github.com/specterops/bloodhound/packages/go/stbernard/cmdrunner"
@@ -29,10 +30,14 @@ func RunGoImports(env environment.Environment) error {
 	if err != nil {
 		return err
 	}
-	cmd := "go"
-	args := []string{"tool", "goimports", "-w", rootDir}
 
-	if _, err := cmdrunner.Run(cmd, args, rootDir, env); err != nil {
+	executionPlan := cmdrunner.ExecutionPlan{
+		Command: "go",
+		Args:    []string{"tool", "goimports", "-w", rootDir},
+		Path:    rootDir,
+		Env:     env.Slice(),
+	}
+	if _, err := cmdrunner.Run(context.TODO(), executionPlan); err != nil {
 		return err
 	}
 

--- a/packages/go/stbernard/workspace/golang/mod.go
+++ b/packages/go/stbernard/workspace/golang/mod.go
@@ -17,6 +17,7 @@
 package golang
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -61,7 +62,13 @@ func ParseModulesAbsPaths(cwd string) ([]string, error) {
 }
 
 func moduleListPackages(modPath string, env environment.Environment) ([]GoPackage, error) {
-	if result, err := cmdrunner.Run("go", []string{"list", "-json", "./..."}, modPath, env); err != nil {
+	executionPlan := cmdrunner.ExecutionPlan{
+		Command: "go",
+		Args:    []string{"list", "-json", "./..."},
+		Path:    modPath,
+		Env:     env.Slice(),
+	}
+	if result, err := cmdrunner.Run(context.TODO(), executionPlan); err != nil {
 		return nil, fmt.Errorf("running go mod list: %w", err)
 	} else {
 		var (

--- a/packages/go/stbernard/workspace/golang/sync.go
+++ b/packages/go/stbernard/workspace/golang/sync.go
@@ -17,6 +17,7 @@
 package golang
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -33,7 +34,13 @@ func TidyModules(modPath string, env environment.Environment) error {
 		args    = []string{"mod", "tidy"}
 	)
 
-	if _, err := cmdrunner.Run(command, args, modPath, env); err != nil {
+	executionPlan := cmdrunner.ExecutionPlan{
+		Command: command,
+		Args:    args,
+		Path:    modPath,
+		Env:     env.Slice(),
+	}
+	if _, err := cmdrunner.Run(context.TODO(), executionPlan); err != nil {
 		return fmt.Errorf("go mod tidy in %s: %w", modPath, err)
 	}
 
@@ -53,7 +60,13 @@ func SyncWorkspace(cwd string, env environment.Environment) error {
 		return nil
 	}
 
-	if _, err := cmdrunner.Run(command, args, cwd, env); err != nil {
+	executionPlan := cmdrunner.ExecutionPlan{
+		Command: command,
+		Args:    args,
+		Path:    cwd,
+		Env:     env.Slice(),
+	}
+	if _, err := cmdrunner.Run(context.TODO(), executionPlan); err != nil {
 		return fmt.Errorf("go work sync: %w", err)
 	} else {
 		return nil

--- a/packages/go/stbernard/workspace/redoc/redoc.go
+++ b/packages/go/stbernard/workspace/redoc/redoc.go
@@ -17,6 +17,7 @@
 package redoc
 
 import (
+	"context"
 	"fmt"
 	"path/filepath"
 
@@ -43,7 +44,13 @@ func GenerateOpenAPIDoc(projectPath string, submodules []string, env environment
 		args       = []string{"@redocly/cli@1.18.1", "bundle", inputPath, "--output", outputPath}
 	)
 
-	if _, err := cmdrunner.Run(command, args, srcPath, env); err != nil {
+	executionPlan := cmdrunner.ExecutionPlan{
+		Command: command,
+		Args:    args,
+		Path:    srcPath,
+		Env:     env.Slice(),
+	}
+	if _, err := cmdrunner.Run(context.TODO(), executionPlan); err != nil {
 		return fmt.Errorf("generate openapi docs: %w", err)
 	}
 

--- a/packages/go/stbernard/workspace/workspace.go
+++ b/packages/go/stbernard/workspace/workspace.go
@@ -17,6 +17,7 @@
 package workspace
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -111,7 +112,13 @@ func GenerateSchema(cwd string, env environment.Environment) error {
 		args = append(args, "github.com/specterops/bloodhound-enterprise/cmd/schemagen")
 	}
 
-	if _, err := cmdrunner.Run(command, args, cwd, env); err != nil {
+	executionPlan := cmdrunner.ExecutionPlan{
+		Command: command,
+		Args:    args,
+		Path:    cwd,
+		Env:     env.Slice(),
+	}
+	if _, err := cmdrunner.Run(context.TODO(), executionPlan); err != nil {
 		return fmt.Errorf("running schemagen: %w", err)
 	} else {
 		return nil

--- a/packages/go/stbernard/workspace/yarn/yarn.go
+++ b/packages/go/stbernard/workspace/yarn/yarn.go
@@ -17,6 +17,7 @@
 package yarn
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -63,7 +64,13 @@ func InstallWorkspaceDeps(cwd string, jsPaths []string, env environment.Environm
 	)
 
 	for _, path := range jsPaths {
-		if _, err := cmdrunner.Run(command, args, path, env); err != nil {
+		executionPlan := cmdrunner.ExecutionPlan{
+			Command: command,
+			Args:    args,
+			Path:    path,
+			Env:     env.Slice(),
+		}
+		if _, err := cmdrunner.Run(context.TODO(), executionPlan); err != nil {
 			return fmt.Errorf("yarn install at %v: %w", path, err)
 		}
 	}
@@ -78,7 +85,13 @@ func Format(cwd string, env environment.Environment) error {
 		args    = []string{"format"}
 	)
 
-	if _, err := cmdrunner.Run(command, args, cwd, env); err != nil {
+	executionPlan := cmdrunner.ExecutionPlan{
+		Command: command,
+		Args:    args,
+		Path:    cwd,
+		Env:     env.Slice(),
+	}
+	if _, err := cmdrunner.Run(context.TODO(), executionPlan); err != nil {
 		return fmt.Errorf("running yarn format: %w", err)
 	} else {
 		return nil
@@ -92,7 +105,13 @@ func BuildWorkspace(cwd string, env environment.Environment) error {
 		args    = []string{"build"}
 	)
 
-	if _, err := cmdrunner.Run(command, args, cwd, env); err != nil {
+	executionPlan := cmdrunner.ExecutionPlan{
+		Command: command,
+		Args:    args,
+		Path:    cwd,
+		Env:     env.Slice(),
+	}
+	if _, err := cmdrunner.Run(context.TODO(), executionPlan); err != nil {
 		return fmt.Errorf("yarn build at %v: %w", cwd, err)
 	} else {
 		return nil
@@ -106,7 +125,13 @@ func TestWorkspace(cwd string, env environment.Environment) error {
 		args    = []string{"test", "--coverage", "--run"}
 	)
 
-	if _, err := cmdrunner.Run(command, args, cwd, env); err != nil {
+	executionPlan := cmdrunner.ExecutionPlan{
+		Command: command,
+		Args:    args,
+		Path:    cwd,
+		Env:     env.Slice(),
+	}
+	if _, err := cmdrunner.Run(context.TODO(), executionPlan); err != nil {
 		return fmt.Errorf("yarn test at %v: %w", cwd, err)
 	} else {
 		return nil

--- a/packages/javascript/bh-shared-ui/src/utils/freeIconsList.ts
+++ b/packages/javascript/bh-shared-ui/src/utils/freeIconsList.ts
@@ -1,3 +1,18 @@
+// Copyright 2025 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 import { IconName } from '@fortawesome/free-solid-svg-icons';
 
 interface IconListItem {


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

St Bernard logging is in some ways in a better state after a previous run of changes, but in other ways is still causing pain. Goal here is two fold:
- Revert default behavior to not include noisy outputs of underlying commands (switch this behavior to debug only)
- Use the buffers of underlying commands to show the full output if that command fails, and do it with error level rather than debug level

This will satisfy one side of the equation where we want things to be relatively low noise when things operate correctly (making it easier to see what steps occurred at a glance), and satisfy the other side where if something goes wrong, we want as much information as possible to diagnose without having to rerun at different log levels.

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-6551

Resolves significant pain points with stbernard in a holisitic way

## How Has This Been Tested?

Local runs of various commands, including with introduced failure modes.

## Screenshots

Underlying command output suppressed when a command is expected to fail (eslint for instance) to prevent confusing output:

<img width="1227" height="365" alt="image" src="https://github.com/user-attachments/assets/b890a71c-1ad1-465d-bb33-054593ef3d68" />
  
  
New warning log when warning levels were detected, even when `-all` isn't passed. Includes a reminder to use `-all` to see warning severity items:

<img width="1230" height="245" alt="image" src="https://github.com/user-attachments/assets/391b23ea-3bbe-4893-9e00-61d6ff54cdbb" />
  
  
Warnings are shown when `-all` is used:

<img width="1225" height="627" alt="image" src="https://github.com/user-attachments/assets/292f9781-efca-45f7-ac13-34a3e1fe1d57" />
  
  
Commands that don't expect errors as part of their process will dump all stdout/stderr buffers to stderr, showing what that process reported (fixes an issue with tests not showing broken output by default):

<img width="1225" height="627" alt="image" src="https://github.com/user-attachments/assets/c0177ebe-e8d8-408a-8133-455491f6007d" />
  
  
If multiple commands are exec'd, only the output of the one or more that error will be displayed (note that we use --quiet for the failing command because it's not as helpful as our error message, so nothing extra is output):

<img width="1220" height="415" alt="image" src="https://github.com/user-attachments/assets/bcc66bf1-5df2-46ba-be2c-ebee1541c5e4" />
  
  
Debug mode will always show stdout/stderr when you want to see everything:

<img width="1393" height="480" alt="image" src="https://github.com/user-attachments/assets/809cb57a-ac88-4dde-8b0f-911fd82c2a4f" />
  
  
:feelsgood: 

```
bhce [stbernard-avalanche-training] % just prepare-for-codereview
time=2025-09-25T19:48:28.483-07:00 level=INFO message=exec command="yarn install"
time=2025-09-25T19:48:29.963-07:00 level=INFO message=exec command="yarn install"
time=2025-09-25T19:48:31.531-07:00 level=INFO message=exec command="yarn install"
time=2025-09-25T19:48:33.048-07:00 level=INFO message="Command `deps` completed successfully"
time=2025-09-25T19:48:33.133-07:00 level=INFO message=exec command="go mod tidy"
time=2025-09-25T19:48:33.713-07:00 level=INFO message="Command `modsync` completed successfully"
time=2025-09-25T19:48:33.791-07:00 level=INFO message=exec command="go run github.com/specterops/bloodhound/packages/go/schemagen"
time=2025-09-25T19:48:33.927-07:00 level=INFO message=exec command="go list -json"
time=2025-09-25T19:48:34.934-07:00 level=INFO message=exec command="go generate /home/alyx/workspace/bloodhound-enterprise/bhce/cmd/api/src/api"
time=2025-09-25T19:48:34.935-07:00 level=INFO message=exec command="go generate /home/alyx/workspace/bloodhound-enterprise/bhce/cmd/api/src/queries"
time=2025-09-25T19:48:34.936-07:00 level=INFO message=exec command="go generate /home/alyx/workspace/bloodhound-enterprise/bhce/cmd/api/src/database"
time=2025-09-25T19:48:34.936-07:00 level=INFO message=exec command="go generate /home/alyx/workspace/bloodhound-enterprise/bhce/cmd/api/src/services/agi"
time=2025-09-25T19:48:34.936-07:00 level=INFO message=exec command="go generate /home/alyx/workspace/bloodhound-enterprise/bhce/cmd/api/src/services"
time=2025-09-25T19:48:34.936-07:00 level=INFO message=exec command="go generate /home/alyx/workspace/bloodhound-enterprise/bhce/cmd/api/src/daemons"
time=2025-09-25T19:48:34.936-07:00 level=INFO message=exec command="go generate /home/alyx/workspace/bloodhound-enterprise/bhce/cmd/api/src/services/dataquality"
time=2025-09-25T19:48:34.937-07:00 level=INFO message=exec command="go generate /home/alyx/workspace/bloodhound-enterprise/bhce/cmd/api/src/daemons/datapipe"
time=2025-09-25T19:48:34.937-07:00 level=INFO message=exec command="go generate /home/alyx/workspace/bloodhound-enterprise/bhce/cmd/api/src/services/fs"
time=2025-09-25T19:48:34.938-07:00 level=INFO message=exec command="go generate /home/alyx/workspace/bloodhound-enterprise/bhce/cmd/api/src/services/oidc"
time=2025-09-25T19:48:34.938-07:00 level=INFO message=exec command="go generate /home/alyx/workspace/bloodhound-enterprise/bhce/cmd/api/src/services/saml"
time=2025-09-25T19:48:34.942-07:00 level=INFO message=exec command="go generate /home/alyx/workspace/bloodhound-enterprise/bhce/cmd/api/src/services/graphify"
time=2025-09-25T19:48:34.950-07:00 level=INFO message=exec command="go generate /home/alyx/workspace/bloodhound-enterprise/bhce/cmd/api/src/services/upload"
time=2025-09-25T19:48:34.959-07:00 level=INFO message=exec command="go generate /home/alyx/workspace/bloodhound-enterprise/bhce/cmd/api/src/utils/validation"
time=2025-09-25T19:48:34.960-07:00 level=INFO message=exec command="go generate /home/alyx/workspace/bloodhound-enterprise/bhce/cmd/api/src/vendormocks"
time=2025-09-25T19:48:34.967-07:00 level=INFO message=exec command="go generate /home/alyx/workspace/bloodhound-enterprise/bhce/cmd/api/src/utils"
time=2025-09-25T19:48:34.999-07:00 level=INFO message=exec command="go generate /home/alyx/workspace/bloodhound-enterprise/bhce/packages/go/crypto"
time=2025-09-25T19:48:35.037-07:00 level=INFO message=exec command="go generate /home/alyx/workspace/bloodhound-enterprise/bhce/packages/go/headers"
time=2025-09-25T19:48:35.051-07:00 level=INFO message=exec command="go generate /home/alyx/workspace/bloodhound-enterprise/bhce/packages/go/mediatypes"
time=2025-09-25T19:48:42.345-07:00 level=INFO message=exec command="go tool goimports"
time=2025-09-25T19:48:43.969-07:00 level=INFO message=exec command="yarn format"
time=2025-09-25T19:49:03.788-07:00 level=INFO message=exec command="npx @redocly/cli@1.18.1 bundle"
time=2025-09-25T19:49:06.910-07:00 level=INFO message="Command `generate` completed successfully"
time=2025-09-25T19:49:06.987-07:00 level=WARN message="unknown extension" path=/home/alyx/workspace/bloodhound-enterprise/bhce/.github/CODEOWNERS
time=2025-09-25T19:49:06.991-07:00 level=WARN message="unknown extension" path=/home/alyx/workspace/bloodhound-enterprise/bhce/cmd/api/src/test/fixtures/fixtures/v6/ingest/deleted.json.bad
time=2025-09-25T19:49:06.994-07:00 level=WARN message="unknown extension" path=/home/alyx/workspace/bloodhound-enterprise/bhce/debian/changelog
time=2025-09-25T19:49:06.994-07:00 level=WARN message="unknown extension" path=/home/alyx/workspace/bloodhound-enterprise/bhce/debian/bloodhound.postinst
time=2025-09-25T19:49:06.994-07:00 level=WARN message="unknown extension" path=/home/alyx/workspace/bloodhound-enterprise/bhce/debian/copyright
time=2025-09-25T19:49:06.994-07:00 level=WARN message="unknown extension" path=/home/alyx/workspace/bloodhound-enterprise/bhce/debian/bloodhound.dirs
time=2025-09-25T19:49:06.994-07:00 level=WARN message="unknown extension" path=/home/alyx/workspace/bloodhound-enterprise/bhce/debian/control
time=2025-09-25T19:49:06.994-07:00 level=WARN message="unknown extension" path=/home/alyx/workspace/bloodhound-enterprise/bhce/debian/bloodhound.service
time=2025-09-25T19:49:06.994-07:00 level=WARN message="unknown extension" path=/home/alyx/workspace/bloodhound-enterprise/bhce/debian/generate_changelog.sh
time=2025-09-25T19:49:06.994-07:00 level=WARN message="unknown extension" path=/home/alyx/workspace/bloodhound-enterprise/bhce/debian/bhapi.json.default
time=2025-09-25T19:49:06.995-07:00 level=WARN message="unknown extension" path=/home/alyx/workspace/bloodhound-enterprise/bhce/docs/README.MD
time=2025-09-25T19:49:06.994-07:00 level=WARN message="unknown extension" path=/home/alyx/workspace/bloodhound-enterprise/bhce/debian/bloodhound.install
time=2025-09-25T19:49:06.994-07:00 level=WARN message="unknown extension" path=/home/alyx/workspace/bloodhound-enterprise/bhce/debian/rules
time=2025-09-25T19:49:07.011-07:00 level=WARN message="unknown extension" path=/home/alyx/workspace/bloodhound-enterprise/bhce/test.log
time=2025-09-25T19:49:07.012-07:00 level=WARN message="unknown extension" path=/home/alyx/workspace/bloodhound-enterprise/bhce/tmp/coverage/71ce8ad7-f639-4c0b-a8c3-e2d3f27f2821.coverage
time=2025-09-25T19:49:07.012-07:00 level=INFO message="running scans on bhce" execution_time=25.578818ms
time=2025-09-25T19:49:07.012-07:00 level=INFO message="Command `license` completed successfully"
time=2025-09-25T19:49:07.091-07:00 level=INFO message=exec command="go tool golangci-lint"
time=2025-09-25T19:49:08.993-07:00 level=INFO message="Running eslint"
time=2025-09-25T19:49:08.993-07:00 level=INFO message=exec command="yarn run lint"
time=2025-09-25T19:49:11.842-07:00 level=INFO message=exec command="yarn run lint"
time=2025-09-25T19:49:19.391-07:00 level=INFO message=exec command="yarn run lint"
time=2025-09-25T19:49:21.029-07:00 level=INFO message="Completed eslint"
time=2025-09-25T19:49:21.030-07:00 level=WARN message="Analysis completed with warnings. Rerun with `-all` to see results."
time=2025-09-25T19:49:21.030-07:00 level=INFO message="Command `analysis` completed successfully"
time=2025-09-25T19:49:21.110-07:00 level=INFO message=exec command="git rev-parse HEAD"
time=2025-09-25T19:49:21.112-07:00 level=INFO message="Listing tags for /home/alyx/workspace/bloodhound-enterprise/bhce"
time=2025-09-25T19:49:21.113-07:00 level=INFO message="Finished listing tags for /home/alyx/workspace/bloodhound-enterprise/bhce"
time=2025-09-25T19:49:21.114-07:00 level=INFO message="Checking repository clean for /home/alyx/workspace/bloodhound-enterprise/bhce"
time=2025-09-25T19:49:21.114-07:00 level=INFO message=exec command="git status"
time=2025-09-25T19:49:21.129-07:00 level=INFO message=exec command="git diff-index --quiet"
time=2025-09-25T19:49:21.134-07:00 level=INFO message="Finished checking repository clean for /home/alyx/workspace/bloodhound-enterprise/bhce"
Repository Report For /home/alyx/workspace/bloodhound-enterprise/bhce
Current HEAD: 94b0c67445bdb492ab2a3a0d0a35ef361df848a7
Detected version: 8.2.0
Repository Clean

time=2025-09-25T19:49:21.134-07:00 level=INFO message="Command `show` completed successfully"
```

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Clearer warning reporting from analyzers without failing commands.
  - Standardized, direct-to-stdout output for consistent CLI behavior.
  - More visible ESLint output (quiet mode removed).

- Bug Fixes
  - More accurate detection of dirty Git workspaces.
  - Consistent exit behavior when only low-severity findings are present.

- Documentation
  - Added Apache-2.0 license header to a shared UI utility.

- Refactor
  - Migrated command execution to a context-aware runner for more reliable execution and logging across tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->