### PR TITLE
docs: hide early access opengraph api documentation BED-7122

### DIFF
--- a/packages/go/openapi/doc/openapi.json
+++ b/packages/go/openapi/doc/openapi.json
@@ -7523,79 +7523,6 @@
         }
       }
     },
-    "/api/v2/graph-schema/edges": {
-      "parameters": [
-        {
-          "$ref": "#/components/parameters/header.prefer"
-        }
-      ],
-      "get": {
-        "operationId": "ListEdgeKinds",
-        "summary": "List Edge Kinds",
-        "description": "List all Edge Kinds across Graph Schemas",
-        "tags": [
-          "Graph Schema",
-          "OpenGraph",
-          "Enterprise",
-          "Community"
-        ],
-        "parameters": [
-          {
-            "name": "schemas",
-            "description": "Schema names to filter response by",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          },
-          {
-            "name": "is_traversable",
-            "description": "Filter response by whether or not an edge is traversable",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "$ref": "#/components/schemas/api.params.predicate.filter.boolean"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "data": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/model.graph-schema-edge-kinds"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "$ref": "#/components/responses/bad-request"
-          },
-          "401": {
-            "$ref": "#/components/responses/unauthorized"
-          },
-          "429": {
-            "$ref": "#/components/responses/too-many-requests"
-          },
-          "500": {
-            "$ref": "#/components/responses/internal-server-error"
-          }
-        }
-      }
-    },
     "/api/v2/saved-queries": {
       "parameters": [
         {
@@ -20227,27 +20154,6 @@
             "items": {
               "$ref": "#/components/schemas/model.unified-graph.edge"
             }
-          }
-        }
-      },
-      "model.graph-schema-edge-kinds": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "name": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string"
-          },
-          "is_traversable": {
-            "type": "boolean"
-          },
-          "schema_name": {
-            "type": "string"
           }
         }
       },

--- a/packages/go/openapi/src/openapi.yaml
+++ b/packages/go/openapi/src/openapi.yaml
@@ -381,9 +381,9 @@ paths:
   /api/v2/graphs/acl-inheritance:
     $ref: './paths/graph.graphs.acl-inheritance.yaml'
 
-   # opengraph
-  /api/v2/graph-schema/edges:
-    $ref: './paths/graph-schema.edge-kinds.yaml'
+  #  # opengraph (disabled for EA)
+  # /api/v2/graph-schema/edges:
+  #   $ref: './paths/graph-schema.edge-kinds.yaml'
 
   # cypher
   /api/v2/saved-queries:


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

- Hides the OpenAPI definition for early access opengraph APIs

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-7122

## How Has This Been Tested?

Ran `just gen-spec` and observed the API documentation was removed in the app

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **API Changes**
  * The `/api/v2/graph-schema/edges` API endpoint has been disabled and removed from the service specification. This early access endpoint is no longer available. Applications and integrations currently using this endpoint must be updated to discontinue usage.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->