### PR TITLE
fix(Graph): Prevent zoom on graph double click  - BED-6965

### DIFF
--- a/cmd/ui/src/components/SigmaChart/GraphEvents.tsx
+++ b/cmd/ui/src/components/SigmaChart/GraphEvents.tsx
@@ -243,6 +243,10 @@ export const GraphEvents = forwardRef(function GraphEvents(
                 // Prevent zoom when node is double clicked
                 preventAllDefaults(event);
             },
+            doubleClick: (event) => {
+                // Prevent zoom when graph is double clicked
+                preventAllDefaults(event);
+            },
             clickNode: (event) => {
                 if (draggedMeta.cancelNextClick) {
                     // Click handler is skipped, canceling the click. State is unset


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Prevent sigma js from zooming in when graph is double clicked.

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-6965
Closes #2071 

*Why is this change required? What problem does it solve?*

Parity with BHE

## How Has This Been Tested?

Ran app locally, confirmed that graph did not zoom when double clicked

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed unwanted zoom behavior triggered by double-clicking on the graph visualization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->