### PR TITLE
chore: environment ID should be uppercase BED-7421

### DIFF
--- a/cmd/api/src/services/graphify/convertors.go
+++ b/cmd/api/src/services/graphify/convertors.go
@@ -28,6 +28,8 @@ import (
 	"github.com/specterops/dawgs/graph"
 )
 
+const environmentIDKey = "environment_id"
+
 func ConvertGenericNode(entity ein.GenericNode, converted *ConvertedData) error {
 	objectID := strings.ToUpper(entity.ID) // BloodHound convention: object IDs are uppercased
 
@@ -56,6 +58,13 @@ func ConvertGenericNode(entity ein.GenericNode, converted *ConvertedData) error 
 	// it is critical to specify this information because a node can have up to 3 kinds.
 	if len(node.Labels) > 0 {
 		node.PropertyMap[common.PrimaryKind.String()] = node.Labels[0]
+	}
+
+	// BloodHound convention: environment IDs are uppercased
+	if envID, ok := node.PropertyMap[environmentIDKey]; ok {
+		if envIDStr, ok := envID.(string); ok {
+			node.PropertyMap[environmentIDKey] = strings.ToUpper(envIDStr)
+		}
 	}
 
 	converted.NodeProps = append(converted.NodeProps, node)

--- a/cmd/api/src/services/graphify/ingest_integration_test.go
+++ b/cmd/api/src/services/graphify/ingest_integration_test.go
@@ -38,7 +38,7 @@ import (
 func Test_ReadFileForIngest(t *testing.T) {
 	var (
 		ingestSchema, _ = upload.LoadIngestSchema()
-		validReader     = bytes.NewReader([]byte(`{"graph":{"nodes":[{"id": "1234", "kinds": ["kindA","kindB"],"properties":{"true": true,"hello":"world"}}]}}`))
+		validReader     = bytes.NewReader([]byte(`{"graph":{"nodes":[{"id": "1234", "kinds": ["kindA","kindB"],"properties":{"true": true,"hello":"world","environment_id": "env-001"}}]}}`))
 		// invalidReader simulates reading a file that doesn't pass jsonschema validation against the nodes schema.
 		// ReadFileForIngest() should kick out, ingesting no graph data
 		invalidReader = bytes.NewReader([]byte(`{"graph":{"nodes": [{"id":1234}]}}`))
@@ -74,6 +74,10 @@ func Test_ReadFileForIngest(t *testing.T) {
 						require.Equal(t, true, booleanProperty)
 						stringProperty, _ := node.Properties.Get("hello").String()
 						require.Equal(t, "world", stringProperty)
+
+						// assert that environment_id was uppercased
+						envID, _ := node.Properties.Get("environment_id").String()
+						require.Equal(t, "ENV-001", envID)
 
 						numNodes++
 					}


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

If environment_id is present on a node, it should be capitalized to maintain BloodHound convention for environment identifiers. 

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-7421

*Why is this change required? What problem does it solve?*

## How Has This Been Tested?

Integration test updated, and also tested locally by ingesting a schemaless opengraph config and confirming that the `environment_id` field is uppercased. 

## Screenshots (optional):

<img width="380" height="477" alt="Screenshot 2026-03-03 at 12 53 09" src="https://github.com/user-attachments/assets/4233e661-b986-4da2-890e-7e680d1f0f2c" />


## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)


## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Environment ID values are now automatically normalized to uppercase format during data ingestion and retrieval.

* **Tests**
  * Added validation tests to verify environment ID normalization in both in-memory operations and graph persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->