### PR TITLE
chore: migrate GM selectors to PZ BED-7388

### DIFF
--- a/cmd/api/src/database/migration/migrations/v8.7.0.sql
+++ b/cmd/api/src/database/migration/migrations/v8.7.0.sql
@@ -146,3 +146,50 @@ CREATE TABLE IF NOT EXISTS schema_list_findings (
 
 CREATE INDEX IF NOT EXISTS idx_schema_list_findings_extension_id ON schema_list_findings (schema_extension_id);
 CREATE INDEX IF NOT EXISTS idx_schema_list_findings_environment_id ON schema_list_findings(environment_id);
+
+-- Drop unique name constraint before migrating to PZ in case AGT names are not unique
+ALTER TABLE IF EXISTS asset_group_tag_selectors DROP CONSTRAINT IF EXISTS asset_group_tag_selectors_unique_name_asset_group_tag;
+
+-- Remigrate old custom AGI selectors to PZ selectors for any instances without PZ feature flag enabled
+DO $$
+  BEGIN
+		IF
+      (SELECT enabled FROM feature_flags WHERE key  = 'tier_management_engine') = false
+    THEN
+       -- Delete custom selectors
+       DELETE FROM asset_group_tag_selectors WHERE is_default = false AND asset_group_tag_id IN ((SELECT id FROM asset_group_tags WHERE position = 1), (SELECT id FROM asset_group_tags WHERE type = 3));
+
+       -- Re-Migrate existing Tier Zero selectors
+       WITH inserted_selector AS (
+         INSERT INTO asset_group_tag_selectors (asset_group_tag_id, created_at, created_by, updated_at, updated_by, name, description, is_default, allow_disable, auto_certify)
+         SELECT (SELECT id FROM asset_group_tags WHERE position = 1), current_timestamp, 'BloodHound', current_timestamp, 'BloodHound', s.name, s.selector, false, true, 2
+         FROM asset_group_selectors s JOIN asset_groups ag ON ag.id = s.asset_group_id
+         WHERE ag.tag = 'admin_tier_0' and NOT EXISTS(SELECT 1 FROM asset_group_tag_selectors WHERE name = s.name)
+         RETURNING id, description
+         )
+       INSERT INTO asset_group_tag_selector_seeds (selector_id, type, value) SELECT id, 1, description FROM inserted_selector;
+
+      -- Re-Migrate existing Owned selectors
+      WITH inserted_selector AS (
+        INSERT INTO asset_group_tag_selectors (asset_group_tag_id, created_at, created_by, updated_at, updated_by, name, description, is_default, allow_disable, auto_certify)
+        SELECT (SELECT id FROM asset_group_tags WHERE type = 3), current_timestamp, 'BloodHound', current_timestamp, 'BloodHound', s.name, s.selector, false, true, 0
+        FROM asset_group_selectors s JOIN asset_groups ag ON ag.id = s.asset_group_id
+        WHERE ag.tag = 'owned' and NOT EXISTS(SELECT 1 FROM asset_group_tag_selectors WHERE name = s.name)
+          RETURNING id, description
+          )
+      INSERT INTO asset_group_tag_selector_seeds (selector_id, type, value) SELECT id, 1, description FROM inserted_selector;
+    END IF;
+  END;
+$$;
+
+-- Before we add unique constraint, rename any duplicates with `_X` to prevent constraint failing
+WITH duplicate_selectors AS (
+  SELECT id, name, asset_group_tag_id, ROW_NUMBER() OVER (PARTITION BY name, asset_group_tag_id ORDER BY id) AS rowNumber
+  FROM asset_group_tag_selectors
+)
+UPDATE asset_group_tag_selectors agts
+SET name = agts.name || '_' || rowNumber FROM duplicate_selectors
+WHERE agts.id = duplicate_selectors.id AND duplicate_selectors.rowNumber > 1;
+
+-- Reinstate unique constraint for asset group tag selectors name per asset group tag
+ALTER TABLE IF EXISTS asset_group_tag_selectors ADD CONSTRAINT asset_group_tag_selectors_unique_name_asset_group_tag UNIQUE ("name",asset_group_tag_id,is_default);


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

This PR adds a DB migration for v8.7.0 that remigrates AGI -> PZ for tenants where PZ is disabled.

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-7388

*Why is this change required? What problem does it solve?*

## How Has This Been Tested?
The migration has been tested locally both from a fresh install, and from v8.6.0.

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)
- Database Migrations

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
