### PR TITLE
BED-6660 Hide UI Elements

### DIFF
--- a/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/Details/DynamicDetails.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/Details/DynamicDetails.tsx
@@ -107,7 +107,7 @@ const TagDetails: FC<{ tagData: AssetGroupTag }> = ({ tagData }) => {
                     <DetailField label='Last Updated' value={lastUpdated} />
                 </div>
                 {type === AssetGroupTagTypeZone && (
-                    <div className='mt-4'>
+                    <div className='mt-4 hidden'>
                         <DetailField label='Certification' value={require_certify ? 'Required' : 'Not Required'} />
                     </div>
                 )}
@@ -146,7 +146,7 @@ const SelectorDetails: FC<{ selectorData: AssetGroupTagSelector }> = ({ selector
                     <DetailField label='Last Updated' value={lastUpdated} />
                 </div>
                 {isZonePage && (
-                    <div className='mt-4'>
+                    <div className='mt-4 hidden'>
                         <DetailField
                             label='Automatic Certification'
                             value={AssetGroupTagSelectorAutoCertifyMap[auto_certify] ?? 'Off'}

--- a/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/Save/SelectorForm/BasicInfo.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/Save/SelectorForm/BasicInfo.tsx
@@ -220,7 +220,7 @@ const BasicInfo: FC<{ control: Control<SelectorFormInputs, any, SelectorFormInpu
                                     control={control}
                                     name='auto_certify'
                                     render={({ field }) => (
-                                        <FormItem>
+                                        <FormItem className='hidden'>
                                             <FormLabel aria-labelledby='auto_certify'>
                                                 Automatic Certification
                                             </FormLabel>

--- a/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/Save/TagForm/TagForm.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/Save/TagForm/TagForm.tsx
@@ -287,7 +287,7 @@ export const TagForm: FC = () => {
                                     <Skeleton className='h-16 w-full' />
                                 </div>
                                 {isZonePage && (
-                                    <div className='grid gap-2'>
+                                    <div className='grid gap-2 hidden'>
                                         <Label>Require Certification</Label>
                                         <Skeleton className='h-3 w-6' />
                                     </div>
@@ -407,7 +407,7 @@ export const TagForm: FC = () => {
                                         control={control}
                                         name='require_certify'
                                         render={({ field }) => (
-                                            <FormItem>
+                                            <FormItem className='hidden'>
                                                 <FormLabel>Require Certification</FormLabel>
                                                 <div className='flex gap-2'>
                                                     <FormControl>


### PR DESCRIPTION

## Description

On Privilege Zone, it hides elements from the UI, specifically Certification in Zone Details,  Automatic Certification in Selector Details, the Description and Drop Down List for Certification in Selector Create and Edit and the Require Certification in Zone Create and Edit

## Motivation and Context

Resolves https://specterops.atlassian.net/browse/BED-6660


## How Has This Been Tested?

Tested Locally

## Screenshots (optional):

## Types of changes

- Chore (a change that does not modify the application functionality)


## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [ x ] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [ x ] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [ x ] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
