### PR TITLE
refactor(API migrations): Enables "analysis.citrix_rdp_support" BED-6392

### DIFF
--- a/cmd/api/src/database/migration/migrations/v8.5.0.sql
+++ b/cmd/api/src/database/migration/migrations/v8.5.0.sql
@@ -159,5 +159,5 @@ ALTER TABLE completed_tasks
 
 UPDATE parameters
 SET
-    value = '{ "enabled": true }',
+    value = '{ "enabled": true }'
 WHERE key = 'analysis.citrix_rdp_support';


### PR DESCRIPTION
…rameters database table to true

- Sets "analysis.citrix_rdp_support" row from "key" column in parameters database table to "enabled: true" in the "value" column

closes BED-6392

<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

*Describe your changes in detail*
- Sets "analysis.citrix_rdp_support" row from "key" column in parameters database table to "enabled: true" in the "value" column

## Motivation and Context

<!-- Please replace "BED-6392" with the associated ticket or issue number -->
Resolves BED-6392
*Why is this change required? What problem does it solve?*
- Sets "analysis.citrix_rdp_support" row from "key" column in parameters database table to "enabled: true" in the "value" column

## How Has This Been Tested?
- Manually in Postgres database of both bhe and bhce database

*Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc.*
- Manually in Postgres database of both bhe and bhce database

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Database Migrations

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Citrix RDP support is enabled by default — remote access-related features are activated automatically for users.
* **Chores**
  * Data-only update to enable the setting; no additional user-facing configuration required.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->