### PR TITLE
fix: pattern matching and comment cleanup BED-6917

### DIFF
--- a/.github/workflows/reusable.conventional-commits.yml
+++ b/.github/workflows/reusable.conventional-commits.yml
@@ -80,7 +80,11 @@ jobs:
 
           set -euo pipefail
 
+          # Trim the title in case there is whitespace surrounding the issue
           PR_TITLE="${{ github.event.pull_request.title }}"
+          PR_TITLE="${PR_TITLE##*( )}"
+          TRIMMED_TITLE="${PR_TITLE%%*( )}"
+
           JIRA_ISSUE_REGEX=" (BED-[0-9]+|PQE-[0-9]+)$"
           GH_ISSUE_REGEX=" (#[0-9]+)$"
 
@@ -139,9 +143,9 @@ jobs:
           }
 
           function main() {
-              if [[ $PR_TITLE =~ $JIRA_ISSUE_REGEX ]]; then
+              if [[ $TRIMMED_TITLE=~ $JIRA_ISSUE_REGEX ]]; then
                   check_jira_ref "${BASH_REMATCH[1]}"
-              elif  [[ $PR_TITLE =~ $GH_ISSUE_REGEX ]]; then
+              elif  [[ $TRIMMED_TITLE=~ $GH_ISSUE_REGEX ]]; then
                   check_github_ref "${BASH_REMATCH[1]}"
               else
                   local NO_REF_ERROR="No issue reference found in the title."


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description
Pattern matching specifications are removed from the conventional commit reusable workflow. 
The reference for removing a stale comment is updated to point to the correct step.

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-6917

*Why is this change required? What problem does it solve?*

## How Has This Been Tested?

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved pull request title validation and reference-checking in CI to better trim whitespace, normalize titles, and more reliably detect/clean up reference-check comments for PRs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->