### PR TITLE
docs(OpenGraph): Update search API docs to clarify type param only works with built in types BED-7132

### DIFF
--- a/packages/go/openapi/doc/openapi.json
+++ b/packages/go/openapi/doc/openapi.json
@@ -3452,7 +3452,7 @@
           },
           {
             "name": "type",
-            "description": "Node type.\nSome AD examples: `Base`, `User`, `Computer`, `Group`, `Container`.\nSome Azure examples: `AZBase`, `AZApp`, `AZDevice`.\n",
+            "description": "Node type. Currently only supports built-in types.\nSome AD examples: `Base`, `User`, `Computer`, `Group`, `Container`.\nSome Azure examples: `AZBase`, `AZApp`, `AZDevice`.\n",
             "in": "query",
             "schema": {
               "type": "string"

--- a/packages/go/openapi/src/paths/search.search.yaml
+++ b/packages/go/openapi/src/paths/search.search.yaml
@@ -33,7 +33,7 @@ get:
         type: string
     - name: type
       description: |
-        Node type.
+        Node type. Currently only supports built-in types.
         Some AD examples: `Base`, `User`, `Computer`, `Group`, `Container`.
         Some Azure examples: `AZBase`, `AZApp`, `AZDevice`.
       in: query


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Adding a line to clarify that the `type` param only works with built-in types, not OpenGraph types. 

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-7132

I made this change because I thought it's a little confusing now that this endpoint includes OpenGraph nodes, but the `type` param does not work with OpenGraph types. Wanted to make sure our API users know what the valid types are for this param.

## How Has This Been Tested?

N/A, just a docs change.  

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Search endpoint documentation to clarify that the "type" parameter currently only supports built-in types.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->