### PR TITLE
feat(dogtags): add Name() to providers for startup logging BED-7364

### DIFF
--- a/cmd/api/src/services/dogtags/provider.go
+++ b/cmd/api/src/services/dogtags/provider.go
@@ -24,6 +24,7 @@ var ErrProviderNotImplemented = errors.New("no-op provider not implemented")
 // Providers are simple key-value stores - they don't know about defaults.
 // The service layer handles defaults when a key isn't found.
 type Provider interface {
+	Name() string
 	GetFlagAsBool(key string) (bool, error)
 	GetFlagAsString(key string) (string, error)
 	GetFlagAsInt(key string) (int64, error)
@@ -33,8 +34,14 @@ type Provider interface {
 // The service will use defaults for everything.
 type NoopProvider struct{}
 
+const NoopProviderName = "NoopProvider"
+
 func NewNoopProvider() *NoopProvider {
 	return &NoopProvider{}
+}
+
+func (p *NoopProvider) Name() string {
+	return NoopProviderName
 }
 
 func (p *NoopProvider) GetFlagAsBool(key string) (bool, error) {

--- a/cmd/api/src/services/dogtags/service.go
+++ b/cmd/api/src/services/dogtags/service.go
@@ -17,6 +17,7 @@ package dogtags
 
 // Service defines the interface for the dogtags service
 type Service interface {
+	ProviderName() string
 	GetFlagAsBool(key BoolDogTag) bool
 	GetFlagAsString(key StringDogTag) string
 	GetFlagAsInt(key IntDogTag) int64
@@ -52,6 +53,10 @@ type testService struct {
 	overrides TestOverrides
 }
 
+func (s *testService) ProviderName() string {
+	return "TestProvider"
+}
+
 func (s *testService) GetFlagAsBool(key BoolDogTag) bool {
 	if val, ok := s.overrides.Bools[key]; ok {
 		return val
@@ -82,6 +87,10 @@ func (s *testService) GetAllDogTags() map[string]any {
 		result[string(key)] = s.GetFlagAsInt(key)
 	}
 	return result
+}
+
+func (s *service) ProviderName() string {
+	return s.provider.Name()
 }
 
 func (s *service) GetFlagAsBool(key BoolDogTag) bool {

--- a/cmd/api/src/services/entrypoint.go
+++ b/cmd/api/src/services/entrypoint.go
@@ -82,6 +82,10 @@ func Entrypoint(ctx context.Context, cfg config.Configuration, connections boots
 
 	dogtagsService := dogtags.NewDefaultService()
 
+	slog.InfoContext(ctx, "DogTags provider initialized",
+		slog.String("namespace", "dogtags"),
+		slog.String("provider", dogtagsService.ProviderName()))
+
 	flags := dogtagsService.GetAllDogTags()
 	slog.InfoContext(ctx, "DogTags Configuration",
 		slog.String("namespace", "dogtags"),


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description
Add Logging of the provider on startup

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-7364

## How Has This Been Tested?

*Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc.*

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)
- Database Migrations

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [ ] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [ ] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [ ] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced provider identification and initialization logging for improved observability of the DogTags service startup process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->