### PR TITLE
feat: Add TierID to SearchTierNodesCtx: BED-7415

### DIFF
--- a/packages/go/analysis/tiering/helpers.go
+++ b/packages/go/analysis/tiering/helpers.go
@@ -24,7 +24,7 @@ import (
 )
 
 type SearchTierNodesCtx struct {
-	TierID                    int // Tier ID for findings processing
+	PrimaryTierID             int // Tier ID for findings processing
 	IsTierZero                bool
 	PrimaryTierKind           graph.Kind
 	SearchTierNodes           graph.Criteria
@@ -35,7 +35,7 @@ type SearchTierNodesCtx struct {
 
 func NewSearchTierNodesCtx(tieringEnabled bool, isTierZero bool, tierID int, primaryKind graph.Kind, tierKinds ...graph.Kind) SearchTierNodesCtx {
 	return SearchTierNodesCtx{
-		TierID:                    tierID,
+		PrimaryTierID:             tierID,
 		IsTierZero:                isTierZero,
 		PrimaryTierKind:           primaryKind,
 		SearchTierNodesRel:        searchTierNodesRel(tieringEnabled, tierKinds...),


### PR DESCRIPTION
## Description
To support some BHE analysis work, we want to add the PrimaryTierID to the tiering context.

## Motivation and Context
BED-7415

## How Has This Been Tested?

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)
- Database Migrations

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [ ] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [ ] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [ ] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated internal context handling to include primary-tier information for tiered search operations.
  * Adjusted context construction so tier details are captured at creation, improving consistency when evaluating tiered data.
  * No user-facing UI changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->