### PR TITLE
fix: Do not exit CanRDP Post-Processing Early on Not Found Error - BED-7147

### DIFF
--- a/packages/go/analysis/ad/local_groups.go
+++ b/packages/go/analysis/ad/local_groups.go
@@ -147,7 +147,9 @@ func PostCanRDP(parentCtx context.Context, graphDB graph.Database, localGroupDat
 					}
 
 					if computerCanRDPData, err := canRDPData.FetchCanRDPComputerData(tx, nextComputerID); err != nil {
-						return err
+						if !graph.IsErrNotFound(err) {
+							return err
+						}
 					} else if !channels.Submit(ctx, computerC, computerCanRDPData) {
 						break
 					}


### PR DESCRIPTION
## Description

Modify CanRDP behavior to not exit when a `RemoteDesktopUsers` local group is not found for a given computer.

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-7147

Previous logic would skip the computer instead of exiting post-processing. This logic was slightly opaque and did not have a corresponding negative test.

## How Has This Been Tested?

* Test dataset

## Types of changes

<!-- Please remove any items that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
