### PR TITLE
fix: do not trust auth keys that are just an empty string - BED-7285

### DIFF
--- a/cmd/api/src/api/auth.go
+++ b/cmd/api/src/api/auth.go
@@ -104,6 +104,10 @@ func NewAuthExtensions(cfg config.Configuration, db database.Database) AuthExten
 }
 
 func (s authExtensions) InitContextFromToken(ctx context.Context, authToken model.AuthToken) (auth.Context, error) {
+	if authToken.Key == "" {
+		return auth.Context{}, database.ErrAuthContextInvalid
+	}
+
 	if authToken.UserID.Valid {
 		if user, err := s.db.GetUser(ctx, authToken.UserID.UUID); err != nil {
 			return auth.Context{}, err


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Do not allow AuthTokens with key set to "" to be valid.

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-7285

## How Has This Been Tested?

This has been tested by running the application and ensuring a signed request cannot be signed by a key with no bytes. 

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [X] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [X] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [X] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication token validation to detect and reject invalid tokens earlier in the authentication process, preventing downstream errors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->