### PR TITLE
fix: Fixes for query 'Computers with membership in Protected Users' - BED-7273

### DIFF
--- a/packages/javascript/bh-shared-ui/src/commonSearchesAGI.ts
+++ b/packages/javascript/bh-shared-ui/src/commonSearchesAGI.ts
@@ -543,7 +543,7 @@ RETURN p\nLIMIT 1000`,
                 query: `MATCH (c:Computer)\nWHERE c.restrictoutboundntlm = True\nRETURN c LIMIT 1000`,
             },
             {
-                name: 'Computers with membership in Protected Users',
+                name: 'All members of Protected Users',
                 description: '',
                 query: `MATCH p = (:Base)-[:MemberOf*1..]->(g:Group)\nWHERE g.objectid ENDS WITH '-525'\nRETURN p LIMIT 1000`,
             },

--- a/packages/javascript/bh-shared-ui/src/commonSearchesAGT.ts
+++ b/packages/javascript/bh-shared-ui/src/commonSearchesAGT.ts
@@ -543,7 +543,7 @@ RETURN p\nLIMIT 1000`,
                 query: `MATCH (c:Computer)\nWHERE c.restrictoutboundntlm = True\nRETURN c LIMIT 1000`,
             },
             {
-                name: 'Computers with membership in Protected Users',
+                name: 'All members of Protected Users',
                 description: '',
                 query: `MATCH p = (:Base)-[:MemberOf*1..]->(g:Group)\nWHERE g.objectid ENDS WITH '-525'\nRETURN p LIMIT 1000`,
             },


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

[BHQL got a PR](https://github.com/SpecterOps/BloodHoundQueryLibrary/issues/44) for the pre-built query Computers with membership in Protected Users in the NTLM Relay category.

Query name specifies "Computers", but the query uses :Base, thus returns all AD node types

MATCH p = (:Base)-[:MemberOf*1..]->(g:Group)
WHERE g.objectid ENDS WITH '-525'
RETURN p LIMIT 1000

When working with NTLM Relay security in general, the query is more useful when also returning User nodes.

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-7273

## How Has This Been Tested?

Built BHC locally and confirmed name was changed and query executed.

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [X] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [X] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [X] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Refined search terminology for improved user clarity. A common search option previously labeled "Computers with membership in Protected Users" has been updated to "All members of Protected Users." This change ensures users have a more accurate understanding of what this search query retrieves.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->