### PR TITLE
feat(OpenGraph Extensions): add OpenGraph extension permissions BED-7501

### DIFF
--- a/cmd/api/src/api/registration/v2.go
+++ b/cmd/api/src/api/registration/v2.go
@@ -367,11 +367,11 @@ func NewV2API(resources v2.Resources, routerInst *router.Router) {
 		routerInst.DELETE(fmt.Sprintf("/api/v2/custom-nodes/{%s}", v2.CustomNodeKindParameter), resources.DeleteCustomNodeKind).RequireAuth(),
 
 		// Open Graph Schema
-		routerInst.PUT("/api/v2/extensions", resources.OpenGraphSchemaIngest).CheckFeatureFlag(resources.DB, appcfg.FeatureOpenGraphExtensionManagement).RequireAuth(),
-		routerInst.GET("/api/v2/extensions", resources.ListExtensions).CheckFeatureFlag(resources.DB, appcfg.FeatureOpenGraphExtensionManagement).RequireAuth(),
-		routerInst.DELETE(fmt.Sprintf("/api/v2/extensions/{%s}", api.URIPathVariableExtensionID), resources.DeleteExtension).CheckFeatureFlag(resources.DB, appcfg.FeatureOpenGraphExtensionManagement).RequireAuth(),
+		routerInst.PUT("/api/v2/extensions", resources.OpenGraphSchemaIngest).CheckFeatureFlag(resources.DB, appcfg.FeatureOpenGraphExtensionManagement).RequirePermissions(permissions.OpenGraphWrite),
+		routerInst.GET("/api/v2/extensions", resources.ListExtensions).CheckFeatureFlag(resources.DB, appcfg.FeatureOpenGraphExtensionManagement).RequirePermissions(permissions.OpenGraphRead),
+		routerInst.DELETE(fmt.Sprintf("/api/v2/extensions/{%s}", api.URIPathVariableExtensionID), resources.DeleteExtension).CheckFeatureFlag(resources.DB, appcfg.FeatureOpenGraphExtensionManagement).RequirePermissions(permissions.OpenGraphWrite),
 
 		// Graph Schema API
-		routerInst.GET("/api/v2/extensions-edges", resources.ListEdgeTypes).CheckFeatureFlag(resources.DB, appcfg.FeatureOpenGraphExtensionManagement).RequirePermissions(permissions.GraphDBRead),
+		routerInst.GET("/api/v2/extensions-edges", resources.ListEdgeTypes).CheckFeatureFlag(resources.DB, appcfg.FeatureOpenGraphExtensionManagement).RequirePermissions(permissions.GraphDBRead).RequirePermissions(permissions.OpenGraphRead),
 	)
 }

--- a/cmd/api/src/api/v2/opengraphschema.go
+++ b/cmd/api/src/api/v2/opengraphschema.go
@@ -28,8 +28,6 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/specterops/bloodhound/cmd/api/src/api"
-	"github.com/specterops/bloodhound/cmd/api/src/auth"
-	authctx "github.com/specterops/bloodhound/cmd/api/src/ctx"
 	"github.com/specterops/bloodhound/cmd/api/src/database"
 	"github.com/specterops/bloodhound/cmd/api/src/model"
 	"github.com/specterops/bloodhound/cmd/api/src/model/ingest"
@@ -119,16 +117,7 @@ func (s Resources) OpenGraphSchemaIngest(response http.ResponseWriter, request *
 		graphExtensionPayload GraphExtensionPayload
 	)
 
