### PR TITLE
BED-6549: fix windows zip file upload for saved queries

### DIFF
--- a/packages/javascript/bh-shared-ui/src/views/Explore/ExploreSearch/SavedQueries/ImportQueryDialog.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/Explore/ExploreSearch/SavedQueries/ImportQueryDialog.tsx
@@ -31,7 +31,7 @@ import { useImportSavedQuery } from '../../../../hooks';
 import { useNotifications } from '../../../../providers';
 import { QuickUploadExclusionIds } from '../../../../utils';
 
-const allowedFileTypes = ['application/json', 'application/zip'];
+const allowedFileTypes = ['application/json', 'application/zip', 'application/x-zip-compressed'];
 
 const ImportQueryDialog: React.FC<{
     open: boolean;


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

This change fixes a bug that occurred when users on Windows tried to upload `.zip` files in the saved queries import dialog.

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-6549

This adds the MIME type for Windows zip files, `application/x-zip-compressed`. 

## How Has This Been Tested?

Tested locally on a Windows VM.

## Screenshots (optional):

https://github.com/user-attachments/assets/283192ff-6cdf-40ff-bc35-fdabd27ed8eb



## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended query import functionality to support an additional compressed file format, allowing users to import query files in more file type options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->