### PR TITLE
BED-6662: Migration to toggle Feature Flag 'open_graph_phase_2'

### DIFF
--- a/cmd/api/src/database/migration/migrations/v8.3.0.sql
+++ b/cmd/api/src/database/migration/migrations/v8.3.0.sql
@@ -137,3 +137,6 @@ WHERE key = 'targeted_access_control';
 UPDATE asset_group_tag_selector_seeds 
 SET value = E'MATCH (n:Computer)\nWHERE n.isreadonlydc = true\nRETURN n;' 
 WHERE selector_id in (SELECT id FROM asset_group_tag_selectors WHERE name = 'Read-Only DCs' AND is_default = true);
+
+-- Set Open Graph Phase 2 feature flag to enable UI behind it
+UPDATE feature_flags SET enabled = true WHERE key = 'open_graph_phase_2'


### PR DESCRIPTION
## Description

Added migration to toggle open_graph_phase_2 feature flag to enable UI features behind it

## Motivation and Context

Resolves: [BED-6662](https://specterops.atlassian.net/browse/BED-6662)

## How Has This Been Tested?

Manually tore down the DB and rebuilt to test if the flag was enabled

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


[BED-6662]: https://specterops.atlassian.net/browse/BED-6662?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