### PR TITLE
fix: pathfinding filter modal option overflow BED-7939

### DIFF
--- a/packages/javascript/bh-shared-ui/src/views/Explore/ExploreSearch/EdgeFilter/EdgeFilter.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/Explore/ExploreSearch/EdgeFilter/EdgeFilter.test.tsx
@@ -93,7 +93,7 @@ describe('EdgeFilter', () => {
         const toggleDialogButton = screen.getByRole('button', { name: /filter/i });
         await user.click(toggleDialogButton);
 
-        const activeDirectoryCategoryCheckbox = screen.getByRole('checkbox', { name: /active directory/i });
+        const activeDirectoryCategoryCheckbox = screen.getByRole('checkbox', { name: 'Active Directory' });
         expect(activeDirectoryCategoryCheckbox).toBeChecked();
 
         // 2: click active directory category, deselecting those edges
@@ -116,7 +116,7 @@ describe('EdgeFilter', () => {
 
         // 7. open dialog a third time, active directory category should be unselected
         await user.click(toggleDialogButton);
-        expect(await screen.findByRole('checkbox', { name: /active directory/i })).not.toBeChecked();
+        expect(await screen.findByRole('checkbox', { name: 'Active Directory' })).not.toBeChecked();
     });
 
     // Skipping this since our url param state is not syncing correctly in tests
@@ -126,8 +126,8 @@ describe('EdgeFilter', () => {
         const pathfindingButton = screen.getByRole('button', { name: /filter/i });
         await user.click(pathfindingButton);
 
-        const categoryADCheckbox = screen.getByRole('checkbox', { name: /active directory/i });
-        const categoryAzureCheckbox = screen.getByRole('checkbox', { name: /azure/i });
+        const categoryADCheckbox = screen.getByRole('checkbox', { name: 'Active Directory' });
+        const categoryAzureCheckbox = screen.getByRole('checkbox', { name: 'Azure' });
         expect(categoryADCheckbox).toBeChecked();
         expect(categoryAzureCheckbox).toBeChecked();
 

--- a/packages/javascript/bh-shared-ui/src/views/Explore/ExploreSearch/EdgeFilter/EdgeFilteringDialog.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/Explore/ExploreSearch/EdgeFilter/EdgeFilteringDialog.test.tsx
@@ -259,4 +259,25 @@ describe('Pathfinding', () => {
             expect(position & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
         }
     });
+
+    it('subcategory with duplicate name does not show indeterminate when all its children are unchecked', async () => {
+        const user = userEvent.setup();
+
+        // "Cross Platform" exists under both AD and Azure categories
+        // Uncheck the AD category to uncheck all its children including AD's "Cross Platform"
+        const adCategoryCheckbox = screen.getByRole('checkbox', { name: 'Active Directory' });
+        await user.click(adCategoryCheckbox);
+
+        // Both "Cross Platform" subcategory checkboxes should exist
+        const crossPlatformCheckboxes = screen.getAllByRole('checkbox', { name: 'Cross Platform' });
+        expect(crossPlatformCheckboxes.length).toBe(2);
+
+        // AD's "Cross Platform" (first one) should be unchecked, not indeterminate
+        expect(crossPlatformCheckboxes[0]).not.toBeChecked();
+        expect(crossPlatformCheckboxes[0]).toHaveAttribute('data-state', 'unchecked');
+
+        // Azure's "Cross Platform" (second one) should still be checked
+        expect(crossPlatformCheckboxes[1]).toBeChecked();
+        expect(crossPlatformCheckboxes[1]).toHaveAttribute('data-state', 'checked');
+    });
 });

--- a/packages/javascript/bh-shared-ui/src/views/Explore/ExploreSearch/EdgeFilter/EdgeFilteringDialog.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/Explore/ExploreSearch/EdgeFilter/EdgeFilteringDialog.test.tsx
@@ -46,6 +46,7 @@ const WrappedDialog = () => {
             handleCancel={vi.fn()}
             handleApply={vi.fn()}
             handleUpdate={(filters) => setSelectedFilters(filters)}
+            searchClearDelay={0}
         />
     );
 };

--- a/packages/javascript/bh-shared-ui/src/views/Explore/ExploreSearch/EdgeFilter/EdgeFilteringDialog.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/Explore/ExploreSearch/EdgeFilter/EdgeFilteringDialog.test.tsx
@@ -59,46 +59,54 @@ describe('Pathfinding', () => {
 
     it('should render', async () => {
         expect(await screen.findByRole('dialog', { name: /Path Edge Filtering/i })).toBeInTheDocument();
-        expect(
-            screen.getByRole('heading', { name: /select the edge types to include in your pathfinding/i })
-        ).toBeInTheDocument();
+        expect(screen.getByText(/select the edge types to include in your pathfinding/i)).toBeInTheDocument();
 
-        const categoryAD = screen.getByRole('checkbox', { name: /active directory/i });
+        const categoryAD = screen.getByRole('checkbox', { name: 'Active Directory' });
         expect(categoryAD).toBeInTheDocument();
 
-        const categoryAzure = screen.getByRole('checkbox', { name: /azure/i });
+        const categoryAzure = screen.getByRole('checkbox', { name: 'Azure' });
         expect(categoryAzure).toBeInTheDocument();
+    });
+
+    it('should render search input', async () => {
+        const searchInput = screen.getByPlaceholderText('Search edges...');
+        expect(searchInput).toBeInTheDocument();
+    });
+
+    it('should render expand all and collapse all buttons', async () => {
+        expect(screen.getByRole('button', { name: /Expand All/i })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /Collapse All/i })).toBeInTheDocument();
+    });
+
+    it('categories default to expanded', async () => {
+        // categories start expanded, so minimize buttons should be visible
+        expect(screen.getByRole('button', { name: 'minimize-Active Directory' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'minimize-Azure' })).toBeInTheDocument();
+
+        // subcategories should also be visible since they default expanded
+        const subcategoryCheckbox = screen.getByRole('checkbox', { name: 'Active Directory Structure' });
+        expect(subcategoryCheckbox).toBeInTheDocument();
     });
 
     it('checking a category updates all children and grandchildren', async () => {
         const user = userEvent.setup();
 
-        // expand the category
-        const expandCategoryButton = screen.getByRole('button', { name: 'expand-Active Directory' });
-        await user.click(expandCategoryButton);
-
-        // expand the subcategory
-        const expandSubcategoryButton = screen.getByRole('button', {
-            name: 'expand-Active Directory Structure',
-        });
-        await user.click(expandSubcategoryButton);
-
-        // assert all subcategories underneath `Active Directory` category are `CHECKED`
+        // all subcategories and edge types are already visible since sections default expanded
         const activeDirectorySubcategories = BUILTIN_EDGE_CATEGORIES[0].subcategories;
         activeDirectorySubcategories.forEach((subcategory) => {
-            const subcategoryElement = screen.getByRole('checkbox', { name: subcategory.name });
-            expect(subcategoryElement).toBeChecked();
+            const matches = screen.getAllByRole('checkbox', { name: subcategory.name });
+            expect(matches[0]).toBeChecked();
         });
 
-        // BOOM! click the top level checkbox
+        // click the top level checkbox
         const categoryCheckbox = screen.getByRole('checkbox', { name: 'Active Directory' });
         await user.click(categoryCheckbox);
 
         // assert all subcategories underneath `Active Directory` are now `UNCHECKED`
         expect(categoryCheckbox).not.toBeChecked();
         activeDirectorySubcategories.forEach((subcategory) => {
-            const subcategoryElement = screen.getByRole('checkbox', { name: subcategory.name });
-            expect(subcategoryElement).not.toBeChecked();
+            const matches = screen.getAllByRole('checkbox', { name: subcategory.name });
+            expect(matches[0]).not.toBeChecked();
         });
 
         // assert all edge types underneath first subcategory are now `UNCHECKED`.
@@ -112,17 +120,7 @@ describe('Pathfinding', () => {
     it('checking a subcategory updates all children (edge types) in its group', async () => {
         const user = userEvent.setup();
 
-        // expand category
-        const expandCategoryButton = screen.getByRole('button', { name: 'expand-Active Directory' });
-        await user.click(expandCategoryButton);
-
-        // expand subcategory
-        const expandSubcategoryButton = screen.getByRole('button', {
-            name: 'expand-Active Directory Structure',
-        });
-        await user.click(expandSubcategoryButton);
-
-        // assert that subcategory and all children are checked
+        // assert that subcategory and all children are checked (already visible)
         const subcategoryCheckbox = screen.getByRole('checkbox', { name: 'Active Directory Structure' });
         expect(subcategoryCheckbox).toBeChecked();
         const edgeTypes = BUILTIN_EDGE_CATEGORIES[0].subcategories[0].edgeTypes;
@@ -144,29 +142,121 @@ describe('Pathfinding', () => {
     it('checking a single edge type updates its parent and grandparent', async () => {
         const user = userEvent.setup();
 
-        // expand category
-        const expandCategoryButton = screen.getByRole('button', { name: 'expand-Active Directory' });
-        await user.click(expandCategoryButton);
-
-        // expand subcategory
-        const expandSubcategoryButton = screen.getByRole('button', {
-            name: 'expand-Active Directory Structure',
-        });
-        await user.click(expandSubcategoryButton);
-
-        // assert initial state: parent and grandparent elements are checked
+        // assert initial state: parent and grandparent elements are checked (already visible)
         const categoryCheckbox = screen.getByRole('checkbox', { name: 'Active Directory' });
         const subcategoryCheckbox = screen.getByRole('checkbox', { name: 'Active Directory Structure' });
         expect(categoryCheckbox).toBeChecked();
         expect(subcategoryCheckbox).toBeChecked();
 
         // select an edge type and uncheck it
-        const edgeTypeCheckbox = screen.getByRole('checkbox', { name: /contains/i });
+        const edgeTypeCheckbox = screen.getByRole('checkbox', { name: 'Contains' });
         await user.click(edgeTypeCheckbox);
 
         // assert that parent and grandparent elements (subcategory and category) are now indeterminate
         expect(edgeTypeCheckbox).not.toBeChecked();
-        expect(subcategoryCheckbox).toHaveAttribute('data-indeterminate', 'true');
-        expect(categoryCheckbox).toHaveAttribute('data-indeterminate', 'true');
+        expect(subcategoryCheckbox).toHaveAttribute('data-state', 'indeterminate');
+        expect(categoryCheckbox).toHaveAttribute('data-state', 'indeterminate');
+    });
+
+    it('collapse all button collapses all sections', async () => {
+        const user = userEvent.setup();
+
+        // subcategories should be visible initially
+        expect(screen.getByRole('checkbox', { name: 'Active Directory Structure' })).toBeInTheDocument();
+
+        // click Collapse All
+        await user.click(screen.getByRole('button', { name: /Collapse All/i }));
+
+        // subcategories should no longer be visible
+        expect(screen.queryByRole('checkbox', { name: 'Active Directory Structure' })).not.toBeInTheDocument();
+
+        // category expand buttons should now show expand instead of minimize
+        expect(screen.getByRole('button', { name: 'expand-Active Directory' })).toBeInTheDocument();
+    });
+
+    it('expand all button expands all sections after collapsing', async () => {
+        const user = userEvent.setup();
+
+        // collapse all first
+        await user.click(screen.getByRole('button', { name: /Collapse All/i }));
+        expect(screen.queryByRole('checkbox', { name: 'Active Directory Structure' })).not.toBeInTheDocument();
+
+        // click Expand All
+        await user.click(screen.getByRole('button', { name: /Expand All/i }));
+
+        // subcategories should be visible again
+        expect(screen.getByRole('checkbox', { name: 'Active Directory Structure' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'minimize-Active Directory' })).toBeInTheDocument();
+    });
+
+    it('search filters edges by name', async () => {
+        const user = userEvent.setup();
+
+        const searchInput = screen.getByPlaceholderText('Search edges...');
+        await user.type(searchInput, 'Contains');
+
+        // matching edge should be visible
+        expect(screen.getByRole('checkbox', { name: /^Contains$/i })).toBeInTheDocument();
+
+        // non-matching edges should not be visible
+        expect(screen.queryByRole('checkbox', { name: 'AdminTo' })).not.toBeInTheDocument();
+    });
+
+    it('search highlights matching substring with text-link class', async () => {
+        const user = userEvent.setup();
+
+        const searchInput = screen.getByPlaceholderText('Search edges...');
+        await user.type(searchInput, 'Contains');
+
+        const highlightedSpan = document.querySelector('.text-link');
+        expect(highlightedSpan).toBeInTheDocument();
+        expect(highlightedSpan?.textContent).toBe('Contains');
+    });
+
+    it('search forces sections to expand when there is a match', async () => {
+        const user = userEvent.setup();
+
+        // collapse all first
+        await user.click(screen.getByRole('button', { name: /Collapse All/i }));
+        expect(screen.queryByRole('checkbox', { name: 'Active Directory Structure' })).not.toBeInTheDocument();
+
+        // search for an edge type
+        const searchInput = screen.getByPlaceholderText('Search edges...');
+        await user.type(searchInput, 'Contains');
+
+        // matching category and subcategory should be force-expanded
+        expect(screen.getByRole('checkbox', { name: /^Contains$/i })).toBeInTheDocument();
+    });
+
+    it('expand/collapse all buttons are disabled when searching', async () => {
+        const user = userEvent.setup();
+
+        const expandAllButton = screen.getByRole('button', { name: /Expand All/i });
+        const collapseAllButton = screen.getByRole('button', { name: /Collapse All/i });
+
+        expect(expandAllButton).not.toBeDisabled();
+        expect(collapseAllButton).not.toBeDisabled();
+
+        const searchInput = screen.getByPlaceholderText('Search edges...');
+        await user.type(searchInput, 'test');
+
+        expect(expandAllButton).toBeDisabled();
+        expect(collapseAllButton).toBeDisabled();
+    });
+
+    it('edges are displayed in alphabetical order', async () => {
+        // get all edge type checkboxes under the first subcategory
+        const edgeTypes = BUILTIN_EDGE_CATEGORIES[0].subcategories[0].edgeTypes;
+        const sortedEdgeTypes = [...edgeTypes].sort((a, b) => a.localeCompare(b));
+
+        // get all checkboxes matching the edge types
+        const edgeCheckboxes = sortedEdgeTypes.map((edgeType) => screen.getByRole('checkbox', { name: edgeType }));
+
+        // verify they all exist and are in sorted order by checking DOM position
+        for (let i = 0; i < edgeCheckboxes.length - 1; i++) {
+            const position = edgeCheckboxes[i].compareDocumentPosition(edgeCheckboxes[i + 1]);
+            // Node.DOCUMENT_POSITION_FOLLOWING = 4
+            expect(position & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+        }
     });
 });

--- a/packages/javascript/bh-shared-ui/src/views/Explore/ExploreSearch/EdgeFilter/EdgeFilteringDialog.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/Explore/ExploreSearch/EdgeFilter/EdgeFilteringDialog.tsx
@@ -14,29 +14,11 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { faChevronDown, faChevronUp } from '@fortawesome/free-solid-svg-icons';
+import { faAnglesDown, faAnglesUp, faChevronDown, faChevronUp } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import {
-    Checkbox,
-    Collapse,
-    Dialog,
-    DialogActions,
-    DialogContent,
-    DialogTitle,
-    Divider,
-    FormControlLabel,
-    Grid,
-    IconButton,
-    List,
-    ListItem,
-    ListItemButton,
-    ListItemIcon,
-    ListItemText,
-    SvgIcon,
-    Typography,
-} from '@mui/material';
-import { Button } from 'doodle-ui';
-import { useState } from 'react';
+import { Button, Checkbox, Dialog, DialogActions, DialogContent, DialogDescription, DialogTitle } from 'doodle-ui';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { SearchInput } from '../../../../components/SearchInput';
 import { BUILTIN_EDGE_CATEGORIES, Category, EdgeCheckboxType, Subcategory } from './edgeCategories';
 import { useEdgeCategories } from './useEdgeCategories';
 
@@ -57,25 +39,66 @@ const EdgeFilteringDialog = ({
 }: EdgeFilteringDialogProps) => {
     const title = 'Path Edge Filtering';
     const description = 'Select the edge types to include in your pathfinding search.';
+    const [searchQuery, setSearchQuery] = useState('');
+    const [collapseSignal, setCollapseSignal] = useState(0);
+    const [expandSignal, setExpandSignal] = useState(0);
+    const isSearching = searchQuery.trim().length > 0;
 
     return (
-        <Dialog open={isOpen} fullWidth maxWidth={'md'}>
-            <DialogTitle>{title}</DialogTitle>
-            <Divider className='ml-2 mr-2' />
-            <Typography variant='subtitle1' ml={3} mt={1}>
-                {description}
-            </Typography>
+        <Dialog open={isOpen}>
+            <DialogContent maxWidth='md' className='flex flex-col h-[80vh]'>
+                <div className='flex items-start justify-between'>
+                    <div>
+                        <DialogTitle>{title}</DialogTitle>
+                        <DialogDescription className='ml-1 mt-1'>{description}</DialogDescription>
+                    </div>
+                    <div className='flex gap-1'>
+                        <Button
+                            variant='text'
+                            size='small'
+                            disabled={isSearching}
+                            onClick={() => setExpandSignal((s) => s + 1)}>
+                            <FontAwesomeIcon icon={faAnglesDown} className='mr-1' />
+                            Expand All
+                        </Button>
+                        <Button
+                            variant='text'
+                            size='small'
+                            disabled={isSearching}
+                            onClick={() => setCollapseSignal((s) => s + 1)}>
+                            <FontAwesomeIcon icon={faAnglesUp} className='mr-1' />
+                            Collapse All
+                        </Button>
+                    </div>
+                </div>
 
-            <DialogContent>
-                <CategoryList selectedFilters={selectedFilters} handleUpdate={handleUpdate} />
+                <div className='flex gap-2 mt-2'>
+                    <SearchInput
+                        id='edge-filter-search'
+                        placeholder='Search edges...'
+                        value={searchQuery}
+                        onInputChange={setSearchQuery}
+                        className='flex-1'
+                    />
+                </div>
+
+                <div className='overflow-y-auto flex-1 mt-2'>
+                    <CategoryList
+                        selectedFilters={selectedFilters}
+                        handleUpdate={handleUpdate}
+                        searchQuery={searchQuery}
+                        collapseSignal={collapseSignal}
+                        expandSignal={expandSignal}
+                    />
+                </div>
+
+                <DialogActions className='flex justify-end gap-2 pt-4'>
+                    <Button variant='tertiary' onClick={handleCancel}>
+                        Cancel
+                    </Button>
+                    <Button onClick={handleApply}>Apply</Button>
+                </DialogActions>
             </DialogContent>
-
-            <DialogActions>
-                <Button variant='tertiary' onClick={handleCancel}>
-                    Cancel
-                </Button>
-                <Button onClick={handleApply}>Apply</Button>
-            </DialogActions>
         </Dialog>
     );
 };
@@ -83,16 +106,44 @@ const EdgeFilteringDialog = ({
 interface CategoryListProps {
     selectedFilters: Array<EdgeCheckboxType>;
     handleUpdate: (checked: EdgeCheckboxType[]) => void;
+    searchQuery: string;
+    collapseSignal: number;
+    expandSignal: number;
 }
 
-const CategoryList = ({ selectedFilters, handleUpdate }: CategoryListProps) => {
+const CategoryList = ({
+    selectedFilters,
+    handleUpdate,
+    searchQuery,
+    collapseSignal,
+    expandSignal,
+}: CategoryListProps) => {
     const { isLoading, edgeCategories } = useEdgeCategories();
 
     const categories = isLoading ? BUILTIN_EDGE_CATEGORIES : edgeCategories;
 
+    const filteredCategories = useMemo(() => {
+        if (!searchQuery.trim()) return categories;
+
+        const lowerQuery = searchQuery.toLowerCase();
+        return categories
+            .map((category) => ({
+                ...category,
+                subcategories: category.subcategories
+                    .map((subcategory) => ({
+                        ...subcategory,
+                        edgeTypes: subcategory.edgeTypes.filter((edgeType) =>
+                            edgeType.toLowerCase().includes(lowerQuery)
+                        ),
+                    }))
+                    .filter((subcategory) => subcategory.edgeTypes.length > 0),
+            }))
+            .filter((category) => category.subcategories.length > 0);
+    }, [categories, searchQuery]);
+
     return (
-        <List>
-            {categories.map((category: Category) => {
+        <ul role='list'>
+            {filteredCategories.map((category: Category) => {
                 const { categoryName } = category;
                 return (
                     <CategoryListItem
@@ -100,24 +151,42 @@ const CategoryList = ({ selectedFilters, handleUpdate }: CategoryListProps) => {
                         category={category}
                         checked={selectedFilters}
                         setChecked={handleUpdate}
+                        defaultExpanded
+                        collapseSignal={collapseSignal}
+                        expandSignal={expandSignal}
+                        searchQuery={searchQuery}
                     />
                 );
             })}
-        </List>
+        </ul>
     );
 };
 
 interface CategoryListItemProps {
     category: Category;
-
     checked: EdgeCheckboxType[];
     setChecked: (checked: EdgeCheckboxType[]) => void;
+    defaultExpanded?: boolean;
+    collapseSignal?: number;
+    expandSignal?: number;
+    searchQuery?: string;
 }
 
-const CategoryListItem = ({ category, checked, setChecked }: CategoryListItemProps) => {
+const CategoryListItem = ({
+    category,
+    checked,
+    setChecked,
+    defaultExpanded = false,
+    collapseSignal = 0,
+    expandSignal = 0,
+    searchQuery = '',
+}: CategoryListItemProps) => {
     const { categoryName, subcategories } = category;
 
     const categoryFilter = (element: EdgeCheckboxType) => element.category === categoryName;
+
+    const isSearching = searchQuery.trim().length > 0;
+    const childDefaultExpanded = expandSignal > collapseSignal || (expandSignal === collapseSignal && defaultExpanded);
 
     return (
         <IndeterminateListItem
@@ -125,8 +194,12 @@ const CategoryListItem = ({ category, checked, setChecked }: CategoryListItemPro
             checkboxFilter={categoryFilter}
             checked={checked}
             setChecked={setChecked}
+            defaultExpanded={defaultExpanded}
+            collapseSignal={collapseSignal}
+            expandSignal={expandSignal}
+            forceExpanded={isSearching}
             collapsibleContent={
-                <List className='pl-4'>
+                <ul className='pl-4'>
                     {subcategories.map((subcategory) => {
                         return (
                             <SubcategoryListItem
@@ -134,10 +207,14 @@ const CategoryListItem = ({ category, checked, setChecked }: CategoryListItemPro
                                 checked={checked}
                                 setChecked={setChecked}
                                 subcategory={subcategory}
+                                defaultExpanded={childDefaultExpanded}
+                                collapseSignal={collapseSignal}
+                                expandSignal={expandSignal}
+                                searchQuery={searchQuery}
                             />
                         );
                     })}
-                </List>
+                </ul>
             }
         />
     );
@@ -145,15 +222,28 @@ const CategoryListItem = ({ category, checked, setChecked }: CategoryListItemPro
 
 interface SubcategoryListItemProps {
     subcategory: Subcategory;
-
     checked: EdgeCheckboxType[];
     setChecked: (checked: EdgeCheckboxType[]) => void;
+    defaultExpanded?: boolean;
+    collapseSignal?: number;
+    expandSignal?: number;
+    searchQuery?: string;
 }
 
-const SubcategoryListItem = ({ subcategory, checked, setChecked }: SubcategoryListItemProps) => {
+const SubcategoryListItem = ({
+    subcategory,
+    checked,
+    setChecked,
+    defaultExpanded = false,
+    collapseSignal = 0,
+    expandSignal = 0,
+    searchQuery = '',
+}: SubcategoryListItemProps) => {
     const { name, edgeTypes } = subcategory;
 
     const subcategoryFilter = (element: EdgeCheckboxType) => element.subcategory === name;
+
+    const isSearching = searchQuery.trim().length > 0;
 
     return (
         <IndeterminateListItem
@@ -161,66 +251,97 @@ const SubcategoryListItem = ({ subcategory, checked, setChecked }: SubcategoryLi
             checkboxFilter={subcategoryFilter}
             checked={checked}
             setChecked={setChecked}
+            defaultExpanded={defaultExpanded}
+            collapseSignal={collapseSignal}
+            expandSignal={expandSignal}
+            forceExpanded={isSearching}
             collapsibleContent={
-                <List className='pl-8'>
-                    <ListItem className='block'>
-                        <EdgesView edgeTypes={edgeTypes} checked={checked} setChecked={setChecked} />
-                    </ListItem>
-                </List>
+                <div className='pl-8'>
+                    <EdgesView
+                        edgeTypes={edgeTypes}
+                        checked={checked}
+                        setChecked={setChecked}
+                        searchQuery={searchQuery}
+                    />
+                </div>
             }
         />
     );
 };
 
+const HighlightMatch = ({ text, query }: { text: string; query: string }) => {
+    if (!query.trim()) return <>{text}</>;
+
+    const lowerText = text.toLowerCase();
+    const lowerQuery = query.toLowerCase();
+    const matchIndex = lowerText.indexOf(lowerQuery);
+
+    if (matchIndex === -1) return <>{text}</>;
+
+    const before = text.slice(0, matchIndex);
+    const match = text.slice(matchIndex, matchIndex + query.length);
+    const after = text.slice(matchIndex + query.length);
+
+    return (
+        <>
+            {before}
+            <span className='text-link'>{match}</span>
+            {after}
+        </>
+    );
+};
+
 interface EdgesViewProps {
     edgeTypes: string[];
-
     checked: EdgeCheckboxType[];
     setChecked: (checked: EdgeCheckboxType[]) => void;
+    searchQuery?: string;
 }
 
-const EdgesView = ({ edgeTypes, checked, setChecked }: EdgesViewProps) => {
-    const changeCheckbox = (event: React.ChangeEvent<HTMLInputElement>, edgeType: string) => {
+const EdgesView = ({ edgeTypes, checked, setChecked, searchQuery = '' }: EdgesViewProps) => {
+    const changeCheckbox = (isChecked: boolean | 'indeterminate', edgeType: string) => {
         const newChecked = [...checked];
         const indexToUpdate = newChecked.findIndex((element) => element.edgeType === edgeType);
-        newChecked[indexToUpdate] = { ...newChecked[indexToUpdate], checked: event.target.checked };
+        newChecked[indexToUpdate] = { ...newChecked[indexToUpdate], checked: isChecked === true };
 
         setChecked(newChecked);
     };
 
     return (
-        <div className='bg-neutral-3 p-2 rounded-lg'>
-            <Grid container spacing={2}>
-                {edgeTypes.map((edgeType, index) => {
+        <ul className='p-2 rounded-lg list-none'>
+            {[...edgeTypes]
+                .sort((a, b) => a.localeCompare(b))
+                .map((edgeType, index) => {
+                    const edgeIsChecked = checked.find((element) => element.edgeType === edgeType)?.checked ?? false;
                     return (
-                        <Grid item xs={6} sm={4} key={index}>
-                            <FormControlLabel
-                                label={edgeType}
-                                control={
-                                    <Checkbox
-                                        inputProps={{ 'aria-label': edgeType }}
-                                        name={edgeType}
-                                        checked={checked.find((element) => element.edgeType === edgeType)?.checked}
-                                        onChange={(e) => changeCheckbox(e, edgeType)}
-                                    />
-                                }
-                            />
-                        </Grid>
+                        <li key={index} className='hover:underline'>
+                            <label className='flex items-center gap-2 cursor-pointer py-0.5'>
+                                <Checkbox
+                                    aria-label={edgeType}
+                                    name={edgeType}
+                                    checked={edgeIsChecked}
+                                    onCheckedChange={(value) => changeCheckbox(value, edgeType)}
+                                />
+                                <span className='text-sm'>
+                                    <HighlightMatch text={edgeType} query={searchQuery} />
+                                </span>
+                            </label>
+                        </li>
                     );
                 })}
-            </Grid>
-        </div>
+        </ul>
     );
 };
 
 interface IndeterminateListItemProps {
     name: string;
-
     checkboxFilter: (element: EdgeCheckboxType) => boolean;
-
     checked: EdgeCheckboxType[];
     setChecked: (checked: EdgeCheckboxType[]) => void;
-
+    defaultExpanded?: boolean;
+    collapseSignal?: number;
+    expandSignal?: number;
+    forceExpanded?: boolean;
     collapsibleContent: React.ReactNode;
 }
 
@@ -229,14 +350,36 @@ const IndeterminateListItem = ({
     checkboxFilter,
     checked,
     setChecked,
+    defaultExpanded = false,
+    collapseSignal = 0,
+    expandSignal = 0,
+    forceExpanded = false,
     collapsibleContent,
 }: IndeterminateListItemProps) => {
-    const [showCollapsibleContent, setShowCollapsibleContent] = useState(false);
+    const [showCollapsibleContent, setShowCollapsibleContent] = useState(defaultExpanded);
+    const initialCollapseSignal = useRef(collapseSignal);
+    const initialExpandSignal = useRef(expandSignal);
+
+    useEffect(() => {
+        if (collapseSignal !== initialCollapseSignal.current) {
+            setShowCollapsibleContent(false);
+        }
+    }, [collapseSignal]);
+
+    useEffect(() => {
+        if (expandSignal !== initialExpandSignal.current) {
+            setShowCollapsibleContent(true);
+        }
+    }, [expandSignal]);
 
     const checkboxes = checked.filter(checkboxFilter);
     const elementIsChecked = (element: EdgeCheckboxType) => element.checked;
-    const elementIsEqual = (element: EdgeCheckboxType, index: number, arr: EdgeCheckboxType[]) =>
+    const elementIsEqual = (element: EdgeCheckboxType, _index: number, arr: EdgeCheckboxType[]) =>
         element.checked === arr[0].checked;
+
+    const allChecked = checkboxes.every(elementIsChecked);
+    const isIndeterminate = !checkboxes.every(elementIsEqual);
+    const checkedState: boolean | 'indeterminate' = isIndeterminate ? 'indeterminate' : allChecked;
 
     const changeAllChildren = (value: boolean) => {
         const newChecked = [...checked];
@@ -249,10 +392,9 @@ const IndeterminateListItem = ({
         setChecked(newChecked);
     };
 
-    const onCheckboxClick = () => {
-        const isChecked = checkboxes.every((element) => element.checked);
+    const handleCheck = () => {
         // if item is checked, uncheck all children
-        if (isChecked) {
+        if (allChecked) {
             changeAllChildren(false);
         } else {
             // if item is not checked, check all children
@@ -260,41 +402,43 @@ const IndeterminateListItem = ({
         }
     };
 
+    const isExpanded = forceExpanded || showCollapsibleContent;
     const toggleCollapsibleContent = () => setShowCollapsibleContent((v) => !v);
 
     return (
-        <>
-            <ListItem
-                disablePadding
-                dense
-                secondaryAction={
-                    <IconButton
-                        title={showCollapsibleContent ? `minimize-${name}` : `expand-${name}`}
-                        onClick={toggleCollapsibleContent}>
-                        <SvgIcon>
-                            <FontAwesomeIcon icon={showCollapsibleContent ? faChevronUp : faChevronDown} />
-                        </SvgIcon>
-                    </IconButton>
-                }>
-                <ListItemButton onClick={toggleCollapsibleContent}>
-                    <ListItemIcon>
-                        <Checkbox
-                            onClick={(e) => {
-                                e.stopPropagation();
-                                onCheckboxClick();
-                            }}
-                            inputProps={{
-                                'aria-label': name,
-                            }}
-                            checked={checkboxes.every(elementIsChecked)}
-                            indeterminate={!checkboxes.every(elementIsEqual)}
-                        />
-                    </ListItemIcon>
-                    <ListItemText>{name}</ListItemText>
-                </ListItemButton>
-            </ListItem>
-            <Collapse in={showCollapsibleContent}>{collapsibleContent}</Collapse>
-        </>
+        <li className='list-none'>
+            <div className='flex items-center py-1 group'>
+                <div
+                    role='button'
+                    tabIndex={0}
+                    className='flex items-center gap-2 flex-1 cursor-pointer p-1 text-left rounded-l peer hover:bg-neutral-3'
+                    onClick={toggleCollapsibleContent}
+                    onKeyDown={(e) => {
+                        if (e.key === 'Enter' || e.key === ' ') {
+                            e.preventDefault();
+                            toggleCollapsibleContent();
+                        }
+                    }}>
+                    <Checkbox
+                        aria-label={name}
+                        checked={checkedState}
+                        onCheckedChange={() => handleCheck()}
+                        onClick={(e) => e.stopPropagation()}
+                        icon={isIndeterminate ? <span className='block w-2/3 mx-auto h-0.5 bg-current' /> : undefined}
+                    />
+                    <span className='text-sm font-medium'>{name}</span>
+                </div>
+                <button
+                    type='button'
+                    aria-label={isExpanded ? `minimize-${name}` : `expand-${name}`}
+                    className='px-2 self-stretch flex items-center cursor-pointer bg-transparent border-none rounded-r peer-hover:bg-neutral-3'
+                    onClick={toggleCollapsibleContent}>
+                    <FontAwesomeIcon icon={isExpanded ? faChevronUp : faChevronDown} />
+                </button>
+            </div>
+            {isExpanded && collapsibleContent}
+        </li>
     );
 };
+
 export default EdgeFilteringDialog;

--- a/packages/javascript/bh-shared-ui/src/views/Explore/ExploreSearch/EdgeFilter/EdgeFilteringDialog.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/Explore/ExploreSearch/EdgeFilter/EdgeFilteringDialog.tsx
@@ -204,6 +204,7 @@ const CategoryListItem = ({
                         return (
                             <SubcategoryListItem
                                 key={subcategory.name}
+                                categoryName={categoryName}
                                 checked={checked}
                                 setChecked={setChecked}
                                 subcategory={subcategory}
@@ -221,6 +222,7 @@ const CategoryListItem = ({
 };
 
 interface SubcategoryListItemProps {
+    categoryName: string;
     subcategory: Subcategory;
     checked: EdgeCheckboxType[];
     setChecked: (checked: EdgeCheckboxType[]) => void;
@@ -231,6 +233,7 @@ interface SubcategoryListItemProps {
 }
 
 const SubcategoryListItem = ({
+    categoryName,
     subcategory,
     checked,
     setChecked,
@@ -241,7 +244,8 @@ const SubcategoryListItem = ({
 }: SubcategoryListItemProps) => {
     const { name, edgeTypes } = subcategory;
 
-    const subcategoryFilter = (element: EdgeCheckboxType) => element.subcategory === name;
+    const subcategoryFilter = (element: EdgeCheckboxType) =>
+        element.category === categoryName && element.subcategory === name;
 
     const isSearching = searchQuery.trim().length > 0;
 
@@ -308,21 +312,22 @@ const EdgesView = ({ edgeTypes, checked, setChecked, searchQuery = '' }: EdgesVi
     };
 
     return (
-        <ul className='p-2 rounded-lg list-none'>
+        <ul className='p-2 rounded-lg list-none flex flex-wrap'>
             {[...edgeTypes]
                 .sort((a, b) => a.localeCompare(b))
                 .map((edgeType, index) => {
                     const edgeIsChecked = checked.find((element) => element.edgeType === edgeType)?.checked ?? false;
                     return (
-                        <li key={index} className='hover:underline'>
-                            <label className='flex items-center gap-2 cursor-pointer py-0.5'>
+                        <li key={index} className='w-1/2 min-w-0 pr-4'>
+                            <label className='flex items-start gap-2 cursor-pointer py-0.5 hover:underline'>
                                 <Checkbox
                                     aria-label={edgeType}
                                     name={edgeType}
                                     checked={edgeIsChecked}
                                     onCheckedChange={(value) => changeCheckbox(value, edgeType)}
+                                    className='mt-0.5 shrink-0'
                                 />
-                                <span className='text-sm'>
+                                <span className='text-sm break-words min-w-0'>
                                     <HighlightMatch text={edgeType} query={searchQuery} />
                                 </span>
                             </label>

--- a/packages/javascript/bh-shared-ui/src/views/Explore/ExploreSearch/EdgeFilter/EdgeFilteringDialog.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/Explore/ExploreSearch/EdgeFilter/EdgeFilteringDialog.tsx
@@ -16,7 +16,16 @@
 
 import { faAnglesDown, faAnglesUp, faChevronDown, faChevronUp } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { Button, Checkbox, Dialog, DialogActions, DialogContent, DialogDescription, DialogTitle } from 'doodle-ui';
+import {
+    Button,
+    Checkbox,
+    Dialog,
+    DialogActions,
+    DialogContent,
+    DialogDescription,
+    DialogTitle,
+    Label,
+} from 'doodle-ui';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { SearchInput } from '../../../../components/SearchInput';
 import { BUILTIN_EDGE_CATEGORIES, Category, EdgeCheckboxType, Subcategory } from './edgeCategories';
@@ -28,6 +37,8 @@ interface EdgeFilteringDialogProps {
     handleApply: () => void;
     handleUpdate: (checked: EdgeCheckboxType[]) => void;
     handleCancel: () => void;
+    /** Delay in ms before clearing the search after apply/cancel. Set to 0 in tests. Defaults to 250. */
+    searchClearDelay?: number;
 }
 
 const EdgeFilteringDialog = ({
@@ -36,6 +47,7 @@ const EdgeFilteringDialog = ({
     handleApply,
     handleUpdate,
     handleCancel,
+    searchClearDelay = 250,
 }: EdgeFilteringDialogProps) => {
     const title = 'Path Edge Filtering';
     const description = 'Select the edge types to include in your pathfinding search.';
@@ -43,6 +55,24 @@ const EdgeFilteringDialog = ({
     const [collapseSignal, setCollapseSignal] = useState(0);
     const [expandSignal, setExpandSignal] = useState(0);
     const isSearching = searchQuery.trim().length > 0;
+    const searchClearTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    const clearSearch = () => {
+        if (searchClearDelay > 0) {
+            // the dialog fades out on close so wait a bit before clearing the search state to avoid a flash of changing content
+            searchClearTimerRef.current = setTimeout(() => setSearchQuery(''), searchClearDelay);
+        } else {
+            setSearchQuery('');
+        }
+    };
+
+    useEffect(() => {
+        return () => {
+            if (searchClearTimerRef.current) {
+                clearTimeout(searchClearTimerRef.current);
+            }
+        };
+    }, []);
 
     return (
         <Dialog open={isOpen}>
@@ -93,10 +123,21 @@ const EdgeFilteringDialog = ({
                 </div>
 
                 <DialogActions className='flex justify-end gap-2 pt-4'>
-                    <Button variant='tertiary' onClick={handleCancel}>
+                    <Button
+                        variant='tertiary'
+                        onClick={() => {
+                            handleCancel();
+                            clearSearch();
+                        }}>
                         Cancel
                     </Button>
-                    <Button onClick={handleApply}>Apply</Button>
+                    <Button
+                        onClick={() => {
+                            handleApply();
+                            clearSearch();
+                        }}>
+                        Apply
+                    </Button>
                 </DialogActions>
             </DialogContent>
         </Dialog>
@@ -142,7 +183,7 @@ const CategoryList = ({
     }, [categories, searchQuery]);
 
     return (
-        <ul role='list'>
+        <ul>
             {filteredCategories.map((category: Category) => {
                 const { categoryName } = category;
                 return (
@@ -319,18 +360,22 @@ const EdgesView = ({ edgeTypes, checked, setChecked, searchQuery = '' }: EdgesVi
                     const edgeIsChecked = checked.find((element) => element.edgeType === edgeType)?.checked ?? false;
                     return (
                         <li key={index} className='w-1/2 min-w-0 pr-4'>
-                            <label className='flex items-start gap-2 cursor-pointer py-0.5 hover:underline'>
+                            <div className='flex items-start gap-2'>
                                 <Checkbox
+                                    id={edgeType}
                                     aria-label={edgeType}
                                     name={edgeType}
                                     checked={edgeIsChecked}
                                     onCheckedChange={(value) => changeCheckbox(value, edgeType)}
                                     className='mt-0.5 shrink-0'
                                 />
-                                <span className='text-sm break-words min-w-0'>
+                                <Label
+                                    size={'small'}
+                                    htmlFor={edgeType}
+                                    className='break-words min-w-0 w-full cursor-pointer hover:underline'>
                                     <HighlightMatch text={edgeType} query={searchQuery} />
-                                </span>
-                            </label>
+                                </Label>
+                            </div>
                         </li>
                     );
                 })}
@@ -441,7 +486,12 @@ const IndeterminateListItem = ({
                     <FontAwesomeIcon icon={isExpanded ? faChevronUp : faChevronDown} />
                 </button>
             </div>
-            {isExpanded && collapsibleContent}
+            <div
+                className='grid transition-[grid-template-rows] duration-200 ease-out'
+                aria-hidden={!isExpanded}
+                style={{ gridTemplateRows: isExpanded ? '1fr' : '0fr' }}>
+                <div className='overflow-hidden min-h-0'>{collapsibleContent}</div>
+            </div>
         </li>
     );
 };


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

The pathfinding edge filter dialog is refactored so that long edge names break and wrap onto the next line instead of overflowing into the adjacent options.

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-7939

## How Has This Been Tested?
Unit tests have been updated and bolstered 

## Screenshots (optional):

Before:

<img width="1570" height="1627" alt="image" src="https://github.com/user-attachments/assets/362c62b3-b123-4c15-89ef-06e3fd38ae05" />


After:

<img width="903" height="1043" alt="image" src="https://github.com/user-attachments/assets/44dc9820-eaf1-44b7-8459-7cdcd6fca2de" />


## Types of changes

<!-- Please remove any items that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Edge search with substring highlighting, real-time filtering, and forced expansion for matches.
  * Global Expand All / Collapse All controls; sections now default to expanded and auto-expand when matches occur.
  * Redesigned dialog layout with fixed-height, scrollable content; expand/collapse controls are disabled while searching.

* **Tests**
  * Expanded coverage for search, filtering, expand/collapse behavior, alphabetical ordering, and duplicate-subcategory regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->