### PR TITLE
fix(ApiExplorer): Modified the predicate filter files to use type string. BED-6051

### DIFF
--- a/packages/go/openapi/doc/openapi.json
+++ b/packages/go/openapi/doc/openapi.json
@@ -18469,6 +18469,10 @@
       },
       "api.params.predicate.filter.integer": {
         "type": "string",
+        "examples": {
+          "equals": "eq:7",
+          "greaterthan": "gt:3"
+        },
         "description": "Filter results by column integer value. Valid filter predicates are `eq`, `neq`, `gt`, `gte`, `lt`, `lte`.\n"
       },
       "api.params.predicate.filter.time": {
@@ -19404,6 +19408,7 @@
       },
       "api.params.predicate.filter.integer-strict": {
         "type": "string",
+        "example": "eq:7",
         "description": "Filter results by column integer value. Valid filter predicates are `eq`, `neq`.\n"
       },
       "api.params.predicate.filter.string-strict": {
@@ -19411,7 +19416,8 @@
         "description": "Filter results by column string value. Valid filter predicates are `eq`, `neq`.\n"
       },
       "api.params.predicate.filter.boolean": {
-        "type": "boolean",
+        "type": "string",
+        "example": "eq:true",
         "description": "Filter results by column boolean value. Valid filter predicates are `eq`, `neq`.\n"
       },
       "model.asset-group-tag-request": {

--- a/packages/go/openapi/src/schemas/api.params.predicate.filter.boolean.yaml
+++ b/packages/go/openapi/src/schemas/api.params.predicate.filter.boolean.yaml
@@ -15,5 +15,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 type: string
+example: eq:true
 description: |
   Filter results by column boolean value. Valid filter predicates are `eq`, `neq`.

--- a/packages/go/openapi/src/schemas/api.params.predicate.filter.integer-strict.yaml
+++ b/packages/go/openapi/src/schemas/api.params.predicate.filter.integer-strict.yaml
@@ -15,5 +15,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 type: string
+example: eq:7
 description: |
   Filter results by column integer value. Valid filter predicates are `eq`, `neq`.

--- a/packages/go/openapi/src/schemas/api.params.predicate.filter.integer.yaml
+++ b/packages/go/openapi/src/schemas/api.params.predicate.filter.integer.yaml
@@ -15,5 +15,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 type: string
+examples: 
+  equals: eq:7
+  greaterthan: gt:3
 description: |
   Filter results by column integer value. Valid filter predicates are `eq`, `neq`, `gt`, `gte`, `lt`, `lte`.


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Modified the predicate filters to use type string instead of integer and boolean. This enabled the predicates to be read correctly instead of throwing a validation error when entering a value such as, "eq:7".

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-6051

*Why is this change required? What problem does it solve?*

The change is required to correctly enable the use of predicates in fields that traditionally are looking for an integer or boolean.

## How Has This Been Tested?

Manually tested making requests using the API Explorer, using with and without predicates.

## Screenshots (optional):

<img width="2604" height="2080" alt="image" src="https://github.com/user-attachments/assets/e783104b-6eb3-4428-8b85-4a29b716f8dd" />

## Types of changes

<!-- Please remove any items that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * API filter parameters for integer and boolean fields now accept string-formatted predicates (e.g., "eq:7", "gt:3", "eq:true") instead of native integer/boolean values.
  * Examples added to the API schema to illustrate the new string predicate formats for filtering.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->