### PR TITLE
BED-6533 Ingestion Throughput Observability Bug

### DIFF
--- a/cmd/api/src/services/graphify/ingestrelationships.go
+++ b/cmd/api/src/services/graphify/ingestrelationships.go
@@ -59,6 +59,9 @@ func IngestRelationships(ingestCtx *IngestContext, sourceKind graph.Kind, relati
 // maybeSubmitRelationshipUpdate decides whether to upsert a node directly, or route it
 // through the changelog for deduplication and caching.
 func maybeSubmitRelationshipUpdate(ingestCtx *IngestContext, update graph.RelationshipUpdate) error {
+	// Track that we processed this relationship (regardless of whether it's written)
+	ingestCtx.Stats.RelationshipsProcessed.Add(1)
+
 	if !ingestCtx.HasChangelog() {
 		// No changelog: always update via dawgs batch
 		return ingestCtx.Batch.UpdateRelationshipBy(update)

--- a/cmd/api/src/services/graphify/ingestrelationships_internal_test.go
+++ b/cmd/api/src/services/graphify/ingestrelationships_internal_test.go
@@ -17,10 +17,14 @@
 package graphify
 
 import (
+	"context"
 	"testing"
 
+	"github.com/specterops/bloodhound/cmd/api/src/daemons/changelog"
+	"github.com/specterops/bloodhound/cmd/api/src/services/graphify/mocks"
 	"github.com/specterops/dawgs/graph"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 )
 
 func TestDeduplicateKinds(t *testing.T) {
@@ -50,4 +54,128 @@ func TestMergeNodeKinds(t *testing.T) {
 	require.Len(t, merged, 2)
 	require.Equal(t, merged[0].String(), "Same")
 	require.Equal(t, merged[1].String(), "Different")
+}
+
+func TestMaybeSubmitRelationshipUpdate(t *testing.T) {
+	t.Run("there is no changelog, submit to batch and track stats", func(t *testing.T) {
+		var (
+			ctx              = context.Background()
+			ctrl             = gomock.NewController(t)
+			mockBatchUpdater = mocks.NewMockBatchUpdater(ctrl)
+			ingestCtx        = NewIngestContext(ctx)
+
+			startNode = graph.PrepareNode(graph.NewProperties().Set("objectid", "start123"), graph.StringKind("kindA"))
+			endNode   = graph.PrepareNode(graph.NewProperties().Set("objectid", "end456"), graph.StringKind("kindB"))
+			rel       = graph.PrepareRelationship(graph.NewProperties().Set("hello", "world"), graph.StringKind("relKind"))
+			relUpdate = graph.RelationshipUpdate{
+				Start:        startNode,
+				End:          endNode,
+				Relationship: rel,
+			}
+		)
+
+		// Wrap the mock with counting wrapper to track stats
+		ingestCtx.BindBatchUpdater(mockBatchUpdater)
+
+		// Verify initial stats
+		_, relsProcessed, _, relsWritten := ingestCtx.Stats.GetCounts()
+		require.Equal(t, int64(0), relsProcessed)
+		require.Equal(t, int64(0), relsWritten)
+
+		// mock expects
+		mockBatchUpdater.EXPECT().UpdateRelationshipBy(relUpdate).Return(nil).Times(1)
+
+		err := maybeSubmitRelationshipUpdate(ingestCtx, relUpdate)
+		require.NoError(t, err)
+
+		// Verify stats were incremented
+		_, relsProcessed, _, relsWritten = ingestCtx.Stats.GetCounts()
+		require.Equal(t, int64(1), relsProcessed, "RelationshipsProcessed should be incremented")
+		require.Equal(t, int64(1), relsWritten, "RelationshipsWritten should be incremented")
+	})
+
+	t.Run("new change, submit to batch and track stats", func(t *testing.T) {
+		var (
+			ctx               = context.Background()
+			ctrl              = gomock.NewController(t)
+			mockBatchUpdater  = mocks.NewMockBatchUpdater(ctrl)
+			mockChangeManager = mocks.NewMockChangeManager(ctrl)
+			ingestCtx         = NewIngestContext(ctx, WithChangeManager(mockChangeManager))
+
+			sourceObjectID = "source123"
+			targetObjectID = "target456"
+			startNode      = graph.PrepareNode(graph.NewProperties().Set("objectid", sourceObjectID), graph.StringKind("kindA"))
+			endNode        = graph.PrepareNode(graph.NewProperties().Set("objectid", targetObjectID), graph.StringKind("kindB"))
+			rel            = graph.PrepareRelationship(graph.NewProperties().Set("hello", "world"), graph.StringKind("relKind"))
+			relUpdate      = graph.RelationshipUpdate{
+				Start:        startNode,
+				End:          endNode,
+				Relationship: rel,
+			}
+			change = changelog.NewEdgeChange(sourceObjectID, targetObjectID, rel.Kind, rel.Properties)
+		)
+
+		// Wrap the mock with counting wrapper to track stats
+		ingestCtx.BindBatchUpdater(mockBatchUpdater)
+
+		// Verify initial stats
+		_, relsProcessed, _, relsWritten := ingestCtx.Stats.GetCounts()
+		require.Equal(t, int64(0), relsProcessed)
+		require.Equal(t, int64(0), relsWritten)
+
+		// mock expects
+		mockChangeManager.EXPECT().ResolveChange(change).Return(true, nil).Times(1)
+		mockBatchUpdater.EXPECT().UpdateRelationshipBy(relUpdate).Return(nil).Times(1)
+
+		err := maybeSubmitRelationshipUpdate(ingestCtx, relUpdate)
+		require.NoError(t, err)
+
+		// Verify stats were incremented
+		_, relsProcessed, _, relsWritten = ingestCtx.Stats.GetCounts()
+		require.Equal(t, int64(1), relsProcessed, "RelationshipsProcessed should be incremented")
+		require.Equal(t, int64(1), relsWritten, "RelationshipsWritten should be incremented")
+	})
+
+	t.Run("unmodified, submit to changelog and track processed only", func(t *testing.T) {
+		var (
+			ctx               = context.Background()
+			ctrl              = gomock.NewController(t)
+			mockBatchUpdater  = mocks.NewMockBatchUpdater(ctrl)
+			mockChangeManager = mocks.NewMockChangeManager(ctrl)
+			ingestCtx         = NewIngestContext(ctx, WithChangeManager(mockChangeManager))
+
+			sourceObjectID = "source123"
+			targetObjectID = "target456"
+			startNode      = graph.PrepareNode(graph.NewProperties().Set("objectid", sourceObjectID), graph.StringKind("kindA"))
+			endNode        = graph.PrepareNode(graph.NewProperties().Set("objectid", targetObjectID), graph.StringKind("kindB"))
+			rel            = graph.PrepareRelationship(graph.NewProperties().Set("hello", "world"), graph.StringKind("relKind"))
+			relUpdate      = graph.RelationshipUpdate{
+				Start:        startNode,
+				End:          endNode,
+				Relationship: rel,
+			}
+			change = changelog.NewEdgeChange(sourceObjectID, targetObjectID, rel.Kind, rel.Properties)
+		)
+
+		// Wrap the mock with counting wrapper to track stats
+		ingestCtx.BindBatchUpdater(mockBatchUpdater)
+
+		// Verify initial stats
+		_, relsProcessed, _, relsWritten := ingestCtx.Stats.GetCounts()
+		require.Equal(t, int64(0), relsProcessed)
+		require.Equal(t, int64(0), relsWritten)
+
+		// mock expects
+		mockChangeManager.EXPECT().ResolveChange(change).Return(false, nil).Times(1)
+		mockBatchUpdater.EXPECT().UpdateRelationshipBy(gomock.Any()).Times(0)
+		mockChangeManager.EXPECT().Submit(ctx, change).Times(1)
+
+		err := maybeSubmitRelationshipUpdate(ingestCtx, relUpdate)
+		require.NoError(t, err)
+
+		// Verify stats: processed incremented, written NOT incremented (deduplicated)
+		_, relsProcessed, _, relsWritten = ingestCtx.Stats.GetCounts()
+		require.Equal(t, int64(1), relsProcessed, "RelationshipsProcessed should be incremented even when deduplicated")
+		require.Equal(t, int64(0), relsWritten, "RelationshipsWritten should NOT be incremented when deduplicated")
+	})
 }


### PR DESCRIPTION
## Description
While testing the RC I saw that the observability logs I added to ingest had negative values for throughput (number of entities processed per second).

The values were sometimes negative because the stats counter was not incremented properly. Specifically, each time a relationship is processed we need to do an ADD operation on the relationshipsWritten counter.

## Motivation and Context
We want to observe ingestion throughput rates as we continue to improve its performance.

## How Has This Been Tested?
Unit test coverage has been added to both code paths where ingest throughput stats are calculated. This will prevent any regressions from happening in this area.

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)
- Database Migrations

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [ ] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [ ] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [ ] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
