### PR TITLE
BED-6040 ETAC posture-stats

### DIFF
--- a/cmd/api/src/api/constant.go
+++ b/cmd/api/src/api/constant.go
@@ -47,6 +47,7 @@ const (
 	QueryParameterFindingType     = "finding"
 	QueryParameterAssetGroupTagId = "asset_group_tag_id"
 	QueryParameterEnvironments    = "environments"
+	QueryParameterDomainSid       = "domain_sid"
 
 	// URI path parameters
 	URIPathVariableApplicationConfigurationParameter = "parameter"


### PR DESCRIPTION
## Description
This PR adds a constant used for ETAC filtering for the /posture-stats endpoint.

## Motivation and Context

Resolves [BED-6040](https://specterops.atlassian.net/browse/BED-6040?atlOrigin=eyJpIjoiNmM2OGQ0OWIyYzdiNGMwZjg1YzE2NDRiYWFmMmViYjMiLCJwIjoiaiJ9)

## How Has This Been Tested?
Tests pass locally.

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [X] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [X] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [X] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


[BED-6040]: https://specterops.atlassian.net/browse/BED-6040?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for a new query parameter, domain_sid, allowing API consumers to specify or filter by a domain SID when interacting with relevant endpoints. This extends flexibility for domain-scoped queries without changing existing behavior; current integrations require no changes unless they opt to use the new parameter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->