### PR TITLE
test: Added unit tests for the method ShareSavedQueries. BED-6855

### DIFF
--- a/cmd/api/src/api/v2/saved_queries_permissions_test.go
+++ b/cmd/api/src/api/v2/saved_queries_permissions_test.go
@@ -47,10 +47,7 @@ import (
 )
 
 var (
-	ErrInvalidSelfShare   = errors.New("invalidSelfShare")
-	ErrForbidden          = errors.New("forbidden")
-	ErrInvalidPublicShare = errors.New("invalidPublicShare")
-	ErrMockDatabaseError  = errors.New("mockDatabaseError")
+	ErrMockDatabaseError = errors.New("mockDatabaseError")
 )
 
 func TestResources_ShareSavedQueriesPermissions_CanUpdateSavedQueriesPermission(t *testing.T) {


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Added unit tests for the method ShareSavedQueries.

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-6855

*Why is this change required? What problem does it solve?*

Improves Unit Test Coverage.

## How Has This Been Tested?

Unit Tests Pass

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for saved-query permission flows with many new edge cases for admin and non-admin scenarios (missing context, invalid inputs, non-existent resources, error paths, self-sharing and public/private sharing rules).
  * Added a test-only sentinel error and updated test imports to exercise additional error and boundary conditions; no production logic changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->