### PR TITLE
fix: enable extended globbing for white space trimming in cc workflow…

### DIFF
--- a/.github/workflows/reusable.conventional-commits.yml
+++ b/.github/workflows/reusable.conventional-commits.yml
@@ -79,6 +79,7 @@ jobs:
           #!/usr/bin/env bash
 
           set -euo pipefail
+          shopt -s extglob
 
           # Trim the title in case there is whitespace surrounding the issue
           PR_TITLE="${{ github.event.pull_request.title }}"
@@ -143,9 +144,9 @@ jobs:
           }
 
           function main() {
-              if [[ $TRIMMED_TITLE=~ $JIRA_ISSUE_REGEX ]]; then
+              if [[ $TRIMMED_TITLE =~ $JIRA_ISSUE_REGEX ]]; then
                   check_jira_ref "${BASH_REMATCH[1]}"
-              elif  [[ $TRIMMED_TITLE=~ $GH_ISSUE_REGEX ]]; then
+              elif  [[ $TRIMMED_TITLE =~ $GH_ISSUE_REGEX ]]; then
                   check_github_ref "${BASH_REMATCH[1]}"
               else
                   local NO_REF_ERROR="No issue reference found in the title."


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Extended globbing is enabled in the conventional commit reusable workflow.

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-6925

This setting needs to be enabled for the whitespace trimming to be effective.

## How Has This Been Tested?

Used a local bash script to test the changes.

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
