### PR TITLE
draft poc: changelog + post processing

### DIFF
--- a/cmd/api/src/analysis/ad/post.go
+++ b/cmd/api/src/analysis/ad/post.go
@@ -34,11 +34,11 @@ func Post(ctx context.Context, db graph.Database, adcsEnabled, citrixEnabled, nt
 		return &aggregateStats, err
 	} else if dcSyncStats, err := adAnalysis.PostDCSync(ctx, db, groupExpansions, changeManager); err != nil {
 		return &aggregateStats, err
-	} else if protectAdminGroupsStats, err := adAnalysis.PostProtectAdminGroups(ctx, db); err != nil {
+	} else if protectAdminGroupsStats, err := adAnalysis.PostProtectAdminGroups(ctx, db, changeManager); err != nil {
 		return &aggregateStats, err
-	} else if syncLAPSStats, err := adAnalysis.PostSyncLAPSPassword(ctx, db, groupExpansions); err != nil {
+	} else if syncLAPSStats, err := adAnalysis.PostSyncLAPSPassword(ctx, db, groupExpansions, changeManager); err != nil {
 		return &aggregateStats, err
-	} else if hasTrustKeyStats, err := adAnalysis.PostHasTrustKeys(ctx, db); err != nil {
+	} else if hasTrustKeyStats, err := adAnalysis.PostHasTrustKeys(ctx, db, changeManager); err != nil {
 		return &aggregateStats, err
 	} else if localGroupStats, err := adAnalysis.PostLocalGroups(ctx, db, groupExpansions, false, citrixEnabled); err != nil {
 		return &aggregateStats, err

--- a/cmd/api/src/analysis/ad/post.go
+++ b/cmd/api/src/analysis/ad/post.go
@@ -26,13 +26,13 @@ import (
 	"github.com/specterops/dawgs/graph"
 )
 
-func Post(ctx context.Context, db graph.Database, adcsEnabled, citrixEnabled, ntlmEnabled bool, compositionCounter *analysis.CompositionCounter) (*analysis.AtomicPostProcessingStats, error) {
+func Post(ctx context.Context, db graph.Database, adcsEnabled, citrixEnabled, ntlmEnabled bool, compositionCounter *analysis.CompositionCounter, changeManager analysis.ChangeManager) (*analysis.AtomicPostProcessingStats, error) {
 	aggregateStats := analysis.NewAtomicPostProcessingStats()
 	if stats, err := analysis.DeleteTransitEdges(ctx, db, graph.Kinds{ad.Entity, azure.Entity}, adAnalysis.PostProcessedRelationships()...); err != nil {
 		return &aggregateStats, err
 	} else if groupExpansions, err := adAnalysis.ExpandAllRDPLocalGroups(ctx, db); err != nil {
 		return &aggregateStats, err
-	} else if dcSyncStats, err := adAnalysis.PostDCSync(ctx, db, groupExpansions); err != nil {
+	} else if dcSyncStats, err := adAnalysis.PostDCSync(ctx, db, groupExpansions, changeManager); err != nil {
 		return &aggregateStats, err
 	} else if protectAdminGroupsStats, err := adAnalysis.PostProtectAdminGroups(ctx, db); err != nil {
 		return &aggregateStats, err

--- a/cmd/api/src/services/graphify/analysis_integration_test.go
+++ b/cmd/api/src/services/graphify/analysis_integration_test.go
@@ -48,7 +48,7 @@ func TestVersion5Analysis(t *testing.T) {
 	err = generic.WriteGraphToDatabase(testSuite.GraphDB, &expected)
 	require.NoError(t, err)
 
-	err = datapipe.RunAnalysisOperations(ctx, testSuite.BHDatabase, testSuite.GraphDB, config.Configuration{})
+	err = datapipe.RunAnalysisOperations(ctx, testSuite.BHDatabase, testSuite.GraphDB, config.Configuration{}, nil)
 	require.NoError(t, err)
 
 	expected, err = generic.LoadGraphFromFile(os.DirFS(analysisFilePath), "analyzed.json")
@@ -76,7 +76,7 @@ func TestVersion6ADCSAnalysis(t *testing.T) {
 	err = generic.WriteGraphToDatabase(testSuite.GraphDB, &expected)
 	require.NoError(t, err)
 
-	err = datapipe.RunAnalysisOperations(ctx, testSuite.BHDatabase, testSuite.GraphDB, config.Configuration{})
+	err = datapipe.RunAnalysisOperations(ctx, testSuite.BHDatabase, testSuite.GraphDB, config.Configuration{}, nil)
 	require.NoError(t, err)
 
 	expected, err = generic.LoadGraphFromFile(os.DirFS(analysisFilePath), "analyzed.json")
@@ -104,7 +104,7 @@ func TestVersion6AllAnalysis(t *testing.T) {
 	err = generic.WriteGraphToDatabase(testSuite.GraphDB, &expected)
 	require.NoError(t, err)
 
-	err = datapipe.RunAnalysisOperations(ctx, testSuite.BHDatabase, testSuite.GraphDB, config.Configuration{})
+	err = datapipe.RunAnalysisOperations(ctx, testSuite.BHDatabase, testSuite.GraphDB, config.Configuration{}, nil)
 	require.NoError(t, err)
 
 	expected, err = generic.LoadGraphFromFile(os.DirFS(analysisFilePath), "analyzed.json")
@@ -132,7 +132,7 @@ func TestVersion6Analysis(t *testing.T) {
 	err = generic.WriteGraphToDatabase(testSuite.GraphDB, &expected)
 	require.NoError(t, err)
 
-	err = datapipe.RunAnalysisOperations(ctx, testSuite.BHDatabase, testSuite.GraphDB, config.Configuration{})
+	err = datapipe.RunAnalysisOperations(ctx, testSuite.BHDatabase, testSuite.GraphDB, config.Configuration{}, nil)
 	require.NoError(t, err)
 
 	expected, err = generic.LoadGraphFromFile(os.DirFS(analysisFilePath), "analyzed.json")

--- a/packages/go/analysis/ad/post.go
+++ b/packages/go/analysis/ad/post.go
@@ -36,6 +36,79 @@ import (
 	"github.com/specterops/dawgs/util/channels"
 )
 
+// submitPostRelationshipJob checks the changelog for deduplication before submitting a post-processing job.
+// If the relationship is unchanged, it submits to changelog for lastseen tracking only.
+// If the relationship is new/modified, it submits the job for actual creation.
+func submitPostRelationshipJob(
+	ctx context.Context,
+	tx graph.Transaction,
+	outC chan<- analysis.CreatePostRelationshipJob,
+	job analysis.CreatePostRelationshipJob,
+	changeManager analysis.ChangeManager,
+) bool {
+	// If no changelog, submit job directly
+	if changeManager == nil {
+		return channels.Submit(ctx, outC, job)
+	}
+
+	// Get objectids for changelog check
+	fromObjectID, err := getNodeObjectID(tx, job.FromID)
+	if err != nil {
+		slog.WarnContext(ctx, "failed to get from node objectid for changelog check", "node_id", job.FromID, "err", err)
+		return channels.Submit(ctx, outC, job) // Fall back to submitting job
+	}
+
+	toObjectID, err := getNodeObjectID(tx, job.ToID)
+	if err != nil {
+		slog.WarnContext(ctx, "failed to get to node objectid for changelog check", "node_id", job.ToID, "err", err)
+		return channels.Submit(ctx, outC, job) // Fall back to submitting job
+	}
+
+	// Create changelog edge change
+	relProps := graph.NewProperties().Set("lastseen", time.Now().UTC())
+	// Add any additional properties from the job
+	if job.RelProperties != nil {
+		for key, value := range job.RelProperties {
+			relProps.Set(key, value)
+		}
+	}
+
+	change := analysis.NewEdgeChange(fromObjectID, toObjectID, job.Kind, relProps)
+
+	// Check if this relationship needs to be created
+	shouldSubmit, err := changeManager.ResolveChange(change)
+	if err != nil {
+		slog.WarnContext(ctx, "changelog resolve failed", "err", err)
+		return channels.Submit(ctx, outC, job) // Fall back to submitting job
+	}
+
+	if !shouldSubmit {
+		// Unchanged: submit to changelog for lastseen tracking only
+		changeManager.Submit(ctx, change)
+		return true // Successfully handled (no job submission needed)
+	}
+
+	// New or modified: submit the job for creation
+	return channels.Submit(ctx, outC, job)
+}
+
+// getNodeObjectID fetches the objectid property for a given node ID
+func getNodeObjectID(tx graph.Transaction, nodeID graph.ID) (string, error) {
+	node, err := tx.Nodes().Filterf(func() graph.Criteria {
+		return query.Equals(query.NodeID(), nodeID)
+	}).First()
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch node %d: %w", nodeID, err)
+	}
+
+	objectID, err := node.Properties.Get("objectid").String()
+	if err != nil {
+		return "", fmt.Errorf("node %d missing objectid property: %w", nodeID, err)
+	}
+
+	return objectID, nil
+}
+
 func PostProcessedRelationships() []graph.Kind {
 	return []graph.Kind{
 		ad.DCSync,
@@ -74,7 +147,7 @@ func PostProcessedRelationships() []graph.Kind {
 	}
 }
 
-func PostSyncLAPSPassword(ctx context.Context, db graph.Database, groupExpansions impact.PathAggregator) (*analysis.AtomicPostProcessingStats, error) {
+func PostSyncLAPSPassword(ctx context.Context, db graph.Database, groupExpansions impact.PathAggregator, changeManager analysis.ChangeManager) (*analysis.AtomicPostProcessingStats, error) {
 	if domainNodes, err := fetchCollectedDomainNodes(ctx, db); err != nil {
 		return &analysis.AtomicPostProcessingStats{}, err
 	} else {
@@ -91,11 +164,11 @@ func PostSyncLAPSPassword(ctx context.Context, db graph.Database, groupExpansion
 				} else {
 					for _, computer := range computers {
 						lapsSyncers.Each(func(value uint64) bool {
-							channels.Submit(ctx, outC, analysis.CreatePostRelationshipJob{
+							submitPostRelationshipJob(ctx, tx, outC, analysis.CreatePostRelationshipJob{
 								FromID: graph.ID(value),
 								ToID:   computer,
 								Kind:   ad.SyncLAPSPassword,
-							})
+							}, changeManager)
 							return true
 						})
 					}
@@ -123,46 +196,12 @@ func PostDCSync(ctx context.Context, db graph.Database, groupExpansions impact.P
 				} else if dcSyncers.Cardinality() == 0 {
 					return nil
 				} else {
-					// Get domain objectid for changelog
-					domainObjectID, err := innerDomain.Properties.Get("objectid").String()
-					if err != nil {
-						return fmt.Errorf("failed to get domain objectid: %w", err)
-					}
-
 					dcSyncers.Each(func(value uint64) bool {
-						nodeID := graph.ID(value)
-
-						// Fetch the node to get its objectid
-						if node, err := tx.Nodes().Filterf(func() graph.Criteria {
-							return query.Equals(query.NodeID(), nodeID)
-						}).First(); err != nil {
-							slog.WarnContext(ctx, "failed to fetch node for changelog check", "node_id", nodeID, "err", err)
-							// Fall through to submit the job anyway
-						} else if nodeObjectID, err := node.Properties.Get("objectid").String(); err != nil {
-							slog.WarnContext(ctx, "node missing objectid property", "node_id", nodeID, "err", err)
-							// Fall through to submit the job anyway
-						} else if changeManager != nil {
-							// Create changelog edge change
-							relProps := graph.NewProperties().Set("lastseen", time.Now().UTC())
-							change := analysis.NewEdgeChange(nodeObjectID, domainObjectID, ad.DCSync, relProps)
-
-							// Check if this relationship needs to be created
-							if shouldSubmit, err := changeManager.ResolveChange(change); err != nil {
-								slog.WarnContext(ctx, "changelog resolve failed", "err", err)
-								// Fall through to submit the job anyway
-							} else if !shouldSubmit {
-								// Unchanged: submit to changelog for lastseen tracking
-								changeManager.Submit(ctx, change)
-								return true // Continue to next dcSyncer
-							}
-						}
-
-						// New or modified: submit the job for creation
-						channels.Submit(ctx, outC, analysis.CreatePostRelationshipJob{
-							FromID: nodeID,
+						submitPostRelationshipJob(ctx, tx, outC, analysis.CreatePostRelationshipJob{
+							FromID: graph.ID(value),
 							ToID:   innerDomain.ID,
 							Kind:   ad.DCSync,
-						})
+						}, changeManager)
 						return true
 					})
 
@@ -177,7 +216,7 @@ func PostDCSync(ctx context.Context, db graph.Database, groupExpansions impact.P
 	}
 }
 
-func PostProtectAdminGroups(ctx context.Context, db graph.Database) (*analysis.AtomicPostProcessingStats, error) {
+func PostProtectAdminGroups(ctx context.Context, db graph.Database, changeManager analysis.ChangeManager) (*analysis.AtomicPostProcessingStats, error) {
 	domainNodes, err := fetchCollectedDomainNodes(ctx, db)
 	if err != nil {
 		return &analysis.AtomicPostProcessingStats{}, err
@@ -201,11 +240,11 @@ func PostProtectAdminGroups(ctx context.Context, db graph.Database) (*analysis.A
 			} else {
 				fromID := adminSDHolderIDs[0] // AdminSDHolder should be unique per domain
 				for _, toID := range protectedObjectIDs {
-					channels.Submit(ctx, outC, analysis.CreatePostRelationshipJob{
+					submitPostRelationshipJob(ctx, tx, outC, analysis.CreatePostRelationshipJob{
 						FromID: fromID,
 						ToID:   toID,
 						Kind:   ad.ProtectAdminGroups,
-					})
+					}, changeManager)
 				}
 				return nil
 			}
@@ -215,7 +254,7 @@ func PostProtectAdminGroups(ctx context.Context, db graph.Database) (*analysis.A
 	return &operation.Stats, operation.Done()
 }
 
-func PostHasTrustKeys(ctx context.Context, db graph.Database) (*analysis.AtomicPostProcessingStats, error) {
+func PostHasTrustKeys(ctx context.Context, db graph.Database, changeManager analysis.ChangeManager) (*analysis.AtomicPostProcessingStats, error) {
 	if domainNodes, err := fetchCollectedDomainNodes(ctx, db); err != nil {
 		return &analysis.AtomicPostProcessingStats{}, err
 	} else {
@@ -240,11 +279,11 @@ func PostHasTrustKeys(ctx context.Context, db graph.Database) (*analysis.AtomicP
 							slog.DebugContext(ctx, fmt.Sprintf("Trust account not found for domain SID %s and NetBIOS %s", trustingDomainSid, netbios))
 							continue
 						} else {
-							channels.Submit(ctx, outC, analysis.CreatePostRelationshipJob{
+							submitPostRelationshipJob(ctx, tx, outC, analysis.CreatePostRelationshipJob{
 								FromID: domain.ID,
 								ToID:   trustAccount.ID,
 								Kind:   ad.HasTrustKeys,
-							})
+							}, changeManager)
 						}
 					}
 				}

--- a/packages/go/analysis/post.go
+++ b/packages/go/analysis/post.go
@@ -31,6 +31,32 @@ import (
 	"github.com/specterops/dawgs/util/channels"
 )
 
+// ChangeManager represents a minimal interface for changelog operations during post-processing.
+// This interface is defined here to avoid import cycles with the graphify package.
+type ChangeManager interface {
+	ResolveChange(change any) (bool, error)
+	Submit(ctx context.Context, change any) bool
+	FlushStats()
+}
+
+// EdgeChange represents a generic edge change for post-processing deduplication
+type EdgeChange struct {
+	SourceNodeID string
+	TargetNodeID string
+	Kind         graph.Kind
+	Properties   *graph.Properties
+}
+
+// NewEdgeChange creates a new edge change for post-processing
+func NewEdgeChange(sourceNodeID, targetNodeID string, kind graph.Kind, properties *graph.Properties) *EdgeChange {
+	return &EdgeChange{
+		SourceNodeID: sourceNodeID,
+		TargetNodeID: targetNodeID,
+		Kind:         kind,
+		Properties:   properties,
+	}
+}
+
 func statsSortedKeys(value map[graph.Kind]int) []graph.Kind {
 	kinds := make([]graph.Kind, 0, len(value))
 
@@ -168,6 +194,9 @@ func DeleteTransitEdges(ctx context.Context, db graph.Database, baseKinds graph.
 		relationshipIDs []graph.ID
 		stats           = NewAtomicPostProcessingStats()
 	)
+
+	// POC: don't delete PPE's
+	return &stats, nil
 
 	for _, kind := range targetRelationships {
 		closureKindCopy := kind

--- a/packages/go/graphify/graph/graph.go
+++ b/packages/go/graphify/graph/graph.go
@@ -188,7 +188,7 @@ func (s *CommunityGraphService) Ingest(ctx context.Context, batch *graphify.Inge
 }
 
 func (s *CommunityGraphService) RunAnalysis(ctx context.Context, graphDB graph.Database) error {
-	// Pass nil for changelog since community edition doesn't have changelog support
+	// POC: Pass nil for changelog
 	return datapipe.RunAnalysisOperations(ctx, s.db, graphDB, config.Configuration{}, nil)
 }
 

--- a/packages/go/graphify/graph/graph.go
+++ b/packages/go/graphify/graph/graph.go
@@ -188,7 +188,8 @@ func (s *CommunityGraphService) Ingest(ctx context.Context, batch *graphify.Inge
 }
 
 func (s *CommunityGraphService) RunAnalysis(ctx context.Context, graphDB graph.Database) error {
-	return datapipe.RunAnalysisOperations(ctx, s.db, graphDB, config.Configuration{})
+	// Pass nil for changelog since community edition doesn't have changelog support
+	return datapipe.RunAnalysisOperations(ctx, s.db, graphDB, config.Configuration{}, nil)
 }
 
 // Run generate command


### PR DESCRIPTION
this poc demonstrates how changelog could change the post processing flow. for POC purposes, the DCSync edge is the only PPE (post processed edge) implemented w changelog.
the value of this pattern is to reduce time spent in post processing to the same degree that we are expecting to reduce ingest time.

general idea:
- stop deleting all PPE's on each tick
- only submit PPE's if they don't exist in changelog 
- lastseen reconciliation cleans up stale PPE's (this converges the way we time out ingested entities and post processed entities)

open questions:
- is it acceptable to time out old PPE's using lastseen. my hunch is yes, since that is how we handle deleting ingested edges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional change-tracking integration during analysis to review, dedupe, and submit proposed relationship changes, with aggregated stats and flush behavior.

* **Behavior Changes**
  * Transit-edge deletions temporarily disabled to preserve existing relationships.

* **Improvements**
  * More resilient processing when related nodes are missing, with warnings and fallback submissions.

* **Tests**
  * Integration tests updated to the new analysis invocation signature (no user-facing functional changes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->