### PR TITLE
BED-6024: refactor environment select state calculations and initialization

### DIFF
--- a/packages/javascript/bh-shared-ui/src/components/CreateUserForm/CreateUserForm.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/CreateUserForm/CreateUserForm.tsx
@@ -539,7 +539,7 @@ const CreateUserForm: React.FC<{
                             </DialogActions>
                         </Card>
                         {showEnvironmentAccessControls && selectedETACEnabledRole && (
-                            <EnvironmentSelectPanel form={form as unknown as UseFormReturn} isNewUser={true} />
+                            <EnvironmentSelectPanel form={form as unknown as UseFormReturn} />
                         )}
                     </div>
                 )}

--- a/packages/javascript/bh-shared-ui/src/components/UpdateUserForm/UpdateUserForm.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/UpdateUserForm/UpdateUserForm.tsx
@@ -572,11 +572,7 @@ const UpdateUserFormInner: React.FC<{
                         </DialogActions>
                     </Card>
                     {showEnvironmentAccessControls && selectedETACEnabledRole && (
-                        <EnvironmentSelectPanel
-                            form={form as unknown as UseFormReturn}
-                            initialData={initialData}
-                            isNewUser={false}
-                        />
+                        <EnvironmentSelectPanel form={form as unknown as UseFormReturn} initialData={initialData} />
                     )}
                 </div>
             </form>


### PR DESCRIPTION
## Description
Another subtask for BED-6024 to be merged into the main feature branch. This one cleans up some of our logic around the environment select form and makes sure initial values are loaded in correctly; this was previously not being updated after the "List all environments" query had finished running.

## Motivation and Context

Resolves BED-6024

## How Has This Been Tested?

*Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc.*

## Screenshots (optional):

## Types of changes

- Chore (a change that does not modify the application functionality)
- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
