### PR TITLE
fix(analysis): Resolve datapipe ordering issue for analysis - BED-7354

### DIFF
--- a/cmd/api/src/daemons/datapipe/analysis.go
+++ b/cmd/api/src/daemons/datapipe/analysis.go
@@ -59,12 +59,6 @@ func RunAnalysisOperations(ctx context.Context, db database.Database, graphDB gr
 		collectedErrors = append(collectedErrors, fmt.Errorf("well known group linking failed: %w", err))
 	}
 
-	if errs := TagAssetGroupsAndTierZero(ctx, db, graphDB); len(errs) > 0 {
-		for _, err := range errs {
-			collectedErrors = append(collectedErrors, fmt.Errorf("tagging asset groups and tier zero failed: %w", err))
-		}
-	}
-
 	var (
 		adFailed          = false
 		azureFailed       = false
@@ -89,6 +83,12 @@ func RunAnalysisOperations(ctx context.Context, db database.Database, graphDB gr
 		azureFailed = true
 	} else {
 		stats.LogStats()
+	}
+
+	if errs := TagAssetGroupsAndTierZero(ctx, db, graphDB); len(errs) > 0 {
+		for _, err := range errs {
+			collectedErrors = append(collectedErrors, fmt.Errorf("tagging asset groups and tier zero failed: %w", err))
+		}
 	}
 
 	if !tieringEnabled {


### PR DESCRIPTION
## Merge Request Runbook
See the runbook for more information on formatting and managing your MRs:
https://specterops.atlassian.net/wiki/spaces/BE/pages/233504866/Merge+Requests

## Description
Re-orders analysis processes to accurately run selection/tagging after post-processing. Several default T0 roles rely on post-processed edges, so post- must run prior to tagging.

## Motivation and Context
Resolves: BED-7354

## How Has This Been Tested?
Validated against local build that ordering ran correctly.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (a change that does not modify the application functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Documentation updates are needed, and have been made accordingly.
- [ ] I have added and/or updated tests to cover my changes.
- [X] All new and existing tests passed.
- [ ] My changes include a database migration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Adjusted the sequence of internal asset tagging operations during data analysis processing to occur after Azure post-processing steps instead of before.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->