### PR TITLE
fix: Fixed spec endpoint BED-6941

### DIFF
--- a/packages/go/openapi/doc/openapi.json
+++ b/packages/go/openapi/doc/openapi.json
@@ -3387,7 +3387,7 @@
         }
       }
     },
-    "/api/v2/spec/openapi.yaml": {
+    "/api/v2/spec": {
       "parameters": [
         {
           "$ref": "#/components/parameters/header.prefer"

--- a/packages/go/openapi/src/openapi.yaml
+++ b/packages/go/openapi/src/openapi.yaml
@@ -300,7 +300,7 @@ paths:
   # api info
   /api/version:
     $ref: './paths/api-info.version.yaml'
-  /api/v2/spec/openapi.yaml:
+  /api/v2/spec:
     $ref: './paths/api-info.spec.yaml'
 
   # search


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Endpoint for OpenAPI spec is incorrect in API Explorer and Documentation. Should be /api/v2/spec but shows as /api/v2/spec/openapi.yaml.

## Motivation and Context

Resolves BED-6941

## How Has This Been Tested?

Tested locally

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **API Changes**
  * OpenAPI specification endpoint updated from `/api/v2/spec/openapi.yaml` to `/api/v2/spec`. Developers accessing the API documentation should update their references to the new simplified endpoint path.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->