### PR TITLE
feat: implementing AZAddOwner relationship BED-4754

### DIFF
--- a/packages/go/analysis/azure/azure_integration_suite_test.go
+++ b/packages/go/analysis/azure/azure_integration_suite_test.go
@@ -1,0 +1,200 @@
+// Copyright 2026 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//go:build integration
+
+package azure_test
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/peterldowns/pgtestdb"
+	"github.com/specterops/bloodhound/cmd/api/src/migrations"
+	"github.com/specterops/bloodhound/cmd/api/src/test/integration/utils"
+	"github.com/specterops/bloodhound/packages/go/graphschema"
+	"github.com/specterops/bloodhound/packages/go/graphschema/azure"
+	"github.com/specterops/bloodhound/packages/go/graphschema/common"
+	"github.com/specterops/dawgs"
+	"github.com/specterops/dawgs/drivers/pg"
+	"github.com/specterops/dawgs/graph"
+	"github.com/stretchr/testify/require"
+)
+
+type IntegrationTestSuite struct {
+	Context context.Context
+	GraphDB graph.Database
+}
+
+// setupIntegrationTestSuite initializes and returns a test suite containing
+// all necessary dependencies for integration tests
+func setupIntegrationTestSuite(t *testing.T) IntegrationTestSuite {
+	t.Helper()
+
+	var (
+		ctx      = context.Background()
+		connConf = pgtestdb.Custom(t, getPostgresConfig(t), pgtestdb.NoopMigrator{})
+	)
+
+	pool, err := pg.NewPool(connConf.URL())
+	require.NoError(t, err)
+
+	graphDB, err := dawgs.Open(ctx, pg.DriverName, dawgs.Config{
+		GraphQueryMemoryLimit: 1024 * 1024 * 1024 * 2,
+		ConnectionString:      connConf.URL(),
+		Pool:                  pool,
+	})
+	require.NoError(t, err)
+
+	err = migrations.NewGraphMigrator(graphDB).Migrate(ctx)
+	require.NoError(t, err)
+
+	err = graphDB.AssertSchema(ctx, graphschema.DefaultGraphSchema())
+	require.NoError(t, err)
+
+	return IntegrationTestSuite{
+		Context: ctx,
+		GraphDB: graphDB,
+	}
+}
+
+// getPostgresConfig reads key/value pairs from the default integration
+// config file and creates a pgtestdb configuration object.
+func getPostgresConfig(t *testing.T) pgtestdb.Config {
+	t.Helper()
+
+	config, err := utils.LoadIntegrationTestConfig()
+	require.NoError(t, err)
+
+	environmentMap := make(map[string]string)
+	for _, entry := range strings.Fields(config.Database.Connection) {
+		if parts := strings.SplitN(entry, "=", 2); len(parts) == 2 {
+			environmentMap[parts[0]] = parts[1]
+		}
+	}
+
+	if strings.HasPrefix(environmentMap["host"], "/") {
+		return pgtestdb.Config{
+			DriverName: "pgx",
+			User:       environmentMap["user"],
+			Password:   environmentMap["password"],
+			Database:   environmentMap["dbname"],
+			Options:    fmt.Sprintf("host=%s", url.PathEscape(environmentMap["host"])),
+			TestRole: &pgtestdb.Role{
+				Username:     environmentMap["user"],
+				Password:     environmentMap["password"],
+				Capabilities: "NOSUPERUSER NOCREATEROLE",
+			},
+		}
+	}
+
+	return pgtestdb.Config{
+		DriverName:                "pgx",
+		Host:                      environmentMap["host"],
+		Port:                      environmentMap["port"],
+		User:                      environmentMap["user"],
+		Password:                  environmentMap["password"],
+		Database:                  environmentMap["dbname"],
+		Options:                   "sslmode=disable",
+		ForceTerminateConnections: true,
+	}
+}
+
+func teardownIntegrationTestSuite(t *testing.T, suite *IntegrationTestSuite) {
+	t.Helper()
+
+	if suite.GraphDB != nil {
+		if err := suite.GraphDB.Close(suite.Context); err != nil {
+			t.Logf("Failed to close GraphDB: %v", err)
+		}
+	}
+}
+
+func NewNode(t *testing.T, suite *IntegrationTestSuite, properties *graph.Properties, kinds ...graph.Kind) *graph.Node {
+	var (
+		node *graph.Node
+		err  error
+	)
+
+	err = suite.GraphDB.WriteTransaction(suite.Context, func(tx graph.Transaction) error {
+		if node, err = tx.CreateNode(properties, kinds...); err != nil {
+			return err
+		}
+
+		return nil
+	})
+
+	require.NoError(t, err)
+
+	return node
+}
+
+func NewRelationship(t *testing.T, suite *IntegrationTestSuite, startNode, endNode *graph.Node, kind graph.Kind, propertyBags ...*graph.Properties) *graph.Relationship {
+	var (
+		relationshipProperties = graph.NewPropertiesRed()
+		relationship           *graph.Relationship
+		err                    error
+	)
+
+	for _, additionalProperties := range propertyBags {
+		relationshipProperties.Merge(additionalProperties)
+	}
+
+	err = suite.GraphDB.WriteTransaction(suite.Context, func(tx graph.Transaction) error {
+		relationship, err = tx.CreateRelationshipByIDs(startNode.ID, endNode.ID, kind, relationshipProperties)
+		return err
+	})
+
+	require.NoError(t, err)
+
+	return relationship
+}
+
+func NewAzureTenant(t *testing.T, suite *IntegrationTestSuite, tenantID string) *graph.Node {
+	return NewNode(t, suite, graph.AsProperties(graph.PropertyMap{
+		common.Name:     "New Tenant",
+		common.ObjectID: tenantID,
+		azure.TenantID:  tenantID,
+		azure.License:   "license",
+	}), azure.Entity, azure.Tenant)
+}
+
+func NewAzureApplication(t *testing.T, suite *IntegrationTestSuite, name, objectID, tenantID string) *graph.Node {
+	return NewNode(t, suite, graph.AsProperties(graph.PropertyMap{
+		common.Name:     name,
+		common.ObjectID: objectID,
+		azure.TenantID:  tenantID,
+	}), azure.Entity, azure.App)
+}
+
+func NewAzureServicePrincipal(t *testing.T, suite *IntegrationTestSuite, name, objectID, tenantID string) *graph.Node {
+	return NewNode(t, suite, graph.AsProperties(graph.PropertyMap{
+		common.Name:     name,
+		common.ObjectID: objectID,
+		azure.TenantID:  tenantID,
+	}), azure.Entity, azure.ServicePrincipal)
+}
+
+func NewAzureRole(t *testing.T, suite *IntegrationTestSuite, name, objectID, roleTemplateID, tenantID string) *graph.Node {
+	return NewNode(t, suite, graph.AsProperties(graph.PropertyMap{
+		common.Name:          name,
+		common.ObjectID:      objectID,
+		azure.RoleTemplateID: roleTemplateID,
+		azure.TenantID:       tenantID,
+	}), azure.Entity, azure.Role)
+}

