### PR TITLE
fix: Revert 'fix(ApiExplorer): Modified the predicate filter files to use type string. BED-6051' BED-6051

### DIFF
--- a/packages/go/openapi/doc/openapi.json
+++ b/packages/go/openapi/doc/openapi.json
@@ -18468,11 +18468,7 @@
         "description": "Filter results by column string value. Valid filter predicates are `eq`, `~eq`, `neq`.\n"
       },
       "api.params.predicate.filter.integer": {
-        "type": "string",
-        "examples": {
-          "equals": "eq:7",
-          "greaterthan": "gt:3"
-        },
+        "type": "integer",
         "description": "Filter results by column integer value. Valid filter predicates are `eq`, `neq`, `gt`, `gte`, `lt`, `lte`.\n"
       },
       "api.params.predicate.filter.time": {
@@ -19407,8 +19403,7 @@
         }
       },
       "api.params.predicate.filter.integer-strict": {
-        "type": "string",
-        "example": "eq:7",
+        "type": "integer",
         "description": "Filter results by column integer value. Valid filter predicates are `eq`, `neq`.\n"
       },
       "api.params.predicate.filter.string-strict": {
@@ -19416,8 +19411,7 @@
         "description": "Filter results by column string value. Valid filter predicates are `eq`, `neq`.\n"
       },
       "api.params.predicate.filter.boolean": {
-        "type": "string",
-        "example": "eq:true",
+        "type": "boolean",
         "description": "Filter results by column boolean value. Valid filter predicates are `eq`, `neq`.\n"
       },
       "model.asset-group-tag-request": {

--- a/packages/go/openapi/src/schemas/api.params.predicate.filter.boolean.yaml
+++ b/packages/go/openapi/src/schemas/api.params.predicate.filter.boolean.yaml
@@ -14,7 +14,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-type: string
-example: eq:true
+type: boolean
 description: |
   Filter results by column boolean value. Valid filter predicates are `eq`, `neq`.

--- a/packages/go/openapi/src/schemas/api.params.predicate.filter.integer-strict.yaml
+++ b/packages/go/openapi/src/schemas/api.params.predicate.filter.integer-strict.yaml
@@ -14,7 +14,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-type: string
-example: eq:7
+type: integer
 description: |
   Filter results by column integer value. Valid filter predicates are `eq`, `neq`.

--- a/packages/go/openapi/src/schemas/api.params.predicate.filter.integer.yaml
+++ b/packages/go/openapi/src/schemas/api.params.predicate.filter.integer.yaml
@@ -14,9 +14,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-type: string
-examples: 
-  equals: eq:7
-  greaterthan: gt:3
+type: integer
 description: |
   Filter results by column integer value. Valid filter predicates are `eq`, `neq`, `gt`, `gte`, `lt`, `lte`.


### PR DESCRIPTION
Reverts SpecterOps/BloodHound#2114 for BED-6051

This story was blocked pending more discussion, reverting this PR to continue with those discussions before rebuilding a solution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Predicate filter type specifications updated: integer and integer-strict filters now require proper integer values instead of strings; boolean filters now require boolean values instead of strings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->