### PR TITLE
refactor: simplify custom node kinds and valid primary kinds BED-7920

### DIFF
--- a/cmd/api/src/api/bloodhoundgraph/bloodhoundgraph.go
+++ b/cmd/api/src/api/bloodhoundgraph/bloodhoundgraph.go
@@ -19,7 +19,8 @@ package bloodhoundgraph
 import (
 	"fmt"
 
-	"github.com/specterops/bloodhound/cmd/api/src/model"
+	"github.com/specterops/bloodhound/packages/go/graphschema"
+	"github.com/specterops/dawgs/graph"
 )
 
 //TODO: Move styling responsibilities to the UI or move shared styling definitions to a cue file to generate from one source of truth
@@ -144,30 +145,19 @@ type BloodHoundGraphLink struct {
 	Width     int                       `json:"width,omitempty"`
 }
 
-func (s *BloodHoundGraphNode) SetFontIcon(nodeKind string, schemaNodeKinds model.GraphSchemaNodeKindMap, schemalessNodeKinds model.CustomNodeKindMap) {
+func (s *BloodHoundGraphNode) SetFontIcon(nodeKind string, validPrimaryKinds graphschema.ValidPrimaryKinds) {
 	if nodeKind == metaNodeKindLabel {
 		s.Color = metaNodeColor
+		s.Image = metaImageDefault
 
-		if tier, ok := s.Data["admintier"]; ok {
-			if tier.(int64) == 0 {
-				s.Image = metaImageTierZero
-			} else {
-				s.Image = metaImageDefault
-			}
-		} else {
-			s.Image = metaImageDefault
+		if tier, ok := s.Data["admintier"]; ok && tier.(int64) == 0 {
+			s.Image = metaImageTierZero
 		}
-	} else if nodeKindConfig, ok := schemaNodeKinds[nodeKind]; ok {
+	} else if primaryKind, ok := validPrimaryKinds[graph.StringKind(nodeKind)]; ok {
 		s.FontIcon = &BloodHoundGraphFontIcon{
-			Text: fmt.Sprintf("%s%s", fontAwesomePrefix, nodeKindConfig.Icon),
+			Text: fmt.Sprintf("%s%s", fontAwesomePrefix, primaryKind.Icon.Name),
 		}
-		s.Color = nodeKindConfig.IconColor
-	} else if schemalessNodeKindConfig, ok := schemalessNodeKinds[nodeKind]; ok {
-		s.Data["nodetype"] = nodeKind
-		s.FontIcon = &BloodHoundGraphFontIcon{
-			Text: fmt.Sprintf("%s%s", fontAwesomePrefix, schemalessNodeKindConfig.Icon.Name),
-		}
-		s.Color = schemalessNodeKindConfig.Icon.Color
+		s.Color = primaryKind.Icon.Color
 	} else {
 		s.FontIcon = &BloodHoundGraphFontIcon{
 			Text: defaultUnknownIcon,

--- a/cmd/api/src/api/bloodhoundgraph/bloodhoundgraph.go
+++ b/cmd/api/src/api/bloodhoundgraph/bloodhoundgraph.go
@@ -154,9 +154,15 @@ func (s *BloodHoundGraphNode) SetFontIcon(nodeKind string, primaryDisplayKinds g
 			s.Image = metaImageTierZero
 		}
 	} else if primaryKind, ok := primaryDisplayKinds[graph.StringKind(nodeKind)]; ok {
-		s.FontIcon = &BloodHoundGraphFontIcon{
-			Text: fmt.Sprintf("%s%s", fontAwesomePrefix, primaryKind.Icon.Name),
+		switch primaryKind.Icon.Type {
+		case graphschema.DisplayNodeTypeFontAwesome:
+			s.FontIcon = &BloodHoundGraphFontIcon{
+				Text: fmt.Sprintf("%s%s", fontAwesomePrefix, primaryKind.Icon.Name),
+			}
+		default:
+			s.FontIcon = &BloodHoundGraphFontIcon{Text: primaryKind.Icon.Name}
 		}
+
 		s.Color = primaryKind.Icon.Color
 	} else {
 		s.FontIcon = &BloodHoundGraphFontIcon{

--- a/cmd/api/src/api/bloodhoundgraph/bloodhoundgraph.go
+++ b/cmd/api/src/api/bloodhoundgraph/bloodhoundgraph.go
@@ -145,7 +145,7 @@ type BloodHoundGraphLink struct {
 	Width     int                       `json:"width,omitempty"`
 }
 
-func (s *BloodHoundGraphNode) SetFontIcon(nodeKind string, validPrimaryKinds graphschema.ValidPrimaryKinds) {
+func (s *BloodHoundGraphNode) SetFontIcon(nodeKind string, primaryDisplayKinds graphschema.PrimaryDisplayKinds) {
 	if nodeKind == metaNodeKindLabel {
 		s.Color = metaNodeColor
 		s.Image = metaImageDefault
@@ -153,7 +153,7 @@ func (s *BloodHoundGraphNode) SetFontIcon(nodeKind string, validPrimaryKinds gra
 		if tier, ok := s.Data["admintier"]; ok && tier.(int64) == 0 {
 			s.Image = metaImageTierZero
 		}
-	} else if primaryKind, ok := validPrimaryKinds[graph.StringKind(nodeKind)]; ok {
+	} else if primaryKind, ok := primaryDisplayKinds[graph.StringKind(nodeKind)]; ok {
 		s.FontIcon = &BloodHoundGraphFontIcon{
 			Text: fmt.Sprintf("%s%s", fontAwesomePrefix, primaryKind.Icon.Name),
 		}

--- a/cmd/api/src/api/bloodhoundgraph/bloodhoundgraph_test.go
+++ b/cmd/api/src/api/bloodhoundgraph/bloodhoundgraph_test.go
@@ -73,7 +73,7 @@ func TestSetFontIcon(t *testing.T) {
 	})
 
 	t.Run("sets font icon and color for known schema node kind", func(t *testing.T) {
-		nodeKindMap := graphschema.ValidPrimaryKinds{
+		nodeKindMap := graphschema.PrimaryDisplayKinds{
 			graph.StringKind("User"): graphschema.DisplayKind{
 				Name: "User",
 				Icon: graphschema.DisplayNodeIcon{
@@ -113,7 +113,7 @@ func TestSetFontIcon(t *testing.T) {
 	})
 
 	t.Run("Meta takes priority over schema map entry", func(t *testing.T) {
-		nodeKindMap := graphschema.ValidPrimaryKinds{
+		nodeKindMap := graphschema.PrimaryDisplayKinds{
 			graph.StringKind("Meta"): graphschema.DisplayKind{
 				Name: "Meta",
 				Icon: graphschema.DisplayNodeIcon{

--- a/cmd/api/src/api/bloodhoundgraph/bloodhoundgraph_test.go
+++ b/cmd/api/src/api/bloodhoundgraph/bloodhoundgraph_test.go
@@ -79,6 +79,7 @@ func TestSetFontIcon(t *testing.T) {
 				Icon: graphschema.DisplayNodeIcon{
 					Name:  "user",
 					Color: "#17E625",
+					Type:  graphschema.DisplayNodeTypeFontAwesome,
 				},
 			},
 		}

--- a/cmd/api/src/api/bloodhoundgraph/bloodhoundgraph_test.go
+++ b/cmd/api/src/api/bloodhoundgraph/bloodhoundgraph_test.go
@@ -19,7 +19,8 @@ package bloodhoundgraph
 import (
 	"testing"
 
-	"github.com/specterops/bloodhound/cmd/api/src/model"
+	"github.com/specterops/bloodhound/packages/go/graphschema"
+	"github.com/specterops/dawgs/graph"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -32,7 +33,7 @@ func TestSetFontIcon(t *testing.T) {
 			},
 		}
 
-		node.SetFontIcon("Meta", model.GraphSchemaNodeKindMap{}, nil)
+		node.SetFontIcon("Meta", nil)
 
 		assert.Equal(t, "#000", node.Color)
 		assert.Equal(t, "/ui/meta.png", node.Image)
@@ -48,7 +49,7 @@ func TestSetFontIcon(t *testing.T) {
 			},
 		}
 
-		node.SetFontIcon("Meta", model.GraphSchemaNodeKindMap{}, nil)
+		node.SetFontIcon("Meta", nil)
 
 		assert.Equal(t, "#000", node.Color)
 		assert.Equal(t, "/ui/metat0.png", node.Image)
@@ -64,7 +65,7 @@ func TestSetFontIcon(t *testing.T) {
 			},
 		}
 
-		node.SetFontIcon("Meta", model.GraphSchemaNodeKindMap{}, nil)
+		node.SetFontIcon("Meta", nil)
 
 		assert.Equal(t, "#000", node.Color)
 		assert.Equal(t, "/ui/meta.png", node.Image)
@@ -72,11 +73,13 @@ func TestSetFontIcon(t *testing.T) {
 	})
 
 	t.Run("sets font icon and color for known schema node kind", func(t *testing.T) {
-		nodeKindMap := model.GraphSchemaNodeKindMap{
-			"User": model.GraphSchemaNodeKind{
-				Name:      "User",
-				Icon:      "user",
-				IconColor: "#17E625",
+		nodeKindMap := graphschema.ValidPrimaryKinds{
+			graph.StringKind("User"): graphschema.DisplayKind{
+				Name: "User",
+				Icon: graphschema.DisplayKindIcon{
+					Name:  "user",
+					Color: "#17E625",
+				},
 			},
 		}
 
@@ -86,7 +89,7 @@ func TestSetFontIcon(t *testing.T) {
 			},
 		}
 
-		node.SetFontIcon("User", nodeKindMap, nil)
+		node.SetFontIcon("User", nodeKindMap)
 
 		require.NotNil(t, node.FontIcon)
 		assert.Equal(t, "fas fa-user", node.FontIcon.Text)
@@ -101,7 +104,7 @@ func TestSetFontIcon(t *testing.T) {
 			},
 		}
 
-		node.SetFontIcon("SomeUnknownKind", model.GraphSchemaNodeKindMap{}, nil)
+		node.SetFontIcon("SomeUnknownKind", nil)
 
 		require.NotNil(t, node.FontIcon)
 		assert.Equal(t, "fas fa-question", node.FontIcon.Text)
@@ -110,50 +113,25 @@ func TestSetFontIcon(t *testing.T) {
 	})
 
 	t.Run("Meta takes priority over schema map entry", func(t *testing.T) {
-		nodeKindMap := model.GraphSchemaNodeKindMap{
-			"Meta": model.GraphSchemaNodeKind{
-				Name:      "Meta",
-				Icon:      "star",
-				IconColor: "#FFF",
+		nodeKindMap := graphschema.ValidPrimaryKinds{
+			graph.StringKind("Meta"): graphschema.DisplayKind{
+				Name: "Meta",
+				Icon: graphschema.DisplayKindIcon{
+					Name:  "star",
+					Color: "#FFF",
+				},
 			},
 		}
-
 		node := &BloodHoundGraphNode{
 			BloodHoundGraphItem: &BloodHoundGraphItem{
 				Data: map[string]any{},
 			},
 		}
 
-		node.SetFontIcon("Meta", nodeKindMap, nil)
+		node.SetFontIcon("Meta", nodeKindMap)
 
 		assert.Equal(t, "#000", node.Color)
 		assert.Equal(t, "/ui/meta.png", node.Image)
 		assert.Nil(t, node.FontIcon)
-	})
-
-	t.Run("sets font icon, color, and node type for custom node kind", func(t *testing.T) {
-		customNodeKindsMap := model.CustomNodeKindMap{
-			"CustomWidget": model.CustomNodeKindConfig{
-				Icon: model.CustomNodeIcon{
-					Type:  "font-awesome",
-					Name:  "cogs",
-					Color: "#FF5733",
-				},
-			},
-		}
-
-		node := &BloodHoundGraphNode{
-			BloodHoundGraphItem: &BloodHoundGraphItem{
-				Data: map[string]any{},
-			},
-		}
-
-		node.SetFontIcon("CustomWidget", model.GraphSchemaNodeKindMap{}, customNodeKindsMap)
-
-		require.NotNil(t, node.FontIcon)
-		assert.Equal(t, "fas fa-cogs", node.FontIcon.Text)
-		assert.Equal(t, "#FF5733", node.Color)
-		assert.Empty(t, node.Image)
-		assert.Equal(t, "CustomWidget", node.Data["nodetype"])
 	})
 }

--- a/cmd/api/src/api/bloodhoundgraph/bloodhoundgraph_test.go
+++ b/cmd/api/src/api/bloodhoundgraph/bloodhoundgraph_test.go
@@ -76,7 +76,7 @@ func TestSetFontIcon(t *testing.T) {
 		nodeKindMap := graphschema.ValidPrimaryKinds{
 			graph.StringKind("User"): graphschema.DisplayKind{
 				Name: "User",
-				Icon: graphschema.DisplayKindIcon{
+				Icon: graphschema.DisplayNodeIcon{
 					Name:  "user",
 					Color: "#17E625",
 				},
@@ -116,7 +116,7 @@ func TestSetFontIcon(t *testing.T) {
 		nodeKindMap := graphschema.ValidPrimaryKinds{
 			graph.StringKind("Meta"): graphschema.DisplayKind{
 				Name: "Meta",
-				Icon: graphschema.DisplayKindIcon{
+				Icon: graphschema.DisplayNodeIcon{
 					Name:  "star",
 					Color: "#FFF",
 				},

--- a/cmd/api/src/api/bloodhoundgraph/conversions.go
+++ b/cmd/api/src/api/bloodhoundgraph/conversions.go
@@ -29,13 +29,13 @@ const (
 	defaultRelationshipColor   = "3a5464"
 )
 
-func NodeToBloodHoundGraph(validPrimaryKinds graphschema.ValidPrimaryKinds, node *graph.Node) BloodHoundGraphNode {
+func NodeToBloodHoundGraph(primaryDisplayKinds graphschema.PrimaryDisplayKinds, node *graph.Node) BloodHoundGraphNode {
 	var (
-		nodeKindLabel       = graphschema.GetNodeKindDisplayLabel(validPrimaryKinds, node)
+		nodeKindLabel       = graphschema.GetNodeKindDisplayLabel(primaryDisplayKinds, node)
 		name, _             = node.Properties.GetWithFallback(common.Name.String(), graphschema.DefaultMissingName, common.DisplayName.String(), common.ObjectID.String()).String()
 		bloodHoundGraphNode = BloodHoundGraphNode{
 			BloodHoundGraphItem: &BloodHoundGraphItem{
-				Data: getNodeDisplayProperties(validPrimaryKinds, node),
+				Data: getNodeDisplayProperties(primaryDisplayKinds, node),
 			},
 			Size: 1,
 			Border: &BloodHoundGraphNodeBorder{
@@ -50,7 +50,7 @@ func NodeToBloodHoundGraph(validPrimaryKinds graphschema.ValidPrimaryKinds, node
 		}
 	)
 
-	bloodHoundGraphNode.SetFontIcon(nodeKindLabel, validPrimaryKinds)
+	bloodHoundGraphNode.SetFontIcon(nodeKindLabel, primaryDisplayKinds)
 
 	return bloodHoundGraphNode
 }
@@ -78,7 +78,7 @@ func RelationshipToBloodHoundGraph(rel *graph.Relationship) BloodHoundGraphLink 
 	}
 }
 
-func PathSetToBloodHoundGraph(graphSchemaNodeValidDisplayKinds graphschema.ValidPrimaryKinds, paths graph.PathSet) map[string]any {
+func PathSetToBloodHoundGraph(graphSchemaNodeValidDisplayKinds graphschema.PrimaryDisplayKinds, paths graph.PathSet) map[string]any {
 	result := make(map[string]any)
 
 	for _, path := range paths.Paths() {

--- a/cmd/api/src/api/bloodhoundgraph/conversions.go
+++ b/cmd/api/src/api/bloodhoundgraph/conversions.go
@@ -17,9 +17,6 @@
 package bloodhoundgraph
 
 import (
-	"maps"
-
-	"github.com/specterops/bloodhound/cmd/api/src/model"
 	"github.com/specterops/bloodhound/packages/go/graphschema"
 	"github.com/specterops/bloodhound/packages/go/graphschema/common"
 	"github.com/specterops/dawgs/graph"
@@ -32,10 +29,7 @@ const (
 	defaultRelationshipColor   = "3a5464"
 )
 
-func NodeToBloodHoundGraph(graphSchemaNodeValidDisplayKinds model.GraphSchemaNodeKindMap, customNodeKinds model.CustomNodeKindMap, node *graph.Node) BloodHoundGraphNode {
-	validPrimaryKinds := graphSchemaNodeValidDisplayKinds.ToKindsMap()
-	// Add custom node kinds to valid primary kinds
-	maps.Copy(validPrimaryKinds, customNodeKinds.ValidKinds())
+func NodeToBloodHoundGraph(validPrimaryKinds graphschema.ValidPrimaryKinds, node *graph.Node) BloodHoundGraphNode {
 	var (
 		nodeKindLabel       = graphschema.GetNodeKindDisplayLabel(validPrimaryKinds, node)
 		name, _             = node.Properties.GetWithFallback(common.Name.String(), graphschema.DefaultMissingName, common.DisplayName.String(), common.ObjectID.String()).String()
@@ -56,7 +50,7 @@ func NodeToBloodHoundGraph(graphSchemaNodeValidDisplayKinds model.GraphSchemaNod
 		}
 	)
 
-	bloodHoundGraphNode.SetFontIcon(nodeKindLabel, graphSchemaNodeValidDisplayKinds, customNodeKinds)
+	bloodHoundGraphNode.SetFontIcon(nodeKindLabel, validPrimaryKinds)
 
 	return bloodHoundGraphNode
 }
@@ -84,7 +78,7 @@ func RelationshipToBloodHoundGraph(rel *graph.Relationship) BloodHoundGraphLink 
 	}
 }
 
-func PathSetToBloodHoundGraph(graphSchemaNodeValidDisplayKinds model.GraphSchemaNodeKindMap, customNodeKinds model.CustomNodeKindMap, paths graph.PathSet) map[string]any {
+func PathSetToBloodHoundGraph(graphSchemaNodeValidDisplayKinds graphschema.ValidPrimaryKinds, paths graph.PathSet) map[string]any {
 	result := make(map[string]any)
 
 	for _, path := range paths.Paths() {
@@ -94,7 +88,7 @@ func PathSetToBloodHoundGraph(graphSchemaNodeValidDisplayKinds model.GraphSchema
 	}
 
 	for _, node := range paths.AllNodes() {
-		result[node.ID.String()] = NodeToBloodHoundGraph(graphSchemaNodeValidDisplayKinds, customNodeKinds, node)
+		result[node.ID.String()] = NodeToBloodHoundGraph(graphSchemaNodeValidDisplayKinds, node)
 	}
 
 	return result

--- a/cmd/api/src/api/bloodhoundgraph/properties.go
+++ b/cmd/api/src/api/bloodhoundgraph/properties.go
@@ -22,7 +22,7 @@ import (
 	"github.com/specterops/dawgs/graph"
 )
 
-func getNodeDisplayProperties(validPrimaryKinds graphschema.ValidPrimaryKinds, target *graph.Node) map[string]any {
+func getNodeDisplayProperties(primaryDisplayKinds graphschema.PrimaryDisplayKinds, target *graph.Node) map[string]any {
 	properties := target.Properties.Map
 
 	// Set the node level. This is legacy behavior that should be eventually refactored.
@@ -35,7 +35,7 @@ func getNodeDisplayProperties(validPrimaryKinds graphschema.ValidPrimaryKinds, t
 	}
 
 	// Set the legacy node type
-	properties["nodetype"] = graphschema.GetNodeKindDisplayLabel(validPrimaryKinds, target)
+	properties["nodetype"] = graphschema.GetNodeKindDisplayLabel(primaryDisplayKinds, target)
 
 	// Append the kinds for pz glyph
 	properties["kinds"] = target.Kinds.Strings()
@@ -43,9 +43,9 @@ func getNodeDisplayProperties(validPrimaryKinds graphschema.ValidPrimaryKinds, t
 	return properties
 }
 
-func SetAssetGroupPropertiesForNode(validPrimaryKinds graphschema.ValidPrimaryKinds, node *graph.Node) *graph.Node {
+func SetAssetGroupPropertiesForNode(primaryDisplayKinds graphschema.PrimaryDisplayKinds, node *graph.Node) *graph.Node {
 	node.Properties.Set("category", "Asset Groups")
-	node.Properties.Set("type", graphschema.GetNodeKindDisplayLabel(validPrimaryKinds, node))
+	node.Properties.Set("type", graphschema.GetNodeKindDisplayLabel(primaryDisplayKinds, node))
 	node.Properties.Set("level", 0)
 	return node
 }

--- a/cmd/api/src/api/v2/ad_related_entity.go
+++ b/cmd/api/src/api/v2/ad_related_entity.go
@@ -57,7 +57,7 @@ func (s *Resources) handleAdRelatedEntityQuery(response http.ResponseWriter, req
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusForbidden, api.ErrorResponseDetailsForbidden, request), response)
 	} else if entityPanelCachingFlag, err := s.DB.GetFlagByKey(request.Context(), appcfg.FeatureEntityPanelCaching); err != nil {
 		api.HandleDatabaseError(request, response, err)
-	} else if primaryDisplayKinds, err := s.DB.GetValidDisplayKinds(request.Context()); err != nil {
+	} else if primaryDisplayKinds, err := s.DB.GetPrimaryDisplayKinds(request.Context()); err != nil {
 		api.HandleDatabaseError(request, response, err)
 	} else {
 		if results, count, err := s.GraphQuery.GetADEntityQueryResult(request.Context(), primaryDisplayKinds, params, entityPanelCachingFlag.Enabled); err != nil {

--- a/cmd/api/src/api/v2/ad_related_entity.go
+++ b/cmd/api/src/api/v2/ad_related_entity.go
@@ -57,10 +57,10 @@ func (s *Resources) handleAdRelatedEntityQuery(response http.ResponseWriter, req
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusForbidden, api.ErrorResponseDetailsForbidden, request), response)
 	} else if entityPanelCachingFlag, err := s.DB.GetFlagByKey(request.Context(), appcfg.FeatureEntityPanelCaching); err != nil {
 		api.HandleDatabaseError(request, response, err)
-	} else if validPrimaryKinds, err := s.DB.GetValidDisplayKinds(request.Context()); err != nil {
+	} else if primaryDisplayKinds, err := s.DB.GetValidDisplayKinds(request.Context()); err != nil {
 		api.HandleDatabaseError(request, response, err)
 	} else {
-		if results, count, err := s.GraphQuery.GetADEntityQueryResult(request.Context(), validPrimaryKinds, params, entityPanelCachingFlag.Enabled); err != nil {
+		if results, count, err := s.GraphQuery.GetADEntityQueryResult(request.Context(), primaryDisplayKinds, params, entityPanelCachingFlag.Enabled); err != nil {
 			if errors.Is(err, queries.ErrGraphUnsupported) || errors.Is(err, queries.ErrUnsupportedDataType) {
 				api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, fmt.Sprintf(api.FmtErrorResponseDetailsBadQueryParameters, err), request), response)
 			} else if errors.Is(err, ops.ErrGraphQueryMemoryLimit) {

--- a/cmd/api/src/api/v2/ad_related_entity.go
+++ b/cmd/api/src/api/v2/ad_related_entity.go
@@ -57,14 +57,10 @@ func (s *Resources) handleAdRelatedEntityQuery(response http.ResponseWriter, req
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusForbidden, api.ErrorResponseDetailsForbidden, request), response)
 	} else if entityPanelCachingFlag, err := s.DB.GetFlagByKey(request.Context(), appcfg.FeatureEntityPanelCaching); err != nil {
 		api.HandleDatabaseError(request, response, err)
-	} else if validPrimaryKinds, err := s.DB.GetDisplayGraphSchemaNodeKinds(request.Context()); err != nil {
+	} else if validPrimaryKinds, err := s.DB.GetValidDisplayKinds(request.Context()); err != nil {
 		api.HandleDatabaseError(request, response, err)
 	} else {
-		customNodeKinds, err := s.DB.GetCustomNodeKindsMap(request.Context())
-		if err != nil {
-			slog.Warn("Unable to fetch custom nodes from database; will fall back to defaults")
-		}
-		if results, count, err := s.GraphQuery.GetADEntityQueryResult(request.Context(), validPrimaryKinds, customNodeKinds, params, entityPanelCachingFlag.Enabled); err != nil {
+		if results, count, err := s.GraphQuery.GetADEntityQueryResult(request.Context(), validPrimaryKinds, params, entityPanelCachingFlag.Enabled); err != nil {
 			if errors.Is(err, queries.ErrGraphUnsupported) || errors.Is(err, queries.ErrUnsupportedDataType) {
 				api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, fmt.Sprintf(api.FmtErrorResponseDetailsBadQueryParameters, err), request), response)
 			} else if errors.Is(err, ops.ErrGraphQueryMemoryLimit) {

--- a/cmd/api/src/api/v2/ad_related_entity_test.go
+++ b/cmd/api/src/api/v2/ad_related_entity_test.go
@@ -88,7 +88,6 @@ func setupCases(mockGraph *mocks.MockGraph, mockDB *dbMocks.MockDatabase) []apit
 					GetFlagByKey(gomock.Any(), "entity_panel_cache").
 					Return(appcfg.FeatureFlag{Enabled: true}, nil)
 				mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
-				mockDB.EXPECT().GetCustomNodeKindsMap(gomock.Any())
 			},
 			Test: func(output apitest.Output) {
 				apitest.StatusCode(output, http.StatusBadRequest)
@@ -109,7 +108,6 @@ func setupCases(mockGraph *mocks.MockGraph, mockDB *dbMocks.MockDatabase) []apit
 					GetFlagByKey(gomock.Any(), "entity_panel_cache").
 					Return(appcfg.FeatureFlag{Enabled: true}, nil)
 				mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
-				mockDB.EXPECT().GetCustomNodeKindsMap(gomock.Any())
 			},
 			Test: func(output apitest.Output) {
 				apitest.StatusCode(output, http.StatusBadRequest)
@@ -130,7 +128,6 @@ func setupCases(mockGraph *mocks.MockGraph, mockDB *dbMocks.MockDatabase) []apit
 					GetFlagByKey(gomock.Any(), "entity_panel_cache").
 					Return(appcfg.FeatureFlag{Enabled: true}, nil)
 				mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
-				mockDB.EXPECT().GetCustomNodeKindsMap(gomock.Any())
 			},
 			Test: func(output apitest.Output) {
 				apitest.StatusCode(output, http.StatusInternalServerError)
@@ -151,7 +148,6 @@ func setupCases(mockGraph *mocks.MockGraph, mockDB *dbMocks.MockDatabase) []apit
 					GetFlagByKey(gomock.Any(), "entity_panel_cache").
 					Return(appcfg.FeatureFlag{Enabled: true}, nil)
 				mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
-				mockDB.EXPECT().GetCustomNodeKindsMap(gomock.Any())
 			},
 			Test: func(output apitest.Output) {
 				apitest.StatusCode(output, http.StatusInternalServerError)
@@ -173,7 +169,6 @@ func setupCases(mockGraph *mocks.MockGraph, mockDB *dbMocks.MockDatabase) []apit
 					GetFlagByKey(gomock.Any(), "entity_panel_cache").
 					Return(appcfg.FeatureFlag{Enabled: true}, nil)
 				mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
-				mockDB.EXPECT().GetCustomNodeKindsMap(gomock.Any())
 			},
 			Test: func(output apitest.Output) {
 				apitest.StatusCode(output, http.StatusOK)
@@ -201,7 +196,6 @@ func setupCases(mockGraph *mocks.MockGraph, mockDB *dbMocks.MockDatabase) []apit
 					GetFlagByKey(gomock.Any(), "entity_panel_cache").
 					Return(appcfg.FeatureFlag{Enabled: true}, nil)
 				mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
-				mockDB.EXPECT().GetCustomNodeKindsMap(gomock.Any())
 			},
 			Test: func(output apitest.Output) {
 				apitest.StatusCode(output, http.StatusOK)
@@ -633,7 +627,6 @@ func TestResources_ListADIssuancePolicyLinkedCertTemplates(t *testing.T) {
 			setupMocks: func(t *testing.T, mock *mock) {
 				t.Helper()
 				mock.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any())
-				mock.mockDatabase.EXPECT().GetCustomNodeKindsMap(gomock.Any())
 				mock.mockDatabase.EXPECT().GetFlagByKey(gomock.Any(), "entity_panel_cache").Return(appcfg.FeatureFlag{Enabled: true}, nil)
 				mock.mockGraphQuery.EXPECT().GetADEntityQueryResult(gomock.Any(), gomock.Any(), gomock.Any(), true).Return("", 0, queries.ErrGraphUnsupported)
 			},
@@ -657,7 +650,6 @@ func TestResources_ListADIssuancePolicyLinkedCertTemplates(t *testing.T) {
 			setupMocks: func(t *testing.T, mock *mock) {
 				t.Helper()
 				mock.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any())
-				mock.mockDatabase.EXPECT().GetCustomNodeKindsMap(gomock.Any())
 				mock.mockDatabase.EXPECT().GetFlagByKey(gomock.Any(), "entity_panel_cache").Return(appcfg.FeatureFlag{Enabled: true}, nil)
 				mock.mockGraphQuery.EXPECT().GetADEntityQueryResult(gomock.Any(), gomock.Any(), gomock.Any(), true).Return("", 0, ops.ErrGraphQueryMemoryLimit)
 			},
@@ -681,7 +673,6 @@ func TestResources_ListADIssuancePolicyLinkedCertTemplates(t *testing.T) {
 			setupMocks: func(t *testing.T, mock *mock) {
 				t.Helper()
 				mock.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any())
-				mock.mockDatabase.EXPECT().GetCustomNodeKindsMap(gomock.Any())
 				mock.mockDatabase.EXPECT().GetFlagByKey(gomock.Any(), "entity_panel_cache").Return(appcfg.FeatureFlag{Enabled: true}, nil)
 				mock.mockGraphQuery.EXPECT().GetADEntityQueryResult(gomock.Any(), gomock.Any(), gomock.Any(), true).Return("", 0, errors.New("error"))
 			},
@@ -705,7 +696,6 @@ func TestResources_ListADIssuancePolicyLinkedCertTemplates(t *testing.T) {
 			setupMocks: func(t *testing.T, mock *mock) {
 				t.Helper()
 				mock.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any())
-				mock.mockDatabase.EXPECT().GetCustomNodeKindsMap(gomock.Any())
 				mock.mockDatabase.EXPECT().GetFlagByKey(gomock.Any(), "entity_panel_cache").Return(appcfg.FeatureFlag{Enabled: true}, nil)
 				mock.mockGraphQuery.EXPECT().GetADEntityQueryResult(gomock.Any(), gomock.Any(), gomock.Any(), true).Return("results", 1, nil)
 			},
@@ -728,7 +718,6 @@ func TestResources_ListADIssuancePolicyLinkedCertTemplates(t *testing.T) {
 			setupMocks: func(t *testing.T, mock *mock) {
 				t.Helper()
 				mock.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any())
-				mock.mockDatabase.EXPECT().GetCustomNodeKindsMap(gomock.Any())
 				mock.mockDatabase.EXPECT().GetFlagByKey(gomock.Any(), "entity_panel_cache").Return(appcfg.FeatureFlag{Enabled: true}, nil)
 				mock.mockGraphQuery.EXPECT().GetADEntityQueryResult(gomock.Any(), gomock.Any(), gomock.Any(), true).Return("", 1, nil)
 			},
@@ -751,7 +740,6 @@ func TestResources_ListADIssuancePolicyLinkedCertTemplates(t *testing.T) {
 			setupMocks: func(t *testing.T, mock *mock) {
 				t.Helper()
 				mock.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any())
-				mock.mockDatabase.EXPECT().GetCustomNodeKindsMap(gomock.Any())
 				mock.mockDatabase.EXPECT().GetFlagByKey(gomock.Any(), "entity_panel_cache").Return(appcfg.FeatureFlag{Enabled: true}, nil)
 				mock.mockGraphQuery.EXPECT().GetADEntityQueryResult(gomock.Any(), gomock.Any(), gomock.Any(), true).Return("results", 1, nil)
 			},
@@ -789,7 +777,6 @@ func TestResources_ListADIssuancePolicyLinkedCertTemplates(t *testing.T) {
 					}),
 				}, nil)
 				mock.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any())
-				mock.mockDatabase.EXPECT().GetCustomNodeKindsMap(gomock.Any())
 				mock.mockDatabase.EXPECT().GetFlagByKey(gomock.Any(), "entity_panel_cache").Return(appcfg.FeatureFlag{Enabled: true}, nil)
 				mock.mockGraphQuery.EXPECT().GetADEntityQueryResult(gomock.Any(), gomock.Any(), gomock.Any(), true).Return("results", 1, nil)
 			},

--- a/cmd/api/src/api/v2/ad_related_entity_test.go
+++ b/cmd/api/src/api/v2/ad_related_entity_test.go
@@ -87,7 +87,7 @@ func setupCases(mockGraph *mocks.MockGraph, mockDB *dbMocks.MockDatabase) []apit
 				mockDB.EXPECT().
 					GetFlagByKey(gomock.Any(), "entity_panel_cache").
 					Return(appcfg.FeatureFlag{Enabled: true}, nil)
-				mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+				mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 			},
 			Test: func(output apitest.Output) {
 				apitest.StatusCode(output, http.StatusBadRequest)
@@ -107,7 +107,7 @@ func setupCases(mockGraph *mocks.MockGraph, mockDB *dbMocks.MockDatabase) []apit
 				mockDB.EXPECT().
 					GetFlagByKey(gomock.Any(), "entity_panel_cache").
 					Return(appcfg.FeatureFlag{Enabled: true}, nil)
-				mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+				mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 			},
 			Test: func(output apitest.Output) {
 				apitest.StatusCode(output, http.StatusBadRequest)
@@ -127,7 +127,7 @@ func setupCases(mockGraph *mocks.MockGraph, mockDB *dbMocks.MockDatabase) []apit
 				mockDB.EXPECT().
 					GetFlagByKey(gomock.Any(), "entity_panel_cache").
 					Return(appcfg.FeatureFlag{Enabled: true}, nil)
-				mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+				mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 			},
 			Test: func(output apitest.Output) {
 				apitest.StatusCode(output, http.StatusInternalServerError)
@@ -147,7 +147,7 @@ func setupCases(mockGraph *mocks.MockGraph, mockDB *dbMocks.MockDatabase) []apit
 				mockDB.EXPECT().
 					GetFlagByKey(gomock.Any(), "entity_panel_cache").
 					Return(appcfg.FeatureFlag{Enabled: true}, nil)
-				mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+				mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 			},
 			Test: func(output apitest.Output) {
 				apitest.StatusCode(output, http.StatusInternalServerError)
@@ -168,7 +168,7 @@ func setupCases(mockGraph *mocks.MockGraph, mockDB *dbMocks.MockDatabase) []apit
 				mockDB.EXPECT().
 					GetFlagByKey(gomock.Any(), "entity_panel_cache").
 					Return(appcfg.FeatureFlag{Enabled: true}, nil)
-				mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+				mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 			},
 			Test: func(output apitest.Output) {
 				apitest.StatusCode(output, http.StatusOK)
@@ -195,7 +195,7 @@ func setupCases(mockGraph *mocks.MockGraph, mockDB *dbMocks.MockDatabase) []apit
 				mockDB.EXPECT().
 					GetFlagByKey(gomock.Any(), "entity_panel_cache").
 					Return(appcfg.FeatureFlag{Enabled: true}, nil)
-				mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+				mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 			},
 			Test: func(output apitest.Output) {
 				apitest.StatusCode(output, http.StatusOK)
@@ -626,7 +626,7 @@ func TestResources_ListADIssuancePolicyLinkedCertTemplates(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mock *mock) {
 				t.Helper()
-				mock.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any())
+				mock.mockDatabase.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 				mock.mockDatabase.EXPECT().GetFlagByKey(gomock.Any(), "entity_panel_cache").Return(appcfg.FeatureFlag{Enabled: true}, nil)
 				mock.mockGraphQuery.EXPECT().GetADEntityQueryResult(gomock.Any(), gomock.Any(), gomock.Any(), true).Return("", 0, queries.ErrGraphUnsupported)
 			},
@@ -649,7 +649,7 @@ func TestResources_ListADIssuancePolicyLinkedCertTemplates(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mock *mock) {
 				t.Helper()
-				mock.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any())
+				mock.mockDatabase.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 				mock.mockDatabase.EXPECT().GetFlagByKey(gomock.Any(), "entity_panel_cache").Return(appcfg.FeatureFlag{Enabled: true}, nil)
 				mock.mockGraphQuery.EXPECT().GetADEntityQueryResult(gomock.Any(), gomock.Any(), gomock.Any(), true).Return("", 0, ops.ErrGraphQueryMemoryLimit)
 			},
@@ -672,7 +672,7 @@ func TestResources_ListADIssuancePolicyLinkedCertTemplates(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mock *mock) {
 				t.Helper()
-				mock.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any())
+				mock.mockDatabase.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 				mock.mockDatabase.EXPECT().GetFlagByKey(gomock.Any(), "entity_panel_cache").Return(appcfg.FeatureFlag{Enabled: true}, nil)
 				mock.mockGraphQuery.EXPECT().GetADEntityQueryResult(gomock.Any(), gomock.Any(), gomock.Any(), true).Return("", 0, errors.New("error"))
 			},
@@ -695,7 +695,7 @@ func TestResources_ListADIssuancePolicyLinkedCertTemplates(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mock *mock) {
 				t.Helper()
-				mock.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any())
+				mock.mockDatabase.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 				mock.mockDatabase.EXPECT().GetFlagByKey(gomock.Any(), "entity_panel_cache").Return(appcfg.FeatureFlag{Enabled: true}, nil)
 				mock.mockGraphQuery.EXPECT().GetADEntityQueryResult(gomock.Any(), gomock.Any(), gomock.Any(), true).Return("results", 1, nil)
 			},
@@ -717,7 +717,7 @@ func TestResources_ListADIssuancePolicyLinkedCertTemplates(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mock *mock) {
 				t.Helper()
-				mock.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any())
+				mock.mockDatabase.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 				mock.mockDatabase.EXPECT().GetFlagByKey(gomock.Any(), "entity_panel_cache").Return(appcfg.FeatureFlag{Enabled: true}, nil)
 				mock.mockGraphQuery.EXPECT().GetADEntityQueryResult(gomock.Any(), gomock.Any(), gomock.Any(), true).Return("", 1, nil)
 			},
@@ -739,7 +739,7 @@ func TestResources_ListADIssuancePolicyLinkedCertTemplates(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mock *mock) {
 				t.Helper()
-				mock.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any())
+				mock.mockDatabase.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 				mock.mockDatabase.EXPECT().GetFlagByKey(gomock.Any(), "entity_panel_cache").Return(appcfg.FeatureFlag{Enabled: true}, nil)
 				mock.mockGraphQuery.EXPECT().GetADEntityQueryResult(gomock.Any(), gomock.Any(), gomock.Any(), true).Return("results", 1, nil)
 			},
@@ -776,7 +776,7 @@ func TestResources_ListADIssuancePolicyLinkedCertTemplates(t *testing.T) {
 						"domainsid": "12345",
 					}),
 				}, nil)
-				mock.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any())
+				mock.mockDatabase.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 				mock.mockDatabase.EXPECT().GetFlagByKey(gomock.Any(), "entity_panel_cache").Return(appcfg.FeatureFlag{Enabled: true}, nil)
 				mock.mockGraphQuery.EXPECT().GetADEntityQueryResult(gomock.Any(), gomock.Any(), gomock.Any(), true).Return("results", 1, nil)
 			},

--- a/cmd/api/src/api/v2/ad_related_entity_test.go
+++ b/cmd/api/src/api/v2/ad_related_entity_test.go
@@ -82,12 +82,12 @@ func setupCases(mockGraph *mocks.MockGraph, mockDB *dbMocks.MockDatabase) []apit
 			},
 			Setup: func() {
 				mockGraph.EXPECT().
-					GetADEntityQueryResult(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					GetADEntityQueryResult(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(nil, 0, queries.ErrGraphUnsupported)
 				mockDB.EXPECT().
 					GetFlagByKey(gomock.Any(), "entity_panel_cache").
 					Return(appcfg.FeatureFlag{Enabled: true}, nil)
-				mockDB.EXPECT().GetDisplayGraphSchemaNodeKinds(gomock.Any())
+				mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
 				mockDB.EXPECT().GetCustomNodeKindsMap(gomock.Any())
 			},
 			Test: func(output apitest.Output) {
@@ -103,12 +103,12 @@ func setupCases(mockGraph *mocks.MockGraph, mockDB *dbMocks.MockDatabase) []apit
 			},
 			Setup: func() {
 				mockGraph.EXPECT().
-					GetADEntityQueryResult(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					GetADEntityQueryResult(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(nil, 0, queries.ErrUnsupportedDataType)
 				mockDB.EXPECT().
 					GetFlagByKey(gomock.Any(), "entity_panel_cache").
 					Return(appcfg.FeatureFlag{Enabled: true}, nil)
-				mockDB.EXPECT().GetDisplayGraphSchemaNodeKinds(gomock.Any())
+				mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
 				mockDB.EXPECT().GetCustomNodeKindsMap(gomock.Any())
 			},
 			Test: func(output apitest.Output) {
@@ -124,12 +124,12 @@ func setupCases(mockGraph *mocks.MockGraph, mockDB *dbMocks.MockDatabase) []apit
 			},
 			Setup: func() {
 				mockGraph.EXPECT().
-					GetADEntityQueryResult(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					GetADEntityQueryResult(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(nil, 0, ops.ErrGraphQueryMemoryLimit)
 				mockDB.EXPECT().
 					GetFlagByKey(gomock.Any(), "entity_panel_cache").
 					Return(appcfg.FeatureFlag{Enabled: true}, nil)
-				mockDB.EXPECT().GetDisplayGraphSchemaNodeKinds(gomock.Any())
+				mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
 				mockDB.EXPECT().GetCustomNodeKindsMap(gomock.Any())
 			},
 			Test: func(output apitest.Output) {
@@ -145,12 +145,12 @@ func setupCases(mockGraph *mocks.MockGraph, mockDB *dbMocks.MockDatabase) []apit
 			},
 			Setup: func() {
 				mockGraph.EXPECT().
-					GetADEntityQueryResult(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					GetADEntityQueryResult(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(nil, 0, errors.New("any other error"))
 				mockDB.EXPECT().
 					GetFlagByKey(gomock.Any(), "entity_panel_cache").
 					Return(appcfg.FeatureFlag{Enabled: true}, nil)
-				mockDB.EXPECT().GetDisplayGraphSchemaNodeKinds(gomock.Any())
+				mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
 				mockDB.EXPECT().GetCustomNodeKindsMap(gomock.Any())
 			},
 			Test: func(output apitest.Output) {
@@ -167,12 +167,12 @@ func setupCases(mockGraph *mocks.MockGraph, mockDB *dbMocks.MockDatabase) []apit
 			},
 			Setup: func() {
 				mockGraph.EXPECT().
-					GetADEntityQueryResult(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					GetADEntityQueryResult(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(nil, 0, nil)
 				mockDB.EXPECT().
 					GetFlagByKey(gomock.Any(), "entity_panel_cache").
 					Return(appcfg.FeatureFlag{Enabled: true}, nil)
-				mockDB.EXPECT().GetDisplayGraphSchemaNodeKinds(gomock.Any())
+				mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
 				mockDB.EXPECT().GetCustomNodeKindsMap(gomock.Any())
 			},
 			Test: func(output apitest.Output) {
@@ -195,12 +195,12 @@ func setupCases(mockGraph *mocks.MockGraph, mockDB *dbMocks.MockDatabase) []apit
 			},
 			Setup: func() {
 				mockGraph.EXPECT().
-					GetADEntityQueryResult(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					GetADEntityQueryResult(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(nil, 0, nil)
 				mockDB.EXPECT().
 					GetFlagByKey(gomock.Any(), "entity_panel_cache").
 					Return(appcfg.FeatureFlag{Enabled: true}, nil)
-				mockDB.EXPECT().GetDisplayGraphSchemaNodeKinds(gomock.Any())
+				mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
 				mockDB.EXPECT().GetCustomNodeKindsMap(gomock.Any())
 			},
 			Test: func(output apitest.Output) {
@@ -632,10 +632,10 @@ func TestResources_ListADIssuancePolicyLinkedCertTemplates(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mock *mock) {
 				t.Helper()
-				mock.mockDatabase.EXPECT().GetDisplayGraphSchemaNodeKinds(gomock.Any())
+				mock.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any())
 				mock.mockDatabase.EXPECT().GetCustomNodeKindsMap(gomock.Any())
 				mock.mockDatabase.EXPECT().GetFlagByKey(gomock.Any(), "entity_panel_cache").Return(appcfg.FeatureFlag{Enabled: true}, nil)
-				mock.mockGraphQuery.EXPECT().GetADEntityQueryResult(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), true).Return("", 0, queries.ErrGraphUnsupported)
+				mock.mockGraphQuery.EXPECT().GetADEntityQueryResult(gomock.Any(), gomock.Any(), gomock.Any(), true).Return("", 0, queries.ErrGraphUnsupported)
 			},
 			expected: expected{
 				responseCode:   http.StatusBadRequest,
@@ -656,10 +656,10 @@ func TestResources_ListADIssuancePolicyLinkedCertTemplates(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mock *mock) {
 				t.Helper()
-				mock.mockDatabase.EXPECT().GetDisplayGraphSchemaNodeKinds(gomock.Any())
+				mock.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any())
 				mock.mockDatabase.EXPECT().GetCustomNodeKindsMap(gomock.Any())
 				mock.mockDatabase.EXPECT().GetFlagByKey(gomock.Any(), "entity_panel_cache").Return(appcfg.FeatureFlag{Enabled: true}, nil)
-				mock.mockGraphQuery.EXPECT().GetADEntityQueryResult(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), true).Return("", 0, ops.ErrGraphQueryMemoryLimit)
+				mock.mockGraphQuery.EXPECT().GetADEntityQueryResult(gomock.Any(), gomock.Any(), gomock.Any(), true).Return("", 0, ops.ErrGraphQueryMemoryLimit)
 			},
 			expected: expected{
 				responseCode:   http.StatusInternalServerError,
@@ -680,10 +680,10 @@ func TestResources_ListADIssuancePolicyLinkedCertTemplates(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mock *mock) {
 				t.Helper()
-				mock.mockDatabase.EXPECT().GetDisplayGraphSchemaNodeKinds(gomock.Any())
+				mock.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any())
 				mock.mockDatabase.EXPECT().GetCustomNodeKindsMap(gomock.Any())
 				mock.mockDatabase.EXPECT().GetFlagByKey(gomock.Any(), "entity_panel_cache").Return(appcfg.FeatureFlag{Enabled: true}, nil)
-				mock.mockGraphQuery.EXPECT().GetADEntityQueryResult(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), true).Return("", 0, errors.New("error"))
+				mock.mockGraphQuery.EXPECT().GetADEntityQueryResult(gomock.Any(), gomock.Any(), gomock.Any(), true).Return("", 0, errors.New("error"))
 			},
 			expected: expected{
 				responseCode:   http.StatusInternalServerError,
@@ -704,10 +704,10 @@ func TestResources_ListADIssuancePolicyLinkedCertTemplates(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mock *mock) {
 				t.Helper()
-				mock.mockDatabase.EXPECT().GetDisplayGraphSchemaNodeKinds(gomock.Any())
+				mock.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any())
 				mock.mockDatabase.EXPECT().GetCustomNodeKindsMap(gomock.Any())
 				mock.mockDatabase.EXPECT().GetFlagByKey(gomock.Any(), "entity_panel_cache").Return(appcfg.FeatureFlag{Enabled: true}, nil)
-				mock.mockGraphQuery.EXPECT().GetADEntityQueryResult(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), true).Return("results", 1, nil)
+				mock.mockGraphQuery.EXPECT().GetADEntityQueryResult(gomock.Any(), gomock.Any(), gomock.Any(), true).Return("results", 1, nil)
 			},
 			expected: expected{
 				responseCode:   http.StatusOK,
@@ -727,10 +727,10 @@ func TestResources_ListADIssuancePolicyLinkedCertTemplates(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mock *mock) {
 				t.Helper()
-				mock.mockDatabase.EXPECT().GetDisplayGraphSchemaNodeKinds(gomock.Any())
+				mock.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any())
 				mock.mockDatabase.EXPECT().GetCustomNodeKindsMap(gomock.Any())
 				mock.mockDatabase.EXPECT().GetFlagByKey(gomock.Any(), "entity_panel_cache").Return(appcfg.FeatureFlag{Enabled: true}, nil)
-				mock.mockGraphQuery.EXPECT().GetADEntityQueryResult(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), true).Return("", 1, nil)
+				mock.mockGraphQuery.EXPECT().GetADEntityQueryResult(gomock.Any(), gomock.Any(), gomock.Any(), true).Return("", 1, nil)
 			},
 			expected: expected{
 				responseCode:   http.StatusOK,
@@ -750,10 +750,10 @@ func TestResources_ListADIssuancePolicyLinkedCertTemplates(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mock *mock) {
 				t.Helper()
-				mock.mockDatabase.EXPECT().GetDisplayGraphSchemaNodeKinds(gomock.Any())
+				mock.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any())
 				mock.mockDatabase.EXPECT().GetCustomNodeKindsMap(gomock.Any())
 				mock.mockDatabase.EXPECT().GetFlagByKey(gomock.Any(), "entity_panel_cache").Return(appcfg.FeatureFlag{Enabled: true}, nil)
-				mock.mockGraphQuery.EXPECT().GetADEntityQueryResult(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), true).Return("results", 1, nil)
+				mock.mockGraphQuery.EXPECT().GetADEntityQueryResult(gomock.Any(), gomock.Any(), gomock.Any(), true).Return("results", 1, nil)
 			},
 			expected: expected{
 				responseCode:   http.StatusOK,
@@ -788,10 +788,10 @@ func TestResources_ListADIssuancePolicyLinkedCertTemplates(t *testing.T) {
 						"domainsid": "12345",
 					}),
 				}, nil)
-				mock.mockDatabase.EXPECT().GetDisplayGraphSchemaNodeKinds(gomock.Any())
+				mock.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any())
 				mock.mockDatabase.EXPECT().GetCustomNodeKindsMap(gomock.Any())
 				mock.mockDatabase.EXPECT().GetFlagByKey(gomock.Any(), "entity_panel_cache").Return(appcfg.FeatureFlag{Enabled: true}, nil)
-				mock.mockGraphQuery.EXPECT().GetADEntityQueryResult(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), true).Return("results", 1, nil)
+				mock.mockGraphQuery.EXPECT().GetADEntityQueryResult(gomock.Any(), gomock.Any(), gomock.Any(), true).Return("results", 1, nil)
 			},
 			expected: expected{
 				responseCode:   http.StatusOK,

--- a/cmd/api/src/api/v2/agi.go
+++ b/cmd/api/src/api/v2/agi.go
@@ -443,7 +443,7 @@ func (s Resources) getAssetGroupMembers(response http.ResponseWriter, request *h
 		} else if assetGroupNodes, err := s.GraphQuery.GetAssetGroupNodes(request.Context(), assetGroup.Tag, assetGroup.SystemGroup); err != nil {
 			api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusInternalServerError, fmt.Sprintf("Graph error fetching nodes for asset group ID %v: %v", assetGroup.ID, err), request), response)
 			return agMembers, err
-		} else if primaryDisplayKinds, err := s.DB.GetValidDisplayKinds(request.Context()); err != nil {
+		} else if primaryDisplayKinds, err := s.DB.GetPrimaryDisplayKinds(request.Context()); err != nil {
 			api.HandleDatabaseError(request, response, err)
 			return agMembers, err
 		} else if agMembers, err = parseAGMembersFromNodes(primaryDisplayKinds, assetGroupNodes, assetGroup.Selectors, int(assetGroup.ID)).SortBy(sortByColumns); err != nil {

--- a/cmd/api/src/api/v2/agi.go
+++ b/cmd/api/src/api/v2/agi.go
@@ -443,10 +443,10 @@ func (s Resources) getAssetGroupMembers(response http.ResponseWriter, request *h
 		} else if assetGroupNodes, err := s.GraphQuery.GetAssetGroupNodes(request.Context(), assetGroup.Tag, assetGroup.SystemGroup); err != nil {
 			api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusInternalServerError, fmt.Sprintf("Graph error fetching nodes for asset group ID %v: %v", assetGroup.ID, err), request), response)
 			return agMembers, err
-		} else if validPrimaryKinds, err := s.DB.GetValidDisplayKinds(request.Context()); err != nil {
+		} else if primaryDisplayKinds, err := s.DB.GetValidDisplayKinds(request.Context()); err != nil {
 			api.HandleDatabaseError(request, response, err)
 			return agMembers, err
-		} else if agMembers, err = parseAGMembersFromNodes(validPrimaryKinds, assetGroupNodes, assetGroup.Selectors, int(assetGroup.ID)).SortBy(sortByColumns); err != nil {
+		} else if agMembers, err = parseAGMembersFromNodes(primaryDisplayKinds, assetGroupNodes, assetGroup.Selectors, int(assetGroup.ID)).SortBy(sortByColumns); err != nil {
 			api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, err.Error(), request), response)
 			return agMembers, err
 		} else if agMembers, err = agMembers.Filter(queryFilters); err != nil {
@@ -489,7 +489,7 @@ func (s Resources) ListAssetGroupMemberCountsByKind(response http.ResponseWriter
 	}
 }
 
-func parseAGMembersFromNodes(validPrimaryKinds graphschema.ValidPrimaryKinds, nodes graph.NodeSet, selectors model.AssetGroupSelectors, assetGroupID int) api.AssetGroupMembers {
+func parseAGMembersFromNodes(primaryDisplayKinds graphschema.PrimaryDisplayKinds, nodes graph.NodeSet, selectors model.AssetGroupSelectors, assetGroupID int) api.AssetGroupMembers {
 	agMembers := api.AssetGroupMembers{}
 	for _, node := range nodes {
 		isCustomMember := false
@@ -533,7 +533,7 @@ func parseAGMembersFromNodes(validPrimaryKinds graphschema.ValidPrimaryKinds, no
 		agMember := api.AssetGroupMember{
 			AssetGroupID: assetGroupID,
 			ObjectID:     memberObjectId,
-			PrimaryKind:  graphschema.GetNodeKindDisplayLabel(validPrimaryKinds, node),
+			PrimaryKind:  graphschema.GetNodeKindDisplayLabel(primaryDisplayKinds, node),
 			Kinds:        node.Kinds.Strings(),
 			Name:         memberName,
 			CustomMember: isCustomMember,

--- a/cmd/api/src/api/v2/agi_test.go
+++ b/cmd/api/src/api/v2/agi_test.go
@@ -1219,12 +1219,12 @@ func TestResources_ListAssetGroupMembers(t *testing.T) {
 				},
 			},
 			{
-				Name: "GetValidDisplayKindsError",
+				Name: "GetPrimaryDisplayKindsError",
 				Input: func(input *apitest.Input) {
 					apitest.SetURLVar(input, api.URIPathVariableAssetGroupID, "1")
 				},
 				Setup: func() {
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any()).Return(nil, errors.New("database error"))
+					mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any()).Return(nil, errors.New("database error"))
 					mockDB.EXPECT().GetAssetGroup(gomock.Any(), gomock.Any()).Return(assetGroup, nil)
 					mockGraph.EXPECT().GetAssetGroupNodes(gomock.Any(), gomock.Any(), gomock.Any()).Return(graph.NodeSet{}, nil)
 				},
@@ -1238,7 +1238,7 @@ func TestResources_ListAssetGroupMembers(t *testing.T) {
 					apitest.SetURLVar(input, api.URIPathVariableAssetGroupID, "1")
 				},
 				Setup: func() {
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+					mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 					mockDB.EXPECT().GetAssetGroup(gomock.Any(), gomock.Any()).Return(assetGroup, nil)
 					mockGraph.EXPECT().
 						GetAssetGroupNodes(gomock.Any(), gomock.Any(), gomock.Any()).
@@ -1287,7 +1287,7 @@ func TestResources_ListAssetGroupMembers(t *testing.T) {
 					apitest.SetURLVar(input, api.URIPathVariableAssetGroupID, "1")
 				},
 				Setup: func() {
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+					mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 					mockDB.EXPECT().GetAssetGroup(gomock.Any(), gomock.Any()).Return(assetGroup, nil)
 					mockGraph.EXPECT().
 						GetAssetGroupNodes(gomock.Any(), gomock.Any(), gomock.Any()).
@@ -1322,7 +1322,7 @@ func TestResources_ListAssetGroupMembers(t *testing.T) {
 					apitest.AddQueryParam(input, model.PaginationQueryParameterLimit, "4")
 				},
 				Setup: func() {
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+					mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 					mockDB.EXPECT().GetAssetGroup(gomock.Any(), gomock.Any()).Return(assetGroup, nil)
 					mockGraph.EXPECT().
 						GetAssetGroupNodes(gomock.Any(), gomock.Any(), gomock.Any()).
@@ -1362,7 +1362,7 @@ func TestResources_ListAssetGroupMembers(t *testing.T) {
 					apitest.AddQueryParam(input, model.PaginationQueryParameterLimit, "4")
 				},
 				Setup: func() {
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+					mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 					mockDB.EXPECT().GetAssetGroup(gomock.Any(), gomock.Any()).Return(assetGroup, nil)
 					mockGraph.EXPECT().
 						GetAssetGroupNodes(gomock.Any(), gomock.Any(), gomock.Any()).
@@ -1404,7 +1404,7 @@ func TestResources_ListAssetGroupMembers(t *testing.T) {
 					apitest.AddQueryParam(input, api.QueryParameterSortBy, "-object_id")
 				},
 				Setup: func() {
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+					mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 					mockDB.EXPECT().GetAssetGroup(gomock.Any(), gomock.Any()).Return(assetGroup, nil)
 					mockGraph.EXPECT().
 						GetAssetGroupNodes(gomock.Any(), gomock.Any(), gomock.Any()).
@@ -1438,7 +1438,7 @@ func TestResources_ListAssetGroupMembers(t *testing.T) {
 					apitest.SetURLVar(input, api.URIPathVariableAssetGroupID, "1")
 				},
 				Setup: func() {
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+					mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 					mockDB.EXPECT().GetAssetGroup(gomock.Any(), gomock.Any()).Return(assetGroup, nil)
 					mockGraph.EXPECT().
 						GetAssetGroupNodes(gomock.Any(), gomock.Any(), gomock.Any()).
@@ -1590,12 +1590,12 @@ func TestResources_ListAssetGroupMembersCount(t *testing.T) {
 				},
 			},
 			{
-				Name: "GetValidDisplayKindsError",
+				Name: "GetPrimaryDisplayKindsError",
 				Input: func(input *apitest.Input) {
 					apitest.SetURLVar(input, api.URIPathVariableAssetGroupID, "1")
 				},
 				Setup: func() {
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any()).Return(nil, errors.New("database error"))
+					mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any()).Return(nil, errors.New("database error"))
 					mockDB.EXPECT().GetAssetGroup(gomock.Any(), gomock.Any()).Return(assetGroup, nil)
 					mockGraph.EXPECT().GetAssetGroupNodes(gomock.Any(), gomock.Any(), gomock.Any()).Return(graph.NodeSet{}, nil)
 				},
@@ -1609,7 +1609,7 @@ func TestResources_ListAssetGroupMembersCount(t *testing.T) {
 					apitest.SetURLVar(input, api.URIPathVariableAssetGroupID, "1")
 				},
 				Setup: func() {
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+					mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 					mockDB.EXPECT().
 						GetAssetGroup(gomock.Any(), gomock.Any()).
 						Return(assetGroup, nil)
@@ -1646,7 +1646,7 @@ func TestResources_ListAssetGroupMembersCount(t *testing.T) {
 					apitest.SetURLVar(input, api.URIPathVariableAssetGroupID, "1")
 				},
 				Setup: func() {
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+					mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 					mockDB.EXPECT().
 						GetAssetGroup(gomock.Any(), gomock.Any()).
 						Return(assetGroup, nil)

--- a/cmd/api/src/api/v2/assetgrouptags.go
+++ b/cmd/api/src/api/v2/assetgrouptags.go
@@ -767,13 +767,13 @@ func (s *Resources) GetAssetGroupTagMemberCountsByKind(response http.ResponseWri
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusNotFound, api.ErrorResponseDetailsIDMalformed, request), response)
 	} else if tag, err := s.DB.GetAssetGroupTag(request.Context(), tagId); err != nil {
 		api.HandleDatabaseError(request, response, err)
-	} else if validPrimaryKinds, err := s.DB.GetValidDisplayKinds(request.Context()); err != nil {
+	} else if primaryDisplayKinds, err := s.DB.GetValidDisplayKinds(request.Context()); err != nil {
 		api.HandleDatabaseError(request, response, err)
 	} else {
 		filters := []graph.Criteria{}
 		filters = maybeAddEnvironmentIdFilter(filters, request.URL.Query()[api.QueryParameterEnvironments])
 
-		primaryNodeKindsCounts, err := s.GraphQuery.GetPrimaryNodeKindCounts(request.Context(), validPrimaryKinds, tag.ToKind(), filters...)
+		primaryNodeKindsCounts, err := s.GraphQuery.GetPrimaryNodeKindCounts(request.Context(), primaryDisplayKinds, tag.ToKind(), filters...)
 		if err != nil {
 			api.HandleDatabaseError(request, response, err)
 			return
@@ -803,8 +803,8 @@ type AssetGroupMember struct {
 }
 
 // Used to minimize the response shape to just the necessary member display fields
-func nodeToAssetGroupMember(validPrimaryKinds graphschema.ValidPrimaryKinds, node *graph.Node, includeProperties bool) AssetGroupMember {
-	primaryKind, displayName, objectId, envId := model.GetAssetGroupMemberProperties(validPrimaryKinds, node)
+func nodeToAssetGroupMember(primaryDisplayKinds graphschema.PrimaryDisplayKinds, node *graph.Node, includeProperties bool) AssetGroupMember {
+	primaryKind, displayName, objectId, envId := model.GetAssetGroupMemberProperties(primaryDisplayKinds, node)
 
 	member := AssetGroupMember{
 		NodeId:        node.ID,
@@ -867,10 +867,10 @@ func (s *Resources) GetAssetGroupTagMemberInfo(response http.ResponseWriter, req
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusNotFound, api.ErrorResponseDetailsResourceNotFound, request), response)
 	} else if node, err := queries.Graph.FetchNodeByGraphId(s.GraphQuery, request.Context(), graph.ID(memberID)); err != nil {
 		api.HandleDatabaseError(request, response, err)
-	} else if validPrimaryKinds, err := s.DB.GetValidDisplayKinds(request.Context()); err != nil {
+	} else if primaryDisplayKinds, err := s.DB.GetValidDisplayKinds(request.Context()); err != nil {
 		api.HandleDatabaseError(request, response, err)
 	} else {
-		groupMember := nodeToAssetGroupMember(validPrimaryKinds, node, includeProperties)
+		groupMember := nodeToAssetGroupMember(primaryDisplayKinds, node, includeProperties)
 		groupMember.AssetGroupTagId = assetGroupTagID
 		api.WriteBasicResponse(request.Context(), MemberInfoResponse{Member: memberInfo{groupMember, selectors}}, http.StatusOK, response)
 	}
@@ -936,11 +936,11 @@ func (s *Resources) GetAssetGroupMembersByTag(response http.ResponseWriter, requ
 			api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusInternalServerError, fmt.Sprintf("Error getting members: %v", err), request), response)
 		} else if count, err := s.GraphQuery.CountFilteredNodes(request.Context(), query.And(filters...)); err != nil {
 			api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusInternalServerError, fmt.Sprintf("Error getting member count: %v", err), request), response)
-		} else if validPrimaryKinds, err := s.DB.GetValidDisplayKinds(request.Context()); err != nil {
+		} else if primaryDisplayKinds, err := s.DB.GetValidDisplayKinds(request.Context()); err != nil {
 			api.HandleDatabaseError(request, response, err)
 		} else {
 			for _, node := range nodes {
-				groupMember := nodeToAssetGroupMember(validPrimaryKinds, node, excludeProperties)
+				groupMember := nodeToAssetGroupMember(primaryDisplayKinds, node, excludeProperties)
 				groupMember.AssetGroupTagId = assetGroupTag.ID
 				members = append(members, groupMember)
 			}
@@ -1152,11 +1152,11 @@ func (s *Resources) GetAssetGroupMembersBySelector(response http.ResponseWriter,
 				api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusInternalServerError, fmt.Sprintf("Error getting members: %v", err), request), response)
 			} else if count, err := s.GraphQuery.CountFilteredNodes(request.Context(), query.And(filters...)); err != nil {
 				api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusInternalServerError, fmt.Sprintf("Error getting member count: %v", err), request), response)
-			} else if validPrimaryKinds, err := s.DB.GetValidDisplayKinds(request.Context()); err != nil {
+			} else if primaryDisplayKinds, err := s.DB.GetValidDisplayKinds(request.Context()); err != nil {
 				api.HandleDatabaseError(request, response, err)
 			} else {
 				for _, node := range nodes {
-					member := nodeToAssetGroupMember(validPrimaryKinds, node, false)
+					member := nodeToAssetGroupMember(primaryDisplayKinds, node, false)
 					member.AssetGroupTagId = assetGroupTag.ID
 					member.Source = sourceByNodeId[node.ID]
 					members = append(members, member)
@@ -1206,12 +1206,12 @@ func (s *Resources) PreviewSelectors(response http.ResponseWriter, request *http
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, err.Error(), request), response)
 	} else if nodes, errs := analysis.FetchNodesFromSeeds(request.Context(), appcfg.GetAGTParameters(request.Context(), s.DB), s.Graph, body.Seeds, expansion, limit); len(errs) > 0 {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusInternalServerError, api.ErrorResponseDetailsInternalServerError, request), response)
-	} else if validPrimaryKinds, err := s.DB.GetValidDisplayKinds(request.Context()); err != nil {
+	} else if primaryDisplayKinds, err := s.DB.GetValidDisplayKinds(request.Context()); err != nil {
 		api.HandleDatabaseError(request, response, err)
 	} else {
 		for _, node := range nodes {
 			if node.Node != nil {
-				member := nodeToAssetGroupMember(validPrimaryKinds, node.Node, excludeProperties)
+				member := nodeToAssetGroupMember(primaryDisplayKinds, node.Node, excludeProperties)
 				member.Source = node.Source
 
 				members = append(members, member)
@@ -1307,12 +1307,12 @@ func (s *Resources) SearchAssetGroupTags(response http.ResponseWriter, request *
 		} else if nodes, err := s.GraphQuery.GetFilteredAndSortedNodesPaginated(query.SortItems{{SortCriteria: query.NodeProperty(common.Name.String()), Direction: query.SortDirectionAscending}}, nodeFilter, 0, AssetGroupTagDefaultLimit); err != nil {
 			api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusInternalServerError, fmt.Sprintf("Error getting members: %v", err), request), response)
 			return
-		} else if validPrimaryKinds, err := s.DB.GetValidDisplayKinds(request.Context()); err != nil {
+		} else if primaryDisplayKinds, err := s.DB.GetValidDisplayKinds(request.Context()); err != nil {
 			api.HandleDatabaseError(request, response, err)
 			return
 		} else {
 			for _, node := range nodes {
-				groupMember := nodeToAssetGroupMember(validPrimaryKinds, node, excludeProperties)
+				groupMember := nodeToAssetGroupMember(primaryDisplayKinds, node, excludeProperties)
 				for _, kind := range node.Kinds {
 					// Find the first valid kind for this search type and attribute it to this member
 					if tagId, ok := tagIdByKind[kind]; ok {
@@ -1443,7 +1443,7 @@ func (s *Resources) GetAssetGroupSelectorMemberCountsByKind(response http.Respon
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusNotFound, "selector is not part of asset group tag", request), response)
 	} else if selector.DisabledAt.Valid {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusConflict, "selector is disabled", request), response)
-	} else if validPrimaryKinds, err := s.DB.GetValidDisplayKinds(request.Context()); err != nil {
+	} else if primaryDisplayKinds, err := s.DB.GetValidDisplayKinds(request.Context()); err != nil {
 		api.HandleDatabaseError(request, response, err)
 	} else {
 		if len(environmentIds) > 0 {
@@ -1465,7 +1465,7 @@ func (s *Resources) GetAssetGroupSelectorMemberCountsByKind(response http.Respon
 				nodeIds = append(nodeIds, node.NodeId)
 			}
 
-			if primaryNodeKindsCounts, err := s.GraphQuery.GetPrimaryNodeKindCounts(request.Context(), validPrimaryKinds, tag.ToKind(),
+			if primaryNodeKindsCounts, err := s.GraphQuery.GetPrimaryNodeKindCounts(request.Context(), primaryDisplayKinds, tag.ToKind(),
 				query.InIDs(query.NodeID(), nodeIds...)); err != nil {
 				api.HandleDatabaseError(request, response, err)
 			} else {

--- a/cmd/api/src/api/v2/assetgrouptags.go
+++ b/cmd/api/src/api/v2/assetgrouptags.go
@@ -767,7 +767,7 @@ func (s *Resources) GetAssetGroupTagMemberCountsByKind(response http.ResponseWri
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusNotFound, api.ErrorResponseDetailsIDMalformed, request), response)
 	} else if tag, err := s.DB.GetAssetGroupTag(request.Context(), tagId); err != nil {
 		api.HandleDatabaseError(request, response, err)
-	} else if primaryDisplayKinds, err := s.DB.GetValidDisplayKinds(request.Context()); err != nil {
+	} else if primaryDisplayKinds, err := s.DB.GetPrimaryDisplayKinds(request.Context()); err != nil {
 		api.HandleDatabaseError(request, response, err)
 	} else {
 		filters := []graph.Criteria{}
@@ -867,7 +867,7 @@ func (s *Resources) GetAssetGroupTagMemberInfo(response http.ResponseWriter, req
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusNotFound, api.ErrorResponseDetailsResourceNotFound, request), response)
 	} else if node, err := queries.Graph.FetchNodeByGraphId(s.GraphQuery, request.Context(), graph.ID(memberID)); err != nil {
 		api.HandleDatabaseError(request, response, err)
-	} else if primaryDisplayKinds, err := s.DB.GetValidDisplayKinds(request.Context()); err != nil {
+	} else if primaryDisplayKinds, err := s.DB.GetPrimaryDisplayKinds(request.Context()); err != nil {
 		api.HandleDatabaseError(request, response, err)
 	} else {
 		groupMember := nodeToAssetGroupMember(primaryDisplayKinds, node, includeProperties)
@@ -936,7 +936,7 @@ func (s *Resources) GetAssetGroupMembersByTag(response http.ResponseWriter, requ
 			api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusInternalServerError, fmt.Sprintf("Error getting members: %v", err), request), response)
 		} else if count, err := s.GraphQuery.CountFilteredNodes(request.Context(), query.And(filters...)); err != nil {
 			api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusInternalServerError, fmt.Sprintf("Error getting member count: %v", err), request), response)
-		} else if primaryDisplayKinds, err := s.DB.GetValidDisplayKinds(request.Context()); err != nil {
+		} else if primaryDisplayKinds, err := s.DB.GetPrimaryDisplayKinds(request.Context()); err != nil {
 			api.HandleDatabaseError(request, response, err)
 		} else {
 			for _, node := range nodes {
@@ -1152,7 +1152,7 @@ func (s *Resources) GetAssetGroupMembersBySelector(response http.ResponseWriter,
 				api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusInternalServerError, fmt.Sprintf("Error getting members: %v", err), request), response)
 			} else if count, err := s.GraphQuery.CountFilteredNodes(request.Context(), query.And(filters...)); err != nil {
 				api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusInternalServerError, fmt.Sprintf("Error getting member count: %v", err), request), response)
-			} else if primaryDisplayKinds, err := s.DB.GetValidDisplayKinds(request.Context()); err != nil {
+			} else if primaryDisplayKinds, err := s.DB.GetPrimaryDisplayKinds(request.Context()); err != nil {
 				api.HandleDatabaseError(request, response, err)
 			} else {
 				for _, node := range nodes {
@@ -1206,7 +1206,7 @@ func (s *Resources) PreviewSelectors(response http.ResponseWriter, request *http
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, err.Error(), request), response)
 	} else if nodes, errs := analysis.FetchNodesFromSeeds(request.Context(), appcfg.GetAGTParameters(request.Context(), s.DB), s.Graph, body.Seeds, expansion, limit); len(errs) > 0 {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusInternalServerError, api.ErrorResponseDetailsInternalServerError, request), response)
-	} else if primaryDisplayKinds, err := s.DB.GetValidDisplayKinds(request.Context()); err != nil {
+	} else if primaryDisplayKinds, err := s.DB.GetPrimaryDisplayKinds(request.Context()); err != nil {
 		api.HandleDatabaseError(request, response, err)
 	} else {
 		for _, node := range nodes {
@@ -1307,7 +1307,7 @@ func (s *Resources) SearchAssetGroupTags(response http.ResponseWriter, request *
 		} else if nodes, err := s.GraphQuery.GetFilteredAndSortedNodesPaginated(query.SortItems{{SortCriteria: query.NodeProperty(common.Name.String()), Direction: query.SortDirectionAscending}}, nodeFilter, 0, AssetGroupTagDefaultLimit); err != nil {
 			api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusInternalServerError, fmt.Sprintf("Error getting members: %v", err), request), response)
 			return
-		} else if primaryDisplayKinds, err := s.DB.GetValidDisplayKinds(request.Context()); err != nil {
+		} else if primaryDisplayKinds, err := s.DB.GetPrimaryDisplayKinds(request.Context()); err != nil {
 			api.HandleDatabaseError(request, response, err)
 			return
 		} else {
@@ -1443,7 +1443,7 @@ func (s *Resources) GetAssetGroupSelectorMemberCountsByKind(response http.Respon
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusNotFound, "selector is not part of asset group tag", request), response)
 	} else if selector.DisabledAt.Valid {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusConflict, "selector is disabled", request), response)
-	} else if primaryDisplayKinds, err := s.DB.GetValidDisplayKinds(request.Context()); err != nil {
+	} else if primaryDisplayKinds, err := s.DB.GetPrimaryDisplayKinds(request.Context()); err != nil {
 		api.HandleDatabaseError(request, response, err)
 	} else {
 		if len(environmentIds) > 0 {

--- a/cmd/api/src/api/v2/assetgrouptags_test.go
+++ b/cmd/api/src/api/v2/assetgrouptags_test.go
@@ -1932,7 +1932,7 @@ func TestResources_GetAssetGroupTagMemberCountsByKind(t *testing.T) {
 					apitest.SetURLVar(input, api.URIPathVariableAssetGroupTagID, "1")
 				},
 				Setup: func() {
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+					mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 					mockDB.EXPECT().
 						GetAssetGroupTag(gomock.Any(), 1).
 						Return(assetGroupTag, nil)
@@ -1945,12 +1945,12 @@ func TestResources_GetAssetGroupTagMemberCountsByKind(t *testing.T) {
 				},
 			},
 			{
-				Name: "GetValidDisplayKindsError",
+				Name: "GetPrimaryDisplayKindsError",
 				Input: func(input *apitest.Input) {
 					apitest.SetURLVar(input, api.URIPathVariableAssetGroupTagID, "1")
 				},
 				Setup: func() {
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any()).Return(nil, errors.New("database error"))
+					mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any()).Return(nil, errors.New("database error"))
 					mockDB.EXPECT().GetAssetGroupTag(gomock.Any(), 1).Return(assetGroupTag, nil)
 				},
 				Test: func(output apitest.Output) {
@@ -1964,7 +1964,7 @@ func TestResources_GetAssetGroupTagMemberCountsByKind(t *testing.T) {
 					apitest.AddQueryParam(input, "environments", "testenv")
 				},
 				Setup: func() {
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+					mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 					mockDB.EXPECT().
 						GetAssetGroupTag(gomock.Any(), 1).
 						Return(assetGroupTag, nil)
@@ -1995,7 +1995,7 @@ func TestResources_GetAssetGroupTagMemberCountsByKind(t *testing.T) {
 					mockDB.EXPECT().
 						GetAssetGroupTag(gomock.Any(), 1).
 						Return(assetGroupTag, nil)
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+					mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 					mockGraphDb.EXPECT().
 						GetPrimaryNodeKindCounts(gomock.Any(), gomock.Any(), assetGroupTag.ToKind(), gomock.Any()).
 						Return(map[string]int{ad.Domain.String(): 2}, nil)
@@ -2081,7 +2081,7 @@ func TestResources_GetAssetGroupTagMemberInfo(t *testing.T) {
 				},
 			},
 			{
-				Name: "DB error - GetValidDisplayKindsError",
+				Name: "DB error - GetPrimaryDisplayKindsError",
 				Input: func(input *apitest.Input) {
 
 					apitest.SetURLVar(input, api.URIPathVariableAssetGroupTagID, "1")
@@ -2093,7 +2093,7 @@ func TestResources_GetAssetGroupTagMemberInfo(t *testing.T) {
 					mockDB.EXPECT().GetAssetGroupTag(gomock.Any(), 1).Return(model.AssetGroupTag{}, nil)
 					mockGraphDb.EXPECT().FetchNodeByGraphId(gomock.Any(), graph.ID(1)).
 						Return(testNode, nil)
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any()).Return(nil, errors.New("database error"))
+					mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any()).Return(nil, errors.New("database error"))
 				},
 				Test: func(output apitest.Output) {
 					apitest.StatusCode(output, http.StatusInternalServerError)
@@ -2147,7 +2147,7 @@ func TestResources_GetAssetGroupTagMemberInfo(t *testing.T) {
 						Return(model.AssetGroupTag{}, nil)
 					mockGraphDb.EXPECT().FetchNodeByGraphId(gomock.Any(), graph.ID(1)).
 						Return(testNode, nil)
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+					mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 				},
 				Test: func(output apitest.Output) {
 					resp := v2.MemberInfoResponse{}
@@ -2171,7 +2171,7 @@ func TestResources_GetAssetGroupTagMemberInfo(t *testing.T) {
 						Return(model.AssetGroupTag{}, nil)
 					mockGraphDb.EXPECT().FetchNodeByGraphId(gomock.Any(), graph.ID(1)).
 						Return(testNode2, nil)
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+					mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 				},
 				Test: func(output apitest.Output) {
 					resp := v2.MemberInfoResponse{}
@@ -2269,7 +2269,7 @@ func Test_GetAssetGroupMembersByTag(t *testing.T) {
 				},
 			},
 			{
-				Name: "Fail with GetValidDisplayKindsError",
+				Name: "Fail with GetPrimaryDisplayKindsError",
 				Input: func(input *apitest.Input) {
 					apitest.SetURLVar(input, api.URIPathVariableAssetGroupTagID, "1")
 				},
@@ -2278,7 +2278,7 @@ func Test_GetAssetGroupMembersByTag(t *testing.T) {
 					mockGraphDb.EXPECT().GetFilteredAndSortedNodesPaginated(gomock.Any(), gomock.Any(), 0, 50).
 						Return([]*graph.Node{}, nil)
 					mockGraphDb.EXPECT().CountFilteredNodes(gomock.Any(), gomock.Any()).Return(int64(0), nil)
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any()).Return(nil, errors.New("database error"))
+					mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any()).Return(nil, errors.New("database error"))
 				},
 				Test: func(output apitest.Output) {
 					apitest.StatusCode(output, http.StatusInternalServerError)
@@ -2308,7 +2308,7 @@ func Test_GetAssetGroupMembersByTag(t *testing.T) {
 					mockGraphDb.EXPECT().
 						CountFilteredNodes(gomock.Any(), nodeFilter).
 						Return(int64(0), nil)
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+					mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 				},
 				Test: func(output apitest.Output) {
 					apitest.StatusCode(output, http.StatusOK)
@@ -2338,7 +2338,7 @@ func Test_GetAssetGroupMembersByTag(t *testing.T) {
 					mockGraphDb.EXPECT().
 						CountFilteredNodes(gomock.Any(), nodeFilter).
 						Return(int64(0), nil)
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+					mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 				},
 				Test: func(output apitest.Output) {
 					apitest.StatusCode(output, http.StatusOK)
@@ -2368,7 +2368,7 @@ func Test_GetAssetGroupMembersByTag(t *testing.T) {
 					mockGraphDb.EXPECT().
 						CountFilteredNodes(gomock.Any(), nodeFilter).
 						Return(int64(0), nil)
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+					mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 				},
 				Test: func(output apitest.Output) {
 					apitest.StatusCode(output, http.StatusOK)
@@ -2400,7 +2400,7 @@ func Test_GetAssetGroupMembersByTag(t *testing.T) {
 					mockGraphDb.EXPECT().
 						CountFilteredNodes(gomock.Any(), nodeFilter).
 						Return(int64(0), nil)
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+					mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 				},
 				Test: func(output apitest.Output) {
 					apitest.StatusCode(output, http.StatusOK)
@@ -2458,7 +2458,7 @@ func Test_GetAssetGroupMembersByTag(t *testing.T) {
 					mockGraphDb.EXPECT().
 						CountFilteredNodes(gomock.Any(), nodeFilter).
 						Return(int64(0), nil)
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+					mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 				},
 				Test: func(output apitest.Output) {
 					apitest.StatusCode(output, http.StatusOK)
@@ -2486,7 +2486,7 @@ func Test_GetAssetGroupMembersByTag(t *testing.T) {
 					mockGraphDb.EXPECT().
 						CountFilteredNodes(gomock.Any(), nodeFilter).
 						Return(int64(0), nil)
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+					mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 				},
 				Test: func(output apitest.Output) {
 					apitest.StatusCode(output, http.StatusOK)
@@ -2514,7 +2514,7 @@ func Test_GetAssetGroupMembersByTag(t *testing.T) {
 					mockGraphDb.EXPECT().
 						CountFilteredNodes(gomock.Any(), nodeFilter).
 						Return(int64(0), nil)
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+					mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 				},
 				Test: func(output apitest.Output) {
 					apitest.StatusCode(output, http.StatusOK)
@@ -2539,7 +2539,7 @@ func Test_GetAssetGroupMembersByTag(t *testing.T) {
 					mockGraphDb.EXPECT().
 						CountFilteredNodes(gomock.Any(), nodeFilter).
 						Return(int64(0), nil)
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+					mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 				},
 				Test: func(output apitest.Output) {
 					apitest.StatusCode(output, http.StatusOK)
@@ -2564,7 +2564,7 @@ func Test_GetAssetGroupMembersByTag(t *testing.T) {
 					mockGraphDb.EXPECT().
 						CountFilteredNodes(gomock.Any(), nodeFilter).
 						Return(int64(0), nil)
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+					mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 				},
 				Test: func(output apitest.Output) {
 					apitest.StatusCode(output, http.StatusOK)
@@ -2603,7 +2603,7 @@ func Test_GetAssetGroupMembersByTag(t *testing.T) {
 					mockGraphDb.EXPECT().
 						CountFilteredNodes(gomock.Any(), nodeFilter).
 						Return(int64(2), nil)
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+					mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 				},
 				Test: func(output apitest.Output) {
 					apitest.StatusCode(output, http.StatusOK)
@@ -2758,13 +2758,13 @@ func Test_GetAssetGroupMembersBySelector(t *testing.T) {
 				},
 			},
 			{
-				Name: "GetValidDisplayKindsError",
+				Name: "GetPrimaryDisplayKindsError",
 				Input: func(input *apitest.Input) {
 					apitest.SetURLVar(input, api.URIPathVariableAssetGroupTagID, "1")
 					apitest.SetURLVar(input, api.URIPathVariableAssetGroupTagSelectorID, "1")
 				},
 				Setup: func() {
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any()).Return(nil, errors.New("database error"))
+					mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any()).Return(nil, errors.New("database error"))
 					mockDB.EXPECT().GetAssetGroupTag(gomock.Any(), 1).Return(assetGroupTag, nil)
 					mockDB.EXPECT().
 						GetAssetGroupTagSelectorBySelectorId(gomock.Any(), 1).
@@ -2796,7 +2796,7 @@ func Test_GetAssetGroupMembersBySelector(t *testing.T) {
 					orderCriteria, err := api.ParseGraphSortParameters(v2.AssetGroupMember{}, params)
 					require.Nil(t, err)
 
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+					mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 					mockDB.EXPECT().
 						GetAssetGroupTag(gomock.Any(), 1).
 						Return(assetGroupTag, nil)
@@ -2830,7 +2830,7 @@ func Test_GetAssetGroupMembersBySelector(t *testing.T) {
 					orderCriteria, err := api.ParseGraphSortParameters(v2.AssetGroupMember{}, params)
 					require.Nil(t, err)
 
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+					mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 					mockDB.EXPECT().
 						GetAssetGroupTag(gomock.Any(), 1).
 						Return(assetGroupTag, nil)
@@ -2864,7 +2864,7 @@ func Test_GetAssetGroupMembersBySelector(t *testing.T) {
 					orderCriteria, err := api.ParseGraphSortParameters(v2.AssetGroupMember{}, params)
 					require.Nil(t, err)
 
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+					mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 					mockDB.EXPECT().
 						GetAssetGroupTag(gomock.Any(), 1).
 						Return(assetGroupTag, nil)
@@ -2893,7 +2893,7 @@ func Test_GetAssetGroupMembersBySelector(t *testing.T) {
 					apitest.AddQueryParam(input, "limit", "5")
 				},
 				Setup: func() {
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+					mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 					mockDB.EXPECT().
 						GetAssetGroupTag(gomock.Any(), 1).
 						Return(assetGroupTag, nil)
@@ -2922,7 +2922,7 @@ func Test_GetAssetGroupMembersBySelector(t *testing.T) {
 					apitest.AddQueryParam(input, "skip", "100")
 				},
 				Setup: func() {
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+					mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 					mockDB.EXPECT().
 						GetAssetGroupTag(gomock.Any(), 1).
 						Return(assetGroupTag, nil)
@@ -2955,7 +2955,7 @@ func Test_GetAssetGroupMembersBySelector(t *testing.T) {
 						query.KindIn(query.Node(), assetGroupTag.ToKind()),
 						query.InIDs(query.NodeID(), graph.ID(1)),
 					)
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+					mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 					mockDB.EXPECT().
 						GetAssetGroupTag(gomock.Any(), 1).
 						Return(assetGroupTag, nil)
@@ -2986,7 +2986,7 @@ func Test_GetAssetGroupMembersBySelector(t *testing.T) {
 					apitest.SetURLVar(input, api.URIPathVariableAssetGroupTagSelectorID, "1")
 				},
 				Setup: func() {
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+					mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 					mockDB.EXPECT().
 						GetAssetGroupTag(gomock.Any(), 1).
 						Return(assetGroupTag, nil)
@@ -3060,7 +3060,7 @@ func Test_GetAssetGroupMembersBySelector(t *testing.T) {
 					apitest.AddQueryParam(input, queryParamTagType, "eq:User")
 				},
 				Setup: func() {
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+					mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 					mockDB.EXPECT().
 						GetAssetGroupTag(gomock.Any(), 1).
 						Return(assetGroupTag, nil)
@@ -3117,7 +3117,7 @@ func Test_GetAssetGroupMembersBySelector(t *testing.T) {
 					apitest.AddQueryParam(input, queryParamTagType, "eq:User")
 				},
 				Setup: func() {
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+					mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 					mockDB.EXPECT().
 						GetAssetGroupTag(gomock.Any(), 1).
 						Return(assetGroupTagWithRequireCertify, nil)
@@ -3259,7 +3259,7 @@ func TestResources_PreviewSelectors(t *testing.T) {
 				},
 			},
 			{
-				Name: "Internal Server Error - GetValidDisplayKindsError",
+				Name: "Internal Server Error - GetPrimaryDisplayKindsError",
 				Input: func(input *apitest.Input) {
 					apitest.SetContext(input, userCtx)
 					apitest.BodyStruct(input, v2.PreviewSelectorBody{
@@ -3274,7 +3274,7 @@ func TestResources_PreviewSelectors(t *testing.T) {
 						Return(queries.PreparedQuery{}, nil).Times(1)
 					mockGraphDb.EXPECT().ReadTransaction(gomock.Any(), gomock.Any()).Times(1)
 					mockDB.EXPECT().GetConfigurationParameter(gomock.Any(), appcfg.AGTParameterKey).Return(appcfg.Parameter{}, nil)
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any()).Return(nil, errors.New("database error"))
+					mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any()).Return(nil, errors.New("database error"))
 				},
 				Test: func(output apitest.Output) {
 					apitest.StatusCode(output, http.StatusInternalServerError)
@@ -3306,7 +3306,7 @@ func TestResources_PreviewSelectors(t *testing.T) {
 					})
 				},
 				Setup: func() {
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+					mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 					mockGraphQuery.EXPECT().
 						PrepareCypherQuery("MATCH (n:User) RETURN n LIMIT 1;", int64(queries.DefaultQueryFitnessLowerBoundSelector)).
 						Return(queries.PreparedQuery{}, nil).Times(1)
@@ -3417,8 +3417,8 @@ func TestResources_SearchAssetGroupTags(t *testing.T) {
 
 		require.Equal(t, http.StatusInternalServerError, response.Code)
 	})
-	t.Run("GetValidDisplayKindsError", func(t *testing.T) {
-		mockDB.EXPECT().GetValidDisplayKinds(gomock.Any()).Return(nil, errors.New("database error"))
+	t.Run("GetPrimaryDisplayKindsError", func(t *testing.T) {
+		mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any()).Return(nil, errors.New("database error"))
 		mockDB.EXPECT().GetAssetGroupTags(gomock.Any(), model.SQLFilter{}).Return(model.AssetGroupTags{}, nil)
 		mockDB.EXPECT().GetAssetGroupTagSelectors(gomock.Any(), gomock.Any(), v2.AssetGroupTagDefaultLimit).
 			Return(model.AssetGroupTagSelectors{{Name: "test selector"}}, nil)
@@ -3445,7 +3445,7 @@ func TestResources_SearchAssetGroupTags(t *testing.T) {
 			),
 			query.KindIn(query.Node(), myKinds...),
 		)
-		mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+		mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 		mockDB.EXPECT().GetAssetGroupTags(gomock.Any(), model.SQLFilter{}).Return(myTags, nil)
 		mockDB.EXPECT().GetAssetGroupTagSelectors(gomock.Any(), model.SQLFilter{
 			SQLString: "name ILIKE ? AND asset_group_tag_id IN ?",
@@ -3519,7 +3519,7 @@ func TestResources_SearchAssetGroupTags(t *testing.T) {
 			query.KindIn(query.Node(), myKinds...),
 		)
 
-		mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+		mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 		mockDB.EXPECT().GetAssetGroupTags(gomock.Any(), model.SQLFilter{}).Return(model.AssetGroupTags{{Name: "test label", Type: model.AssetGroupTagTypeLabel}}, nil)
 		mockDB.EXPECT().GetAssetGroupTagSelectors(gomock.Any(), model.SQLFilter{
 			SQLString: "name ILIKE ? AND asset_group_tag_id IN ?",
@@ -3592,7 +3592,7 @@ func TestResources_SearchAssetGroupTags(t *testing.T) {
 			query.KindIn(query.Node(), myKinds...),
 		)
 
-		mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+		mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 		mockDB.EXPECT().GetAssetGroupTags(gomock.Any(), model.SQLFilter{}).Return(model.AssetGroupTags{{Name: "test owned label", Type: model.AssetGroupTagTypeLabel}, {Name: "owned", Type: model.AssetGroupTagTypeOwned}}, nil)
 		mockDB.EXPECT().GetAssetGroupTagSelectors(gomock.Any(), model.SQLFilter{
 			SQLString: "name ILIKE ? AND asset_group_tag_id IN ?",
@@ -3665,7 +3665,7 @@ func TestResources_SearchAssetGroupTags(t *testing.T) {
 			query.KindIn(query.Node(), myKinds...),
 		)
 
-		mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+		mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 		mockDB.EXPECT().GetAssetGroupTags(gomock.Any(), model.SQLFilter{}).Return(model.AssetGroupTags{{Name: "test tier", Type: model.AssetGroupTagTypeTier}}, nil)
 		mockDB.EXPECT().GetAssetGroupTagSelectors(gomock.Any(), model.SQLFilter{
 			SQLString: "name ILIKE ? AND asset_group_tag_id IN ?",
@@ -3732,7 +3732,7 @@ func TestResources_SearchAssetGroupTags(t *testing.T) {
 			{ID: 2, Name: "Another tier", Type: model.AssetGroupTagTypeTier},
 			{ID: assetGroupTagIdLabel, Name: "test label", Type: model.AssetGroupTagTypeLabel}}
 
-		mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+		mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 		mockDB.EXPECT().GetAssetGroupTags(gomock.Any(), model.SQLFilter{
 			SQLString: "id = ?",
 			Params:    []any{assetGroupTagIdZone},
@@ -3818,7 +3818,7 @@ func TestResources_SearchAssetGroupTags(t *testing.T) {
 			{ID: 2, Name: "Another tier", Type: model.AssetGroupTagTypeTier},
 			{ID: assetGroupTagIdLabel, Name: "test label", Type: model.AssetGroupTagTypeLabel}}
 
-		mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+		mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 		mockDB.EXPECT().GetAssetGroupTags(gomock.Any(), model.SQLFilter{
 			SQLString: "id = ?",
 			Params:    []any{assetGroupTagIdLabel},
@@ -4546,7 +4546,7 @@ func TestResources_GetAssetGroupSelectorMemberCountsByKind(t *testing.T) {
 					mockDB.EXPECT().
 						GetAssetGroupTag(gomock.Any(), 1).
 						Return(assetGroupTag, nil)
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+					mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 					mockDB.EXPECT().
 						GetAssetGroupTagSelectorBySelectorId(gomock.Any(), 1).
 						Return(selector, nil)
@@ -4569,7 +4569,7 @@ func TestResources_GetAssetGroupSelectorMemberCountsByKind(t *testing.T) {
 					mockDB.EXPECT().
 						GetAssetGroupTag(gomock.Any(), 1).
 						Return(assetGroupTag, nil)
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+					mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 					mockDB.EXPECT().
 						GetAssetGroupTagSelectorBySelectorId(gomock.Any(), 1).
 						Return(selector, nil)
@@ -4586,14 +4586,14 @@ func TestResources_GetAssetGroupSelectorMemberCountsByKind(t *testing.T) {
 				},
 			},
 			{
-				Name: "GetValidDisplayKindsError",
+				Name: "GetPrimaryDisplayKindsError",
 				Input: func(input *apitest.Input) {
 					apitest.SetURLVar(input, api.URIPathVariableAssetGroupTagID, "1")
 					apitest.SetURLVar(input, api.URIPathVariableAssetGroupTagSelectorID, "1")
 				},
 				Setup: func() {
 					mockDB.EXPECT().GetAssetGroupTag(gomock.Any(), 1).Return(assetGroupTag, nil)
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any()).Return(nil, errors.New("database error"))
+					mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any()).Return(nil, errors.New("database error"))
 					mockDB.EXPECT().GetAssetGroupTagSelectorBySelectorId(gomock.Any(), 1).Return(selector, nil)
 				},
 				Test: func(output apitest.Output) {
@@ -4612,7 +4612,7 @@ func TestResources_GetAssetGroupSelectorMemberCountsByKind(t *testing.T) {
 					mockDB.EXPECT().
 						GetAssetGroupTag(gomock.Any(), 1).
 						Return(assetGroupTag, nil)
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+					mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 					mockDB.EXPECT().
 						GetAssetGroupTagSelectorBySelectorId(gomock.Any(), 1).
 						Return(selector, nil)
@@ -4644,7 +4644,7 @@ func TestResources_GetAssetGroupSelectorMemberCountsByKind(t *testing.T) {
 					mockDB.EXPECT().
 						GetAssetGroupTag(gomock.Any(), 1).
 						Return(assetGroupTag, nil)
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+					mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 					mockDB.EXPECT().
 						GetAssetGroupTagSelectorBySelectorId(gomock.Any(), 1).
 						Return(selector, nil)

--- a/cmd/api/src/api/v2/azure.go
+++ b/cmd/api/src/api/v2/azure.go
@@ -81,7 +81,7 @@ var (
 func graphRelatedEntityType(request *http.Request, db database.Database, graphDb graph.Database, entityType, objectID string) (any, int, *api.ErrorWrapper) {
 	ctx := request.Context()
 
-	validPrimaryKinds, err := db.GetValidDisplayKinds(request.Context())
+	primaryDisplayKinds, err := db.GetValidDisplayKinds(request.Context())
 	if err != nil {
 		return nil, 0, api.BuildErrorResponse(http.StatusInternalServerError, fmt.Sprintf("error fetching valid primary kinds: %v", err), request)
 	}
@@ -101,102 +101,102 @@ func graphRelatedEntityType(request *http.Request, db database.Database, graphDb
 		if descendents, err := azure.ListEntityDescendentPaths(ctx, graphDb, relatedEntityType, objectID); err != nil {
 			return nil, 0, api.BuildErrorResponse(http.StatusInternalServerError, fmt.Sprintf("error fetching related entity type %s: %v", entityType, err), request)
 		} else {
-			return bloodhoundgraph.PathSetToBloodHoundGraph(validPrimaryKinds, descendents), descendents.Len(), nil
+			return bloodhoundgraph.PathSetToBloodHoundGraph(primaryDisplayKinds, descendents), descendents.Len(), nil
 		}
 
 	case azure.RelatedEntityTypeActiveAssignments:
 		if assignments, err := azure.ListEntityActiveAssignmentPaths(ctx, graphDb, objectID); err != nil {
 			return nil, 0, api.BuildErrorResponse(http.StatusInternalServerError, fmt.Sprintf("error fetching related entity type %s: %v", entityType, err), request)
 		} else {
-			return bloodhoundgraph.PathSetToBloodHoundGraph(validPrimaryKinds, assignments), assignments.Len(), nil
+			return bloodhoundgraph.PathSetToBloodHoundGraph(primaryDisplayKinds, assignments), assignments.Len(), nil
 		}
 
 	case azure.RelatedEntityTypePIMAssignments:
 		if assignments, err := azure.ListEntityPIMAssignmentPaths(ctx, graphDb, objectID); err != nil {
 			return nil, 0, api.BuildErrorResponse(http.StatusInternalServerError, fmt.Sprintf("error fetching related entity type %s: %v", entityType, err), request)
 		} else {
-			return bloodhoundgraph.PathSetToBloodHoundGraph(validPrimaryKinds, assignments), assignments.Len(), nil
+			return bloodhoundgraph.PathSetToBloodHoundGraph(primaryDisplayKinds, assignments), assignments.Len(), nil
 		}
 	case azure.RelatedEntityTypeRoleApprovers:
 		if approvers, err := azure.ListRoleApproverPaths(ctx, graphDb, objectID); err != nil {
 			return nil, 0, api.BuildErrorResponse(http.StatusInternalServerError, fmt.Sprintf("error fetching related entity type %s: %v", entityType, err), request)
 		} else {
-			return bloodhoundgraph.PathSetToBloodHoundGraph(validPrimaryKinds, approvers), approvers.Len(), nil
+			return bloodhoundgraph.PathSetToBloodHoundGraph(primaryDisplayKinds, approvers), approvers.Len(), nil
 		}
 	case azure.RelatedEntityTypeVaultKeyReaders, azure.RelatedEntityTypeVaultSecretReaders, azure.RelatedEntityTypeVaultCertReaders, azure.RelatedEntityTypeVaultAllReaders:
 		if groupMembers, err := azure.ListKeyVaultReaderPaths(ctx, graphDb, relatedEntityType, objectID); err != nil {
 			return nil, 0, api.BuildErrorResponse(http.StatusInternalServerError, fmt.Sprintf("error fetching related entity type %s: %v", entityType, err), request)
 		} else {
-			return bloodhoundgraph.PathSetToBloodHoundGraph(validPrimaryKinds, groupMembers), groupMembers.Len(), nil
+			return bloodhoundgraph.PathSetToBloodHoundGraph(primaryDisplayKinds, groupMembers), groupMembers.Len(), nil
 		}
 
 	case azure.RelatedEntityTypeGroupMembers:
 		if groupMembers, err := azure.ListEntityGroupMemberPaths(ctx, graphDb, objectID); err != nil {
 			return nil, 0, api.BuildErrorResponse(http.StatusInternalServerError, fmt.Sprintf("error fetching related entity type %s: %v", entityType, err), request)
 		} else {
-			return bloodhoundgraph.PathSetToBloodHoundGraph(validPrimaryKinds, groupMembers), groupMembers.Len(), nil
+			return bloodhoundgraph.PathSetToBloodHoundGraph(primaryDisplayKinds, groupMembers), groupMembers.Len(), nil
 		}
 
 	case azure.RelatedEntityTypeGroupMembership:
 		if groupMembership, err := azure.ListEntityGroupMembershipPaths(ctx, graphDb, objectID); err != nil {
 			return nil, 0, api.BuildErrorResponse(http.StatusInternalServerError, fmt.Sprintf("error fetching related entity type %s: %v", entityType, err), request)
 		} else {
-			return bloodhoundgraph.PathSetToBloodHoundGraph(validPrimaryKinds, groupMembership), groupMembership.Len(), nil
+			return bloodhoundgraph.PathSetToBloodHoundGraph(primaryDisplayKinds, groupMembership), groupMembership.Len(), nil
 		}
 
 	case azure.RelatedEntityTypeRoles:
 		if userRoles, err := azure.ListEntityRolePaths(ctx, graphDb, objectID); err != nil {
 			return nil, 0, api.BuildErrorResponse(http.StatusInternalServerError, fmt.Sprintf("error fetching related entity type %s: %v", entityType, err), request)
 		} else {
-			return bloodhoundgraph.PathSetToBloodHoundGraph(validPrimaryKinds, userRoles), userRoles.Len(), nil
+			return bloodhoundgraph.PathSetToBloodHoundGraph(primaryDisplayKinds, userRoles), userRoles.Len(), nil
 		}
 
 	case azure.RelatedEntityTypeOutboundExecutionPrivileges:
 		if executionPrivileges, err := azure.ListEntityExecutionPrivilegePaths(ctx, graphDb, objectID, graph.DirectionOutbound); err != nil {
 			return nil, 0, api.BuildErrorResponse(http.StatusInternalServerError, fmt.Sprintf("error fetching related entity type %s: %v", entityType, err), request)
 		} else {
-			return bloodhoundgraph.PathSetToBloodHoundGraph(validPrimaryKinds, executionPrivileges), executionPrivileges.Len(), nil
+			return bloodhoundgraph.PathSetToBloodHoundGraph(primaryDisplayKinds, executionPrivileges), executionPrivileges.Len(), nil
 		}
 
 	case azure.RelatedEntityTypeInboundExecutionPrivileges:
 		if executionPrivileges, err := azure.ListEntityExecutionPrivilegePaths(ctx, graphDb, objectID, graph.DirectionInbound); err != nil {
 			return nil, 0, api.BuildErrorResponse(http.StatusInternalServerError, fmt.Sprintf("error fetching related entity type %s: %v", entityType, err), request)
 		} else {
-			return bloodhoundgraph.PathSetToBloodHoundGraph(validPrimaryKinds, executionPrivileges), executionPrivileges.Len(), nil
+			return bloodhoundgraph.PathSetToBloodHoundGraph(primaryDisplayKinds, executionPrivileges), executionPrivileges.Len(), nil
 		}
 
 	case azure.RelatedEntityTypeOutboundAbusableAppRoleAssignments:
 		if objectControl, err := azure.ListEntityAbusableAppRoleAssignmentsPaths(ctx, graphDb, objectID, graph.DirectionOutbound); err != nil {
 			return nil, 0, api.BuildErrorResponse(http.StatusInternalServerError, fmt.Sprintf("error fetching related entity type %s: %v", entityType, err), request)
 		} else {
-			return bloodhoundgraph.PathSetToBloodHoundGraph(validPrimaryKinds, objectControl), objectControl.Len(), nil
+			return bloodhoundgraph.PathSetToBloodHoundGraph(primaryDisplayKinds, objectControl), objectControl.Len(), nil
 		}
 
 	case azure.RelatedEntityTypeInboundAbusableAppRoleAssignments:
 		if objectControl, err := azure.ListEntityAbusableAppRoleAssignmentsPaths(ctx, graphDb, objectID, graph.DirectionInbound); err != nil {
 			return nil, 0, api.BuildErrorResponse(http.StatusInternalServerError, fmt.Sprintf("error fetching related entity type %s: %v", entityType, err), request)
 		} else {
-			return bloodhoundgraph.PathSetToBloodHoundGraph(validPrimaryKinds, objectControl), objectControl.Len(), nil
+			return bloodhoundgraph.PathSetToBloodHoundGraph(primaryDisplayKinds, objectControl), objectControl.Len(), nil
 		}
 
 	case azure.RelatedEntityTypeOutboundControl:
 		if objectControl, err := azure.ListEntityObjectControlPaths(ctx, graphDb, objectID, graph.DirectionOutbound); err != nil {
 			return nil, 0, api.BuildErrorResponse(http.StatusInternalServerError, fmt.Sprintf("error fetching related entity type %s: %v", entityType, err), request)
 		} else {
-			return bloodhoundgraph.PathSetToBloodHoundGraph(validPrimaryKinds, objectControl), objectControl.Len(), nil
+			return bloodhoundgraph.PathSetToBloodHoundGraph(primaryDisplayKinds, objectControl), objectControl.Len(), nil
 		}
 
 	case azure.RelatedEntityTypeInboundControl:
 		if objectControl, err := azure.ListEntityObjectControlPaths(ctx, graphDb, objectID, graph.DirectionInbound); err != nil {
 			return nil, 0, api.BuildErrorResponse(http.StatusInternalServerError, fmt.Sprintf("error fetching related entity type %s: %v", entityType, err), request)
 		} else {
-			return bloodhoundgraph.PathSetToBloodHoundGraph(validPrimaryKinds, objectControl), objectControl.Len(), nil
+			return bloodhoundgraph.PathSetToBloodHoundGraph(primaryDisplayKinds, objectControl), objectControl.Len(), nil
 		}
 	case azure.RelatedEntityTypeFederatedIdentityCredentials:
 		if fics, err := azure.ListAppFederatedIdentityCredentialPaths(ctx, graphDb, objectID); err != nil {
 			return nil, 0, api.BuildErrorResponse(http.StatusInternalServerError, fmt.Sprintf("error fetching related entity type %s: %v", entityType, err), request)
 		} else {
-			return bloodhoundgraph.PathSetToBloodHoundGraph(validPrimaryKinds, fics), fics.Len(), nil
+			return bloodhoundgraph.PathSetToBloodHoundGraph(primaryDisplayKinds, fics), fics.Len(), nil
 		}
 
 	default:
@@ -214,7 +214,7 @@ func nodeSetToOrderedSlice(nodeSet graph.NodeSet) []*graph.Node {
 	return nodes
 }
 
-func listRelatedEntityType(ctx context.Context, db graph.Database, validPrimaryKinds graphschema.ValidPrimaryKinds, entityType, objectID string, skip, limit int) ([]azure.Node, int, error) {
+func listRelatedEntityType(ctx context.Context, db graph.Database, primaryDisplayKinds graphschema.PrimaryDisplayKinds, entityType, objectID string, skip, limit int) ([]azure.Node, int, error) {
 	var (
 		nodeSet graph.NodeSet
 		err     error
@@ -317,7 +317,7 @@ func listRelatedEntityType(ctx context.Context, db graph.Database, validPrimaryK
 
 	s := nodeSetToOrderedSlice(nodeSet)[skip : skip+limit]
 
-	return azure.FromGraphNodes(validPrimaryKinds, s), nodeCount, nil
+	return azure.FromGraphNodes(primaryDisplayKinds, s), nodeCount, nil
 }
 
 func (s *Resources) GetAZRelatedEntities(ctx context.Context, response http.ResponseWriter, request *http.Request, objectID string) {
@@ -345,10 +345,10 @@ func (s *Resources) GetAZRelatedEntities(ctx context.Context, response http.Resp
 		} else {
 			api.WriteJSONResponse(ctx, data, http.StatusOK, response)
 		}
-	} else if validPrimaryKinds, err := s.DB.GetValidDisplayKinds(request.Context()); err != nil {
+	} else if primaryDisplayKinds, err := s.DB.GetValidDisplayKinds(request.Context()); err != nil {
 		api.HandleDatabaseError(request, response, err)
 	} else {
-		if nodes, count, err := listRelatedEntityType(ctx, s.Graph, validPrimaryKinds, relatedEntityType, objectID, skip, limit); err != nil {
+		if nodes, count, err := listRelatedEntityType(ctx, s.Graph, primaryDisplayKinds, relatedEntityType, objectID, skip, limit); err != nil {
 			if errors.Is(err, ErrParameterSkip) {
 				api.WriteErrorResponse(ctx, api.BuildErrorResponse(http.StatusBadRequest, fmt.Sprintf(utils.ErrorInvalidSkip, skip), request), response)
 			} else if errors.Is(err, ErrParameterRelatedEntityType) {
@@ -365,54 +365,54 @@ func (s *Resources) GetAZRelatedEntities(ctx context.Context, response http.Resp
 }
 
 func GetAZEntityInformation(ctx context.Context, db database.Database, graphDb graph.Database, entityType, objectID string, hydrateCounts bool) (any, error) {
-	validPrimaryKinds, err := db.GetValidDisplayKinds(ctx)
+	primaryDisplayKinds, err := db.GetValidDisplayKinds(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("error fetching valid primary kinds: %v", err)
 	}
 
 	switch entityType {
 	case entityTypeBase:
-		return azure.BaseEntityDetails(ctx, graphDb, validPrimaryKinds, objectID, hydrateCounts)
+		return azure.BaseEntityDetails(ctx, graphDb, primaryDisplayKinds, objectID, hydrateCounts)
 	case entityTypeUsers:
-		return azure.UserEntityDetails(ctx, graphDb, validPrimaryKinds, objectID, hydrateCounts)
+		return azure.UserEntityDetails(ctx, graphDb, primaryDisplayKinds, objectID, hydrateCounts)
 	case entityTypeGroups:
-		return azure.GroupEntityDetails(ctx, graphDb, validPrimaryKinds, objectID, hydrateCounts)
+		return azure.GroupEntityDetails(ctx, graphDb, primaryDisplayKinds, objectID, hydrateCounts)
 	case entityTypeTenants:
-		return azure.TenantEntityDetails(ctx, graphDb, validPrimaryKinds, objectID, hydrateCounts)
+		return azure.TenantEntityDetails(ctx, graphDb, primaryDisplayKinds, objectID, hydrateCounts)
 	case entityTypeManagementGroups:
-		return azure.ManagementGroupEntityDetails(ctx, graphDb, validPrimaryKinds, objectID, hydrateCounts)
+		return azure.ManagementGroupEntityDetails(ctx, graphDb, primaryDisplayKinds, objectID, hydrateCounts)
 	case entityTypeSubscriptions:
-		return azure.SubscriptionEntityDetails(ctx, graphDb, validPrimaryKinds, objectID, hydrateCounts)
+		return azure.SubscriptionEntityDetails(ctx, graphDb, primaryDisplayKinds, objectID, hydrateCounts)
 	case entityTypeResourceGroups:
-		return azure.ResourceGroupEntityDetails(ctx, graphDb, validPrimaryKinds, objectID, hydrateCounts)
+		return azure.ResourceGroupEntityDetails(ctx, graphDb, primaryDisplayKinds, objectID, hydrateCounts)
 	case entityTypeVMs:
-		return azure.VMEntityDetails(ctx, graphDb, validPrimaryKinds, objectID, hydrateCounts)
+		return azure.VMEntityDetails(ctx, graphDb, primaryDisplayKinds, objectID, hydrateCounts)
 	case entityTypeManagedClusters:
-		return azure.ManagedClusterEntityDetails(ctx, graphDb, validPrimaryKinds, objectID, hydrateCounts)
+		return azure.ManagedClusterEntityDetails(ctx, graphDb, primaryDisplayKinds, objectID, hydrateCounts)
 	case entityTypeContainerRegistries:
-		return azure.ContainerRegistryEntityDetails(ctx, graphDb, validPrimaryKinds, objectID, hydrateCounts)
+		return azure.ContainerRegistryEntityDetails(ctx, graphDb, primaryDisplayKinds, objectID, hydrateCounts)
 	case entityTypeWebApps:
-		return azure.WebAppEntityDetails(ctx, graphDb, validPrimaryKinds, objectID, hydrateCounts)
+		return azure.WebAppEntityDetails(ctx, graphDb, primaryDisplayKinds, objectID, hydrateCounts)
 	case entityTypeLogicApps:
-		return azure.LogicAppEntityDetails(ctx, graphDb, validPrimaryKinds, objectID, hydrateCounts)
+		return azure.LogicAppEntityDetails(ctx, graphDb, primaryDisplayKinds, objectID, hydrateCounts)
 	case entityTypeAutomationAccounts:
-		return azure.AutomationAccountEntityDetails(ctx, graphDb, validPrimaryKinds, objectID, hydrateCounts)
+		return azure.AutomationAccountEntityDetails(ctx, graphDb, primaryDisplayKinds, objectID, hydrateCounts)
 	case entityTypeKeyVaults:
-		return azure.KeyVaultEntityDetails(ctx, graphDb, validPrimaryKinds, objectID, hydrateCounts)
+		return azure.KeyVaultEntityDetails(ctx, graphDb, primaryDisplayKinds, objectID, hydrateCounts)
 	case entityTypeDevices:
-		return azure.DeviceEntityDetails(ctx, graphDb, validPrimaryKinds, objectID, hydrateCounts)
+		return azure.DeviceEntityDetails(ctx, graphDb, primaryDisplayKinds, objectID, hydrateCounts)
 	case entityTypeApplications:
-		return azure.ApplicationEntityDetails(ctx, graphDb, validPrimaryKinds, objectID, hydrateCounts)
+		return azure.ApplicationEntityDetails(ctx, graphDb, primaryDisplayKinds, objectID, hydrateCounts)
 	case entityTypeVMScaleSets:
-		return azure.VMScaleSetEntityDetails(ctx, graphDb, validPrimaryKinds, objectID, hydrateCounts)
+		return azure.VMScaleSetEntityDetails(ctx, graphDb, primaryDisplayKinds, objectID, hydrateCounts)
 	case entityTypeServicePrincipals:
-		return azure.ServicePrincipalEntityDetails(ctx, graphDb, validPrimaryKinds, objectID, hydrateCounts)
+		return azure.ServicePrincipalEntityDetails(ctx, graphDb, primaryDisplayKinds, objectID, hydrateCounts)
 	case entityTypeRoles:
-		return azure.RoleEntityDetails(ctx, graphDb, validPrimaryKinds, objectID, hydrateCounts)
+		return azure.RoleEntityDetails(ctx, graphDb, primaryDisplayKinds, objectID, hydrateCounts)
 	case entityTypeFunctionApps:
-		return azure.FunctionAppEntityDetails(ctx, graphDb, validPrimaryKinds, objectID, hydrateCounts)
+		return azure.FunctionAppEntityDetails(ctx, graphDb, primaryDisplayKinds, objectID, hydrateCounts)
 	case entityTypeFederatedIdentityCredentials:
-		return azure.FederatedIdentityCredentialEntityDetails(ctx, graphDb, validPrimaryKinds, objectID, hydrateCounts)
+		return azure.FederatedIdentityCredentialEntityDetails(ctx, graphDb, primaryDisplayKinds, objectID, hydrateCounts)
 	default:
 		return nil, fmt.Errorf("unknown azure entity %s", entityType)
 	}

--- a/cmd/api/src/api/v2/azure.go
+++ b/cmd/api/src/api/v2/azure.go
@@ -81,12 +81,7 @@ var (
 func graphRelatedEntityType(request *http.Request, db database.Database, graphDb graph.Database, entityType, objectID string) (any, int, *api.ErrorWrapper) {
 	ctx := request.Context()
 
-	customNodeKinds, err := db.GetCustomNodeKindsMap(ctx)
-	if err != nil {
-		slog.Warn("Unable to fetch custom nodes from database; will fall back to defaults")
-	}
-
-	validPrimaryKinds, err := db.GetDisplayGraphSchemaNodeKinds(request.Context())
+	validPrimaryKinds, err := db.GetValidDisplayKinds(request.Context())
 	if err != nil {
 		return nil, 0, api.BuildErrorResponse(http.StatusInternalServerError, fmt.Sprintf("error fetching valid primary kinds: %v", err), request)
 	}
@@ -106,102 +101,102 @@ func graphRelatedEntityType(request *http.Request, db database.Database, graphDb
 		if descendents, err := azure.ListEntityDescendentPaths(ctx, graphDb, relatedEntityType, objectID); err != nil {
 			return nil, 0, api.BuildErrorResponse(http.StatusInternalServerError, fmt.Sprintf("error fetching related entity type %s: %v", entityType, err), request)
 		} else {
-			return bloodhoundgraph.PathSetToBloodHoundGraph(validPrimaryKinds, customNodeKinds, descendents), descendents.Len(), nil
+			return bloodhoundgraph.PathSetToBloodHoundGraph(validPrimaryKinds, descendents), descendents.Len(), nil
 		}
 
 	case azure.RelatedEntityTypeActiveAssignments:
 		if assignments, err := azure.ListEntityActiveAssignmentPaths(ctx, graphDb, objectID); err != nil {
 			return nil, 0, api.BuildErrorResponse(http.StatusInternalServerError, fmt.Sprintf("error fetching related entity type %s: %v", entityType, err), request)
 		} else {
-			return bloodhoundgraph.PathSetToBloodHoundGraph(validPrimaryKinds, customNodeKinds, assignments), assignments.Len(), nil
+			return bloodhoundgraph.PathSetToBloodHoundGraph(validPrimaryKinds, assignments), assignments.Len(), nil
 		}
 
 	case azure.RelatedEntityTypePIMAssignments:
 		if assignments, err := azure.ListEntityPIMAssignmentPaths(ctx, graphDb, objectID); err != nil {
 			return nil, 0, api.BuildErrorResponse(http.StatusInternalServerError, fmt.Sprintf("error fetching related entity type %s: %v", entityType, err), request)
 		} else {
-			return bloodhoundgraph.PathSetToBloodHoundGraph(validPrimaryKinds, customNodeKinds, assignments), assignments.Len(), nil
+			return bloodhoundgraph.PathSetToBloodHoundGraph(validPrimaryKinds, assignments), assignments.Len(), nil
 		}
 	case azure.RelatedEntityTypeRoleApprovers:
 		if approvers, err := azure.ListRoleApproverPaths(ctx, graphDb, objectID); err != nil {
 			return nil, 0, api.BuildErrorResponse(http.StatusInternalServerError, fmt.Sprintf("error fetching related entity type %s: %v", entityType, err), request)
 		} else {
-			return bloodhoundgraph.PathSetToBloodHoundGraph(validPrimaryKinds, customNodeKinds, approvers), approvers.Len(), nil
+			return bloodhoundgraph.PathSetToBloodHoundGraph(validPrimaryKinds, approvers), approvers.Len(), nil
 		}
 	case azure.RelatedEntityTypeVaultKeyReaders, azure.RelatedEntityTypeVaultSecretReaders, azure.RelatedEntityTypeVaultCertReaders, azure.RelatedEntityTypeVaultAllReaders:
 		if groupMembers, err := azure.ListKeyVaultReaderPaths(ctx, graphDb, relatedEntityType, objectID); err != nil {
 			return nil, 0, api.BuildErrorResponse(http.StatusInternalServerError, fmt.Sprintf("error fetching related entity type %s: %v", entityType, err), request)
 		} else {
-			return bloodhoundgraph.PathSetToBloodHoundGraph(validPrimaryKinds, customNodeKinds, groupMembers), groupMembers.Len(), nil
+			return bloodhoundgraph.PathSetToBloodHoundGraph(validPrimaryKinds, groupMembers), groupMembers.Len(), nil
 		}
 
 	case azure.RelatedEntityTypeGroupMembers:
 		if groupMembers, err := azure.ListEntityGroupMemberPaths(ctx, graphDb, objectID); err != nil {
 			return nil, 0, api.BuildErrorResponse(http.StatusInternalServerError, fmt.Sprintf("error fetching related entity type %s: %v", entityType, err), request)
 		} else {
-			return bloodhoundgraph.PathSetToBloodHoundGraph(validPrimaryKinds, customNodeKinds, groupMembers), groupMembers.Len(), nil
+			return bloodhoundgraph.PathSetToBloodHoundGraph(validPrimaryKinds, groupMembers), groupMembers.Len(), nil
 		}
 
 	case azure.RelatedEntityTypeGroupMembership:
 		if groupMembership, err := azure.ListEntityGroupMembershipPaths(ctx, graphDb, objectID); err != nil {
 			return nil, 0, api.BuildErrorResponse(http.StatusInternalServerError, fmt.Sprintf("error fetching related entity type %s: %v", entityType, err), request)
 		} else {
-			return bloodhoundgraph.PathSetToBloodHoundGraph(validPrimaryKinds, customNodeKinds, groupMembership), groupMembership.Len(), nil
+			return bloodhoundgraph.PathSetToBloodHoundGraph(validPrimaryKinds, groupMembership), groupMembership.Len(), nil
 		}
 
 	case azure.RelatedEntityTypeRoles:
 		if userRoles, err := azure.ListEntityRolePaths(ctx, graphDb, objectID); err != nil {
 			return nil, 0, api.BuildErrorResponse(http.StatusInternalServerError, fmt.Sprintf("error fetching related entity type %s: %v", entityType, err), request)
 		} else {
-			return bloodhoundgraph.PathSetToBloodHoundGraph(validPrimaryKinds, customNodeKinds, userRoles), userRoles.Len(), nil
+			return bloodhoundgraph.PathSetToBloodHoundGraph(validPrimaryKinds, userRoles), userRoles.Len(), nil
 		}
 
 	case azure.RelatedEntityTypeOutboundExecutionPrivileges:
 		if executionPrivileges, err := azure.ListEntityExecutionPrivilegePaths(ctx, graphDb, objectID, graph.DirectionOutbound); err != nil {
 			return nil, 0, api.BuildErrorResponse(http.StatusInternalServerError, fmt.Sprintf("error fetching related entity type %s: %v", entityType, err), request)
 		} else {
-			return bloodhoundgraph.PathSetToBloodHoundGraph(validPrimaryKinds, customNodeKinds, executionPrivileges), executionPrivileges.Len(), nil
+			return bloodhoundgraph.PathSetToBloodHoundGraph(validPrimaryKinds, executionPrivileges), executionPrivileges.Len(), nil
 		}
 
 	case azure.RelatedEntityTypeInboundExecutionPrivileges:
 		if executionPrivileges, err := azure.ListEntityExecutionPrivilegePaths(ctx, graphDb, objectID, graph.DirectionInbound); err != nil {
 			return nil, 0, api.BuildErrorResponse(http.StatusInternalServerError, fmt.Sprintf("error fetching related entity type %s: %v", entityType, err), request)
 		} else {
-			return bloodhoundgraph.PathSetToBloodHoundGraph(validPrimaryKinds, customNodeKinds, executionPrivileges), executionPrivileges.Len(), nil
+			return bloodhoundgraph.PathSetToBloodHoundGraph(validPrimaryKinds, executionPrivileges), executionPrivileges.Len(), nil
 		}
 
 	case azure.RelatedEntityTypeOutboundAbusableAppRoleAssignments:
 		if objectControl, err := azure.ListEntityAbusableAppRoleAssignmentsPaths(ctx, graphDb, objectID, graph.DirectionOutbound); err != nil {
 			return nil, 0, api.BuildErrorResponse(http.StatusInternalServerError, fmt.Sprintf("error fetching related entity type %s: %v", entityType, err), request)
 		} else {
-			return bloodhoundgraph.PathSetToBloodHoundGraph(validPrimaryKinds, customNodeKinds, objectControl), objectControl.Len(), nil
+			return bloodhoundgraph.PathSetToBloodHoundGraph(validPrimaryKinds, objectControl), objectControl.Len(), nil
 		}
 
 	case azure.RelatedEntityTypeInboundAbusableAppRoleAssignments:
 		if objectControl, err := azure.ListEntityAbusableAppRoleAssignmentsPaths(ctx, graphDb, objectID, graph.DirectionInbound); err != nil {
 			return nil, 0, api.BuildErrorResponse(http.StatusInternalServerError, fmt.Sprintf("error fetching related entity type %s: %v", entityType, err), request)
 		} else {
-			return bloodhoundgraph.PathSetToBloodHoundGraph(validPrimaryKinds, customNodeKinds, objectControl), objectControl.Len(), nil
+			return bloodhoundgraph.PathSetToBloodHoundGraph(validPrimaryKinds, objectControl), objectControl.Len(), nil
 		}
 
 	case azure.RelatedEntityTypeOutboundControl:
 		if objectControl, err := azure.ListEntityObjectControlPaths(ctx, graphDb, objectID, graph.DirectionOutbound); err != nil {
 			return nil, 0, api.BuildErrorResponse(http.StatusInternalServerError, fmt.Sprintf("error fetching related entity type %s: %v", entityType, err), request)
 		} else {
-			return bloodhoundgraph.PathSetToBloodHoundGraph(validPrimaryKinds, customNodeKinds, objectControl), objectControl.Len(), nil
+			return bloodhoundgraph.PathSetToBloodHoundGraph(validPrimaryKinds, objectControl), objectControl.Len(), nil
 		}
 
 	case azure.RelatedEntityTypeInboundControl:
 		if objectControl, err := azure.ListEntityObjectControlPaths(ctx, graphDb, objectID, graph.DirectionInbound); err != nil {
 			return nil, 0, api.BuildErrorResponse(http.StatusInternalServerError, fmt.Sprintf("error fetching related entity type %s: %v", entityType, err), request)
 		} else {
-			return bloodhoundgraph.PathSetToBloodHoundGraph(validPrimaryKinds, customNodeKinds, objectControl), objectControl.Len(), nil
+			return bloodhoundgraph.PathSetToBloodHoundGraph(validPrimaryKinds, objectControl), objectControl.Len(), nil
 		}
 	case azure.RelatedEntityTypeFederatedIdentityCredentials:
 		if fics, err := azure.ListAppFederatedIdentityCredentialPaths(ctx, graphDb, objectID); err != nil {
 			return nil, 0, api.BuildErrorResponse(http.StatusInternalServerError, fmt.Sprintf("error fetching related entity type %s: %v", entityType, err), request)
 		} else {
-			return bloodhoundgraph.PathSetToBloodHoundGraph(validPrimaryKinds, customNodeKinds, fics), fics.Len(), nil
+			return bloodhoundgraph.PathSetToBloodHoundGraph(validPrimaryKinds, fics), fics.Len(), nil
 		}
 
 	default:

--- a/cmd/api/src/api/v2/azure.go
+++ b/cmd/api/src/api/v2/azure.go
@@ -81,7 +81,7 @@ var (
 func graphRelatedEntityType(request *http.Request, db database.Database, graphDb graph.Database, entityType, objectID string) (any, int, *api.ErrorWrapper) {
 	ctx := request.Context()
 
-	primaryDisplayKinds, err := db.GetValidDisplayKinds(request.Context())
+	primaryDisplayKinds, err := db.GetPrimaryDisplayKinds(request.Context())
 	if err != nil {
 		return nil, 0, api.BuildErrorResponse(http.StatusInternalServerError, fmt.Sprintf("error fetching valid primary kinds: %v", err), request)
 	}
@@ -345,7 +345,7 @@ func (s *Resources) GetAZRelatedEntities(ctx context.Context, response http.Resp
 		} else {
 			api.WriteJSONResponse(ctx, data, http.StatusOK, response)
 		}
-	} else if primaryDisplayKinds, err := s.DB.GetValidDisplayKinds(request.Context()); err != nil {
+	} else if primaryDisplayKinds, err := s.DB.GetPrimaryDisplayKinds(request.Context()); err != nil {
 		api.HandleDatabaseError(request, response, err)
 	} else {
 		if nodes, count, err := listRelatedEntityType(ctx, s.Graph, primaryDisplayKinds, relatedEntityType, objectID, skip, limit); err != nil {
@@ -365,7 +365,7 @@ func (s *Resources) GetAZRelatedEntities(ctx context.Context, response http.Resp
 }
 
 func GetAZEntityInformation(ctx context.Context, db database.Database, graphDb graph.Database, entityType, objectID string, hydrateCounts bool) (any, error) {
-	primaryDisplayKinds, err := db.GetValidDisplayKinds(ctx)
+	primaryDisplayKinds, err := db.GetPrimaryDisplayKinds(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("error fetching valid primary kinds: %v", err)
 	}

--- a/cmd/api/src/api/v2/azure.go
+++ b/cmd/api/src/api/v2/azure.go
@@ -83,7 +83,7 @@ func graphRelatedEntityType(request *http.Request, db database.Database, graphDb
 
 	primaryDisplayKinds, err := db.GetPrimaryDisplayKinds(request.Context())
 	if err != nil {
-		return nil, 0, api.BuildErrorResponse(http.StatusInternalServerError, fmt.Sprintf("error fetching valid primary kinds: %v", err), request)
+		return nil, 0, api.BuildErrorResponse(http.StatusInternalServerError, fmt.Sprintf("error fetching primary display kinds: %v", err), request)
 	}
 
 	switch relatedEntityType := azure.RelatedEntityType(entityType); relatedEntityType {
@@ -367,7 +367,7 @@ func (s *Resources) GetAZRelatedEntities(ctx context.Context, response http.Resp
 func GetAZEntityInformation(ctx context.Context, db database.Database, graphDb graph.Database, entityType, objectID string, hydrateCounts bool) (any, error) {
 	primaryDisplayKinds, err := db.GetPrimaryDisplayKinds(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("error fetching valid primary kinds: %v", err)
+		return nil, fmt.Errorf("error fetching primary display kinds: %v", err)
 	}
 
 	switch entityType {

--- a/cmd/api/src/api/v2/azure_test.go
+++ b/cmd/api/src/api/v2/azure_test.go
@@ -180,7 +180,7 @@ func TestResources_GetAZRelatedEntities(t *testing.T) {
 			},
 			expected: expected{
 				responseCode:   http.StatusInternalServerError,
-				responseBody:   `{"errors":[{"context":"","message":"error fetching valid primary kinds: database error"}],"http_status":500,"request_id":"","timestamp":"0001-01-01T00:00:00Z"}`,
+				responseBody:   `{"errors":[{"context":"","message":"error fetching primary display kinds: database error"}],"http_status":500,"request_id":"","timestamp":"0001-01-01T00:00:00Z"}`,
 				responseHeader: http.Header{"Content-Type": []string{"application/json"}},
 			},
 		},
@@ -1145,7 +1145,7 @@ func TestResources_GetAZEntityInformation(t *testing.T) {
 			},
 			want: want{
 				res: nil,
-				err: errors.New("error fetching valid primary kinds: database error"),
+				err: errors.New("error fetching primary display kinds: database error"),
 			},
 		},
 	}
@@ -1310,7 +1310,7 @@ func TestManagementResource_GetAZEntity(t *testing.T) {
 			},
 			expected: expected{
 				responseCode:   http.StatusInternalServerError,
-				responseBody:   `{"errors":[{"context":"","message":"db error: error fetching valid primary kinds: database error"}],"http_status":500,"request_id":"","timestamp":"0001-01-01T00:00:00Z"}`,
+				responseBody:   `{"errors":[{"context":"","message":"db error: error fetching primary display kinds: database error"}],"http_status":500,"request_id":"","timestamp":"0001-01-01T00:00:00Z"}`,
 				responseHeader: http.Header{"Content-Type": []string{"application/json"}},
 			},
 		},

--- a/cmd/api/src/api/v2/azure_test.go
+++ b/cmd/api/src/api/v2/azure_test.go
@@ -154,7 +154,7 @@ func TestResources_GetAZRelatedEntities(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mocks *mock) {
 				t.Helper()
-				mocks.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any())
+				mocks.mockDatabase.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 				mocks.mockGraphDB.EXPECT().ReadTransaction(gomock.Any(), gomock.Any()).Return(v2.ErrParameterSkip)
 			},
 			expected: expected{
@@ -164,7 +164,7 @@ func TestResources_GetAZRelatedEntities(t *testing.T) {
 			},
 		},
 		{
-			name: "Error: GetValidDisplayKindsError",
+			name: "Error: GetPrimaryDisplayKindsError",
 			buildRequest: func() *http.Request {
 				return &http.Request{
 					URL: &url.URL{
@@ -176,7 +176,7 @@ func TestResources_GetAZRelatedEntities(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mocks *mock) {
 				t.Helper()
-				mocks.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any()).Return(nil, errors.New("database error"))
+				mocks.mockDatabase.EXPECT().GetPrimaryDisplayKinds(gomock.Any()).Return(nil, errors.New("database error"))
 			},
 			expected: expected{
 				responseCode:   http.StatusInternalServerError,
@@ -197,7 +197,7 @@ func TestResources_GetAZRelatedEntities(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mocks *mock) {
 				t.Helper()
-				mocks.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any())
+				mocks.mockDatabase.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 				mocks.mockGraphDB.EXPECT().ReadTransaction(gomock.Any(), gomock.Any()).Return(nil)
 			},
 			expected: expected{
@@ -219,7 +219,7 @@ func TestResources_GetAZRelatedEntities(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mocks *mock) {
 				t.Helper()
-				mocks.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any())
+				mocks.mockDatabase.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 				mocks.mockGraphDB.EXPECT().ReadTransaction(gomock.Any(), gomock.Any()).Return(v2.ErrParameterSkip)
 			},
 			expected: expected{
@@ -241,7 +241,7 @@ func TestResources_GetAZRelatedEntities(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mocks *mock) {
 				t.Helper()
-				mocks.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any())
+				mocks.mockDatabase.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 				mocks.mockGraphDB.EXPECT().ReadTransaction(gomock.Any(), gomock.Any()).Return(v2.ErrParameterRelatedEntityType)
 			},
 			expected: expected{
@@ -263,7 +263,7 @@ func TestResources_GetAZRelatedEntities(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mocks *mock) {
 				t.Helper()
-				mocks.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any())
+				mocks.mockDatabase.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 				mocks.mockGraphDB.EXPECT().ReadTransaction(gomock.Any(), gomock.Any()).Return(ops.ErrGraphQueryMemoryLimit)
 			},
 			expected: expected{
@@ -285,7 +285,7 @@ func TestResources_GetAZRelatedEntities(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mocks *mock) {
 				t.Helper()
-				mocks.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any())
+				mocks.mockDatabase.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 				mocks.mockGraphDB.EXPECT().ReadTransaction(gomock.Any(), gomock.Any()).Return(errors.New("error"))
 			},
 			expected: expected{
@@ -295,7 +295,7 @@ func TestResources_GetAZRelatedEntities(t *testing.T) {
 			},
 		},
 		{
-			name: "Error: GetValidDisplayKindsError",
+			name: "Error: GetPrimaryDisplayKindsError",
 			buildRequest: func() *http.Request {
 				return &http.Request{
 					URL: &url.URL{
@@ -307,7 +307,7 @@ func TestResources_GetAZRelatedEntities(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mocks *mock) {
 				t.Helper()
-				mocks.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any()).Return(nil, errors.New("database error"))
+				mocks.mockDatabase.EXPECT().GetPrimaryDisplayKinds(gomock.Any()).Return(nil, errors.New("database error"))
 			},
 			expected: expected{
 				responseCode:   http.StatusInternalServerError,
@@ -328,7 +328,7 @@ func TestResources_GetAZRelatedEntities(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mocks *mock) {
 				t.Helper()
-				mocks.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any())
+				mocks.mockDatabase.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 				mocks.mockGraphDB.EXPECT().ReadTransaction(gomock.Any(), gomock.Any()).Return(nil)
 			},
 			expected: expected{
@@ -350,7 +350,7 @@ func TestResources_GetAZRelatedEntities(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mock *mock) {
 				t.Helper()
-				mock.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any())
+				mock.mockDatabase.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 				mock.mockGraphDB.EXPECT().ReadTransaction(gomock.Any(), gomock.Any()).Return(nil)
 			},
 			expected: expected{
@@ -381,7 +381,7 @@ func TestResources_GetAZRelatedEntities(t *testing.T) {
 			setupMocks: func(t *testing.T, mock *mock) {
 				t.Helper()
 				mock.mockGraphDB.EXPECT().ReadTransaction(gomock.Any(), gomock.Any()).Return(nil)
-				mock.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any())
+				mock.mockDatabase.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 				props := graph.AsProperties(map[string]any{
 					"tenantid": "12345",
 				})
@@ -527,7 +527,7 @@ func TestResources_GetAZEntityInformation(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mocks *mock) {
 				t.Helper()
-				mocks.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any())
+				mocks.mockDatabase.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 				mocks.mockGraphDB.EXPECT().ReadTransaction(gomock.Any(), gomock.Any()).Return(errors.New("error"))
 			},
 			want: want{
@@ -542,7 +542,7 @@ func TestResources_GetAZEntityInformation(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mocks *mock) {
 				t.Helper()
-				mocks.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any())
+				mocks.mockDatabase.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 				mocks.mockGraphDB.EXPECT().ReadTransaction(gomock.Any(), gomock.Any()).Return(nil)
 			},
 			want: want{
@@ -557,7 +557,7 @@ func TestResources_GetAZEntityInformation(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mocks *mock) {
 				t.Helper()
-				mocks.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any())
+				mocks.mockDatabase.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 				mocks.mockGraphDB.EXPECT().ReadTransaction(gomock.Any(), gomock.Any()).Return(errors.New("error"))
 			},
 			want: want{
@@ -572,7 +572,7 @@ func TestResources_GetAZEntityInformation(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mocks *mock) {
 				t.Helper()
-				mocks.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any())
+				mocks.mockDatabase.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 				mocks.mockGraphDB.EXPECT().ReadTransaction(gomock.Any(), gomock.Any()).Return(nil)
 			},
 			want: want{
@@ -587,7 +587,7 @@ func TestResources_GetAZEntityInformation(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mocks *mock) {
 				t.Helper()
-				mocks.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any())
+				mocks.mockDatabase.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 				mocks.mockGraphDB.EXPECT().ReadTransaction(gomock.Any(), gomock.Any()).Return(errors.New("error"))
 			},
 			want: want{
@@ -602,7 +602,7 @@ func TestResources_GetAZEntityInformation(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mocks *mock) {
 				t.Helper()
-				mocks.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any())
+				mocks.mockDatabase.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 				mocks.mockGraphDB.EXPECT().ReadTransaction(gomock.Any(), gomock.Any()).Return(nil)
 			},
 			want: want{
@@ -617,7 +617,7 @@ func TestResources_GetAZEntityInformation(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mocks *mock) {
 				t.Helper()
-				mocks.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any())
+				mocks.mockDatabase.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 				mocks.mockGraphDB.EXPECT().ReadTransaction(gomock.Any(), gomock.Any()).Return(errors.New("error"))
 			},
 			want: want{
@@ -632,7 +632,7 @@ func TestResources_GetAZEntityInformation(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mocks *mock) {
 				t.Helper()
-				mocks.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any())
+				mocks.mockDatabase.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 				mocks.mockGraphDB.EXPECT().ReadTransaction(gomock.Any(), gomock.Any()).Return(nil)
 			},
 			want: want{
@@ -647,7 +647,7 @@ func TestResources_GetAZEntityInformation(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mocks *mock) {
 				t.Helper()
-				mocks.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any())
+				mocks.mockDatabase.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 				mocks.mockGraphDB.EXPECT().ReadTransaction(gomock.Any(), gomock.Any()).Return(errors.New("error"))
 			},
 			want: want{
@@ -662,7 +662,7 @@ func TestResources_GetAZEntityInformation(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mocks *mock) {
 				t.Helper()
-				mocks.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any())
+				mocks.mockDatabase.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 				mocks.mockGraphDB.EXPECT().ReadTransaction(gomock.Any(), gomock.Any()).Return(nil)
 			},
 			want: want{
@@ -677,7 +677,7 @@ func TestResources_GetAZEntityInformation(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mocks *mock) {
 				t.Helper()
-				mocks.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any())
+				mocks.mockDatabase.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 				mocks.mockGraphDB.EXPECT().ReadTransaction(gomock.Any(), gomock.Any()).Return(errors.New("error"))
 			},
 			want: want{
@@ -692,7 +692,7 @@ func TestResources_GetAZEntityInformation(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mocks *mock) {
 				t.Helper()
-				mocks.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any())
+				mocks.mockDatabase.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 				mocks.mockGraphDB.EXPECT().ReadTransaction(gomock.Any(), gomock.Any()).Return(nil)
 			},
 			want: want{
@@ -707,7 +707,7 @@ func TestResources_GetAZEntityInformation(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mocks *mock) {
 				t.Helper()
-				mocks.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any())
+				mocks.mockDatabase.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 				mocks.mockGraphDB.EXPECT().ReadTransaction(gomock.Any(), gomock.Any()).Return(errors.New("error"))
 			},
 			want: want{
@@ -722,7 +722,7 @@ func TestResources_GetAZEntityInformation(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mocks *mock) {
 				t.Helper()
-				mocks.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any())
+				mocks.mockDatabase.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 				mocks.mockGraphDB.EXPECT().ReadTransaction(gomock.Any(), gomock.Any()).Return(nil)
 			},
 			want: want{
@@ -737,7 +737,7 @@ func TestResources_GetAZEntityInformation(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mocks *mock) {
 				t.Helper()
-				mocks.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any())
+				mocks.mockDatabase.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 				mocks.mockGraphDB.EXPECT().ReadTransaction(gomock.Any(), gomock.Any()).Return(errors.New("error"))
 			},
 			want: want{
@@ -752,7 +752,7 @@ func TestResources_GetAZEntityInformation(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mocks *mock) {
 				t.Helper()
-				mocks.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any())
+				mocks.mockDatabase.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 				mocks.mockGraphDB.EXPECT().ReadTransaction(gomock.Any(), gomock.Any()).Return(nil)
 			},
 			want: want{
@@ -767,7 +767,7 @@ func TestResources_GetAZEntityInformation(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mocks *mock) {
 				t.Helper()
-				mocks.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any())
+				mocks.mockDatabase.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 				mocks.mockGraphDB.EXPECT().ReadTransaction(gomock.Any(), gomock.Any()).Return(errors.New("error"))
 			},
 			want: want{
@@ -782,7 +782,7 @@ func TestResources_GetAZEntityInformation(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mocks *mock) {
 				t.Helper()
-				mocks.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any())
+				mocks.mockDatabase.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 				mocks.mockGraphDB.EXPECT().ReadTransaction(gomock.Any(), gomock.Any()).Return(nil)
 			},
 			want: want{
@@ -797,7 +797,7 @@ func TestResources_GetAZEntityInformation(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mocks *mock) {
 				t.Helper()
-				mocks.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any())
+				mocks.mockDatabase.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 				mocks.mockGraphDB.EXPECT().ReadTransaction(gomock.Any(), gomock.Any()).Return(errors.New("error"))
 			},
 			want: want{
@@ -812,7 +812,7 @@ func TestResources_GetAZEntityInformation(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mocks *mock) {
 				t.Helper()
-				mocks.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any())
+				mocks.mockDatabase.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 				mocks.mockGraphDB.EXPECT().ReadTransaction(gomock.Any(), gomock.Any()).Return(nil)
 			},
 			want: want{
@@ -827,7 +827,7 @@ func TestResources_GetAZEntityInformation(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mocks *mock) {
 				t.Helper()
-				mocks.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any())
+				mocks.mockDatabase.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 				mocks.mockGraphDB.EXPECT().ReadTransaction(gomock.Any(), gomock.Any()).Return(errors.New("error"))
 			},
 			want: want{
@@ -842,7 +842,7 @@ func TestResources_GetAZEntityInformation(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mocks *mock) {
 				t.Helper()
-				mocks.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any())
+				mocks.mockDatabase.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 				mocks.mockGraphDB.EXPECT().ReadTransaction(gomock.Any(), gomock.Any()).Return(nil)
 			},
 			want: want{
@@ -857,7 +857,7 @@ func TestResources_GetAZEntityInformation(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mocks *mock) {
 				t.Helper()
-				mocks.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any())
+				mocks.mockDatabase.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 				mocks.mockGraphDB.EXPECT().ReadTransaction(gomock.Any(), gomock.Any()).Return(errors.New("error"))
 			},
 			want: want{
@@ -872,7 +872,7 @@ func TestResources_GetAZEntityInformation(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mocks *mock) {
 				t.Helper()
-				mocks.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any())
+				mocks.mockDatabase.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 				mocks.mockGraphDB.EXPECT().ReadTransaction(gomock.Any(), gomock.Any()).Return(nil)
 			},
 			want: want{
@@ -887,7 +887,7 @@ func TestResources_GetAZEntityInformation(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mocks *mock) {
 				t.Helper()
-				mocks.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any())
+				mocks.mockDatabase.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 				mocks.mockGraphDB.EXPECT().ReadTransaction(gomock.Any(), gomock.Any()).Return(errors.New("error"))
 			},
 			want: want{
@@ -902,7 +902,7 @@ func TestResources_GetAZEntityInformation(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mocks *mock) {
 				t.Helper()
-				mocks.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any())
+				mocks.mockDatabase.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 				mocks.mockGraphDB.EXPECT().ReadTransaction(gomock.Any(), gomock.Any()).Return(nil)
 			},
 			want: want{
@@ -917,7 +917,7 @@ func TestResources_GetAZEntityInformation(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mocks *mock) {
 				t.Helper()
-				mocks.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any())
+				mocks.mockDatabase.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 				mocks.mockGraphDB.EXPECT().ReadTransaction(gomock.Any(), gomock.Any()).Return(errors.New("error"))
 			},
 			want: want{
@@ -932,7 +932,7 @@ func TestResources_GetAZEntityInformation(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mocks *mock) {
 				t.Helper()
-				mocks.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any())
+				mocks.mockDatabase.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 				mocks.mockGraphDB.EXPECT().ReadTransaction(gomock.Any(), gomock.Any()).Return(nil)
 			},
 			want: want{
@@ -947,7 +947,7 @@ func TestResources_GetAZEntityInformation(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mocks *mock) {
 				t.Helper()
-				mocks.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any())
+				mocks.mockDatabase.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 				mocks.mockGraphDB.EXPECT().ReadTransaction(gomock.Any(), gomock.Any()).Return(errors.New("error"))
 			},
 			want: want{
@@ -962,7 +962,7 @@ func TestResources_GetAZEntityInformation(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mocks *mock) {
 				t.Helper()
-				mocks.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any())
+				mocks.mockDatabase.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 				mocks.mockGraphDB.EXPECT().ReadTransaction(gomock.Any(), gomock.Any()).Return(nil)
 			},
 			want: want{
@@ -977,7 +977,7 @@ func TestResources_GetAZEntityInformation(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mocks *mock) {
 				t.Helper()
-				mocks.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any())
+				mocks.mockDatabase.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 				mocks.mockGraphDB.EXPECT().ReadTransaction(gomock.Any(), gomock.Any()).Return(errors.New("error"))
 			},
 			want: want{
@@ -992,7 +992,7 @@ func TestResources_GetAZEntityInformation(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mocks *mock) {
 				t.Helper()
-				mocks.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any())
+				mocks.mockDatabase.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 				mocks.mockGraphDB.EXPECT().ReadTransaction(gomock.Any(), gomock.Any()).Return(nil)
 			},
 			want: want{
@@ -1007,7 +1007,7 @@ func TestResources_GetAZEntityInformation(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mocks *mock) {
 				t.Helper()
-				mocks.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any())
+				mocks.mockDatabase.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 				mocks.mockGraphDB.EXPECT().ReadTransaction(gomock.Any(), gomock.Any()).Return(errors.New("error"))
 			},
 			want: want{
@@ -1022,7 +1022,7 @@ func TestResources_GetAZEntityInformation(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mocks *mock) {
 				t.Helper()
-				mocks.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any())
+				mocks.mockDatabase.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 				mocks.mockGraphDB.EXPECT().ReadTransaction(gomock.Any(), gomock.Any()).Return(nil)
 			},
 			want: want{
@@ -1037,7 +1037,7 @@ func TestResources_GetAZEntityInformation(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mocks *mock) {
 				t.Helper()
-				mocks.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any())
+				mocks.mockDatabase.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 				mocks.mockGraphDB.EXPECT().ReadTransaction(gomock.Any(), gomock.Any()).Return(errors.New("error"))
 			},
 			want: want{
@@ -1052,7 +1052,7 @@ func TestResources_GetAZEntityInformation(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mocks *mock) {
 				t.Helper()
-				mocks.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any())
+				mocks.mockDatabase.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 				mocks.mockGraphDB.EXPECT().ReadTransaction(gomock.Any(), gomock.Any()).Return(nil)
 			},
 			want: want{
@@ -1067,7 +1067,7 @@ func TestResources_GetAZEntityInformation(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mocks *mock) {
 				t.Helper()
-				mocks.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any())
+				mocks.mockDatabase.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 				mocks.mockGraphDB.EXPECT().ReadTransaction(gomock.Any(), gomock.Any()).Return(errors.New("error"))
 			},
 			want: want{
@@ -1082,7 +1082,7 @@ func TestResources_GetAZEntityInformation(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mocks *mock) {
 				t.Helper()
-				mocks.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any())
+				mocks.mockDatabase.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 				mocks.mockGraphDB.EXPECT().ReadTransaction(gomock.Any(), gomock.Any()).Return(nil)
 			},
 			want: want{
@@ -1097,7 +1097,7 @@ func TestResources_GetAZEntityInformation(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mocks *mock) {
 				t.Helper()
-				mocks.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any())
+				mocks.mockDatabase.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 				mocks.mockGraphDB.EXPECT().ReadTransaction(gomock.Any(), gomock.Any()).Return(errors.New("error"))
 			},
 			want: want{
@@ -1112,7 +1112,7 @@ func TestResources_GetAZEntityInformation(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mocks *mock) {
 				t.Helper()
-				mocks.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any())
+				mocks.mockDatabase.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 				mocks.mockGraphDB.EXPECT().ReadTransaction(gomock.Any(), gomock.Any()).Return(nil)
 			},
 			want: want{
@@ -1127,7 +1127,7 @@ func TestResources_GetAZEntityInformation(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mocks *mock) {
 				t.Helper()
-				mocks.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any())
+				mocks.mockDatabase.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 			},
 			want: want{
 				res: nil,
@@ -1135,13 +1135,13 @@ func TestResources_GetAZEntityInformation(t *testing.T) {
 			},
 		},
 		{
-			name: "Error: GetValidDisplayKindsError",
+			name: "Error: GetPrimaryDisplayKindsError",
 			args: args{
 				entityType: "base",
 			},
 			setupMocks: func(t *testing.T, mocks *mock) {
 				t.Helper()
-				mocks.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any()).Return(nil, errors.New("database error"))
+				mocks.mockDatabase.EXPECT().GetPrimaryDisplayKinds(gomock.Any()).Return(nil, errors.New("database error"))
 			},
 			want: want{
 				res: nil,
@@ -1227,7 +1227,7 @@ func TestManagementResource_GetAZEntity(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mock *mock) {
 				t.Helper()
-				mock.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any())
+				mock.mockDatabase.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 			},
 			expected: expected{
 				responseCode:   http.StatusNotFound,
@@ -1266,7 +1266,7 @@ func TestManagementResource_GetAZEntity(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mock *mock) {
 				t.Helper()
-				mock.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any())
+				mock.mockDatabase.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 				mock.mockGraphDB.EXPECT().ReadTransaction(gomock.Any(), gomock.Any()).Return(graph.ErrNoResultsFound)
 			},
 			expected: expected{
@@ -1294,7 +1294,7 @@ func TestManagementResource_GetAZEntity(t *testing.T) {
 			},
 		},
 		{
-			name: "Error: GetValidDisplayKindsError",
+			name: "Error: GetPrimaryDisplayKindsError",
 			buildRequest: func() *http.Request {
 				return &http.Request{
 					URL: &url.URL{
@@ -1306,7 +1306,7 @@ func TestManagementResource_GetAZEntity(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mock *mock) {
 				t.Helper()
-				mock.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any()).Return(nil, errors.New("database error"))
+				mock.mockDatabase.EXPECT().GetPrimaryDisplayKinds(gomock.Any()).Return(nil, errors.New("database error"))
 			},
 			expected: expected{
 				responseCode:   http.StatusInternalServerError,
@@ -1327,7 +1327,7 @@ func TestManagementResource_GetAZEntity(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mock *mock) {
 				t.Helper()
-				mock.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any())
+				mock.mockDatabase.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 				mock.mockGraphDB.EXPECT().ReadTransaction(gomock.Any(), gomock.Any()).Return(nil)
 			},
 			expected: expected{
@@ -1349,7 +1349,7 @@ func TestManagementResource_GetAZEntity(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mock *mock) {
 				t.Helper()
-				mock.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any())
+				mock.mockDatabase.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 				mock.mockGraphDB.EXPECT().ReadTransaction(gomock.Any(), gomock.Any()).Return(nil)
 			},
 			expected: expected{
@@ -1379,7 +1379,7 @@ func TestManagementResource_GetAZEntity(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mock *mock) {
 				t.Helper()
-				mock.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any())
+				mock.mockDatabase.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 				mock.mockGraphDB.EXPECT().ReadTransaction(gomock.Any(), gomock.Any()).Return(nil)
 
 				props := graph.AsProperties(map[string]any{

--- a/cmd/api/src/api/v2/azure_test.go
+++ b/cmd/api/src/api/v2/azure_test.go
@@ -154,7 +154,6 @@ func TestResources_GetAZRelatedEntities(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mocks *mock) {
 				t.Helper()
-				mocks.mockDatabase.EXPECT().GetCustomNodeKindsMap(gomock.Any())
 				mocks.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any())
 				mocks.mockGraphDB.EXPECT().ReadTransaction(gomock.Any(), gomock.Any()).Return(v2.ErrParameterSkip)
 			},
@@ -177,7 +176,6 @@ func TestResources_GetAZRelatedEntities(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mocks *mock) {
 				t.Helper()
-				mocks.mockDatabase.EXPECT().GetCustomNodeKindsMap(gomock.Any())
 				mocks.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any()).Return(nil, errors.New("database error"))
 			},
 			expected: expected{
@@ -199,7 +197,6 @@ func TestResources_GetAZRelatedEntities(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mocks *mock) {
 				t.Helper()
-				mocks.mockDatabase.EXPECT().GetCustomNodeKindsMap(gomock.Any())
 				mocks.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any())
 				mocks.mockGraphDB.EXPECT().ReadTransaction(gomock.Any(), gomock.Any()).Return(nil)
 			},

--- a/cmd/api/src/api/v2/azure_test.go
+++ b/cmd/api/src/api/v2/azure_test.go
@@ -155,7 +155,7 @@ func TestResources_GetAZRelatedEntities(t *testing.T) {
 			setupMocks: func(t *testing.T, mocks *mock) {
 				t.Helper()
 				mocks.mockDatabase.EXPECT().GetCustomNodeKindsMap(gomock.Any())
-				mocks.mockDatabase.EXPECT().GetDisplayGraphSchemaNodeKinds(gomock.Any())
+				mocks.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any())
 				mocks.mockGraphDB.EXPECT().ReadTransaction(gomock.Any(), gomock.Any()).Return(v2.ErrParameterSkip)
 			},
 			expected: expected{
@@ -165,7 +165,7 @@ func TestResources_GetAZRelatedEntities(t *testing.T) {
 			},
 		},
 		{
-			name: "Error: GetDisplayGraphSchemaNodeKindsError",
+			name: "Error: GetValidDisplayKindsError",
 			buildRequest: func() *http.Request {
 				return &http.Request{
 					URL: &url.URL{
@@ -178,7 +178,7 @@ func TestResources_GetAZRelatedEntities(t *testing.T) {
 			setupMocks: func(t *testing.T, mocks *mock) {
 				t.Helper()
 				mocks.mockDatabase.EXPECT().GetCustomNodeKindsMap(gomock.Any())
-				mocks.mockDatabase.EXPECT().GetDisplayGraphSchemaNodeKinds(gomock.Any()).Return(nil, errors.New("database error"))
+				mocks.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any()).Return(nil, errors.New("database error"))
 			},
 			expected: expected{
 				responseCode:   http.StatusInternalServerError,
@@ -200,7 +200,7 @@ func TestResources_GetAZRelatedEntities(t *testing.T) {
 			setupMocks: func(t *testing.T, mocks *mock) {
 				t.Helper()
 				mocks.mockDatabase.EXPECT().GetCustomNodeKindsMap(gomock.Any())
-				mocks.mockDatabase.EXPECT().GetDisplayGraphSchemaNodeKinds(gomock.Any())
+				mocks.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any())
 				mocks.mockGraphDB.EXPECT().ReadTransaction(gomock.Any(), gomock.Any()).Return(nil)
 			},
 			expected: expected{

--- a/cmd/api/src/api/v2/customnode_test.go
+++ b/cmd/api/src/api/v2/customnode_test.go
@@ -27,6 +27,7 @@ import (
 	"testing"
 
 	"github.com/specterops/bloodhound/cmd/api/src/auth"
+	"github.com/specterops/bloodhound/packages/go/graphschema"
 	"github.com/specterops/bloodhound/packages/go/headers"
 
 	"github.com/gorilla/mux"
@@ -72,7 +73,7 @@ func TestResources_CreateCustomNodeKindsTest(t *testing.T) {
 				payload := &v2.CreateCustomNodeRequest{
 					CustomTypes: map[string]model.CustomNodeKindConfig{
 						"KindA": {
-							Icon: model.CustomNodeIcon{
+							Icon: graphschema.DisplayNodeIcon{
 								Type:  "font-stupid",
 								Name:  "coffee",
 								Color: "#FFFFFF",
@@ -111,8 +112,8 @@ func TestResources_CreateCustomNodeKindsTest(t *testing.T) {
 				payload := &v2.CreateCustomNodeRequest{
 					CustomTypes: map[string]model.CustomNodeKindConfig{
 						"KindA": {
-							Icon: model.CustomNodeIcon{
-								Type:  model.CustomNodeKindTypeFontAwesome,
+							Icon: graphschema.DisplayNodeIcon{
+								Type:  graphschema.DisplayNodeTypeFontAwesome,
 								Name:  "coffee",
 								Color: "FFFFFF",
 							},
@@ -150,15 +151,15 @@ func TestResources_CreateCustomNodeKindsTest(t *testing.T) {
 				payload := &v2.CreateCustomNodeRequest{
 					CustomTypes: map[string]model.CustomNodeKindConfig{
 						"KindA": {
-							Icon: model.CustomNodeIcon{
-								Type:  model.CustomNodeKindTypeFontAwesome,
+							Icon: graphschema.DisplayNodeIcon{
+								Type:  graphschema.DisplayNodeTypeFontAwesome,
 								Name:  "coffee",
 								Color: "#FFFFFF",
 							},
 						},
 						"KindB": {
-							Icon: model.CustomNodeIcon{
-								Type:  model.CustomNodeKindTypeFontAwesome,
+							Icon: graphschema.DisplayNodeIcon{
+								Type:  graphschema.DisplayNodeTypeFontAwesome,
 								Name:  "house",
 								Color: "#000",
 							},
@@ -182,8 +183,8 @@ func TestResources_CreateCustomNodeKindsTest(t *testing.T) {
 						ID:       1,
 						KindName: "KindA",
 						Config: model.CustomNodeKindConfig{
-							Icon: model.CustomNodeIcon{
-								Type:  model.CustomNodeKindTypeFontAwesome,
+							Icon: graphschema.DisplayNodeIcon{
+								Type:  graphschema.DisplayNodeTypeFontAwesome,
 								Name:  "coffee",
 								Color: "#FFFFFF",
 							},
@@ -193,8 +194,8 @@ func TestResources_CreateCustomNodeKindsTest(t *testing.T) {
 						ID:       2,
 						KindName: "KindB",
 						Config: model.CustomNodeKindConfig{
-							Icon: model.CustomNodeIcon{
-								Type:  model.CustomNodeKindTypeFontAwesome,
+							Icon: graphschema.DisplayNodeIcon{
+								Type:  graphschema.DisplayNodeTypeFontAwesome,
 								Name:  "house",
 								Color: "#000",
 							},
@@ -222,8 +223,8 @@ func TestResources_CreateCustomNodeKindsTest(t *testing.T) {
 				payload := &v2.CreateCustomNodeRequest{
 					CustomTypes: map[string]model.CustomNodeKindConfig{
 						"": {
-							Icon: model.CustomNodeIcon{
-								Type:  model.CustomNodeKindTypeFontAwesome,
+							Icon: graphschema.DisplayNodeIcon{
+								Type:  graphschema.DisplayNodeTypeFontAwesome,
 								Name:  "coffee",
 								Color: "#FFFFFF",
 							},
@@ -316,7 +317,7 @@ func TestResources_UpdateCustomNodeKindsTest(t *testing.T) {
 
 				payload := &v2.UpdateCustomNodeKindRequest{
 					Config: model.CustomNodeKindConfig{
-						Icon: model.CustomNodeIcon{
+						Icon: graphschema.DisplayNodeIcon{
 							Type:  "font-stupid",
 							Name:  "coffee",
 							Color: "#FFFFFF",
@@ -357,8 +358,8 @@ func TestResources_UpdateCustomNodeKindsTest(t *testing.T) {
 
 				payload := &v2.UpdateCustomNodeKindRequest{
 					Config: model.CustomNodeKindConfig{
-						Icon: model.CustomNodeIcon{
-							Type:  model.CustomNodeKindTypeFontAwesome,
+						Icon: graphschema.DisplayNodeIcon{
+							Type:  graphschema.DisplayNodeTypeFontAwesome,
 							Name:  "coffee",
 							Color: "FFFFFF",
 						},
@@ -398,8 +399,8 @@ func TestResources_UpdateCustomNodeKindsTest(t *testing.T) {
 
 				payload := &v2.UpdateCustomNodeKindRequest{
 					Config: model.CustomNodeKindConfig{
-						Icon: model.CustomNodeIcon{
-							Type:  model.CustomNodeKindTypeFontAwesome,
+						Icon: graphschema.DisplayNodeIcon{
+							Type:  graphschema.DisplayNodeTypeFontAwesome,
 							Name:  "coffee",
 							Color: "#FFFFFF",
 						},
@@ -421,8 +422,8 @@ func TestResources_UpdateCustomNodeKindsTest(t *testing.T) {
 					ID:       1,
 					KindName: "KindA",
 					Config: model.CustomNodeKindConfig{
-						Icon: model.CustomNodeIcon{
-							Type:  model.CustomNodeKindTypeFontAwesome,
+						Icon: graphschema.DisplayNodeIcon{
+							Type:  graphschema.DisplayNodeTypeFontAwesome,
 							Name:  "coffee",
 							Color: "#FFFFFF",
 						},

--- a/cmd/api/src/api/v2/customnode_test.go
+++ b/cmd/api/src/api/v2/customnode_test.go
@@ -112,7 +112,7 @@ func TestResources_CreateCustomNodeKindsTest(t *testing.T) {
 					CustomTypes: map[string]model.CustomNodeKindConfig{
 						"KindA": {
 							Icon: model.CustomNodeIcon{
-								Type:  "font-awesome",
+								Type:  model.CustomNodeKindTypeFontAwesome,
 								Name:  "coffee",
 								Color: "FFFFFF",
 							},
@@ -151,14 +151,14 @@ func TestResources_CreateCustomNodeKindsTest(t *testing.T) {
 					CustomTypes: map[string]model.CustomNodeKindConfig{
 						"KindA": {
 							Icon: model.CustomNodeIcon{
-								Type:  "font-awesome",
+								Type:  model.CustomNodeKindTypeFontAwesome,
 								Name:  "coffee",
 								Color: "#FFFFFF",
 							},
 						},
 						"KindB": {
 							Icon: model.CustomNodeIcon{
-								Type:  "font-awesome",
+								Type:  model.CustomNodeKindTypeFontAwesome,
 								Name:  "house",
 								Color: "#000",
 							},
@@ -183,7 +183,7 @@ func TestResources_CreateCustomNodeKindsTest(t *testing.T) {
 						KindName: "KindA",
 						Config: model.CustomNodeKindConfig{
 							Icon: model.CustomNodeIcon{
-								Type:  "font-awesome",
+								Type:  model.CustomNodeKindTypeFontAwesome,
 								Name:  "coffee",
 								Color: "#FFFFFF",
 							},
@@ -194,7 +194,7 @@ func TestResources_CreateCustomNodeKindsTest(t *testing.T) {
 						KindName: "KindB",
 						Config: model.CustomNodeKindConfig{
 							Icon: model.CustomNodeIcon{
-								Type:  "font-awesome",
+								Type:  model.CustomNodeKindTypeFontAwesome,
 								Name:  "house",
 								Color: "#000",
 							},
@@ -223,7 +223,7 @@ func TestResources_CreateCustomNodeKindsTest(t *testing.T) {
 					CustomTypes: map[string]model.CustomNodeKindConfig{
 						"": {
 							Icon: model.CustomNodeIcon{
-								Type:  "font-awesome",
+								Type:  model.CustomNodeKindTypeFontAwesome,
 								Name:  "coffee",
 								Color: "#FFFFFF",
 							},
@@ -358,7 +358,7 @@ func TestResources_UpdateCustomNodeKindsTest(t *testing.T) {
 				payload := &v2.UpdateCustomNodeKindRequest{
 					Config: model.CustomNodeKindConfig{
 						Icon: model.CustomNodeIcon{
-							Type:  "font-awesome",
+							Type:  model.CustomNodeKindTypeFontAwesome,
 							Name:  "coffee",
 							Color: "FFFFFF",
 						},
@@ -399,7 +399,7 @@ func TestResources_UpdateCustomNodeKindsTest(t *testing.T) {
 				payload := &v2.UpdateCustomNodeKindRequest{
 					Config: model.CustomNodeKindConfig{
 						Icon: model.CustomNodeIcon{
-							Type:  "font-awesome",
+							Type:  model.CustomNodeKindTypeFontAwesome,
 							Name:  "coffee",
 							Color: "#FFFFFF",
 						},
@@ -422,7 +422,7 @@ func TestResources_UpdateCustomNodeKindsTest(t *testing.T) {
 					KindName: "KindA",
 					Config: model.CustomNodeKindConfig{
 						Icon: model.CustomNodeIcon{
-							Type:  "font-awesome",
+							Type:  model.CustomNodeKindTypeFontAwesome,
 							Name:  "coffee",
 							Color: "#FFFFFF",
 						},

--- a/cmd/api/src/api/v2/cypherquery.go
+++ b/cmd/api/src/api/v2/cypherquery.go
@@ -104,7 +104,7 @@ func (s Resources) CypherQuery(response http.ResponseWriter, request *http.Reque
 		return
 	}
 
-	validPrimaryKinds, err := s.DB.GetValidDisplayKinds(request.Context())
+	primaryDisplayKinds, err := s.DB.GetValidDisplayKinds(request.Context())
 	if err != nil {
 		api.HandleDatabaseError(request, response, err)
 		return
@@ -112,10 +112,10 @@ func (s Resources) CypherQuery(response http.ResponseWriter, request *http.Reque
 
 	if preparedQuery.HasMutation {
 		// defaulting include properties to true so ETAC filtering logic has access to node properties
-		graphResponse, err = s.cypherMutation(request, validPrimaryKinds, preparedQuery, true)
+		graphResponse, err = s.cypherMutation(request, primaryDisplayKinds, preparedQuery, true)
 	} else {
 		// defaulting include properties to true so ETAC filtering logic has access to node properties
-		graphResponse, err = s.GraphQuery.RawCypherQuery(request.Context(), validPrimaryKinds, preparedQuery, true)
+		graphResponse, err = s.GraphQuery.RawCypherQuery(request.Context(), primaryDisplayKinds, preparedQuery, true)
 	}
 
 	if err != nil {
@@ -157,7 +157,7 @@ func (s Resources) CypherQuery(response http.ResponseWriter, request *http.Reque
 	}
 }
 
-func (s Resources) cypherMutation(request *http.Request, validPrimaryKinds graphschema.ValidPrimaryKinds, preparedQuery queries.PreparedQuery, includeProperties bool) (model.UnifiedGraph, error) {
+func (s Resources) cypherMutation(request *http.Request, primaryDisplayKinds graphschema.PrimaryDisplayKinds, preparedQuery queries.PreparedQuery, includeProperties bool) (model.UnifiedGraph, error) {
 	var (
 		auditLogEntry model.AuditEntry
 		graphResponse model.UnifiedGraph
@@ -179,7 +179,7 @@ func (s Resources) cypherMutation(request *http.Request, validPrimaryKinds graph
 		return model.UnifiedGraph{}, err
 	}
 
-	if graphResponse, err = s.GraphQuery.RawCypherQuery(request.Context(), validPrimaryKinds, preparedQuery, includeProperties); err != nil {
+	if graphResponse, err = s.GraphQuery.RawCypherQuery(request.Context(), primaryDisplayKinds, preparedQuery, includeProperties); err != nil {
 		auditLogEntry.Status = model.AuditLogStatusFailure
 	} else {
 		auditLogEntry.Status = model.AuditLogStatusSuccess

--- a/cmd/api/src/api/v2/cypherquery.go
+++ b/cmd/api/src/api/v2/cypherquery.go
@@ -104,7 +104,7 @@ func (s Resources) CypherQuery(response http.ResponseWriter, request *http.Reque
 		return
 	}
 
-	primaryDisplayKinds, err := s.DB.GetValidDisplayKinds(request.Context())
+	primaryDisplayKinds, err := s.DB.GetPrimaryDisplayKinds(request.Context())
 	if err != nil {
 		api.HandleDatabaseError(request, response, err)
 		return

--- a/cmd/api/src/api/v2/cypherquery_test.go
+++ b/cmd/api/src/api/v2/cypherquery_test.go
@@ -103,7 +103,7 @@ func TestResources_CypherQuery(t *testing.T) {
 				mocks.mockGraphQuery.EXPECT().PrepareCypherQuery("query", int64(queries.DefaultQueryFitnessLowerBoundExplore)).Return(queries.PreparedQuery{
 					HasMutation: false,
 				}, nil)
-				mocks.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any()).Return(primaryDisplayKinds, nil)
+				mocks.mockDatabase.EXPECT().GetPrimaryDisplayKinds(gomock.Any()).Return(primaryDisplayKinds, nil)
 				mocks.mockGraphQuery.EXPECT().RawCypherQuery(gomock.Any(), gomock.Eq(primaryDisplayKinds), gomock.Any(), gomock.Any()).Return(model.UnifiedGraph{
 					Nodes: map[string]model.UnifiedNode{
 						"1": {
@@ -232,7 +232,7 @@ func TestResources_CypherQuery(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mocks *mock) {
 				t.Helper()
-				mocks.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any()).Return(primaryDisplayKinds, nil)
+				mocks.mockDatabase.EXPECT().GetPrimaryDisplayKinds(gomock.Any()).Return(primaryDisplayKinds, nil)
 				mocks.mockGraphQuery.EXPECT().PrepareCypherQuery("query", int64(queries.DefaultQueryFitnessLowerBoundExplore)).Return(queries.PreparedQuery{
 					HasMutation: true,
 				}, nil)
@@ -277,7 +277,7 @@ func TestResources_CypherQuery(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mocks *mock) {
 				t.Helper()
-				mocks.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any()).Return(primaryDisplayKinds, nil)
+				mocks.mockDatabase.EXPECT().GetPrimaryDisplayKinds(gomock.Any()).Return(primaryDisplayKinds, nil)
 				mocks.mockGraphQuery.EXPECT().PrepareCypherQuery("query", int64(queries.DefaultQueryFitnessLowerBoundExplore)).Return(queries.PreparedQuery{
 					HasMutation: false,
 				}, nil)
@@ -322,7 +322,7 @@ func TestResources_CypherQuery(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mocks *mock) {
 				t.Helper()
-				mocks.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any()).Return(primaryDisplayKinds, nil)
+				mocks.mockDatabase.EXPECT().GetPrimaryDisplayKinds(gomock.Any()).Return(primaryDisplayKinds, nil)
 				mocks.mockGraphQuery.EXPECT().PrepareCypherQuery("query", int64(queries.DefaultQueryFitnessLowerBoundExplore)).Return(queries.PreparedQuery{
 					HasMutation: false,
 				}, nil)
@@ -335,7 +335,7 @@ func TestResources_CypherQuery(t *testing.T) {
 			},
 		},
 		{
-			name: "Error: GetValidDisplayKindsError",
+			name: "Error: GetPrimaryDisplayKindsError",
 			buildRequest: func() *http.Request {
 				payload := &v2.CypherQueryPayload{
 					Query:             "query",
@@ -367,7 +367,7 @@ func TestResources_CypherQuery(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mocks *mock) {
 				t.Helper()
-				mocks.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any()).Return(nil, errors.New("database error"))
+				mocks.mockDatabase.EXPECT().GetPrimaryDisplayKinds(gomock.Any()).Return(nil, errors.New("database error"))
 				mocks.mockGraphQuery.EXPECT().PrepareCypherQuery("query", int64(queries.DefaultQueryFitnessLowerBoundExplore)).Return(queries.PreparedQuery{
 					HasMutation: false,
 				}, nil)
@@ -411,7 +411,7 @@ func TestResources_CypherQuery(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mocks *mock) {
 				t.Helper()
-				mocks.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any()).Return(primaryDisplayKinds, nil)
+				mocks.mockDatabase.EXPECT().GetPrimaryDisplayKinds(gomock.Any()).Return(primaryDisplayKinds, nil)
 				mocks.mockGraphQuery.EXPECT().PrepareCypherQuery("query", int64(queries.DefaultQueryFitnessLowerBoundExplore)).Return(queries.PreparedQuery{
 					HasMutation: false,
 				}, nil)
@@ -470,7 +470,7 @@ func TestResources_CypherQuery(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mocks *mock) {
 				t.Helper()
-				mocks.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any()).Return(primaryDisplayKinds, nil)
+				mocks.mockDatabase.EXPECT().GetPrimaryDisplayKinds(gomock.Any()).Return(primaryDisplayKinds, nil)
 				mocks.mockGraphQuery.EXPECT().PrepareCypherQuery("query", int64(queries.DefaultQueryFitnessLowerBoundExplore)).Return(queries.PreparedQuery{
 					HasMutation: false,
 				}, nil)
@@ -537,7 +537,7 @@ func TestResources_CypherQuery(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mocks *mock) {
 				t.Helper()
-				mocks.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any()).Return(primaryDisplayKinds, nil)
+				mocks.mockDatabase.EXPECT().GetPrimaryDisplayKinds(gomock.Any()).Return(primaryDisplayKinds, nil)
 				mocks.mockGraphQuery.EXPECT().PrepareCypherQuery("query", int64(queries.DefaultQueryFitnessLowerBoundExplore)).Return(queries.PreparedQuery{
 					HasMutation: false,
 				}, nil)
@@ -614,7 +614,7 @@ func TestResources_CypherQuery(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mocks *mock) {
 				t.Helper()
-				mocks.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any()).Return(primaryDisplayKinds, nil)
+				mocks.mockDatabase.EXPECT().GetPrimaryDisplayKinds(gomock.Any()).Return(primaryDisplayKinds, nil)
 				mocks.mockGraphQuery.EXPECT().PrepareCypherQuery("query", int64(queries.DefaultQueryFitnessLowerBoundExplore)).Return(queries.PreparedQuery{
 					HasMutation: false,
 				}, nil)

--- a/cmd/api/src/api/v2/cypherquery_test.go
+++ b/cmd/api/src/api/v2/cypherquery_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 	"github.com/specterops/bloodhound/cmd/api/src/services/dogtags"
+	"github.com/specterops/bloodhound/packages/go/graphschema"
 	"github.com/specterops/bloodhound/packages/go/headers"
 	"github.com/specterops/dawgs/graph"
 	"github.com/stretchr/testify/assert"
@@ -63,7 +64,7 @@ func TestResources_CypherQuery(t *testing.T) {
 		dogTagsOverrides dogtags.TestOverrides
 	}
 
-	validPrimaryKinds := map[graph.Kind]bool{graph.StringKind("KindA"): true}
+	validPrimaryKinds := graphschema.ValidPrimaryKinds{graph.StringKind("KindA"): graphschema.DisplayKind{}}
 
 	tt := []testData{
 		{

--- a/cmd/api/src/api/v2/cypherquery_test.go
+++ b/cmd/api/src/api/v2/cypherquery_test.go
@@ -64,7 +64,7 @@ func TestResources_CypherQuery(t *testing.T) {
 		dogTagsOverrides dogtags.TestOverrides
 	}
 
-	validPrimaryKinds := graphschema.ValidPrimaryKinds{graph.StringKind("KindA"): graphschema.DisplayKind{}}
+	primaryDisplayKinds := graphschema.PrimaryDisplayKinds{graph.StringKind("KindA"): graphschema.DisplayKind{}}
 
 	tt := []testData{
 		{
@@ -103,8 +103,8 @@ func TestResources_CypherQuery(t *testing.T) {
 				mocks.mockGraphQuery.EXPECT().PrepareCypherQuery("query", int64(queries.DefaultQueryFitnessLowerBoundExplore)).Return(queries.PreparedQuery{
 					HasMutation: false,
 				}, nil)
-				mocks.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any()).Return(validPrimaryKinds, nil)
-				mocks.mockGraphQuery.EXPECT().RawCypherQuery(gomock.Any(), gomock.Eq(validPrimaryKinds), gomock.Any(), gomock.Any()).Return(model.UnifiedGraph{
+				mocks.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any()).Return(primaryDisplayKinds, nil)
+				mocks.mockGraphQuery.EXPECT().RawCypherQuery(gomock.Any(), gomock.Eq(primaryDisplayKinds), gomock.Any(), gomock.Any()).Return(model.UnifiedGraph{
 					Nodes: map[string]model.UnifiedNode{
 						"1": {
 							Label:      "label",
@@ -232,7 +232,7 @@ func TestResources_CypherQuery(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mocks *mock) {
 				t.Helper()
-				mocks.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any()).Return(validPrimaryKinds, nil)
+				mocks.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any()).Return(primaryDisplayKinds, nil)
 				mocks.mockGraphQuery.EXPECT().PrepareCypherQuery("query", int64(queries.DefaultQueryFitnessLowerBoundExplore)).Return(queries.PreparedQuery{
 					HasMutation: true,
 				}, nil)
@@ -277,11 +277,11 @@ func TestResources_CypherQuery(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mocks *mock) {
 				t.Helper()
-				mocks.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any()).Return(validPrimaryKinds, nil)
+				mocks.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any()).Return(primaryDisplayKinds, nil)
 				mocks.mockGraphQuery.EXPECT().PrepareCypherQuery("query", int64(queries.DefaultQueryFitnessLowerBoundExplore)).Return(queries.PreparedQuery{
 					HasMutation: false,
 				}, nil)
-				mocks.mockGraphQuery.EXPECT().RawCypherQuery(gomock.Any(), gomock.Eq(validPrimaryKinds), gomock.Any(), gomock.Any()).Return(model.UnifiedGraph{}, &neo4j.Neo4jError{})
+				mocks.mockGraphQuery.EXPECT().RawCypherQuery(gomock.Any(), gomock.Eq(primaryDisplayKinds), gomock.Any(), gomock.Any()).Return(model.UnifiedGraph{}, &neo4j.Neo4jError{})
 			},
 			expected: expected{
 				responseCode:   http.StatusInternalServerError,
@@ -322,11 +322,11 @@ func TestResources_CypherQuery(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mocks *mock) {
 				t.Helper()
-				mocks.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any()).Return(validPrimaryKinds, nil)
+				mocks.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any()).Return(primaryDisplayKinds, nil)
 				mocks.mockGraphQuery.EXPECT().PrepareCypherQuery("query", int64(queries.DefaultQueryFitnessLowerBoundExplore)).Return(queries.PreparedQuery{
 					HasMutation: false,
 				}, nil)
-				mocks.mockGraphQuery.EXPECT().RawCypherQuery(gomock.Any(), gomock.Eq(validPrimaryKinds), gomock.Any(), gomock.Any()).Return(model.UnifiedGraph{}, nil)
+				mocks.mockGraphQuery.EXPECT().RawCypherQuery(gomock.Any(), gomock.Eq(primaryDisplayKinds), gomock.Any(), gomock.Any()).Return(model.UnifiedGraph{}, nil)
 			},
 			expected: expected{
 				responseCode:   http.StatusNotFound,
@@ -411,11 +411,11 @@ func TestResources_CypherQuery(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mocks *mock) {
 				t.Helper()
-				mocks.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any()).Return(validPrimaryKinds, nil)
+				mocks.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any()).Return(primaryDisplayKinds, nil)
 				mocks.mockGraphQuery.EXPECT().PrepareCypherQuery("query", int64(queries.DefaultQueryFitnessLowerBoundExplore)).Return(queries.PreparedQuery{
 					HasMutation: false,
 				}, nil)
-				mocks.mockGraphQuery.EXPECT().RawCypherQuery(gomock.Any(), gomock.Eq(validPrimaryKinds), gomock.Any(), gomock.Any()).Return(model.UnifiedGraph{
+				mocks.mockGraphQuery.EXPECT().RawCypherQuery(gomock.Any(), gomock.Eq(primaryDisplayKinds), gomock.Any(), gomock.Any()).Return(model.UnifiedGraph{
 					Nodes: map[string]model.UnifiedNode{
 						"1": {
 							Label:      "label",
@@ -470,11 +470,11 @@ func TestResources_CypherQuery(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mocks *mock) {
 				t.Helper()
-				mocks.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any()).Return(validPrimaryKinds, nil)
+				mocks.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any()).Return(primaryDisplayKinds, nil)
 				mocks.mockGraphQuery.EXPECT().PrepareCypherQuery("query", int64(queries.DefaultQueryFitnessLowerBoundExplore)).Return(queries.PreparedQuery{
 					HasMutation: false,
 				}, nil)
-				mocks.mockGraphQuery.EXPECT().RawCypherQuery(gomock.Any(), gomock.Eq(validPrimaryKinds), gomock.Any(), gomock.Any()).Return(model.UnifiedGraph{
+				mocks.mockGraphQuery.EXPECT().RawCypherQuery(gomock.Any(), gomock.Eq(primaryDisplayKinds), gomock.Any(), gomock.Any()).Return(model.UnifiedGraph{
 					Nodes: map[string]model.UnifiedNode{
 						"1": {
 							Label:      "label",
@@ -537,11 +537,11 @@ func TestResources_CypherQuery(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mocks *mock) {
 				t.Helper()
-				mocks.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any()).Return(validPrimaryKinds, nil)
+				mocks.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any()).Return(primaryDisplayKinds, nil)
 				mocks.mockGraphQuery.EXPECT().PrepareCypherQuery("query", int64(queries.DefaultQueryFitnessLowerBoundExplore)).Return(queries.PreparedQuery{
 					HasMutation: false,
 				}, nil)
-				mocks.mockGraphQuery.EXPECT().RawCypherQuery(gomock.Any(), gomock.Eq(validPrimaryKinds), gomock.Any(), gomock.Any()).Return(model.UnifiedGraph{
+				mocks.mockGraphQuery.EXPECT().RawCypherQuery(gomock.Any(), gomock.Eq(primaryDisplayKinds), gomock.Any(), gomock.Any()).Return(model.UnifiedGraph{
 					Nodes: map[string]model.UnifiedNode{
 						"1": {
 							Label:      "label",
@@ -614,11 +614,11 @@ func TestResources_CypherQuery(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mocks *mock) {
 				t.Helper()
-				mocks.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any()).Return(validPrimaryKinds, nil)
+				mocks.mockDatabase.EXPECT().GetValidDisplayKinds(gomock.Any()).Return(primaryDisplayKinds, nil)
 				mocks.mockGraphQuery.EXPECT().PrepareCypherQuery("query", int64(queries.DefaultQueryFitnessLowerBoundExplore)).Return(queries.PreparedQuery{
 					HasMutation: false,
 				}, nil)
-				mocks.mockGraphQuery.EXPECT().RawCypherQuery(gomock.Any(), gomock.Eq(validPrimaryKinds), gomock.Any(), gomock.Any()).Return(model.UnifiedGraph{
+				mocks.mockGraphQuery.EXPECT().RawCypherQuery(gomock.Any(), gomock.Eq(primaryDisplayKinds), gomock.Any(), gomock.Any()).Return(model.UnifiedGraph{
 					Nodes: map[string]model.UnifiedNode{
 						"1": {
 							Label:      "label",

--- a/cmd/api/src/api/v2/edge.go
+++ b/cmd/api/src/api/v2/edge.go
@@ -63,12 +63,12 @@ func (s *Resources) GetEdgeRelayTargets(response http.ResponseWriter, request *h
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, fmt.Sprintf("Could not find edge matching criteria: %v", err), request), response)
 	} else if nodeSet, err := ad.GetRelayTargets(request.Context(), s.Graph, edge); err != nil {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusInternalServerError, fmt.Sprintf("Error getting composition for edge: %v", err), request), response)
-	} else if validPrimaryKinds, err := s.DB.GetValidDisplayKinds(request.Context()); err != nil {
+	} else if primaryDisplayKinds, err := s.DB.GetValidDisplayKinds(request.Context()); err != nil {
 		api.HandleDatabaseError(request, response, err)
 	} else {
 		unifiedGraph := model.NewUnifiedGraph()
 		for _, node := range nodeSet {
-			unifiedGraph.AddNode(validPrimaryKinds, node, true)
+			unifiedGraph.AddNode(primaryDisplayKinds, node, true)
 		}
 		api.WriteBasicResponse(request.Context(), unifiedGraph, http.StatusOK, response)
 	}
@@ -101,11 +101,11 @@ func (s *Resources) GetEdgeComposition(response http.ResponseWriter, request *ht
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, fmt.Sprintf("Could not find edge matching criteria: %v", err), request), response)
 	} else if pathSet, err := ad.GetEdgeCompositionPath(request.Context(), s.Graph, edge); err != nil {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusInternalServerError, fmt.Sprintf("Error getting composition for edge: %v", err), request), response)
-	} else if validPrimaryKinds, err := s.DB.GetValidDisplayKinds(request.Context()); err != nil {
+	} else if primaryDisplayKinds, err := s.DB.GetValidDisplayKinds(request.Context()); err != nil {
 		api.HandleDatabaseError(request, response, err)
 	} else {
 		unifiedGraph := model.NewUnifiedGraph()
-		unifiedGraph.AddPathSet(validPrimaryKinds, pathSet, true)
+		unifiedGraph.AddPathSet(primaryDisplayKinds, pathSet, true)
 		api.WriteBasicResponse(request.Context(), unifiedGraph, http.StatusOK, response)
 	}
 }
@@ -137,11 +137,11 @@ func (s *Resources) GetEdgeACLInheritancePath(response http.ResponseWriter, requ
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, fmt.Sprintf("Could not find edge matching criteria: %v", err), request), response)
 	} else if pathSet, err := ad.FetchACLInheritancePath(request.Context(), s.Graph, edge); err != nil {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusInternalServerError, fmt.Sprintf("Error getting ACL inheritance path for edge: %v", err), request), response)
-	} else if validPrimaryKinds, err := s.DB.GetValidDisplayKinds(request.Context()); err != nil {
+	} else if primaryDisplayKinds, err := s.DB.GetValidDisplayKinds(request.Context()); err != nil {
 		api.HandleDatabaseError(request, response, err)
 	} else {
 		unifiedGraph := model.NewUnifiedGraph()
-		unifiedGraph.AddPathSet(validPrimaryKinds, pathSet, true)
+		unifiedGraph.AddPathSet(primaryDisplayKinds, pathSet, true)
 		api.WriteBasicResponse(request.Context(), unifiedGraph, http.StatusOK, response)
 	}
 }

--- a/cmd/api/src/api/v2/edge.go
+++ b/cmd/api/src/api/v2/edge.go
@@ -63,7 +63,7 @@ func (s *Resources) GetEdgeRelayTargets(response http.ResponseWriter, request *h
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, fmt.Sprintf("Could not find edge matching criteria: %v", err), request), response)
 	} else if nodeSet, err := ad.GetRelayTargets(request.Context(), s.Graph, edge); err != nil {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusInternalServerError, fmt.Sprintf("Error getting composition for edge: %v", err), request), response)
-	} else if primaryDisplayKinds, err := s.DB.GetValidDisplayKinds(request.Context()); err != nil {
+	} else if primaryDisplayKinds, err := s.DB.GetPrimaryDisplayKinds(request.Context()); err != nil {
 		api.HandleDatabaseError(request, response, err)
 	} else {
 		unifiedGraph := model.NewUnifiedGraph()
@@ -101,7 +101,7 @@ func (s *Resources) GetEdgeComposition(response http.ResponseWriter, request *ht
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, fmt.Sprintf("Could not find edge matching criteria: %v", err), request), response)
 	} else if pathSet, err := ad.GetEdgeCompositionPath(request.Context(), s.Graph, edge); err != nil {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusInternalServerError, fmt.Sprintf("Error getting composition for edge: %v", err), request), response)
-	} else if primaryDisplayKinds, err := s.DB.GetValidDisplayKinds(request.Context()); err != nil {
+	} else if primaryDisplayKinds, err := s.DB.GetPrimaryDisplayKinds(request.Context()); err != nil {
 		api.HandleDatabaseError(request, response, err)
 	} else {
 		unifiedGraph := model.NewUnifiedGraph()
@@ -137,7 +137,7 @@ func (s *Resources) GetEdgeACLInheritancePath(response http.ResponseWriter, requ
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, fmt.Sprintf("Could not find edge matching criteria: %v", err), request), response)
 	} else if pathSet, err := ad.FetchACLInheritancePath(request.Context(), s.Graph, edge); err != nil {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusInternalServerError, fmt.Sprintf("Error getting ACL inheritance path for edge: %v", err), request), response)
-	} else if primaryDisplayKinds, err := s.DB.GetValidDisplayKinds(request.Context()); err != nil {
+	} else if primaryDisplayKinds, err := s.DB.GetPrimaryDisplayKinds(request.Context()); err != nil {
 		api.HandleDatabaseError(request, response, err)
 	} else {
 		unifiedGraph := model.NewUnifiedGraph()

--- a/cmd/api/src/api/v2/edge_test.go
+++ b/cmd/api/src/api/v2/edge_test.go
@@ -258,7 +258,7 @@ func TestResources_GetEdgeComposition(t *testing.T) {
 			},
 		},
 		{
-			name: "Error: GetValidDisplayKindsError",
+			name: "Error: GetPrimaryDisplayKindsError",
 			buildRequest: func() *http.Request {
 				return &http.Request{
 					URL: &url.URL{
@@ -272,7 +272,7 @@ func TestResources_GetEdgeComposition(t *testing.T) {
 				t.Helper()
 				mock.mockGraph.EXPECT().ReadTransaction(gomock.Any(), gomock.Any()).Return(nil)
 				mock.mockGraph.EXPECT().ReadTransaction(gomock.Any(), gomock.Any()).Return(nil)
-				mock.mockDb.EXPECT().GetValidDisplayKinds(gomock.Any()).Return(nil, errors.New("database error"))
+				mock.mockDb.EXPECT().GetPrimaryDisplayKinds(gomock.Any()).Return(nil, errors.New("database error"))
 			},
 			expected: expected{
 				responseCode:   http.StatusInternalServerError,
@@ -295,7 +295,7 @@ func TestResources_GetEdgeComposition(t *testing.T) {
 				t.Helper()
 				mock.mockGraph.EXPECT().ReadTransaction(gomock.Any(), gomock.Any()).Return(nil)
 				mock.mockGraph.EXPECT().ReadTransaction(gomock.Any(), gomock.Any()).Return(nil)
-				mock.mockDb.EXPECT().GetValidDisplayKinds(gomock.Any())
+				mock.mockDb.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 			},
 			expected: expected{
 				responseCode:   http.StatusOK,
@@ -531,7 +531,7 @@ func TestResources_GetEdgeRelayTargets(t *testing.T) {
 			},
 		},
 		{
-			name: "GetValidDisplayKindsError",
+			name: "GetPrimaryDisplayKindsError",
 			request: http.Request{
 				URL: &url.URL{
 					RawQuery: "edge_type=AZBase&source_node=1&target_node=2",
@@ -545,7 +545,7 @@ func TestResources_GetEdgeRelayTargets(t *testing.T) {
 			testSetup: func(t *testing.T, ctx context.Context, mocks mock) {
 				t.Helper()
 				mocks.mockGraph.EXPECT().ReadTransaction(ctx, gomock.Any()).Return(nil).Times(2)
-				mocks.mockDb.EXPECT().GetValidDisplayKinds(gomock.Any()).Return(nil, errors.New("database error"))
+				mocks.mockDb.EXPECT().GetPrimaryDisplayKinds(gomock.Any()).Return(nil, errors.New("database error"))
 			},
 		},
 		{
@@ -563,7 +563,7 @@ func TestResources_GetEdgeRelayTargets(t *testing.T) {
 			testSetup: func(t *testing.T, ctx context.Context, mocks mock) {
 				t.Helper()
 				mocks.mockGraph.EXPECT().ReadTransaction(ctx, gomock.Any()).Return(nil).Times(2)
-				mocks.mockDb.EXPECT().GetValidDisplayKinds(gomock.Any())
+				mocks.mockDb.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 			},
 		},
 	}
@@ -823,7 +823,7 @@ func TestResources_GetEdgeACLInheritancePath(t *testing.T) {
 			},
 		},
 		{
-			name: "Error: GetValidDisplayKindsError",
+			name: "Error: GetPrimaryDisplayKindsError",
 			buildRequest: func() *http.Request {
 				return &http.Request{
 					URL: &url.URL{
@@ -837,7 +837,7 @@ func TestResources_GetEdgeACLInheritancePath(t *testing.T) {
 				t.Helper()
 				mock.mockGraph.EXPECT().ReadTransaction(gomock.Any(), gomock.Any()).Return(nil)
 				mock.mockGraph.EXPECT().ReadTransaction(gomock.Any(), gomock.Any()).Return(nil)
-				mock.mockDb.EXPECT().GetValidDisplayKinds(gomock.Any()).Return(nil, errors.New("database error"))
+				mock.mockDb.EXPECT().GetPrimaryDisplayKinds(gomock.Any()).Return(nil, errors.New("database error"))
 			},
 			expected: expected{
 				responseCode:   http.StatusInternalServerError,
@@ -860,7 +860,7 @@ func TestResources_GetEdgeACLInheritancePath(t *testing.T) {
 				t.Helper()
 				mock.mockGraph.EXPECT().ReadTransaction(gomock.Any(), gomock.Any()).Return(nil)
 				mock.mockGraph.EXPECT().ReadTransaction(gomock.Any(), gomock.Any()).Return(nil)
-				mock.mockDb.EXPECT().GetValidDisplayKinds(gomock.Any())
+				mock.mockDb.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 			},
 			expected: expected{
 				responseCode:   http.StatusOK,

--- a/cmd/api/src/api/v2/pathfinding.go
+++ b/cmd/api/src/api/v2/pathfinding.go
@@ -57,7 +57,7 @@ func (s Resources) GetPathfindingResult(response http.ResponseWriter, request *h
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, "Missing query parameter: end_node", request), response)
 	} else if paths, err := s.GraphQuery.GetAllShortestPaths(request.Context(), startNodeObjectID, endNodeObjectID, nil); err != nil {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusInternalServerError, fmt.Sprintf("Error: %v", err), request), response)
-	} else if primaryDisplayKinds, err := s.DB.GetValidDisplayKinds(request.Context()); err != nil {
+	} else if primaryDisplayKinds, err := s.DB.GetPrimaryDisplayKinds(request.Context()); err != nil {
 		api.HandleDatabaseError(request, response, err)
 	} else {
 		api.WriteBasicResponse(request.Context(), bloodhoundgraph.PathSetToBloodHoundGraph(primaryDisplayKinds, paths), http.StatusOK, response)
@@ -147,7 +147,7 @@ func (s Resources) GetShortestPath(response http.ResponseWriter, request *http.R
 		api.WriteErrorResponse(requestContext, api.BuildErrorResponse(http.StatusBadRequest, "Missing query parameter: end_node", request), response)
 	} else if ogExtensionManagementFeatureFlag, err := s.DB.GetFlagByKey(requestContext, appcfg.FeatureOpenGraphExtensionManagement); err != nil {
 		api.HandleDatabaseError(request, response, err)
-	} else if primaryDisplayKinds, err := s.DB.GetValidDisplayKinds(request.Context()); err != nil {
+	} else if primaryDisplayKinds, err := s.DB.GetPrimaryDisplayKinds(request.Context()); err != nil {
 		api.HandleDatabaseError(request, response, err)
 	} else {
 		if onlyIncludeTraversableKinds {
@@ -284,7 +284,7 @@ func (s *Resources) GetSearchResult(response http.ResponseWriter, request *http.
 			api.HandleDatabaseError(request, response, err)
 		} else if nodes, err := s.GraphQuery.SearchByNameOrObjectID(request.Context(), openGraphSearchFeatureFlag.Enabled, searchValue, searchType); err != nil {
 			api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, fmt.Sprintf("Error getting search results: %v", err), request), response)
-		} else if primaryDisplayKinds, err := s.DB.GetValidDisplayKinds(request.Context()); err != nil {
+		} else if primaryDisplayKinds, err := s.DB.GetPrimaryDisplayKinds(request.Context()); err != nil {
 			api.HandleDatabaseError(request, response, err)
 		} else {
 			bhGraph := make(map[string]bloodhoundgraph.BloodHoundGraphNode)

--- a/cmd/api/src/api/v2/pathfinding.go
+++ b/cmd/api/src/api/v2/pathfinding.go
@@ -57,12 +57,10 @@ func (s Resources) GetPathfindingResult(response http.ResponseWriter, request *h
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, "Missing query parameter: end_node", request), response)
 	} else if paths, err := s.GraphQuery.GetAllShortestPaths(request.Context(), startNodeObjectID, endNodeObjectID, nil); err != nil {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusInternalServerError, fmt.Sprintf("Error: %v", err), request), response)
-	} else if validPrimaryKinds, err := s.DB.GetDisplayGraphSchemaNodeKinds(request.Context()); err != nil {
-		api.HandleDatabaseError(request, response, err)
-	} else if customNodeKinds, err := s.DB.GetCustomNodeKindsMap(request.Context()); err != nil {
+	} else if validPrimaryKinds, err := s.DB.GetValidDisplayKinds(request.Context()); err != nil {
 		api.HandleDatabaseError(request, response, err)
 	} else {
-		api.WriteBasicResponse(request.Context(), bloodhoundgraph.PathSetToBloodHoundGraph(validPrimaryKinds, customNodeKinds, paths), http.StatusOK, response)
+		api.WriteBasicResponse(request.Context(), bloodhoundgraph.PathSetToBloodHoundGraph(validPrimaryKinds, paths), http.StatusOK, response)
 	}
 }
 
@@ -286,16 +284,12 @@ func (s *Resources) GetSearchResult(response http.ResponseWriter, request *http.
 			api.HandleDatabaseError(request, response, err)
 		} else if nodes, err := s.GraphQuery.SearchByNameOrObjectID(request.Context(), openGraphSearchFeatureFlag.Enabled, searchValue, searchType); err != nil {
 			api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, fmt.Sprintf("Error getting search results: %v", err), request), response)
-		} else if validPrimaryKinds, err := s.DB.GetDisplayGraphSchemaNodeKinds(request.Context()); err != nil {
+		} else if validPrimaryKinds, err := s.DB.GetValidDisplayKinds(request.Context()); err != nil {
 			api.HandleDatabaseError(request, response, err)
 		} else {
-			var customNodeKinds model.CustomNodeKindMap
-			if customNodeKinds, err = s.DB.GetCustomNodeKindsMap(request.Context()); err != nil {
-				slog.Warn("Unable to fetch custom nodes from database; will fall back to defaults")
-			}
 			bhGraph := make(map[string]bloodhoundgraph.BloodHoundGraphNode)
 			for _, node := range nodes {
-				bhGraph[node.ID.String()] = bloodhoundgraph.NodeToBloodHoundGraph(validPrimaryKinds, customNodeKinds, node)
+				bhGraph[node.ID.String()] = bloodhoundgraph.NodeToBloodHoundGraph(validPrimaryKinds, node)
 			}
 
 			// ETAC DogTags filtering

--- a/cmd/api/src/api/v2/pathfinding.go
+++ b/cmd/api/src/api/v2/pathfinding.go
@@ -57,10 +57,10 @@ func (s Resources) GetPathfindingResult(response http.ResponseWriter, request *h
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, "Missing query parameter: end_node", request), response)
 	} else if paths, err := s.GraphQuery.GetAllShortestPaths(request.Context(), startNodeObjectID, endNodeObjectID, nil); err != nil {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusInternalServerError, fmt.Sprintf("Error: %v", err), request), response)
-	} else if validPrimaryKinds, err := s.DB.GetValidDisplayKinds(request.Context()); err != nil {
+	} else if primaryDisplayKinds, err := s.DB.GetValidDisplayKinds(request.Context()); err != nil {
 		api.HandleDatabaseError(request, response, err)
 	} else {
-		api.WriteBasicResponse(request.Context(), bloodhoundgraph.PathSetToBloodHoundGraph(validPrimaryKinds, paths), http.StatusOK, response)
+		api.WriteBasicResponse(request.Context(), bloodhoundgraph.PathSetToBloodHoundGraph(primaryDisplayKinds, paths), http.StatusOK, response)
 	}
 }
 
@@ -147,7 +147,7 @@ func (s Resources) GetShortestPath(response http.ResponseWriter, request *http.R
 		api.WriteErrorResponse(requestContext, api.BuildErrorResponse(http.StatusBadRequest, "Missing query parameter: end_node", request), response)
 	} else if ogExtensionManagementFeatureFlag, err := s.DB.GetFlagByKey(requestContext, appcfg.FeatureOpenGraphExtensionManagement); err != nil {
 		api.HandleDatabaseError(request, response, err)
-	} else if validPrimaryKinds, err := s.DB.GetValidDisplayKinds(request.Context()); err != nil {
+	} else if primaryDisplayKinds, err := s.DB.GetValidDisplayKinds(request.Context()); err != nil {
 		api.HandleDatabaseError(request, response, err)
 	} else {
 		if onlyIncludeTraversableKinds {
@@ -175,7 +175,7 @@ func (s Resources) GetShortestPath(response http.ResponseWriter, request *http.R
 
 			for _, n := range paths.AllNodes() {
 				// ETAC filtering requires pulling the node's properties
-				graphResponse.Nodes[n.ID.String()] = model.FromDAWGSNode(validPrimaryKinds, n, true)
+				graphResponse.Nodes[n.ID.String()] = model.FromDAWGSNode(primaryDisplayKinds, n, true)
 			}
 
 			edges := slicesext.FlatMap(paths, func(path graph.Path) []model.UnifiedEdge {
@@ -284,12 +284,12 @@ func (s *Resources) GetSearchResult(response http.ResponseWriter, request *http.
 			api.HandleDatabaseError(request, response, err)
 		} else if nodes, err := s.GraphQuery.SearchByNameOrObjectID(request.Context(), openGraphSearchFeatureFlag.Enabled, searchValue, searchType); err != nil {
 			api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, fmt.Sprintf("Error getting search results: %v", err), request), response)
-		} else if validPrimaryKinds, err := s.DB.GetValidDisplayKinds(request.Context()); err != nil {
+		} else if primaryDisplayKinds, err := s.DB.GetValidDisplayKinds(request.Context()); err != nil {
 			api.HandleDatabaseError(request, response, err)
 		} else {
 			bhGraph := make(map[string]bloodhoundgraph.BloodHoundGraphNode)
 			for _, node := range nodes {
-				bhGraph[node.ID.String()] = bloodhoundgraph.NodeToBloodHoundGraph(validPrimaryKinds, node)
+				bhGraph[node.ID.String()] = bloodhoundgraph.NodeToBloodHoundGraph(primaryDisplayKinds, node)
 			}
 
 			// ETAC DogTags filtering

--- a/cmd/api/src/api/v2/pathfinding_test.go
+++ b/cmd/api/src/api/v2/pathfinding_test.go
@@ -1278,7 +1278,7 @@ func TestResources_GetSearchResult(t *testing.T) {
 						GetFlagByKey(gomock.Any(), appcfg.FeatureOpenGraphSearch).
 						Return(appcfg.FeatureFlag{Enabled: true}, nil)
 					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any()).Return(graphschema.ValidPrimaryKinds{
-						graph.StringKind("Person"): graphschema.DisplayKind{Name: "Person", Icon: graphschema.DisplayKindIcon{Type: "font-awesome", Name: "person-half-dress", Color: "#ff91af"}}}, nil)
+						graph.StringKind("Person"): graphschema.DisplayKind{Name: "Person", Icon: graphschema.DisplayKindIcon{Type: model.CustomNodeKindTypeFontAwesome, Name: "person-half-dress", Color: "#ff91af"}}}, nil)
 
 					nodeSet := graph.NewNodeSet()
 					personNode := &graph.Node{
@@ -1342,7 +1342,7 @@ func TestResources_GetSearchResult(t *testing.T) {
 
 					nodeSet.Add(personNode)
 					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any()).Return(graphschema.ValidPrimaryKinds{
-						graph.StringKind("Person"): graphschema.DisplayKind{Name: "Person", Icon: graphschema.DisplayKindIcon{Type: "font-awesome", Name: "person-half-dress", Color: "#ff91af"}}}, nil)
+						graph.StringKind("Person"): graphschema.DisplayKind{Name: "Person", Icon: graphschema.DisplayKindIcon{Type: model.CustomNodeKindTypeFontAwesome, Name: "person-half-dress", Color: "#ff91af"}}}, nil)
 					mockGraph.EXPECT().
 						SearchByNameOrObjectID(gomock.Any(), true, "some query", queries.SearchTypeFuzzy).
 						Return(nodeSet, nil)

--- a/cmd/api/src/api/v2/pathfinding_test.go
+++ b/cmd/api/src/api/v2/pathfinding_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/specterops/bloodhound/cmd/api/src/queries"
 	mocks_graph "github.com/specterops/bloodhound/cmd/api/src/queries/mocks"
 	"github.com/specterops/bloodhound/cmd/api/src/services/dogtags"
+	"github.com/specterops/bloodhound/packages/go/graphschema"
 	"github.com/specterops/bloodhound/packages/go/graphschema/ad"
 	"github.com/specterops/bloodhound/packages/go/graphschema/azure"
 	"github.com/specterops/bloodhound/packages/go/graphschema/common"
@@ -114,7 +115,6 @@ func TestResources_GetPathfindingResult(t *testing.T) {
 						GetAllShortestPaths(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 						Return(graph.NewPathSet(), nil)
 					mockDb.EXPECT().GetValidDisplayKinds(gomock.Any())
-					mockDb.EXPECT().GetCustomNodeKindsMap(gomock.Any())
 				},
 				Test: func(output apitest.Output) {
 					apitest.StatusCode(output, http.StatusOK)
@@ -1235,26 +1235,6 @@ func TestResources_GetSearchResult(t *testing.T) {
 				},
 			},
 			{
-				Name: "DBGetCustomNodeKindsError -- should still return results",
-				Input: func(input *apitest.Input) {
-					apitest.AddQueryParam(input, "query", "some query")
-					apitest.SetContext(input, userCtx)
-				},
-				Setup: func() {
-					mockDB.EXPECT().
-						GetFlagByKey(gomock.Any(), appcfg.FeatureOpenGraphSearch).
-						Return(appcfg.FeatureFlag{Enabled: true}, nil)
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
-					mockGraph.EXPECT().
-						SearchByNameOrObjectID(gomock.Any(), true, "some query", queries.SearchTypeFuzzy).
-						Return(graph.NewNodeSet(), nil)
-					mockDB.EXPECT().GetCustomNodeKindsMap(gomock.Any()).Return(model.CustomNodeKindMap{}, errors.New("error"))
-				},
-				Test: func(output apitest.Output) {
-					apitest.StatusCode(output, http.StatusOK)
-				},
-			},
-			{
 				Name: "Error -- GetValidDisplayKindsError",
 				Input: func(input *apitest.Input) {
 					apitest.AddQueryParam(input, "query", "some query")
@@ -1297,7 +1277,8 @@ func TestResources_GetSearchResult(t *testing.T) {
 					mockDB.EXPECT().
 						GetFlagByKey(gomock.Any(), appcfg.FeatureOpenGraphSearch).
 						Return(appcfg.FeatureFlag{Enabled: true}, nil)
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any()).Return(graphschema.ValidPrimaryKinds{
+						graph.StringKind("Person"): graphschema.DisplayKind{Name: "Person", Icon: graphschema.DisplayKindIcon{Type: "font-awesome", Name: "person-half-dress", Color: "#ff91af"}}}, nil)
 
 					nodeSet := graph.NewNodeSet()
 					personNode := &graph.Node{
@@ -1313,8 +1294,6 @@ func TestResources_GetSearchResult(t *testing.T) {
 					mockGraph.EXPECT().
 						SearchByNameOrObjectID(gomock.Any(), true, "some query", queries.SearchTypeFuzzy).
 						Return(nodeSet, nil)
-					mockDB.EXPECT().GetCustomNodeKindsMap(gomock.Any()).Return(model.CustomNodeKindMap{
-						"Person": model.CustomNodeKindConfig{Icon: model.CustomNodeIcon{Type: "font-awesome", Name: "person-half-dress", Color: "#ff91af"}}}, nil)
 				},
 				Test: func(output apitest.Output) {
 					apitest.StatusCode(output, http.StatusOK)
@@ -1336,7 +1315,6 @@ func TestResources_GetSearchResult(t *testing.T) {
 					mockGraph.EXPECT().
 						SearchByNameOrObjectID(gomock.Any(), false, "some query", queries.SearchTypeFuzzy).
 						Return(graph.NewNodeSet(), nil)
-					mockDB.EXPECT().GetCustomNodeKindsMap(gomock.Any()).Return(model.CustomNodeKindMap{}, nil)
 				},
 				Test: func(output apitest.Output) {
 					apitest.StatusCode(output, http.StatusOK)
@@ -1363,12 +1341,11 @@ func TestResources_GetSearchResult(t *testing.T) {
 					}
 
 					nodeSet.Add(personNode)
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any()).Return(graphschema.ValidPrimaryKinds{
+						graph.StringKind("Person"): graphschema.DisplayKind{Name: "Person", Icon: graphschema.DisplayKindIcon{Type: "font-awesome", Name: "person-half-dress", Color: "#ff91af"}}}, nil)
 					mockGraph.EXPECT().
 						SearchByNameOrObjectID(gomock.Any(), true, "some query", queries.SearchTypeFuzzy).
 						Return(nodeSet, nil)
-					mockDB.EXPECT().GetCustomNodeKindsMap(gomock.Any()).Return(model.CustomNodeKindMap{
-						"Person": model.CustomNodeKindConfig{Icon: model.CustomNodeIcon{Type: "font-awesome", Name: "person-half-dress", Color: "#ff91af"}}}, nil)
 				},
 				Test: func(output apitest.Output) {
 					apitest.StatusCode(output, http.StatusOK)
@@ -1405,9 +1382,6 @@ func TestResources_GetSearchResult_ETAC(t *testing.T) {
 				mockGraph.EXPECT().
 					SearchByNameOrObjectID(gomock.Any(), true, "some query", queries.SearchTypeFuzzy).
 					Return(graph.NewNodeSet(), nil)
-
-				mockDB.EXPECT().GetCustomNodeKindsMap(gomock.Any()).Return(model.CustomNodeKindMap{}, nil)
-
 			},
 			expectedStatusCode: http.StatusOK,
 			assertBody: func(t *testing.T, body string) {
@@ -1461,8 +1435,6 @@ func TestResources_GetSearchResult_ETAC(t *testing.T) {
 				mockGraph.EXPECT().
 					SearchByNameOrObjectID(gomock.Any(), true, "some query", queries.SearchTypeFuzzy).
 					Return(nodeSet, nil)
-
-				mockDB.EXPECT().GetCustomNodeKindsMap(gomock.Any()).Return(model.CustomNodeKindMap{}, nil)
 			},
 			expectedStatusCode: http.StatusOK,
 			assertBody: func(t *testing.T, body string) {

--- a/cmd/api/src/api/v2/pathfinding_test.go
+++ b/cmd/api/src/api/v2/pathfinding_test.go
@@ -1277,7 +1277,7 @@ func TestResources_GetSearchResult(t *testing.T) {
 					mockDB.EXPECT().
 						GetFlagByKey(gomock.Any(), appcfg.FeatureOpenGraphSearch).
 						Return(appcfg.FeatureFlag{Enabled: true}, nil)
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any()).Return(graphschema.ValidPrimaryKinds{
+					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any()).Return(graphschema.PrimaryDisplayKinds{
 						graph.StringKind("Person"): graphschema.DisplayKind{Name: "Person", Icon: graphschema.DisplayNodeIcon{Type: graphschema.DisplayNodeTypeFontAwesome, Name: "person-half-dress", Color: "#ff91af"}}}, nil)
 
 					nodeSet := graph.NewNodeSet()
@@ -1341,7 +1341,7 @@ func TestResources_GetSearchResult(t *testing.T) {
 					}
 
 					nodeSet.Add(personNode)
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any()).Return(graphschema.ValidPrimaryKinds{
+					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any()).Return(graphschema.PrimaryDisplayKinds{
 						graph.StringKind("Person"): graphschema.DisplayKind{Name: "Person", Icon: graphschema.DisplayNodeIcon{Type: graphschema.DisplayNodeTypeFontAwesome, Name: "person-half-dress", Color: "#ff91af"}}}, nil)
 					mockGraph.EXPECT().
 						SearchByNameOrObjectID(gomock.Any(), true, "some query", queries.SearchTypeFuzzy).

--- a/cmd/api/src/api/v2/pathfinding_test.go
+++ b/cmd/api/src/api/v2/pathfinding_test.go
@@ -1278,7 +1278,7 @@ func TestResources_GetSearchResult(t *testing.T) {
 						GetFlagByKey(gomock.Any(), appcfg.FeatureOpenGraphSearch).
 						Return(appcfg.FeatureFlag{Enabled: true}, nil)
 					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any()).Return(graphschema.ValidPrimaryKinds{
-						graph.StringKind("Person"): graphschema.DisplayKind{Name: "Person", Icon: graphschema.DisplayKindIcon{Type: model.CustomNodeKindTypeFontAwesome, Name: "person-half-dress", Color: "#ff91af"}}}, nil)
+						graph.StringKind("Person"): graphschema.DisplayKind{Name: "Person", Icon: graphschema.DisplayNodeIcon{Type: graphschema.DisplayNodeTypeFontAwesome, Name: "person-half-dress", Color: "#ff91af"}}}, nil)
 
 					nodeSet := graph.NewNodeSet()
 					personNode := &graph.Node{
@@ -1342,7 +1342,7 @@ func TestResources_GetSearchResult(t *testing.T) {
 
 					nodeSet.Add(personNode)
 					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any()).Return(graphschema.ValidPrimaryKinds{
-						graph.StringKind("Person"): graphschema.DisplayKind{Name: "Person", Icon: graphschema.DisplayKindIcon{Type: model.CustomNodeKindTypeFontAwesome, Name: "person-half-dress", Color: "#ff91af"}}}, nil)
+						graph.StringKind("Person"): graphschema.DisplayKind{Name: "Person", Icon: graphschema.DisplayNodeIcon{Type: graphschema.DisplayNodeTypeFontAwesome, Name: "person-half-dress", Color: "#ff91af"}}}, nil)
 					mockGraph.EXPECT().
 						SearchByNameOrObjectID(gomock.Any(), true, "some query", queries.SearchTypeFuzzy).
 						Return(nodeSet, nil)

--- a/cmd/api/src/api/v2/pathfinding_test.go
+++ b/cmd/api/src/api/v2/pathfinding_test.go
@@ -88,7 +88,7 @@ func TestResources_GetPathfindingResult(t *testing.T) {
 				},
 			},
 			{
-				Name: "GetDisplayGraphSchemaNodeKindsError",
+				Name: "GetValidDisplayKindsError",
 				Input: func(input *apitest.Input) {
 					apitest.AddQueryParam(input, "start_node", "someID")
 					apitest.AddQueryParam(input, "end_node", "someOtherID")
@@ -97,7 +97,7 @@ func TestResources_GetPathfindingResult(t *testing.T) {
 					mockGraph.EXPECT().
 						GetAllShortestPaths(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 						Return(graph.NewPathSet(), nil)
-					mockDb.EXPECT().GetDisplayGraphSchemaNodeKinds(gomock.Any()).Return(nil, errors.New("database error"))
+					mockDb.EXPECT().GetValidDisplayKinds(gomock.Any()).Return(nil, errors.New("database error"))
 				},
 				Test: func(output apitest.Output) {
 					apitest.StatusCode(output, http.StatusInternalServerError)
@@ -113,7 +113,7 @@ func TestResources_GetPathfindingResult(t *testing.T) {
 					mockGraph.EXPECT().
 						GetAllShortestPaths(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 						Return(graph.NewPathSet(), nil)
-					mockDb.EXPECT().GetDisplayGraphSchemaNodeKinds(gomock.Any())
+					mockDb.EXPECT().GetValidDisplayKinds(gomock.Any())
 					mockDb.EXPECT().GetCustomNodeKindsMap(gomock.Any())
 				},
 				Test: func(output apitest.Output) {
@@ -1244,7 +1244,7 @@ func TestResources_GetSearchResult(t *testing.T) {
 					mockDB.EXPECT().
 						GetFlagByKey(gomock.Any(), appcfg.FeatureOpenGraphSearch).
 						Return(appcfg.FeatureFlag{Enabled: true}, nil)
-					mockDB.EXPECT().GetDisplayGraphSchemaNodeKinds(gomock.Any())
+					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
 					mockGraph.EXPECT().
 						SearchByNameOrObjectID(gomock.Any(), true, "some query", queries.SearchTypeFuzzy).
 						Return(graph.NewNodeSet(), nil)
@@ -1255,7 +1255,7 @@ func TestResources_GetSearchResult(t *testing.T) {
 				},
 			},
 			{
-				Name: "Error -- GetDisplayGraphSchemaNodeKindsError",
+				Name: "Error -- GetValidDisplayKindsError",
 				Input: func(input *apitest.Input) {
 					apitest.AddQueryParam(input, "query", "some query")
 					apitest.AddQueryParam(input, "type", "fuzzy")
@@ -1265,7 +1265,7 @@ func TestResources_GetSearchResult(t *testing.T) {
 					mockDB.EXPECT().
 						GetFlagByKey(gomock.Any(), appcfg.FeatureOpenGraphSearch).
 						Return(appcfg.FeatureFlag{Enabled: true}, nil)
-					mockDB.EXPECT().GetDisplayGraphSchemaNodeKinds(gomock.Any()).Return(nil, errors.New("database error"))
+					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any()).Return(nil, errors.New("database error"))
 
 					nodeSet := graph.NewNodeSet()
 					personNode := &graph.Node{
@@ -1297,7 +1297,7 @@ func TestResources_GetSearchResult(t *testing.T) {
 					mockDB.EXPECT().
 						GetFlagByKey(gomock.Any(), appcfg.FeatureOpenGraphSearch).
 						Return(appcfg.FeatureFlag{Enabled: true}, nil)
-					mockDB.EXPECT().GetDisplayGraphSchemaNodeKinds(gomock.Any())
+					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
 
 					nodeSet := graph.NewNodeSet()
 					personNode := &graph.Node{
@@ -1332,7 +1332,7 @@ func TestResources_GetSearchResult(t *testing.T) {
 					mockDB.EXPECT().
 						GetFlagByKey(gomock.Any(), appcfg.FeatureOpenGraphSearch).
 						Return(appcfg.FeatureFlag{Enabled: false}, nil)
-					mockDB.EXPECT().GetDisplayGraphSchemaNodeKinds(gomock.Any())
+					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
 					mockGraph.EXPECT().
 						SearchByNameOrObjectID(gomock.Any(), false, "some query", queries.SearchTypeFuzzy).
 						Return(graph.NewNodeSet(), nil)
@@ -1363,7 +1363,7 @@ func TestResources_GetSearchResult(t *testing.T) {
 					}
 
 					nodeSet.Add(personNode)
-					mockDB.EXPECT().GetDisplayGraphSchemaNodeKinds(gomock.Any())
+					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
 					mockGraph.EXPECT().
 						SearchByNameOrObjectID(gomock.Any(), true, "some query", queries.SearchTypeFuzzy).
 						Return(nodeSet, nil)
@@ -1401,7 +1401,7 @@ func TestResources_GetSearchResult_ETAC(t *testing.T) {
 				mockDB.EXPECT().
 					GetFlagByKey(gomock.Any(), appcfg.FeatureOpenGraphSearch).
 					Return(appcfg.FeatureFlag{Enabled: true}, nil)
-				mockDB.EXPECT().GetDisplayGraphSchemaNodeKinds(gomock.Any())
+				mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
 				mockGraph.EXPECT().
 					SearchByNameOrObjectID(gomock.Any(), true, "some query", queries.SearchTypeFuzzy).
 					Return(graph.NewNodeSet(), nil)
@@ -1457,7 +1457,7 @@ func TestResources_GetSearchResult_ETAC(t *testing.T) {
 				}
 				nodeSet.Add(accessibleNode)
 				nodeSet.Add(hiddenNode)
-				mockDB.EXPECT().GetDisplayGraphSchemaNodeKinds(gomock.Any())
+				mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
 				mockGraph.EXPECT().
 					SearchByNameOrObjectID(gomock.Any(), true, "some query", queries.SearchTypeFuzzy).
 					Return(nodeSet, nil)

--- a/cmd/api/src/api/v2/pathfinding_test.go
+++ b/cmd/api/src/api/v2/pathfinding_test.go
@@ -89,7 +89,7 @@ func TestResources_GetPathfindingResult(t *testing.T) {
 				},
 			},
 			{
-				Name: "GetValidDisplayKindsError",
+				Name: "GetPrimaryDisplayKindsError",
 				Input: func(input *apitest.Input) {
 					apitest.AddQueryParam(input, "start_node", "someID")
 					apitest.AddQueryParam(input, "end_node", "someOtherID")
@@ -98,7 +98,7 @@ func TestResources_GetPathfindingResult(t *testing.T) {
 					mockGraph.EXPECT().
 						GetAllShortestPaths(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 						Return(graph.NewPathSet(), nil)
-					mockDb.EXPECT().GetValidDisplayKinds(gomock.Any()).Return(nil, errors.New("database error"))
+					mockDb.EXPECT().GetPrimaryDisplayKinds(gomock.Any()).Return(nil, errors.New("database error"))
 				},
 				Test: func(output apitest.Output) {
 					apitest.StatusCode(output, http.StatusInternalServerError)
@@ -114,7 +114,7 @@ func TestResources_GetPathfindingResult(t *testing.T) {
 					mockGraph.EXPECT().
 						GetAllShortestPaths(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 						Return(graph.NewPathSet(), nil)
-					mockDb.EXPECT().GetValidDisplayKinds(gomock.Any())
+					mockDb.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 				},
 				Test: func(output apitest.Output) {
 					apitest.StatusCode(output, http.StatusOK)
@@ -189,7 +189,7 @@ func TestResources_GetShortestPath(t *testing.T) {
 				},
 			},
 			{
-				Name: "GetValidDisplayKindsError",
+				Name: "GetPrimaryDisplayKindsError",
 				Input: func(input *apitest.Input) {
 					apitest.AddQueryParam(input, "start_node", "someID")
 					apitest.AddQueryParam(input, "end_node", "someOtherID")
@@ -197,7 +197,7 @@ func TestResources_GetShortestPath(t *testing.T) {
 				},
 				Setup: func() {
 					mockDB.EXPECT().GetFlagByKey(gomock.Any(), appcfg.FeatureOpenGraphExtensionManagement).Return(appcfg.FeatureFlag{}, nil)
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any()).Return(nil, errors.New("database error"))
+					mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any()).Return(nil, errors.New("database error"))
 				},
 				Test: func(output apitest.Output) {
 					apitest.StatusCode(output, http.StatusInternalServerError)
@@ -215,7 +215,7 @@ func TestResources_GetShortestPath(t *testing.T) {
 					mockDB.EXPECT().
 						GetFlagByKey(gomock.Any(), appcfg.FeatureOpenGraphExtensionManagement).
 						Return(appcfg.FeatureFlag{Enabled: false}, nil)
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+					mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 				},
 				Test: func(output apitest.Output) {
 					apitest.StatusCode(output, http.StatusBadRequest)
@@ -234,7 +234,7 @@ func TestResources_GetShortestPath(t *testing.T) {
 					mockDB.EXPECT().
 						GetFlagByKey(gomock.Any(), appcfg.FeatureOpenGraphExtensionManagement).
 						Return(appcfg.FeatureFlag{Enabled: false}, nil)
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+					mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 				},
 				Test: func(output apitest.Output) {
 					apitest.StatusCode(output, http.StatusBadRequest)
@@ -253,7 +253,7 @@ func TestResources_GetShortestPath(t *testing.T) {
 					mockDB.EXPECT().
 						GetFlagByKey(gomock.Any(), appcfg.FeatureOpenGraphExtensionManagement).
 						Return(appcfg.FeatureFlag{Enabled: false}, nil)
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+					mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 				},
 				Test: func(output apitest.Output) {
 					apitest.StatusCode(output, http.StatusBadRequest)
@@ -271,7 +271,7 @@ func TestResources_GetShortestPath(t *testing.T) {
 					mockDB.EXPECT().
 						GetFlagByKey(gomock.Any(), appcfg.FeatureOpenGraphExtensionManagement).
 						Return(appcfg.FeatureFlag{Enabled: false}, nil)
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+					mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 				},
 				Test: func(output apitest.Output) {
 					apitest.StatusCode(output, http.StatusBadRequest)
@@ -290,7 +290,7 @@ func TestResources_GetShortestPath(t *testing.T) {
 					mockDB.EXPECT().
 						GetFlagByKey(gomock.Any(), appcfg.FeatureOpenGraphExtensionManagement).
 						Return(appcfg.FeatureFlag{Enabled: false}, nil)
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+					mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 				},
 				Test: func(output apitest.Output) {
 					apitest.StatusCode(output, http.StatusBadRequest)
@@ -307,7 +307,7 @@ func TestResources_GetShortestPath(t *testing.T) {
 					mockDB.EXPECT().
 						GetFlagByKey(gomock.Any(), appcfg.FeatureOpenGraphExtensionManagement).
 						Return(appcfg.FeatureFlag{Enabled: false}, nil)
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+					mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 					mockGraph.EXPECT().
 						GetAllShortestPaths(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 						Return(nil, errors.New("graph error"))
@@ -331,7 +331,7 @@ func TestResources_GetShortestPath(t *testing.T) {
 					mockDB.EXPECT().
 						GetFlagByKey(gomock.Any(), appcfg.FeatureOpenGraphExtensionManagement).
 						Return(appcfg.FeatureFlag{Enabled: false}, nil)
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+					mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 					mockGraph.EXPECT().
 						GetAllShortestPaths(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 						Return(graph.NewPathSet(), nil)
@@ -356,7 +356,7 @@ func TestResources_GetShortestPath(t *testing.T) {
 					mockDB.EXPECT().
 						GetFlagByKey(gomock.Any(), appcfg.FeatureOpenGraphExtensionManagement).
 						Return(appcfg.FeatureFlag{Enabled: false}, nil)
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+					mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 					mockGraph.EXPECT().
 						GetAllShortestPaths(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 						Return(graph.NewPathSet(), nil)
@@ -379,7 +379,7 @@ func TestResources_GetShortestPath(t *testing.T) {
 					mockDB.EXPECT().
 						GetFlagByKey(gomock.Any(), appcfg.FeatureOpenGraphExtensionManagement).
 						Return(appcfg.FeatureFlag{Enabled: false}, nil)
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+					mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 					mockGraph.EXPECT().
 						GetAllShortestPaths(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 						Return(graph.NewPathSet(), nil)
@@ -402,7 +402,7 @@ func TestResources_GetShortestPath(t *testing.T) {
 					mockDB.EXPECT().
 						GetFlagByKey(gomock.Any(), appcfg.FeatureOpenGraphExtensionManagement).
 						Return(appcfg.FeatureFlag{Enabled: false}, nil)
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+					mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 					mockGraph.EXPECT().
 						GetAllShortestPaths(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 						Return(graph.NewPathSet(graph.Path{
@@ -447,7 +447,7 @@ func TestResources_GetShortestPath(t *testing.T) {
 					mockDB.EXPECT().
 						GetFlagByKey(gomock.Any(), appcfg.FeatureOpenGraphExtensionManagement).
 						Return(appcfg.FeatureFlag{Enabled: false}, nil)
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+					mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 					mockGraph.EXPECT().
 						GetAllShortestPaths(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 						Return(graph.NewPathSet(graph.Path{
@@ -492,7 +492,7 @@ func TestResources_GetShortestPath(t *testing.T) {
 					mockDB.EXPECT().
 						GetFlagByKey(gomock.Any(), appcfg.FeatureOpenGraphExtensionManagement).
 						Return(appcfg.FeatureFlag{Enabled: false}, nil)
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+					mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 					mockGraph.EXPECT().
 						GetAllShortestPaths(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 						Return(graph.NewPathSet(), nil)
@@ -515,7 +515,7 @@ func TestResources_GetShortestPath(t *testing.T) {
 					mockDB.EXPECT().
 						GetFlagByKey(gomock.Any(), appcfg.FeatureOpenGraphExtensionManagement).
 						Return(appcfg.FeatureFlag{Enabled: false}, nil)
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+					mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 					mockGraph.EXPECT().
 						GetAllShortestPaths(gomock.Any(), "someID", "someOtherID", allKindsFilter).
 						Return(graph.NewPathSet(), nil)
@@ -540,7 +540,7 @@ func TestResources_GetShortestPath(t *testing.T) {
 					mockDB.EXPECT().
 						GetFlagByKey(gomock.Any(), appcfg.FeatureOpenGraphExtensionManagement).
 						Return(appcfg.FeatureFlag{Enabled: false}, nil)
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+					mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 					mockGraph.EXPECT().
 						GetAllShortestPaths(gomock.Any(), "someID", "someOtherID", traversableKindsFilter).
 						Return(graph.NewPathSet(), nil)
@@ -566,7 +566,7 @@ func TestResources_GetShortestPath(t *testing.T) {
 					mockDB.EXPECT().
 						GetFlagByKey(gomock.Any(), appcfg.FeatureOpenGraphExtensionManagement).
 						Return(appcfg.FeatureFlag{Enabled: false}, nil)
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+					mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 					mockGraph.EXPECT().
 						GetAllShortestPaths(gomock.Any(), "someID", "someOtherID", query.KindIn(query.Relationship(), ad.Contains)).
 						Return(graph.NewPathSet(), nil)
@@ -588,7 +588,7 @@ func TestResources_GetShortestPath(t *testing.T) {
 					mockDB.EXPECT().
 						GetFlagByKey(gomock.Any(), appcfg.FeatureOpenGraphExtensionManagement).
 						Return(appcfg.FeatureFlag{Enabled: true}, nil)
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+					mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 					mockDB.EXPECT().GetGraphSchemaRelationshipKinds(gomock.Any(), model.Filters{}, model.Sort{}, 0, 0).Return(model.GraphSchemaRelationshipKinds{}, 0, errors.New("database error"))
 				},
 				Test: func(output apitest.Output) {
@@ -607,7 +607,7 @@ func TestResources_GetShortestPath(t *testing.T) {
 					mockDB.EXPECT().
 						GetFlagByKey(gomock.Any(), appcfg.FeatureOpenGraphExtensionManagement).
 						Return(appcfg.FeatureFlag{Enabled: true}, nil)
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+					mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 					mockDB.EXPECT().GetGraphSchemaRelationshipKinds(gomock.Any(), model.Filters{}, model.Sort{}, 0, 0).Return(openGraphEdges, 2, nil)
 				},
 				Test: func(output apitest.Output) {
@@ -627,7 +627,7 @@ func TestResources_GetShortestPath(t *testing.T) {
 					mockDB.EXPECT().
 						GetFlagByKey(gomock.Any(), appcfg.FeatureOpenGraphExtensionManagement).
 						Return(appcfg.FeatureFlag{Enabled: true}, nil)
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+					mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 					mockDB.EXPECT().GetGraphSchemaRelationshipKinds(gomock.Any(), model.Filters{}, model.Sort{}, 0, 0).Return(openGraphEdges, 2, nil)
 				},
 				Test: func(output apitest.Output) {
@@ -647,7 +647,7 @@ func TestResources_GetShortestPath(t *testing.T) {
 					mockDB.EXPECT().
 						GetFlagByKey(gomock.Any(), appcfg.FeatureOpenGraphExtensionManagement).
 						Return(appcfg.FeatureFlag{Enabled: true}, nil)
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+					mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 					mockDB.EXPECT().GetGraphSchemaRelationshipKinds(gomock.Any(), model.Filters{}, model.Sort{}, 0, 0).Return(openGraphEdges, 2, nil)
 
 				},
@@ -667,7 +667,7 @@ func TestResources_GetShortestPath(t *testing.T) {
 					mockDB.EXPECT().
 						GetFlagByKey(gomock.Any(), appcfg.FeatureOpenGraphExtensionManagement).
 						Return(appcfg.FeatureFlag{Enabled: true}, nil)
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+					mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 					mockDB.EXPECT().GetGraphSchemaRelationshipKinds(gomock.Any(), model.Filters{}, model.Sort{}, 0, 0).Return(openGraphEdges, 2, nil)
 
 				},
@@ -686,7 +686,7 @@ func TestResources_GetShortestPath(t *testing.T) {
 					mockDB.EXPECT().
 						GetFlagByKey(gomock.Any(), appcfg.FeatureOpenGraphExtensionManagement).
 						Return(appcfg.FeatureFlag{Enabled: true}, nil)
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+					mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 					mockDB.EXPECT().GetGraphSchemaRelationshipKinds(gomock.Any(), model.Filters{}, model.Sort{}, 0, 0).Return(openGraphEdges, 2, nil)
 					mockGraph.EXPECT().
 						GetAllShortestPathsWithOpenGraph(gomock.Any(), "someID", "someOtherID", allKindsFilterWithOpenGraph).
@@ -711,7 +711,7 @@ func TestResources_GetShortestPath(t *testing.T) {
 					mockDB.EXPECT().
 						GetFlagByKey(gomock.Any(), appcfg.FeatureOpenGraphExtensionManagement).
 						Return(appcfg.FeatureFlag{Enabled: true}, nil)
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+					mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 					mockDB.EXPECT().GetGraphSchemaRelationshipKinds(gomock.Any(), model.Filters{}, model.Sort{}, 0, 0).Return(openGraphEdges, 2, nil)
 					mockGraph.EXPECT().
 						GetAllShortestPathsWithOpenGraph(gomock.Any(), "someID", "someOtherID", allKindsFilterWithOpenGraph).
@@ -737,7 +737,7 @@ func TestResources_GetShortestPath(t *testing.T) {
 					mockDB.EXPECT().
 						GetFlagByKey(gomock.Any(), appcfg.FeatureOpenGraphExtensionManagement).
 						Return(appcfg.FeatureFlag{Enabled: true}, nil)
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+					mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 					mockDB.EXPECT().GetGraphSchemaRelationshipKinds(gomock.Any(), model.Filters{}, model.Sort{}, 0, 0).Return(openGraphEdges, 2, nil)
 					mockGraph.EXPECT().
 						GetAllShortestPathsWithOpenGraph(gomock.Any(), "someID", "someOtherID", query.KindIn(query.Relationship(), allKindsWithOpenGraph.Exclude(graph.Kinds{}.Add(ad.Owns, ad.GenericAll, azure.ServicePrincipalEndpointReadWriteAll))...)).
@@ -761,7 +761,7 @@ func TestResources_GetShortestPath(t *testing.T) {
 					mockDB.EXPECT().
 						GetFlagByKey(gomock.Any(), appcfg.FeatureOpenGraphExtensionManagement).
 						Return(appcfg.FeatureFlag{Enabled: true}, nil)
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+					mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 					mockDB.EXPECT().GetGraphSchemaRelationshipKinds(gomock.Any(), model.Filters{}, model.Sort{}, 0, 0).Return(openGraphEdges, 2, nil)
 					mockGraph.EXPECT().
 						GetAllShortestPathsWithOpenGraph(gomock.Any(), "someID", "someOtherID", query.KindIn(query.Relationship(), graph.Kinds{}.Add(ad.Owns, ad.GenericAll, ad.GenericWrite, azure.ServicePrincipalEndpointReadWriteAll)...)).
@@ -785,7 +785,7 @@ func TestResources_GetShortestPath(t *testing.T) {
 					mockDB.EXPECT().
 						GetFlagByKey(gomock.Any(), appcfg.FeatureOpenGraphExtensionManagement).
 						Return(appcfg.FeatureFlag{Enabled: true}, nil)
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+					mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 					mockDB.EXPECT().GetGraphSchemaRelationshipKinds(gomock.Any(), model.Filters{}, model.Sort{}, 0, 0).Return(openGraphEdges, 2, nil)
 					mockGraph.EXPECT().
 						GetAllShortestPathsWithOpenGraph(gomock.Any(), "someID", "someOtherID", query.KindIn(query.Relationship(), allKindsWithOpenGraph.Exclude(graph.Kinds{}.Add(ad.Owns, ad.GenericAll, azure.ServicePrincipalEndpointReadWriteAll))...)).
@@ -831,7 +831,7 @@ func TestResources_GetShortestPath(t *testing.T) {
 					mockDB.EXPECT().
 						GetFlagByKey(gomock.Any(), appcfg.FeatureOpenGraphExtensionManagement).
 						Return(appcfg.FeatureFlag{Enabled: true}, nil)
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+					mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 					mockDB.EXPECT().GetGraphSchemaRelationshipKinds(gomock.Any(), model.Filters{}, model.Sort{}, 0, 0).Return(openGraphEdges, 2, nil)
 					mockGraph.EXPECT().
 						GetAllShortestPathsWithOpenGraph(gomock.Any(), "someID", "someOtherID", query.KindIn(query.Relationship(), graph.Kinds{}.Add(ad.Owns, ad.GenericAll, ad.GenericWrite, azure.ServicePrincipalEndpointReadWriteAll)...)).
@@ -877,7 +877,7 @@ func TestResources_GetShortestPath(t *testing.T) {
 					mockDB.EXPECT().
 						GetFlagByKey(gomock.Any(), appcfg.FeatureOpenGraphExtensionManagement).
 						Return(appcfg.FeatureFlag{Enabled: true}, nil)
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+					mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 					mockDB.EXPECT().GetGraphSchemaRelationshipKinds(gomock.Any(), model.Filters{}, model.Sort{}, 0, 0).Return(openGraphEdges, 2, nil)
 					mockGraph.EXPECT().
 						GetAllShortestPathsWithOpenGraph(gomock.Any(), "someID", "someOtherID", query.KindIn(query.Relationship(), ad.Owns)).
@@ -901,7 +901,7 @@ func TestResources_GetShortestPath(t *testing.T) {
 					mockDB.EXPECT().
 						GetFlagByKey(gomock.Any(), appcfg.FeatureOpenGraphExtensionManagement).
 						Return(appcfg.FeatureFlag{Enabled: true}, nil)
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+					mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 					mockDB.EXPECT().GetGraphSchemaRelationshipKinds(gomock.Any(), model.Filters{"is_traversable": []model.Filter{{Operator: model.Equals, Value: "true"}}}, model.Sort{}, 0, 0).Return(openGraphEdges, 2, nil)
 					mockGraph.EXPECT().
 						GetAllShortestPathsWithOpenGraph(gomock.Any(), "someID", "someOtherID", traversableKindsFilterWithOpenGraph).
@@ -928,7 +928,7 @@ func TestResources_GetShortestPath(t *testing.T) {
 					mockDB.EXPECT().
 						GetFlagByKey(gomock.Any(), appcfg.FeatureOpenGraphExtensionManagement).
 						Return(appcfg.FeatureFlag{Enabled: true}, nil)
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+					mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 					mockDB.EXPECT().GetGraphSchemaRelationshipKinds(gomock.Any(), model.Filters{"is_traversable": []model.Filter{{Operator: model.Equals, Value: "true"}}}, model.Sort{}, 0, 0).Return(openGraphEdges, 2, nil)
 					mockGraph.EXPECT().
 						GetAllShortestPathsWithOpenGraph(gomock.Any(), "someID", "someOtherID", query.KindIn(query.Relationship(), ad.Contains)).
@@ -956,7 +956,7 @@ func TestResources_GetShortestPath(t *testing.T) {
 					mockDB.EXPECT().
 						GetFlagByKey(gomock.Any(), appcfg.FeatureOpenGraphExtensionManagement).
 						Return(appcfg.FeatureFlag{Enabled: true}, nil)
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+					mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 					mockDB.EXPECT().GetGraphSchemaRelationshipKinds(gomock.Any(), model.Filters{"is_traversable": []model.Filter{{Operator: model.Equals, Value: "true"}}}, model.Sort{}, 0, 0).Return(openGraphEdges, 2, nil)
 					mockGraph.EXPECT().
 						GetAllShortestPathsWithOpenGraph(gomock.Any(), "someID", "someOtherID", query.KindIn(query.Relationship(), traversableKindsWithOpenGraph.Exclude(graph.Kinds{}.Add(ad.Contains))...)).
@@ -1006,7 +1006,7 @@ func TestResources_GetShortestPath_ETAC(t *testing.T) {
 				mockDB.EXPECT().
 					GetFlagByKey(gomock.Any(), appcfg.FeatureOpenGraphExtensionManagement).
 					Return(appcfg.FeatureFlag{Enabled: false}, nil)
-				mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+				mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 				mockGraph.EXPECT().
 					GetAllShortestPaths(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(graph.NewPathSet(graph.Path{
@@ -1071,7 +1071,7 @@ func TestResources_GetShortestPath_ETAC(t *testing.T) {
 				mockDB.EXPECT().
 					GetFlagByKey(gomock.Any(), appcfg.FeatureOpenGraphExtensionManagement).
 					Return(appcfg.FeatureFlag{Enabled: false}, nil)
-				mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+				mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 				mockGraph.EXPECT().
 					GetAllShortestPaths(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(graph.NewPathSet(graph.Path{
@@ -1235,7 +1235,7 @@ func TestResources_GetSearchResult(t *testing.T) {
 				},
 			},
 			{
-				Name: "Error -- GetValidDisplayKindsError",
+				Name: "Error -- GetPrimaryDisplayKindsError",
 				Input: func(input *apitest.Input) {
 					apitest.AddQueryParam(input, "query", "some query")
 					apitest.AddQueryParam(input, "type", "fuzzy")
@@ -1245,7 +1245,7 @@ func TestResources_GetSearchResult(t *testing.T) {
 					mockDB.EXPECT().
 						GetFlagByKey(gomock.Any(), appcfg.FeatureOpenGraphSearch).
 						Return(appcfg.FeatureFlag{Enabled: true}, nil)
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any()).Return(nil, errors.New("database error"))
+					mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any()).Return(nil, errors.New("database error"))
 
 					nodeSet := graph.NewNodeSet()
 					personNode := &graph.Node{
@@ -1277,7 +1277,7 @@ func TestResources_GetSearchResult(t *testing.T) {
 					mockDB.EXPECT().
 						GetFlagByKey(gomock.Any(), appcfg.FeatureOpenGraphSearch).
 						Return(appcfg.FeatureFlag{Enabled: true}, nil)
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any()).Return(graphschema.PrimaryDisplayKinds{
+					mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any()).Return(graphschema.PrimaryDisplayKinds{
 						graph.StringKind("Person"): graphschema.DisplayKind{Name: "Person", Icon: graphschema.DisplayNodeIcon{Type: graphschema.DisplayNodeTypeFontAwesome, Name: "person-half-dress", Color: "#ff91af"}}}, nil)
 
 					nodeSet := graph.NewNodeSet()
@@ -1311,7 +1311,7 @@ func TestResources_GetSearchResult(t *testing.T) {
 					mockDB.EXPECT().
 						GetFlagByKey(gomock.Any(), appcfg.FeatureOpenGraphSearch).
 						Return(appcfg.FeatureFlag{Enabled: false}, nil)
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+					mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 					mockGraph.EXPECT().
 						SearchByNameOrObjectID(gomock.Any(), false, "some query", queries.SearchTypeFuzzy).
 						Return(graph.NewNodeSet(), nil)
@@ -1341,7 +1341,7 @@ func TestResources_GetSearchResult(t *testing.T) {
 					}
 
 					nodeSet.Add(personNode)
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any()).Return(graphschema.PrimaryDisplayKinds{
+					mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any()).Return(graphschema.PrimaryDisplayKinds{
 						graph.StringKind("Person"): graphschema.DisplayKind{Name: "Person", Icon: graphschema.DisplayNodeIcon{Type: graphschema.DisplayNodeTypeFontAwesome, Name: "person-half-dress", Color: "#ff91af"}}}, nil)
 					mockGraph.EXPECT().
 						SearchByNameOrObjectID(gomock.Any(), true, "some query", queries.SearchTypeFuzzy).
@@ -1378,7 +1378,7 @@ func TestResources_GetSearchResult_ETAC(t *testing.T) {
 				mockDB.EXPECT().
 					GetFlagByKey(gomock.Any(), appcfg.FeatureOpenGraphSearch).
 					Return(appcfg.FeatureFlag{Enabled: true}, nil)
-				mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+				mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 				mockGraph.EXPECT().
 					SearchByNameOrObjectID(gomock.Any(), true, "some query", queries.SearchTypeFuzzy).
 					Return(graph.NewNodeSet(), nil)
@@ -1431,7 +1431,7 @@ func TestResources_GetSearchResult_ETAC(t *testing.T) {
 				}
 				nodeSet.Add(accessibleNode)
 				nodeSet.Add(hiddenNode)
-				mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+				mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 				mockGraph.EXPECT().
 					SearchByNameOrObjectID(gomock.Any(), true, "some query", queries.SearchTypeFuzzy).
 					Return(nodeSet, nil)

--- a/cmd/api/src/api/v2/search.go
+++ b/cmd/api/src/api/v2/search.go
@@ -58,38 +58,38 @@ func (s Resources) SearchHandler(response http.ResponseWriter, request *http.Req
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, fmt.Sprintf("Invalid query parameter: %v", err), request), response)
 	} else if openGraphSearchFeatureFlag, err := s.DB.GetFlagByKey(request.Context(), appcfg.FeatureOpenGraphSearch); err != nil {
 		api.HandleDatabaseError(request, response, err)
-	} else if validPrimaryKinds, err := s.DB.GetValidDisplayKinds(request.Context()); err != nil {
+	} else if primaryDisplayKinds, err := s.DB.GetValidDisplayKinds(request.Context()); err != nil {
 		api.HandleDatabaseError(request, response, err)
-	} else if searchableNodeKinds, err := getSearchableNodeKinds(openGraphSearchFeatureFlag.Enabled, validPrimaryKinds, graph.StringsToKinds(nodeTypes)); err != nil {
+	} else if searchableNodeKinds, err := getSearchableNodeKinds(openGraphSearchFeatureFlag.Enabled, primaryDisplayKinds, graph.StringsToKinds(nodeTypes)); err != nil {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, "Invalid type parameter", request), response)
 	} else if nodes, err := s.GraphQuery.SearchNodesByNameOrObjectId(ctx, searchableNodeKinds, searchQuery, skip, limit); err != nil {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusInternalServerError, fmt.Sprintf("Graph error: %v", err), request), response)
 	} else {
-		result := filterAndFormatSearchResults(nodes, etacAllowedList, validPrimaryKinds)
+		result := filterAndFormatSearchResults(nodes, etacAllowedList, primaryDisplayKinds)
 
 		api.WriteBasicResponse(request.Context(), result, http.StatusOK, response)
 	}
 }
 
-func filterAndFormatSearchResults(nodes []*graph.Node, etacAllowedList []string, validPrimaryKinds graphschema.ValidPrimaryKinds) []model.SearchResult {
+func filterAndFormatSearchResults(nodes []*graph.Node, etacAllowedList []string, primaryDisplayKinds graphschema.PrimaryDisplayKinds) []model.SearchResult {
 	var results []model.SearchResult
 
 	for _, node := range nodes {
 		if !nodeGatedByETAC(etacAllowedList, node) {
-			results = append(results, graphNodeToSearchResult(node, validPrimaryKinds))
+			results = append(results, graphNodeToSearchResult(node, primaryDisplayKinds))
 		}
 	}
 
 	return results
 }
 
-func graphNodeToSearchResult(node *graph.Node, validPrimaryKinds graphschema.ValidPrimaryKinds) model.SearchResult {
+func graphNodeToSearchResult(node *graph.Node, primaryDisplayKinds graphschema.PrimaryDisplayKinds) model.SearchResult {
 	var (
 		name, _              = node.Properties.GetWithFallback(common.Name.String(), graphschema.DefaultMissingName, common.DisplayName.String(), common.ObjectID.String()).String()
 		objectID, _          = node.Properties.GetOrDefault(common.ObjectID.String(), graphschema.DefaultMissingObjectId).String()
 		distinguishedName, _ = node.Properties.GetOrDefault(ad.DistinguishedName.String(), "").String()
 		systemTags, _        = node.Properties.GetOrDefault(common.SystemTags.String(), "").String()
-		kindLabel            = graphschema.GetNodeKindDisplayLabel(validPrimaryKinds, node)
+		kindLabel            = graphschema.GetNodeKindDisplayLabel(primaryDisplayKinds, node)
 	)
 
 	return model.SearchResult{
@@ -102,10 +102,10 @@ func graphNodeToSearchResult(node *graph.Node, validPrimaryKinds graphschema.Val
 }
 
 // getSearchableNodeKinds returns the kinds that should be searched based on the OpenGraphSearch feature flag and the valid primary kinds.
-func getSearchableNodeKinds(openGraphSearchEnabled bool, validPrimaryKinds graphschema.ValidPrimaryKinds, typeParams graph.Kinds) (graph.Kinds, error) {
+func getSearchableNodeKinds(openGraphSearchEnabled bool, primaryDisplayKinds graphschema.PrimaryDisplayKinds, typeParams graph.Kinds) (graph.Kinds, error) {
 	var (
 		searchableKinds                graph.Kinds
-		validKinds                     graphschema.ValidPrimaryKinds
+		validKinds                     graphschema.PrimaryDisplayKinds
 		emptyParams                    = len(typeParams) == 0
 		invalidParamError              = fmt.Errorf("no valid primary kinds found for search types: %v", typeParams)
 		kindsShouldNotBeConstrained    = emptyParams && openGraphSearchEnabled
@@ -120,12 +120,12 @@ func getSearchableNodeKinds(openGraphSearchEnabled bool, validPrimaryKinds graph
 
 		if openGraphSearchEnabled {
 			// only assign validKinds if OpenGraphSearch is enabled
-			// otherwise we pass nil to PrimaryNodeKind to emulate the old behavior
-			validKinds = validPrimaryKinds
+			// otherwise we pass nil to PrimaryDisplayKind to emulate the old behavior
+			validKinds = primaryDisplayKinds
 		}
 
 		for _, kind := range typeParams {
-			kind := graphschema.PrimaryNodeKind(validKinds, graph.Kinds{kind})
+			kind := graphschema.PrimaryDisplayKind(validKinds, graph.Kinds{kind})
 
 			if !kind.Is(graphschema.UnknownKind) {
 				searchableKinds = searchableKinds.Add(kind)

--- a/cmd/api/src/api/v2/search.go
+++ b/cmd/api/src/api/v2/search.go
@@ -101,13 +101,13 @@ func graphNodeToSearchResult(node *graph.Node, primaryDisplayKinds graphschema.P
 	}
 }
 
-// getSearchableNodeKinds returns the kinds that should be searched based on the OpenGraphSearch feature flag and the valid primary kinds.
+// getSearchableNodeKinds returns the kinds that should be searched based on the OpenGraphSearch feature flag and the primary display kinds.
 func getSearchableNodeKinds(openGraphSearchEnabled bool, primaryDisplayKinds graphschema.PrimaryDisplayKinds, typeParams graph.Kinds) (graph.Kinds, error) {
 	var (
 		searchableKinds                graph.Kinds
 		validKinds                     graphschema.PrimaryDisplayKinds
 		emptyParams                    = len(typeParams) == 0
-		invalidParamError              = fmt.Errorf("no valid primary kinds found for search types: %v", typeParams)
+		invalidParamError              = fmt.Errorf("no primary display kinds found for search types: %v", typeParams)
 		kindsShouldNotBeConstrained    = emptyParams && openGraphSearchEnabled
 		kindsConstrainedToDefaultKinds = emptyParams && !openGraphSearchEnabled
 	)

--- a/cmd/api/src/api/v2/search.go
+++ b/cmd/api/src/api/v2/search.go
@@ -58,7 +58,7 @@ func (s Resources) SearchHandler(response http.ResponseWriter, request *http.Req
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, fmt.Sprintf("Invalid query parameter: %v", err), request), response)
 	} else if openGraphSearchFeatureFlag, err := s.DB.GetFlagByKey(request.Context(), appcfg.FeatureOpenGraphSearch); err != nil {
 		api.HandleDatabaseError(request, response, err)
-	} else if primaryDisplayKinds, err := s.DB.GetValidDisplayKinds(request.Context()); err != nil {
+	} else if primaryDisplayKinds, err := s.DB.GetPrimaryDisplayKinds(request.Context()); err != nil {
 		api.HandleDatabaseError(request, response, err)
 	} else if searchableNodeKinds, err := getSearchableNodeKinds(openGraphSearchFeatureFlag.Enabled, primaryDisplayKinds, graph.StringsToKinds(nodeTypes)); err != nil {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, "Invalid type parameter", request), response)

--- a/cmd/api/src/api/v2/search.go
+++ b/cmd/api/src/api/v2/search.go
@@ -20,8 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log/slog"
-	"maps"
 	"net/http"
 
 	"github.com/specterops/bloodhound/cmd/api/src/api"
@@ -44,8 +42,6 @@ func (s Resources) SearchHandler(response http.ResponseWriter, request *http.Req
 		searchQuery     = queryParams.Get("q")
 		nodeTypes       = queryParams["type"]
 		ctx             = request.Context()
-		err             error
-		customNodeKinds model.CustomNodeKindMap
 		etacAllowedList []string
 	)
 
@@ -54,10 +50,6 @@ func (s Resources) SearchHandler(response http.ResponseWriter, request *http.Req
 		return
 	} else if ShouldFilterForETAC(s.DogTags, user) {
 		etacAllowedList = ExtractEnvironmentIDsFromUser(&user)
-	}
-
-	if customNodeKinds, err = s.DB.GetCustomNodeKindsMap(request.Context()); err != nil {
-		slog.Warn("Unable to fetch custom nodes from database; will fall back to defaults")
 	}
 
 	if searchQuery == "" {
@@ -73,24 +65,18 @@ func (s Resources) SearchHandler(response http.ResponseWriter, request *http.Req
 	} else if nodes, err := s.GraphQuery.SearchNodesByNameOrObjectId(ctx, searchableNodeKinds, searchQuery, skip, limit); err != nil {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusInternalServerError, fmt.Sprintf("Graph error: %v", err), request), response)
 	} else {
-		result := filterAndFormatSearchResults(nodes, etacAllowedList, validPrimaryKinds, customNodeKinds)
+		result := filterAndFormatSearchResults(nodes, etacAllowedList, validPrimaryKinds)
 
 		api.WriteBasicResponse(request.Context(), result, http.StatusOK, response)
 	}
 }
 
-func filterAndFormatSearchResults(nodes []*graph.Node, etacAllowedList []string, validPrimaryKinds graphschema.ValidPrimaryKinds, customNodeKinds model.CustomNodeKindMap) []model.SearchResult {
-	var (
-		results    []model.SearchResult
-		validKinds = customNodeKinds.ValidKinds()
-	)
-
-	// Add custom node kinds to valid primary kinds
-	maps.Copy(validKinds, validPrimaryKinds)
+func filterAndFormatSearchResults(nodes []*graph.Node, etacAllowedList []string, validPrimaryKinds graphschema.ValidPrimaryKinds) []model.SearchResult {
+	var results []model.SearchResult
 
 	for _, node := range nodes {
 		if !nodeGatedByETAC(etacAllowedList, node) {
-			results = append(results, graphNodeToSearchResult(node, validKinds))
+			results = append(results, graphNodeToSearchResult(node, validPrimaryKinds))
 		}
 	}
 

--- a/cmd/api/src/api/v2/search_internal_test.go
+++ b/cmd/api/src/api/v2/search_internal_test.go
@@ -122,7 +122,7 @@ func Test_filterAndFormatSearchResults(t *testing.T) {
 		}
 		validPrimaryKinds = make(graphschema.ValidPrimaryKinds)
 	)
-	validPrimaryKinds.Add("Person", "person-half-dress", "ff91af", model.CustomNodeKindTypeFontAwesome)
+	validPrimaryKinds.Add("Person", "person-half-dress", "ff91af", graphschema.DisplayNodeTypeFontAwesome)
 
 	actual := filterAndFormatSearchResults(input, nil, validPrimaryKinds)
 
@@ -147,7 +147,7 @@ func Test_filterAndFormatSearchResults_default(t *testing.T) {
 
 		validPrimaryKinds = make(graphschema.ValidPrimaryKinds)
 	)
-	validPrimaryKinds.Add("Person", "person-half-dress", "ff91af", model.CustomNodeKindTypeFontAwesome)
+	validPrimaryKinds.Add("Person", "person-half-dress", "ff91af", graphschema.DisplayNodeTypeFontAwesome)
 
 	actual := filterAndFormatSearchResults(input, nil, validPrimaryKinds)
 
@@ -169,7 +169,7 @@ func Test_filterAndFormatSearchResults_includeOpenGraphNodes(t *testing.T) {
 		}
 		validPrimaryKinds = make(graphschema.ValidPrimaryKinds)
 	)
-	validPrimaryKinds.Add("CustomKind", "person-half-dress", "ff91af", model.CustomNodeKindTypeFontAwesome)
+	validPrimaryKinds.Add("CustomKind", "person-half-dress", "ff91af", graphschema.DisplayNodeTypeFontAwesome)
 
 	actual := filterAndFormatSearchResults(input, nil, validPrimaryKinds)
 
@@ -205,7 +205,7 @@ func Test_filterAndFormatSearchResults_filterEnvironments(t *testing.T) {
 
 		validPrimaryKinds = make(graphschema.ValidPrimaryKinds)
 	)
-	validPrimaryKinds.Add("Person", "person-half-dress", "ff91af", model.CustomNodeKindTypeFontAwesome)
+	validPrimaryKinds.Add("Person", "person-half-dress", "ff91af", graphschema.DisplayNodeTypeFontAwesome)
 
 	actual := filterAndFormatSearchResults(input, []string{"54321"}, validPrimaryKinds)
 
@@ -246,7 +246,7 @@ func Test_filterAndFormatSearchResults_filterEnvironmentsEmpty(t *testing.T) {
 
 		validPrimaryKinds = make(graphschema.ValidPrimaryKinds)
 	)
-	validPrimaryKinds.Add("Person", "person-half-dress", "ff91af", model.CustomNodeKindTypeFontAwesome)
+	validPrimaryKinds.Add("Person", "person-half-dress", "ff91af", graphschema.DisplayNodeTypeFontAwesome)
 
 	actual := filterAndFormatSearchResults(input, []string{}, validPrimaryKinds)
 
@@ -280,7 +280,7 @@ func Test_filterAndFormatSearchResults_filterEnvironments_domainSIDFail(t *testi
 		input             = []*graph.Node{&inputNodeProp1, &inputNodeProp2, &inputNodeProp3}
 		validPrimaryKinds = make(graphschema.ValidPrimaryKinds)
 	)
-	validPrimaryKinds.Add("Person", "person-half-dress", "ff91af", model.CustomNodeKindTypeFontAwesome)
+	validPrimaryKinds.Add("Person", "person-half-dress", "ff91af", graphschema.DisplayNodeTypeFontAwesome)
 
 	result := filterAndFormatSearchResults(input, []string{"54321"}, validPrimaryKinds)
 	require.Len(t, result, 0)
@@ -314,7 +314,7 @@ func Test_filterAndFormatSearchResults_filterEnvironments_tenantIDFail(t *testin
 
 		validPrimaryKinds = make(graphschema.ValidPrimaryKinds)
 	)
-	validPrimaryKinds.Add("Person", "person-half-dress", "ff91af", model.CustomNodeKindTypeFontAwesome)
+	validPrimaryKinds.Add("Person", "person-half-dress", "ff91af", graphschema.DisplayNodeTypeFontAwesome)
 
 	result := filterAndFormatSearchResults(input, []string{"azure12345"}, validPrimaryKinds)
 	require.Len(t, result, 0)
@@ -348,7 +348,7 @@ func Test_filterAndFormatSearchResults_filterEnvironmentsOG(t *testing.T) {
 
 		validPrimaryKinds = make(graphschema.ValidPrimaryKinds)
 	)
-	validPrimaryKinds.Add("Person", "person-half-dress", "ff91af", model.CustomNodeKindTypeFontAwesome)
+	validPrimaryKinds.Add("Person", "person-half-dress", "ff91af", graphschema.DisplayNodeTypeFontAwesome)
 
 	actual := filterAndFormatSearchResults(input, []string{"og-12345"}, validPrimaryKinds)
 

--- a/cmd/api/src/api/v2/search_internal_test.go
+++ b/cmd/api/src/api/v2/search_internal_test.go
@@ -122,7 +122,7 @@ func Test_filterAndFormatSearchResults(t *testing.T) {
 		}
 		validPrimaryKinds = make(graphschema.ValidPrimaryKinds)
 	)
-	validPrimaryKinds.Add("Person", "person-half-dress", "ff91af", "font-awesome")
+	validPrimaryKinds.Add("Person", "person-half-dress", "ff91af", model.CustomNodeKindTypeFontAwesome)
 
 	actual := filterAndFormatSearchResults(input, nil, validPrimaryKinds)
 
@@ -147,7 +147,7 @@ func Test_filterAndFormatSearchResults_default(t *testing.T) {
 
 		validPrimaryKinds = make(graphschema.ValidPrimaryKinds)
 	)
-	validPrimaryKinds.Add("Person", "person-half-dress", "ff91af", "font-awesome")
+	validPrimaryKinds.Add("Person", "person-half-dress", "ff91af", model.CustomNodeKindTypeFontAwesome)
 
 	actual := filterAndFormatSearchResults(input, nil, validPrimaryKinds)
 
@@ -169,7 +169,7 @@ func Test_filterAndFormatSearchResults_includeOpenGraphNodes(t *testing.T) {
 		}
 		validPrimaryKinds = make(graphschema.ValidPrimaryKinds)
 	)
-	validPrimaryKinds.Add("CustomKind", "person-half-dress", "ff91af", "font-awesome")
+	validPrimaryKinds.Add("CustomKind", "person-half-dress", "ff91af", model.CustomNodeKindTypeFontAwesome)
 
 	actual := filterAndFormatSearchResults(input, nil, validPrimaryKinds)
 
@@ -205,7 +205,7 @@ func Test_filterAndFormatSearchResults_filterEnvironments(t *testing.T) {
 
 		validPrimaryKinds = make(graphschema.ValidPrimaryKinds)
 	)
-	validPrimaryKinds.Add("Person", "person-half-dress", "ff91af", "font-awesome")
+	validPrimaryKinds.Add("Person", "person-half-dress", "ff91af", model.CustomNodeKindTypeFontAwesome)
 
 	actual := filterAndFormatSearchResults(input, []string{"54321"}, validPrimaryKinds)
 
@@ -246,7 +246,7 @@ func Test_filterAndFormatSearchResults_filterEnvironmentsEmpty(t *testing.T) {
 
 		validPrimaryKinds = make(graphschema.ValidPrimaryKinds)
 	)
-	validPrimaryKinds.Add("Person", "person-half-dress", "ff91af", "font-awesome")
+	validPrimaryKinds.Add("Person", "person-half-dress", "ff91af", model.CustomNodeKindTypeFontAwesome)
 
 	actual := filterAndFormatSearchResults(input, []string{}, validPrimaryKinds)
 
@@ -280,7 +280,7 @@ func Test_filterAndFormatSearchResults_filterEnvironments_domainSIDFail(t *testi
 		input             = []*graph.Node{&inputNodeProp1, &inputNodeProp2, &inputNodeProp3}
 		validPrimaryKinds = make(graphschema.ValidPrimaryKinds)
 	)
-	validPrimaryKinds.Add("Person", "person-half-dress", "ff91af", "font-awesome")
+	validPrimaryKinds.Add("Person", "person-half-dress", "ff91af", model.CustomNodeKindTypeFontAwesome)
 
 	result := filterAndFormatSearchResults(input, []string{"54321"}, validPrimaryKinds)
 	require.Len(t, result, 0)
@@ -314,7 +314,7 @@ func Test_filterAndFormatSearchResults_filterEnvironments_tenantIDFail(t *testin
 
 		validPrimaryKinds = make(graphschema.ValidPrimaryKinds)
 	)
-	validPrimaryKinds.Add("Person", "person-half-dress", "ff91af", "font-awesome")
+	validPrimaryKinds.Add("Person", "person-half-dress", "ff91af", model.CustomNodeKindTypeFontAwesome)
 
 	result := filterAndFormatSearchResults(input, []string{"azure12345"}, validPrimaryKinds)
 	require.Len(t, result, 0)
@@ -348,7 +348,7 @@ func Test_filterAndFormatSearchResults_filterEnvironmentsOG(t *testing.T) {
 
 		validPrimaryKinds = make(graphschema.ValidPrimaryKinds)
 	)
-	validPrimaryKinds.Add("Person", "person-half-dress", "ff91af", "font-awesome")
+	validPrimaryKinds.Add("Person", "person-half-dress", "ff91af", model.CustomNodeKindTypeFontAwesome)
 
 	actual := filterAndFormatSearchResults(input, []string{"og-12345"}, validPrimaryKinds)
 

--- a/cmd/api/src/api/v2/search_internal_test.go
+++ b/cmd/api/src/api/v2/search_internal_test.go
@@ -120,10 +120,11 @@ func Test_filterAndFormatSearchResults(t *testing.T) {
 		input = []*graph.Node{
 			{Properties: inputNodeProps},
 		}
-		customNodeKindsMap = model.CustomNodeKindMap{"Person": model.CustomNodeKindConfig{Icon: model.CustomNodeIcon{Type: "font-awesome", Name: "person-half-dress", Color: "#ff91af"}}}
+		validPrimaryKinds graphschema.ValidPrimaryKinds
 	)
+	validPrimaryKinds.Add("Person", "person-half-dress", "ff91af", "font-awesome")
 
-	actual := filterAndFormatSearchResults(input, nil, customNodeKindsMap.ValidKinds(), nil)
+	actual := filterAndFormatSearchResults(input, nil, validPrimaryKinds)
 
 	expectedName, _ := inputNodeProps.Get("name").String()
 	expectedObjectId, _ := inputNodeProps.Get("objectid").String()
@@ -144,10 +145,11 @@ func Test_filterAndFormatSearchResults_default(t *testing.T) {
 		expectedObjectId          = graphschema.DefaultMissingObjectId
 		expectedDistinguishedName = ""
 
-		customNodeKindsMap = model.CustomNodeKindMap{"Person": model.CustomNodeKindConfig{Icon: model.CustomNodeIcon{Type: "font-awesome", Name: "person-half-dress", Color: "#ff91af"}}}
+		validPrimaryKinds graphschema.ValidPrimaryKinds
 	)
+	validPrimaryKinds.Add("Person", "person-half-dress", "ff91af", "font-awesome")
 
-	actual := filterAndFormatSearchResults(input, nil, customNodeKindsMap.ValidKinds(), nil)
+	actual := filterAndFormatSearchResults(input, nil, validPrimaryKinds)
 
 	require.Equal(t, 1, len(actual))
 	require.Equal(t, expectedName, actual[0].Name)
@@ -165,11 +167,11 @@ func Test_filterAndFormatSearchResults_includeOpenGraphNodes(t *testing.T) {
 			{Kinds: []graph.Kind{graph.StringKind("OtherKind"), graph.StringKind(customKind)},
 				Properties: inputNodeProps},
 		}
-
-		customNodeKindsMap = model.CustomNodeKindMap{customKind: model.CustomNodeKindConfig{Icon: model.CustomNodeIcon{Type: "font-awesome", Name: "person-half-dress", Color: "#ff91af"}}}
+		validPrimaryKinds graphschema.ValidPrimaryKinds
 	)
+	validPrimaryKinds.Add("Person", "person-half-dress", "ff91af", "font-awesome")
 
-	actual := filterAndFormatSearchResults(input, nil, customNodeKindsMap.ValidKinds(), nil)
+	actual := filterAndFormatSearchResults(input, nil, validPrimaryKinds)
 
 	require.Equal(t, 1, len(actual))
 	require.Equal(t, customKind, actual[0].Type)
@@ -201,10 +203,11 @@ func Test_filterAndFormatSearchResults_filterEnvironments(t *testing.T) {
 
 		input = []*graph.Node{&inputNodeProp1, &inputNodeProp2, &inputNodeProp3}
 
-		customNodeKindsMap = model.CustomNodeKindMap{"Person": model.CustomNodeKindConfig{Icon: model.CustomNodeIcon{Type: "font-awesome", Name: "person-half-dress", Color: "#ff91af"}}}
+		validPrimaryKinds graphschema.ValidPrimaryKinds
 	)
+	validPrimaryKinds.Add("Person", "person-half-dress", "ff91af", "font-awesome")
 
-	actual := filterAndFormatSearchResults(input, []string{"54321"}, customNodeKindsMap.ValidKinds(), nil)
+	actual := filterAndFormatSearchResults(input, []string{"54321"}, validPrimaryKinds)
 
 	expectedName, _ := inputNodeProp2.Properties.Get(common.Name.String()).String()
 	expectedObjectId, _ := inputNodeProp2.Properties.Get(common.ObjectID.String()).String()
@@ -241,10 +244,11 @@ func Test_filterAndFormatSearchResults_filterEnvironmentsEmpty(t *testing.T) {
 
 		input = []*graph.Node{&inputNodeProp1, &inputNodeProp2, &inputNodeProp3}
 
-		customNodeKindsMap = model.CustomNodeKindMap{"Person": model.CustomNodeKindConfig{Icon: model.CustomNodeIcon{Type: "font-awesome", Name: "person-half-dress", Color: "#ff91af"}}}
+		validPrimaryKinds graphschema.ValidPrimaryKinds
 	)
+	validPrimaryKinds.Add("Person", "person-half-dress", "ff91af", "font-awesome")
 
-	actual := filterAndFormatSearchResults(input, []string{}, customNodeKindsMap.ValidKinds(), nil)
+	actual := filterAndFormatSearchResults(input, []string{}, validPrimaryKinds)
 
 	require.Empty(t, actual)
 }
@@ -273,12 +277,12 @@ func Test_filterAndFormatSearchResults_filterEnvironments_domainSIDFail(t *testi
 			},
 		}
 
-		input = []*graph.Node{&inputNodeProp1, &inputNodeProp2, &inputNodeProp3}
-
-		customNodeKindsMap = model.CustomNodeKindMap{"Person": model.CustomNodeKindConfig{Icon: model.CustomNodeIcon{Type: "font-awesome", Name: "person-half-dress", Color: "#ff91af"}}}
+		input             = []*graph.Node{&inputNodeProp1, &inputNodeProp2, &inputNodeProp3}
+		validPrimaryKinds graphschema.ValidPrimaryKinds
 	)
+	validPrimaryKinds.Add("Person", "person-half-dress", "ff91af", "font-awesome")
 
-	result := filterAndFormatSearchResults(input, []string{"54321"}, customNodeKindsMap.ValidKinds(), nil)
+	result := filterAndFormatSearchResults(input, []string{"54321"}, validPrimaryKinds)
 	require.Len(t, result, 0)
 }
 
@@ -308,10 +312,11 @@ func Test_filterAndFormatSearchResults_filterEnvironments_tenantIDFail(t *testin
 
 		input = []*graph.Node{&inputNodeProp1, &inputNodeProp2, &inputNodeProp3}
 
-		customNodeKindsMap = model.CustomNodeKindMap{"Person": model.CustomNodeKindConfig{Icon: model.CustomNodeIcon{Type: "font-awesome", Name: "person-half-dress", Color: "#ff91af"}}}
+		validPrimaryKinds graphschema.ValidPrimaryKinds
 	)
+	validPrimaryKinds.Add("Person", "person-half-dress", "ff91af", "font-awesome")
 
-	result := filterAndFormatSearchResults(input, []string{"azure12345"}, customNodeKindsMap.ValidKinds(), nil)
+	result := filterAndFormatSearchResults(input, []string{"azure12345"}, validPrimaryKinds)
 	require.Len(t, result, 0)
 }
 
@@ -341,10 +346,11 @@ func Test_filterAndFormatSearchResults_filterEnvironmentsOG(t *testing.T) {
 
 		input = []*graph.Node{&inputNodeProp1, &inputNodeProp2, &inputNodeProp3}
 
-		customNodeKindsMap = model.CustomNodeKindMap{"Person": model.CustomNodeKindConfig{Icon: model.CustomNodeIcon{Type: "font-awesome", Name: "person-half-dress", Color: "#ff91af"}}}
+		validPrimaryKinds graphschema.ValidPrimaryKinds
 	)
+	validPrimaryKinds.Add("Person", "person-half-dress", "ff91af", "font-awesome")
 
-	actual := filterAndFormatSearchResults(input, []string{"og-12345"}, customNodeKindsMap.ValidKinds(), nil)
+	actual := filterAndFormatSearchResults(input, []string{"og-12345"}, validPrimaryKinds)
 
 	require.Len(t, actual, 1)
 	require.Equal(t, "objectid3", actual[0].ObjectID)
@@ -362,7 +368,7 @@ func Test_getSearchableNodeKinds(t *testing.T) {
 		{
 			name:                   "returns unconstrained kinds when open graph search is enabled and no types are provided",
 			openGraphSearchEnabled: true,
-			validPrimaryKinds:      graphschema.ValidPrimaryKinds{graph.StringKind("CustomKind"): true},
+			validPrimaryKinds:      graphschema.ValidPrimaryKinds{graph.StringKind("CustomKind"): graphschema.DisplayKind{}},
 			typeParams:             nil,
 			expected:               nil,
 		},
@@ -375,7 +381,7 @@ func Test_getSearchableNodeKinds(t *testing.T) {
 		{
 			name:                   "returns custom kinds when open graph search is enabled",
 			openGraphSearchEnabled: true,
-			validPrimaryKinds:      graphschema.ValidPrimaryKinds{graph.StringKind("CustomKind"): true},
+			validPrimaryKinds:      graphschema.ValidPrimaryKinds{graph.StringKind("CustomKind"): graphschema.DisplayKind{}},
 			typeParams:             graph.Kinds{graph.StringKind("CustomKind")},
 			expected:               graph.Kinds{graph.StringKind("CustomKind")},
 		},

--- a/cmd/api/src/api/v2/search_internal_test.go
+++ b/cmd/api/src/api/v2/search_internal_test.go
@@ -120,11 +120,11 @@ func Test_filterAndFormatSearchResults(t *testing.T) {
 		input = []*graph.Node{
 			{Properties: inputNodeProps},
 		}
-		validPrimaryKinds = make(graphschema.ValidPrimaryKinds)
+		primaryDisplayKinds = make(graphschema.PrimaryDisplayKinds)
 	)
-	validPrimaryKinds.Add("Person", "person-half-dress", "ff91af", graphschema.DisplayNodeTypeFontAwesome)
+	primaryDisplayKinds.Add("Person", "person-half-dress", "ff91af", graphschema.DisplayNodeTypeFontAwesome)
 
-	actual := filterAndFormatSearchResults(input, nil, validPrimaryKinds)
+	actual := filterAndFormatSearchResults(input, nil, primaryDisplayKinds)
 
 	expectedName, _ := inputNodeProps.Get("name").String()
 	expectedObjectId, _ := inputNodeProps.Get("objectid").String()
@@ -145,11 +145,11 @@ func Test_filterAndFormatSearchResults_default(t *testing.T) {
 		expectedObjectId          = graphschema.DefaultMissingObjectId
 		expectedDistinguishedName = ""
 
-		validPrimaryKinds = make(graphschema.ValidPrimaryKinds)
+		primaryDisplayKinds = make(graphschema.PrimaryDisplayKinds)
 	)
-	validPrimaryKinds.Add("Person", "person-half-dress", "ff91af", graphschema.DisplayNodeTypeFontAwesome)
+	primaryDisplayKinds.Add("Person", "person-half-dress", "ff91af", graphschema.DisplayNodeTypeFontAwesome)
 
-	actual := filterAndFormatSearchResults(input, nil, validPrimaryKinds)
+	actual := filterAndFormatSearchResults(input, nil, primaryDisplayKinds)
 
 	require.Equal(t, 1, len(actual))
 	require.Equal(t, expectedName, actual[0].Name)
@@ -167,11 +167,11 @@ func Test_filterAndFormatSearchResults_includeOpenGraphNodes(t *testing.T) {
 			{Kinds: []graph.Kind{graph.StringKind("OtherKind"), graph.StringKind(customKind)},
 				Properties: inputNodeProps},
 		}
-		validPrimaryKinds = make(graphschema.ValidPrimaryKinds)
+		primaryDisplayKinds = make(graphschema.PrimaryDisplayKinds)
 	)
-	validPrimaryKinds.Add("CustomKind", "person-half-dress", "ff91af", graphschema.DisplayNodeTypeFontAwesome)
+	primaryDisplayKinds.Add("CustomKind", "person-half-dress", "ff91af", graphschema.DisplayNodeTypeFontAwesome)
 
-	actual := filterAndFormatSearchResults(input, nil, validPrimaryKinds)
+	actual := filterAndFormatSearchResults(input, nil, primaryDisplayKinds)
 
 	require.Equal(t, 1, len(actual))
 	require.Equal(t, customKind, actual[0].Type)
@@ -203,11 +203,11 @@ func Test_filterAndFormatSearchResults_filterEnvironments(t *testing.T) {
 
 		input = []*graph.Node{&inputNodeProp1, &inputNodeProp2, &inputNodeProp3}
 
-		validPrimaryKinds = make(graphschema.ValidPrimaryKinds)
+		primaryDisplayKinds = make(graphschema.PrimaryDisplayKinds)
 	)
-	validPrimaryKinds.Add("Person", "person-half-dress", "ff91af", graphschema.DisplayNodeTypeFontAwesome)
+	primaryDisplayKinds.Add("Person", "person-half-dress", "ff91af", graphschema.DisplayNodeTypeFontAwesome)
 
-	actual := filterAndFormatSearchResults(input, []string{"54321"}, validPrimaryKinds)
+	actual := filterAndFormatSearchResults(input, []string{"54321"}, primaryDisplayKinds)
 
 	expectedName, _ := inputNodeProp2.Properties.Get(common.Name.String()).String()
 	expectedObjectId, _ := inputNodeProp2.Properties.Get(common.ObjectID.String()).String()
@@ -244,11 +244,11 @@ func Test_filterAndFormatSearchResults_filterEnvironmentsEmpty(t *testing.T) {
 
 		input = []*graph.Node{&inputNodeProp1, &inputNodeProp2, &inputNodeProp3}
 
-		validPrimaryKinds = make(graphschema.ValidPrimaryKinds)
+		primaryDisplayKinds = make(graphschema.PrimaryDisplayKinds)
 	)
-	validPrimaryKinds.Add("Person", "person-half-dress", "ff91af", graphschema.DisplayNodeTypeFontAwesome)
+	primaryDisplayKinds.Add("Person", "person-half-dress", "ff91af", graphschema.DisplayNodeTypeFontAwesome)
 
-	actual := filterAndFormatSearchResults(input, []string{}, validPrimaryKinds)
+	actual := filterAndFormatSearchResults(input, []string{}, primaryDisplayKinds)
 
 	require.Empty(t, actual)
 }
@@ -277,12 +277,12 @@ func Test_filterAndFormatSearchResults_filterEnvironments_domainSIDFail(t *testi
 			},
 		}
 
-		input             = []*graph.Node{&inputNodeProp1, &inputNodeProp2, &inputNodeProp3}
-		validPrimaryKinds = make(graphschema.ValidPrimaryKinds)
+		input               = []*graph.Node{&inputNodeProp1, &inputNodeProp2, &inputNodeProp3}
+		primaryDisplayKinds = make(graphschema.PrimaryDisplayKinds)
 	)
-	validPrimaryKinds.Add("Person", "person-half-dress", "ff91af", graphschema.DisplayNodeTypeFontAwesome)
+	primaryDisplayKinds.Add("Person", "person-half-dress", "ff91af", graphschema.DisplayNodeTypeFontAwesome)
 
-	result := filterAndFormatSearchResults(input, []string{"54321"}, validPrimaryKinds)
+	result := filterAndFormatSearchResults(input, []string{"54321"}, primaryDisplayKinds)
 	require.Len(t, result, 0)
 }
 
@@ -312,11 +312,11 @@ func Test_filterAndFormatSearchResults_filterEnvironments_tenantIDFail(t *testin
 
 		input = []*graph.Node{&inputNodeProp1, &inputNodeProp2, &inputNodeProp3}
 
-		validPrimaryKinds = make(graphschema.ValidPrimaryKinds)
+		primaryDisplayKinds = make(graphschema.PrimaryDisplayKinds)
 	)
-	validPrimaryKinds.Add("Person", "person-half-dress", "ff91af", graphschema.DisplayNodeTypeFontAwesome)
+	primaryDisplayKinds.Add("Person", "person-half-dress", "ff91af", graphschema.DisplayNodeTypeFontAwesome)
 
-	result := filterAndFormatSearchResults(input, []string{"azure12345"}, validPrimaryKinds)
+	result := filterAndFormatSearchResults(input, []string{"azure12345"}, primaryDisplayKinds)
 	require.Len(t, result, 0)
 }
 
@@ -346,11 +346,11 @@ func Test_filterAndFormatSearchResults_filterEnvironmentsOG(t *testing.T) {
 
 		input = []*graph.Node{&inputNodeProp1, &inputNodeProp2, &inputNodeProp3}
 
-		validPrimaryKinds = make(graphschema.ValidPrimaryKinds)
+		primaryDisplayKinds = make(graphschema.PrimaryDisplayKinds)
 	)
-	validPrimaryKinds.Add("Person", "person-half-dress", "ff91af", graphschema.DisplayNodeTypeFontAwesome)
+	primaryDisplayKinds.Add("Person", "person-half-dress", "ff91af", graphschema.DisplayNodeTypeFontAwesome)
 
-	actual := filterAndFormatSearchResults(input, []string{"og-12345"}, validPrimaryKinds)
+	actual := filterAndFormatSearchResults(input, []string{"og-12345"}, primaryDisplayKinds)
 
 	require.Len(t, actual, 1)
 	require.Equal(t, "objectid3", actual[0].ObjectID)
@@ -360,7 +360,7 @@ func Test_getSearchableNodeKinds(t *testing.T) {
 	tests := []struct {
 		name                   string
 		openGraphSearchEnabled bool
-		validPrimaryKinds      graphschema.ValidPrimaryKinds
+		primaryDisplayKinds    graphschema.PrimaryDisplayKinds
 		typeParams             graph.Kinds
 		expected               graph.Kinds
 		expectErr              bool
@@ -368,7 +368,7 @@ func Test_getSearchableNodeKinds(t *testing.T) {
 		{
 			name:                   "returns unconstrained kinds when open graph search is enabled and no types are provided",
 			openGraphSearchEnabled: true,
-			validPrimaryKinds:      graphschema.ValidPrimaryKinds{graph.StringKind("CustomKind"): graphschema.DisplayKind{}},
+			primaryDisplayKinds:    graphschema.PrimaryDisplayKinds{graph.StringKind("CustomKind"): graphschema.DisplayKind{}},
 			typeParams:             nil,
 			expected:               nil,
 		},
@@ -381,7 +381,7 @@ func Test_getSearchableNodeKinds(t *testing.T) {
 		{
 			name:                   "returns custom kinds when open graph search is enabled",
 			openGraphSearchEnabled: true,
-			validPrimaryKinds:      graphschema.ValidPrimaryKinds{graph.StringKind("CustomKind"): graphschema.DisplayKind{}},
+			primaryDisplayKinds:    graphschema.PrimaryDisplayKinds{graph.StringKind("CustomKind"): graphschema.DisplayKind{}},
 			typeParams:             graph.Kinds{graph.StringKind("CustomKind")},
 			expected:               graph.Kinds{graph.StringKind("CustomKind")},
 		},
@@ -395,7 +395,7 @@ func Test_getSearchableNodeKinds(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			actual, err := getSearchableNodeKinds(tt.openGraphSearchEnabled, tt.validPrimaryKinds, tt.typeParams)
+			actual, err := getSearchableNodeKinds(tt.openGraphSearchEnabled, tt.primaryDisplayKinds, tt.typeParams)
 
 			if tt.expectErr {
 				require.Error(t, err)

--- a/cmd/api/src/api/v2/search_internal_test.go
+++ b/cmd/api/src/api/v2/search_internal_test.go
@@ -120,7 +120,7 @@ func Test_filterAndFormatSearchResults(t *testing.T) {
 		input = []*graph.Node{
 			{Properties: inputNodeProps},
 		}
-		validPrimaryKinds graphschema.ValidPrimaryKinds
+		validPrimaryKinds = make(graphschema.ValidPrimaryKinds)
 	)
 	validPrimaryKinds.Add("Person", "person-half-dress", "ff91af", "font-awesome")
 
@@ -145,7 +145,7 @@ func Test_filterAndFormatSearchResults_default(t *testing.T) {
 		expectedObjectId          = graphschema.DefaultMissingObjectId
 		expectedDistinguishedName = ""
 
-		validPrimaryKinds graphschema.ValidPrimaryKinds
+		validPrimaryKinds = make(graphschema.ValidPrimaryKinds)
 	)
 	validPrimaryKinds.Add("Person", "person-half-dress", "ff91af", "font-awesome")
 
@@ -167,9 +167,9 @@ func Test_filterAndFormatSearchResults_includeOpenGraphNodes(t *testing.T) {
 			{Kinds: []graph.Kind{graph.StringKind("OtherKind"), graph.StringKind(customKind)},
 				Properties: inputNodeProps},
 		}
-		validPrimaryKinds graphschema.ValidPrimaryKinds
+		validPrimaryKinds = make(graphschema.ValidPrimaryKinds)
 	)
-	validPrimaryKinds.Add("Person", "person-half-dress", "ff91af", "font-awesome")
+	validPrimaryKinds.Add("CustomKind", "person-half-dress", "ff91af", "font-awesome")
 
 	actual := filterAndFormatSearchResults(input, nil, validPrimaryKinds)
 
@@ -203,7 +203,7 @@ func Test_filterAndFormatSearchResults_filterEnvironments(t *testing.T) {
 
 		input = []*graph.Node{&inputNodeProp1, &inputNodeProp2, &inputNodeProp3}
 
-		validPrimaryKinds graphschema.ValidPrimaryKinds
+		validPrimaryKinds = make(graphschema.ValidPrimaryKinds)
 	)
 	validPrimaryKinds.Add("Person", "person-half-dress", "ff91af", "font-awesome")
 
@@ -244,7 +244,7 @@ func Test_filterAndFormatSearchResults_filterEnvironmentsEmpty(t *testing.T) {
 
 		input = []*graph.Node{&inputNodeProp1, &inputNodeProp2, &inputNodeProp3}
 
-		validPrimaryKinds graphschema.ValidPrimaryKinds
+		validPrimaryKinds = make(graphschema.ValidPrimaryKinds)
 	)
 	validPrimaryKinds.Add("Person", "person-half-dress", "ff91af", "font-awesome")
 
@@ -278,7 +278,7 @@ func Test_filterAndFormatSearchResults_filterEnvironments_domainSIDFail(t *testi
 		}
 
 		input             = []*graph.Node{&inputNodeProp1, &inputNodeProp2, &inputNodeProp3}
-		validPrimaryKinds graphschema.ValidPrimaryKinds
+		validPrimaryKinds = make(graphschema.ValidPrimaryKinds)
 	)
 	validPrimaryKinds.Add("Person", "person-half-dress", "ff91af", "font-awesome")
 
@@ -312,7 +312,7 @@ func Test_filterAndFormatSearchResults_filterEnvironments_tenantIDFail(t *testin
 
 		input = []*graph.Node{&inputNodeProp1, &inputNodeProp2, &inputNodeProp3}
 
-		validPrimaryKinds graphschema.ValidPrimaryKinds
+		validPrimaryKinds = make(graphschema.ValidPrimaryKinds)
 	)
 	validPrimaryKinds.Add("Person", "person-half-dress", "ff91af", "font-awesome")
 
@@ -346,7 +346,7 @@ func Test_filterAndFormatSearchResults_filterEnvironmentsOG(t *testing.T) {
 
 		input = []*graph.Node{&inputNodeProp1, &inputNodeProp2, &inputNodeProp3}
 
-		validPrimaryKinds graphschema.ValidPrimaryKinds
+		validPrimaryKinds = make(graphschema.ValidPrimaryKinds)
 	)
 	validPrimaryKinds.Add("Person", "person-half-dress", "ff91af", "font-awesome")
 

--- a/cmd/api/src/api/v2/search_test.go
+++ b/cmd/api/src/api/v2/search_test.go
@@ -132,7 +132,7 @@ func TestResources_SearchHandler(t *testing.T) {
 								}),
 							},
 						}, nil)
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any()).Return(graphschema.ValidPrimaryKinds{
+					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any()).Return(graphschema.PrimaryDisplayKinds{
 						graph.StringKind("Person"): graphschema.DisplayKind{Name: "Person", Icon: graphschema.DisplayNodeIcon{Type: graphschema.DisplayNodeTypeFontAwesome, Name: "person-half-dress", Color: "#ff91af"}}}, nil)
 				},
 				Test: func(output apitest.Output) {

--- a/cmd/api/src/api/v2/search_test.go
+++ b/cmd/api/src/api/v2/search_test.go
@@ -106,7 +106,7 @@ func TestResources_SearchHandler(t *testing.T) {
 				},
 				Setup: func() {
 					mockDB.EXPECT().GetFlagByKey(gomock.Any(), appcfg.FeatureOpenGraphSearch).Return(appcfg.FeatureFlag{Enabled: true}, nil)
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+					mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 				},
 				Test: func(output apitest.Output) {
 					apitest.StatusCode(output, http.StatusBadRequest)
@@ -132,7 +132,7 @@ func TestResources_SearchHandler(t *testing.T) {
 								}),
 							},
 						}, nil)
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any()).Return(graphschema.PrimaryDisplayKinds{
+					mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any()).Return(graphschema.PrimaryDisplayKinds{
 						graph.StringKind("Person"): graphschema.DisplayKind{Name: "Person", Icon: graphschema.DisplayNodeIcon{Type: graphschema.DisplayNodeTypeFontAwesome, Name: "person-half-dress", Color: "#ff91af"}}}, nil)
 				},
 				Test: func(output apitest.Output) {
@@ -149,7 +149,7 @@ func TestResources_SearchHandler(t *testing.T) {
 				},
 				Setup: func() {
 					mockDB.EXPECT().GetFlagByKey(gomock.Any(), appcfg.FeatureOpenGraphSearch).Return(appcfg.FeatureFlag{Enabled: true}, nil)
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+					mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 					mockGraph.EXPECT().
 						SearchNodesByNameOrObjectId(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 						Return(nil, errors.New("graph error"))
@@ -160,14 +160,14 @@ func TestResources_SearchHandler(t *testing.T) {
 				},
 			},
 			{
-				Name: "GetValidDisplayKindsError",
+				Name: "GetPrimaryDisplayKindsError",
 				Input: func(input *apitest.Input) {
 					apitest.AddQueryParam(input, "q", "search value")
 					apitest.SetContext(input, userCtx)
 				},
 				Setup: func() {
 					mockDB.EXPECT().GetFlagByKey(gomock.Any(), appcfg.FeatureOpenGraphSearch).Return(appcfg.FeatureFlag{Enabled: true}, nil)
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any()).Return(nil, errors.New("database error"))
+					mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any()).Return(nil, errors.New("database error"))
 				},
 				Test: func(output apitest.Output) {
 					apitest.StatusCode(output, http.StatusInternalServerError)
@@ -182,7 +182,7 @@ func TestResources_SearchHandler(t *testing.T) {
 				},
 				Setup: func() {
 					mockDB.EXPECT().GetFlagByKey(gomock.Any(), appcfg.FeatureOpenGraphSearch).Return(appcfg.FeatureFlag{Enabled: true}, nil)
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+					mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 					mockGraph.EXPECT().
 						SearchNodesByNameOrObjectId(gomock.Any(), gomock.Any(), "search value", 0, 10).
 						Return(nil, nil)
@@ -200,7 +200,7 @@ func TestResources_SearchHandler(t *testing.T) {
 				},
 				Setup: func() {
 					mockDB.EXPECT().GetFlagByKey(gomock.Any(), appcfg.FeatureOpenGraphSearch).Return(appcfg.FeatureFlag{Enabled: false}, nil)
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+					mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 					mockGraph.EXPECT().
 						SearchNodesByNameOrObjectId(gomock.Any(), graph.Kinds{ad.Entity, azure.Entity}, "search value", 0, 10).
 						Return(nil, nil)
@@ -236,7 +236,7 @@ func TestResources_SearchHandler_ETAC(t *testing.T) {
 			},
 			expectedMocks: func(mockDB *dbMocks.MockDatabase, mockGraph *graphMocks.MockGraph) {
 				mockDB.EXPECT().GetFlagByKey(gomock.Any(), appcfg.FeatureOpenGraphSearch).Return(appcfg.FeatureFlag{Enabled: false}, nil)
-				mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+				mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 				mockGraph.EXPECT().
 					SearchNodesByNameOrObjectId(gomock.Any(), graph.Kinds{ad.Entity, azure.Entity}, "search value", 0, 10).
 					Return(nil, nil)
@@ -262,7 +262,7 @@ func TestResources_SearchHandler_ETAC(t *testing.T) {
 			},
 			expectedMocks: func(mockDB *dbMocks.MockDatabase, mockGraph *graphMocks.MockGraph) {
 				mockDB.EXPECT().GetFlagByKey(gomock.Any(), appcfg.FeatureOpenGraphSearch).Return(appcfg.FeatureFlag{Enabled: false}, nil)
-				mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
+				mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
 				mockGraph.EXPECT().
 					SearchNodesByNameOrObjectId(gomock.Any(), graph.Kinds{ad.Entity, azure.Entity}, "search value", 0, 10).
 					Return(nil, nil)

--- a/cmd/api/src/api/v2/search_test.go
+++ b/cmd/api/src/api/v2/search_test.go
@@ -133,7 +133,7 @@ func TestResources_SearchHandler(t *testing.T) {
 							},
 						}, nil)
 					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any()).Return(graphschema.ValidPrimaryKinds{
-						graph.StringKind("Person"): graphschema.DisplayKind{Name: "Person", Icon: graphschema.DisplayKindIcon{Type: "font-awesome", Name: "person-half-dress", Color: "#ff91af"}}}, nil)
+						graph.StringKind("Person"): graphschema.DisplayKind{Name: "Person", Icon: graphschema.DisplayKindIcon{Type: model.CustomNodeKindTypeFontAwesome, Name: "person-half-dress", Color: "#ff91af"}}}, nil)
 				},
 				Test: func(output apitest.Output) {
 					apitest.StatusCode(output, http.StatusOK)

--- a/cmd/api/src/api/v2/search_test.go
+++ b/cmd/api/src/api/v2/search_test.go
@@ -133,7 +133,7 @@ func TestResources_SearchHandler(t *testing.T) {
 							},
 						}, nil)
 					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any()).Return(graphschema.ValidPrimaryKinds{
-						graph.StringKind("Person"): graphschema.DisplayKind{Name: "Person", Icon: graphschema.DisplayKindIcon{Type: model.CustomNodeKindTypeFontAwesome, Name: "person-half-dress", Color: "#ff91af"}}}, nil)
+						graph.StringKind("Person"): graphschema.DisplayKind{Name: "Person", Icon: graphschema.DisplayNodeIcon{Type: graphschema.DisplayNodeTypeFontAwesome, Name: "person-half-dress", Color: "#ff91af"}}}, nil)
 				},
 				Test: func(output apitest.Output) {
 					apitest.StatusCode(output, http.StatusOK)

--- a/cmd/api/src/api/v2/search_test.go
+++ b/cmd/api/src/api/v2/search_test.go
@@ -35,6 +35,7 @@ import (
 	graphMocks "github.com/specterops/bloodhound/cmd/api/src/queries/mocks"
 	"github.com/specterops/bloodhound/cmd/api/src/services/dogtags"
 	"github.com/specterops/bloodhound/cmd/api/src/utils/test"
+	"github.com/specterops/bloodhound/packages/go/graphschema"
 	"github.com/specterops/bloodhound/packages/go/graphschema/ad"
 	"github.com/specterops/bloodhound/packages/go/graphschema/azure"
 	"github.com/specterops/bloodhound/packages/go/graphschema/common"
@@ -62,9 +63,7 @@ func TestResources_SearchHandler(t *testing.T) {
 				Input: func(input *apitest.Input) {
 					apitest.SetContext(input, userCtx)
 				},
-				Setup: func() {
-					mockDB.EXPECT().GetCustomNodeKindsMap(gomock.Any()).Return(model.CustomNodeKindMap{}, nil)
-				},
+				Setup: func() {},
 				Test: func(output apitest.Output) {
 					apitest.StatusCode(output, http.StatusBadRequest)
 					apitest.BodyContains(output, "Invalid search parameter")
@@ -77,9 +76,7 @@ func TestResources_SearchHandler(t *testing.T) {
 					apitest.AddQueryParam(input, "skip", "notAnInt")
 					apitest.SetContext(input, userCtx)
 				},
-				Setup: func() {
-					mockDB.EXPECT().GetCustomNodeKindsMap(gomock.Any()).Return(model.CustomNodeKindMap{}, nil)
-				},
+				Setup: func() {},
 				Test: func(output apitest.Output) {
 					apitest.StatusCode(output, http.StatusBadRequest)
 					apitest.BodyContains(output, "Invalid query parameter")
@@ -93,7 +90,6 @@ func TestResources_SearchHandler(t *testing.T) {
 					apitest.SetContext(input, userCtx)
 				},
 				Setup: func() {
-					mockDB.EXPECT().GetCustomNodeKindsMap(gomock.Any()).Return(model.CustomNodeKindMap{}, nil)
 					mockDB.EXPECT().GetFlagByKey(gomock.Any(), appcfg.FeatureOpenGraphSearch).Return(appcfg.FeatureFlag{}, errors.New("database error"))
 				},
 				Test: func(output apitest.Output) {
@@ -109,7 +105,6 @@ func TestResources_SearchHandler(t *testing.T) {
 					apitest.SetContext(input, userCtx)
 				},
 				Setup: func() {
-					mockDB.EXPECT().GetCustomNodeKindsMap(gomock.Any()).Return(model.CustomNodeKindMap{}, nil)
 					mockDB.EXPECT().GetFlagByKey(gomock.Any(), appcfg.FeatureOpenGraphSearch).Return(appcfg.FeatureFlag{Enabled: true}, nil)
 					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
 				},
@@ -119,25 +114,6 @@ func TestResources_SearchHandler(t *testing.T) {
 				},
 			},
 			{
-				Name: "Success -- GetCustomNodesKinds error does not cause request to fail ",
-				Input: func(input *apitest.Input) {
-					apitest.AddQueryParam(input, "q", "search value")
-					apitest.SetContext(input, userCtx)
-				},
-				Setup: func() {
-					mockDB.EXPECT().GetFlagByKey(gomock.Any(), appcfg.FeatureOpenGraphSearch).Return(appcfg.FeatureFlag{Enabled: false}, nil)
-					mockDB.EXPECT().GetCustomNodeKindsMap(gomock.Any()).Return(model.CustomNodeKindMap{}, errors.New("database error"))
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
-					mockGraph.EXPECT().
-						SearchNodesByNameOrObjectId(gomock.Any(), graph.Kinds{ad.Entity, azure.Entity}, "search value", 0, 10).
-						Return(nil, nil)
-				},
-				Test: func(output apitest.Output) {
-					apitest.StatusCode(output, http.StatusOK)
-				},
-			},
-
-			{
 				Name: "Success -- Custom Node Icon is set correctly",
 				Input: func(input *apitest.Input) {
 					apitest.AddQueryParam(input, "q", "search value")
@@ -145,8 +121,6 @@ func TestResources_SearchHandler(t *testing.T) {
 				},
 				Setup: func() {
 					mockDB.EXPECT().GetFlagByKey(gomock.Any(), appcfg.FeatureOpenGraphSearch).Return(appcfg.FeatureFlag{Enabled: true}, nil)
-					mockDB.EXPECT().GetCustomNodeKindsMap(gomock.Any()).Return(model.CustomNodeKindMap{
-						"Person": model.CustomNodeKindConfig{Icon: model.CustomNodeIcon{Type: "font-awesome", Name: "person-half-dress", Color: "#ff91af"}}}, nil)
 					mockGraph.EXPECT().
 						SearchNodesByNameOrObjectId(gomock.Any(), gomock.Any(), "search value", 0, 10).
 						Return([]*graph.Node{
@@ -158,8 +132,8 @@ func TestResources_SearchHandler(t *testing.T) {
 								}),
 							},
 						}, nil)
-					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
-
+					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any()).Return(graphschema.ValidPrimaryKinds{
+						graph.StringKind("Person"): graphschema.DisplayKind{Name: "Person", Icon: graphschema.DisplayKindIcon{Type: "font-awesome", Name: "person-half-dress", Color: "#ff91af"}}}, nil)
 				},
 				Test: func(output apitest.Output) {
 					apitest.StatusCode(output, http.StatusOK)
@@ -175,7 +149,6 @@ func TestResources_SearchHandler(t *testing.T) {
 				},
 				Setup: func() {
 					mockDB.EXPECT().GetFlagByKey(gomock.Any(), appcfg.FeatureOpenGraphSearch).Return(appcfg.FeatureFlag{Enabled: true}, nil)
-					mockDB.EXPECT().GetCustomNodeKindsMap(gomock.Any()).Return(model.CustomNodeKindMap{}, nil)
 					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
 					mockGraph.EXPECT().
 						SearchNodesByNameOrObjectId(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
@@ -194,7 +167,6 @@ func TestResources_SearchHandler(t *testing.T) {
 				},
 				Setup: func() {
 					mockDB.EXPECT().GetFlagByKey(gomock.Any(), appcfg.FeatureOpenGraphSearch).Return(appcfg.FeatureFlag{Enabled: true}, nil)
-					mockDB.EXPECT().GetCustomNodeKindsMap(gomock.Any()).Return(model.CustomNodeKindMap{}, nil)
 					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any()).Return(nil, errors.New("database error"))
 				},
 				Test: func(output apitest.Output) {
@@ -210,7 +182,6 @@ func TestResources_SearchHandler(t *testing.T) {
 				},
 				Setup: func() {
 					mockDB.EXPECT().GetFlagByKey(gomock.Any(), appcfg.FeatureOpenGraphSearch).Return(appcfg.FeatureFlag{Enabled: true}, nil)
-					mockDB.EXPECT().GetCustomNodeKindsMap(gomock.Any()).Return(model.CustomNodeKindMap{}, nil)
 					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
 					mockGraph.EXPECT().
 						SearchNodesByNameOrObjectId(gomock.Any(), gomock.Any(), "search value", 0, 10).
@@ -229,7 +200,6 @@ func TestResources_SearchHandler(t *testing.T) {
 				},
 				Setup: func() {
 					mockDB.EXPECT().GetFlagByKey(gomock.Any(), appcfg.FeatureOpenGraphSearch).Return(appcfg.FeatureFlag{Enabled: false}, nil)
-					mockDB.EXPECT().GetCustomNodeKindsMap(gomock.Any()).Return(model.CustomNodeKindMap{}, nil)
 					mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
 					mockGraph.EXPECT().
 						SearchNodesByNameOrObjectId(gomock.Any(), graph.Kinds{ad.Entity, azure.Entity}, "search value", 0, 10).
@@ -266,7 +236,6 @@ func TestResources_SearchHandler_ETAC(t *testing.T) {
 			},
 			expectedMocks: func(mockDB *dbMocks.MockDatabase, mockGraph *graphMocks.MockGraph) {
 				mockDB.EXPECT().GetFlagByKey(gomock.Any(), appcfg.FeatureOpenGraphSearch).Return(appcfg.FeatureFlag{Enabled: false}, nil)
-				mockDB.EXPECT().GetCustomNodeKindsMap(gomock.Any()).Return(model.CustomNodeKindMap{}, nil)
 				mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
 				mockGraph.EXPECT().
 					SearchNodesByNameOrObjectId(gomock.Any(), graph.Kinds{ad.Entity, azure.Entity}, "search value", 0, 10).
@@ -293,7 +262,6 @@ func TestResources_SearchHandler_ETAC(t *testing.T) {
 			},
 			expectedMocks: func(mockDB *dbMocks.MockDatabase, mockGraph *graphMocks.MockGraph) {
 				mockDB.EXPECT().GetFlagByKey(gomock.Any(), appcfg.FeatureOpenGraphSearch).Return(appcfg.FeatureFlag{Enabled: false}, nil)
-				mockDB.EXPECT().GetCustomNodeKindsMap(gomock.Any()).Return(model.CustomNodeKindMap{}, nil)
 				mockDB.EXPECT().GetValidDisplayKinds(gomock.Any())
 				mockGraph.EXPECT().
 					SearchNodesByNameOrObjectId(gomock.Any(), graph.Kinds{ad.Entity, azure.Entity}, "search value", 0, 10).

--- a/cmd/api/src/database/customnode.go
+++ b/cmd/api/src/database/customnode.go
@@ -24,18 +24,12 @@ import (
 	"strings"
 
 	"github.com/specterops/bloodhound/cmd/api/src/model"
-	"github.com/specterops/bloodhound/cmd/api/src/model/appcfg"
 	"gorm.io/gorm"
-)
-
-const (
-	customNodeKindTable = "custom_node_kinds"
 )
 
 type CustomNodeKindData interface {
 	CreateCustomNodeKinds(ctx context.Context, customNodeKind model.CustomNodeKinds) (model.CustomNodeKinds, error)
 	GetCustomNodeKinds(ctx context.Context, filters model.Filters) ([]model.CustomNodeKind, error)
-	GetCustomNodeKindsMap(ctx context.Context) (model.CustomNodeKindMap, error)
 	GetCustomNodeKind(ctx context.Context, kindName string) (model.CustomNodeKind, error)
 	UpdateCustomNodeKind(ctx context.Context, customNodeKind model.CustomNodeKind) (model.CustomNodeKind, error)
 	DeleteCustomNodeKind(ctx context.Context, kindName string) error
@@ -76,7 +70,7 @@ func (s *BloodhoundDB) GetCustomNodeKinds(ctx context.Context, filters model.Fil
 	if sqlFilter.sqlString != "" {
 		whereClause = fmt.Sprintf("WHERE %s", sqlFilter.sqlString)
 	}
-	result := s.db.WithContext(ctx).Raw(fmt.Sprintf("SELECT id, kind_name, config FROM %s %s;", customNodeKindTable, whereClause)).Scan(&customNodeKinds)
+	result := s.db.WithContext(ctx).Raw(fmt.Sprintf("SELECT id, kind_name, config FROM %s %s;", model.CustomNodeKind{}.TableName(), whereClause)).Scan(&customNodeKinds)
 
 	return customNodeKinds, CheckError(result)
 }
@@ -92,22 +86,6 @@ func (s *BloodhoundDB) GetCustomNodeKind(ctx context.Context, kindName string) (
 	}
 }
 
-func (s *BloodhoundDB) GetCustomNodeKindsMap(ctx context.Context) (model.CustomNodeKindMap, error) {
-	if openGraphSearchFeatureFlag, err := s.GetFlagByKey(ctx, appcfg.FeatureOpenGraphSearch); err != nil {
-		return nil, err
-	} else if !openGraphSearchFeatureFlag.Enabled {
-		return nil, nil
-	} else if customNodeKinds, err := s.GetCustomNodeKinds(ctx, nil); err != nil {
-		return nil, err
-	} else {
-		customNodeKindMap := make(model.CustomNodeKindMap, len(customNodeKinds))
-		for _, kind := range customNodeKinds {
-			customNodeKindMap[kind.KindName] = kind.Config
-		}
-		return customNodeKindMap, nil
-	}
-}
-
 func (s *BloodhoundDB) UpdateCustomNodeKind(ctx context.Context, customNodeKind model.CustomNodeKind) (model.CustomNodeKind, error) {
 	var (
 		auditEntry = model.AuditEntry{
@@ -118,7 +96,7 @@ func (s *BloodhoundDB) UpdateCustomNodeKind(ctx context.Context, customNodeKind 
 
 	err := s.AuditableTransaction(ctx, auditEntry, func(tx *gorm.DB) error {
 		bhdb := NewBloodhoundDB(tx, s.idResolver, s.config)
-		if result := tx.Raw(fmt.Sprintf("UPDATE %s SET schema_node_kind_id = COALESCE(?, schema_node_kind_id), config = ?, updated_at = NOW() WHERE kind_name = ? RETURNING id, kind_name, schema_node_kind_id, config", customNodeKindTable), customNodeKind.SchemaNodeKindId, customNodeKind.Config, customNodeKind.KindName).
+		if result := tx.Raw(fmt.Sprintf("UPDATE %s SET schema_node_kind_id = COALESCE(?, schema_node_kind_id), config = ?, updated_at = NOW() WHERE kind_name = ? RETURNING id, kind_name, schema_node_kind_id, config", model.CustomNodeKind{}.TableName()), customNodeKind.SchemaNodeKindId, customNodeKind.Config, customNodeKind.KindName).
 			Scan(&customNodeKind); result.RowsAffected == 0 {
 			return ErrNotFound
 		} else if result.Error != nil {
@@ -148,7 +126,7 @@ func (s *BloodhoundDB) DeleteCustomNodeKind(ctx context.Context, kindName string
 	)
 
 	err := s.AuditableTransaction(ctx, auditEntry, func(tx *gorm.DB) error {
-		if err := tx.Raw(fmt.Sprintf("DELETE FROM %s WHERE kind_name = ? RETURNING id, config;", customNodeKindTable), kindName).
+		if err := tx.Raw(fmt.Sprintf("DELETE FROM %s WHERE kind_name = ? RETURNING id, config;", model.CustomNodeKind{}.TableName()), kindName).
 			Row().Scan(&customNodeKind.ID, &customNodeKind.Config); errors.Is(err, sql.ErrNoRows) {
 			return ErrNotFound
 		} else {

--- a/cmd/api/src/database/customnode_integration_test.go
+++ b/cmd/api/src/database/customnode_integration_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/specterops/bloodhound/cmd/api/src/database"
 	"github.com/specterops/bloodhound/cmd/api/src/model"
+	"github.com/specterops/bloodhound/packages/go/graphschema"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -44,11 +45,11 @@ func TestCreateCustomNodeKinds(t *testing.T) {
 				{
 					KindName: "TestKind",
 					Config: model.CustomNodeKindConfig{
-						Icon: model.CustomNodeIcon{Type: model.CustomNodeKindTypeFontAwesome, Name: "coffee", Color: "#FFFFFF"},
+						Icon: graphschema.DisplayNodeIcon{Type: graphschema.DisplayNodeTypeFontAwesome, Name: "coffee", Color: "#FFFFFF"},
 					},
 				},
 			},
-			wantMap: model.CustomNodeKindMap{"TestKind": model.CustomNodeKindConfig{Icon: model.CustomNodeIcon{Type: model.CustomNodeKindTypeFontAwesome, Name: "coffee", Color: "#FFFFFF"}}},
+			wantMap: model.CustomNodeKindMap{"TestKind": model.CustomNodeKindConfig{Icon: graphschema.DisplayNodeIcon{Type: graphschema.DisplayNodeTypeFontAwesome, Name: "coffee", Color: "#FFFFFF"}}},
 			wantErr: nil,
 		},
 		{
@@ -60,17 +61,17 @@ func TestCreateCustomNodeKinds(t *testing.T) {
 				{
 					KindName: "TestKindA",
 					Config: model.CustomNodeKindConfig{
-						Icon: model.CustomNodeIcon{Type: model.CustomNodeKindTypeFontAwesome, Name: "house", Color: "#000000"},
+						Icon: graphschema.DisplayNodeIcon{Type: graphschema.DisplayNodeTypeFontAwesome, Name: "house", Color: "#000000"},
 					},
 				},
 				{
 					KindName: "TestKindB",
 					Config: model.CustomNodeKindConfig{
-						Icon: model.CustomNodeIcon{Type: model.CustomNodeKindTypeFontAwesome, Name: "star", Color: "#FF0000"},
+						Icon: graphschema.DisplayNodeIcon{Type: graphschema.DisplayNodeTypeFontAwesome, Name: "star", Color: "#FF0000"},
 					},
 				},
 			},
-			wantMap: model.CustomNodeKindMap{"TestKindA": model.CustomNodeKindConfig{Icon: model.CustomNodeIcon{Type: model.CustomNodeKindTypeFontAwesome, Name: "house", Color: "#000000"}}, "TestKindB": model.CustomNodeKindConfig{Icon: model.CustomNodeIcon{Type: model.CustomNodeKindTypeFontAwesome, Name: "star", Color: "#FF0000"}}},
+			wantMap: model.CustomNodeKindMap{"TestKindA": model.CustomNodeKindConfig{Icon: graphschema.DisplayNodeIcon{Type: graphschema.DisplayNodeTypeFontAwesome, Name: "house", Color: "#000000"}}, "TestKindB": model.CustomNodeKindConfig{Icon: graphschema.DisplayNodeIcon{Type: graphschema.DisplayNodeTypeFontAwesome, Name: "star", Color: "#FF0000"}}},
 			wantErr: nil,
 		},
 
@@ -83,17 +84,17 @@ func TestCreateCustomNodeKinds(t *testing.T) {
 				{
 					KindName: "TestKindA",
 					Config: model.CustomNodeKindConfig{
-						Icon: model.CustomNodeIcon{Type: model.CustomNodeKindTypeFontAwesome, Color: "#000000"},
+						Icon: graphschema.DisplayNodeIcon{Type: graphschema.DisplayNodeTypeFontAwesome, Color: "#000000"},
 					},
 				},
 				{
 					KindName: "TestKindB",
 					Config: model.CustomNodeKindConfig{
-						Icon: model.CustomNodeIcon{Type: model.CustomNodeKindTypeFontAwesome, Name: "star"},
+						Icon: graphschema.DisplayNodeIcon{Type: graphschema.DisplayNodeTypeFontAwesome, Name: "star"},
 					},
 				},
 			},
-			wantMap: model.CustomNodeKindMap{"TestKindA": model.CustomNodeKindConfig{Icon: model.CustomNodeIcon{Type: model.CustomNodeKindTypeFontAwesome, Color: "#000000"}}, "TestKindB": model.CustomNodeKindConfig{Icon: model.CustomNodeIcon{Type: model.CustomNodeKindTypeFontAwesome, Name: "star"}}},
+			wantMap: model.CustomNodeKindMap{"TestKindA": model.CustomNodeKindConfig{Icon: graphschema.DisplayNodeIcon{Type: graphschema.DisplayNodeTypeFontAwesome, Color: "#000000"}}, "TestKindB": model.CustomNodeKindConfig{Icon: graphschema.DisplayNodeIcon{Type: graphschema.DisplayNodeTypeFontAwesome, Name: "star"}}},
 			wantErr: nil,
 		},
 		{
@@ -104,7 +105,7 @@ func TestCreateCustomNodeKinds(t *testing.T) {
 					{
 						KindName: "DuplicateKind",
 						Config: model.CustomNodeKindConfig{
-							Icon: model.CustomNodeIcon{Type: model.CustomNodeKindTypeFontAwesome, Name: "coffee", Color: "#FFFFFF"},
+							Icon: graphschema.DisplayNodeIcon{Type: graphschema.DisplayNodeTypeFontAwesome, Name: "coffee", Color: "#FFFFFF"},
 						},
 					},
 				})
@@ -115,7 +116,7 @@ func TestCreateCustomNodeKinds(t *testing.T) {
 				{
 					KindName: "DuplicateKind",
 					Config: model.CustomNodeKindConfig{
-						Icon: model.CustomNodeIcon{Type: model.CustomNodeKindTypeFontAwesome, Name: "coffee", Color: "#FFFFFF"},
+						Icon: graphschema.DisplayNodeIcon{Type: graphschema.DisplayNodeTypeFontAwesome, Name: "coffee", Color: "#FFFFFF"},
 					},
 				},
 			},
@@ -165,13 +166,13 @@ func TestGetCustomNodeKinds(t *testing.T) {
 					{
 						KindName: "KindOne",
 						Config: model.CustomNodeKindConfig{
-							Icon: model.CustomNodeIcon{Type: model.CustomNodeKindTypeFontAwesome, Name: "fire", Color: "#FF5733"},
+							Icon: graphschema.DisplayNodeIcon{Type: graphschema.DisplayNodeTypeFontAwesome, Name: "fire", Color: "#FF5733"},
 						},
 					},
 					{
 						KindName: "KindTwo",
 						Config: model.CustomNodeKindConfig{
-							Icon: model.CustomNodeIcon{Type: model.CustomNodeKindTypeFontAwesome, Name: "star", Color: "#FFFF00"},
+							Icon: graphschema.DisplayNodeIcon{Type: graphschema.DisplayNodeTypeFontAwesome, Name: "star", Color: "#FFFF00"},
 						},
 					},
 				})
@@ -222,7 +223,7 @@ func TestGetCustomNodeKind(t *testing.T) {
 					{
 						KindName: "RetrievableKind",
 						Config: model.CustomNodeKindConfig{
-							Icon: model.CustomNodeIcon{Type: model.CustomNodeKindTypeFontAwesome, Name: "bell", Color: "#123456"},
+							Icon: graphschema.DisplayNodeIcon{Type: graphschema.DisplayNodeTypeFontAwesome, Name: "bell", Color: "#123456"},
 						},
 					},
 				})
@@ -270,7 +271,7 @@ func TestUpdateCustomNodeKind(t *testing.T) {
 			input: model.CustomNodeKind{
 				KindName: "NonExistentKind",
 				Config: model.CustomNodeKindConfig{
-					Icon: model.CustomNodeIcon{Type: model.CustomNodeKindTypeFontAwesome, Name: "bell", Color: "#FFFFFF"},
+					Icon: graphschema.DisplayNodeIcon{Type: graphschema.DisplayNodeTypeFontAwesome, Name: "bell", Color: "#FFFFFF"},
 				},
 			},
 			wantErr: database.ErrNotFound,
@@ -283,7 +284,7 @@ func TestUpdateCustomNodeKind(t *testing.T) {
 					{
 						KindName: "UpdatableKind",
 						Config: model.CustomNodeKindConfig{
-							Icon: model.CustomNodeIcon{Type: model.CustomNodeKindTypeFontAwesome, Name: "coffee", Color: "#FFFFFF"},
+							Icon: graphschema.DisplayNodeIcon{Type: graphschema.DisplayNodeTypeFontAwesome, Name: "coffee", Color: "#FFFFFF"},
 						},
 					},
 				})
@@ -293,7 +294,7 @@ func TestUpdateCustomNodeKind(t *testing.T) {
 			input: model.CustomNodeKind{
 				KindName: "UpdatableKind",
 				Config: model.CustomNodeKindConfig{
-					Icon: model.CustomNodeIcon{Type: model.CustomNodeKindTypeFontAwesome, Name: "star", Color: "#000000"},
+					Icon: graphschema.DisplayNodeIcon{Type: graphschema.DisplayNodeTypeFontAwesome, Name: "star", Color: "#000000"},
 				},
 			},
 			want: struct {
@@ -303,7 +304,7 @@ func TestUpdateCustomNodeKind(t *testing.T) {
 				CustomNodeKind: model.CustomNodeKind{
 					KindName: "UpdatableKind",
 					Config: model.CustomNodeKindConfig{
-						Icon: model.CustomNodeIcon{Type: model.CustomNodeKindTypeFontAwesome, Name: "star", Color: "#000000"},
+						Icon: graphschema.DisplayNodeIcon{Type: graphschema.DisplayNodeTypeFontAwesome, Name: "star", Color: "#000000"},
 					},
 				},
 			},
@@ -324,7 +325,7 @@ func TestUpdateCustomNodeKind(t *testing.T) {
 						KindName:         "UpdatableKind",
 						SchemaNodeKindId: &schemaNodeKindID,
 						Config: model.CustomNodeKindConfig{
-							Icon: model.CustomNodeIcon{Type: model.CustomNodeKindTypeFontAwesome, Name: "coffee", Color: "#FFFFFF"},
+							Icon: graphschema.DisplayNodeIcon{Type: graphschema.DisplayNodeTypeFontAwesome, Name: "coffee", Color: "#FFFFFF"},
 						},
 					},
 				})
@@ -336,7 +337,7 @@ func TestUpdateCustomNodeKind(t *testing.T) {
 				KindName:         "UpdatableKind",
 				SchemaNodeKindId: &schemaNodeKindID,
 				Config: model.CustomNodeKindConfig{
-					Icon: model.CustomNodeIcon{Type: model.CustomNodeKindTypeFontAwesome, Name: "star", Color: "#000000"},
+					Icon: graphschema.DisplayNodeIcon{Type: graphschema.DisplayNodeTypeFontAwesome, Name: "star", Color: "#000000"},
 				},
 			},
 			want: struct {
@@ -346,7 +347,7 @@ func TestUpdateCustomNodeKind(t *testing.T) {
 				CustomNodeKind: model.CustomNodeKind{
 					KindName: "UpdatableKind",
 					Config: model.CustomNodeKindConfig{
-						Icon: model.CustomNodeIcon{Type: model.CustomNodeKindTypeFontAwesome, Name: "star", Color: "#000000"},
+						Icon: graphschema.DisplayNodeIcon{Type: graphschema.DisplayNodeTypeFontAwesome, Name: "star", Color: "#000000"},
 					},
 				},
 				SchemaNodeKind: model.GraphSchemaNodeKind{
@@ -404,7 +405,7 @@ func TestDeleteCustomNodeKind(t *testing.T) {
 					{
 						KindName: "DeletableKind",
 						Config: model.CustomNodeKindConfig{
-							Icon: model.CustomNodeIcon{Type: model.CustomNodeKindTypeFontAwesome, Name: "trash", Color: "#FF0000"},
+							Icon: graphschema.DisplayNodeIcon{Type: graphschema.DisplayNodeTypeFontAwesome, Name: "trash", Color: "#FF0000"},
 						},
 					},
 				})

--- a/cmd/api/src/database/customnode_integration_test.go
+++ b/cmd/api/src/database/customnode_integration_test.go
@@ -44,11 +44,11 @@ func TestCreateCustomNodeKinds(t *testing.T) {
 				{
 					KindName: "TestKind",
 					Config: model.CustomNodeKindConfig{
-						Icon: model.CustomNodeIcon{Type: "font-awesome", Name: "coffee", Color: "#FFFFFF"},
+						Icon: model.CustomNodeIcon{Type: model.CustomNodeKindTypeFontAwesome, Name: "coffee", Color: "#FFFFFF"},
 					},
 				},
 			},
-			wantMap: model.CustomNodeKindMap{"TestKind": model.CustomNodeKindConfig{Icon: model.CustomNodeIcon{Type: "font-awesome", Name: "coffee", Color: "#FFFFFF"}}},
+			wantMap: model.CustomNodeKindMap{"TestKind": model.CustomNodeKindConfig{Icon: model.CustomNodeIcon{Type: model.CustomNodeKindTypeFontAwesome, Name: "coffee", Color: "#FFFFFF"}}},
 			wantErr: nil,
 		},
 		{
@@ -60,17 +60,17 @@ func TestCreateCustomNodeKinds(t *testing.T) {
 				{
 					KindName: "TestKindA",
 					Config: model.CustomNodeKindConfig{
-						Icon: model.CustomNodeIcon{Type: "font-awesome", Name: "house", Color: "#000000"},
+						Icon: model.CustomNodeIcon{Type: model.CustomNodeKindTypeFontAwesome, Name: "house", Color: "#000000"},
 					},
 				},
 				{
 					KindName: "TestKindB",
 					Config: model.CustomNodeKindConfig{
-						Icon: model.CustomNodeIcon{Type: "font-awesome", Name: "star", Color: "#FF0000"},
+						Icon: model.CustomNodeIcon{Type: model.CustomNodeKindTypeFontAwesome, Name: "star", Color: "#FF0000"},
 					},
 				},
 			},
-			wantMap: model.CustomNodeKindMap{"TestKindA": model.CustomNodeKindConfig{Icon: model.CustomNodeIcon{Type: "font-awesome", Name: "house", Color: "#000000"}}, "TestKindB": model.CustomNodeKindConfig{Icon: model.CustomNodeIcon{Type: "font-awesome", Name: "star", Color: "#FF0000"}}},
+			wantMap: model.CustomNodeKindMap{"TestKindA": model.CustomNodeKindConfig{Icon: model.CustomNodeIcon{Type: model.CustomNodeKindTypeFontAwesome, Name: "house", Color: "#000000"}}, "TestKindB": model.CustomNodeKindConfig{Icon: model.CustomNodeIcon{Type: model.CustomNodeKindTypeFontAwesome, Name: "star", Color: "#FF0000"}}},
 			wantErr: nil,
 		},
 
@@ -83,17 +83,17 @@ func TestCreateCustomNodeKinds(t *testing.T) {
 				{
 					KindName: "TestKindA",
 					Config: model.CustomNodeKindConfig{
-						Icon: model.CustomNodeIcon{Type: "font-awesome", Color: "#000000"},
+						Icon: model.CustomNodeIcon{Type: model.CustomNodeKindTypeFontAwesome, Color: "#000000"},
 					},
 				},
 				{
 					KindName: "TestKindB",
 					Config: model.CustomNodeKindConfig{
-						Icon: model.CustomNodeIcon{Type: "font-awesome", Name: "star"},
+						Icon: model.CustomNodeIcon{Type: model.CustomNodeKindTypeFontAwesome, Name: "star"},
 					},
 				},
 			},
-			wantMap: model.CustomNodeKindMap{"TestKindA": model.CustomNodeKindConfig{Icon: model.CustomNodeIcon{Type: "font-awesome", Color: "#000000"}}, "TestKindB": model.CustomNodeKindConfig{Icon: model.CustomNodeIcon{Type: "font-awesome", Name: "star"}}},
+			wantMap: model.CustomNodeKindMap{"TestKindA": model.CustomNodeKindConfig{Icon: model.CustomNodeIcon{Type: model.CustomNodeKindTypeFontAwesome, Color: "#000000"}}, "TestKindB": model.CustomNodeKindConfig{Icon: model.CustomNodeIcon{Type: model.CustomNodeKindTypeFontAwesome, Name: "star"}}},
 			wantErr: nil,
 		},
 		{
@@ -104,7 +104,7 @@ func TestCreateCustomNodeKinds(t *testing.T) {
 					{
 						KindName: "DuplicateKind",
 						Config: model.CustomNodeKindConfig{
-							Icon: model.CustomNodeIcon{Type: "font-awesome", Name: "coffee", Color: "#FFFFFF"},
+							Icon: model.CustomNodeIcon{Type: model.CustomNodeKindTypeFontAwesome, Name: "coffee", Color: "#FFFFFF"},
 						},
 					},
 				})
@@ -115,7 +115,7 @@ func TestCreateCustomNodeKinds(t *testing.T) {
 				{
 					KindName: "DuplicateKind",
 					Config: model.CustomNodeKindConfig{
-						Icon: model.CustomNodeIcon{Type: "font-awesome", Name: "coffee", Color: "#FFFFFF"},
+						Icon: model.CustomNodeIcon{Type: model.CustomNodeKindTypeFontAwesome, Name: "coffee", Color: "#FFFFFF"},
 					},
 				},
 			},
@@ -165,13 +165,13 @@ func TestGetCustomNodeKinds(t *testing.T) {
 					{
 						KindName: "KindOne",
 						Config: model.CustomNodeKindConfig{
-							Icon: model.CustomNodeIcon{Type: "font-awesome", Name: "fire", Color: "#FF5733"},
+							Icon: model.CustomNodeIcon{Type: model.CustomNodeKindTypeFontAwesome, Name: "fire", Color: "#FF5733"},
 						},
 					},
 					{
 						KindName: "KindTwo",
 						Config: model.CustomNodeKindConfig{
-							Icon: model.CustomNodeIcon{Type: "font-awesome", Name: "star", Color: "#FFFF00"},
+							Icon: model.CustomNodeIcon{Type: model.CustomNodeKindTypeFontAwesome, Name: "star", Color: "#FFFF00"},
 						},
 					},
 				})
@@ -222,7 +222,7 @@ func TestGetCustomNodeKind(t *testing.T) {
 					{
 						KindName: "RetrievableKind",
 						Config: model.CustomNodeKindConfig{
-							Icon: model.CustomNodeIcon{Type: "font-awesome", Name: "bell", Color: "#123456"},
+							Icon: model.CustomNodeIcon{Type: model.CustomNodeKindTypeFontAwesome, Name: "bell", Color: "#123456"},
 						},
 					},
 				})
@@ -270,7 +270,7 @@ func TestUpdateCustomNodeKind(t *testing.T) {
 			input: model.CustomNodeKind{
 				KindName: "NonExistentKind",
 				Config: model.CustomNodeKindConfig{
-					Icon: model.CustomNodeIcon{Type: "font-awesome", Name: "bell", Color: "#FFFFFF"},
+					Icon: model.CustomNodeIcon{Type: model.CustomNodeKindTypeFontAwesome, Name: "bell", Color: "#FFFFFF"},
 				},
 			},
 			wantErr: database.ErrNotFound,
@@ -283,7 +283,7 @@ func TestUpdateCustomNodeKind(t *testing.T) {
 					{
 						KindName: "UpdatableKind",
 						Config: model.CustomNodeKindConfig{
-							Icon: model.CustomNodeIcon{Type: "font-awesome", Name: "coffee", Color: "#FFFFFF"},
+							Icon: model.CustomNodeIcon{Type: model.CustomNodeKindTypeFontAwesome, Name: "coffee", Color: "#FFFFFF"},
 						},
 					},
 				})
@@ -293,7 +293,7 @@ func TestUpdateCustomNodeKind(t *testing.T) {
 			input: model.CustomNodeKind{
 				KindName: "UpdatableKind",
 				Config: model.CustomNodeKindConfig{
-					Icon: model.CustomNodeIcon{Type: "font-awesome", Name: "star", Color: "#000000"},
+					Icon: model.CustomNodeIcon{Type: model.CustomNodeKindTypeFontAwesome, Name: "star", Color: "#000000"},
 				},
 			},
 			want: struct {
@@ -303,7 +303,7 @@ func TestUpdateCustomNodeKind(t *testing.T) {
 				CustomNodeKind: model.CustomNodeKind{
 					KindName: "UpdatableKind",
 					Config: model.CustomNodeKindConfig{
-						Icon: model.CustomNodeIcon{Type: "font-awesome", Name: "star", Color: "#000000"},
+						Icon: model.CustomNodeIcon{Type: model.CustomNodeKindTypeFontAwesome, Name: "star", Color: "#000000"},
 					},
 				},
 			},
@@ -324,7 +324,7 @@ func TestUpdateCustomNodeKind(t *testing.T) {
 						KindName:         "UpdatableKind",
 						SchemaNodeKindId: &schemaNodeKindID,
 						Config: model.CustomNodeKindConfig{
-							Icon: model.CustomNodeIcon{Type: "font-awesome", Name: "coffee", Color: "#FFFFFF"},
+							Icon: model.CustomNodeIcon{Type: model.CustomNodeKindTypeFontAwesome, Name: "coffee", Color: "#FFFFFF"},
 						},
 					},
 				})
@@ -336,7 +336,7 @@ func TestUpdateCustomNodeKind(t *testing.T) {
 				KindName:         "UpdatableKind",
 				SchemaNodeKindId: &schemaNodeKindID,
 				Config: model.CustomNodeKindConfig{
-					Icon: model.CustomNodeIcon{Type: "font-awesome", Name: "star", Color: "#000000"},
+					Icon: model.CustomNodeIcon{Type: model.CustomNodeKindTypeFontAwesome, Name: "star", Color: "#000000"},
 				},
 			},
 			want: struct {
@@ -346,7 +346,7 @@ func TestUpdateCustomNodeKind(t *testing.T) {
 				CustomNodeKind: model.CustomNodeKind{
 					KindName: "UpdatableKind",
 					Config: model.CustomNodeKindConfig{
-						Icon: model.CustomNodeIcon{Type: "font-awesome", Name: "star", Color: "#000000"},
+						Icon: model.CustomNodeIcon{Type: model.CustomNodeKindTypeFontAwesome, Name: "star", Color: "#000000"},
 					},
 				},
 				SchemaNodeKind: model.GraphSchemaNodeKind{
@@ -404,7 +404,7 @@ func TestDeleteCustomNodeKind(t *testing.T) {
 					{
 						KindName: "DeletableKind",
 						Config: model.CustomNodeKindConfig{
-							Icon: model.CustomNodeIcon{Type: "font-awesome", Name: "trash", Color: "#FF0000"},
+							Icon: model.CustomNodeIcon{Type: model.CustomNodeKindTypeFontAwesome, Name: "trash", Color: "#FF0000"},
 						},
 					},
 				})

--- a/cmd/api/src/database/customnode_integration_test.go
+++ b/cmd/api/src/database/customnode_integration_test.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/specterops/bloodhound/cmd/api/src/database"
 	"github.com/specterops/bloodhound/cmd/api/src/model"
-	"github.com/specterops/bloodhound/cmd/api/src/model/appcfg"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -196,70 +195,6 @@ func TestGetCustomNodeKinds(t *testing.T) {
 				require.NoError(t, err)
 				assert.Len(t, kinds, testCase.wantLen)
 			}
-		})
-	}
-}
-
-func TestGetCustomNodeKindsMap(t *testing.T) {
-	tests := []struct {
-		name    string
-		setup   func() IntegrationTestSuite
-		wantLen int
-	}{
-		{
-			name: "success - retrieves nil when OG disabled",
-			setup: func() IntegrationTestSuite {
-				testSuite := setupIntegrationTestSuite(t)
-				flag, err := testSuite.BHDatabase.GetFlagByKey(testSuite.Context, appcfg.FeatureOpenGraphSearch)
-				require.NoError(t, err)
-				flag.Enabled = false
-				require.NoError(t, testSuite.BHDatabase.SetFlag(testSuite.Context, flag))
-
-				_, err = testSuite.BHDatabase.CreateCustomNodeKinds(testSuite.Context, model.CustomNodeKinds{
-					{
-						KindName: "RetrievableKind",
-						Config: model.CustomNodeKindConfig{
-							Icon: model.CustomNodeIcon{Type: "font-awesome", Name: "bell", Color: "#123456"},
-						},
-					},
-				})
-				require.NoError(t, err)
-				return testSuite
-			},
-			wantLen: 0,
-		},
-		{
-			name: "success - retrieves kind map when OG enabled",
-			setup: func() IntegrationTestSuite {
-				testSuite := setupIntegrationTestSuite(t)
-				flag, err := testSuite.BHDatabase.GetFlagByKey(testSuite.Context, appcfg.FeatureOpenGraphSearch)
-				require.NoError(t, err)
-				flag.Enabled = true
-				require.NoError(t, testSuite.BHDatabase.SetFlag(testSuite.Context, flag))
-
-				_, err = testSuite.BHDatabase.CreateCustomNodeKinds(testSuite.Context, model.CustomNodeKinds{
-					{
-						KindName: "RetrievableKind",
-						Config: model.CustomNodeKindConfig{
-							Icon: model.CustomNodeIcon{Type: "font-awesome", Name: "bell", Color: "#123456"},
-						},
-					},
-				})
-				require.NoError(t, err)
-				return testSuite
-			},
-			wantLen: 1,
-		},
-	}
-
-	for _, testCase := range tests {
-		t.Run(testCase.name, func(t *testing.T) {
-			testSuite := testCase.setup()
-			defer teardownIntegrationTestSuite(t, &testSuite)
-
-			customNodeKindMap, err := testSuite.BHDatabase.GetCustomNodeKindsMap(testSuite.Context)
-			require.NoError(t, err)
-			assert.Len(t, customNodeKindMap, testCase.wantLen)
 		})
 	}
 }

--- a/cmd/api/src/database/database_integration_test.go
+++ b/cmd/api/src/database/database_integration_test.go
@@ -266,7 +266,7 @@ func TestGetNodeKindDisplayLabel(t *testing.T) {
 	nodeKindNoDis, err := testSuite.BHDatabase.CreateGraphSchemaNodeKind(testSuite.Context, "TestKindNoDis", extension.ID, "", "", false, "", "")
 	require.NoError(t, err)
 
-	primaryNodeKinds, err := testSuite.BHDatabase.GetValidDisplayKinds(testSuite.Context)
+	primaryNodeKinds, err := testSuite.BHDatabase.GetPrimaryDisplayKinds(testSuite.Context)
 	require.NoError(t, err)
 
 	assert.Equal(t, ad.Entity.String(), graphschema.GetNodeKindDisplayLabel(primaryNodeKinds, graph.PrepareNode(graph.NewProperties(), ad.Entity)), "should return base kind if no other valid kinds are present")

--- a/cmd/api/src/database/graphschema.go
+++ b/cmd/api/src/database/graphschema.go
@@ -41,7 +41,7 @@ type OpenGraphSchema interface {
 	GetGraphSchemaNodeKindById(ctx context.Context, schemaNodeKindID int32) (model.GraphSchemaNodeKind, error)
 	GetGraphSchemaNodeKinds(ctx context.Context, nodeKindFilters model.Filters, sort model.Sort, skip, limit int) (model.GraphSchemaNodeKinds, int, error)
 	UpdateGraphSchemaNodeKind(ctx context.Context, schemaNodeKind model.GraphSchemaNodeKind) (model.GraphSchemaNodeKind, error)
-	UpdateGraphSchemaNodeKindIconById(ctx context.Context, kindId int32, icon model.CustomNodeIcon) (model.GraphSchemaNodeKind, error)
+	UpdateGraphSchemaNodeKindIconById(ctx context.Context, kindId int32, icon graphschema.DisplayNodeIcon) (model.GraphSchemaNodeKind, error)
 	DeleteGraphSchemaNodeKind(ctx context.Context, schemaNodeKindId int32) error
 
 	CreateGraphSchemaProperty(ctx context.Context, extensionId int32, name string, displayName string, dataType string, description string) (model.GraphSchemaProperty, error)
@@ -417,7 +417,7 @@ func (s *BloodhoundDB) UpdateGraphSchemaNodeKind(ctx context.Context, schemaNode
 
 // UpdateGraphSchemaNodeKindIconByKindId - updates the icon name and color for a row in the schema_node_kinds table based on the provided id. It will return an
 // error if the target schema node kind does not exist.
-func (s *BloodhoundDB) UpdateGraphSchemaNodeKindIconById(ctx context.Context, id int32, icon model.CustomNodeIcon) (model.GraphSchemaNodeKind, error) {
+func (s *BloodhoundDB) UpdateGraphSchemaNodeKindIconById(ctx context.Context, id int32, icon graphschema.DisplayNodeIcon) (model.GraphSchemaNodeKind, error) {
 	var schemaNodeKind model.GraphSchemaNodeKind
 	if result := s.db.WithContext(ctx).Raw(fmt.Sprintf(`
 		WITH updated_row AS (
@@ -1362,9 +1362,9 @@ func (s *BloodhoundDB) GetValidDisplayKinds(ctx context.Context) (graphschema.Va
 				customKind := customKindsByName[kind.Name]
 				validPrimaryKinds[kind.ToKind()] = graphschema.DisplayKind{
 					Name: kind.Name,
-					Icon: graphschema.DisplayKindIcon{
+					Icon: graphschema.DisplayNodeIcon{
 						Name:  customKind.Config.Icon.Name,
-						Type:  string(customKind.Config.Icon.Type),
+						Type:  customKind.Config.Icon.Type,
 						Color: customKind.Config.Icon.Color,
 					},
 				}
@@ -1372,10 +1372,10 @@ func (s *BloodhoundDB) GetValidDisplayKinds(ctx context.Context) (graphschema.Va
 			for _, kind := range displaySchemaNodeKinds {
 				validPrimaryKinds[kind.ToKind()] = graphschema.DisplayKind{
 					Name: kind.Name,
-					Icon: graphschema.DisplayKindIcon{
+					Icon: graphschema.DisplayNodeIcon{
 						Name:  kind.Icon,
 						Color: kind.IconColor,
-						Type:  string(model.CustomNodeKindTypeFontAwesome),
+						Type:  graphschema.DisplayNodeTypeFontAwesome,
 					},
 				}
 			}

--- a/cmd/api/src/database/graphschema.go
+++ b/cmd/api/src/database/graphschema.go
@@ -40,7 +40,6 @@ type OpenGraphSchema interface {
 	CreateGraphSchemaNodeKind(ctx context.Context, name string, extensionId int32, displayName string, description string, isDisplayKind bool, icon, iconColor string) (model.GraphSchemaNodeKind, error)
 	GetGraphSchemaNodeKindById(ctx context.Context, schemaNodeKindID int32) (model.GraphSchemaNodeKind, error)
 	GetGraphSchemaNodeKinds(ctx context.Context, nodeKindFilters model.Filters, sort model.Sort, skip, limit int) (model.GraphSchemaNodeKinds, int, error)
-	GetDisplayGraphSchemaNodeKinds(ctx context.Context) (model.GraphSchemaNodeKindMap, error)
 	UpdateGraphSchemaNodeKind(ctx context.Context, schemaNodeKind model.GraphSchemaNodeKind) (model.GraphSchemaNodeKind, error)
 	UpdateGraphSchemaNodeKindIconById(ctx context.Context, kindId int32, icon model.CustomNodeIcon) (model.GraphSchemaNodeKind, error)
 	DeleteGraphSchemaNodeKind(ctx context.Context, schemaNodeKindId int32) error
@@ -358,26 +357,6 @@ func (s *BloodhoundDB) GetGraphSchemaNodeKinds(ctx context.Context, filters mode
 			}
 		}
 		return schemaNodeKinds, totalRowCount, nil
-	}
-}
-
-// GetDisplayGraphSchemaNodeKinds - returns a map of display kinds where the key is the node kind name and the value is the entire schema node kind row.
-// An empty map will be returned if no valid node kinds exist. An error will be returned if encountered.
-func (s *BloodhoundDB) GetDisplayGraphSchemaNodeKinds(ctx context.Context) (model.GraphSchemaNodeKindMap, error) {
-	if displaySchemaNodeKinds, _, err := s.GetGraphSchemaNodeKinds(ctx, model.Filters{"is_display_kind": []model.Filter{
-		{
-			Operator:    model.Equals,
-			Value:       "true",
-			SetOperator: model.FilterAnd,
-		},
-	}}, model.Sort{}, 0, 0); err != nil {
-		return nil, err
-	} else {
-		var displayKindsNodes = model.GraphSchemaNodeKindMap{}
-		for _, schemaNodeKind := range displaySchemaNodeKinds {
-			displayKindsNodes[schemaNodeKind.Name] = schemaNodeKind
-		}
-		return displayKindsNodes, nil
 	}
 }
 
@@ -1354,13 +1333,53 @@ func (s *BloodhoundDB) DeletePrincipalKind(ctx context.Context, environmentId in
 	return nil
 }
 
-// GetValidDisplayKinds - returns a map of all node kinds that are display kinds.
-// An empty map will be returned if no valid node kinds exist. An error will be returned if encountered.
+// GetValidDisplayKinds - returns a map of all node kinds that are display kinds, this pulls from both custom_node_kinds(schemaless)
+// and schema_node_kinds to create a single source of truth for all valid node kinds
 func (s *BloodhoundDB) GetValidDisplayKinds(ctx context.Context) (graphschema.ValidPrimaryKinds, error) {
-	if displaySchemaNodeKinds, err := s.GetDisplayGraphSchemaNodeKinds(ctx); err != nil {
+	if displaySchemaNodeKinds, _, err := s.GetGraphSchemaNodeKinds(ctx, model.Filters{"is_display_kind": []model.Filter{
+		{
+			Operator:    model.Equals,
+			Value:       "true",
+			SetOperator: model.FilterAnd,
+		},
+	}}, model.Sort{}, 0, 0); err != nil {
+		return nil, err
+	} else if customNodeKinds, err := s.GetCustomNodeKinds(ctx, nil); err != nil {
 		return nil, err
 	} else {
-		return displaySchemaNodeKinds.ToKindsMap(), nil
+		var customNames []string
+		var customKindsByName = make(map[string]model.CustomNodeKind)
+		for _, kind := range customNodeKinds {
+			customNames = append(customNames, kind.KindName)
+			customKindsByName[kind.KindName] = kind
+		}
+		// Until work is complete to ensure custom_node_kinds are properly kind backed, this will filter out invalid kinds
+		if kinds, err := s.GetKindsByNames(ctx, customNames...); err != nil {
+			return nil, err
+		} else {
+			var validPrimaryKinds = make(graphschema.ValidPrimaryKinds)
+			for _, kind := range kinds {
+				customKind := customKindsByName[kind.Name]
+				validPrimaryKinds[kind.ToKind()] = graphschema.DisplayKind{
+					Name: kind.Name,
+					Icon: graphschema.DisplayKindIcon{
+						Name:  customKind.Config.Icon.Name,
+						Type:  customKind.Config.Icon.Type,
+						Color: customKind.Config.Icon.Color,
+					},
+				}
+			}
+			for _, kind := range displaySchemaNodeKinds {
+				validPrimaryKinds[kind.ToKind()] = graphschema.DisplayKind{
+					Name: kind.Name,
+					Icon: graphschema.DisplayKindIcon{
+						Name:  kind.Icon,
+						Color: kind.IconColor,
+					},
+				}
+			}
+			return validPrimaryKinds, nil
+		}
 	}
 }
 

--- a/cmd/api/src/database/graphschema.go
+++ b/cmd/api/src/database/graphschema.go
@@ -87,7 +87,7 @@ type OpenGraphSchema interface {
 	GetPrincipalKindsByEnvironmentId(ctx context.Context, environmentId int32) (model.SchemaEnvironmentPrincipalKinds, error)
 	DeletePrincipalKind(ctx context.Context, environmentId int32, principalKind int32) error
 
-	GetValidDisplayKinds(ctx context.Context) (graphschema.PrimaryDisplayKinds, error)
+	GetPrimaryDisplayKinds(ctx context.Context) (graphschema.PrimaryDisplayKinds, error)
 }
 
 const (
@@ -1333,9 +1333,9 @@ func (s *BloodhoundDB) DeletePrincipalKind(ctx context.Context, environmentId in
 	return nil
 }
 
-// GetValidDisplayKinds - returns a map of all node kinds that are display kinds, this pulls from both custom_node_kinds(schemaless)
+// GetPrimaryDisplayKinds - returns a map of all node kinds that are display kinds, this pulls from both custom_node_kinds(schemaless)
 // and schema_node_kinds to create a single source of truth for all valid node kinds
-func (s *BloodhoundDB) GetValidDisplayKinds(ctx context.Context) (graphschema.PrimaryDisplayKinds, error) {
+func (s *BloodhoundDB) GetPrimaryDisplayKinds(ctx context.Context) (graphschema.PrimaryDisplayKinds, error) {
 	if displaySchemaNodeKinds, _, err := s.GetGraphSchemaNodeKinds(ctx, model.Filters{"is_display_kind": []model.Filter{
 		{
 			Operator:    model.Equals,

--- a/cmd/api/src/database/graphschema.go
+++ b/cmd/api/src/database/graphschema.go
@@ -1364,7 +1364,7 @@ func (s *BloodhoundDB) GetValidDisplayKinds(ctx context.Context) (graphschema.Va
 					Name: kind.Name,
 					Icon: graphschema.DisplayKindIcon{
 						Name:  customKind.Config.Icon.Name,
-						Type:  customKind.Config.Icon.Type,
+						Type:  string(customKind.Config.Icon.Type),
 						Color: customKind.Config.Icon.Color,
 					},
 				}
@@ -1375,6 +1375,7 @@ func (s *BloodhoundDB) GetValidDisplayKinds(ctx context.Context) (graphschema.Va
 					Icon: graphschema.DisplayKindIcon{
 						Name:  kind.Icon,
 						Color: kind.IconColor,
+						Type:  string(model.CustomNodeKindTypeFontAwesome),
 					},
 				}
 			}

--- a/cmd/api/src/database/graphschema.go
+++ b/cmd/api/src/database/graphschema.go
@@ -87,7 +87,7 @@ type OpenGraphSchema interface {
 	GetPrincipalKindsByEnvironmentId(ctx context.Context, environmentId int32) (model.SchemaEnvironmentPrincipalKinds, error)
 	DeletePrincipalKind(ctx context.Context, environmentId int32, principalKind int32) error
 
-	GetValidDisplayKinds(ctx context.Context) (graphschema.ValidPrimaryKinds, error)
+	GetValidDisplayKinds(ctx context.Context) (graphschema.PrimaryDisplayKinds, error)
 }
 
 const (
@@ -1335,7 +1335,7 @@ func (s *BloodhoundDB) DeletePrincipalKind(ctx context.Context, environmentId in
 
 // GetValidDisplayKinds - returns a map of all node kinds that are display kinds, this pulls from both custom_node_kinds(schemaless)
 // and schema_node_kinds to create a single source of truth for all valid node kinds
-func (s *BloodhoundDB) GetValidDisplayKinds(ctx context.Context) (graphschema.ValidPrimaryKinds, error) {
+func (s *BloodhoundDB) GetValidDisplayKinds(ctx context.Context) (graphschema.PrimaryDisplayKinds, error) {
 	if displaySchemaNodeKinds, _, err := s.GetGraphSchemaNodeKinds(ctx, model.Filters{"is_display_kind": []model.Filter{
 		{
 			Operator:    model.Equals,
@@ -1357,10 +1357,10 @@ func (s *BloodhoundDB) GetValidDisplayKinds(ctx context.Context) (graphschema.Va
 		if kinds, err := s.GetKindsByNames(ctx, customNames...); err != nil {
 			return nil, err
 		} else {
-			var validPrimaryKinds = make(graphschema.ValidPrimaryKinds)
+			var primaryDisplayKinds = make(graphschema.PrimaryDisplayKinds)
 			for _, kind := range kinds {
 				customKind := customKindsByName[kind.Name]
-				validPrimaryKinds[kind.ToKind()] = graphschema.DisplayKind{
+				primaryDisplayKinds[kind.ToKind()] = graphschema.DisplayKind{
 					Name: kind.Name,
 					Icon: graphschema.DisplayNodeIcon{
 						Name:  customKind.Config.Icon.Name,
@@ -1370,7 +1370,7 @@ func (s *BloodhoundDB) GetValidDisplayKinds(ctx context.Context) (graphschema.Va
 				}
 			}
 			for _, kind := range displaySchemaNodeKinds {
-				validPrimaryKinds[kind.ToKind()] = graphschema.DisplayKind{
+				primaryDisplayKinds[kind.ToKind()] = graphschema.DisplayKind{
 					Name: kind.Name,
 					Icon: graphschema.DisplayNodeIcon{
 						Name:  kind.Icon,
@@ -1379,7 +1379,7 @@ func (s *BloodhoundDB) GetValidDisplayKinds(ctx context.Context) (graphschema.Va
 					},
 				}
 			}
-			return validPrimaryKinds, nil
+			return primaryDisplayKinds, nil
 		}
 	}
 }

--- a/cmd/api/src/database/graphschema_integration_test.go
+++ b/cmd/api/src/database/graphschema_integration_test.go
@@ -4529,13 +4529,13 @@ func TestDatabase_GetSchemaFindings(t *testing.T) {
 }
 
 func TestDatabase_GetDisplayGraphKinds(t *testing.T) {
-	assertContainsDisplayKind := func(t *testing.T, got graphschema.ValidPrimaryKinds, name string) {
+	assertContainsDisplayKind := func(t *testing.T, got graphschema.PrimaryDisplayKinds, name string) {
 		t.Helper()
 		_, ok := got[graph.StringKind(name)]
 		assert.True(t, ok, "expected display kind %s to be present in result", name)
 	}
 
-	assertDoesNotContainDisplayKind := func(t *testing.T, got graphschema.ValidPrimaryKinds, name string) {
+	assertDoesNotContainDisplayKind := func(t *testing.T, got graphschema.PrimaryDisplayKinds, name string) {
 		t.Helper()
 		_, ok := got[graph.StringKind(name)]
 		assert.False(t, ok, "expected kind %s to not be present in result", name)

--- a/cmd/api/src/database/graphschema_integration_test.go
+++ b/cmd/api/src/database/graphschema_integration_test.go
@@ -1321,7 +1321,7 @@ func TestDatabase_UpdateGraphSchemaNodeKindIconById(t *testing.T) {
 				extension := createTestExtension(t, testSuite, "test_extension", "test_extension", "1.0.0", "Test")
 				createdNodeKind := createTestNodeKind(t, testSuite, "Test Kind 1", extension.ID, "Test_Kind_1", "Test Kind 1", true, "user", "#17E625")
 
-				updatedNodeKind, err := testSuite.BHDatabase.UpdateGraphSchemaNodeKindIconById(testSuite.Context, createdNodeKind.ID, model.CustomNodeIcon{Type: model.CustomNodeKindTypeFontAwesome, Name: "coffee", Color: "#3a0b138c"})
+				updatedNodeKind, err := testSuite.BHDatabase.UpdateGraphSchemaNodeKindIconById(testSuite.Context, createdNodeKind.ID, graphschema.DisplayNodeIcon{Type: graphschema.DisplayNodeTypeFontAwesome, Name: "coffee", Color: "#3a0b138c"})
 				require.NoError(t, err, "unexpected error occurred when updating node kind icon")
 
 				// Retrieve Node Kind 1
@@ -1335,7 +1335,7 @@ func TestDatabase_UpdateGraphSchemaNodeKindIconById(t *testing.T) {
 		}, {
 			name: "Error: failed to update schema node kind icon that does not exist",
 			assert: func(t *testing.T, testSuite IntegrationTestSuite) {
-				_, err := testSuite.BHDatabase.UpdateGraphSchemaNodeKindIconById(testSuite.Context, 12345, model.CustomNodeIcon{Type: model.CustomNodeKindTypeFontAwesome, Name: "coffee", Color: "#3a0b138c"})
+				_, err := testSuite.BHDatabase.UpdateGraphSchemaNodeKindIconById(testSuite.Context, 12345, graphschema.DisplayNodeIcon{Type: graphschema.DisplayNodeTypeFontAwesome, Name: "coffee", Color: "#3a0b138c"})
 				require.EqualError(t, err, database.ErrNotFound.Error())
 			},
 		},

--- a/cmd/api/src/database/graphschema_integration_test.go
+++ b/cmd/api/src/database/graphschema_integration_test.go
@@ -4548,7 +4548,7 @@ func TestDatabase_GetDisplayGraphKinds(t *testing.T) {
 		{
 			name: "Success: returns display kinds",
 			assert: func(t *testing.T, testSuite IntegrationTestSuite) {
-				baseline, err := testSuite.BHDatabase.GetValidDisplayKinds(testSuite.Context)
+				baseline, err := testSuite.BHDatabase.GetPrimaryDisplayKinds(testSuite.Context)
 				require.NoError(t, err, "unexpected error occurred when getting baseline display kinds")
 
 				extension := createTestExtension(t, testSuite, "test_extension", "test_extension", "1.0.0", "Test")
@@ -4557,7 +4557,7 @@ func TestDatabase_GetDisplayGraphKinds(t *testing.T) {
 				createTestNodeKind(t, testSuite, "Display_Kind_1", extension.ID, "Display Kind 1", "a display kind", true, "icon", "blue")
 				createTestNodeKind(t, testSuite, "Display_Kind_2", extension.ID, "Display Kind 2", "a display kind", true, "icon", "red")
 
-				displayKinds, err := testSuite.BHDatabase.GetValidDisplayKinds(testSuite.Context)
+				displayKinds, err := testSuite.BHDatabase.GetPrimaryDisplayKinds(testSuite.Context)
 				assert.NoError(t, err, "unexpected error occurred when retrieving display kinds")
 
 				// Both new display kinds should appear in the result
@@ -4572,7 +4572,7 @@ func TestDatabase_GetDisplayGraphKinds(t *testing.T) {
 		{
 			name: "Success: does not include non-display kinds",
 			assert: func(t *testing.T, testSuite IntegrationTestSuite) {
-				baseline, err := testSuite.BHDatabase.GetValidDisplayKinds(testSuite.Context)
+				baseline, err := testSuite.BHDatabase.GetPrimaryDisplayKinds(testSuite.Context)
 				require.NoError(t, err, "unexpected error occurred when getting baseline display kinds")
 
 				extension := createTestExtension(t, testSuite, "test_extension", "test_extension", "1.0.0", "Test")
@@ -4581,7 +4581,7 @@ func TestDatabase_GetDisplayGraphKinds(t *testing.T) {
 				createTestNodeKind(t, testSuite, "Display_Kind_1", extension.ID, "Display Kind 1", "a display kind", true, "icon", "blue")
 				createTestNodeKind(t, testSuite, "Non_Display_Kind_1", extension.ID, "Non Display Kind 1", "a non-display kind", false, "", "")
 
-				displayKinds, err := testSuite.BHDatabase.GetValidDisplayKinds(testSuite.Context)
+				displayKinds, err := testSuite.BHDatabase.GetPrimaryDisplayKinds(testSuite.Context)
 				assert.NoError(t, err, "unexpected error occurred when retrieving display kinds")
 
 				// Only the display kind should appear, not the non-display kind

--- a/cmd/api/src/database/graphschema_integration_test.go
+++ b/cmd/api/src/database/graphschema_integration_test.go
@@ -59,9 +59,9 @@ func registerAndGetKind(t *testing.T, testSuite IntegrationTestSuite, name strin
 func getKindByName(t *testing.T, testSuite IntegrationTestSuite, name string) model.Kind {
 	t.Helper()
 	// Create Kind by name from DAWGS Kind Table
-	kind, err := testSuite.BHDatabase.GetKindByName(testSuite.Context, name)
+	kind, err := testSuite.BHDatabase.GetKindsByNames(testSuite.Context, name)
 	require.NoError(t, err, "unexpected error occurred when getting kind by name")
-	return kind
+	return kind[0]
 }
 
 func createTestEnvironment(t *testing.T, testSuite IntegrationTestSuite, extensionID int32, envKindID int32, sourceKindID int32) model.SchemaEnvironment {

--- a/cmd/api/src/database/graphschema_integration_test.go
+++ b/cmd/api/src/database/graphschema_integration_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/specterops/bloodhound/cmd/api/src/database"
 	"github.com/specterops/bloodhound/cmd/api/src/model"
 	"github.com/specterops/bloodhound/cmd/api/src/model/appcfg"
+	"github.com/specterops/bloodhound/packages/go/graphschema"
 	"github.com/specterops/dawgs/graph"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -4528,14 +4529,16 @@ func TestDatabase_GetSchemaFindings(t *testing.T) {
 }
 
 func TestDatabase_GetDisplayGraphKinds(t *testing.T) {
-	assertContainsDisplayKind := func(t *testing.T, got map[graph.Kind]bool, name string) {
+	assertContainsDisplayKind := func(t *testing.T, got graphschema.ValidPrimaryKinds, name string) {
 		t.Helper()
-		assert.True(t, got[graph.StringKind(name)], "expected display kind %s to be present in result", name)
+		_, ok := got[graph.StringKind(name)]
+		assert.True(t, ok, "expected display kind %s to be present in result", name)
 	}
 
-	assertDoesNotContainDisplayKind := func(t *testing.T, got map[graph.Kind]bool, name string) {
+	assertDoesNotContainDisplayKind := func(t *testing.T, got graphschema.ValidPrimaryKinds, name string) {
 		t.Helper()
-		assert.False(t, got[graph.StringKind(name)], "expected kind %s to not be present in result", name)
+		_, ok := got[graph.StringKind(name)]
+		assert.False(t, ok, "expected kind %s to not be present in result", name)
 	}
 
 	tests := []struct {

--- a/cmd/api/src/database/graphschema_integration_test.go
+++ b/cmd/api/src/database/graphschema_integration_test.go
@@ -1321,7 +1321,7 @@ func TestDatabase_UpdateGraphSchemaNodeKindIconById(t *testing.T) {
 				extension := createTestExtension(t, testSuite, "test_extension", "test_extension", "1.0.0", "Test")
 				createdNodeKind := createTestNodeKind(t, testSuite, "Test Kind 1", extension.ID, "Test_Kind_1", "Test Kind 1", true, "user", "#17E625")
 
-				updatedNodeKind, err := testSuite.BHDatabase.UpdateGraphSchemaNodeKindIconById(testSuite.Context, createdNodeKind.ID, model.CustomNodeIcon{Type: "font-awesome", Name: "coffee", Color: "#3a0b138c"})
+				updatedNodeKind, err := testSuite.BHDatabase.UpdateGraphSchemaNodeKindIconById(testSuite.Context, createdNodeKind.ID, model.CustomNodeIcon{Type: model.CustomNodeKindTypeFontAwesome, Name: "coffee", Color: "#3a0b138c"})
 				require.NoError(t, err, "unexpected error occurred when updating node kind icon")
 
 				// Retrieve Node Kind 1
@@ -1335,7 +1335,7 @@ func TestDatabase_UpdateGraphSchemaNodeKindIconById(t *testing.T) {
 		}, {
 			name: "Error: failed to update schema node kind icon that does not exist",
 			assert: func(t *testing.T, testSuite IntegrationTestSuite) {
-				_, err := testSuite.BHDatabase.UpdateGraphSchemaNodeKindIconById(testSuite.Context, 12345, model.CustomNodeIcon{Type: "font-awesome", Name: "coffee", Color: "#3a0b138c"})
+				_, err := testSuite.BHDatabase.UpdateGraphSchemaNodeKindIconById(testSuite.Context, 12345, model.CustomNodeIcon{Type: model.CustomNodeKindTypeFontAwesome, Name: "coffee", Color: "#3a0b138c"})
 				require.EqualError(t, err, database.ErrNotFound.Error())
 			},
 		},

--- a/cmd/api/src/database/kind.go
+++ b/cmd/api/src/database/kind.go
@@ -25,30 +25,25 @@ import (
 )
 
 type Kind interface {
-	GetKindByName(ctx context.Context, name string) (model.Kind, error)
+	GetKindsByNames(ctx context.Context, names ...string) ([]model.Kind, error)
 	GetKindsByIDs(ctx context.Context, ids ...int32) ([]model.Kind, error)
 	UpsertKind(ctx context.Context, name string) (model.Kind, error)
 }
 
-func (s *BloodhoundDB) GetKindByName(ctx context.Context, name string) (model.Kind, error) {
-	const query = `
-		SELECT id, name
-		FROM kind
-		WHERE name = $1;
-	`
+func (s *BloodhoundDB) GetKindsByNames(ctx context.Context, names ...string) ([]model.Kind, error) {
+	var (
+		uniqueNames = utils.Dedupe(names)
+		query       = `SELECT id, name FROM kind WHERE name in (?);`
+	)
 
-	var kind model.Kind
-	result := s.db.WithContext(ctx).Raw(query, name).Scan(&kind)
-
-	if result.Error != nil {
-		return model.Kind{}, result.Error
+	var kinds []model.Kind
+	if result := s.db.WithContext(ctx).Raw(query, uniqueNames).Scan(&kinds); result.Error != nil {
+		return nil, result.Error
+	} else if len(kinds) != len(uniqueNames) {
+		return nil, ErrNotFound
 	}
 
-	if result.RowsAffected == 0 || kind.ID == 0 {
-		return model.Kind{}, ErrNotFound
-	}
-
-	return kind, nil
+	return kinds, nil
 }
 
 func (s *BloodhoundDB) GetKindsByIDs(ctx context.Context, ids ...int32) ([]model.Kind, error) {

--- a/cmd/api/src/database/kind_integration_test.go
+++ b/cmd/api/src/database/kind_integration_test.go
@@ -65,12 +65,12 @@ func TestGetKindByName(t *testing.T) {
 			testSuite := testCase.setup()
 			defer teardownIntegrationTestSuite(t, &testSuite)
 
-			kind, err := testSuite.BHDatabase.GetKindByName(testSuite.Context, testCase.args.name)
+			kind, err := testSuite.BHDatabase.GetKindsByNames(testSuite.Context, testCase.args.name)
 			if testCase.want.err != nil {
 				assert.EqualError(t, err, testCase.want.err.Error())
 			} else {
 				assert.NoError(t, err)
-				assert.Equal(t, testCase.want.kind, kind)
+				assert.Equal(t, testCase.want.kind, kind[0])
 			}
 		})
 	}

--- a/cmd/api/src/database/mocks/db.go
+++ b/cmd/api/src/database/mocks/db.go
@@ -2155,6 +2155,21 @@ func (mr *MockDatabaseMockRecorder) GetPermission(ctx, id any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPermission", reflect.TypeOf((*MockDatabase)(nil).GetPermission), ctx, id)
 }
 
+// GetPrimaryDisplayKinds mocks base method.
+func (m *MockDatabase) GetPrimaryDisplayKinds(ctx context.Context) (graphschema.PrimaryDisplayKinds, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetPrimaryDisplayKinds", ctx)
+	ret0, _ := ret[0].(graphschema.PrimaryDisplayKinds)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetPrimaryDisplayKinds indicates an expected call of GetPrimaryDisplayKinds.
+func (mr *MockDatabaseMockRecorder) GetPrimaryDisplayKinds(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPrimaryDisplayKinds", reflect.TypeOf((*MockDatabase)(nil).GetPrimaryDisplayKinds), ctx)
+}
+
 // GetPrincipalKindsByEnvironmentId mocks base method.
 func (m *MockDatabase) GetPrincipalKindsByEnvironmentId(ctx context.Context, environmentId int32) (model.SchemaEnvironmentPrincipalKinds, error) {
 	m.ctrl.T.Helper()
@@ -2665,21 +2680,6 @@ func (m *MockDatabase) GetUserToken(ctx context.Context, userId, tokenId uuid.UU
 func (mr *MockDatabaseMockRecorder) GetUserToken(ctx, userId, tokenId any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserToken", reflect.TypeOf((*MockDatabase)(nil).GetUserToken), ctx, userId, tokenId)
-}
-
-// GetValidDisplayKinds mocks base method.
-func (m *MockDatabase) GetValidDisplayKinds(ctx context.Context) (graphschema.PrimaryDisplayKinds, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetValidDisplayKinds", ctx)
-	ret0, _ := ret[0].(graphschema.PrimaryDisplayKinds)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetValidDisplayKinds indicates an expected call of GetValidDisplayKinds.
-func (mr *MockDatabaseMockRecorder) GetValidDisplayKinds(ctx any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetValidDisplayKinds", reflect.TypeOf((*MockDatabase)(nil).GetValidDisplayKinds), ctx)
 }
 
 // HasAnalysisRequest mocks base method.

--- a/cmd/api/src/database/mocks/db.go
+++ b/cmd/api/src/database/mocks/db.go
@@ -2668,10 +2668,10 @@ func (mr *MockDatabaseMockRecorder) GetUserToken(ctx, userId, tokenId any) *gomo
 }
 
 // GetValidDisplayKinds mocks base method.
-func (m *MockDatabase) GetValidDisplayKinds(ctx context.Context) (graphschema.ValidPrimaryKinds, error) {
+func (m *MockDatabase) GetValidDisplayKinds(ctx context.Context) (graphschema.PrimaryDisplayKinds, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetValidDisplayKinds", ctx)
-	ret0, _ := ret[0].(graphschema.ValidPrimaryKinds)
+	ret0, _ := ret[0].(graphschema.PrimaryDisplayKinds)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/cmd/api/src/database/mocks/db.go
+++ b/cmd/api/src/database/mocks/db.go
@@ -1735,21 +1735,6 @@ func (mr *MockDatabaseMockRecorder) GetCustomNodeKinds(ctx, filters any) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCustomNodeKinds", reflect.TypeOf((*MockDatabase)(nil).GetCustomNodeKinds), ctx, filters)
 }
 
-// GetCustomNodeKindsMap mocks base method.
-func (m *MockDatabase) GetCustomNodeKindsMap(ctx context.Context) (model.CustomNodeKindMap, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetCustomNodeKindsMap", ctx)
-	ret0, _ := ret[0].(model.CustomNodeKindMap)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetCustomNodeKindsMap indicates an expected call of GetCustomNodeKindsMap.
-func (mr *MockDatabaseMockRecorder) GetCustomNodeKindsMap(ctx any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCustomNodeKindsMap", reflect.TypeOf((*MockDatabase)(nil).GetCustomNodeKindsMap), ctx)
-}
-
 // GetDatapipeStatus mocks base method.
 func (m *MockDatabase) GetDatapipeStatus(ctx context.Context) (model.DatapipeStatusWrapper, error) {
 	m.ctrl.T.Helper()

--- a/cmd/api/src/database/mocks/db.go
+++ b/cmd/api/src/database/mocks/db.go
@@ -2101,9 +2101,9 @@ func (mr *MockDatabaseMockRecorder) GetInstallation(ctx any) *gomock.Call {
 }
 
 // GetKindByName mocks base method.
-func (m *MockDatabase) GetKindByName(ctx context.Context, name string) (model.Kind, error) {
+func (m *MockDatabase) GetKindsByNames(ctx context.Context, name string) (model.Kind, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetKindByName", ctx, name)
+	ret := m.ctrl.Call(m, "GetKindsByNames", ctx, name)
 	ret0, _ := ret[0].(model.Kind)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
@@ -2112,7 +2112,7 @@ func (m *MockDatabase) GetKindByName(ctx context.Context, name string) (model.Ki
 // GetKindByName indicates an expected call of GetKindByName.
 func (mr *MockDatabaseMockRecorder) GetKindByName(ctx, name any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetKindByName", reflect.TypeOf((*MockDatabase)(nil).GetKindByName), ctx, name)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetKindsByNames", reflect.TypeOf((*MockDatabase)(nil).GetKindsByNames), ctx, name)
 }
 
 // GetKindsByIDs mocks base method.

--- a/cmd/api/src/database/mocks/db.go
+++ b/cmd/api/src/database/mocks/db.go
@@ -1765,21 +1765,6 @@ func (mr *MockDatabaseMockRecorder) GetDatapipeStatus(ctx any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDatapipeStatus", reflect.TypeOf((*MockDatabase)(nil).GetDatapipeStatus), ctx)
 }
 
-// GetDisplayGraphSchemaNodeKinds mocks base method.
-func (m *MockDatabase) GetDisplayGraphSchemaNodeKinds(ctx context.Context) (model.GraphSchemaNodeKindMap, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetDisplayGraphSchemaNodeKinds", ctx)
-	ret0, _ := ret[0].(model.GraphSchemaNodeKindMap)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetDisplayGraphSchemaNodeKinds indicates an expected call of GetDisplayGraphSchemaNodeKinds.
-func (mr *MockDatabaseMockRecorder) GetDisplayGraphSchemaNodeKinds(ctx any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDisplayGraphSchemaNodeKinds", reflect.TypeOf((*MockDatabase)(nil).GetDisplayGraphSchemaNodeKinds), ctx)
-}
-
 // GetEnvironmentByEnvironmentKindId mocks base method.
 func (m *MockDatabase) GetEnvironmentByEnvironmentKindId(ctx context.Context, environmentKindId int32) (model.SchemaEnvironment, error) {
 	m.ctrl.T.Helper()
@@ -2100,21 +2085,6 @@ func (mr *MockDatabaseMockRecorder) GetInstallation(ctx any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInstallation", reflect.TypeOf((*MockDatabase)(nil).GetInstallation), ctx)
 }
 
-// GetKindByName mocks base method.
-func (m *MockDatabase) GetKindsByNames(ctx context.Context, name string) (model.Kind, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetKindsByNames", ctx, name)
-	ret0, _ := ret[0].(model.Kind)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetKindByName indicates an expected call of GetKindByName.
-func (mr *MockDatabaseMockRecorder) GetKindByName(ctx, name any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetKindsByNames", reflect.TypeOf((*MockDatabase)(nil).GetKindsByNames), ctx, name)
-}
-
 // GetKindsByIDs mocks base method.
 func (m *MockDatabase) GetKindsByIDs(ctx context.Context, ids ...int32) ([]model.Kind, error) {
 	m.ctrl.T.Helper()
@@ -2133,6 +2103,26 @@ func (mr *MockDatabaseMockRecorder) GetKindsByIDs(ctx any, ids ...any) *gomock.C
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]any{ctx}, ids...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetKindsByIDs", reflect.TypeOf((*MockDatabase)(nil).GetKindsByIDs), varargs...)
+}
+
+// GetKindsByNames mocks base method.
+func (m *MockDatabase) GetKindsByNames(ctx context.Context, names ...string) ([]model.Kind, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx}
+	for _, a := range names {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "GetKindsByNames", varargs...)
+	ret0, _ := ret[0].([]model.Kind)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetKindsByNames indicates an expected call of GetKindsByNames.
+func (mr *MockDatabaseMockRecorder) GetKindsByNames(ctx any, names ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx}, names...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetKindsByNames", reflect.TypeOf((*MockDatabase)(nil).GetKindsByNames), varargs...)
 }
 
 // GetLatestAssetGroupCollection mocks base method.

--- a/cmd/api/src/database/mocks/db.go
+++ b/cmd/api/src/database/mocks/db.go
@@ -3214,7 +3214,7 @@ func (mr *MockDatabaseMockRecorder) UpdateGraphSchemaNodeKind(ctx, schemaNodeKin
 }
 
 // UpdateGraphSchemaNodeKindIconById mocks base method.
-func (m *MockDatabase) UpdateGraphSchemaNodeKindIconById(ctx context.Context, kindId int32, icon model.CustomNodeIcon) (model.GraphSchemaNodeKind, error) {
+func (m *MockDatabase) UpdateGraphSchemaNodeKindIconById(ctx context.Context, kindId int32, icon graphschema.DisplayNodeIcon) (model.GraphSchemaNodeKind, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateGraphSchemaNodeKindIconById", ctx, kindId, icon)
 	ret0, _ := ret[0].(model.GraphSchemaNodeKind)

--- a/cmd/api/src/database/upsert_schema_environment.go
+++ b/cmd/api/src/database/upsert_schema_environment.go
@@ -26,13 +26,13 @@ import (
 // CreateEnvironmentWithPrincipalKinds translates FK names, creates the environment row,
 // and reconciles its principal kinds.
 func (s *BloodhoundDB) CreateEnvironmentWithPrincipalKinds(ctx context.Context, extensionId int32, input model.EnvironmentInput) (model.SchemaEnvironment, error) {
-	if envKind, err := s.GetKindByName(ctx, input.EnvironmentKindName); err != nil {
+	if envKind, err := s.GetKindsByNames(ctx, input.EnvironmentKindName); err != nil {
 		return model.SchemaEnvironment{}, fmt.Errorf("error retrieving environment kind '%s': %w", input.EnvironmentKindName, err)
 	} else if sourceKind, err := s.UpsertKind(ctx, input.SourceKindName); err != nil {
 		return model.SchemaEnvironment{}, fmt.Errorf("error registering source kind '%s': %w", input.SourceKindName, err)
 	} else if principalKinds, err := s.buildPrincipalKindsFromNames(ctx, input.PrincipalKinds); err != nil {
 		return model.SchemaEnvironment{}, err
-	} else if created, err := s.CreateEnvironment(ctx, extensionId, envKind.ID, sourceKind.ID); err != nil {
+	} else if created, err := s.CreateEnvironment(ctx, extensionId, envKind[0].ID, sourceKind.ID); err != nil {
 		return model.SchemaEnvironment{}, fmt.Errorf("error creating environment: %w", err)
 	} else if _, err := reconcile(ctx, principalKinds, nil, s.principalKindReconcileConfig(created.ID)); err != nil {
 		return model.SchemaEnvironment{}, fmt.Errorf("error reconciling principal kinds: %w", err)
@@ -72,10 +72,10 @@ func (s *BloodhoundDB) buildPrincipalKindsFromNames(ctx context.Context, names [
 	principalKinds := make([]model.SchemaEnvironmentPrincipalKind, len(names))
 
 	for i, name := range names {
-		if kind, err := s.GetKindByName(ctx, name); err != nil {
+		if kind, err := s.GetKindsByNames(ctx, name); err != nil {
 			return nil, fmt.Errorf("error retrieving principal kind '%s': %w", name, err)
 		} else {
-			principalKinds[i] = model.SchemaEnvironmentPrincipalKind{PrincipalKind: kind.ID}
+			principalKinds[i] = model.SchemaEnvironmentPrincipalKind{PrincipalKind: kind[0].ID}
 		}
 	}
 

--- a/cmd/api/src/database/upsert_schema_environment_integration_test.go
+++ b/cmd/api/src/database/upsert_schema_environment_integration_test.go
@@ -66,21 +66,21 @@ func TestCreateEnvironmentWithPrincipalKinds(t *testing.T) {
 				require.NoError(t, err)
 				assert.NotZero(t, env.ID)
 
-				envKind, err := db.GetKindByName(context.Background(), args.environmentKindName)
+				envKind, err := db.GetKindsByNames(context.Background(), args.environmentKindName)
 				require.NoError(t, err)
-				assert.Equal(t, envKind.ID, env.EnvironmentKindId)
+				assert.Equal(t, envKind[0].ID, env.EnvironmentKindId)
 
-				sourceKind, err := db.GetKindByName(context.Background(), args.sourceKindName)
+				sourceKind, err := db.GetKindsByNames(context.Background(), args.sourceKindName)
 				require.NoError(t, err)
-				assert.Equal(t, sourceKind.ID, env.SourceKindId)
+				assert.Equal(t, sourceKind[0].ID, env.SourceKindId)
 
 				principalKinds, err := db.GetPrincipalKindsByEnvironmentId(context.Background(), env.ID)
 				require.NoError(t, err)
 				require.Len(t, principalKinds, len(args.principalKinds))
 				for i, pk := range principalKinds {
-					expectedKind, err := db.GetKindByName(context.Background(), args.principalKinds[i])
+					expectedKind, err := db.GetKindsByNames(context.Background(), args.principalKinds[i])
 					require.NoError(t, err)
-					assert.Equal(t, expectedKind.ID, pk.PrincipalKind)
+					assert.Equal(t, expectedKind[0].ID, pk.PrincipalKind)
 				}
 			},
 		},
@@ -244,17 +244,17 @@ func TestUpdateEnvironmentWithPrincipalKinds(t *testing.T) {
 				require.NoError(t, err)
 				assert.NotZero(t, updated.ID)
 
-				sourceKind, err := db.GetKindByName(context.Background(), args.newSourceKindName)
+				sourceKind, err := db.GetKindsByNames(context.Background(), args.newSourceKindName)
 				require.NoError(t, err)
-				assert.Equal(t, sourceKind.ID, updated.SourceKindId)
+				assert.Equal(t, sourceKind[0].ID, updated.SourceKindId)
 
 				principalKinds, err := db.GetPrincipalKindsByEnvironmentId(context.Background(), updated.ID)
 				require.NoError(t, err)
 				require.Len(t, principalKinds, len(args.newPrincipalKinds))
 				for i, pk := range principalKinds {
-					expectedKind, err := db.GetKindByName(context.Background(), args.newPrincipalKinds[i])
+					expectedKind, err := db.GetKindsByNames(context.Background(), args.newPrincipalKinds[i])
 					require.NoError(t, err)
-					assert.Equal(t, expectedKind.ID, pk.PrincipalKind)
+					assert.Equal(t, expectedKind[0].ID, pk.PrincipalKind)
 				}
 			},
 		},
@@ -283,9 +283,9 @@ func TestUpdateEnvironmentWithPrincipalKinds(t *testing.T) {
 				require.NoError(t, err)
 				assert.NotZero(t, updated.ID)
 
-				sourceKind, err := db.GetKindByName(context.Background(), args.newSourceKindName)
+				sourceKind, err := db.GetKindsByNames(context.Background(), args.newSourceKindName)
 				require.NoError(t, err)
-				assert.Equal(t, sourceKind.ID, updated.SourceKindId)
+				assert.Equal(t, sourceKind[0].ID, updated.SourceKindId)
 			},
 		},
 	}

--- a/cmd/api/src/database/upsert_schema_extension.go
+++ b/cmd/api/src/database/upsert_schema_extension.go
@@ -266,17 +266,17 @@ func parseIconDefinitionFromNodeKind(nodeKind model.GraphSchemaNodeKind, existin
 		},
 	}
 
-	// preserve existing icon if provided
+	// fallback to existing icon if provided
 	if existingIcon != nil {
 		customNodeKind.Config.Icon = existingIcon.Config.Icon
-	} else {
-		if nodeKind.Icon != "" {
-			customNodeKind.Config.Icon.Name = nodeKind.Icon
-		}
+	}
 
-		if nodeKind.IconColor != "" {
-			customNodeKind.Config.Icon.Color = nodeKind.IconColor
-		}
+	if nodeKind.Icon != "" {
+		customNodeKind.Config.Icon.Name = nodeKind.Icon
+	}
+
+	if nodeKind.IconColor != "" {
+		customNodeKind.Config.Icon.Color = nodeKind.IconColor
 	}
 
 	return customNodeKind

--- a/cmd/api/src/database/upsert_schema_extension.go
+++ b/cmd/api/src/database/upsert_schema_extension.go
@@ -26,8 +26,8 @@ import (
 
 const CustomNodeIconType = "font-awesome"
 
-// UpsertOpenGraphExtension reconciles the full state of a graph extension and all of its child
-// entities (node kinds, relationship kinds, environments, and findings) against the provided input.
+// UpsertOpenGraphExtension - upserts the incoming graph extension by checking to see if the extension exists already,
+// if so, deleting it and inserting the new extension.
 //
 // Each entity set is diffed against the input: absent rows are deleted, matching rows are updated
 // in place with their IDs preserved, and new rows are created. All mutations run inside a single
@@ -257,26 +257,27 @@ func getExistingIconsMap(ctx context.Context, db *BloodhoundDB) (map[string]mode
 // custom_node_kinds and schema_node_kinds tables. If an existingIcon is provided, its name and color are
 // preserved for any fields not supplied by the node kind.
 func parseIconDefinitionFromNodeKind(nodeKind model.GraphSchemaNodeKind, existingIcon *model.CustomNodeKind) model.CustomNodeKind {
-	var customNodeKind model.CustomNodeKind
-	var customNodeIcon = model.CustomNodeIcon{Type: CustomNodeIconType}
-
-	if nodeKind.Icon != "" {
-		customNodeIcon.Name = nodeKind.Icon
-	} else if existingIcon != nil {
-		// preserve existing icon name if not provided
-		customNodeIcon.Name = existingIcon.Config.Icon.Name
+	var customNodeKind = model.CustomNodeKind{
+		KindName:         nodeKind.Name,
+		SchemaNodeKindId: &nodeKind.ID,
+		Config: model.CustomNodeKindConfig{
+			Icon: model.CustomNodeIcon{Type: model.CustomNodeKindTypeFontAwesome},
+		},
 	}
 
-	if nodeKind.IconColor != "" {
-		customNodeIcon.Color = nodeKind.IconColor
-	} else if existingIcon != nil {
-		// preserve existing icon color if not provided
-		customNodeIcon.Color = existingIcon.Config.Icon.Color
+	// preserve existing icon if provided
+	if existingIcon != nil {
+		customNodeKind.Config.Icon = existingIcon.Config.Icon
+	} else {
+		if nodeKind.Icon != "" {
+			customNodeKind.Config.Icon.Name = nodeKind.Icon
+		}
+
+		if nodeKind.IconColor != "" {
+			customNodeKind.Config.Icon.Color = nodeKind.IconColor
+		}
 	}
 
-	customNodeKind.KindName = nodeKind.Name
-	customNodeKind.Config = model.CustomNodeKindConfig{Icon: customNodeIcon}
-	customNodeKind.SchemaNodeKindId = &nodeKind.ID
 	return customNodeKind
 
 }

--- a/cmd/api/src/database/upsert_schema_extension.go
+++ b/cmd/api/src/database/upsert_schema_extension.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 
 	"github.com/specterops/bloodhound/cmd/api/src/model"
+	"github.com/specterops/bloodhound/packages/go/graphschema"
 )
 
 const CustomNodeIconType = "font-awesome"
@@ -261,7 +262,7 @@ func parseIconDefinitionFromNodeKind(nodeKind model.GraphSchemaNodeKind, existin
 		KindName:         nodeKind.Name,
 		SchemaNodeKindId: &nodeKind.ID,
 		Config: model.CustomNodeKindConfig{
-			Icon: model.CustomNodeIcon{Type: model.CustomNodeKindTypeFontAwesome},
+			Icon: graphschema.DisplayNodeIcon{Type: graphschema.DisplayNodeTypeFontAwesome},
 		},
 	}
 

--- a/cmd/api/src/database/upsert_schema_finding.go
+++ b/cmd/api/src/database/upsert_schema_finding.go
@@ -25,12 +25,12 @@ import (
 
 // resolveFindingFKs translates the FK names in a RelationshipFindingInput to their corresponding IDs.
 func (s *BloodhoundDB) resolveFindingFKs(ctx context.Context, input model.RelationshipFindingInput) (int32, int32, error) {
-	if relKind, err := s.GetKindByName(ctx, input.RelationshipKindName); err != nil {
+	if relKind, err := s.GetKindsByNames(ctx, input.RelationshipKindName); err != nil {
 		return 0, 0, fmt.Errorf("error retrieving relationship kind '%s': %w", input.RelationshipKindName, err)
 	} else if environment, err := s.GetEnvironmentKindName(ctx, input.EnvironmentKindName); err != nil {
 		return 0, 0, fmt.Errorf("error retrieving environment kind '%s': %w", input.EnvironmentKindName, err)
 	} else {
-		return relKind.ID, environment.ID, nil
+		return relKind[0].ID, environment.ID, nil
 	}
 }
 

--- a/cmd/api/src/model/assetgrouptags.go
+++ b/cmd/api/src/model/assetgrouptags.go
@@ -324,8 +324,8 @@ func (s AssetGroupSelectorNode) ValidFilters() map[string][]FilterOperator {
 /*
 These are the relevant properties for asset group tags. This method serves to keep consistency across the feature
 */
-func GetAssetGroupMemberProperties(validPrimaryKinds graphschema.ValidPrimaryKinds, node *graph.Node) (primaryKind, displayName, objectId, envId string) {
-	primaryKind = graphschema.GetNodeKindDisplayLabel(validPrimaryKinds, node)
+func GetAssetGroupMemberProperties(primaryDisplayKinds graphschema.PrimaryDisplayKinds, node *graph.Node) (primaryKind, displayName, objectId, envId string) {
+	primaryKind = graphschema.GetNodeKindDisplayLabel(primaryDisplayKinds, node)
 	displayName, _ = node.Properties.GetWithFallback(common.Name.String(), graphschema.DefaultMissingName, common.DisplayName.String(), common.ObjectID.String()).String()
 	objectId, _ = node.Properties.GetOrDefault(common.ObjectID.String(), graphschema.DefaultMissingObjectId).String()
 	envId, _ = node.Properties.GetWithFallback(ad.DomainSID.String(), "", azure.TenantID.String(), graphschema.EnvironmentIDKey).String()

--- a/cmd/api/src/model/customnode.go
+++ b/cmd/api/src/model/customnode.go
@@ -22,9 +22,6 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
-
-	"github.com/specterops/bloodhound/packages/go/graphschema"
-	"github.com/specterops/dawgs/graph"
 )
 
 var ValidColorStringRegex = regexp.MustCompile("^#([a-fA-F0-9]{6}|[a-fA-F0-9]{3})$")
@@ -69,16 +66,6 @@ type CustomNodeIcon struct {
 }
 
 type CustomNodeKindMap map[string]CustomNodeKindConfig
-
-func (s CustomNodeKindMap) ValidKinds() graphschema.ValidPrimaryKinds {
-	validKinds := make(graphschema.ValidPrimaryKinds, len(s))
-
-	for kind := range s {
-		validKinds[graph.StringKind(kind)] = true
-	}
-
-	return validKinds
-}
 
 func (s *CustomNodeKindConfig) Scan(value interface{}) error {
 	if value == nil {

--- a/cmd/api/src/model/customnode.go
+++ b/cmd/api/src/model/customnode.go
@@ -22,6 +22,8 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+
+	"github.com/specterops/bloodhound/packages/go/graphschema"
 )
 
 var ValidColorStringRegex = regexp.MustCompile("^#([a-fA-F0-9]{6}|[a-fA-F0-9]{3})$")
@@ -58,20 +60,10 @@ func (s CustomNodeKind) AuditData() AuditData {
 }
 
 type CustomNodeKindConfig struct {
-	Icon CustomNodeIcon `json:"icon"`
+	Icon graphschema.DisplayNodeIcon `json:"icon"`
 }
 
 type CustomNodeKindType string
-
-const (
-	CustomNodeKindTypeFontAwesome CustomNodeKindType = "font-awesome"
-)
-
-type CustomNodeIcon struct {
-	Type  CustomNodeKindType `json:"type"`
-	Name  string             `json:"name"`
-	Color string             `json:"color"`
-}
 
 type CustomNodeKindMap map[string]CustomNodeKindConfig
 
@@ -93,7 +85,7 @@ func (s CustomNodeKindConfig) Value() (driver.Value, error) {
 }
 
 func (s CustomNodeKindConfig) Validate() error {
-	if s.Icon.Type != CustomNodeKindTypeFontAwesome {
+	if s.Icon.Type != graphschema.DisplayNodeTypeFontAwesome {
 		return fmt.Errorf("invalid icon type. only Font Awesome icons are supported")
 	} else if s.Icon.Color != "" && !IsValidIconColor(s.Icon.Color) {
 		return fmt.Errorf("icon color must be a valid hexadecimal color string starting with '#' followed by 3 or 6 hex digits")

--- a/cmd/api/src/model/customnode.go
+++ b/cmd/api/src/model/customnode.go
@@ -47,6 +47,10 @@ type CustomNodeKind struct {
 	Config           CustomNodeKindConfig `json:"config"`
 }
 
+func (s CustomNodeKind) TableName() string {
+	return "custom_node_kinds"
+}
+
 func (s CustomNodeKind) AuditData() AuditData {
 	return AuditData{
 		"id":     s.ID,

--- a/cmd/api/src/model/customnode.go
+++ b/cmd/api/src/model/customnode.go
@@ -26,8 +26,6 @@ import (
 
 var ValidColorStringRegex = regexp.MustCompile("^#([a-fA-F0-9]{6}|[a-fA-F0-9]{3})$")
 
-const ValidIconType = "font-awesome"
-
 type CustomNodeKinds []CustomNodeKind
 
 func (s CustomNodeKinds) AuditData() AuditData {
@@ -63,10 +61,16 @@ type CustomNodeKindConfig struct {
 	Icon CustomNodeIcon `json:"icon"`
 }
 
+type CustomNodeKindType string
+
+const (
+	CustomNodeKindTypeFontAwesome CustomNodeKindType = "font-awesome"
+)
+
 type CustomNodeIcon struct {
-	Type  string `json:"type"`
-	Name  string `json:"name"`
-	Color string `json:"color"`
+	Type  CustomNodeKindType `json:"type"`
+	Name  string             `json:"name"`
+	Color string             `json:"color"`
 }
 
 type CustomNodeKindMap map[string]CustomNodeKindConfig
@@ -89,7 +93,7 @@ func (s CustomNodeKindConfig) Value() (driver.Value, error) {
 }
 
 func (s CustomNodeKindConfig) Validate() error {
-	if s.Icon.Type != ValidIconType {
+	if s.Icon.Type != CustomNodeKindTypeFontAwesome {
 		return fmt.Errorf("invalid icon type. only Font Awesome icons are supported")
 	} else if s.Icon.Color != "" && !IsValidIconColor(s.Icon.Color) {
 		return fmt.Errorf("icon color must be a valid hexadecimal color string starting with '#' followed by 3 or 6 hex digits")

--- a/cmd/api/src/model/graphschema.go
+++ b/cmd/api/src/model/graphschema.go
@@ -22,7 +22,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/specterops/bloodhound/packages/go/graphschema"
 	"github.com/specterops/dawgs/graph"
 )
 
@@ -106,16 +105,6 @@ type GraphSchemaNodeKind struct {
 	IsDisplayKind     bool   // indicates if this kind should supersede others and be displayed
 	Icon              string // font-awesome icon for the registered node kind
 	IconColor         string // icon hex color
-}
-
-type GraphSchemaNodeKindMap map[string]GraphSchemaNodeKind
-
-func (s GraphSchemaNodeKindMap) ToKindsMap() graphschema.ValidPrimaryKinds {
-	var kindsMap = make(graphschema.ValidPrimaryKinds)
-	for _, schemaNodeKind := range s {
-		kindsMap[schemaNodeKind.ToKind()] = true
-	}
-	return kindsMap
 }
 
 func (s GraphSchemaNodeKind) ToKind() graph.Kind {

--- a/cmd/api/src/model/unified_graph.go
+++ b/cmd/api/src/model/unified_graph.go
@@ -73,7 +73,7 @@ type UnifiedEdge struct {
 	Properties map[string]any `json:"properties,omitempty"`
 }
 
-func FromDAWGSNode(validPrimaryKinds graphschema.ValidPrimaryKinds, node *graph.Node, includeProperties bool) UnifiedNode {
+func FromDAWGSNode(primaryDisplayKinds graphschema.PrimaryDisplayKinds, node *graph.Node, includeProperties bool) UnifiedNode {
 	var (
 		props       = node.Properties
 		objectId    = getTypedPropertyOrDefault(props, common.ObjectID.String(), "")
@@ -85,7 +85,7 @@ func FromDAWGSNode(validPrimaryKinds graphschema.ValidPrimaryKinds, node *graph.
 	// only generic-ingested nodes have the PrimaryKind property set to control what icon the UI displays.
 	kind := primaryKind
 	if kind == "" {
-		kind = graphschema.GetNodeKind(validPrimaryKinds, node).String()
+		kind = graphschema.GetNodeKind(primaryDisplayKinds, node).String()
 	}
 
 	var properties map[string]any
@@ -130,16 +130,16 @@ func (s *UnifiedGraph) AddRelationship(rel *graph.Relationship, includePropertie
 	s.Edges = append(s.Edges, formattedRelationship)
 }
 
-func (s *UnifiedGraph) AddNode(validPrimaryKinds graphschema.ValidPrimaryKinds, node *graph.Node, includeProperties bool) {
-	formattedNode := FromDAWGSNode(validPrimaryKinds, node, includeProperties)
+func (s *UnifiedGraph) AddNode(primaryDisplayKinds graphschema.PrimaryDisplayKinds, node *graph.Node, includeProperties bool) {
+	formattedNode := FromDAWGSNode(primaryDisplayKinds, node, includeProperties)
 	s.Nodes[node.ID.String()] = formattedNode
 }
 
-func (s *UnifiedGraph) AddPathSet(validPrimaryKinds graphschema.ValidPrimaryKinds, paths graph.PathSet, includeProperties bool) {
+func (s *UnifiedGraph) AddPathSet(primaryDisplayKinds graphschema.PrimaryDisplayKinds, paths graph.PathSet, includeProperties bool) {
 	nonDuplicateEdges := make(map[graph.ID]bool)
 	for _, path := range paths.Paths() {
 		for _, node := range path.Nodes {
-			s.AddNode(validPrimaryKinds, node, includeProperties)
+			s.AddNode(primaryDisplayKinds, node, includeProperties)
 		}
 
 		for _, edge := range path.Edges {

--- a/cmd/api/src/queries/graph.go
+++ b/cmd/api/src/queries/graph.go
@@ -136,17 +136,17 @@ func BuildEntityQueryParams(request *http.Request, queryName string, pathDelegat
 }
 
 type Graph interface {
-	GetAssetGroupComboNode(ctx context.Context, primaryNodeKinds graphschema.ValidPrimaryKinds, owningObjectID string, assetGroupTag string) (map[string]any, error)
+	GetAssetGroupComboNode(ctx context.Context, primaryNodeKinds graphschema.PrimaryDisplayKinds, owningObjectID string, assetGroupTag string) (map[string]any, error)
 	GetAssetGroupNodes(ctx context.Context, assetGroupTag string, isSystemGroup bool) (graph.NodeSet, error)
 	GetAllShortestPaths(ctx context.Context, startNodeID string, endNodeID string, filter graph.Criteria) (graph.PathSet, error)
 	GetAllShortestPathsWithOpenGraph(ctx context.Context, startNodeID string, endNodeID string, filter graph.Criteria) (graph.PathSet, error)
 	SearchNodesByNameOrObjectId(ctx context.Context, nodeKinds graph.Kinds, nameOrObjectIdQuery string, skip int, limit int) ([]*graph.Node, error)
 	SearchByNameOrObjectID(ctx context.Context, includeOpenGraphNodes bool, searchValue string, searchType string) (graph.NodeSet, error)
-	GetADEntityQueryResult(ctx context.Context, primaryNodeKinds graphschema.ValidPrimaryKinds, params EntityQueryParameters, cacheEnabled bool) (any, int, error)
+	GetADEntityQueryResult(ctx context.Context, primaryNodeKinds graphschema.PrimaryDisplayKinds, params EntityQueryParameters, cacheEnabled bool) (any, int, error)
 	GetEntityByObjectId(ctx context.Context, objectID string, kinds ...graph.Kind) (*graph.Node, error)
 	GetEntityCountResults(ctx context.Context, node *graph.Node, delegates map[string]any) map[string]any
 	GetNodesByKind(ctx context.Context, kinds ...graph.Kind) (graph.NodeSet, error)
-	GetPrimaryNodeKindCounts(ctx context.Context, validPrimaryKinds graphschema.ValidPrimaryKinds, kind graph.Kind, additionalFilters ...graph.Criteria) (map[string]int, error)
+	GetPrimaryNodeKindCounts(ctx context.Context, primaryDisplayKinds graphschema.PrimaryDisplayKinds, kind graph.Kind, additionalFilters ...graph.Criteria) (map[string]int, error)
 	CountFilteredNodes(ctx context.Context, filterCriteria graph.Criteria) (int64, error)
 	CountNodesByKind(ctx context.Context, kinds ...graph.Kind) (int64, error)
 	GetFilteredAndSortedNodesPaginated(sortItems query.SortItems, filterCriteria graph.Criteria, offset, limit int) ([]*graph.Node, error)
@@ -155,7 +155,7 @@ type Graph interface {
 	FetchNodesByObjectIDsAndKinds(ctx context.Context, kinds graph.Kinds, objectIDs ...string) (graph.NodeSet, error)
 	ValidateOUs(ctx context.Context, ous []string) ([]string, error)
 	BatchNodeUpdate(ctx context.Context, nodeUpdate graph.NodeUpdate) error
-	RawCypherQuery(ctx context.Context, validPrimaryKinds graphschema.ValidPrimaryKinds, pQuery PreparedQuery, includeProperties bool) (model.UnifiedGraph, error)
+	RawCypherQuery(ctx context.Context, primaryDisplayKinds graphschema.PrimaryDisplayKinds, pQuery PreparedQuery, includeProperties bool) (model.UnifiedGraph, error)
 	PrepareCypherQuery(rawCypher string, queryComplexityLimit int64) (PreparedQuery, error)
 	UpdateSelectorTags(ctx context.Context, db database.AgiData, selectors model.UpdatedAssetGroupSelectors) error
 	FetchNodeByGraphId(ctx context.Context, id graph.ID) (*graph.Node, error)
@@ -183,7 +183,7 @@ func NewGraphQuery(graphDB graph.Database, cache cache.Cache, cfg config.Configu
 	}
 }
 
-func (s *GraphQuery) GetAssetGroupComboNode(ctx context.Context, primaryNodeKinds graphschema.ValidPrimaryKinds, owningObjectID string, assetGroupTag string) (map[string]any, error) {
+func (s *GraphQuery) GetAssetGroupComboNode(ctx context.Context, primaryNodeKinds graphschema.PrimaryDisplayKinds, owningObjectID string, assetGroupTag string) (map[string]any, error) {
 	var graphData = map[string]any{}
 
 	return graphData, s.Graph.ReadTransaction(ctx, func(tx graph.Transaction) error {
@@ -491,7 +491,7 @@ func (s *GraphQuery) PrepareCypherQuery(rawCypher string, queryComplexityLimit i
 
 // RawCypherQuery executes the given PreparedQuery and returns a model.UnifiedGraph or any error encountered during
 // query execution.
-func (s *GraphQuery) RawCypherQuery(ctx context.Context, validPrimaryKinds graphschema.ValidPrimaryKinds, pQuery PreparedQuery, includeProperties bool) (model.UnifiedGraph, error) {
+func (s *GraphQuery) RawCypherQuery(ctx context.Context, primaryDisplayKinds graphschema.PrimaryDisplayKinds, pQuery PreparedQuery, includeProperties bool) (model.UnifiedGraph, error) {
 	var (
 		err error
 
@@ -502,7 +502,7 @@ func (s *GraphQuery) RawCypherQuery(ctx context.Context, validPrimaryKinds graph
 			if result, err := ops.FetchByQuery(tx, pQuery.query); err != nil {
 				return err
 			} else {
-				graphResponse.AddPathSet(validPrimaryKinds, result.Paths, includeProperties)
+				graphResponse.AddPathSet(primaryDisplayKinds, result.Paths, includeProperties)
 				graphResponse.Literals = result.Literals
 			}
 
@@ -607,7 +607,7 @@ func (s *GraphQuery) SearchByNameOrObjectID(ctx context.Context, includeOpenGrap
 	}
 }
 
-func (s *GraphQuery) GetADEntityQueryResult(ctx context.Context, primaryNodeKinds graphschema.ValidPrimaryKinds, params EntityQueryParameters, cacheEnabled bool) (any, int, error) {
+func (s *GraphQuery) GetADEntityQueryResult(ctx context.Context, primaryNodeKinds graphschema.PrimaryDisplayKinds, params EntityQueryParameters, cacheEnabled bool) (any, int, error) {
 	if params.RequestedType == model.DataTypeGraph && params.PathDelegate == nil {
 		return nil, 0, ErrGraphUnsupported
 	}
@@ -728,7 +728,7 @@ func (s *GraphQuery) FetchNodeByGraphId(ctx context.Context, id graph.ID) (*grap
 	}
 }
 
-func (s *GraphQuery) GetPrimaryNodeKindCounts(ctx context.Context, validPrimaryKinds graphschema.ValidPrimaryKinds, kind graph.Kind, additionalFilters ...graph.Criteria) (map[string]int, error) {
+func (s *GraphQuery) GetPrimaryNodeKindCounts(ctx context.Context, primaryDisplayKinds graphschema.PrimaryDisplayKinds, kind graph.Kind, additionalFilters ...graph.Criteria) (map[string]int, error) {
 	var (
 		results = map[string]int{}
 		filters = []graph.Criteria{query.KindIn(query.Node(), kind)}
@@ -741,7 +741,7 @@ func (s *GraphQuery) GetPrimaryNodeKindCounts(ctx context.Context, validPrimaryK
 	return results, s.Graph.ReadTransaction(ctx, func(tx graph.Transaction) error {
 		return tx.Nodes().Filter(query.And(filters...)).FetchKinds(func(cursor graph.Cursor[graph.KindsResult]) error {
 			for next := range cursor.Chan() {
-				primaryKindStr := graphschema.PrimaryNodeKind(validPrimaryKinds, next.Kinds).String()
+				primaryKindStr := graphschema.PrimaryDisplayKind(primaryDisplayKinds, next.Kinds).String()
 				results[primaryKindStr] += 1
 			}
 
@@ -993,7 +993,7 @@ func (s *GraphQuery) runMaybeCachedEntityQuery(ctx context.Context, node *graph.
 	return result, nil
 }
 
-func (s *GraphQuery) runListQuery(ctx context.Context, validPrimaryKinds graphschema.ValidPrimaryKinds, node *graph.Node, params EntityQueryParameters, cacheEnabled bool) ([]model.PagedNodeListEntry, int, error) {
+func (s *GraphQuery) runListQuery(ctx context.Context, primaryDisplayKinds graphschema.PrimaryDisplayKinds, node *graph.Node, params EntityQueryParameters, cacheEnabled bool) ([]model.PagedNodeListEntry, int, error) {
 	var (
 		skip  = params.Skip
 		limit = params.Limit
@@ -1008,7 +1008,7 @@ func (s *GraphQuery) runListQuery(ctx context.Context, validPrimaryKinds graphsc
 			limit = result.Len() - skip
 		}
 
-		return fromGraphNodes(validPrimaryKinds, graph.NewNodeSet(nodeSetToOrderedSlice(result)[skip:skip+limit]...)), result.Len(), nil
+		return fromGraphNodes(primaryDisplayKinds, graph.NewNodeSet(nodeSetToOrderedSlice(result)[skip:skip+limit]...)), result.Len(), nil
 	}
 }
 
@@ -1017,7 +1017,7 @@ func (s *GraphQuery) runCountQuery(ctx context.Context, node *graph.Node, params
 	return nil, result.Len(), err
 }
 
-func (s *GraphQuery) runPathQuery(ctx context.Context, validPrimaryKinds graphschema.ValidPrimaryKinds, node *graph.Node, pathDelegate any) (map[string]any, int, error) {
+func (s *GraphQuery) runPathQuery(ctx context.Context, primaryDisplayKinds graphschema.PrimaryDisplayKinds, node *graph.Node, pathDelegate any) (map[string]any, int, error) {
 	var (
 		result graph.PathSet
 		err    error
@@ -1043,17 +1043,17 @@ func (s *GraphQuery) runPathQuery(ctx context.Context, validPrimaryKinds graphsc
 	if err != nil {
 		return nil, 0, err
 	} else {
-		return bloodhoundgraph.PathSetToBloodHoundGraph(validPrimaryKinds, result), result.Len(), nil
+		return bloodhoundgraph.PathSetToBloodHoundGraph(primaryDisplayKinds, result), result.Len(), nil
 	}
 }
 
-func (s *GraphQuery) GetEntityResults(ctx context.Context, validPrimaryKinds graphschema.ValidPrimaryKinds, node *graph.Node, params EntityQueryParameters, cacheEnabled bool) (any, int, error) {
+func (s *GraphQuery) GetEntityResults(ctx context.Context, primaryDisplayKinds graphschema.PrimaryDisplayKinds, node *graph.Node, params EntityQueryParameters, cacheEnabled bool) (any, int, error) {
 	// Graph type isn't currently under a caching model and is handled separately from other supported RequestedTypes
 	switch params.RequestedType {
 	case model.DataTypeGraph:
-		return s.runPathQuery(ctx, validPrimaryKinds, node, params.PathDelegate)
+		return s.runPathQuery(ctx, primaryDisplayKinds, node, params.PathDelegate)
 	case model.DataTypeList:
-		return s.runListQuery(ctx, validPrimaryKinds, node, params, cacheEnabled)
+		return s.runListQuery(ctx, primaryDisplayKinds, node, params, cacheEnabled)
 	case model.DataTypeCount:
 		return s.runCountQuery(ctx, node, params, cacheEnabled)
 	default:
@@ -1061,7 +1061,7 @@ func (s *GraphQuery) GetEntityResults(ctx context.Context, validPrimaryKinds gra
 	}
 }
 
-func fromGraphNodes(validPrimaryKinds graphschema.ValidPrimaryKinds, nodes graph.NodeSet) []model.PagedNodeListEntry {
+func fromGraphNodes(primaryDisplayKinds graphschema.PrimaryDisplayKinds, nodes graph.NodeSet) []model.PagedNodeListEntry {
 	renderedNodes := make([]model.PagedNodeListEntry, 0, nodes.Len())
 
 	for _, node := range nodes {
@@ -1108,7 +1108,7 @@ func fromGraphNodes(validPrimaryKinds graphschema.ValidPrimaryKinds, nodes graph
 			nodeEntry.Name = name
 		}
 
-		nodeEntry.Label = graphschema.GetNodeKindDisplayLabel(validPrimaryKinds, node)
+		nodeEntry.Label = graphschema.GetNodeKindDisplayLabel(primaryDisplayKinds, node)
 		nodeEntry.Kinds = node.Kinds.Strings()
 
 		renderedNodes = append(renderedNodes, nodeEntry)

--- a/cmd/api/src/queries/graph.go
+++ b/cmd/api/src/queries/graph.go
@@ -136,13 +136,13 @@ func BuildEntityQueryParams(request *http.Request, queryName string, pathDelegat
 }
 
 type Graph interface {
-	GetAssetGroupComboNode(ctx context.Context, primaryNodeKinds model.GraphSchemaNodeKindMap, owningObjectID string, assetGroupTag string) (map[string]any, error)
+	GetAssetGroupComboNode(ctx context.Context, primaryNodeKinds graphschema.ValidPrimaryKinds, owningObjectID string, assetGroupTag string) (map[string]any, error)
 	GetAssetGroupNodes(ctx context.Context, assetGroupTag string, isSystemGroup bool) (graph.NodeSet, error)
 	GetAllShortestPaths(ctx context.Context, startNodeID string, endNodeID string, filter graph.Criteria) (graph.PathSet, error)
 	GetAllShortestPathsWithOpenGraph(ctx context.Context, startNodeID string, endNodeID string, filter graph.Criteria) (graph.PathSet, error)
 	SearchNodesByNameOrObjectId(ctx context.Context, nodeKinds graph.Kinds, nameOrObjectIdQuery string, skip int, limit int) ([]*graph.Node, error)
 	SearchByNameOrObjectID(ctx context.Context, includeOpenGraphNodes bool, searchValue string, searchType string) (graph.NodeSet, error)
-	GetADEntityQueryResult(ctx context.Context, primaryNodeKinds model.GraphSchemaNodeKindMap, customNodeKinds model.CustomNodeKindMap, params EntityQueryParameters, cacheEnabled bool) (any, int, error)
+	GetADEntityQueryResult(ctx context.Context, primaryNodeKinds graphschema.ValidPrimaryKinds, params EntityQueryParameters, cacheEnabled bool) (any, int, error)
 	GetEntityByObjectId(ctx context.Context, objectID string, kinds ...graph.Kind) (*graph.Node, error)
 	GetEntityCountResults(ctx context.Context, node *graph.Node, delegates map[string]any) map[string]any
 	GetNodesByKind(ctx context.Context, kinds ...graph.Kind) (graph.NodeSet, error)
@@ -183,7 +183,7 @@ func NewGraphQuery(graphDB graph.Database, cache cache.Cache, cfg config.Configu
 	}
 }
 
-func (s *GraphQuery) GetAssetGroupComboNode(ctx context.Context, primaryNodeKinds model.GraphSchemaNodeKindMap, owningObjectID string, assetGroupTag string) (map[string]any, error) {
+func (s *GraphQuery) GetAssetGroupComboNode(ctx context.Context, primaryNodeKinds graphschema.ValidPrimaryKinds, owningObjectID string, assetGroupTag string) (map[string]any, error) {
 	var graphData = map[string]any{}
 
 	return graphData, s.Graph.ReadTransaction(ctx, func(tx graph.Transaction) error {
@@ -208,7 +208,7 @@ func (s *GraphQuery) GetAssetGroupComboNode(ctx context.Context, primaryNodeKind
 				if groupMembershipPaths, err := analysis.ExpandGroupMembershipPaths(tx, groups); err != nil {
 					return err
 				} else {
-					graphData = bloodhoundgraph.PathSetToBloodHoundGraph(primaryNodeKinds, nil, groupMembershipPaths)
+					graphData = bloodhoundgraph.PathSetToBloodHoundGraph(primaryNodeKinds, groupMembershipPaths)
 
 					for key := range graphData {
 						// Skip the edges/relations and only evaluate the nodes.
@@ -218,16 +218,16 @@ func (s *GraphQuery) GetAssetGroupComboNode(ctx context.Context, primaryNodeKind
 						if id, err := strconv.Atoi(key); err != nil || strings.Contains(key, "rel") {
 							continue
 						} else {
-							assetGroupNode := bloodhoundgraph.SetAssetGroupPropertiesForNode(primaryNodeKinds.ToKindsMap(), groupMembershipPaths.AllNodes().Get(graph.ID(id)))
-							graphData[key] = bloodhoundgraph.NodeToBloodHoundGraph(primaryNodeKinds, nil, assetGroupNode)
+							assetGroupNode := bloodhoundgraph.SetAssetGroupPropertiesForNode(primaryNodeKinds, groupMembershipPaths.AllNodes().Get(graph.ID(id)))
+							graphData[key] = bloodhoundgraph.NodeToBloodHoundGraph(primaryNodeKinds, assetGroupNode)
 						}
 					}
 				}
 			}
 
 			for _, node := range assetGroupNodes {
-				node = bloodhoundgraph.SetAssetGroupPropertiesForNode(primaryNodeKinds.ToKindsMap(), node)
-				graphData[node.ID.String()] = bloodhoundgraph.NodeToBloodHoundGraph(primaryNodeKinds, nil, node)
+				node = bloodhoundgraph.SetAssetGroupPropertiesForNode(primaryNodeKinds, node)
+				graphData[node.ID.String()] = bloodhoundgraph.NodeToBloodHoundGraph(primaryNodeKinds, node)
 			}
 		}
 
@@ -607,7 +607,7 @@ func (s *GraphQuery) SearchByNameOrObjectID(ctx context.Context, includeOpenGrap
 	}
 }
 
-func (s *GraphQuery) GetADEntityQueryResult(ctx context.Context, primaryNodeKinds model.GraphSchemaNodeKindMap, customNodeKinds model.CustomNodeKindMap, params EntityQueryParameters, cacheEnabled bool) (any, int, error) {
+func (s *GraphQuery) GetADEntityQueryResult(ctx context.Context, primaryNodeKinds graphschema.ValidPrimaryKinds, params EntityQueryParameters, cacheEnabled bool) (any, int, error) {
 	if params.RequestedType == model.DataTypeGraph && params.PathDelegate == nil {
 		return nil, 0, ErrGraphUnsupported
 	}
@@ -619,7 +619,7 @@ func (s *GraphQuery) GetADEntityQueryResult(ctx context.Context, primaryNodeKind
 	if node, err := s.GetEntityByObjectId(ctx, params.ObjectID, ad.Entity); err != nil {
 		return nil, 0, fmt.Errorf("error getting entity node: %w", err)
 	} else {
-		return s.GetEntityResults(ctx, primaryNodeKinds, customNodeKinds, node, params, cacheEnabled)
+		return s.GetEntityResults(ctx, primaryNodeKinds, node, params, cacheEnabled)
 	}
 }
 
@@ -1017,7 +1017,7 @@ func (s *GraphQuery) runCountQuery(ctx context.Context, node *graph.Node, params
 	return nil, result.Len(), err
 }
 
-func (s *GraphQuery) runPathQuery(ctx context.Context, validPrimaryKinds model.GraphSchemaNodeKindMap, customNodeKinds model.CustomNodeKindMap, node *graph.Node, pathDelegate any) (map[string]any, int, error) {
+func (s *GraphQuery) runPathQuery(ctx context.Context, validPrimaryKinds graphschema.ValidPrimaryKinds, node *graph.Node, pathDelegate any) (map[string]any, int, error) {
 	var (
 		result graph.PathSet
 		err    error
@@ -1043,17 +1043,17 @@ func (s *GraphQuery) runPathQuery(ctx context.Context, validPrimaryKinds model.G
 	if err != nil {
 		return nil, 0, err
 	} else {
-		return bloodhoundgraph.PathSetToBloodHoundGraph(validPrimaryKinds, customNodeKinds, result), result.Len(), nil
+		return bloodhoundgraph.PathSetToBloodHoundGraph(validPrimaryKinds, result), result.Len(), nil
 	}
 }
 
-func (s *GraphQuery) GetEntityResults(ctx context.Context, validPrimaryKinds model.GraphSchemaNodeKindMap, customNodeKinds model.CustomNodeKindMap, node *graph.Node, params EntityQueryParameters, cacheEnabled bool) (any, int, error) {
+func (s *GraphQuery) GetEntityResults(ctx context.Context, validPrimaryKinds graphschema.ValidPrimaryKinds, node *graph.Node, params EntityQueryParameters, cacheEnabled bool) (any, int, error) {
 	// Graph type isn't currently under a caching model and is handled separately from other supported RequestedTypes
 	switch params.RequestedType {
 	case model.DataTypeGraph:
-		return s.runPathQuery(ctx, validPrimaryKinds, customNodeKinds, node, params.PathDelegate)
+		return s.runPathQuery(ctx, validPrimaryKinds, node, params.PathDelegate)
 	case model.DataTypeList:
-		return s.runListQuery(ctx, validPrimaryKinds.ToKindsMap(), node, params, cacheEnabled)
+		return s.runListQuery(ctx, validPrimaryKinds, node, params, cacheEnabled)
 	case model.DataTypeCount:
 		return s.runCountQuery(ctx, node, params, cacheEnabled)
 	default:

--- a/cmd/api/src/queries/graph_integration_test.go
+++ b/cmd/api/src/queries/graph_integration_test.go
@@ -266,7 +266,7 @@ func TestGetEntityResults(t *testing.T) {
 	queryCache, err := cache.NewCache(cache.Config{MaxSize: 1})
 	require.Nil(t, err)
 
-	validPrimaryKinds, err := dbInst.GetValidDisplayKinds(context.Background())
+	primaryDisplayKinds, err := dbInst.GetValidDisplayKinds(context.Background())
 	require.NoError(t, err)
 
 	testContext.SetupActiveDirectory()
@@ -288,7 +288,7 @@ func TestGetEntityResults(t *testing.T) {
 			ListDelegate:  adAnalysis.FetchInboundADEntityControllers,
 		}
 
-		results, count, err := graphQuery.GetADEntityQueryResult(context.Background(), validPrimaryKinds, params, false)
+		results, count, err := graphQuery.GetADEntityQueryResult(context.Background(), primaryDisplayKinds, params, false)
 		require.Nil(t, err)
 
 		require.Equal(t, 4, count)
@@ -303,7 +303,7 @@ func TestGetEntityResults_QueryShorterThanSlowQueryThreshold(t *testing.T) {
 	queryCache, err := cache.NewCache(cache.Config{MaxSize: 1})
 	require.Nil(t, err)
 
-	validPrimaryKinds, err := dbInst.GetValidDisplayKinds(context.Background())
+	primaryDisplayKinds, err := dbInst.GetValidDisplayKinds(context.Background())
 	require.NoError(t, err)
 
 	testContext.SetupActiveDirectory()
@@ -326,7 +326,7 @@ func TestGetEntityResults_QueryShorterThanSlowQueryThreshold(t *testing.T) {
 			ListDelegate:  adAnalysis.FetchInboundADEntityControllers,
 		}
 
-		results, count, err := graphQuery.GetADEntityQueryResult(context.Background(), validPrimaryKinds, params, true)
+		results, count, err := graphQuery.GetADEntityQueryResult(context.Background(), primaryDisplayKinds, params, true)
 		require.Nil(t, err)
 
 		require.Equal(t, 4, count)
@@ -345,10 +345,10 @@ func TestGetPrimaryNodeKindCounts(t *testing.T) {
 		graphQuery := queries.GraphQuery{
 			Graph: db,
 		}
-		validPrimaryKinds, err := dbInst.GetValidDisplayKinds(testCtx)
+		primaryDisplayKinds, err := dbInst.GetValidDisplayKinds(testCtx)
 		require.NoError(t, err)
 
-		results, err := graphQuery.GetPrimaryNodeKindCounts(context.Background(), validPrimaryKinds, ad.Entity)
+		results, err := graphQuery.GetPrimaryNodeKindCounts(context.Background(), primaryDisplayKinds, ad.Entity)
 		require.Nil(t, err)
 
 		// While this is a very thin test, any more specificity would require constant updates each time the harness added new kind
@@ -379,7 +379,7 @@ func TestGetEntityResults_Cache(t *testing.T) {
 	queryCache, err := cache.NewCache(cache.Config{MaxSize: 2})
 	require.Nil(t, err)
 
-	validPrimaryKinds, err := dbInst.GetValidDisplayKinds(context.Background())
+	primaryDisplayKinds, err := dbInst.GetValidDisplayKinds(context.Background())
 	require.NoError(t, err)
 
 	testContext.SetupActiveDirectory()
@@ -404,7 +404,7 @@ func TestGetEntityResults_Cache(t *testing.T) {
 		}
 
 		// Get results and check that an entry was added to the cache
-		results, count, err := graphQuery.GetADEntityQueryResult(context.Background(), validPrimaryKinds, params, true)
+		results, count, err := graphQuery.GetADEntityQueryResult(context.Background(), primaryDisplayKinds, params, true)
 		require.Nil(t, err)
 
 		require.Equal(t, 4, count)
@@ -412,7 +412,7 @@ func TestGetEntityResults_Cache(t *testing.T) {
 		require.Equal(t, 1, queryCache.Len())
 
 		// Ensure that after being cached, we get the same results
-		results, count, err = graphQuery.GetADEntityQueryResult(context.Background(), validPrimaryKinds, params, true)
+		results, count, err = graphQuery.GetADEntityQueryResult(context.Background(), primaryDisplayKinds, params, true)
 		require.Nil(t, err)
 
 		require.Equal(t, 4, count)
@@ -897,14 +897,14 @@ func TestRawCypherQuery(t *testing.T) {
 	)
 	defer teardownIntegrationTestSuite(t, &testSuite)
 
-	validPrimaryKinds, err := testSuite.BHDatabase.GetValidDisplayKinds(context.Background())
+	primaryDisplayKinds, err := testSuite.BHDatabase.GetValidDisplayKinds(context.Background())
 	require.NoError(t, err)
 
 	t.Run("Test return nodes", func(t *testing.T) {
 		preparedQuery, err := graphQuery.PrepareCypherQuery("match (n:User) return n", queries.DefaultQueryFitnessLowerBoundExplore)
 		require.Nil(t, err)
 
-		results, err := graphQuery.RawCypherQuery(context.Background(), validPrimaryKinds, preparedQuery, false)
+		results, err := graphQuery.RawCypherQuery(context.Background(), primaryDisplayKinds, preparedQuery, false)
 		require.Nil(t, err)
 		require.Equal(t, 5, len(results.Nodes))
 	})
@@ -913,7 +913,7 @@ func TestRawCypherQuery(t *testing.T) {
 		preparedQuery, err := graphQuery.PrepareCypherQuery("match p = (m:Person)-[:Knows]->() return p", queries.DefaultQueryFitnessLowerBoundExplore)
 		require.Nil(t, err)
 
-		results, err := graphQuery.RawCypherQuery(context.Background(), validPrimaryKinds, preparedQuery, false)
+		results, err := graphQuery.RawCypherQuery(context.Background(), primaryDisplayKinds, preparedQuery, false)
 		require.Nil(t, err)
 		require.Equal(t, 3, len(results.Edges))
 	})
@@ -922,7 +922,7 @@ func TestRawCypherQuery(t *testing.T) {
 		preparedQuery, err := graphQuery.PrepareCypherQuery("match (m) where m.name = 'ALICE' return m", queries.DefaultQueryFitnessLowerBoundExplore)
 		require.Nil(t, err)
 
-		results, err := graphQuery.RawCypherQuery(context.Background(), validPrimaryKinds, preparedQuery, true)
+		results, err := graphQuery.RawCypherQuery(context.Background(), primaryDisplayKinds, preparedQuery, true)
 		require.Nil(t, err)
 		require.Equal(t, 1, len(results.Nodes))
 		require.Equal(t, "ALICE", results.Nodes["12"].Properties["name"])
@@ -932,7 +932,7 @@ func TestRawCypherQuery(t *testing.T) {
 		preparedQuery, err := graphQuery.PrepareCypherQuery("match (m) where m.name = 'ALICE' return 7-6 = 1, count(m), max(m.name)", queries.DefaultQueryFitnessLowerBoundExplore)
 		require.Nil(t, err)
 
-		results, err := graphQuery.RawCypherQuery(context.Background(), validPrimaryKinds, preparedQuery, false)
+		results, err := graphQuery.RawCypherQuery(context.Background(), primaryDisplayKinds, preparedQuery, false)
 		require.Nil(t, err)
 		require.Equal(t, 3, len(results.Literals))
 		require.Equal(t, true, results.Literals[0].Value)
@@ -945,7 +945,7 @@ func TestRawCypherQuery(t *testing.T) {
 		preparedQuery, err := graphQuery.PrepareCypherQuery("match (m:User) return m, count(m)", queries.DefaultQueryFitnessLowerBoundExplore)
 		require.Nil(t, err)
 
-		results, err := graphQuery.RawCypherQuery(context.Background(), validPrimaryKinds, preparedQuery, false)
+		results, err := graphQuery.RawCypherQuery(context.Background(), primaryDisplayKinds, preparedQuery, false)
 		require.Nil(t, err)
 		require.Equal(t, 5, len(results.Nodes))
 		require.Equal(t, 5, len(results.Literals))

--- a/cmd/api/src/queries/graph_integration_test.go
+++ b/cmd/api/src/queries/graph_integration_test.go
@@ -266,7 +266,7 @@ func TestGetEntityResults(t *testing.T) {
 	queryCache, err := cache.NewCache(cache.Config{MaxSize: 1})
 	require.Nil(t, err)
 
-	primaryDisplayKinds, err := dbInst.GetValidDisplayKinds(context.Background())
+	primaryDisplayKinds, err := dbInst.GetPrimaryDisplayKinds(context.Background())
 	require.NoError(t, err)
 
 	testContext.SetupActiveDirectory()
@@ -303,7 +303,7 @@ func TestGetEntityResults_QueryShorterThanSlowQueryThreshold(t *testing.T) {
 	queryCache, err := cache.NewCache(cache.Config{MaxSize: 1})
 	require.Nil(t, err)
 
-	primaryDisplayKinds, err := dbInst.GetValidDisplayKinds(context.Background())
+	primaryDisplayKinds, err := dbInst.GetPrimaryDisplayKinds(context.Background())
 	require.NoError(t, err)
 
 	testContext.SetupActiveDirectory()
@@ -345,7 +345,7 @@ func TestGetPrimaryNodeKindCounts(t *testing.T) {
 		graphQuery := queries.GraphQuery{
 			Graph: db,
 		}
-		primaryDisplayKinds, err := dbInst.GetValidDisplayKinds(testCtx)
+		primaryDisplayKinds, err := dbInst.GetPrimaryDisplayKinds(testCtx)
 		require.NoError(t, err)
 
 		results, err := graphQuery.GetPrimaryNodeKindCounts(context.Background(), primaryDisplayKinds, ad.Entity)
@@ -379,7 +379,7 @@ func TestGetEntityResults_Cache(t *testing.T) {
 	queryCache, err := cache.NewCache(cache.Config{MaxSize: 2})
 	require.Nil(t, err)
 
-	primaryDisplayKinds, err := dbInst.GetValidDisplayKinds(context.Background())
+	primaryDisplayKinds, err := dbInst.GetPrimaryDisplayKinds(context.Background())
 	require.NoError(t, err)
 
 	testContext.SetupActiveDirectory()
@@ -426,7 +426,7 @@ func TestGetAssetGroupComboNode(t *testing.T) {
 	testContext := integration.NewGraphTestContext(t, schema.DefaultGraphSchema())
 	testContext.SetupActiveDirectory()
 
-	primaryNodeKinds, err := dbInst.GetValidDisplayKinds(context.Background())
+	primaryNodeKinds, err := dbInst.GetPrimaryDisplayKinds(context.Background())
 	require.NoError(t, err)
 
 	testContext.DatabaseTest(func(harness integration.HarnessDetails, db graph.Database) {
@@ -897,7 +897,7 @@ func TestRawCypherQuery(t *testing.T) {
 	)
 	defer teardownIntegrationTestSuite(t, &testSuite)
 
-	primaryDisplayKinds, err := testSuite.BHDatabase.GetValidDisplayKinds(context.Background())
+	primaryDisplayKinds, err := testSuite.BHDatabase.GetPrimaryDisplayKinds(context.Background())
 	require.NoError(t, err)
 
 	t.Run("Test return nodes", func(t *testing.T) {

--- a/cmd/api/src/queries/graph_integration_test.go
+++ b/cmd/api/src/queries/graph_integration_test.go
@@ -288,7 +288,7 @@ func TestGetEntityResults(t *testing.T) {
 			ListDelegate:  adAnalysis.FetchInboundADEntityControllers,
 		}
 
-		results, count, err := graphQuery.GetADEntityQueryResult(context.Background(), validPrimaryKinds, nil, params, false)
+		results, count, err := graphQuery.GetADEntityQueryResult(context.Background(), validPrimaryKinds, params, false)
 		require.Nil(t, err)
 
 		require.Equal(t, 4, count)
@@ -326,7 +326,7 @@ func TestGetEntityResults_QueryShorterThanSlowQueryThreshold(t *testing.T) {
 			ListDelegate:  adAnalysis.FetchInboundADEntityControllers,
 		}
 
-		results, count, err := graphQuery.GetADEntityQueryResult(context.Background(), validPrimaryKinds, nil, params, true)
+		results, count, err := graphQuery.GetADEntityQueryResult(context.Background(), validPrimaryKinds, params, true)
 		require.Nil(t, err)
 
 		require.Equal(t, 4, count)
@@ -404,7 +404,7 @@ func TestGetEntityResults_Cache(t *testing.T) {
 		}
 
 		// Get results and check that an entry was added to the cache
-		results, count, err := graphQuery.GetADEntityQueryResult(context.Background(), validPrimaryKinds, nil, params, true)
+		results, count, err := graphQuery.GetADEntityQueryResult(context.Background(), validPrimaryKinds, params, true)
 		require.Nil(t, err)
 
 		require.Equal(t, 4, count)
@@ -412,7 +412,7 @@ func TestGetEntityResults_Cache(t *testing.T) {
 		require.Equal(t, 1, queryCache.Len())
 
 		// Ensure that after being cached, we get the same results
-		results, count, err = graphQuery.GetADEntityQueryResult(context.Background(), validPrimaryKinds, nil, params, true)
+		results, count, err = graphQuery.GetADEntityQueryResult(context.Background(), validPrimaryKinds, params, true)
 		require.Nil(t, err)
 
 		require.Equal(t, 4, count)
@@ -426,7 +426,7 @@ func TestGetAssetGroupComboNode(t *testing.T) {
 	testContext := integration.NewGraphTestContext(t, schema.DefaultGraphSchema())
 	testContext.SetupActiveDirectory()
 
-	primaryNodeKinds, err := dbInst.GetDisplayGraphSchemaNodeKinds(context.Background())
+	primaryNodeKinds, err := dbInst.GetValidDisplayKinds(context.Background())
 	require.NoError(t, err)
 
 	testContext.DatabaseTest(func(harness integration.HarnessDetails, db graph.Database) {

--- a/cmd/api/src/queries/graph_integration_test.go
+++ b/cmd/api/src/queries/graph_integration_test.go
@@ -266,7 +266,7 @@ func TestGetEntityResults(t *testing.T) {
 	queryCache, err := cache.NewCache(cache.Config{MaxSize: 1})
 	require.Nil(t, err)
 
-	validPrimaryKinds, err := dbInst.GetDisplayGraphSchemaNodeKinds(context.Background())
+	validPrimaryKinds, err := dbInst.GetValidDisplayKinds(context.Background())
 	require.NoError(t, err)
 
 	testContext.SetupActiveDirectory()
@@ -303,7 +303,7 @@ func TestGetEntityResults_QueryShorterThanSlowQueryThreshold(t *testing.T) {
 	queryCache, err := cache.NewCache(cache.Config{MaxSize: 1})
 	require.Nil(t, err)
 
-	validPrimaryKinds, err := dbInst.GetDisplayGraphSchemaNodeKinds(context.Background())
+	validPrimaryKinds, err := dbInst.GetValidDisplayKinds(context.Background())
 	require.NoError(t, err)
 
 	testContext.SetupActiveDirectory()
@@ -379,7 +379,7 @@ func TestGetEntityResults_Cache(t *testing.T) {
 	queryCache, err := cache.NewCache(cache.Config{MaxSize: 2})
 	require.Nil(t, err)
 
-	validPrimaryKinds, err := dbInst.GetDisplayGraphSchemaNodeKinds(context.Background())
+	validPrimaryKinds, err := dbInst.GetValidDisplayKinds(context.Background())
 	require.NoError(t, err)
 
 	testContext.SetupActiveDirectory()

--- a/cmd/api/src/queries/graph_test.go
+++ b/cmd/api/src/queries/graph_test.go
@@ -295,7 +295,7 @@ func TestQueries_GetEntityResults(t *testing.T) {
 		return delegate(nil)
 	})
 
-	results, count, err := graphQuery.GetEntityResults(context.Background(), nil, nil, node, params, true)
+	results, count, err := graphQuery.GetEntityResults(context.Background(), nil, node, params, true)
 	require.Nil(t, err)
 	require.Len(t, results, 10)
 	require.Equal(t, count, 20)

--- a/cmd/api/src/queries/mocks/graph.go
+++ b/cmd/api/src/queries/mocks/graph.go
@@ -167,7 +167,7 @@ func (mr *MockGraphMockRecorder) FetchNodesByObjectIDsAndKinds(ctx, kinds any, o
 }
 
 // GetADEntityQueryResult mocks base method.
-func (m *MockGraph) GetADEntityQueryResult(ctx context.Context, primaryNodeKinds graphschema.ValidPrimaryKinds, params queries.EntityQueryParameters, cacheEnabled bool) (any, int, error) {
+func (m *MockGraph) GetADEntityQueryResult(ctx context.Context, primaryNodeKinds graphschema.PrimaryDisplayKinds, params queries.EntityQueryParameters, cacheEnabled bool) (any, int, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetADEntityQueryResult", ctx, primaryNodeKinds, params, cacheEnabled)
 	ret0, _ := ret[0].(any)
@@ -213,7 +213,7 @@ func (mr *MockGraphMockRecorder) GetAllShortestPathsWithOpenGraph(ctx, startNode
 }
 
 // GetAssetGroupComboNode mocks base method.
-func (m *MockGraph) GetAssetGroupComboNode(ctx context.Context, primaryNodeKinds graphschema.ValidPrimaryKinds, owningObjectID, assetGroupTag string) (map[string]any, error) {
+func (m *MockGraph) GetAssetGroupComboNode(ctx context.Context, primaryNodeKinds graphschema.PrimaryDisplayKinds, owningObjectID, assetGroupTag string) (map[string]any, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAssetGroupComboNode", ctx, primaryNodeKinds, owningObjectID, assetGroupTag)
 	ret0, _ := ret[0].(map[string]any)
@@ -327,9 +327,9 @@ func (mr *MockGraphMockRecorder) GetNodesByKind(ctx any, kinds ...any) *gomock.C
 }
 
 // GetPrimaryNodeKindCounts mocks base method.
-func (m *MockGraph) GetPrimaryNodeKindCounts(ctx context.Context, validPrimaryKinds graphschema.ValidPrimaryKinds, kind graph.Kind, additionalFilters ...graph.Criteria) (map[string]int, error) {
+func (m *MockGraph) GetPrimaryNodeKindCounts(ctx context.Context, primaryDisplayKinds graphschema.PrimaryDisplayKinds, kind graph.Kind, additionalFilters ...graph.Criteria) (map[string]int, error) {
 	m.ctrl.T.Helper()
-	varargs := []any{ctx, validPrimaryKinds, kind}
+	varargs := []any{ctx, primaryDisplayKinds, kind}
 	for _, a := range additionalFilters {
 		varargs = append(varargs, a)
 	}
@@ -340,9 +340,9 @@ func (m *MockGraph) GetPrimaryNodeKindCounts(ctx context.Context, validPrimaryKi
 }
 
 // GetPrimaryNodeKindCounts indicates an expected call of GetPrimaryNodeKindCounts.
-func (mr *MockGraphMockRecorder) GetPrimaryNodeKindCounts(ctx, validPrimaryKinds, kind any, additionalFilters ...any) *gomock.Call {
+func (mr *MockGraphMockRecorder) GetPrimaryNodeKindCounts(ctx, primaryDisplayKinds, kind any, additionalFilters ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{ctx, validPrimaryKinds, kind}, additionalFilters...)
+	varargs := append([]any{ctx, primaryDisplayKinds, kind}, additionalFilters...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPrimaryNodeKindCounts", reflect.TypeOf((*MockGraph)(nil).GetPrimaryNodeKindCounts), varargs...)
 }
 
@@ -362,18 +362,18 @@ func (mr *MockGraphMockRecorder) PrepareCypherQuery(rawCypher, queryComplexityLi
 }
 
 // RawCypherQuery mocks base method.
-func (m *MockGraph) RawCypherQuery(ctx context.Context, validPrimaryKinds graphschema.ValidPrimaryKinds, pQuery queries.PreparedQuery, includeProperties bool) (model.UnifiedGraph, error) {
+func (m *MockGraph) RawCypherQuery(ctx context.Context, primaryDisplayKinds graphschema.PrimaryDisplayKinds, pQuery queries.PreparedQuery, includeProperties bool) (model.UnifiedGraph, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RawCypherQuery", ctx, validPrimaryKinds, pQuery, includeProperties)
+	ret := m.ctrl.Call(m, "RawCypherQuery", ctx, primaryDisplayKinds, pQuery, includeProperties)
 	ret0, _ := ret[0].(model.UnifiedGraph)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // RawCypherQuery indicates an expected call of RawCypherQuery.
-func (mr *MockGraphMockRecorder) RawCypherQuery(ctx, validPrimaryKinds, pQuery, includeProperties any) *gomock.Call {
+func (mr *MockGraphMockRecorder) RawCypherQuery(ctx, primaryDisplayKinds, pQuery, includeProperties any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RawCypherQuery", reflect.TypeOf((*MockGraph)(nil).RawCypherQuery), ctx, validPrimaryKinds, pQuery, includeProperties)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RawCypherQuery", reflect.TypeOf((*MockGraph)(nil).RawCypherQuery), ctx, primaryDisplayKinds, pQuery, includeProperties)
 }
 
 // SearchByNameOrObjectID mocks base method.

--- a/cmd/api/src/queries/mocks/graph.go
+++ b/cmd/api/src/queries/mocks/graph.go
@@ -167,9 +167,9 @@ func (mr *MockGraphMockRecorder) FetchNodesByObjectIDsAndKinds(ctx, kinds any, o
 }
 
 // GetADEntityQueryResult mocks base method.
-func (m *MockGraph) GetADEntityQueryResult(ctx context.Context, primaryNodeKinds model.GraphSchemaNodeKindMap, customNodeKinds model.CustomNodeKindMap, params queries.EntityQueryParameters, cacheEnabled bool) (any, int, error) {
+func (m *MockGraph) GetADEntityQueryResult(ctx context.Context, primaryNodeKinds graphschema.ValidPrimaryKinds, params queries.EntityQueryParameters, cacheEnabled bool) (any, int, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetADEntityQueryResult", ctx, primaryNodeKinds, customNodeKinds, params, cacheEnabled)
+	ret := m.ctrl.Call(m, "GetADEntityQueryResult", ctx, primaryNodeKinds, params, cacheEnabled)
 	ret0, _ := ret[0].(any)
 	ret1, _ := ret[1].(int)
 	ret2, _ := ret[2].(error)
@@ -177,9 +177,9 @@ func (m *MockGraph) GetADEntityQueryResult(ctx context.Context, primaryNodeKinds
 }
 
 // GetADEntityQueryResult indicates an expected call of GetADEntityQueryResult.
-func (mr *MockGraphMockRecorder) GetADEntityQueryResult(ctx, primaryNodeKinds, customNodeKinds, params, cacheEnabled any) *gomock.Call {
+func (mr *MockGraphMockRecorder) GetADEntityQueryResult(ctx, primaryNodeKinds, params, cacheEnabled any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetADEntityQueryResult", reflect.TypeOf((*MockGraph)(nil).GetADEntityQueryResult), ctx, primaryNodeKinds, customNodeKinds, params, cacheEnabled)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetADEntityQueryResult", reflect.TypeOf((*MockGraph)(nil).GetADEntityQueryResult), ctx, primaryNodeKinds, params, cacheEnabled)
 }
 
 // GetAllShortestPaths mocks base method.
@@ -213,7 +213,7 @@ func (mr *MockGraphMockRecorder) GetAllShortestPathsWithOpenGraph(ctx, startNode
 }
 
 // GetAssetGroupComboNode mocks base method.
-func (m *MockGraph) GetAssetGroupComboNode(ctx context.Context, primaryNodeKinds model.GraphSchemaNodeKindMap, owningObjectID, assetGroupTag string) (map[string]any, error) {
+func (m *MockGraph) GetAssetGroupComboNode(ctx context.Context, primaryNodeKinds graphschema.ValidPrimaryKinds, owningObjectID, assetGroupTag string) (map[string]any, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAssetGroupComboNode", ctx, primaryNodeKinds, owningObjectID, assetGroupTag)
 	ret0, _ := ret[0].(map[string]any)

--- a/cmd/api/src/services/agi/agi.go
+++ b/cmd/api/src/services/agi/agi.go
@@ -67,16 +67,16 @@ func FetchAssetGroupNodes(tx graph.Transaction, assetGroupTag string, isSystemGr
 
 type agiGetter interface {
 	GetAllAssetGroups(ctx context.Context, order string, filter model.SQLFilter) (model.AssetGroups, error)
-	GetValidDisplayKinds(ctx context.Context) (graphschema.ValidPrimaryKinds, error)
+	GetValidDisplayKinds(ctx context.Context) (graphschema.PrimaryDisplayKinds, error)
 	CreateAssetGroupCollection(ctx context.Context, collection model.AssetGroupCollection, entries model.AssetGroupCollectionEntries) error
 }
 
-func RunAssetGroupIsolationCollections(ctx context.Context, db agiGetter, graphDB graph.Database, nodeLabelFn func(graphschema.ValidPrimaryKinds, *graph.Node) string) error {
+func RunAssetGroupIsolationCollections(ctx context.Context, db agiGetter, graphDB graph.Database, nodeLabelFn func(graphschema.PrimaryDisplayKinds, *graph.Node) string) error {
 	defer measure.ContextMeasureWithThreshold(ctx, slog.LevelInfo, "Asset Group Isolation Collections")()
 
 	if assetGroups, err := db.GetAllAssetGroups(ctx, "", model.SQLFilter{}); err != nil {
 		return err
-	} else if validPrimaryKinds, err := db.GetValidDisplayKinds(ctx); err != nil {
+	} else if primaryDisplayKinds, err := db.GetValidDisplayKinds(ctx); err != nil {
 		return err
 	} else {
 		return graphDB.WriteTransaction(ctx, func(tx graph.Transaction) error {
@@ -104,7 +104,7 @@ func RunAssetGroupIsolationCollections(ctx context.Context, db agiGetter, graphD
 						} else {
 							entries[idx] = model.AssetGroupCollectionEntry{
 								ObjectID:   objectID,
-								NodeLabel:  nodeLabelFn(validPrimaryKinds, node),
+								NodeLabel:  nodeLabelFn(primaryDisplayKinds, node),
 								Properties: node.Properties.Map,
 							}
 						}

--- a/cmd/api/src/services/agi/agi.go
+++ b/cmd/api/src/services/agi/agi.go
@@ -67,7 +67,7 @@ func FetchAssetGroupNodes(tx graph.Transaction, assetGroupTag string, isSystemGr
 
 type agiGetter interface {
 	GetAllAssetGroups(ctx context.Context, order string, filter model.SQLFilter) (model.AssetGroups, error)
-	GetValidDisplayKinds(ctx context.Context) (graphschema.PrimaryDisplayKinds, error)
+	GetPrimaryDisplayKinds(ctx context.Context) (graphschema.PrimaryDisplayKinds, error)
 	CreateAssetGroupCollection(ctx context.Context, collection model.AssetGroupCollection, entries model.AssetGroupCollectionEntries) error
 }
 
@@ -76,7 +76,7 @@ func RunAssetGroupIsolationCollections(ctx context.Context, db agiGetter, graphD
 
 	if assetGroups, err := db.GetAllAssetGroups(ctx, "", model.SQLFilter{}); err != nil {
 		return err
-	} else if primaryDisplayKinds, err := db.GetValidDisplayKinds(ctx); err != nil {
+	} else if primaryDisplayKinds, err := db.GetPrimaryDisplayKinds(ctx); err != nil {
 		return err
 	} else {
 		return graphDB.WriteTransaction(ctx, func(tx graph.Transaction) error {

--- a/packages/go/analysis/agt.go
+++ b/packages/go/analysis/agt.go
@@ -559,7 +559,7 @@ func fetchOldSelectedNodes(ctx context.Context, db database.Database, selectorId
 }
 
 // SelectNodes - selects all nodes for a given selector and diffs previous db state for minimal db updates
-func SelectNodes(ctx context.Context, db database.Database, graphDb graph.Database, agtParameters appcfg.AGTParameters, validPrimaryKinds graphschema.ValidPrimaryKinds, selector model.AssetGroupTagSelector, expansionMethod model.AssetGroupExpansionMethod) []error {
+func SelectNodes(ctx context.Context, db database.Database, graphDb graph.Database, agtParameters appcfg.AGTParameters, primaryDisplayKinds graphschema.PrimaryDisplayKinds, selector model.AssetGroupTagSelector, expansionMethod model.AssetGroupExpansionMethod) []error {
 	defer measure.ContextMeasure(ctx, slog.LevelDebug, "Selecting nodes", slog.String("selector", strconv.Itoa(selector.ID)))()
 
 	var (
@@ -582,7 +582,7 @@ func SelectNodes(ctx context.Context, db database.Database, graphDb graph.Databa
 			var (
 				certified                                 = model.AssetGroupCertificationPending
 				certifiedBy                               null.String
-				primaryKind, displayName, objectId, envId = model.GetAssetGroupMemberProperties(validPrimaryKinds, node.Node)
+				primaryKind, displayName, objectId, envId = model.GetAssetGroupMemberProperties(primaryDisplayKinds, node.Node)
 			)
 
 			if (selector.AutoCertify == model.SelectorAutoCertifyMethodSeedsOnly && node.Source == model.AssetGroupSelectorNodeSourceSeed) || selector.AutoCertify == model.SelectorAutoCertifyMethodAllMembers {
@@ -634,7 +634,7 @@ func SelectNodes(ctx context.Context, db database.Database, graphDb graph.Databa
 						slog.Uint64("node_id", oldSelectorNode.NodeId.Uint64()),
 					)
 				} else {
-					primaryKind, displayName, objectId, envId := model.GetAssetGroupMemberProperties(validPrimaryKinds, graphNode.Node)
+					primaryKind, displayName, objectId, envId := model.GetAssetGroupMemberProperties(primaryDisplayKinds, graphNode.Node)
 					if err = db.UpdateSelectorNodesByNodeId(ctx, selector.AssetGroupTagId, selector.ID, oldSelectorNode.NodeId, certified, certifiedBy, primaryKind, envId, objectId, displayName); err != nil {
 						errs = append(errs, err)
 					}
@@ -681,7 +681,7 @@ func selectAssetGroupNodes(ctx context.Context, db database.Database, graphDb gr
 
 	if tags, err := db.GetAssetGroupTagForSelection(ctx); err != nil {
 		errs.Append(err)
-	} else if validPrimaryKinds, err := db.GetValidDisplayKinds(ctx); err != nil {
+	} else if primaryDisplayKinds, err := db.GetValidDisplayKinds(ctx); err != nil {
 		errs.Append(err)
 	} else {
 		agtParameters := appcfg.GetAGTParameters(ctx, db)
@@ -717,7 +717,7 @@ func selectAssetGroupNodes(ctx context.Context, db database.Database, graphDb gr
 					if selector, ok := channels.Receive(ctx, getCh); !ok {
 						return
 					} else {
-						if selectNodeErrors := SelectNodes(ctx, db, graphDb, agtParameters, validPrimaryKinds, selector, expansionByTagId[selector.AssetGroupTagId]); len(selectNodeErrors) > 0 {
+						if selectNodeErrors := SelectNodes(ctx, db, graphDb, agtParameters, primaryDisplayKinds, selector, expansionByTagId[selector.AssetGroupTagId]); len(selectNodeErrors) > 0 {
 							errs.Append(selectNodeErrors...)
 						}
 					}

--- a/packages/go/analysis/agt.go
+++ b/packages/go/analysis/agt.go
@@ -681,7 +681,7 @@ func selectAssetGroupNodes(ctx context.Context, db database.Database, graphDb gr
 
 	if tags, err := db.GetAssetGroupTagForSelection(ctx); err != nil {
 		errs.Append(err)
-	} else if primaryDisplayKinds, err := db.GetValidDisplayKinds(ctx); err != nil {
+	} else if primaryDisplayKinds, err := db.GetPrimaryDisplayKinds(ctx); err != nil {
 		errs.Append(err)
 	} else {
 		agtParameters := appcfg.GetAGTParameters(ctx, db)

--- a/packages/go/analysis/azure/application.go
+++ b/packages/go/analysis/azure/application.go
@@ -28,14 +28,14 @@ import (
 	"github.com/specterops/dawgs/graph"
 )
 
-func ApplicationEntityDetails(ctx context.Context, db graph.Database, validPrimaryKinds graphschema.ValidPrimaryKinds, objectID string, hydrateCounts bool) (ApplicationDetails, error) {
+func ApplicationEntityDetails(ctx context.Context, db graph.Database, primaryDisplayKinds graphschema.PrimaryDisplayKinds, objectID string, hydrateCounts bool) (ApplicationDetails, error) {
 	var details ApplicationDetails
 
 	return details, db.ReadTransaction(ctx, func(tx graph.Transaction) error {
 		if node, err := FetchEntityByObjectID(tx, objectID); err != nil {
 			return err
 		} else {
-			details.Node = FromGraphNode(validPrimaryKinds, node)
+			details.Node = FromGraphNode(primaryDisplayKinds, node)
 			if servicePrincipalID, err := getAppServicePrincipalID(tx, node); err != nil {
 				return err
 			} else {

--- a/packages/go/analysis/azure/automation_account.go
+++ b/packages/go/analysis/azure/automation_account.go
@@ -23,14 +23,14 @@ import (
 	"github.com/specterops/dawgs/graph"
 )
 
-func AutomationAccountEntityDetails(ctx context.Context, db graph.Database, validPrimaryKinds graphschema.ValidPrimaryKinds, objectID string, hydrateCounts bool) (AutomationAccountDetails, error) {
+func AutomationAccountEntityDetails(ctx context.Context, db graph.Database, primaryDisplayKinds graphschema.PrimaryDisplayKinds, objectID string, hydrateCounts bool) (AutomationAccountDetails, error) {
 	var details AutomationAccountDetails
 
 	return details, db.ReadTransaction(ctx, func(tx graph.Transaction) error {
 		if node, err := FetchEntityByObjectID(tx, objectID); err != nil {
 			return err
 		} else {
-			details.Node = FromGraphNode(validPrimaryKinds, node)
+			details.Node = FromGraphNode(primaryDisplayKinds, node)
 			if hydrateCounts {
 				details, err = PopulateAutomationAccountEntityDetailsCounts(tx, node, details)
 			}

--- a/packages/go/analysis/azure/azure_integration_test.go
+++ b/packages/go/analysis/azure/azure_integration_test.go
@@ -560,7 +560,7 @@ func TestEntityDetails(t *testing.T) {
 		testContext = integration.NewGraphTestContext(t, schema.DefaultGraphSchema())
 		dbInst      = integration.SetupDB(t)
 	)
-	primaryDisplayKinds, err := dbInst.GetValidDisplayKinds(testContext.Context())
+	primaryDisplayKinds, err := dbInst.GetPrimaryDisplayKinds(testContext.Context())
 	require.NoError(t, err)
 
 	t.Run("ApplicationEntityDetails", func(t *testing.T) {

--- a/packages/go/analysis/azure/azure_integration_test.go
+++ b/packages/go/analysis/azure/azure_integration_test.go
@@ -560,7 +560,7 @@ func TestEntityDetails(t *testing.T) {
 		testContext = integration.NewGraphTestContext(t, schema.DefaultGraphSchema())
 		dbInst      = integration.SetupDB(t)
 	)
-	validPrimaryKinds, err := dbInst.GetValidDisplayKinds(testContext.Context())
+	primaryDisplayKinds, err := dbInst.GetValidDisplayKinds(testContext.Context())
 	require.NoError(t, err)
 
 	t.Run("ApplicationEntityDetails", func(t *testing.T) {
@@ -573,13 +573,13 @@ func TestEntityDetails(t *testing.T) {
 			require.Nil(t, err)
 			assert.NotEqual(t, "", appObjectID)
 
-			app, err := azure.ApplicationEntityDetails(testContext.Context(), testContext.Graph.Database, validPrimaryKinds, appObjectID, false)
+			app, err := azure.ApplicationEntityDetails(testContext.Context(), testContext.Graph.Database, primaryDisplayKinds, appObjectID, false)
 
 			require.Nil(t, err)
 			assert.Equal(t, harness.AZEntityPanelHarness.Application.Properties.Get(common.ObjectID.String()).Any(), app.Properties[common.ObjectID.String()])
 			assert.Equal(t, 0, app.InboundObjectControl)
 
-			app, err = azure.ApplicationEntityDetails(testContext.Context(), testContext.Graph.Database, validPrimaryKinds, appObjectID, true)
+			app, err = azure.ApplicationEntityDetails(testContext.Context(), testContext.Graph.Database, primaryDisplayKinds, appObjectID, true)
 
 			require.Nil(t, err)
 			assert.NotEqual(t, 0, app.InboundObjectControl)
@@ -596,13 +596,13 @@ func TestEntityDetails(t *testing.T) {
 			require.Nil(t, err)
 			assert.NotEqual(t, "", deviceObjectID)
 
-			device, err := azure.DeviceEntityDetails(testContext.Context(), testContext.Graph.Database, validPrimaryKinds, deviceObjectID, false)
+			device, err := azure.DeviceEntityDetails(testContext.Context(), testContext.Graph.Database, primaryDisplayKinds, deviceObjectID, false)
 
 			require.Nil(t, err)
 			assert.Equal(t, harness.AZEntityPanelHarness.Device.Properties.Get(common.ObjectID.String()).Any(), device.Properties[common.ObjectID.String()])
 			assert.Equal(t, 0, device.InboundObjectControl)
 
-			device, err = azure.DeviceEntityDetails(testContext.Context(), testContext.Graph.Database, validPrimaryKinds, deviceObjectID, true)
+			device, err = azure.DeviceEntityDetails(testContext.Context(), testContext.Graph.Database, primaryDisplayKinds, deviceObjectID, true)
 
 			require.Nil(t, err)
 			assert.NotEqual(t, 0, device.InboundObjectControl)
@@ -619,13 +619,13 @@ func TestEntityDetails(t *testing.T) {
 			require.Nil(t, err)
 			assert.NotEqual(t, "", groupObjectID)
 
-			group, err := azure.GroupEntityDetails(testContext.Context(), testContext.Graph.Database, validPrimaryKinds, groupObjectID, false)
+			group, err := azure.GroupEntityDetails(testContext.Context(), testContext.Graph.Database, primaryDisplayKinds, groupObjectID, false)
 
 			require.Nil(t, err)
 			assert.Equal(t, harness.AZEntityPanelHarness.Group.Properties.Get(common.ObjectID.String()).Any(), group.Properties[common.ObjectID.String()])
 			assert.Equal(t, 0, group.InboundObjectControl)
 
-			group, err = azure.GroupEntityDetails(testContext.Context(), testContext.Graph.Database, validPrimaryKinds, groupObjectID, true)
+			group, err = azure.GroupEntityDetails(testContext.Context(), testContext.Graph.Database, primaryDisplayKinds, groupObjectID, true)
 
 			require.Nil(t, err)
 			assert.NotEqual(t, 0, group.InboundObjectControl)
@@ -642,13 +642,13 @@ func TestEntityDetails(t *testing.T) {
 			require.Nil(t, err)
 			assert.NotEqual(t, "", groupObjectID)
 
-			group, err := azure.ManagementGroupEntityDetails(testContext.Context(), testContext.Graph.Database, validPrimaryKinds, groupObjectID, false)
+			group, err := azure.ManagementGroupEntityDetails(testContext.Context(), testContext.Graph.Database, primaryDisplayKinds, groupObjectID, false)
 
 			require.Nil(t, err)
 			assert.Equal(t, harness.AZEntityPanelHarness.ManagementGroup.Properties.Get(common.ObjectID.String()).Any(), group.Properties[common.ObjectID.String()])
 			assert.Equal(t, 0, group.InboundObjectControl)
 
-			group, err = azure.ManagementGroupEntityDetails(testContext.Context(), testContext.Graph.Database, validPrimaryKinds, groupObjectID, true)
+			group, err = azure.ManagementGroupEntityDetails(testContext.Context(), testContext.Graph.Database, primaryDisplayKinds, groupObjectID, true)
 
 			require.Nil(t, err)
 			assert.NotEqual(t, 0, group.InboundObjectControl)
@@ -665,13 +665,13 @@ func TestEntityDetails(t *testing.T) {
 			require.Nil(t, err)
 			assert.NotEqual(t, "", groupObjectID)
 
-			group, err := azure.ResourceGroupEntityDetails(testContext.Context(), testContext.Graph.Database, validPrimaryKinds, groupObjectID, false)
+			group, err := azure.ResourceGroupEntityDetails(testContext.Context(), testContext.Graph.Database, primaryDisplayKinds, groupObjectID, false)
 
 			require.Nil(t, err)
 			assert.Equal(t, harness.AZEntityPanelHarness.ResourceGroup.Properties.Get(common.ObjectID.String()).Any(), group.Properties[common.ObjectID.String()])
 			assert.Equal(t, 0, group.InboundObjectControl)
 
-			group, err = azure.ResourceGroupEntityDetails(testContext.Context(), testContext.Graph.Database, validPrimaryKinds, groupObjectID, true)
+			group, err = azure.ResourceGroupEntityDetails(testContext.Context(), testContext.Graph.Database, primaryDisplayKinds, groupObjectID, true)
 
 			require.Nil(t, err)
 			assert.NotEqual(t, 0, group.InboundObjectControl)
@@ -688,13 +688,13 @@ func TestEntityDetails(t *testing.T) {
 			require.Nil(t, err)
 			assert.NotEqual(t, "", keyVaultObjectID)
 
-			keyVault, err := azure.KeyVaultEntityDetails(testContext.Context(), testContext.Graph.Database, validPrimaryKinds, keyVaultObjectID, false)
+			keyVault, err := azure.KeyVaultEntityDetails(testContext.Context(), testContext.Graph.Database, primaryDisplayKinds, keyVaultObjectID, false)
 
 			require.Nil(t, err)
 			assert.Equal(t, harness.AZEntityPanelHarness.KeyVault.Properties.Get(common.ObjectID.String()).Any(), keyVault.Properties[common.ObjectID.String()])
 			assert.Equal(t, 0, keyVault.InboundObjectControl)
 
-			keyVault, err = azure.KeyVaultEntityDetails(testContext.Context(), testContext.Graph.Database, validPrimaryKinds, keyVaultObjectID, true)
+			keyVault, err = azure.KeyVaultEntityDetails(testContext.Context(), testContext.Graph.Database, primaryDisplayKinds, keyVaultObjectID, true)
 
 			require.Nil(t, err)
 			assert.NotEqual(t, 0, keyVault.InboundObjectControl)
@@ -711,13 +711,13 @@ func TestEntityDetails(t *testing.T) {
 			require.Nil(t, err)
 			assert.NotEqual(t, "", roleObjectID)
 
-			role, err := azure.RoleEntityDetails(testContext.Context(), testContext.Graph.Database, validPrimaryKinds, roleObjectID, false)
+			role, err := azure.RoleEntityDetails(testContext.Context(), testContext.Graph.Database, primaryDisplayKinds, roleObjectID, false)
 
 			require.Nil(t, err)
 			assert.Equal(t, harness.AZEntityPanelHarness.Role.Properties.Get(common.ObjectID.String()).Any(), role.Properties[common.ObjectID.String()])
 			assert.Equal(t, 0, role.ActiveAssignments)
 
-			role, err = azure.RoleEntityDetails(testContext.Context(), testContext.Graph.Database, validPrimaryKinds, roleObjectID, true)
+			role, err = azure.RoleEntityDetails(testContext.Context(), testContext.Graph.Database, primaryDisplayKinds, roleObjectID, true)
 
 			require.Nil(t, err)
 			assert.NotEqual(t, 0, role.ActiveAssignments)
@@ -758,14 +758,14 @@ func TestEntityDetails(t *testing.T) {
 			require.Nil(t, err)
 			assert.NotEqual(t, "", servicePrincipalObjectID)
 
-			servicePrincipal, err := azure.ServicePrincipalEntityDetails(testContext.Context(), testContext.Graph.Database, validPrimaryKinds, servicePrincipalObjectID, false)
+			servicePrincipal, err := azure.ServicePrincipalEntityDetails(testContext.Context(), testContext.Graph.Database, primaryDisplayKinds, servicePrincipalObjectID, false)
 
 			require.Nil(t, err)
 			assert.Equal(t, harness.AZEntityPanelHarness.ServicePrincipal.Properties.Get(common.ObjectID.String()).Any(), servicePrincipal.Properties[common.ObjectID.String()])
 			assert.Equal(t, harness.AZEntityPanelHarness.Application.Properties.Get(common.ObjectID.String()).Any(), servicePrincipal.Properties[graphAzure.AppID.String()])
 			assert.Equal(t, 0, servicePrincipal.InboundObjectControl)
 
-			servicePrincipal, err = azure.ServicePrincipalEntityDetails(testContext.Context(), testContext.Graph.Database, validPrimaryKinds, servicePrincipalObjectID, true)
+			servicePrincipal, err = azure.ServicePrincipalEntityDetails(testContext.Context(), testContext.Graph.Database, primaryDisplayKinds, servicePrincipalObjectID, true)
 
 			require.Nil(t, err)
 			assert.NotEqual(t, 0, servicePrincipal.InboundObjectControl)
@@ -781,13 +781,13 @@ func TestEntityDetails(t *testing.T) {
 			require.Nil(t, err)
 			assert.NotEqual(t, "", subscriptionObjectID)
 
-			subscription, err := azure.SubscriptionEntityDetails(testContext.Context(), testContext.Graph.Database, validPrimaryKinds, subscriptionObjectID, false)
+			subscription, err := azure.SubscriptionEntityDetails(testContext.Context(), testContext.Graph.Database, primaryDisplayKinds, subscriptionObjectID, false)
 
 			require.Nil(t, err)
 			assert.Equal(t, harness.AZEntityPanelHarness.Subscription.Properties.Get(common.ObjectID.String()).Any(), subscription.Properties[common.ObjectID.String()])
 			assert.Equal(t, 0, subscription.InboundObjectControl)
 
-			subscription, err = azure.SubscriptionEntityDetails(testContext.Context(), testContext.Graph.Database, validPrimaryKinds, subscriptionObjectID, true)
+			subscription, err = azure.SubscriptionEntityDetails(testContext.Context(), testContext.Graph.Database, primaryDisplayKinds, subscriptionObjectID, true)
 
 			require.Nil(t, err)
 			assert.NotEqual(t, 0, subscription.InboundObjectControl)
@@ -803,13 +803,13 @@ func TestEntityDetails(t *testing.T) {
 			require.Nil(t, err)
 			assert.NotEqual(t, "", tenantObjectID)
 
-			tenant, err := azure.TenantEntityDetails(testContext.Context(), testContext.Graph.Database, validPrimaryKinds, tenantObjectID, false)
+			tenant, err := azure.TenantEntityDetails(testContext.Context(), testContext.Graph.Database, primaryDisplayKinds, tenantObjectID, false)
 
 			require.Nil(t, err)
 			assert.Equal(t, harness.AZEntityPanelHarness.Tenant.Properties.Get(common.ObjectID.String()).Any(), tenant.Properties[common.ObjectID.String()])
 			assert.Equal(t, 0, tenant.InboundObjectControl)
 
-			tenant, err = azure.TenantEntityDetails(testContext.Context(), testContext.Graph.Database, validPrimaryKinds, tenantObjectID, true)
+			tenant, err = azure.TenantEntityDetails(testContext.Context(), testContext.Graph.Database, primaryDisplayKinds, tenantObjectID, true)
 
 			require.Nil(t, err)
 			assert.NotEqual(t, 0, tenant.InboundObjectControl)
@@ -825,13 +825,13 @@ func TestEntityDetails(t *testing.T) {
 			require.Nil(t, err)
 			assert.NotEqual(t, "", userObjectID)
 
-			user, err := azure.UserEntityDetails(testContext.Context(), testContext.Graph.Database, validPrimaryKinds, userObjectID, false)
+			user, err := azure.UserEntityDetails(testContext.Context(), testContext.Graph.Database, primaryDisplayKinds, userObjectID, false)
 
 			require.Nil(t, err)
 			assert.Equal(t, harness.AZEntityPanelHarness.User.Properties.Get(common.ObjectID.String()).Any(), user.Properties[common.ObjectID.String()])
 			assert.Equal(t, 0, user.OutboundObjectControl)
 
-			user, err = azure.UserEntityDetails(testContext.Context(), testContext.Graph.Database, validPrimaryKinds, userObjectID, true)
+			user, err = azure.UserEntityDetails(testContext.Context(), testContext.Graph.Database, primaryDisplayKinds, userObjectID, true)
 
 			require.Nil(t, err)
 			assert.NotEqual(t, 0, user.OutboundObjectControl)
@@ -847,13 +847,13 @@ func TestEntityDetails(t *testing.T) {
 			require.Nil(t, err)
 			assert.NotEqual(t, "", vmObjectID)
 
-			vm, err := azure.VMEntityDetails(testContext.Context(), testContext.Graph.Database, validPrimaryKinds, vmObjectID, false)
+			vm, err := azure.VMEntityDetails(testContext.Context(), testContext.Graph.Database, primaryDisplayKinds, vmObjectID, false)
 
 			require.Nil(t, err)
 			assert.Equal(t, harness.AZEntityPanelHarness.VM.Properties.Get(common.ObjectID.String()).Any(), vm.Properties[common.ObjectID.String()])
 			assert.Equal(t, 0, vm.InboundObjectControl)
 
-			vm, err = azure.VMEntityDetails(testContext.Context(), testContext.Graph.Database, validPrimaryKinds, vmObjectID, true)
+			vm, err = azure.VMEntityDetails(testContext.Context(), testContext.Graph.Database, primaryDisplayKinds, vmObjectID, true)
 
 			require.Nil(t, err)
 			assert.NotEqual(t, 0, vm.InboundObjectControl)

--- a/packages/go/analysis/azure/base.go
+++ b/packages/go/analysis/azure/base.go
@@ -23,14 +23,14 @@ import (
 	"github.com/specterops/dawgs/graph"
 )
 
-func BaseEntityDetails(ctx context.Context, db graph.Database, validPrimaryKinds graphschema.ValidPrimaryKinds, objectID string, hydrateCounts bool) (BaseDetails, error) {
+func BaseEntityDetails(ctx context.Context, db graph.Database, primaryDisplayKinds graphschema.PrimaryDisplayKinds, objectID string, hydrateCounts bool) (BaseDetails, error) {
 	var details BaseDetails
 
 	return details, db.ReadTransaction(ctx, func(tx graph.Transaction) error {
 		if node, err := FetchEntityByObjectID(tx, objectID); err != nil {
 			return err
 		} else {
-			details.Node = FromGraphNode(validPrimaryKinds, node)
+			details.Node = FromGraphNode(primaryDisplayKinds, node)
 			if hydrateCounts {
 				details, err = PopulateBaseEntityDetailsCounts(tx, node, details)
 			}

--- a/packages/go/analysis/azure/container_registry.go
+++ b/packages/go/analysis/azure/container_registry.go
@@ -23,14 +23,14 @@ import (
 	"github.com/specterops/dawgs/graph"
 )
 
-func ContainerRegistryEntityDetails(ctx context.Context, db graph.Database, validPrimaryKinds graphschema.ValidPrimaryKinds, objectID string, hydrateCounts bool) (ContainerRegistryDetails, error) {
+func ContainerRegistryEntityDetails(ctx context.Context, db graph.Database, primaryDisplayKinds graphschema.PrimaryDisplayKinds, objectID string, hydrateCounts bool) (ContainerRegistryDetails, error) {
 	var details ContainerRegistryDetails
 
 	return details, db.ReadTransaction(ctx, func(tx graph.Transaction) error {
 		if node, err := FetchEntityByObjectID(tx, objectID); err != nil {
 			return err
 		} else {
-			details.Node = FromGraphNode(validPrimaryKinds, node)
+			details.Node = FromGraphNode(primaryDisplayKinds, node)
 			if hydrateCounts {
 				details, err = PopulateContainerRegistryEntityDetailsCounts(tx, node, details)
 			}

--- a/packages/go/analysis/azure/device.go
+++ b/packages/go/analysis/azure/device.go
@@ -23,14 +23,14 @@ import (
 	"github.com/specterops/dawgs/graph"
 )
 
-func DeviceEntityDetails(ctx context.Context, db graph.Database, validPrimaryKinds graphschema.ValidPrimaryKinds, objectID string, hydrateCounts bool) (DeviceDetails, error) {
+func DeviceEntityDetails(ctx context.Context, db graph.Database, primaryDisplayKinds graphschema.PrimaryDisplayKinds, objectID string, hydrateCounts bool) (DeviceDetails, error) {
 	var details DeviceDetails
 
 	return details, db.ReadTransaction(ctx, func(tx graph.Transaction) error {
 		if node, err := FetchEntityByObjectID(tx, objectID); err != nil {
 			return err
 		} else {
-			details.Node = FromGraphNode(validPrimaryKinds, node)
+			details.Node = FromGraphNode(primaryDisplayKinds, node)
 			if hydrateCounts {
 				if details, err = populateDeviceEntityDetailsCounts(tx, node, details); err != nil {
 					return err

--- a/packages/go/analysis/azure/federated_identity_credentials.go
+++ b/packages/go/analysis/azure/federated_identity_credentials.go
@@ -28,14 +28,14 @@ import (
 	"github.com/specterops/dawgs/query"
 )
 
-func FederatedIdentityCredentialEntityDetails(ctx context.Context, db graph.Database, validPrimaryKinds graphschema.ValidPrimaryKinds, objectID string, hydrateCounts bool) (FederatedIdentityCredentialDetails, error) {
+func FederatedIdentityCredentialEntityDetails(ctx context.Context, db graph.Database, primaryDisplayKinds graphschema.PrimaryDisplayKinds, objectID string, hydrateCounts bool) (FederatedIdentityCredentialDetails, error) {
 	var details FederatedIdentityCredentialDetails
 
 	return details, db.ReadTransaction(ctx, func(tx graph.Transaction) error {
 		if node, err := FetchEntityByObjectID(tx, objectID); err != nil {
 			return err
 		} else {
-			details.Node = FromGraphNode(validPrimaryKinds, node)
+			details.Node = FromGraphNode(primaryDisplayKinds, node)
 			if appID, err := getFICAppID(tx, node); err != nil {
 				return err
 			} else {

--- a/packages/go/analysis/azure/function_app.go
+++ b/packages/go/analysis/azure/function_app.go
@@ -23,14 +23,14 @@ import (
 	"github.com/specterops/dawgs/graph"
 )
 
-func FunctionAppEntityDetails(ctx context.Context, db graph.Database, validPrimaryKinds graphschema.ValidPrimaryKinds, objectID string, hydrateCounts bool) (FunctionAppDetails, error) {
+func FunctionAppEntityDetails(ctx context.Context, db graph.Database, primaryDisplayKinds graphschema.PrimaryDisplayKinds, objectID string, hydrateCounts bool) (FunctionAppDetails, error) {
 	var details FunctionAppDetails
 
 	return details, db.ReadTransaction(ctx, func(tx graph.Transaction) error {
 		if node, err := FetchEntityByObjectID(tx, objectID); err != nil {
 			return err
 		} else {
-			details.Node = FromGraphNode(validPrimaryKinds, node)
+			details.Node = FromGraphNode(primaryDisplayKinds, node)
 			if hydrateCounts {
 				details, err = PopulateFunctionAppEntityDetailsCounts(tx, node, details)
 			}

--- a/packages/go/analysis/azure/group.go
+++ b/packages/go/analysis/azure/group.go
@@ -23,14 +23,14 @@ import (
 	"github.com/specterops/dawgs/graph"
 )
 
-func GroupEntityDetails(ctx context.Context, db graph.Database, validPrimaryKinds graphschema.ValidPrimaryKinds, objectID string, hydrateCounts bool) (GroupDetails, error) {
+func GroupEntityDetails(ctx context.Context, db graph.Database, primaryDisplayKinds graphschema.PrimaryDisplayKinds, objectID string, hydrateCounts bool) (GroupDetails, error) {
 	var details GroupDetails
 
 	return details, db.ReadTransaction(ctx, func(tx graph.Transaction) error {
 		if node, err := FetchEntityByObjectID(tx, objectID); err != nil {
 			return err
 		} else {
-			details.Node = FromGraphNode(validPrimaryKinds, node)
+			details.Node = FromGraphNode(primaryDisplayKinds, node)
 			if hydrateCounts {
 				details, err = PopulateGroupEntityDetailsCounts(tx, node, details)
 			}

--- a/packages/go/analysis/azure/key_vault.go
+++ b/packages/go/analysis/azure/key_vault.go
@@ -23,14 +23,14 @@ import (
 	"github.com/specterops/dawgs/graph"
 )
 
-func KeyVaultEntityDetails(ctx context.Context, db graph.Database, validPrimaryKinds graphschema.ValidPrimaryKinds, objectID string, hydrateCounts bool) (KeyVaultDetails, error) {
+func KeyVaultEntityDetails(ctx context.Context, db graph.Database, primaryDisplayKinds graphschema.PrimaryDisplayKinds, objectID string, hydrateCounts bool) (KeyVaultDetails, error) {
 	var details KeyVaultDetails
 
 	return details, db.ReadTransaction(ctx, func(tx graph.Transaction) error {
 		if node, err := FetchEntityByObjectID(tx, objectID); err != nil {
 			return err
 		} else {
-			details.Node = FromGraphNode(validPrimaryKinds, node)
+			details.Node = FromGraphNode(primaryDisplayKinds, node)
 			if hydrateCounts {
 				details, err = PopulateKeyVaultEntityDetailsCounts(tx, node, details)
 			}

--- a/packages/go/analysis/azure/logic_app.go
+++ b/packages/go/analysis/azure/logic_app.go
@@ -23,14 +23,14 @@ import (
 	"github.com/specterops/dawgs/graph"
 )
 
-func LogicAppEntityDetails(ctx context.Context, db graph.Database, validPrimaryKinds graphschema.ValidPrimaryKinds, objectID string, hydrateCounts bool) (LogicAppDetails, error) {
+func LogicAppEntityDetails(ctx context.Context, db graph.Database, primaryDisplayKinds graphschema.PrimaryDisplayKinds, objectID string, hydrateCounts bool) (LogicAppDetails, error) {
 	var details LogicAppDetails
 
 	return details, db.ReadTransaction(ctx, func(tx graph.Transaction) error {
 		if node, err := FetchEntityByObjectID(tx, objectID); err != nil {
 			return err
 		} else {
-			details.Node = FromGraphNode(validPrimaryKinds, node)
+			details.Node = FromGraphNode(primaryDisplayKinds, node)
 			if hydrateCounts {
 				details, err = PopulateLogicAppEntityDetailsCounts(tx, node, details)
 			}

--- a/packages/go/analysis/azure/managed_cluster.go
+++ b/packages/go/analysis/azure/managed_cluster.go
@@ -23,14 +23,14 @@ import (
 	"github.com/specterops/dawgs/graph"
 )
 
-func ManagedClusterEntityDetails(ctx context.Context, db graph.Database, validPrimaryKinds graphschema.ValidPrimaryKinds, objectID string, hydrateCounts bool) (ManagedClusterDetails, error) {
+func ManagedClusterEntityDetails(ctx context.Context, db graph.Database, primaryDisplayKinds graphschema.PrimaryDisplayKinds, objectID string, hydrateCounts bool) (ManagedClusterDetails, error) {
 	var details ManagedClusterDetails
 
 	return details, db.ReadTransaction(ctx, func(tx graph.Transaction) error {
 		if node, err := FetchEntityByObjectID(tx, objectID); err != nil {
 			return err
 		} else {
-			details.Node = FromGraphNode(validPrimaryKinds, node)
+			details.Node = FromGraphNode(primaryDisplayKinds, node)
 			if hydrateCounts {
 				details, err = managedClusterEntityDetails(tx, node, details)
 			}

--- a/packages/go/analysis/azure/management_group.go
+++ b/packages/go/analysis/azure/management_group.go
@@ -26,14 +26,14 @@ import (
 	"github.com/specterops/dawgs/query"
 )
 
-func ManagementGroupEntityDetails(ctx context.Context, db graph.Database, validPrimaryKinds graphschema.ValidPrimaryKinds, objectID string, hydrateCounts bool) (ManagementGroupDetails, error) {
+func ManagementGroupEntityDetails(ctx context.Context, db graph.Database, primaryDisplayKinds graphschema.PrimaryDisplayKinds, objectID string, hydrateCounts bool) (ManagementGroupDetails, error) {
 	var details ManagementGroupDetails
 
 	return details, db.ReadTransaction(ctx, func(tx graph.Transaction) error {
 		if node, err := FetchEntityByObjectID(tx, objectID); err != nil {
 			return err
 		} else {
-			details.Node = FromGraphNode(validPrimaryKinds, node)
+			details.Node = FromGraphNode(primaryDisplayKinds, node)
 			if hydrateCounts {
 				details, err = PopulateManagementGroupEntityDetailsCounts(tx, node, details)
 			}

--- a/packages/go/analysis/azure/model.go
+++ b/packages/go/analysis/azure/model.go
@@ -66,7 +66,7 @@ const (
 )
 
 // FromGraphNodes takes a slice of *graph.Node and converts them to serializable node structs.
-func FromGraphNodes(primaryNodeKinds graphschema.ValidPrimaryKinds, nodes []*graph.Node) []Node {
+func FromGraphNodes(primaryNodeKinds graphschema.PrimaryDisplayKinds, nodes []*graph.Node) []Node {
 	renderedNodes := make([]Node, len(nodes))
 
 	for idx, node := range nodes {
@@ -77,7 +77,7 @@ func FromGraphNodes(primaryNodeKinds graphschema.ValidPrimaryKinds, nodes []*gra
 }
 
 // FromGraphNode takes a *graph.Node and converts it to serializable node struct.
-func FromGraphNode(primaryNodeKinds graphschema.ValidPrimaryKinds, node *graph.Node) Node {
+func FromGraphNode(primaryNodeKinds graphschema.PrimaryDisplayKinds, node *graph.Node) Node {
 	return Node{
 		Kind:          graphschema.GetNodeKindDisplayLabel(primaryNodeKinds, node),
 		Kinds:         node.Kinds.Strings(),

--- a/packages/go/analysis/azure/resource_group.go
+++ b/packages/go/analysis/azure/resource_group.go
@@ -24,14 +24,14 @@ import (
 	"github.com/specterops/dawgs/graph"
 )
 
-func ResourceGroupEntityDetails(ctx context.Context, db graph.Database, validPrimaryKinds graphschema.ValidPrimaryKinds, objectID string, hydrateCounts bool) (ResourceGroupDetails, error) {
+func ResourceGroupEntityDetails(ctx context.Context, db graph.Database, primaryDisplayKinds graphschema.PrimaryDisplayKinds, objectID string, hydrateCounts bool) (ResourceGroupDetails, error) {
 	var details ResourceGroupDetails
 
 	return details, db.ReadTransaction(ctx, func(tx graph.Transaction) error {
 		if node, err := FetchEntityByObjectID(tx, objectID); err != nil {
 			return err
 		} else {
-			details.Node = FromGraphNode(validPrimaryKinds, node)
+			details.Node = FromGraphNode(primaryDisplayKinds, node)
 			if hydrateCounts {
 				details, err = PopulateResourceGroupEntityDetailsCounts(tx, node, details)
 			}

--- a/packages/go/analysis/azure/role.go
+++ b/packages/go/analysis/azure/role.go
@@ -31,14 +31,14 @@ import (
 	"github.com/specterops/dawgs/query"
 )
 
-func RoleEntityDetails(ctx context.Context, db graph.Database, validPrimaryKinds graphschema.ValidPrimaryKinds, objectID string, hydrateCounts bool) (RoleDetails, error) {
+func RoleEntityDetails(ctx context.Context, db graph.Database, primaryDisplayKinds graphschema.PrimaryDisplayKinds, objectID string, hydrateCounts bool) (RoleDetails, error) {
 	var details RoleDetails
 
 	return details, db.ReadTransaction(ctx, func(tx graph.Transaction) error {
 		if node, err := FetchEntityByObjectID(tx, objectID); err != nil {
 			return err
 		} else {
-			details.Node = FromGraphNode(validPrimaryKinds, node)
+			details.Node = FromGraphNode(primaryDisplayKinds, node)
 			if hydrateCounts {
 				if details, err = PopulateRoleEntityApprovers(tx, node, details); err != nil {
 					return err

--- a/packages/go/analysis/azure/service_principal.go
+++ b/packages/go/analysis/azure/service_principal.go
@@ -28,14 +28,14 @@ import (
 	"github.com/specterops/dawgs/graph"
 )
 
-func ServicePrincipalEntityDetails(ctx context.Context, db graph.Database, validPrimaryKinds graphschema.ValidPrimaryKinds, objectID string, hydrateCounts bool) (ServicePrincipalDetails, error) {
+func ServicePrincipalEntityDetails(ctx context.Context, db graph.Database, primaryDisplayKinds graphschema.PrimaryDisplayKinds, objectID string, hydrateCounts bool) (ServicePrincipalDetails, error) {
 	var details ServicePrincipalDetails
 
 	return details, db.ReadTransaction(ctx, func(tx graph.Transaction) error {
 		if node, err := FetchEntityByObjectID(tx, objectID); err != nil {
 			return err
 		} else {
-			details.Node = FromGraphNode(validPrimaryKinds, node)
+			details.Node = FromGraphNode(primaryDisplayKinds, node)
 			if appID, err := getServicePrincipalAppID(tx, node); err != nil {
 				return err
 			} else {

--- a/packages/go/analysis/azure/subscription.go
+++ b/packages/go/analysis/azure/subscription.go
@@ -24,14 +24,14 @@ import (
 	"github.com/specterops/dawgs/graph"
 )
 
-func SubscriptionEntityDetails(ctx context.Context, db graph.Database, validPrimaryKinds graphschema.ValidPrimaryKinds, objectID string, hydrateCounts bool) (SubscriptionDetails, error) {
+func SubscriptionEntityDetails(ctx context.Context, db graph.Database, primaryDisplayKinds graphschema.PrimaryDisplayKinds, objectID string, hydrateCounts bool) (SubscriptionDetails, error) {
 	var details SubscriptionDetails
 
 	return details, db.ReadTransaction(ctx, func(tx graph.Transaction) error {
 		if node, err := FetchEntityByObjectID(tx, objectID); err != nil {
 			return err
 		} else {
-			details.Node = FromGraphNode(validPrimaryKinds, node)
+			details.Node = FromGraphNode(primaryDisplayKinds, node)
 			if hydrateCounts {
 				details, err = PopulateSubscriptionEntityDetailsCounts(tx, node, details)
 			}

--- a/packages/go/analysis/azure/tenant.go
+++ b/packages/go/analysis/azure/tenant.go
@@ -29,14 +29,14 @@ import (
 	"github.com/specterops/dawgs/query"
 )
 
-func TenantEntityDetails(ctx context.Context, db graph.Database, validPrimaryKinds graphschema.ValidPrimaryKinds, objectID string, hydrateCounts bool) (TenantDetails, error) {
+func TenantEntityDetails(ctx context.Context, db graph.Database, primaryDisplayKinds graphschema.PrimaryDisplayKinds, objectID string, hydrateCounts bool) (TenantDetails, error) {
 	var details TenantDetails
 
 	return details, db.ReadTransaction(ctx, func(tx graph.Transaction) error {
 		if node, err := FetchEntityByObjectID(tx, objectID); err != nil {
 			return err
 		} else {
-			details.Node = FromGraphNode(validPrimaryKinds, node)
+			details.Node = FromGraphNode(primaryDisplayKinds, node)
 			if hydrateCounts {
 				details, err = PopulateTenantEntityDetailsCounts(tx, node, details)
 			}

--- a/packages/go/analysis/azure/user.go
+++ b/packages/go/analysis/azure/user.go
@@ -23,14 +23,14 @@ import (
 	"github.com/specterops/dawgs/graph"
 )
 
-func UserEntityDetails(ctx context.Context, db graph.Database, validPrimaryKinds graphschema.ValidPrimaryKinds, objectID string, hydrateCounts bool) (UserDetails, error) {
+func UserEntityDetails(ctx context.Context, db graph.Database, primaryDisplayKinds graphschema.PrimaryDisplayKinds, objectID string, hydrateCounts bool) (UserDetails, error) {
 	var details UserDetails
 
 	return details, db.ReadTransaction(ctx, func(tx graph.Transaction) error {
 		if node, err := FetchEntityByObjectID(tx, objectID); err != nil {
 			return err
 		} else {
-			details.Node = FromGraphNode(validPrimaryKinds, node)
+			details.Node = FromGraphNode(primaryDisplayKinds, node)
 			if hydrateCounts {
 				details, err = PopulateUserEntityDetailsCounts(tx, node, details)
 			}

--- a/packages/go/analysis/azure/vm.go
+++ b/packages/go/analysis/azure/vm.go
@@ -23,14 +23,14 @@ import (
 	"github.com/specterops/dawgs/graph"
 )
 
-func VMEntityDetails(ctx context.Context, db graph.Database, validPrimaryKinds graphschema.ValidPrimaryKinds, objectID string, hydrateCounts bool) (VMDetails, error) {
+func VMEntityDetails(ctx context.Context, db graph.Database, primaryDisplayKinds graphschema.PrimaryDisplayKinds, objectID string, hydrateCounts bool) (VMDetails, error) {
 	var details VMDetails
 
 	return details, db.ReadTransaction(ctx, func(tx graph.Transaction) error {
 		if node, err := FetchEntityByObjectID(tx, objectID); err != nil {
 			return err
 		} else {
-			details.Node = FromGraphNode(validPrimaryKinds, node)
+			details.Node = FromGraphNode(primaryDisplayKinds, node)
 			if hydrateCounts {
 				details, err = vmEntityDetails(tx, node, details)
 			}

--- a/packages/go/analysis/azure/vm_scale_set.go
+++ b/packages/go/analysis/azure/vm_scale_set.go
@@ -23,14 +23,14 @@ import (
 	"github.com/specterops/dawgs/graph"
 )
 
-func VMScaleSetEntityDetails(ctx context.Context, db graph.Database, validPrimaryKinds graphschema.ValidPrimaryKinds, objectID string, hydrateCounts bool) (VMScaleSetDetails, error) {
+func VMScaleSetEntityDetails(ctx context.Context, db graph.Database, primaryDisplayKinds graphschema.PrimaryDisplayKinds, objectID string, hydrateCounts bool) (VMScaleSetDetails, error) {
 	var details VMScaleSetDetails
 
 	return details, db.ReadTransaction(ctx, func(tx graph.Transaction) error {
 		if node, err := FetchEntityByObjectID(tx, objectID); err != nil {
 			return err
 		} else {
-			details.Node = FromGraphNode(validPrimaryKinds, node)
+			details.Node = FromGraphNode(primaryDisplayKinds, node)
 			if hydrateCounts {
 				details, err = vmssEntityDetails(tx, node, details)
 			}

--- a/packages/go/analysis/azure/web_app.go
+++ b/packages/go/analysis/azure/web_app.go
@@ -23,14 +23,14 @@ import (
 	"github.com/specterops/dawgs/graph"
 )
 
-func WebAppEntityDetails(ctx context.Context, db graph.Database, validPrimaryKinds graphschema.ValidPrimaryKinds, objectID string, hydrateCounts bool) (WebAppDetails, error) {
+func WebAppEntityDetails(ctx context.Context, db graph.Database, primaryDisplayKinds graphschema.PrimaryDisplayKinds, objectID string, hydrateCounts bool) (WebAppDetails, error) {
 	var details WebAppDetails
 
 	return details, db.ReadTransaction(ctx, func(tx graph.Transaction) error {
 		if node, err := FetchEntityByObjectID(tx, objectID); err != nil {
 			return err
 		} else {
-			details.Node = FromGraphNode(validPrimaryKinds, node)
+			details.Node = FromGraphNode(primaryDisplayKinds, node)
 			if hydrateCounts {
 				details, err = webappEntityDetails(tx, node, details)
 			}

--- a/packages/go/graphschema/primarykind.go
+++ b/packages/go/graphschema/primarykind.go
@@ -60,23 +60,29 @@ func buildValidKinds() ValidPrimaryKinds {
 	return validKinds
 }
 
-type DisplayKindIcon struct {
-	Type  string
-	Name  string
-	Color string
+type DisplayNodeType string
+
+const (
+	DisplayNodeTypeFontAwesome DisplayNodeType = "font-awesome"
+)
+
+type DisplayNodeIcon struct {
+	Type  DisplayNodeType `json:"type"`
+	Name  string          `json:"name"`
+	Color string          `json:"color"`
 }
 
 type DisplayKind struct {
 	Name string
-	Icon DisplayKindIcon
+	Icon DisplayNodeIcon
 }
 
 type ValidPrimaryKinds map[graph.Kind]DisplayKind
 
-func (s ValidPrimaryKinds) Add(kindName, iconName, iconColor, iconType string) {
+func (s ValidPrimaryKinds) Add(kindName, iconName, iconColor string, iconType DisplayNodeType) {
 	s[graph.StringKind(kindName)] = DisplayKind{
 		Name: kindName,
-		Icon: DisplayKindIcon{
+		Icon: DisplayNodeIcon{
 			Type:  iconType,
 			Name:  iconName,
 			Color: iconColor,

--- a/packages/go/graphschema/primarykind.go
+++ b/packages/go/graphschema/primarykind.go
@@ -38,9 +38,9 @@ var (
 	ValidKinds = buildValidKinds()
 )
 
-func buildValidKinds() ValidPrimaryKinds {
+func buildValidKinds() PrimaryDisplayKinds {
 	var (
-		validKinds = make(ValidPrimaryKinds)
+		validKinds = make(PrimaryDisplayKinds)
 		kindSlices = []graph.Kinds{
 			ad.NodeKinds(),
 			ad.Relationships(),
@@ -77,9 +77,9 @@ type DisplayKind struct {
 	Icon DisplayNodeIcon
 }
 
-type ValidPrimaryKinds map[graph.Kind]DisplayKind
+type PrimaryDisplayKinds map[graph.Kind]DisplayKind
 
-func (s ValidPrimaryKinds) Add(kindName, iconName, iconColor string, iconType DisplayNodeType) {
+func (s PrimaryDisplayKinds) Add(kindName, iconName, iconColor string, iconType DisplayNodeType) {
 	s[graph.StringKind(kindName)] = DisplayKind{
 		Name: kindName,
 		Icon: DisplayNodeIcon{
@@ -90,23 +90,23 @@ func (s ValidPrimaryKinds) Add(kindName, iconName, iconColor string, iconType Di
 	}
 }
 
-// PrimaryNodeKind - tests if the provided kinds contain a primary or meta kind.
+// PrimaryDisplayKind - tests if the provided kinds contain a primary or meta kind.
 //
-// It accepts a validPrimaryKinds map[graph.Kind]bool that contains valid primary kinds.
+// It accepts a primaryDisplayKinds map[graph.Kind]bool that contains valid primary kinds.
 // This allows devs to validate kinds against an OpenGraph extension's kinds.
 // It will return the first meta kind or the first primary kind it finds. During processing, if
 // a source kind is found it will set the base kind to the source kind. If a primary/meta kind is not
 // found, it will return the base kind which will be the "unknown" kind if no known base kinds are
 // present.
-func PrimaryNodeKind(validPrimaryKinds ValidPrimaryKinds, kinds graph.Kinds) graph.Kind {
+func PrimaryDisplayKind(primaryDisplayKinds PrimaryDisplayKinds, kinds graph.Kinds) graph.Kind {
 	var (
 		resultKind = UnknownKind
 		baseKind   = resultKind
 	)
 
-	if validPrimaryKinds == nil {
-		slog.Warn("PrimaryNodeKind: validPrimaryKinds is nil")
-		validPrimaryKinds = ValidKinds
+	if primaryDisplayKinds == nil {
+		slog.Warn("PrimaryDisplayKind: primaryDisplayKinds is nil")
+		primaryDisplayKinds = ValidKinds
 	}
 
 	for _, kind := range kinds {
@@ -120,7 +120,7 @@ func PrimaryNodeKind(validPrimaryKinds ValidPrimaryKinds, kinds graph.Kinds) gra
 			if resultKind == UnknownKind {
 				resultKind = kind
 			}
-		} else if _, ok := validPrimaryKinds[kind]; ok {
+		} else if _, ok := primaryDisplayKinds[kind]; ok {
 			return kind
 		}
 	}
@@ -132,11 +132,11 @@ func PrimaryNodeKind(validPrimaryKinds ValidPrimaryKinds, kinds graph.Kinds) gra
 	}
 }
 
-func GetNodeKindDisplayLabel(validPrimaryKinds ValidPrimaryKinds, node *graph.Node) string {
-	return GetNodeKind(validPrimaryKinds, node).String()
+func GetNodeKindDisplayLabel(primaryDisplayKinds PrimaryDisplayKinds, node *graph.Node) string {
+	return GetNodeKind(primaryDisplayKinds, node).String()
 }
 
 // GetNodeKind - returns the primary kind of the node.
-func GetNodeKind(validPrimaryKinds ValidPrimaryKinds, node *graph.Node) graph.Kind {
-	return PrimaryNodeKind(validPrimaryKinds, node.Kinds)
+func GetNodeKind(primaryDisplayKinds PrimaryDisplayKinds, node *graph.Node) graph.Kind {
+	return PrimaryDisplayKind(primaryDisplayKinds, node.Kinds)
 }

--- a/packages/go/graphschema/primarykind.go
+++ b/packages/go/graphschema/primarykind.go
@@ -17,6 +17,8 @@
 package graphschema
 
 import (
+	"log/slog"
+
 	"github.com/specterops/bloodhound/packages/go/graphschema/ad"
 	"github.com/specterops/bloodhound/packages/go/graphschema/azure"
 	"github.com/specterops/bloodhound/packages/go/graphschema/common"
@@ -58,7 +60,29 @@ func buildValidKinds() map[graph.Kind]bool {
 	return validKinds
 }
 
-type ValidPrimaryKinds map[graph.Kind]bool
+type DisplayKindIcon struct {
+	Type  string
+	Name  string
+	Color string
+}
+
+type DisplayKind struct {
+	Name string
+	Icon DisplayKindIcon
+}
+
+type ValidPrimaryKinds map[graph.Kind]DisplayKind
+
+func (s ValidPrimaryKinds) Add(kindName, iconName, iconColor, iconType string) {
+	s[graph.StringKind(kindName)] = DisplayKind{
+		Name: kindName,
+		Icon: DisplayKindIcon{
+			Type:  iconType,
+			Name:  iconName,
+			Color: iconColor,
+		},
+	}
+}
 
 // PrimaryNodeKind - tests if the provided kinds contain a primary or meta kind.
 //
@@ -75,7 +99,7 @@ func PrimaryNodeKind(validPrimaryKinds ValidPrimaryKinds, kinds graph.Kinds) gra
 	)
 
 	if validPrimaryKinds == nil {
-		validPrimaryKinds = ValidKinds
+		slog.Error("PrimaryNodeKind: validPrimaryKinds is nil")
 	}
 
 	for _, kind := range kinds {
@@ -89,7 +113,7 @@ func PrimaryNodeKind(validPrimaryKinds ValidPrimaryKinds, kinds graph.Kinds) gra
 			if resultKind == UnknownKind {
 				resultKind = kind
 			}
-		} else if validPrimaryKinds[kind] {
+		} else if _, ok := validPrimaryKinds[kind]; ok {
 			return kind
 		}
 	}

--- a/packages/go/graphschema/primarykind.go
+++ b/packages/go/graphschema/primarykind.go
@@ -38,9 +38,9 @@ var (
 	ValidKinds = buildValidKinds()
 )
 
-func buildValidKinds() map[graph.Kind]bool {
+func buildValidKinds() ValidPrimaryKinds {
 	var (
-		validKinds = make(map[graph.Kind]bool)
+		validKinds = make(ValidPrimaryKinds)
 		kindSlices = []graph.Kinds{
 			ad.NodeKinds(),
 			ad.Relationships(),
@@ -53,7 +53,7 @@ func buildValidKinds() map[graph.Kind]bool {
 
 	for _, kindSlice := range kindSlices {
 		for _, kind := range kindSlice {
-			validKinds[kind] = true
+			validKinds[kind] = DisplayKind{}
 		}
 	}
 
@@ -99,7 +99,8 @@ func PrimaryNodeKind(validPrimaryKinds ValidPrimaryKinds, kinds graph.Kinds) gra
 	)
 
 	if validPrimaryKinds == nil {
-		slog.Error("PrimaryNodeKind: validPrimaryKinds is nil")
+		slog.Warn("PrimaryNodeKind: validPrimaryKinds is nil")
+		validPrimaryKinds = ValidKinds
 	}
 
 	for _, kind := range kinds {

--- a/packages/go/graphschema/primarykind.go
+++ b/packages/go/graphschema/primarykind.go
@@ -17,8 +17,6 @@
 package graphschema
 
 import (
-	"log/slog"
-
 	"github.com/specterops/bloodhound/packages/go/graphschema/ad"
 	"github.com/specterops/bloodhound/packages/go/graphschema/azure"
 	"github.com/specterops/bloodhound/packages/go/graphschema/common"
@@ -105,7 +103,6 @@ func PrimaryDisplayKind(primaryDisplayKinds PrimaryDisplayKinds, kinds graph.Kin
 	)
 
 	if primaryDisplayKinds == nil {
-		slog.Warn("PrimaryDisplayKind: primaryDisplayKinds is nil")
 		primaryDisplayKinds = ValidKinds
 	}
 

--- a/packages/go/graphschema/primarykind.go
+++ b/packages/go/graphschema/primarykind.go
@@ -92,7 +92,7 @@ func (s PrimaryDisplayKinds) Add(kindName, iconName, iconColor string, iconType 
 
 // PrimaryDisplayKind - tests if the provided kinds contain a primary or meta kind.
 //
-// It accepts a primaryDisplayKinds map[graph.Kind]bool that contains valid primary kinds.
+// It accepts a primaryDisplayKinds map[graph.Kind]DisplayKind that contains primary display kinds.
 // This allows devs to validate kinds against an OpenGraph extension's kinds.
 // It will return the first meta kind or the first primary kind it finds. During processing, if
 // a source kind is found it will set the base kind to the source kind. If a primary/meta kind is not

--- a/packages/go/graphschema/primarykind_test.go
+++ b/packages/go/graphschema/primarykind_test.go
@@ -27,32 +27,32 @@ import (
 func Test_PrimaryNodeKind(t *testing.T) {
 
 	t.Run("detects meta kinds", func(t *testing.T) {
-		primaryKind := PrimaryNodeKind(nil, graph.Kinds{meta})
+		primaryKind := PrimaryDisplayKind(nil, graph.Kinds{meta})
 		require.Equal(t, meta, primaryKind)
 	})
 
 	t.Run("ad local group overrides unknown", func(t *testing.T) {
-		primaryKind := PrimaryNodeKind(nil, graph.Kinds{ad.Entity, ad.LocalGroup})
+		primaryKind := PrimaryDisplayKind(nil, graph.Kinds{ad.Entity, ad.LocalGroup})
 		require.Equal(t, ad.LocalGroup, primaryKind)
 	})
 
 	t.Run("detects valid kind", func(t *testing.T) {
-		primaryKind := PrimaryNodeKind(nil, graph.Kinds{ad.Entity, ad.Computer})
+		primaryKind := PrimaryDisplayKind(nil, graph.Kinds{ad.Entity, ad.Computer})
 		require.Equal(t, ad.Computer, primaryKind)
 	})
 
 	t.Run("falls back to base kind if no valid kinds", func(t *testing.T) {
-		primaryKind := PrimaryNodeKind(nil, graph.Kinds{ad.Entity, graph.StringKind("Villain")})
+		primaryKind := PrimaryDisplayKind(nil, graph.Kinds{ad.Entity, graph.StringKind("Villain")})
 		require.Equal(t, ad.Entity, primaryKind)
 	})
 
 	t.Run("falls back to unknown if nothing detected", func(t *testing.T) {
-		primaryKind := PrimaryNodeKind(nil, graph.Kinds{graph.StringKind("Hero")})
+		primaryKind := PrimaryDisplayKind(nil, graph.Kinds{graph.StringKind("Hero")})
 		require.Equal(t, UnknownKind, primaryKind)
 	})
 
 	t.Run("returns the first valid kind in the kinds array", func(t *testing.T) {
-		primaryKind := PrimaryNodeKind(ValidPrimaryKinds{
+		primaryKind := PrimaryDisplayKind(PrimaryDisplayKinds{
 			graph.StringKind("Hero"):    DisplayKind{},
 			graph.StringKind("Villain"): DisplayKind{},
 		}, graph.Kinds{graph.StringKind("Hero"), graph.StringKind("Villain")})

--- a/packages/go/graphschema/primarykind_test.go
+++ b/packages/go/graphschema/primarykind_test.go
@@ -53,8 +53,8 @@ func Test_PrimaryNodeKind(t *testing.T) {
 
 	t.Run("returns the first valid kind in the kinds array", func(t *testing.T) {
 		primaryKind := PrimaryNodeKind(ValidPrimaryKinds{
-			graph.StringKind("Hero"):    true,
-			graph.StringKind("Villain"): true,
+			graph.StringKind("Hero"):    DisplayKind{},
+			graph.StringKind("Villain"): DisplayKind{},
 		}, graph.Kinds{graph.StringKind("Hero"), graph.StringKind("Villain")})
 		require.Equal(t, graph.StringKind("Hero"), primaryKind)
 	})


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

*Describe your changes in detail*
- Cleans up customNodeKinds
- Slots customNodeKinds into validPrimaryKinds to ensure they are never decoupled
- Swaps validPrimaryKind map to carry icon information to further simplify

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-7920

*Why is this change required? What problem does it solve?*

## How Has This Been Tested?

*Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc.*

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Unified node display metadata handling by consolidating icon and color resolution from separate schema and custom sources into a single streamlined display kinds system.
  * Simplified database queries for node display properties, reducing the number of lookups needed to render node icons and labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->