### PR TITLE
fix: BED-6546 URL encode cypher queries

### DIFF
--- a/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/Cypher/Cypher.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/Cypher/Cypher.test.tsx
@@ -76,7 +76,17 @@ describe('Cypher Search component for Zone Management', () => {
         const link = screen.getByRole('link', { name: 'View in Explore' });
         expect(link).toHaveAttribute(
             'href',
-            '/ui/explore?searchType=cypher&exploreSearchTab=cypher&cypherSearch=bWF0Y2gobikgcmV0dXJuIG4gbGltaXQgNQ=='
+            '/ui/explore?searchType=cypher&exploreSearchTab=cypher&cypherSearch=bWF0Y2gobikgcmV0dXJuIG4gbGltaXQgNQ%3D%3D'
+        );
+    });
+
+    it('properly encodes + sign into the "View in Explore" link', () => {
+        render(<Cypher initialInput='hello>world' />);
+
+        const link = screen.getByRole('link', { name: 'View in Explore' });
+        expect(link).toHaveAttribute(
+            'href',
+            '/ui/explore?searchType=cypher&exploreSearchTab=cypher&cypherSearch=aGVsbG8%2Bd29ybGQ%3D'
         );
     });
 

--- a/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/Cypher/Cypher.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/Cypher/Cypher.tsx
@@ -78,7 +78,8 @@ export const Cypher: FC<{
     );
 
     const exploreUrl = useMemo(
-        () => `/ui/explore?searchType=cypher&exploreSearchTab=cypher&cypherSearch=${encodeCypherQuery(cypherQuery)}`,
+        () =>
+            `/ui/explore?searchType=cypher&exploreSearchTab=cypher&cypherSearch=${encodeURIComponent(encodeCypherQuery(cypherQuery))}`,
         [cypherQuery]
     );
 


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Certain cypher queries were breaking when going from the selector overview page to the `View in Explore` page. This is because the base64 encoded queries were not being encoded as URI components, so certain base64 characters like `+` were being put into the URL as spaces, which broke decoding on the explore page.

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-6546

The cypher query mentioned in the ticket was breaking when viewed on the explore page -- these changes fix that issue.

Added `encodeURIComponent` to the cypher query before creating the URL for the explore page.

## How Has This Been Tested?

The cypher query listed in the ticket (not duplicated here for confidentiality reasons) no longer breaks when viewed in the explore page. 

Existing queries still function as expected. 

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected URL encoding for the “View in Explore” link in Cypher, ensuring queries with special characters (e.g., +, >, =) are handled properly and links open as expected.

* **Tests**
  * Updated tests to validate proper percent-encoding of the cypherSearch parameter.
  * Added coverage for special characters to prevent regressions and ensure consistent behavior across edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->