### PR TITLE
fix: tier zero glyph rendering when pz ff is disabled BED-6936

### DIFF
--- a/cmd/ui/src/views/Explore/GraphView.tsx
+++ b/cmd/ui/src/views/Explore/GraphView.tsx
@@ -36,6 +36,7 @@ import {
     useExploreParams,
     useExploreSelectedItem,
     useExploreTableAutoDisplay,
+    useFeatureFlag,
     useGraphHasData,
     useTagGlyphs,
     useToggle,
@@ -78,6 +79,8 @@ const GraphView: FC = () => {
     const isExploreTableSelected = useAppSelector((state) => state.global.view.isExploreTableSelected);
 
     const customIconsQuery = useCustomNodeKinds({ select: transformIconDictionary });
+
+    const { data: pzFeatureFlag } = useFeatureFlag('tier_management_engine');
     const tagGlyphs = useTagGlyphs(glyphUtils, darkMode);
 
     const autoDisplayTableEnabled = !exploreLayout && !isExploreTableSelected;
@@ -97,8 +100,9 @@ const GraphView: FC = () => {
             customIcons: customIconsQuery?.data ?? {},
             hideNodes: displayTable,
             tagGlyphs,
+            pzFeatureFlagEnabled: pzFeatureFlag?.enabled,
         };
-    }, [theme, darkMode, customIconsQuery.data, displayTable, tagGlyphs]);
+    }, [theme, darkMode, customIconsQuery.data, displayTable, tagGlyphs, pzFeatureFlag?.enabled]);
 
     // Initialize graph data for rendering with sigmajs
     useEffect(() => {

--- a/cmd/ui/src/views/Explore/utils.test.ts
+++ b/cmd/ui/src/views/Explore/utils.test.ts
@@ -16,7 +16,8 @@
 
 import { Theme } from '@mui/material';
 import * as layoutDagre from 'src/hooks/useLayoutDagre/useLayoutDagre';
-import { initGraph } from './utils';
+import { GlyphLocation } from 'src/rendering/programs/node.glyphs';
+import { getNodeGlyphs, initGraph } from './utils';
 
 const layoutDagreSpy = vi.spyOn(layoutDagre, 'layoutDagre');
 
@@ -24,20 +25,20 @@ const testNodes = {
     '1': {
         label: 'User 1',
         kind: 'User',
-        kinds: ['User'],
+        kinds: ['User', 'Tag_Tier_Zero'],
         objectId: 'test-user-1',
         lastSeen: '',
-        isTierZero: false,
+        isTierZero: true,
         isOwnedObject: false,
     },
     '2': {
         label: 'Group 1',
         kind: 'Group',
-        kinds: ['Group'],
+        kinds: ['Group', 'Tag_Owned'],
         objectId: 'test-group-1',
         lastSeen: '',
         isTierZero: false,
-        isOwnedObject: false,
+        isOwnedObject: true,
     },
 };
 
@@ -72,6 +73,8 @@ const testEdgesWithDuplicate = [
     },
 ];
 
+const pzFeatureFlagEnabled = true;
+
 describe('Explore utils', () => {
     describe('initGraph', () => {
         const mockTheme = {
@@ -90,6 +93,7 @@ describe('Explore utils', () => {
                     customIcons: {},
                     darkMode: false,
                     tagGlyphs: {},
+                    pzFeatureFlagEnabled,
                 }
             );
 
@@ -104,6 +108,7 @@ describe('Explore utils', () => {
                     customIcons: {},
                     darkMode: false,
                     tagGlyphs: {},
+                    pzFeatureFlagEnabled,
                 }
             );
 
@@ -112,5 +117,135 @@ describe('Explore utils', () => {
             expect(graph.hasEdge('2_MemberOf_1')).toBeTruthy();
             expect(graph.hasEdge('1_GetChangesAll_2')).toBeTruthy();
         });
+    });
+});
+
+describe('getNodeGlyphs', () => {
+    const mockTheme = {
+        palette: {
+            color: { primary: '', links: '' },
+            neutral: { primary: '', secondary: '' },
+            common: { black: '', white: '' },
+        },
+    };
+    const themedOptions = {
+        labels: {
+            labelColor: '#1D1B20',
+            backgroundColor: '#F4F4F4',
+            highlightedBackground: '#1A30FF',
+            highlightedText: '#fff',
+        },
+        nodeBorderColor: '#1D1B20',
+        glyph: {
+            colors: {
+                backgroundColor: '#1D1B20',
+                color: '#FFFFFF',
+            },
+        },
+    };
+
+    const standardGlyphs = {
+        TIER_ZERO: 'tierZero',
+        TIER_ZERO_DARK: 'tierZeroDark',
+        OWNED_OBJECT: 'owned',
+        OWNED_OBJECT_DARK: 'ownedDark',
+    };
+
+    const tagGlyphs = { Tag_Tier_Zero: 'gem', owned: 'Tag_Owned', ownedGlyph: 'skull' };
+
+    it('determines glyphs with the tier_managent_engine feature flag disabled', () => {
+        const firstNodeGlyphs = getNodeGlyphs(
+            testNodes[1],
+            {
+                theme: mockTheme as Theme,
+                hideNodes: false,
+                customIcons: {},
+                darkMode: false,
+                themedOptions,
+                tagGlyphs,
+                pzFeatureFlagEnabled: false,
+            },
+            standardGlyphs
+        );
+
+        expect(firstNodeGlyphs).toHaveLength(1);
+
+        const firstNodeGlyph = firstNodeGlyphs[0];
+
+        expect(firstNodeGlyph.location).toBe(GlyphLocation.TOP_RIGHT);
+        expect(firstNodeGlyph.backgroundColor).toBe(themedOptions.glyph.colors.backgroundColor);
+        expect(firstNodeGlyph.color).toBe(themedOptions.glyph.colors.color);
+        expect(firstNodeGlyph.image).toBe('tierZero');
+
+        const secondNodeGlyphs = getNodeGlyphs(
+            testNodes[2],
+            {
+                theme: mockTheme as Theme,
+                hideNodes: false,
+                customIcons: {},
+                darkMode: false,
+                themedOptions,
+                tagGlyphs,
+                pzFeatureFlagEnabled: false,
+            },
+            standardGlyphs
+        );
+
+        expect(secondNodeGlyphs).toHaveLength(1);
+
+        const secondNodeGlyph = secondNodeGlyphs[0];
+
+        expect(secondNodeGlyph.location).toBe(GlyphLocation.BOTTOM_RIGHT);
+        expect(secondNodeGlyph.backgroundColor).toBe(themedOptions.glyph.colors.backgroundColor);
+        expect(secondNodeGlyph.color).toBe(themedOptions.glyph.colors.color);
+        expect(secondNodeGlyph.image).toBe('owned');
+    });
+
+    it('determines glyphs with the tier_managent_engine feature flag enabled', () => {
+        const firstNodeGlyphs = getNodeGlyphs(
+            testNodes[1],
+            {
+                theme: mockTheme as Theme,
+                hideNodes: false,
+                customIcons: {},
+                darkMode: false,
+                themedOptions,
+                tagGlyphs,
+                pzFeatureFlagEnabled: true,
+            },
+            standardGlyphs
+        );
+
+        expect(firstNodeGlyphs).toHaveLength(1);
+
+        const firstNodeGlyph = firstNodeGlyphs[0];
+
+        expect(firstNodeGlyph.location).toBe(GlyphLocation.TOP_RIGHT);
+        expect(firstNodeGlyph.backgroundColor).toBe(themedOptions.glyph.colors.backgroundColor);
+        expect(firstNodeGlyph.color).toBe(themedOptions.glyph.colors.color);
+        expect(firstNodeGlyph.image).toBe('gem');
+
+        const secondNodeGlyphs = getNodeGlyphs(
+            testNodes[2],
+            {
+                theme: mockTheme as Theme,
+                hideNodes: false,
+                customIcons: {},
+                darkMode: false,
+                themedOptions,
+                tagGlyphs,
+                pzFeatureFlagEnabled: true,
+            },
+            standardGlyphs
+        );
+
+        expect(secondNodeGlyphs).toHaveLength(1);
+
+        const secondNodeGlyph = secondNodeGlyphs[0];
+
+        expect(secondNodeGlyph.location).toBe(GlyphLocation.BOTTOM_RIGHT);
+        expect(secondNodeGlyph.backgroundColor).toBe(themedOptions.glyph.colors.backgroundColor);
+        expect(secondNodeGlyph.color).toBe(themedOptions.glyph.colors.color);
+        expect(secondNodeGlyph.image).toBe('skull');
     });
 });

--- a/cmd/ui/src/views/Explore/utils.ts
+++ b/cmd/ui/src/views/Explore/utils.ts
@@ -14,14 +14,22 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+import { faGem, faSkull } from '@fortawesome/free-solid-svg-icons';
 import { Theme } from '@mui/material';
-import { GetIconInfo, IconDictionary, TagGlyphs, getGlyphFromKinds } from 'bh-shared-ui';
+import {
+    GLYPH_SCALE,
+    GetIconInfo,
+    IconDictionary,
+    TagGlyphs,
+    getGlyphFromKinds,
+    getModifiedSvgUrlFromIcon,
+} from 'bh-shared-ui';
 import { MultiDirectedGraph } from 'graphology';
 import { random } from 'graphology-layout';
 import forceAtlas2 from 'graphology-layout-forceatlas2';
-import { GraphData, GraphEdge, GraphEdges, GraphNodes } from 'js-client-library';
+import { GraphData, GraphEdge, GraphEdges, GraphNode, GraphNodes } from 'js-client-library';
 import { RankDirection, layoutDagre } from 'src/hooks/useLayoutDagre/useLayoutDagre';
-import { GlyphLocation } from 'src/rendering/programs/node.glyphs';
+import { Glyph, GlyphLocation } from 'src/rendering/programs/node.glyphs';
 import { EdgeDirection, EdgeParams, NodeParams, ThemedOptions } from 'src/utils';
 
 export const standardLayout = (graph: MultiDirectedGraph) => {
@@ -54,6 +62,7 @@ type GraphOptions = {
     customIcons: IconDictionary;
     hideNodes: boolean;
     tagGlyphs: TagGlyphs;
+    pzFeatureFlagEnabled: boolean | undefined;
     themedOptions?: ThemedOptions;
 };
 
@@ -90,12 +99,73 @@ export const initGraph = (items: GraphData, options: GraphOptions) => {
     return graph;
 };
 
+const GLYPHS = {
+    TIER_ZERO: getModifiedSvgUrlFromIcon(faGem, {
+        styles: { color: '#FFFFFF', scale: GLYPH_SCALE },
+    }),
+    TIER_ZERO_DARK: getModifiedSvgUrlFromIcon(faGem, {
+        styles: { color: '#000000', scale: GLYPH_SCALE },
+    }),
+    OWNED_OBJECT: getModifiedSvgUrlFromIcon(faSkull, {
+        styles: { color: '#FFFFFF', scale: GLYPH_SCALE },
+    }),
+    OWNED_OBJECT_DARK: getModifiedSvgUrlFromIcon(faSkull, {
+        styles: { color: '#000000', scale: GLYPH_SCALE },
+    }),
+};
+
+export const getNodeGlyphs = (
+    node: GraphNode,
+    options: GraphOptions & { themedOptions: ThemedOptions },
+    standardGlyphs: typeof GLYPHS
+) => {
+    const { themedOptions, pzFeatureFlagEnabled, tagGlyphs } = options;
+    const glyphs: Glyph[] = [];
+
+    if (pzFeatureFlagEnabled) {
+        if (node.kinds.includes(tagGlyphs.owned)) {
+            glyphs.push({
+                location: GlyphLocation.BOTTOM_RIGHT,
+                image: tagGlyphs.ownedGlyph,
+                ...themedOptions.glyph.colors,
+            });
+        }
+
+        const glyphImage = getGlyphFromKinds(node.kinds, tagGlyphs);
+        if (glyphImage) {
+            glyphs.push({
+                location: GlyphLocation.TOP_RIGHT,
+                image: glyphImage,
+                ...themedOptions.glyph.colors,
+            });
+        }
+    } else {
+        if (node.isOwnedObject) {
+            glyphs.push({
+                location: GlyphLocation.BOTTOM_RIGHT,
+                image: options.darkMode ? standardGlyphs.OWNED_OBJECT_DARK : standardGlyphs.OWNED_OBJECT,
+                ...themedOptions.glyph.colors,
+            });
+        }
+
+        if (node.isTierZero) {
+            glyphs.push({
+                location: GlyphLocation.TOP_RIGHT,
+                image: options.darkMode ? standardGlyphs.TIER_ZERO_DARK : standardGlyphs.TIER_ZERO,
+                ...themedOptions.glyph.colors,
+            });
+        }
+    }
+
+    return glyphs;
+};
+
 const initGraphNodes = (
     graph: MultiDirectedGraph,
     nodes: GraphNodes,
     options: GraphOptions & { themedOptions: ThemedOptions }
 ) => {
-    const { themedOptions, customIcons, hideNodes, tagGlyphs } = options;
+    const { themedOptions, customIcons, hideNodes } = options;
 
     Object.keys(nodes).forEach((key: string) => {
         const node = nodes[key];
@@ -111,25 +181,11 @@ const initGraphNodes = (
         const iconInfo = GetIconInfo(node.kind, customIcons);
         nodeParams.color = iconInfo.color;
         nodeParams.image = iconInfo.url || '';
-        nodeParams.glyphs = [];
 
-        if (node.kinds.includes(tagGlyphs.owned)) {
+        const glyphs = getNodeGlyphs(node, options, GLYPHS);
+        if (glyphs.length > 0) {
+            nodeParams.glyphs = glyphs;
             nodeParams.type = 'glyphs';
-            nodeParams.glyphs.push({
-                location: GlyphLocation.BOTTOM_RIGHT,
-                image: tagGlyphs.ownedGlyph,
-                ...themedOptions.glyph.colors,
-            });
-        }
-
-        const glyphImage = getGlyphFromKinds(node.kinds, tagGlyphs);
-        if (glyphImage) {
-            nodeParams.type = 'glyphs';
-            nodeParams.glyphs.push({
-                location: GlyphLocation.TOP_RIGHT,
-                image: glyphImage,
-                ...themedOptions.glyph.colors,
-            });
         }
 
         graph.addNode(key, {


### PR DESCRIPTION
## Merge Request Runbook
See the runbook for more information on formatting and managing your MRs:
https://specterops.atlassian.net/wiki/spaces/BE/pages/233504866/Merge+Requests

## Description
These changes fix a regression in rendering the tier zero glyph when the feature flag for privilege zones is not enabled.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Resolves: BED-6936

Recent glyph rendering updates were made to support rendering custom glyphs associated with the privilege zone tagging system. These updates did not maintain support for glyph rendering when the privilege zone feature flag is not enabled but should have.

## How Has This Been Tested?
Unit tests have been added. Visual inspection verification.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (a change that does not modify the application functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Documentation updates are needed, and have been made accordingly.
- [x] I have added and/or updated tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] My changes include a database migration.
