### PR TITLE
BED-6656 Provide Tool API Controls for Retaining Ingest Files

### DIFF
--- a/cmd/api/src/api/tools/ingest.go
+++ b/cmd/api/src/api/tools/ingest.go
@@ -1,0 +1,206 @@
+// Copyright 2025 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+package tools
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/specterops/bloodhound/cmd/api/src/api"
+	"github.com/specterops/bloodhound/cmd/api/src/config"
+	"github.com/specterops/bloodhound/cmd/api/src/database/types"
+	"github.com/specterops/bloodhound/cmd/api/src/model/appcfg"
+	"github.com/specterops/bloodhound/packages/go/headers"
+)
+
+type IngestControl struct {
+	cfg              config.Configuration
+	retainedFileLock *sync.RWMutex
+	parameterService appcfg.ParameterService
+}
+
+func NewIngestControlTool(cfg config.Configuration, parameterService appcfg.ParameterService) IngestControl {
+	return IngestControl{
+		cfg:              cfg,
+		retainedFileLock: &sync.RWMutex{},
+		parameterService: parameterService,
+	}
+}
+
+func (s *IngestControl) setIngestFileRetention(ctx context.Context, parameter appcfg.RetainIngestedFilesParameter) error {
+	if val, err := types.NewJSONBObject(parameter); err != nil {
+		return fmt.Errorf("failed to convert value to JSONBObject: %w", err)
+	} else {
+		enabledParameter := appcfg.Parameter{
+			Key:         appcfg.RetainIngestedFilesKey,
+			Name:        "Hold Ingested Files",
+			Description: "Boolean switch for holding previously ingested files for operator inspection.",
+			Value:       val,
+		}
+
+		if err := s.parameterService.SetConfigurationParameter(ctx, enabledParameter); err != nil {
+			return fmt.Errorf("failed to set parameter: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (s *IngestControl) FetchRetainedIngestFiles(response http.ResponseWriter, request *http.Request) {
+	if !s.retainedFileLock.TryRLock() {
+		// Unable to acquire a write lock at this time - notify of a conflict. User is expected to retry
+		// the request later.
+		response.WriteHeader(http.StatusConflict)
+		return
+	}
+
+	defer s.retainedFileLock.RUnlock()
+
+	if !appcfg.ShouldRetainIngestedFiles(request.Context(), s.parameterService) {
+		// If the setting for ingest file retention is disabled then assume there is nothing to read.
+		response.WriteHeader(http.StatusNotFound)
+		return
+	}
+
+	retainedFilesDirectory := s.cfg.RetainedFilesDirectory()
+
+	if retainedFilesDirEntries, err := os.ReadDir(retainedFilesDirectory); err != nil {
+		// Unable to stat the retained files directory. Log a warning and inform the user that the
+		// operation failed.
+		slog.WarnContext(request.Context(), fmt.Sprintf("Failed reading retained files directory %s: %v", retainedFilesDirectory, err))
+		response.WriteHeader(http.StatusInternalServerError)
+	} else {
+		// Author the response
+		response.Header().Set(headers.ContentType.String(), "application/gzip")
+		response.Header().Set(headers.ContentEncoding.String(), "gzip")
+		response.Header().Set(headers.ContentDisposition.String(), fmt.Sprintf(`attachment; filename="retained-ingest-%s.tar.gz"`, time.Now().UTC().Format("20060102T150405Z")))
+		response.WriteHeader(http.StatusOK)
+
+		var (
+			gzipWriter = gzip.NewWriter(response)
+			tarWriter  = tar.NewWriter(gzipWriter)
+		)
+
+		for _, retainedFilesDirEntry := range retainedFilesDirEntries {
+			retainedFilePath := filepath.Join(retainedFilesDirectory, retainedFilesDirEntry.Name())
+
+			if retainedFilesDirEntry.IsDir() {
+				// Log a warning for directory entries and skip reading it.
+				slog.WarnContext(request.Context(), fmt.Sprintf("Unexpected directory %s in retained files directory %s: %v", retainedFilePath, retainedFilesDirectory, err))
+				continue
+			}
+
+			if fileInfo, err := retainedFilesDirEntry.Info(); err != nil {
+				slog.WarnContext(request.Context(), fmt.Sprintf("Unable to stat file %s: %v", retainedFilePath, err))
+				break
+			} else {
+				if tarHeader, err := tar.FileInfoHeader(fileInfo, ""); err != nil {
+					slog.WarnContext(request.Context(), fmt.Sprintf("Unable to convert file info for file %s: %v", retainedFilePath, err))
+					break
+				} else if err := tarWriter.WriteHeader(tarHeader); err != nil {
+					slog.WarnContext(request.Context(), fmt.Sprintf("Failed writing tar file header from %s to response: %v", retainedFilePath, err))
+					break
+				}
+
+				if fin, err := os.Open(retainedFilePath); err != nil {
+					slog.WarnContext(request.Context(), fmt.Sprintf("Unexpected directory %s in retained files directory %s: %v", retainedFilePath, retainedFilesDirectory, err))
+					break
+				} else {
+					// Copy and inspect the error only after closing the file.
+					_, copyErr := io.Copy(tarWriter, fin)
+					fin.Close()
+
+					if copyErr != nil {
+						slog.WarnContext(request.Context(), fmt.Sprintf("Failed writing file content from %s to response: %v", retainedFilePath, copyErr))
+						break
+					}
+				}
+			}
+		}
+
+		// Attempt to flush and close the tar.gz writers - best effort
+		tarWriter.Close()
+		gzipWriter.Close()
+	}
+}
+
+func (s *IngestControl) EnableIngestFileRetention(response http.ResponseWriter, request *http.Request) {
+	if !s.retainedFileLock.TryLock() {
+		// Unable to acquire a write lock at this time - notify of a conflict. User is expected to retry
+		// the request later.
+		response.WriteHeader(http.StatusConflict)
+		return
+	}
+
+	defer s.retainedFileLock.Unlock()
+
+	// Set the parameter to inform ingest to retain ingested files.
+	if err := s.setIngestFileRetention(request.Context(), appcfg.RetainIngestedFilesParameter{
+		Enabled: true,
+	}); err != nil {
+		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusInternalServerError, err.Error(), request), response)
+	} else {
+		response.WriteHeader(http.StatusOK)
+	}
+}
+
+func (s *IngestControl) DisableIngestFileRetention(response http.ResponseWriter, request *http.Request) {
+	if !s.retainedFileLock.TryLock() {
+		// Unable to acquire a write lock at this time - notify of a conflict. User is expected to retry
+		// the request later.
+		response.WriteHeader(http.StatusConflict)
+		return
+	}
+
+	// Set the parameter to no longer retain ingest files
+	if err := s.setIngestFileRetention(request.Context(), appcfg.RetainIngestedFilesParameter{
+		Enabled: false,
+	}); err != nil {
+		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusInternalServerError, err.Error(), request), response)
+		return
+	}
+
+	response.WriteHeader(http.StatusAccepted)
+
+	// Clear all retained files in a goroutine that releases the lock once finished. This is best effort as
+	// it is still possible for a file to make it into the retained directory even after the parameter is set.
+	go func() {
+		defer s.retainedFileLock.Unlock()
+
+		retainedFilesDirectory := s.cfg.RetainedFilesDirectory()
+
+		if retainedFilesDirEntries, err := os.ReadDir(retainedFilesDirectory); err != nil {
+			slog.WarnContext(request.Context(), fmt.Sprintf("Failed reading retained files directory %s: %v", retainedFilesDirectory, err))
+		} else {
+			for _, retainedFilesDirEntry := range retainedFilesDirEntries {
+				retainedFilePath := filepath.Join(retainedFilesDirectory, retainedFilesDirEntry.Name())
+
+				if err := os.RemoveAll(retainedFilePath); err != nil {
+					slog.WarnContext(request.Context(), fmt.Sprintf("Failed removing retained file %s: %v", retainedFilePath, err))
+				}
+			}
+		}
+	}()
+}

