### PR TITLE
chore: fix password set for BED-6952 

### DIFF
--- a/cmd/api/src/bootstrap/server.go
+++ b/cmd/api/src/bootstrap/server.go
@@ -81,7 +81,7 @@ func CreateDefaultAdmin(ctx context.Context, cfg config.Configuration, db databa
 	if cfg.DefaultAdmin.Password == "" {
 		needsLog = true
 		if admin, err := defaultAdminFunction(); err != nil {
-			return fmt.Errorf("error in setup initalizing auth secret: %w", err)
+			return fmt.Errorf("error in setup initializing auth secret: %w", err)
 		} else {
 			cfg.DefaultAdmin = admin
 		}


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Timing of the password set was incorrect

## Motivation and Context
https://specterops.atlassian.net/browse/BED-6952

*Why is this change required? What problem does it solve?*

## How Has This Been Tested?

*Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc.*

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [ ] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [ ] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined server startup to initialize the default admin earlier and remove duplicated setup steps.
  * Consolidated admin creation and secret initialization for predictable behavior.
  * Improved startup logging: when a new admin password is generated it’s shown once; otherwise the system notes the password came from existing configuration or environment.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->