### PR TITLE
fix(DateRangeInputs): BED-6514 resolve date range validation bug (#1967)

### DIFF
--- a/packages/javascript/bh-shared-ui/src/components/FileIngestTable/FileIngestFilterDialog.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/FileIngestTable/FileIngestFilterDialog.test.tsx
@@ -26,8 +26,9 @@ const originalTZ = process.env.TZ;
 const mockObjectHook = (initialState = {}) => {
     const applyState = vi.fn();
     const deleteKeys = vi.fn();
+    const setState = vi.fn();
     const state = initialState;
-    vi.spyOn(hooks, 'useObjectState').mockReturnValue({ applyState, deleteKeys, state } as any);
+    vi.spyOn(hooks, 'useObjectState').mockReturnValue({ applyState, deleteKeys, setState, state } as any);
 
     return { applyState, deleteKeys };
 };
@@ -193,7 +194,7 @@ describe('FileIngestFilterDialog', () => {
             await inputDate(user, 'Start Date', '2025-01-01');
             await user.click(screen.getByRole('button', { name: 'Confirm' }));
 
-            expect(onConfirmMock).toBeCalledWith({ start_time: '2025-01-01T00:00:00.000Z' });
+            expect(onConfirmMock).toBeCalledWith({ start_time: '2025-01-01T00:00:00.000+00:00' });
         });
 
         it('does not allow confirmation while dates are invalid', async () => {

--- a/packages/javascript/bh-shared-ui/src/components/FileIngestTable/FileIngestFilterDialog.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/FileIngestTable/FileIngestFilterDialog.tsx
@@ -86,8 +86,12 @@ export const FileIngestFilterDialog: React.FC<Props> = ({ onConfirm }) => {
         onConfirm(filters.state);
     };
 
+    const undoChanges = () => {
+        filters.setState(prevState.current);
+    };
+
     return (
-        <Dialog>
+        <Dialog onOpenChange={undoChanges}>
             <DialogTrigger asChild>
                 <Button data-testid='file_ingest_log-open_filter_dialog' variant='icon'>
                     <AppIcon.FilterOutline size={22} />


### PR DESCRIPTION
## Description

* refactor(ManagedDatePicker): BED-6514 resolve date range validation edge case

## Motivation and Context

Resolves BED-6514

Fixes an edge case where an invalid date cannot be fixed

## How Has This Been Tested?

1. Go to the File Ingest Log
2. Open the filter modal
3. Select a recent start date
4. Select an invalid end date which is before the start date
5. You should be able to fix the validation error by changing the start date to be even earlier

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
