### PR TITLE
fix: fixed expiration period to be number BED-7912 

### DIFF
--- a/packages/javascript/bh-shared-ui/src/hooks/useConfiguration.ts
+++ b/packages/javascript/bh-shared-ui/src/hooks/useConfiguration.ts
@@ -61,7 +61,7 @@ export const useAPITokenExpirationConfiguration = () => {
 
     return {
         enabled: apiTokenExpirationConfig?.enabled ?? false,
-        expiration_period: apiTokenExpirationConfig?.expiration_period ?? '90',
+        expiration_period: String(apiTokenExpirationConfig?.expiration_period ?? 90),
     };
 };
 

--- a/packages/javascript/js-client-library/src/utils/config.ts
+++ b/packages/javascript/js-client-library/src/utils/config.ts
@@ -116,7 +116,7 @@ export type APITokenExpirationConfiguration = {
     key: ConfigurationKey.APITokenExpiration;
     value: {
         enabled: boolean;
-        expiration_period: string;
+        expiration_period: number;
     };
 };
 


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Fix for expiration_period. A string was being sent to the backend whereas they need it to be a number.

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves [BED-7912](https://specterops.atlassian.net/browse/BED-7912)

*Why is this change required? What problem does it solve?*

## How Has This Been Tested?

Manually

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


[BED-7912]: https://specterops.atlassian.net/browse/BED-7912?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