--- a/cmd/api/src/bootstrap/util.go
+++ b/cmd/api/src/bootstrap/util.go
@@ -57,6 +57,10 @@ func EnsureServerDirectories(cfg config.Configuration) error {
 		return err
 	}
 
+	if err := ensureDirectory(cfg.RetainedFilesDirectory()); err != nil {
+		return err
+	}
+
 	if err := ensureDirectory(cfg.ClientLogDirectory()); err != nil {
 		return err
 	}

--- a/cmd/api/src/config/config.go
+++ b/cmd/api/src/config/config.go
@@ -173,6 +173,10 @@ func (s Configuration) TempDirectory() string {
 	return filepath.Join(s.WorkDir, "tmp")
 }
 
+func (s Configuration) RetainedFilesDirectory() string {
+	return filepath.Join(s.WorkDir, "retained")
+}
+
 func (s Configuration) ClientLogDirectory() string {
 	return filepath.Join(s.WorkDir, "client_logs")
 }

--- a/cmd/api/src/model/appcfg/parameter.go
+++ b/cmd/api/src/model/appcfg/parameter.go
@@ -49,6 +49,7 @@ const (
 	FedEULACustomTextKey       ParameterKey = "eula.custom_text"
 	TierManagementParameterKey ParameterKey = "analysis.tiering"
 	StaleClientUpdatedLogicKey ParameterKey = "pipeline.updated_stale_client"
+	RetainIngestedFilesKey     ParameterKey = "analysis.retain_ingest_files"
 )
 
 const (
@@ -93,7 +94,7 @@ func (s *Parameter) IsValidKey(parameterKey ParameterKey) bool {
 // IsProtectedKey These keys should not be updatable by users
 func (s *Parameter) IsProtectedKey(parameterKey ParameterKey) bool {
 	switch parameterKey {
-	case ScheduledAnalysis, TrustedProxiesConfig, FedEULACustomTextKey, TierManagementParameterKey, SessionTTLHours, StaleClientUpdatedLogicKey:
+	case ScheduledAnalysis, TrustedProxiesConfig, FedEULACustomTextKey, TierManagementParameterKey, SessionTTLHours, StaleClientUpdatedLogicKey, RetainIngestedFilesKey:
 		return true
 	default:
 		return false
@@ -445,6 +446,26 @@ func GetStaleClientUpdatedLogic(ctx context.Context, service ParameterService) b
 		slog.WarnContext(ctx, "Failed to fetch StaleClientLogic configuration; returning default values")
 	} else if err := cfg.Map(&result); err != nil {
 		slog.WarnContext(ctx, fmt.Sprintf("Invalid StaleClientLogic configuration supplied, %v. returning default values.", err))
+	}
+
+	return result.Enabled
+}
+
+// RetainIngestedFiles
+type RetainIngestedFilesParameter struct {
+	Enabled bool `json:"enabled,omitempty"`
+}
+
+func ShouldRetainIngestedFiles(ctx context.Context, service ParameterService) bool {
+	result := RetainIngestedFilesParameter{
+		// Retention should always default to false in the case where the parameter may not be set
+		Enabled: false,
+	}
+
+	if cfg, err := service.GetConfigurationParameter(ctx, RetainIngestedFilesKey); err != nil {
+		slog.WarnContext(ctx, "Failed to fetch ShouldRetainIngestedFiles configuration; returning default values")
+	} else if err := cfg.Map(&result); err != nil {
+		slog.WarnContext(ctx, fmt.Sprintf("Invalid ShouldRetainIngestedFiles configuration supplied, %v. returning default values.", err))
 	}
 
 	return result.Enabled

--- a/cmd/api/src/services/graphify/ingest.go
+++ b/cmd/api/src/services/graphify/ingest.go
@@ -62,6 +62,8 @@ type IngestContext struct {
 	IngestTime time.Time
 	// Manager is the caching layer that deduplicates ingest payloads across ingest runs
 	Manager ChangeManager
+	// RetainIngestedFiles determines if the service should clean up working files after ingest
+	RetainIngestedFiles bool
 }
 
 func NewIngestContext(ctx context.Context, opts ...IngestOption) *IngestContext {
@@ -84,16 +86,28 @@ func NewIngestContext(ctx context.Context, opts ...IngestOption) *IngestContext 
 // option helpers
 type IngestOption func(*IngestContext)
 
-func WithIngestTime(t time.Time) IngestOption {
-	return func(s *IngestContext) { s.IngestTime = t }
+func WithIngestTime(ingestTime time.Time) IngestOption {
+	return func(s *IngestContext) {
+		s.IngestTime = ingestTime
+	}
+}
+
+func WithIngestRetentionConfig(shouldRetainIngestedFiles bool) IngestOption {
+	return func(s *IngestContext) {
+		s.RetainIngestedFiles = shouldRetainIngestedFiles
+	}
 }
 
 func WithChangeManager(manager ChangeManager) IngestOption {
-	return func(s *IngestContext) { s.Manager = manager }
+	return func(s *IngestContext) {
+		s.Manager = manager
+	}
 }
 
 func WithBatchUpdater(batchUpdater BatchUpdater) IngestOption {
-	return func(s *IngestContext) { s.Batch = batchUpdater }
+	return func(s *IngestContext) {
+		s.Batch = batchUpdater
+	}
 }
 
 func (s *IngestContext) BindBatchUpdater(batch BatchUpdater) {

--- a/cmd/api/src/services/graphify/service.go
+++ b/cmd/api/src/services/graphify/service.go
@@ -27,6 +27,8 @@ import (
 
 // The GraphifyData interface is designed to manage the lifecycle of ingestion tasks
 type GraphifyData interface {
+	appcfg.ParameterService
+
 	// Task handlers
 	GetAllIngestTasks(ctx context.Context) (model.IngestTasks, error)
 	DeleteIngestTask(ctx context.Context, ingestTask model.IngestTask) error


### PR DESCRIPTION
## Description

Provide Tool API Controls for Retaining Ingest Files

This changeset adds a new database configuration parameter `analysis.retain_ingest_files` that prevents deletion of ingest files and instead moves said files to a `retained` directory under the configured BH `work_dir`.

This parameter is controlled by two additional Tool API endpoints:

#### HTTP PUT `/ingest/retention/enable`

Sets the `analysis.retain_ingest_files` parameter to `true`.

#### HTTP PUT `/ingest/retention/disable`

Sets the `analysis.retain_ingest_files` parameter to `false` and then launches an asynchronous routine to delete all retained ingest files in the `retained` directory under the configured BH `work_dir`

---

A third Tool API endpoint is provided for the retrieval of retained ingest files:

#### HTTP GET `/ingest/retention/fetch`

Fetches all retained ingest files as an `application/x-tar` stream using `gzip` compression.

#### Locking Concerns

All ingest control endpoints operate on a shared `sync.RWMutex` to avoid contention between multiple asynchronous callers. Upon lock contention, the endpoints exit early with a `409 Conflict` HTTP response.

The `sync.RWMutex` allows for multiple asynchronous callers to fetch retained ingest files without conflict.

#### Caveats

Ingest may not refresh the configured `analysis.retain_ingest_files` value for each file. This makes the retention control coarse but for the purposes of operator investigation this was deemed acceptable.

## Motivation and Context

This allows an operator of BHE to store and later fetch ingest files for the purposes of investigation. This is useful for capturing damaged files or other ingest artifacts that may violate expectations but would otherwise be destroyed by normal API operation.

## How Has This Been Tested?

Local Tool API integration testing. Critical paths all default to a disabled feature in the case where the  `analysis.retain_ingest_files` parameter is not present in the BH DB.

## Types of changes

- Chore (a change that does not modify the application functionality)
- New feature (non-breaking change which adds functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added ingest file retention management with three new API endpoints to enable, disable, and fetch retained ingested files as a compressed archive.
* Configuration parameter to control retention behavior system-wide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->