-	// feature flag is checked as part of middleware
-	if user, isUser := auth.GetUserFromAuthCtx(authctx.FromRequest(request).AuthCtx); !isUser {
-		var errMessage = "No associated user found"
-		api.WriteErrorResponse(ctx, api.BuildErrorResponse(http.StatusUnauthorized, errMessage, request), response)
-		return
-	} else if !user.Roles.Has(model.Role{Name: auth.RoleAdministrator}) {
-		var errMessage = "user does not have sufficient permissions to create or update an extension"
-		api.WriteErrorResponse(ctx, api.BuildErrorResponse(http.StatusForbidden, errMessage, request), response)
-		return
-	} else if request.Body == nil {
+	if request.Body == nil {
 		var errMessage = "open graph extension payload cannot be empty"
 		api.WriteErrorResponse(ctx, api.BuildErrorResponse(http.StatusBadRequest, errMessage, request), response)
 		return
@@ -279,12 +268,7 @@ func (s Resources) ListExtensions(response http.ResponseWriter, request *http.Re
 		ctx = request.Context()
 	)
 
-	// feature flag is checked as part of middleware
-	if user, isUser := auth.GetUserFromAuthCtx(authctx.FromRequest(request).AuthCtx); !isUser {
-		api.WriteErrorResponse(ctx, api.BuildErrorResponse(http.StatusUnauthorized, "No associated user found", request), response)
-	} else if !user.Roles.Has(model.Role{Name: auth.RoleAdministrator}) {
-		api.WriteErrorResponse(ctx, api.BuildErrorResponse(http.StatusForbidden, "user does not have sufficient permissions to view extensions", request), response)
-	} else if extensions, err := s.OpenGraphSchemaService.ListExtensions(ctx); err != nil {
+	if extensions, err := s.OpenGraphSchemaService.ListExtensions(ctx); err != nil {
 		api.WriteErrorResponse(ctx, api.BuildErrorResponse(http.StatusInternalServerError, api.ErrorResponseDetailsInternalServerError, request), response)
 		return
 	} else {
@@ -308,12 +292,7 @@ func (s Resources) DeleteExtension(response http.ResponseWriter, request *http.R
 		extensionID = mux.Vars(request)[api.URIPathVariableExtensionID]
 	)
 
-	// feature flag is checked as part of middleware
-	if user, isUser := auth.GetUserFromAuthCtx(authctx.FromRequest(request).AuthCtx); !isUser {
-		api.WriteErrorResponse(ctx, api.BuildErrorResponse(http.StatusUnauthorized, "No associated user found", request), response)
-	} else if !user.Roles.Has(model.Role{Name: auth.RoleAdministrator}) {
-		api.WriteErrorResponse(ctx, api.BuildErrorResponse(http.StatusForbidden, "user does not have sufficient permissions to delete an extension", request), response)
-	} else if extID, err := strconv.ParseInt(extensionID, 10, 32); err != nil {
+	if extID, err := strconv.ParseInt(extensionID, 10, 32); err != nil {
 		api.WriteErrorResponse(ctx, api.BuildErrorResponse(http.StatusBadRequest, api.ErrorResponseDetailsIDMalformed, request), response)
 	} else if err := s.OpenGraphSchemaService.DeleteExtension(ctx, int32(extID)); err != nil {
 		if errors.Is(err, database.ErrNotFound) {

--- a/cmd/api/src/api/v2/opengraphschema_test.go
+++ b/cmd/api/src/api/v2/opengraphschema_test.go
@@ -180,40 +180,6 @@ func TestResources_OpenGraphSchemaIngest(t *testing.T) {
 		want   want
 	}{
 		{
-			name: "fail - no user",
-			fields: fields{
-				setupOpenGraphServiceMock: func(t *testing.T, repository *schemamocks.MockOpenGraphSchemaService) {},
-			},
-			args: args{
-				func() *http.Request {
-					req, err := http.NewRequest(http.MethodPut, "/api/v2/extensions", nil)
-					require.NoError(t, err)
-					return req
-				},
-			},
-			want: want{
-				responseCode: http.StatusUnauthorized,
-				err:          fmt.Errorf("Code: 401 - errors: No associated user found"),
-			},
-		},
-		{
-			name: "fail - user is not admin",
-			fields: fields{
-				setupOpenGraphServiceMock: func(t *testing.T, repository *schemamocks.MockOpenGraphSchemaService) {},
-			},
-			args: args{
-				func() *http.Request {
-					req, err := http.NewRequestWithContext(createContextWithOwnerId(userId), http.MethodPut, "/api/v2/extensions", nil)
-					require.NoError(t, err)
-					return req
-				},
-			},
-			want: want{
-				responseCode: http.StatusForbidden,
-				err:          fmt.Errorf("Code: 403 - errors: user does not have sufficient permissions to create or update an extension"),
-			},
-		},
-		{
 			name: "fail - open graph extension payload cannot be empty",
 			fields: fields{
 				setupOpenGraphServiceMock: func(t *testing.T, repository *schemamocks.MockOpenGraphSchemaService) {},
@@ -458,52 +424,6 @@ func TestResources_ListExtensions(t *testing.T) {
 
 	tt := []testData{
 		{
-			name: "Error: error getting user from context",
-			buildRequest: func() *http.Request {
-				request := &http.Request{
-					URL: &url.URL{
-						Path: "/api/v2/extensions",
-					},
-					Method: http.MethodGet,
-				}
-
-				return request
-			},
-			setupMocks: func(t *testing.T, mock *mock) {},
-			expected: expected{
-				responseCode:   http.StatusUnauthorized,
-				responseHeader: http.Header{"Content-Type": []string{"application/json"}},
-				responseBody:   `{"errors":[{"context":"","message":"No associated user found"}],"http_status":401,"request_id":"","timestamp":"0001-01-01T00:00:00Z"}`,
-			},
-		},
-		{
-			name: "Error: user does not have sufficient permissions",
-			buildRequest: func() *http.Request {
-				request := &http.Request{
-					URL: &url.URL{
-						Path: "/api/v2/extensions",
-					},
-					Method: http.MethodGet,
-				}
-
-				requestCtx := ctx.Context{
-					RequestID: "id",
-					AuthCtx: auth.Context{
-						Owner:   model.User{},
-						Session: model.UserSession{},
-					},
-				}
-
-				return request.WithContext(context.WithValue(context.Background(), ctx.ValueKey, requestCtx.WithRequestID("id")))
-			},
-			setupMocks: func(t *testing.T, mock *mock) {},
-			expected: expected{
-				responseCode:   http.StatusForbidden,
-				responseHeader: http.Header{"Content-Type": []string{"application/json"}},
-				responseBody:   `{"errors":[{"context":"","message":"user does not have sufficient permissions to view extensions"}],"http_status":403,"request_id":"id","timestamp":"0001-01-01T00:00:00Z"}`,
-			},
-		},
-		{
 			name: "Error: error retrieving graph schema extensions",
 			buildRequest: func() *http.Request {
 				request := &http.Request{
@@ -656,52 +576,6 @@ func TestResources_DeleteExtension(t *testing.T) {
 	}
 
 	tt := []testData{
-		{
-			name: "Error: error getting user from context",
-			buildRequest: func() *http.Request {
-				request := &http.Request{
-					URL: &url.URL{
-						Path: "/api/v2/extensions/id",
-					},
-					Method: http.MethodDelete,
-				}
-
-				return request
-			},
-			setupMocks: func(t *testing.T, mock *mock) {},
-			expected: expected{
-				responseCode:   http.StatusUnauthorized,
-				responseHeader: http.Header{"Content-Type": []string{"application/json"}},
-				responseBody:   `{"errors":[{"context":"","message":"No associated user found"}],"http_status":401,"request_id":"","timestamp":"0001-01-01T00:00:00Z"}`,
-			},
-		},
-		{
-			name: "Error: user does not have sufficient permissions",
-			buildRequest: func() *http.Request {
-				request := &http.Request{
-					URL: &url.URL{
-						Path: "/api/v2/extensions/id",
-					},
-					Method: http.MethodDelete,
-				}
-
-				requestCtx := ctx.Context{
-					RequestID: "id",
-					AuthCtx: auth.Context{
-						Owner:   model.User{},
-						Session: model.UserSession{},
-					},
-				}
-
-				return request.WithContext(context.WithValue(context.Background(), ctx.ValueKey, requestCtx.WithRequestID("id")))
-			},
-			setupMocks: func(t *testing.T, mock *mock) {},
-			expected: expected{
-				responseCode:   http.StatusForbidden,
-				responseHeader: http.Header{"Content-Type": []string{"application/json"}},
-				responseBody:   `{"errors":[{"context":"","message":"user does not have sufficient permissions to delete an extension"}],"http_status":403,"request_id":"id","timestamp":"0001-01-01T00:00:00Z"}`,
-			},
-		},
 		{
 			name: "Error: invalid extension id",
 			buildRequest: func() *http.Request {

--- a/cmd/api/src/auth/permission.go
+++ b/cmd/api/src/auth/permission.go
@@ -48,6 +48,9 @@ type PermissionSet struct {
 	GraphDBRead   model.Permission
 	GraphDBWrite  model.Permission
 
+	OpenGraphRead  model.Permission
+	OpenGraphWrite model.Permission
+
 	SavedQueriesRead  model.Permission
 	SavedQueriesWrite model.Permission
 
@@ -74,6 +77,8 @@ func (s PermissionSet) All() model.Permissions {
 		s.GraphDBMutate,
 		s.GraphDBRead,
 		s.GraphDBWrite,
+		s.OpenGraphRead,
+		s.OpenGraphWrite,
 		s.SavedQueriesRead,
 		s.SavedQueriesWrite,
 		s.AuthReadUsers,
@@ -110,6 +115,9 @@ func Permissions() PermissionSet {
 		GraphDBMutate: model.NewPermission("graphdb", "Mutate"),
 		GraphDBRead:   model.NewPermission("graphdb", "Read"),
 		GraphDBWrite:  model.NewPermission("graphdb", "Write"),
+
+		OpenGraphRead:  model.NewPermission("opengraph", "Read"),
+		OpenGraphWrite: model.NewPermission("opengraph", "Write"),
 
 		SavedQueriesRead:  model.NewPermission("saved_queries", "Read"),
 		SavedQueriesWrite: model.NewPermission("saved_queries", "Write"),

--- a/cmd/api/src/auth/role.go
+++ b/cmd/api/src/auth/role.go
@@ -50,6 +50,7 @@ func Roles() map[string]RoleTemplate {
 				permissions.AuthManageSelf,
 				permissions.GraphDBRead,
 				permissions.SavedQueriesRead,
+				permissions.OpenGraphRead,
 			},
 		},
 		RoleUploadOnly: {
@@ -74,6 +75,7 @@ func Roles() map[string]RoleTemplate {
 				permissions.GraphDBRead,
 				permissions.SavedQueriesRead,
 				permissions.CollectionReadJobs,
+				permissions.OpenGraphRead,
 			},
 		},
 		RoleUser: {
@@ -88,6 +90,7 @@ func Roles() map[string]RoleTemplate {
 				permissions.GraphDBRead,
 				permissions.SavedQueriesRead,
 				permissions.SavedQueriesWrite,
+				permissions.OpenGraphRead,
 			},
 		},
 		RolePowerUser: {
@@ -109,6 +112,7 @@ func Roles() map[string]RoleTemplate {
 				permissions.SavedQueriesRead,
 				permissions.SavedQueriesWrite,
 				permissions.GraphDBMutate,
+				permissions.OpenGraphRead,
 			},
 		},
 		RoleAdministrator: {

--- a/cmd/api/src/database/migration/migrations/v9.1.0.sql
+++ b/cmd/api/src/database/migration/migrations/v9.1.0.sql
@@ -1,0 +1,52 @@
+-- Copyright 2026 Specter Ops, Inc.
+--
+-- Licensed under the Apache License, Version 2.0
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- SPDX-License-Identifier: Apache-2.0
+-- Add OpenGraph Phase 2 feature flag
+
+
+-- Add OpenGraph permissions to permissions table
+INSERT INTO permissions(created_at, updated_at, authority, name)
+VALUES (
+        current_timestamp,
+        current_timestamp,
+        'opengraph',
+        'Read'
+       ), 
+       (
+        current_timestamp,
+        current_timestamp,
+        'opengraph',
+        'Write'
+       )
+ON CONFLICT DO NOTHING;
+
+-- Add OpenGraph Read permissions to specific roles 
+
+INSERT INTO roles_permissions (role_id, permission_id)
+SELECT r.id, p.id
+FROM roles r
+JOIN permissions p
+ON (p.authority, p.name) = ('opengraph', 'Read')
+WHERE r.name IN ('Administrator', 'User', 'Read-Only', 'Power User', 'Auditor')
+ON CONFLICT DO NOTHING;
+
+-- Add OpenGraph Write permissions to Admin role
+INSERT INTO roles_permissions (role_id, permission_id)
+SELECT r.id, p.id
+FROM roles r
+JOIN permissions p
+ON (p.authority, p.name) = ('opengraph', 'Write')
+WHERE r.name IN ('Administrator')
+ON CONFLICT DO NOTHING;

--- a/packages/javascript/bh-shared-ui/src/components/DropdownSelector/DropdownTriggerContents.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/DropdownSelector/DropdownTriggerContents.tsx
@@ -1,3 +1,18 @@
+// Copyright 2026 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 import { Button, ButtonProps } from 'doodle-ui';
 import { cn } from '../../utils';
 import { AppIcon } from '../AppIcon';

--- a/packages/javascript/bh-shared-ui/src/components/SchemaUploadDialog/SchemaUploadDialog.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/SchemaUploadDialog/SchemaUploadDialog.test.tsx
@@ -25,6 +25,7 @@ import { SchemaUploadDialog } from './SchemaUploadDialog';
 const testFile = new File([JSON.stringify({ value: 'test' })], 'test.json', { type: 'application/json' });
 
 const addNotificationMock = vi.fn();
+const checkPermissionMock = vi.fn().mockReturnValue(true);
 
 vi.mock('../../providers', async () => {
     const actual = await vi.importActual('../../providers');
@@ -33,6 +34,17 @@ vi.mock('../../providers', async () => {
         useNotifications: () => {
             return { addNotification: addNotificationMock };
         },
+    };
+});
+
+vi.mock('../../hooks/usePermissions', async () => {
+    const actual = await vi.importActual('../../hooks');
+    return {
+        ...actual,
+        usePermissions: () => ({
+            checkPermission: checkPermissionMock,
+            isSuccess: true,
+        }),
     };
 });
 
@@ -74,6 +86,7 @@ beforeAll(() => {
 afterEach(() => {
     server.resetHandlers();
     addNotificationMock.mockClear();
+    checkPermissionMock.mockReturnValue(true);
 });
 afterAll(() => {
     server.close();
@@ -85,6 +98,26 @@ describe('SchemaUploadDialog', () => {
         const screen = render(<SchemaUploadDialog />);
         const button = screen.getByRole('button', { name: 'Upload File' });
         expect(button).toBeInTheDocument();
+    });
+
+    it('disables the upload file button when the user does not have the opengraph write permission', () => {
+        checkPermissionMock.mockReturnValue(false);
+
+        const screen = render(<SchemaUploadDialog />);
+
+        expect(screen.getByRole('button', { name: 'Upload File' })).toBeDisabled();
+    });
+
+    it('does not open the dialog when the user does not have the opengraph write permission', async () => {
+        checkPermissionMock.mockReturnValue(false);
+
+        const screen = render(<SchemaUploadDialog />);
+        const user = userEvent.setup();
+
+        expect(screen.getByRole('button', { name: 'Upload File' })).toBeDisabled();
+
+        await user.click(screen.getByRole('button', { name: 'Upload File' }));
+        expect(screen.queryByRole('dialog', { name: 'Upload Schema Files' })).not.toBeInTheDocument();
     });
 
     it('opens the dialog when the button is clicked', async () => {

--- a/packages/javascript/bh-shared-ui/src/components/SchemaUploadDialog/SchemaUploadDialog.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/SchemaUploadDialog/SchemaUploadDialog.tsx
@@ -25,7 +25,9 @@ import {
     DialogTrigger,
 } from 'doodle-ui';
 import { useState } from 'react';
-import { useExecuteOnFileDrag } from '../../hooks';
+import { useExecuteOnFileDrag, usePermissions } from '../../hooks';
+import { Permission } from '../../utils';
+import { ConditionalTooltip } from '../ConditionalTooltip';
 import FileDrop from '../FileDrop';
 import FileStatusListItem from '../FileStatusListItem';
 import { FileStatus } from '../FileUploadDialog';
@@ -34,6 +36,9 @@ import { useSchemaUploadHandlers } from './useSchemaUploadHandlers';
 export const SchemaUploadDialog = () => {
     const [dialogOpen, setDialogOpen] = useState<boolean>(false);
     const { file, uploadProgress, handleFileDrop, handleUpload, resetDialog } = useSchemaUploadHandlers();
+
+    const { checkPermission } = usePermissions();
+    const hasUploadPermission = checkPermission(Permission.OPENGRAPH_WRITE);
 
     // Dragging a file into the window displays the dialog. The normal global file upload drag and drop behavior is
     // disabled for the OpenGraph Management page
@@ -45,14 +50,19 @@ export const SchemaUploadDialog = () => {
         <Dialog
             open={dialogOpen}
             onOpenChange={(open) => {
+                if (!hasUploadPermission) return;
                 if (open) resetDialog();
                 setDialogOpen(open);
             }}>
-            <DialogTrigger asChild>
-                <Button className='self-start' variant='secondary'>
-                    Upload File
-                </Button>
-            </DialogTrigger>
+            <ConditionalTooltip condition={!hasUploadPermission} tooltip='You do not have permission to upload files.'>
+                <DialogTrigger asChild>
+                    <span className='self-start' tabIndex={!hasUploadPermission ? 0 : undefined}>
+                        <Button variant='secondary' disabled={!hasUploadPermission}>
+                            Upload File
+                        </Button>
+                    </span>
+                </DialogTrigger>
+            </ConditionalTooltip>
             <DialogContent>
                 <DialogTitle>Upload Schema Files</DialogTitle>
                 <DialogDescription className='sr-only'>
@@ -60,7 +70,7 @@ export const SchemaUploadDialog = () => {
                 </DialogDescription>
                 <FileDrop
                     onDrop={handleFileDrop}
-                    disabled={!!file}
+                    disabled={!!file || !hasUploadPermission}
                     multiple={false}
                     icon={faCubes}
                     accept={['application/json']}

--- a/packages/javascript/bh-shared-ui/src/components/SchemaUploadDialog/SchemaUploadDialog.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/SchemaUploadDialog/SchemaUploadDialog.tsx
@@ -42,9 +42,14 @@ export const SchemaUploadDialog = () => {
 
     // Dragging a file into the window displays the dialog. The normal global file upload drag and drop behavior is
     // disabled for the OpenGraph Management page
-    useExecuteOnFileDrag(() => setDialogOpen(true), {
-        acceptedTypes: ['application/json'],
-    });
+    useExecuteOnFileDrag(
+        () => {
+            if (hasUploadPermission) setDialogOpen(true);
+        },
+        {
+            acceptedTypes: ['application/json'],
+        }
+    );
 
     return (
         <Dialog

--- a/packages/javascript/bh-shared-ui/src/utils/permissions.ts
+++ b/packages/javascript/bh-shared-ui/src/utils/permissions.ts
@@ -34,6 +34,7 @@ export enum Permission {
     SAVED_QUERIES_READ,
     SAVED_QUERIES_WRITE,
     WIPE_DB,
+    OPENGRAPH_WRITE,
 }
 
 export type PermissionDefinition = {
@@ -121,5 +122,9 @@ export const PERMISSIONS: PermissionDefinitions = {
     [Permission.WIPE_DB]: {
         authority: 'db',
         name: 'Wipe',
+    },
+    [Permission.OPENGRAPH_WRITE]: {
+        authority: 'opengraph',
+        name: 'Write',
     },
 };

--- a/packages/javascript/bh-shared-ui/src/views/OpenGraphManagement/ActiveExtensionsCard.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/OpenGraphManagement/ActiveExtensionsCard.test.tsx
@@ -29,7 +29,9 @@ import {
 } from './ActiveExtensionsCard';
 
 const addNotificationSpy = vi.hoisted(() => vi.fn());
-const checkPermissionMock = vi.fn(() => true);
+const { checkPermissionMock } = vi.hoisted(() => ({
+    checkPermissionMock: vi.fn(() => true),
+}));
 
 vi.mock('../../providers', async () => {
     const actual = await vi.importActual('../../providers');

--- a/packages/javascript/bh-shared-ui/src/views/OpenGraphManagement/ActiveExtensionsCard.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/OpenGraphManagement/ActiveExtensionsCard.test.tsx
@@ -29,6 +29,7 @@ import {
 } from './ActiveExtensionsCard';
 
 const addNotificationSpy = vi.hoisted(() => vi.fn());
+const checkPermissionMock = vi.fn(() => true);
 
 vi.mock('../../providers', async () => {
     const actual = await vi.importActual('../../providers');
@@ -36,6 +37,17 @@ vi.mock('../../providers', async () => {
         ...actual,
         useNotifications: () => ({
             addNotification: addNotificationSpy,
+        }),
+    };
+});
+
+vi.mock('../../hooks', async () => {
+    const actual = await vi.importActual('../../hooks');
+    return {
+        ...actual,
+        usePermissions: () => ({
+            checkPermission: checkPermissionMock,
+            isSuccess: true,
         }),
     };
 });
@@ -67,9 +79,14 @@ const mockDeleteResponse: AxiosResponse<void> = {
 };
 
 beforeAll(() => server.listen());
+beforeEach(() => {
+    checkPermissionMock.mockImplementation(() => true);
+});
 afterEach(() => {
-    server.resetHandlers();
     vi.restoreAllMocks();
+    server.resetHandlers();
+    addNotificationSpy.mockClear();
+    checkPermissionMock.mockClear();
 });
 afterAll(() => server.close());
 
@@ -89,7 +106,7 @@ describe('ActiveExtensionsCard', () => {
 
     it('displays an error message while fetching fails', async () => {
         server.use(
-            rest.get(`/api/v2/extensions`, (req, res, ctx) => {
+            rest.get(`/api/v2/extensions`, (_req, res, ctx) => {
                 return res(ctx.status(500));
             })
         );
@@ -245,6 +262,14 @@ describe('ActiveExtensionsCard', () => {
         expect(customExtensionDeleteButton).not.toBeDisabled();
     });
 
+    it('disables delete button for user without correct permissions', async () => {
+        checkPermissionMock.mockReturnValue(false);
+        render(<ActiveExtensionsCard />);
+
+        const customExtensionDeleteButton = await screen.findByLabelText('Delete Custom Extension');
+        expect(customExtensionDeleteButton).toBeDisabled();
+    });
+
     it('disables confirm button until extension name is typed correctly', async () => {
         const user = userEvent.setup();
 
@@ -328,7 +353,7 @@ describe('ActiveExtensionsCard', () => {
     });
 
     it('shows error notification when deletion fails', async () => {
-        server.use(rest.delete(`/api/v2/extensions/:id`, (_req, res, ctx) => res.once(ctx.status(500))));
+        server.use(rest.delete(`/api/v2/extensions/:id`, (_req, res, ctx) => res(ctx.status(500))));
 
         const user = userEvent.setup();
         render(<ActiveExtensionsCard />);

--- a/packages/javascript/bh-shared-ui/src/views/OpenGraphManagement/DeleteExtensionButton.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/OpenGraphManagement/DeleteExtensionButton.tsx
@@ -27,8 +27,9 @@ import {
 import { type Extension } from 'js-client-library';
 import { FC, useState } from 'react';
 import { AppIcon, ConditionalTooltip } from '../../components';
-import { useDeleteExtension } from '../../hooks';
+import { useDeleteExtension, usePermissions } from '../../hooks';
 import { DEFAULT_NOTIFICATION, ERROR_NOTIFICATION, useNotifications } from '../../providers';
+import { Permission } from '../../utils';
 import { cn } from '../../utils/theme';
 
 const ConfirmDeleteExtensionDialog: FC<{
@@ -79,6 +80,9 @@ export const DeleteExtensionButton: FC<{ extension: Extension }> = ({ extension 
     const deleteExtensionMutation = useDeleteExtension();
     const { addNotification } = useNotifications();
 
+    const { checkPermission } = usePermissions();
+    const hasDeletePermission = checkPermission(Permission.OPENGRAPH_WRITE);
+
     const { id: extensionId, name: extensionName, is_builtin: isUndeletable } = extension;
 
     const handleButtonClick = () => setIsDialogOpen(true);
@@ -106,13 +110,21 @@ export const DeleteExtensionButton: FC<{ extension: Extension }> = ({ extension 
 
     return (
         <div className='flex content-center justify-center'>
-            <ConditionalTooltip condition={isUndeletable} tooltip='Built-in extensions cannot be deleted.'>
+            <ConditionalTooltip
+                condition={isUndeletable || !hasDeletePermission}
+                tooltip={
+                    isUndeletable
+                        ? 'Built-in extensions cannot be deleted.'
+                        : 'You do not have permission to delete this extension.'
+                }>
                 <button
                     aria-label={`Delete ${extensionName}`}
-                    className={cn({ 'cursor-pointer': !isUndeletable, 'opacity-50 cursor-not-allowed': isUndeletable })}
+                    className={cn({
+                        'cursor-pointer': !isUndeletable && hasDeletePermission,
+                        'opacity-50 cursor-not-allowed': isUndeletable || !hasDeletePermission,
+                    })}
                     onClick={handleButtonClick}
-                    disabled={isUndeletable}
-                    title={isUndeletable ? 'This is a default extension and cannot be deleted.' : undefined}>
+                    disabled={isUndeletable || !hasDeletePermission}>
                     <AppIcon.Trash size={18} />
                 </button>
             </ConditionalTooltip>


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Adds `Read` and `Write` permissions for OpenGraph extensions. 
- Only admins can upload & delete schemas
- Admins, Users, Read-Only users, Power Users, and Auditors can list extensions, findings, and edges.
- The upload and delete extension buttons are disabled if the user does not have the correct permissions.

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-7501

Enables a finer-grain approach to interacting with opengraph extensions

## How Has This Been Tested?

Tested locally by: 
- making sure admins have full access to all opengraph extension features
- making sure non-admins only have read-only access to extension feature
- added tests for the front end 

## Screenshots (optional):

example of read-only user -- can list extensions, but upload and delete buttons are disabled. 
<img width="848" height="615" alt="Screenshot 2026-04-09 at 14 18 59" src="https://github.com/user-attachments/assets/ebe74311-d295-4965-bc1a-7235645d6c3e" />

## Types of changes

<!-- Please remove any items that do not apply. -->
- New feature (non-breaking change which adds functionality)
- Database Migrations

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Granular OpenGraph read/write permissions introduced — API access for listing, uploading, and deleting extensions now requires specific permissions.
  * UI respects permissions: upload/delete controls are disabled when unauthorized, with contextual tooltips explaining restrictions.

* **Tests**
  * Updated test coverage to validate permission-based behaviors for upload and delete flows.

* **Chores**
  * Database migration added to register new OpenGraph permissions/feature flag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->