### PR TITLE
chore: Added min height to History Table BED-7899

### DIFF
--- a/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/History/HistoryContent.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/History/HistoryContent.tsx
@@ -106,7 +106,7 @@ const HistoryContent = () => {
                         ref={scrollRef}
                         // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
                         tabIndex={0}
-                        className='overflow-y-auto mb-1'>
+                        className='overflow-y-auto mb-1 min-h-32'>
                         <DataTable
                             data={records}
                             TableHeaderProps={tableHeaderProps}


### PR DESCRIPTION
## Description

For context: Certifications table was not rendering properly when the result was just one row. 

Since Certifications Table and History Table are almost identical, History Table was having this unwanted behavior as well.

## Motivation and Context


Resolves BED-7899



## How Has This Been Tested?

Tested locally

## Screenshots (optional):
<img width="2359" height="1284" alt="image" src="https://github.com/user-attachments/assets/cb477f6f-d93c-4d6c-94d0-2372fbaab11d" />

## Types of changes

<!-- Please remove any items that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [ ] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
