### PR TITLE
BED-6698: When using the "Quick add" functionality to create a selector, set the default certification to "initial only"

### DIFF
--- a/packages/javascript/bh-shared-ui/src/views/Explore/ContextMenu/ContextMenuPrivilegeZonesEnabled.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/Explore/ContextMenu/ContextMenuPrivilegeZonesEnabled.tsx
@@ -16,7 +16,7 @@
 
 import { Dialog } from '@bloodhoundenterprise/doodleui';
 import { Menu, MenuItem } from '@mui/material';
-import { SeedTypeObjectId } from 'js-client-library';
+import { AssetGroupTagSelectorAutoCertifySeedsOnly, SeedTypeObjectId } from 'js-client-library';
 import { FC, useState } from 'react';
 import { useMutation } from 'react-query';
 import {
@@ -49,6 +49,7 @@ const ContextMenu: FC<{
         mutationFn: ({ assetGroupId, node }: { assetGroupId: string | number; node: NodeResponse }) => {
             return apiClient.createAssetGroupTagSelector(assetGroupId, {
                 name: node.label ?? node.objectId,
+                auto_certify: AssetGroupTagSelectorAutoCertifySeedsOnly,
                 seeds: [
                     {
                         type: SeedTypeObjectId,


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

- Set the default Automatic Certification from "Off" to "Initial members"

## Motivation and Context

This PR addresses:
- BED-6698 

*Why is this change required? What problem does it solve?*
- Currently, when a user uses the quick-add function within the Explore Page to add a new selector, it sets the Automatic Certification level to “Off.” We should change this to “Initial Members” to avoid confusion since the user will expect the object to be tagged after analysis

## How Has This Been Tested?
- Locally within my BHE/BHCE env

## Screenshots (optional):
How to use the quick-add function to add a new selector
<img width="655" height="676" alt="Screenshot 2025-11-20 at 5 50 26 PM" src="https://github.com/user-attachments/assets/9d8a0270-c0eb-4edc-978a-2c294421ef45" />

Successful test
<img width="1410" height="655" alt="Screenshot 2025-11-13 at 4 44 10 PM" src="https://github.com/user-attachments/assets/6d017329-4d98-4a33-97e8-3086e2efb020" />

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected auto-certification handling for asset group seeds in the privilege zones context menu to ensure consistent behavior during asset group management operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->