### PR TITLE
feat: add search functionality to edge filtering dialog BED-6673

### DIFF
--- a/packages/javascript/bh-shared-ui/src/views/Explore/ExploreSearch/EdgeFilteringDialog.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/Explore/ExploreSearch/EdgeFilteringDialog.tsx
@@ -39,7 +39,7 @@ import {
     Typography,
     useTheme,
 } from '@mui/material';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { AllEdgeTypes, Category, EdgeCheckboxType, Subcategory } from '../../../edgeTypes';
 
 interface EdgeFilteringDialogProps {
@@ -61,6 +61,14 @@ const EdgeFilteringDialog = ({
     const title = 'Path Edge Filtering';
     const description = 'Select the edge types to include in your pathfinding search.';
 
+    // Clear search query when dialog closes (for tests and immediate cleanup)
+    useEffect(() => {
+        if (!isOpen) {
+            setSearchQuery('');
+        }
+    }, [isOpen]);
+
+    // Also clear on transition exit (for smooth UX in browser)
     const handleExited = () => {
         setSearchQuery('');
     };
@@ -312,7 +320,12 @@ const IndeterminateListItem = ({
         }
     };
 
-    const toggleCollapsibleContent = () => setShowCollapsibleContent((v) => !v);
+    const toggleCollapsibleContent = () => {
+        // Don't toggle manual state when force-expanded by search
+        if (!forceExpand) {
+            setShowCollapsibleContent((v) => !v);
+        }
+    };
 
     const isExpanded = forceExpand || showCollapsibleContent;
 

--- a/packages/javascript/bh-shared-ui/src/views/Explore/ExploreSearch/EdgeFilteringDialog.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/Explore/ExploreSearch/EdgeFilteringDialog.tsx
@@ -39,7 +39,7 @@ import {
     Typography,
     useTheme,
 } from '@mui/material';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { AllEdgeTypes, Category, EdgeCheckboxType, Subcategory } from '../../../edgeTypes';
 
 interface EdgeFilteringDialogProps {
@@ -61,29 +61,14 @@ const EdgeFilteringDialog = ({
     const title = 'Path Edge Filtering';
     const description = 'Select the edge types to include in your pathfinding search.';
 
-    // Clear search query when dialog closes
-    useEffect(() => {
-        if (!isOpen) {
-            setSearchQuery('');
-        }
-    }, [isOpen]);
-
-    const handleClose = () => {
-        handleCancel();
-    };
-
-    const handleApplyClick = () => {
-        handleApply();
-    };
-
     const handleExited = () => {
         setSearchQuery('');
     };
 
     return (
-        <Dialog open={isOpen} fullWidth maxWidth={'md'} onClose={handleClose} TransitionProps={{ onExited: handleExited }}>
+        <Dialog open={isOpen} fullWidth maxWidth={'md'} onClose={handleCancel} TransitionProps={{ onExited: handleExited }}>
             <DialogTitle>{title}</DialogTitle>
-            <Divider sx={{ ml: 1, mr: 1 }} />
+            <Divider className='mx-1' />
             <Typography variant='subtitle1' ml={3} mt={1}>
                 {description}
             </Typography>
@@ -92,9 +77,10 @@ const EdgeFilteringDialog = ({
                 <TextField
                     fullWidth
                     placeholder='Search edges...'
+                    aria-label='Search edge types'
                     value={searchQuery}
                     onChange={(e) => setSearchQuery(e.target.value)}
-                    sx={{ mb: 2 }}
+                    className='mb-2'
                 />
                 <CategoryList
                     selectedFilters={selectedFilters}
@@ -104,10 +90,10 @@ const EdgeFilteringDialog = ({
             </DialogContent>
 
             <DialogActions>
-                <Button variant='tertiary' onClick={handleClose}>
+                <Button variant='tertiary' onClick={handleCancel}>
                     Cancel
                 </Button>
-                <Button onClick={handleApplyClick}>Apply</Button>
+                <Button onClick={handleApply}>Apply</Button>
             </DialogActions>
         </Dialog>
     );
@@ -182,7 +168,7 @@ const CategoryListItem = ({ category, checked, setChecked, searchQuery }: Catego
             setChecked={setChecked}
             forceExpand={!!searchQuery}
             collapsibleContent={
-                <List sx={{ pl: 2 }}>
+                <List className='pl-2'>
                     {subcategories.filter(filterSubcategory).map((subcategory) => {
                         return (
                             <SubcategoryListItem
@@ -224,8 +210,8 @@ const SubcategoryListItem = ({ subcategory, checked, setChecked, searchQuery }: 
             setChecked={setChecked}
             forceExpand={!!searchQuery}
             collapsibleContent={
-                <List sx={{ pl: 4 }}>
-                    <ListItem sx={{ display: 'block' }}>
+                <List className='pl-4'>
+                    <ListItem className='block'>
                         <EdgesView edgeTypes={filteredEdgeTypes} checked={checked} setChecked={setChecked} />
                     </ListItem>
                 </List>

--- a/packages/javascript/bh-shared-ui/src/views/Explore/ExploreSearch/EdgeFilteringDialog.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/Explore/ExploreSearch/EdgeFilteringDialog.tsx
@@ -39,7 +39,7 @@ import {
     Typography,
     useTheme,
 } from '@mui/material';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { AllEdgeTypes, Category, EdgeCheckboxType, Subcategory } from '../../../edgeTypes';
 
 interface EdgeFilteringDialogProps {
@@ -60,6 +60,13 @@ const EdgeFilteringDialog = ({
     const [searchQuery, setSearchQuery] = useState('');
     const title = 'Path Edge Filtering';
     const description = 'Select the edge types to include in your pathfinding search.';
+
+    // Clear search query when dialog closes
+    useEffect(() => {
+        if (!isOpen) {
+            setSearchQuery('');
+        }
+    }, [isOpen]);
 
     const handleClose = () => {
         handleCancel();


### PR DESCRIPTION
Add a search field in the Pathfinding edge filtering dialog. The search is case-insensitive and automatically expands/collapses accordions to show matching results. Search state clears when the dialog closes to ensure a clean UX on reopening.

## Description

## Detailed Changes

### EdgeFilteringDialog.tsx

**New Feature: Search Functionality**
- Added a `TextField` component above the category list that allows users to search for edge types
- Search field has placeholder text "Search edges..."
- Search query is managed via local state using `useState`

**Search Filtering Logic**
- Implemented `filterCategory` function in `CategoryList` that filters categories based on whether they contain matching edge types
- Implemented `filterSubcategory` function in `CategoryListItem` that filters subcategories similarly
- In `SubcategoryListItem`, edge types are filtered to show only those matching the search query
- All filtering is case-insensitive using `.toLowerCase()`

**Auto-Expand/Collapse Behavior**
- Added `forceExpand` prop to `IndeterminateListItem` component
- When search query exists, `forceExpand={!!searchQuery}` automatically expands all accordions to show matching results
- When search is cleared, accordions collapse back to their default state
- The expand/collapse icon updates based on `isExpanded` state (which combines `forceExpand` and `showCollapsibleContent`)

**Search Persistence/Cleanup**
- Added `handleExited` callback that resets search query to empty string
- This callback is passed to `Dialog`'s `TransitionProps.onExited`
- Ensures search field is cleared when dialog closes (via Cancel or Apply button)
- Provides clean UX when reopening the dialog

**Refactoring**
- Replaced Tailwind CSS classes with Material-UI's `sx` prop for consistency:
  - `className='ml-2 mr-2'` → `sx={{ ml: 1, mr: 1 }}`
  - `className='pl-4'` → `sx={{ pl: 2 }}`
  - `className='pl-8'` → `sx={{ pl: 4 }}`
  - `className='block'` → `sx={{ display: 'block' }}`
- Replaced `<div className='bg-neutral-3 p-2 rounded-lg'>` with `<Box bgcolor={theme.palette.neutral.tertiary} p={1} borderRadius={1}>`
- Added `useTheme` hook to access theme palette
- Added wrapper functions `handleClose` and `handleApplyClick` for better organization

**New Imports**
- `Box` - for styled container
- `TextField` - for search input
- `useTheme` - for accessing theme palette

### EdgeFilteringDialog.test.tsx

**New Test Suite: Search Functionality Tests**
- Test that search field renders correctly
- Test that searching filters edge types and auto-expands accordions
- Test that clearing search collapses accordions
- Test that search only filters edge types (not categories/subcategories)
- Test that search is case-insensitive

**New Test Suite: Search Persistence Tests**
- Test that search field clears when dialog closes via Cancel button
- Test that search field clears when dialog closes via Apply button
- Both tests verify the cleanup behavior by opening, searching, closing, and reopening the dialog

All tests use `@testing-library/user-event` for realistic user interactions and verify both the presence of UI elements and their behavior.

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-6673

If a user wants to uncheck one edge type for filtering, for example CanRDP, they need to either:
- Know which category the edge is in
  - Expand the Active Directory category
  - Expand the Lateral Movement category
  - Uncheck the CanRDP edge
- Look through all 6 categories and 42 edges
  - Expand the Active Directory category
  - Expand all of the 6 categories
  - Manually look for the node, or CTRL+F and search for the node
  - Uncheck the CanRDP edge

## How Has This Been Tested?

- Built BHCE locally, verified the feature works (see below)

## Screenshots (optional):

https://github.com/user-attachments/assets/f74278a5-86ba-42b0-bf38-6794ffc8fe3c

## Types of changes

<!-- Please remove any items that do not apply. -->

- New feature (non-breaking change which adds functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added search to the edge filtering dialog for faster type discovery.
  * Search filters edge types in real time, auto-expands matching sections, is case-insensitive, and only targets edge types (not categories).
  * Search input clears when the dialog is closed (via cancel or apply) and is reset when reopened.

* **Tests**
  * Added comprehensive UI tests covering rendering, filtering, auto-expansion, case-insensitivity, and dialog state persistence.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->