### PR TITLE
BED-6597 - add z-index to file upload dialog to prevent double dialog issue

### DIFF
--- a/packages/javascript/bh-shared-ui/src/components/FileUploadDialog/FileUploadDialog.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/FileUploadDialog/FileUploadDialog.tsx
@@ -66,6 +66,7 @@ const FileUploadDialog: React.FC<{
             scroll='paper'
             onClose={onClose}
             ref={dialogRef}
+            className='z-[1600]'
             TransitionProps={{
                 onExited: () => {
                     setFileUploadStep(FileUploadStep.ADD_FILES);


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

If the user has no data, we launch an instructive dialog automatically. If the user launches the quick file upload dialog, they might expect the quick file upload dialog to be above the less important no data dialog. Instead this happens:

<img width="852" height="595" alt="image" src="https://github.com/user-attachments/assets/3a4d44c1-fead-4efd-9c12-ad97cedcf01d" />

This PR adjusts the z index to fix this issue,

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-6597

*Why is this change required? What problem does it solve?*

## How Has This Been Tested?

*Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc.*

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)
- Database Migrations

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [ ] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [ ] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [ ] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
