### PR TITLE
BED-6727 Merge stage/v8.3.1 to main

### DIFF
--- a/packages/go/openapi/doc/openapi.json
+++ b/packages/go/openapi/doc/openapi.json
@@ -20351,10 +20351,12 @@
             "type": "string"
           },
           "name": {
-            "type": "string"
+            "type": "string",
+            "nullable": true
           },
           "exists": {
-            "type": "boolean"
+            "type": "boolean",
+            "nullable": true
           }
         }
       },
@@ -20367,10 +20369,12 @@
             "type": "object",
             "properties": {
               "distinguishedname": {
-                "type": "string"
+                "type": "string",
+                "nullable": true
               },
               "type": {
-                "type": "string"
+                "type": "string",
+                "nullable": true
               }
             }
           }

--- a/packages/go/openapi/src/schemas/model.components.base-ad-entity.yaml
+++ b/packages/go/openapi/src/schemas/model.components.base-ad-entity.yaml
@@ -20,5 +20,7 @@ properties:
     type: string
   name:
     type: string
+    nullable: true
   exists:
     type: boolean
+    nullable: true

--- a/packages/go/openapi/src/schemas/model.ou-details.yaml
+++ b/packages/go/openapi/src/schemas/model.ou-details.yaml
@@ -20,5 +20,7 @@ allOf:
     properties:
       distinguishedname:
         type: string
+        nullable: true
       type:
         type: string
+        nullable: true

--- a/packages/javascript/js-client-library/src/types.ts
+++ b/packages/javascript/js-client-library/src/types.ts
@@ -453,10 +453,10 @@ export type CustomNodeKindType = {
 
 export type OuDetails = {
     objectid: string;
-    name: string;
-    exists: boolean;
-    distinguishedname: string;
-    type: string;
+    name?: string;
+    exists?: boolean;
+    distinguishedname?: string;
+    type?: string;
 };
 
 export type DomainDetails = {


### PR DESCRIPTION
## Description

Merge v8.3.1 to main

## Motivation and Context

Resolves [BED-6727](https://specterops.atlassian.net/browse/BED-6727)

## How Has This Been Tested?

Tested locally

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [X] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [X] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [X] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


[BED-6727]: https://specterops.atlassian.net/browse/BED-6727?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **API Updates**
  * Designated fields in API responses are now nullable: `name` and `exists` in entity details, and `distinguishedname` and `type` in organizational unit details.
  * TypeScript client library updated to reflect these optional fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->