### PR TITLE
feat(OpenGraph): Stave off kind table ID exhaustion - BED-7259

### DIFF
--- a/cmd/api/src/database/migration/migrations/v8.7.0.sql
+++ b/cmd/api/src/database/migration/migrations/v8.7.0.sql
@@ -43,7 +43,7 @@ BEGIN
     IF kind_row IS NOT NULL THEN
         RETURN kind_row;
     END IF;
-    -- Insert with retry, handles the edge case where two transactions could add the same kind at the same time
+    -- Insert with retry, handles the race condition where two transactions try to add the same kind at the same time
     FOR i IN 1..5 LOOP
         BEGIN
             INSERT INTO kind (name)


### PR DESCRIPTION
## Description

Replace the existing upsert_kind func with a new one to better assist with id exhaustion. 

## Motivation and Context
Resolves: BED-7259

Currently, when performing schema node and relationship upserts, the kind table will begin to unnecessarily exhaust its ID space as an insert that conflicts with an existing kind will always increment even if DO NOTHING or DO UPDATE is provided. 

In order to ensure we don't waste ID space, a new upsert_kind function was created to check if kinds already exist before attempting the insert. 

## How Has This Been Tested?

- Ran integration tests
- TODO: Manual performance testing

## Screenshots (optional):

## Types of changes
- Bug fix (non-breaking change which fixes an issue)
- Database Migrations

## Checklist:
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced rare insertion conflicts during concurrent operations by adding a retry-backed upsert, lowering chance of runtime failures.

* **Chores**
  * Improved database behavior to avoid identifier exhaustion and preserve performance under high-concurrency scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->