### PR TITLE
BED-6620 fix(AGT): get selector members not respecting certification

### DIFF
--- a/cmd/api/src/api/v2/assetgrouptags.go
+++ b/cmd/api/src/api/v2/assetgrouptags.go
@@ -773,6 +773,11 @@ func (s *Resources) GetAssetGroupMembersBySelector(response http.ResponseWriter,
 			filter.Params = append(filter.Params, environmentIds)
 		}
 
+		if assetGroupTag.RequireCertify.ValueOrZero() {
+			filter.SQLString += " AND certified > ?"
+			filter.Params = append(filter.Params, model.AssetGroupCertificationRevoked)
+		}
+
 		if selectorNodes, count, err := s.DB.GetSelectorNodesBySelectorIdsFilteredAndPaginated(request.Context(), filter, sort, skip, limit, selectorId); err != nil {
 			api.HandleDatabaseError(request, response, err)
 		} else {


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

*Describe your changes in detail*
Added filter for certified nodes only when asset group tag has certified required while getting selector members

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-6620

*Why is this change required? What problem does it solve?*

## How Has This Been Tested?
Have certify required disabled and then enabled and see the members list decrease with the latter

*Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc.*

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->
- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Selector-based asset group membership now enforces certification requirements, excluding revoked or uncertified assets when certification is required.
  * Improves accuracy and consistency of group membership in views, reports, and exports that rely on selector-based groups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->