### PR TITLE
docs: Update clear-database documentation to match latest implementation BED-7931

### DIFF
--- a/packages/go/openapi/doc/openapi.json
+++ b/packages/go/openapi/doc/openapi.json
@@ -13867,22 +13867,34 @@
                 "type": "object",
                 "properties": {
                   "deleteCollectedGraphData": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "When true, deletes all collected graph nodes and edges. Cannot be combined with deleteSourceKinds or deleteRelationships.\n"
+                  },
+                  "deleteSourceKinds": {
+                    "type": "array",
+                    "description": "A list of source kind IDs (from the source_kinds table) whose associated graph nodes and source kind records will be deleted. Use 0 as a special value to delete all \"sourceless\" nodes - nodes that exist in the graph but are not attributed to any source kind. Non-existent IDs will result in a 400 error.\n",
+                    "items": {
+                      "type": "integer"
+                    }
                   },
                   "deleteRelationships": {
                     "type": "array",
+                    "description": "A list of relationship kind names (e.g. \"HasSession\") whose edges will be deleted from the graph. Each value must be a valid, known relationship kind. Cannot be combined with deleteCollectedGraphData.\n",
                     "items": {
                       "type": "string"
                     }
                   },
                   "deleteFileIngestHistory": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "When true, deletes all file ingest job history records."
                   },
                   "deleteDataQualityHistory": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "When true, deletes all data quality history records."
                   },
                   "deleteAssetGroupSelectors": {
                     "type": "array",
+                    "description": "A list of asset group IDs whose custom selectors will be deleted. Triggers a re-analysis after deletion.\n",
                     "items": {
                       "type": "integer"
                     }

--- a/packages/go/openapi/src/paths/data-quality.clear-database.yaml
+++ b/packages/go/openapi/src/paths/data-quality.clear-database.yaml
@@ -35,16 +35,35 @@ post:
           properties:
             deleteCollectedGraphData:
               type: boolean
+              description: >
+                When true, deletes all collected graph nodes and edges. Cannot be combined with
+                deleteSourceKinds or deleteRelationships.
+            deleteSourceKinds:
+              type: array
+              description: >
+                A list of source kind IDs (from the source_kinds table) whose associated graph nodes and source kind
+                records will be deleted. Use 0 as a special value to delete all "sourceless" nodes - nodes
+                that exist in the graph but are not attributed to any source kind. Non-existent IDs will result in a 400 error.
+              items:
+                type: integer
             deleteRelationships:
               type: array
+              description: >
+                A list of relationship kind names (e.g. "HasSession") whose edges will be deleted from the graph.
+                Each value must be a valid, known relationship kind. Cannot be combined with deleteCollectedGraphData.
               items:
                 type: string
             deleteFileIngestHistory:
               type: boolean
+              description: When true, deletes all file ingest job history records.
             deleteDataQualityHistory:
               type: boolean
+              description: When true, deletes all data quality history records.
             deleteAssetGroupSelectors:
               type: array
+              description: >
+                A list of asset group IDs whose custom selectors will be deleted.
+                Triggers a re-analysis after deletion.
               items:
                 type: integer
   responses:


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Docs only update to update the clear-database endpoint to match latest implementation. 

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves https://specterops.atlassian.net/browse/BED-7931

## How Has This Been Tested?

Verified OpenAPI docs are correct on local

## Screenshots (optional):
<img width="1512" height="863" alt="image" src="https://github.com/user-attachments/assets/da1a3042-4f7c-45d8-8268-98025e1e45b4" />

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to delete data by source kinds in the database clearing operation.

* **Documentation**
  * Enhanced the clear database API documentation with clarified descriptions for all deletion options and their mutual-exclusion constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->