### PR TITLE
fix: BED-6416 validate opengraph edge names on ingest

### DIFF
--- a/cmd/api/src/services/upload/jsonschema/edge.json
+++ b/cmd/api/src/services/upload/jsonschema/edge.json
@@ -46,7 +46,7 @@
         "kind": {
             "type": "string",
             "description": "Edge kind name must contain only alphanumeric characters and underscores.",
-            "pattern": "(^[A-Za-z0-9_]+$)"
+            "pattern": "^[A-Za-z0-9_]+$"
         },
         "properties": {
             "type": ["object", "null"],

--- a/cmd/api/src/services/upload/streamdecoder_test.go
+++ b/cmd/api/src/services/upload/streamdecoder_test.go
@@ -778,7 +778,7 @@ func edgeSchemaFailureCases() []genericIngestAssertion {
 				},
 			},
 			validationErrContains: [][]string{
-				{"edges[0]", "at '/kind': 'invalid-name' does not match pattern '(^[A-Za-z0-9_]+$)']"},
+				{"edges[0]", "at '/kind': 'invalid-name' does not match pattern '^[A-Za-z0-9_]+$']"},
 			},
 		},
 		{
@@ -797,7 +797,7 @@ func edgeSchemaFailureCases() []genericIngestAssertion {
 				},
 			},
 			validationErrContains: [][]string{
-				{"edges[0]", "at '/kind': 'invalid name' does not match pattern '(^[A-Za-z0-9_]+$)']"},
+				{"edges[0]", "at '/kind': 'invalid name' does not match pattern '^[A-Za-z0-9_]+$']"},
 			},
 		},
 		{
@@ -816,7 +816,7 @@ func edgeSchemaFailureCases() []genericIngestAssertion {
 				},
 			},
 			validationErrContains: [][]string{
-				{"edges[0]", "at '/kind': '`invalidName`' does not match pattern '(^[A-Za-z0-9_]+$)']"},
+				{"edges[0]", "at '/kind': '`invalidName`' does not match pattern '^[A-Za-z0-9_]+$']"},
 			},
 		},
 		{
@@ -835,7 +835,7 @@ func edgeSchemaFailureCases() []genericIngestAssertion {
 				},
 			},
 			validationErrContains: [][]string{
-				{"edges[0]", "at '/kind': 'invalid!!*name!!' does not match pattern '(^[A-Za-z0-9_]+$)']"},
+				{"edges[0]", "at '/kind': 'invalid!!*name!!' does not match pattern '^[A-Za-z0-9_]+$']"},
 			},
 		},
 		{


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

This change adds jsonschema validation to OpenGraph uploaded Edge Kinds. Following the spec, `Kinds` can only have alphanumeric characters and underscores. The file will fail to upload if the Kind does not meet these requirements. 

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-6416

This fixes a bug where users could upload OpenGraph files whose edges had invalid Kinds. When querying for these Kinds, the cypher would not work.  

## How Has This Been Tested?

Added new unit tests, and manually tested uploading invalid schema files 

## Screenshots (optional):
<img width="755" height="380" alt="Screenshot 2025-11-12 at 16 27 52" src="https://github.com/user-attachments/assets/87d46427-901f-484d-85f2-533338cb5a4f" />

## Types of changes

<!-- Please remove any items that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation for edge kind names: only alphanumeric characters and underscores are allowed; invalid names now produce validation errors.

* **Tests**
  * Expanded validation tests to cover various invalid edge kind formats and ensure error messages reflect the new constraint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->