### PR TITLE
feat(OpenGraph Findings): Add migration for list findings table BED-7413

### DIFF
--- a/cmd/api/src/database/migration/migrations/v8.7.0.sql
+++ b/cmd/api/src/database/migration/migrations/v8.7.0.sql
@@ -135,7 +135,7 @@ ALTER TABLE source_kinds DROP COLUMN IF EXISTS name;
 CREATE TABLE IF NOT EXISTS schema_list_findings (
     id SERIAL,
     schema_extension_id INTEGER NOT NULL REFERENCES schema_extensions(id) ON DELETE CASCADE,
-    node_kind_id INTEGER NOT NULL REFERENCES kind(id),
+    node_kind_id SMALLINT NOT NULL REFERENCES kind(id),
     environment_id INTEGER NOT NULL REFERENCES schema_environments(id) ON DELETE CASCADE,
     name TEXT NOT NULL,
     display_name TEXT NOT NULL,
@@ -143,3 +143,6 @@ CREATE TABLE IF NOT EXISTS schema_list_findings (
     PRIMARY KEY(id),
     UNIQUE(name)
 );
+
+CREATE INDEX IF NOT EXISTS idx_schema_list_findings_extension_id ON schema_list_findings (schema_extension_id);
+CREATE INDEX IF NOT EXISTS idx_schema_list_findings_environment_id ON schema_list_findings(environment_id);


### PR DESCRIPTION
## Description

Adds a DB migration to create the `schema_list_findings` table, as part of our effort to migration list findings into the database rather than working off of the cue file. 

Also updates the `source_kinds` migration to be idempotent. 

## Motivation and Context
Resolves BED-7413

We need somewhere to put the list findings in the database, so that we can move away from the hard-coded cue files. 

## How Has This Been Tested?

Ran the migration locally and confirmed that the table was generated. 

## Screenshots (optional):
<img width="319" height="101" alt="Screenshot 2026-02-18 at 13 02 48" src="https://github.com/user-attachments/assets/928a3911-4f5c-4143-9e7a-e7640b287a63" />

## Types of changes

<!-- Please remove any items that do not apply. -->
- Database Migrations

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an OpenGraph "findings" dataset to enable additional listing and discovery capabilities.

* **Chores**
  * Improved database migration robustness with idempotent, guarded operations to reduce update failures.
  * Strengthened schema integrity with additional constraints and safe wiring of new schema fields.
  * Safely removed a legacy field as part of the migration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->