### PR TITLE
fix (api): Saved Query Multi Export is Not Functioning as Expected  - BED-6557

### DIFF
--- a/cmd/api/src/api/registration/v2.go
+++ b/cmd/api/src/api/registration/v2.go
@@ -215,6 +215,8 @@ func NewV2API(resources v2.Resources, routerInst *router.Router) {
 		routerInst.POST("/api/v2/graphs/cypher", resources.CypherQuery).RequirePermissions(permissions.GraphDBRead),
 		routerInst.GET("/api/v2/saved-queries", resources.ListSavedQueries).RequirePermissions(permissions.SavedQueriesRead),
 		routerInst.POST("/api/v2/saved-queries", resources.CreateSavedQuery).RequirePermissions(permissions.SavedQueriesWrite),
+		routerInst.GET("/api/v2/saved-queries/export", resources.ExportSavedQueries).RequirePermissions(permissions.SavedQueriesRead),
+		routerInst.POST("/api/v2/saved-queries/import", resources.ImportSavedQueries).RequirePermissions(permissions.SavedQueriesWrite),
 		routerInst.GET(fmt.Sprintf("/api/v2/saved-queries/{%s}", api.URIPathVariableSavedQueryID), resources.GetSavedQuery).RequirePermissions(permissions.SavedQueriesRead),
 		routerInst.PUT(fmt.Sprintf("/api/v2/saved-queries/{%s}", api.URIPathVariableSavedQueryID), resources.UpdateSavedQuery).RequirePermissions(permissions.SavedQueriesWrite),
 		routerInst.DELETE(fmt.Sprintf("/api/v2/saved-queries/{%s}", api.URIPathVariableSavedQueryID), resources.DeleteSavedQuery).RequirePermissions(permissions.SavedQueriesWrite),
@@ -222,8 +224,6 @@ func NewV2API(resources v2.Resources, routerInst *router.Router) {
 		routerInst.DELETE(fmt.Sprintf("/api/v2/saved-queries/{%s}/permissions", api.URIPathVariableSavedQueryID), resources.DeleteSavedQueryPermissions).RequirePermissions(permissions.SavedQueriesWrite),
 		routerInst.PUT(fmt.Sprintf("/api/v2/saved-queries/{%s}/permissions", api.URIPathVariableSavedQueryID), resources.ShareSavedQueries).RequirePermissions(permissions.SavedQueriesWrite),
 		routerInst.GET(fmt.Sprintf("/api/v2/saved-queries/{%s}/export", api.URIPathVariableSavedQueryID), resources.ExportSavedQuery).RequirePermissions(permissions.SavedQueriesRead),
-		routerInst.GET("/api/v2/saved-queries/export", resources.ExportSavedQueries).RequirePermissions(permissions.SavedQueriesRead),
-		routerInst.POST("/api/v2/saved-queries/import", resources.ImportSavedQueries).RequirePermissions(permissions.SavedQueriesWrite),
 
 		// Azure Entity API
 		routerInst.GET("/api/v2/azure/{entity_type}", resources.GetAZEntity).RequirePermissions(permissions.GraphDBRead),

--- a/cmd/api/src/daemons/ha/ha.go
+++ b/cmd/api/src/daemons/ha/ha.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/javascript/bh-shared-ui/src/components/FileIngestTable/FileIngestTable.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/FileIngestTable/FileIngestTable.tsx
@@ -22,8 +22,8 @@ import { JOB_STATUS_INDICATORS, JOB_STATUS_MAP, getSimpleDuration, toFormatted }
 import DataTable from '../DataTable';
 import { FileIngestUploadButton } from '../FileIngest/FileIngestUploadButton';
 import { StatusIndicator } from '../StatusIndicator';
-import { FileIngestFilterDialog } from './FileIngestFilterDialog';
 import { FileIngestDetailsPanel } from './FileIngestDetailsPanel';
+import { FileIngestFilterDialog } from './FileIngestFilterDialog';
 
 const HEADERS = ['ID / User / Status', 'Message', 'Start Time', 'Duration', 'File Information'];
 

--- a/packages/javascript/bh-shared-ui/src/utils/freeIconsList.ts
+++ b/packages/javascript/bh-shared-ui/src/utils/freeIconsList.ts
@@ -1,3 +1,18 @@
+// Copyright 2025 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 import { IconName } from '@fortawesome/free-solid-svg-icons';
 
 interface IconListItem {

--- a/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/Details/TagList.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/Details/TagList.test.tsx
@@ -19,10 +19,10 @@ import { rest } from 'msw';
 import { setupServer } from 'msw/node';
 import { UseQueryResult } from 'react-query';
 import { useParams } from 'react-router-dom';
+import zoneHandlers from '../../../mocks/handlers/zoneHandlers';
 import { detailsPath, privilegeZonesPath, zonesPath } from '../../../routes';
 import { render, screen, within } from '../../../test-utils';
 import { TagList } from './TagList';
-import zoneHandlers from '../../../mocks/handlers/zoneHandlers';
 
 const testQuery = {
     isLoading: false,


### PR DESCRIPTION
## Description

Moves the export and import endpoints above the GET single query endpoint. This way the API correctly routes to the multi export query endpoint. 

## Motivation and Context
Resolves: 6557

Multi Query export is returning a 400 instead of downloading the expected file. 

## How Has This Been Tested?
- Local testing against API using API explorer

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reordered internal API route registration for saved-query export/import with no functional impact.
* **Documentation**
  * Added license header comments to align with project standards.
* **Style**
  * Cleaned up import ordering and minor comment formatting for consistency.
* **Tests**
  * Removed a duplicate import and streamlined test imports.
* **Chores**
  * General code housekeeping; no user-facing behavior changes.

No changes to endpoints, permissions, or UI behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->