### PR TITLE
fix(db): Do not attempt to delete ETAC list if none exists BED-7037

### DIFF
--- a/cmd/api/src/database/etac.go
+++ b/cmd/api/src/database/etac.go
@@ -43,6 +43,15 @@ func (s *BloodhoundDB) GetEnvironmentTargetedAccessControlForUser(ctx context.Co
 
 // DeleteEnvironmentTargetedAccessControlForUser will remove all rows associated with a user in the environment_targeted_access_control table
 func (s *BloodhoundDB) DeleteEnvironmentTargetedAccessControlForUser(ctx context.Context, user model.User) error {
+	// Prevent an audit log by exiting early if a user does not have an ETAC list applied
+	if originalUser, err := s.GetUser(ctx, user.ID); err != nil {
+		return err
+	} else {
+		if len(originalUser.EnvironmentTargetedAccessControl) == 0 {
+			return nil
+		}
+	}
+
 	var (
 		auditData = model.AuditData{
 			"userUuid": user.ID.String(),


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

This is a small fix to no longer attempt to delete a user's ETAC list if none exists
Specifically, this prevents the audit log from appearing when updating a user with no ETAC list applied.

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves: BED-7037

*Why is this change required? What problem does it solve?*

## How Has This Been Tested?
I reset my BHE database, logged in with the default user, and accepted the EULA
I then verified no audit log existed for `DeleteETACList`
<img width="1944" height="753" alt="image" src="https://github.com/user-attachments/assets/3805909b-20a2-4ee7-ab26-2a56ee51bfd9" />


## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized the environment access control deletion process to skip unnecessary operations when no access control entries exist.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->