### PR TITLE
fix: fetch app ID instead of service principal object ID BED-6440

### DIFF
--- a/cmd/api/src/analysis/azure/azure_integration_test.go
+++ b/cmd/api/src/analysis/azure/azure_integration_test.go
@@ -692,6 +692,7 @@ func TestServicePrincipalEntityDetails(t *testing.T) {
 
 		require.Nil(t, err)
 		assert.Equal(t, harness.AZEntityPanelHarness.ServicePrincipal.Properties.Get(common.ObjectID.String()).Any(), servicePrincipal.Properties[common.ObjectID.String()])
+		assert.Equal(t, harness.AZEntityPanelHarness.Application.Properties.Get(common.ObjectID.String()).Any(), servicePrincipal.Properties[azure.AppID.String()])
 		assert.Equal(t, 0, servicePrincipal.InboundObjectControl)
 
 		servicePrincipal, err = azureanalysis.ServicePrincipalEntityDetails(context.Background(), testContext.Graph.Database, servicePrincipalObjectID, true)

--- a/packages/go/analysis/azure/queries.go
+++ b/packages/go/analysis/azure/queries.go
@@ -564,7 +564,7 @@ func FetchApplicationServicePrincipals(tx graph.Transaction, app *graph.Node) (g
 }
 
 func FetchServicePrincipalApplications(tx graph.Transaction, servicePrincipal *graph.Node) (graph.NodeSet, error) {
-	return ops.FetchEndNodes(tx.Relationships().Filterf(func() graph.Criteria {
+	return ops.FetchStartNodes(tx.Relationships().Filterf(func() graph.Criteria {
 		return query.And(
 			query.Kind(query.Start(), azure.App),
 			query.Kind(query.Relationship(), azure.RunsAs),


### PR DESCRIPTION
## Description

The issue is that the FetchServicePrincipalApplications function called by getServicePrincipalAppID function (https://github.com/SpecterOps/BloodHound/blob/main/packages/go/analysis/azure/service_principal.go#L58 ) gets the end node (the service principal) instead of the application (the end node) on this line: https://github.com/SpecterOps/BloodHound/blob/0c823b12f27b29aa36df0342a49769e20a107e99/packages/go/analysis/azure/queries.go#L567 

Changing FetchEndNodes to FetchStartNodes resolves the issue.

## Motivation and Context

Resolves Issue #1846 (BED-6440, formerly BED-6431)

https://github.com/SpecterOps/BloodHound/issues/1846
https://specterops.atlassian.net/browse/BED-6440 (formerly https://specterops.atlassian.net/browse/BED-6431)

## How Has This Been Tested?

After implementing the change, observed the correct app ID in the node entity panel.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [X] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Azure service principal and application relationship analysis to return accurate query results.

* **Tests**
  * Enhanced test coverage for service principal and application object ID relationship validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->