### PR TITLE
feat(API Client): add finding resource and type - BED-6896

### DIFF
--- a/packages/javascript/js-client-library/src/client.ts
+++ b/packages/javascript/js-client-library/src/client.ts
@@ -1,4 +1,4 @@
-// Copyright 2025 Specter Ops, Inc.
+// Copyright 2026 Specter Ops, Inc.
 //
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
@@ -96,6 +96,7 @@ import {
     UploadFileToIngestResponse,
 } from './responses';
 import * as types from './types';
+import { FindingAssetsResponse } from './types';
 
 /** Return the value as a string with the given prefix */
 const prefixValue = (prefix: string, value: any) => (value ? `${prefix}:${value.toString()}` : undefined);
@@ -485,6 +486,9 @@ class BHEAPIClient {
      */
     getLatestMetaNode = (environmentId: string, options?: RequestOptions) =>
         this.baseClient.get<BasicResponse<types.FlatGraphResponse>>(`/api/v2/meta-nodes/${environmentId}`, options);
+
+    getFindings = (key: string, options?: RequestOptions) =>
+        this.baseClient.get<BasicResponse<FindingAssetsResponse>>(`/api/v2/findings/${key}`, options);
 
     /**
      * getFindingDetails returns data associated with a finding for a given environment

--- a/packages/javascript/js-client-library/src/types.ts
+++ b/packages/javascript/js-client-library/src/types.ts
@@ -589,3 +589,13 @@ export type FileIngestCompletedTask = TimestampFields & {
     id: number;
     parent_file_name: string;
 };
+
+export type FindingAssetsResponse = {
+    long_description: string;
+    long_remediation: string;
+    references: string;
+    short_description: string;
+    short_remediation: string;
+    title: string;
+    type: string;
+};


### PR DESCRIPTION
## Description

* Adds api client and type needed for remediation UI updates
* add finding resource to JS API client
* add finding resource type to JS API client

## Motivation and Context

Resolves BED-6896

## How Has This Been Tested?

Just a basic api call. Integration tests added in BHE.

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- New feature (non-breaking change which adds functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an API endpoint to retrieve findings by key, exposing finding details: title, type, short/long descriptions, short/long remediation, and references.
* **Chores**
  * Updated copyright year.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->