### PR TITLE
docs(bh-rfc-6): DogTags (SKU Feature Entitlements) BED-7094

### DIFF
--- a/rfc/bh-rfc-6.md
+++ b/rfc/bh-rfc-6.md
@@ -79,6 +79,7 @@ Dogtags are exposed via `GET /api/v2/dog-tags`. The response is always a flat ma
 ```json
 {
     "data": {
+        "auth.environment_targeted_access_control": false,
         "privilege_zones.tier_limit": 3,
         "privilege_zones.label_limit": 10,
         "privilege_zones.multi_tier_analysis": false
@@ -118,12 +119,25 @@ if s.DogTags.GetFlagAsBool(dogtags.MY_NEW_FEATURE) {
 
 The service handles defaults, so you never need to check errors.
 
+### 5.4 Migrating Existing Flags
+
+When moving a configuration value to dogtags, all previous references must be deprecated and removed. The old configuration endpoint, any backend code reading from the parameters table, and any UI components consuming the old values should be updated to use the dogtags service instead. Leaving stale references creates a confusing split where the displayed value may not match what the application actually uses.
+
 ## 6. Testing
 
-Use `NoopProvider` for tests - it always returns errors, forcing the service to use defaults. For testing specific flag values, create a mock provider.
+For tests that don't care about specific flag values, use `NewDefaultService()` which returns defaults for everything:
 
 ```go
-dogtagsService := dogtags.NewDefaultService() // uses NoopProvider
+dogtagsService := dogtags.NewDefaultService()
+```
+
+For tests that need specific flag values, use `NewTestService` with `TestOverrides`. Values not in the overrides map fall back to defaults:
+
+```go
+dogtagsService := dogtags.NewTestService(dogtags.TestOverrides{
+    Bools: map[dogtags.BoolDogTag]bool{dogtags.PZ_MULTI_TIER_ANALYSIS: true},
+    Ints:  map[dogtags.IntDogTag]int64{dogtags.PZ_TIER_LIMIT: 5, dogtags.PZ_LABEL_LIMIT: 3},
+})
 ```
 
 ## 7. File Locations


### PR DESCRIPTION
## Description
DogTags RFC, to be paired with https://github.com/SpecterOps/BloodHound/pull/2147

## Motivation and Context
BED-7094


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an RFC describing a SKU-based "Dogtags" feature entitlements system with a provider abstraction, runtime provider injection, startup-time loading/caching, and fail-fast behavior on misconfiguration.
  * Documents a new API endpoint to retrieve entitlements as a flat, dot-notated JSON payload, guidance for adding SKU flags, and testing recommendations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->