### PR TITLE
BED-6631: RODC Default Selector Broken Due To Incorrect Cypher

### DIFF
--- a/cmd/api/src/database/migration/migrations/v8.3.0.sql
+++ b/cmd/api/src/database/migration/migrations/v8.3.0.sql
@@ -124,7 +124,6 @@ WHERE agts.id = duplicate_selectors.id AND duplicate_selectors.rowNumber > 1;
 ALTER TABLE IF EXISTS asset_group_tag_selectors DROP CONSTRAINT IF EXISTS asset_group_tag_selectors_unique_name_asset_group_tag;
 ALTER TABLE IF EXISTS asset_group_tag_selectors ADD CONSTRAINT asset_group_tag_selectors_unique_name_asset_group_tag UNIQUE ("name",asset_group_tag_id,is_default);
 
-
 -- Fix naming inconsistencies for ETAC
 ALTER TABLE IF EXISTS environment_access_control
     RENAME TO environment_targeted_access_control;
@@ -133,3 +132,8 @@ SET key         = 'environment_targeted_access_control',
     name        = 'Environment Targeted Access Control',
     description = 'Enable power users and admins to set environment targeted access controls on users'
 WHERE key = 'targeted_access_control';
+
+-- Update RO-DC default selector within Tier Zero to use the correct attribute name
+UPDATE asset_group_tag_selector_seeds 
+SET value = E'MATCH (n:Computer)\nWHERE n.isreadonlydc = true\nRETURN n;' 
+WHERE selector_id in (SELECT id FROM asset_group_tag_selectors WHERE name = 'Read-Only DCs' AND is_default = true);


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

- Altered v8.3.0 migration file to use the correct attribute name `n.isreadonlydc = true` for the cypher query of the RO-DC default selector

## Motivation and Context

This PR addresses:
- BED-6631

*Why is this change required? What problem does it solve?*
- At the moment, the default selector for Read-Only DCs does not return objects because the cypher query references the attribute incorrectly as `isReadOnlyDC`. The attribute in BloodHound is case-sensitive and is actually stored as `isreadonlydc`. This fix will allow results to be returned when running the cypher query

## How Has This Been Tested?

- Within my local env and the test env _(still working on this)*_

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)
- Database Migrations

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a default "Read‑Only DCs" selector so read‑only data centers are automatically identified for grouping and filtering.

* **Chores**
  * Seeded the default selector with the query used to populate it during setup (no changes to existing selectors).
  * Minor formatting adjustment in migration scripts (no behavioral change).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->