### PR TITLE
fix: resolve typo in Linux abuse commands by renaming groupDistinguidedName to groupDistinguishedName

### DIFF
--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/Owns/LinuxAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/Owns/LinuxAbuse.tsx
@@ -40,7 +40,7 @@ const LinuxAbuse: FC<EdgeInfoProps & { targetId: string; haslaps: boolean }> = (
 
                     <Typography component={'pre'}>
                         {
-                            "dacledit.py -action 'write' -rights 'WriteMembers' -principal 'controlledUser' -target-dn 'groupDistinguidedName' 'domain'/'controlledUser':'password'"
+                            "dacledit.py -action 'write' -rights 'WriteMembers' -principal 'controlledUser' -target-dn 'groupDistinguishedName' 'domain'/'controlledUser':'password'"
                         }
                     </Typography>
 
@@ -94,7 +94,7 @@ const LinuxAbuse: FC<EdgeInfoProps & { targetId: string; haslaps: boolean }> = (
 
                     <Typography component={'pre'}>
                         {
-                            "dacledit.py -action 'remove' -rights 'WriteMembers' -principal 'controlledUser' -target-dn 'groupDistinguidedName' 'domain'/'controlledUser':'password'"
+                            "dacledit.py -action 'remove' -rights 'WriteMembers' -principal 'controlledUser' -target-dn 'groupDistinguishedName' 'domain'/'controlledUser':'password'"
                         }
                     </Typography>
                 </>

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/WriteDacl/LinuxAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/WriteDacl/LinuxAbuse.tsx
@@ -40,7 +40,7 @@ const LinuxAbuse: FC<EdgeInfoProps & { targetId: string; haslaps: boolean }> = (
 
                     <Typography component={'pre'}>
                         {
-                            "dacledit.py -action 'write' -rights 'WriteMembers' -principal 'controlledUser' -target-dn 'groupDistinguidedName' 'domain'/'controlledUser':'password'"
+                            "dacledit.py -action 'write' -rights 'WriteMembers' -principal 'controlledUser' -target-dn 'groupDistinguishedName' 'domain'/'controlledUser':'password'"
                         }
                     </Typography>
 
@@ -94,7 +94,7 @@ const LinuxAbuse: FC<EdgeInfoProps & { targetId: string; haslaps: boolean }> = (
 
                     <Typography component={'pre'}>
                         {
-                            "dacledit.py -action 'remove' -rights 'WriteMembers' -principal 'controlledUser' -target-dn 'groupDistinguidedName' 'domain'/'controlledUser':'password'"
+                            "dacledit.py -action 'remove' -rights 'WriteMembers' -principal 'controlledUser' -target-dn 'groupDistinguishedName' 'domain'/'controlledUser':'password'"
                         }
                     </Typography>
                 </>

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/WriteOwner/LinuxAbuse.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/WriteOwner/LinuxAbuse.tsx
@@ -44,7 +44,7 @@ const LinuxAbuse: FC<EdgeInfoProps & { haslaps: boolean }> = ({ sourceName, targ
 
                     <Typography component={'pre'}>
                         {
-                            "dacledit.py -action 'write' -rights 'WriteMembers' -principal 'controlledUser' -target-dn 'groupDistinguidedName' 'domain'/'controlledUser':'password'"
+                            "dacledit.py -action 'write' -rights 'WriteMembers' -principal 'controlledUser' -target-dn 'groupDistinguishedName' 'domain'/'controlledUser':'password'"
                         }
                     </Typography>
 
@@ -98,7 +98,7 @@ const LinuxAbuse: FC<EdgeInfoProps & { haslaps: boolean }> = ({ sourceName, targ
 
                     <Typography component={'pre'}>
                         {
-                            "dacledit.py -action 'remove' -rights 'WriteMembers' -principal 'controlledUser' -target-dn 'groupDistinguidedName' 'domain'/'controlledUser':'password'"
+                            "dacledit.py -action 'remove' -rights 'WriteMembers' -principal 'controlledUser' -target-dn 'groupDistinguishedName' 'domain'/'controlledUser':'password'"
                         }
                     </Typography>
                 </>


### PR DESCRIPTION
## Description

This pull request corrects a typo in the Linux abuse command documentation and code references. The parameter groupDistinguidedName has been renamed to groupDistinguishedName to ensure proper spelling and consistency with the rest of the codebase.

## Motivation and Context

Resolves #2062 
BED-6831

The incorrect parameter name caused confusion and inconsistency when referencing group objects. Correcting the typo improves clarity, prevents mistakes when following documentation or examples, and aligns the field name with standard terminology.

## How Has This Been Tested?

- Searching the repository for all occurrences of the misspelled identifier and verifying they were updated consistently.
- Ensuring no dependent code or documentation references were broken by the rename.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Corrected typo in Linux abuse help text documentation where group distinguished name references were misspelled in multiple CLI command examples across various abuse scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->