--- a/packages/go/analysis/azure/azure_integration_test.go
+++ b/packages/go/analysis/azure/azure_integration_test.go
@@ -78,7 +78,7 @@ func TestAZAddOwner(t *testing.T) {
 		addOwnerEdges, err := ops.FetchRelationships(tx.Relationships().Filterf(func() graph.Criteria {
 			return query.Kind(query.Relationship(), graphAzure.AddOwner)
 		}))
-		assert.Nil(t, err)
+		require.NoError(t, err)
 		assert.Len(t, addOwnerEdges, 8)
 
 		type edgeKey struct {

--- a/packages/go/analysis/azure/azure_integration_test.go
+++ b/packages/go/analysis/azure/azure_integration_test.go
@@ -64,8 +64,8 @@ func TestAZAddOwner(t *testing.T) {
 	NewRelationship(t, &suite, AZTenant, ConditionalAccessAdministratorRole, graphAzure.Contains)
 	//#endregion
 
-	//#region Running post processing
-	postProcessingStats, err := azure.AppRoleAssignments(context.Background(), suite.GraphDB)
+	//#region Running AZAddOwner edge post processing
+	postProcessingStats, err := azure.CreateAZAddOwnerEdge(context.Background(), suite.GraphDB)
 	//#endregion
 
 	//#region Verifying assertions

--- a/packages/go/analysis/azure/azure_integration_test.go
+++ b/packages/go/analysis/azure/azure_integration_test.go
@@ -70,7 +70,7 @@ func TestAZAddOwner(t *testing.T) {
 
 	//#region Verifying assertions
 	require.NoError(t, err)
-	assert.NotNil(t, postProcessingStats.RelationshipsCreated[graphAzure.AddOwner])
+	require.NotNil(t, postProcessingStats.RelationshipsCreated[graphAzure.AddOwner])
 	assert.Equal(t, 8, int(*postProcessingStats.RelationshipsCreated[graphAzure.AddOwner]))
 
 	// Validate that the AZAddOwner edges were created

--- a/packages/go/analysis/azure/azure_integration_test.go
+++ b/packages/go/analysis/azure/azure_integration_test.go
@@ -35,6 +35,79 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestAZAddOwner(t *testing.T) {
+	t.Parallel()
+
+	//#region Setup for test
+	var (
+		suite = setupIntegrationTestSuite(t)
+
+		tenantID                = integration.RandomObjectID(t)
+		AZTenant                = NewAzureTenant(t, &suite, tenantID)
+		AZApp                   = NewAzureApplication(t, &suite, "AZApp", integration.RandomObjectID(t), tenantID)
+		AZServicePrincipal      = NewAzureServicePrincipal(t, &suite, "AZServicePrincipal", integration.RandomObjectID(t), tenantID)
+		HybridIdentityAdminRole = NewAzureRole(t, &suite, "HybridIdentityAdminRole", integration.RandomObjectID(t), graphAzure.HybridIdentityAdministratorRole, tenantID)
+		PartnerTier1SupportRole = NewAzureRole(t, &suite, "PartnerTier1SupportRole", integration.RandomObjectID(t), graphAzure.PartnerTier1SupportRole, tenantID)
+		PartnerTier2SupportRole = NewAzureRole(t, &suite, "PartnerTier2SupportRole", integration.RandomObjectID(t), graphAzure.PartnerTier2SupportRole, tenantID)
+		DirSyncAccountsRole     = NewAzureRole(t, &suite, "DirSyncAccountsRole", integration.RandomObjectID(t), graphAzure.DirectorySynchronizationAccountsRole, tenantID)
+		// Role that should not generate AZAddOwner Edge
+		ConditionalAccessAdministratorRole = NewAzureRole(t, &suite, "ConditionalAccessAdministratorRole", integration.RandomObjectID(t), graphAzure.ConditionalAccessAdministratorRole, tenantID)
+	)
+
+	NewRelationship(t, &suite, AZTenant, AZApp, graphAzure.Contains)
+	NewRelationship(t, &suite, AZTenant, AZServicePrincipal, graphAzure.Contains)
+	NewRelationship(t, &suite, AZTenant, HybridIdentityAdminRole, graphAzure.Contains)
+	NewRelationship(t, &suite, AZTenant, PartnerTier1SupportRole, graphAzure.Contains)
+	NewRelationship(t, &suite, AZTenant, PartnerTier2SupportRole, graphAzure.Contains)
+	NewRelationship(t, &suite, AZTenant, DirSyncAccountsRole, graphAzure.Contains)
+	NewRelationship(t, &suite, AZTenant, ConditionalAccessAdministratorRole, graphAzure.Contains)
+	//#endregion
+
+	//#region Running post processing
+	postProcessingStats, err := azure.AppRoleAssignments(context.Background(), suite.GraphDB)
+	//#endregion
+
+	//#region Verifying assertions
+	require.NoError(t, err)
+	assert.NotNil(t, postProcessingStats.RelationshipsCreated[graphAzure.AddOwner])
+	assert.Equal(t, 8, int(*postProcessingStats.RelationshipsCreated[graphAzure.AddOwner]))
+
+	// Validate that the AZAddOwner edges were created
+	err = suite.GraphDB.ReadTransaction(suite.Context, func(tx graph.Transaction) error {
+		addOwnerEdges, err := ops.FetchRelationships(tx.Relationships().Filterf(func() graph.Criteria {
+			return query.Kind(query.Relationship(), graphAzure.AddOwner)
+		}))
+		assert.Nil(t, err)
+		assert.Len(t, addOwnerEdges, 8)
+
+		expected := make(map[string]struct{}, 8)
+		expected[HybridIdentityAdminRole.ID.String()+AZApp.ID.String()] = struct{}{}
+		expected[HybridIdentityAdminRole.ID.String()+AZServicePrincipal.ID.String()] = struct{}{}
+		expected[PartnerTier1SupportRole.ID.String()+AZApp.ID.String()] = struct{}{}
+		expected[PartnerTier1SupportRole.ID.String()+AZServicePrincipal.ID.String()] = struct{}{}
+		expected[PartnerTier2SupportRole.ID.String()+AZApp.ID.String()] = struct{}{}
+		expected[PartnerTier2SupportRole.ID.String()+AZServicePrincipal.ID.String()] = struct{}{}
+		expected[DirSyncAccountsRole.ID.String()+AZApp.ID.String()] = struct{}{}
+		expected[DirSyncAccountsRole.ID.String()+AZServicePrincipal.ID.String()] = struct{}{}
+
+		for _, edge := range addOwnerEdges {
+			key := edge.StartID.String() + edge.EndID.String()
+			_, present := expected[key]
+			assert.True(t, present)
+			delete(expected, key)
+		}
+
+		assert.Empty(t, expected, "not all expected edges were found")
+
+		return nil
+	})
+
+	require.NoError(t, err)
+	//#endregion
+
+	teardownIntegrationTestSuite(t, &suite)
+}
+
 func TestFetchEntityByObjectID(t *testing.T) {
 	testContext := integration.NewGraphTestContext(t, schema.DefaultGraphSchema())
 	testContext.ReadTransactionTestWithSetup(func(harness *integration.HarnessDetails) error {

--- a/packages/go/analysis/azure/azure_integration_test.go
+++ b/packages/go/analysis/azure/azure_integration_test.go
@@ -39,9 +39,10 @@ func TestAZAddOwner(t *testing.T) {
 	t.Parallel()
 
 	//#region Setup for test
-	var (
-		suite = setupIntegrationTestSuite(t)
+	suite := setupIntegrationTestSuite(t)
+	defer teardownIntegrationTestSuite(t, &suite)
 
+	var (
 		tenantID                = integration.RandomObjectID(t)
 		AZTenant                = NewAzureTenant(t, &suite, tenantID)
 		AZApp                   = NewAzureApplication(t, &suite, "AZApp", integration.RandomObjectID(t), tenantID)
@@ -80,18 +81,22 @@ func TestAZAddOwner(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Len(t, addOwnerEdges, 8)
 
-		expected := make(map[string]struct{}, 8)
-		expected[HybridIdentityAdminRole.ID.String()+AZApp.ID.String()] = struct{}{}
-		expected[HybridIdentityAdminRole.ID.String()+AZServicePrincipal.ID.String()] = struct{}{}
-		expected[PartnerTier1SupportRole.ID.String()+AZApp.ID.String()] = struct{}{}
-		expected[PartnerTier1SupportRole.ID.String()+AZServicePrincipal.ID.String()] = struct{}{}
-		expected[PartnerTier2SupportRole.ID.String()+AZApp.ID.String()] = struct{}{}
-		expected[PartnerTier2SupportRole.ID.String()+AZServicePrincipal.ID.String()] = struct{}{}
-		expected[DirSyncAccountsRole.ID.String()+AZApp.ID.String()] = struct{}{}
-		expected[DirSyncAccountsRole.ID.String()+AZServicePrincipal.ID.String()] = struct{}{}
+		type edgeKey struct {
+			start graph.ID
+			end   graph.ID
+		}
+		expected := make(map[edgeKey]struct{}, 8)
+		expected[edgeKey{start: HybridIdentityAdminRole.ID, end: AZApp.ID}] = struct{}{}
+		expected[edgeKey{start: HybridIdentityAdminRole.ID, end: AZServicePrincipal.ID}] = struct{}{}
+		expected[edgeKey{start: PartnerTier1SupportRole.ID, end: AZApp.ID}] = struct{}{}
+		expected[edgeKey{start: PartnerTier1SupportRole.ID, end: AZServicePrincipal.ID}] = struct{}{}
+		expected[edgeKey{start: PartnerTier2SupportRole.ID, end: AZApp.ID}] = struct{}{}
+		expected[edgeKey{start: PartnerTier2SupportRole.ID, end: AZServicePrincipal.ID}] = struct{}{}
+		expected[edgeKey{start: DirSyncAccountsRole.ID, end: AZApp.ID}] = struct{}{}
+		expected[edgeKey{start: DirSyncAccountsRole.ID, end: AZServicePrincipal.ID}] = struct{}{}
 
 		for _, edge := range addOwnerEdges {
-			key := edge.StartID.String() + edge.EndID.String()
+			key := edgeKey{start: edge.StartID, end: edge.EndID}
 			_, present := expected[key]
 			assert.True(t, present)
 			delete(expected, key)
@@ -104,8 +109,6 @@ func TestAZAddOwner(t *testing.T) {
 
 	require.NoError(t, err)
 	//#endregion
-
-	teardownIntegrationTestSuite(t, &suite)
 }
 
 func TestFetchEntityByObjectID(t *testing.T) {

--- a/packages/go/analysis/azure/post.go
+++ b/packages/go/analysis/azure/post.go
@@ -239,8 +239,6 @@ func AppRoleAssignments(ctx context.Context, db graph.Database) (*post.AtomicPos
 					return err
 				} else if err := addSecret(operation, tenant); err != nil {
 					return err
-				} else if err := addOwner(operation, tenant); err != nil {
-					return err
 				}
 
 				return nil
@@ -690,8 +688,46 @@ func addSecret(operation post.StatTrackedOperation[post.EnsureRelationshipJob], 
 	})
 }
 
-func addOwner(operation post.StatTrackedOperation[post.EnsureRelationshipJob], tenant *graph.Node) error {
-	return operation.Operation.SubmitReader(func(ctx context.Context, tx graph.Transaction, outC chan<- post.EnsureRelationshipJob) error {
+var addOwnerPostProcessedEdges = graph.Kinds{
+	azure.AddOwner,
+}
+
+func CreateAZAddOwnerEdge(ctx context.Context, db graph.Database) (*post.AtomicPostProcessingStats, error) {
+	defer measure.ContextLogAndMeasure(
+		ctx,
+		slog.LevelInfo,
+		"Post-processing Add Owner Role Assignments",
+		attr.Namespace("analysis"),
+		attr.Function("AddOwnerRoleAssignments"),
+		attr.Scope("process"),
+	)()
+
+	// Clear old post-processed edges that will not have a `firstseen` property
+	if err := post.MigrationForDCAPostProcessedEdges(ctx, db, addOwnerPostProcessedEdges); err != nil {
+		return &post.AtomicPostProcessingStats{}, err
+	}
+
+	// Pull a subgraph to compare against for tracking changes
+	if addOwnerTracker, err := post.FetchTracker(ctx, db, addOwnerPostProcessedEdges); err != nil {
+		return &post.AtomicPostProcessingStats{}, err
+	} else if tenantNodes, err := FetchTenants(ctx, db); err != nil {
+		return &post.AtomicPostProcessingStats{}, err
+	} else {
+		sink := post.NewFilteredRelationshipSink(ctx, "Azure Add Owner Post Processing", db, addOwnerTracker)
+		defer sink.Done()
+
+		for _, tenant := range tenantNodes {
+			if err := postAzureAddOwner(ctx, db, sink, tenant); err != nil {
+				return &post.AtomicPostProcessingStats{}, err
+			}
+		}
+
+		return sink.Stats(), nil
+	}
+}
+
+func postAzureAddOwner(ctx context.Context, db graph.Database, sink *post.FilteredRelationshipSink, tenant *graph.Node) error {
+	return db.ReadTransaction(ctx, func(tx graph.Transaction) error {
 		if addOwnerRoles, err := TenantRoles(tx, tenant, AddOwnerRoleIDs()...); err != nil {
 			return err
 		} else if tenantAppsAndSPs, err := TenantApplicationsAndServicePrincipals(tx, tenant); err != nil {
@@ -712,8 +748,8 @@ func addOwner(operation post.StatTrackedOperation[post.EnsureRelationshipJob], t
 						Kind:   azure.AddOwner,
 					}
 
-					if !channels.Submit(ctx, outC, nextJob) {
-						return nil
+					if !sink.Submit(ctx, nextJob) {
+						return fmt.Errorf("unable to submit to channel in postAzureAddOwner")
 					}
 				}
 			}
@@ -1172,6 +1208,8 @@ func Post(ctx context.Context, db graph.Database) (*post.AtomicPostProcessingSta
 		return &aggregateStats, err
 	} else if appRoleAssignmentStats, err := AppRoleAssignments(ctx, db); err != nil {
 		return &aggregateStats, err
+	} else if addOwnerStats, err := CreateAZAddOwnerEdge(ctx, db); err != nil {
+		return &aggregateStats, err
 	} else if hybridStats, err := hybrid.PostHybrid(ctx, db); err != nil {
 		return &aggregateStats, err
 	} else if pimRolesStats, err := CreateAZRoleApproverEdge(ctx, db); err != nil {
@@ -1179,6 +1217,7 @@ func Post(ctx context.Context, db graph.Database) (*post.AtomicPostProcessingSta
 	} else {
 		aggregateStats.Merge(executeCommandStats)
 		aggregateStats.Merge(appRoleAssignmentStats)
+		aggregateStats.Merge(addOwnerStats)
 		aggregateStats.Merge(hybridStats)
 		aggregateStats.Merge(pimRolesStats)
 

--- a/packages/go/analysis/azure/post.go
+++ b/packages/go/analysis/azure/post.go
@@ -75,6 +75,15 @@ func AddSecretRoleIDs() []string {
 	}
 }
 
+func AddOwnerRoleIDs() []string {
+	return []string{
+		azure.HybridIdentityAdministratorRole,
+		azure.PartnerTier1SupportRole,
+		azure.PartnerTier2SupportRole,
+		azure.DirectorySynchronizationAccountsRole,
+	}
+}
+
 func HelpdeskAdministratorPasswordResetTargetRoles() []string {
 	return []string{
 		azure.ReportsReaderRole,
@@ -229,6 +238,8 @@ func AppRoleAssignments(ctx context.Context, db graph.Database) (*post.AtomicPos
 				} else if err := createAZMGServicePrincipalEndpointReadWriteAllEdges(ctx, db, operation, tenantContainsServicePrincipalRelationships); err != nil {
 					return err
 				} else if err := addSecret(operation, tenant); err != nil {
+					return err
+				} else if err := addOwner(operation, tenant); err != nil {
 					return err
 				}
 
@@ -666,6 +677,39 @@ func addSecret(operation post.StatTrackedOperation[post.EnsureRelationshipJob], 
 						FromID: role.ID,
 						ToID:   target.ID,
 						Kind:   azure.AddSecret,
+					}
+
+					if !channels.Submit(ctx, outC, nextJob) {
+						return nil
+					}
+				}
+			}
+		}
+
+		return nil
+	})
+}
+
+func addOwner(operation post.StatTrackedOperation[post.EnsureRelationshipJob], tenant *graph.Node) error {
+	return operation.Operation.SubmitReader(func(ctx context.Context, tx graph.Transaction, outC chan<- post.EnsureRelationshipJob) error {
+		if addOwnerRoles, err := TenantRoles(tx, tenant, AddOwnerRoleIDs()...); err != nil {
+			return err
+		} else if tenantAppsAndSPs, err := TenantApplicationsAndServicePrincipals(tx, tenant); err != nil {
+			return err
+		} else {
+			for _, role := range addOwnerRoles {
+				for _, target := range tenantAppsAndSPs {
+					slog.DebugContext(
+						ctx,
+						"Adding AZAddOwner edge from role to target",
+						slog.String("role_id", role.ID.String()),
+						slog.String("target_kinds", strings.Join(target.Kinds.Strings(), ",")),
+						slog.Uint64("target_id", target.ID.Uint64()),
+					)
+					nextJob := post.EnsureRelationshipJob{
+						FromID: role.ID,
+						ToID:   target.ID,
+						Kind:   azure.AddOwner,
 					}
 
 					if !channels.Submit(ctx, outC, nextJob) {

--- a/packages/go/analysis/azure/post_test.go
+++ b/packages/go/analysis/azure/post_test.go
@@ -281,6 +281,16 @@ func TestFetchTenants(t *testing.T) {
 	assert.Contains(t, tenants.Slice(), stubTenant)
 }
 
+func TestAddOwnerRoleIDs(t *testing.T) {
+	roleIDs := azure.AddOwnerRoleIDs()
+
+	assert.Len(t, roleIDs, 4)
+	assert.Contains(t, roleIDs, azschema.HybridIdentityAdministratorRole)
+	assert.Contains(t, roleIDs, azschema.PartnerTier1SupportRole)
+	assert.Contains(t, roleIDs, azschema.PartnerTier2SupportRole)
+	assert.Contains(t, roleIDs, azschema.DirectorySynchronizationAccountsRole)
+}
+
 func TestEndNodes(t *testing.T) {
 	var (
 		ctrl         = gomock.NewController(t)

--- a/packages/go/graphschema/azure/roles.go
+++ b/packages/go/graphschema/azure/roles.go
@@ -45,6 +45,7 @@ const (
 	DirectoryReadersRole                        = "88d8e3e3-8f55-4a1e-953a-9b9898b8876b"
 	DirectorySynchronizationAccountsRole        = "d29b2b05-8046-44ba-8758-1e26182fcf32"
 	DirectoryWritersRole                        = "9360feb5-f418-4baa-8175-e2a00bac4301"
+	HybridIdentityAdministratorRole             = "8ac3fc64-6eca-42ea-9e69-59f4c7b60eb2"
 	TeamsServiceAdministratorRole               = "69091246-20e8-4a56-aa4d-066075b2a7a8"
 	TeamsCommunicationsSupportSpecialistRole    = "fcf91098-03e3-41a9-b5ba-6f0ec8188a12"
 	TeamsCommunicationsSupportEngineerRole      = "f70938a0-fc10-4177-9e90-2178f8765737"


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

This PR implements the AZAddOwner relationship in Azure post processing. Previously this relationship was unimplemented. The PR also includes an integration test for the new functionality. 

The HybridIdentityAdministratorRole literal was found from: https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/permissions-reference. 

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves [BED-4754](https://specterops.atlassian.net/browse/BED-4754)

*Why is this change required? What problem does it solve?*

## How Has This Been Tested?

I created a new integration test for post processing to test the creation of the AZAddOwner relationship. All new and existing tests compile and pass locally. Additionally, creation of relationships with sample data has been verified. 

## Screenshots (optional):

<img width="1512" height="831" alt="image" src="https://github.com/user-attachments/assets/2ec5847b-ca73-4a02-93b9-a9a49cb3b7cd" />

## Types of changes

<!-- Please remove any items that do not apply. -->

- New feature (non-breaking change which adds functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [X] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [X] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [X] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


[BED-4754]: https://specterops.atlassian.net/browse/BED-4754?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detects Azure role assignments that grant owner capabilities and emits corresponding post-processed relationships.
  * Adds the Hybrid Identity Administrator role to tracked Azure owner-capable roles.

* **Tests**
  * Added an integration test validating owner-relationship creation across tenants, applications, service principals, and roles.
  * Added integration test helpers and a unit test to verify the tracked role-ID list and integration setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->