### PR TITLE
fix: updated parsing logic to include format vX.Y.Z-rc#-docker BED-7980

### DIFF
--- a/cmd/api/src/utils/util.go
+++ b/cmd/api/src/utils/util.go
@@ -199,10 +199,6 @@ func isValidCollectorSemver(parsedVersion *semver.Version, clientType ClientType
 	}
 
 	if clientType == ClientTypeAzureHound {
-		if parsedVersion.Prerelease() != "" && parsedVersion.Metadata() != "" {
-			return false
-		}
-
 		return parsedVersion.Metadata() == "" || parsedVersion.Metadata() == "docker"
 	}
 

--- a/cmd/api/src/utils/util.go
+++ b/cmd/api/src/utils/util.go
@@ -82,6 +82,11 @@ func IsValidClientVersion(userAgent string) (ClientVersion, error) {
 	}
 }
 
+// ParseClientVersion extracts the client type from a user agent string and delegates to
+// the appropriate version parser. Supported formats:
+//   - azurehound/vX.Y.Z[-rcN][+docker]
+//   - openhound/vX.Y.Z[-rcN]
+//   - sharphound/X.Y.Z.W[-rcN]
 func ParseClientVersion(userAgent string) (ClientVersion, error) {
 	clientType, rawVersion, err := parseClientUserAgent(userAgent)
 	if err != nil {
@@ -98,6 +103,7 @@ func ParseClientVersion(userAgent string) (ClientVersion, error) {
 	}
 }
 
+// clientVersionFromSemver maps a parsed semver.Version into a ClientVersion struct.
 func clientVersionFromSemver(clientType ClientType, parsedVersion *semver.Version, extra int) ClientVersion {
 	return ClientVersion{
 		ClientType:    clientType,
@@ -110,6 +116,8 @@ func clientVersionFromSemver(clientType ClientType, parsedVersion *semver.Versio
 	}
 }
 
+// parseClientUserAgent splits a user agent string into its client type and raw version component.
+// Returns ErrInvalidClientType if the user agent does not match a known client prefix.
 func parseClientUserAgent(userAgent string) (ClientType, string, error) {
 	switch {
 	case strings.HasPrefix(userAgent, "azurehound/"):
@@ -126,6 +134,8 @@ func parseClientUserAgent(userAgent string) (ClientType, string, error) {
 	}
 }
 
+// parseCollectorVersion parses a raw version string for AzureHound or OpenHound collectors
+// using semver, then validates that the prerelease and build metadata conform to allowed values.
 func parseCollectorVersion(clientType ClientType, rawVersion string) (ClientVersion, error) {
 	version := ClientVersion{ClientType: clientType}
 
@@ -145,6 +155,8 @@ func parseCollectorVersion(clientType ClientType, rawVersion string) (ClientVers
 	return clientVersionFromSemver(clientType, parsedVersion, 0), nil
 }
 
+// parseSharpHoundVersion parses a raw version string in SharpHound's X.Y.Z.W[-rcN] format.
+// The fourth numeric component is stored as Extra, and the first three are parsed via semver.
 func parseSharpHoundVersion(rawVersion string) (ClientVersion, error) {
 	version := ClientVersion{ClientType: ClientTypeSharpHound}
 
@@ -169,6 +181,8 @@ func parseSharpHoundVersion(rawVersion string) (ClientVersion, error) {
 	return clientVersionFromSemver(ClientTypeSharpHound, parsedVersion, extra), nil
 }
 
+// splitSharpHoundVersion splits a SharpHound version string into a semver-compatible version
+// and the fourth numeric component (extra). For example, "2.1.0.3-rc1" returns ("2.1.0-rc1", 3, nil).
 func splitSharpHoundVersion(rawVersion string) (string, int, error) {
 	sharpHoundParts := strings.Split(rawVersion, ".")
 
@@ -185,6 +199,8 @@ func splitSharpHoundVersion(rawVersion string) (string, int, error) {
 	return strings.Join(sharpHoundParts[:3], ".") + buildPrereleaseSuffix(prereleasePart), extra, nil
 }
 
+// buildPrereleaseSuffix returns a prerelease suffix prefixed with "-" for use in semver strings,
+// or an empty string if no prerelease is present.
 func buildPrereleaseSuffix(prerelease string) string {
 	if prerelease == "" {
 		return ""
@@ -193,6 +209,10 @@ func buildPrereleaseSuffix(prerelease string) string {
 	return "-" + prerelease
 }
 
+// isValidCollectorSemver validates that a parsed semver version conforms to collector-specific rules:
+//   - Prerelease must be empty or match the format "rcN" where N >= 1.
+//   - AzureHound build metadata must be empty or "docker".
+//   - OpenHound build metadata must be empty.
 func isValidCollectorSemver(parsedVersion *semver.Version, clientType ClientType) bool {
 	if !isValidRCPrerelease(parsedVersion.Prerelease()) {
 		return false
@@ -205,6 +225,8 @@ func isValidCollectorSemver(parsedVersion *semver.Version, clientType ClientType
 	return parsedVersion.Metadata() == ""
 }
 
+// isValidRCPrerelease validates that a prerelease string is either empty or matches the
+// format "rcN" where N is an integer >= 1.
 func isValidRCPrerelease(prerelease string) bool {
 	if prerelease == "" {
 		return true
@@ -227,10 +249,13 @@ func isValidRCPrerelease(prerelease string) bool {
 	return true
 }
 
+// isValidSharpHoundSemver validates that a parsed semver version conforms to SharpHound rules:
+// prerelease must be empty or "rcN" where N >= 1, and build metadata must be empty.
 func isValidSharpHoundSemver(parsedVersion *semver.Version) bool {
 	return isValidRCPrerelease(parsedVersion.Prerelease()) && parsedVersion.Metadata() == ""
 }
 
+// parseSemverVersion strips an optional leading "v" and parses the version using semver.StrictNewVersion.
 func parseSemverVersion(rawVersion string) (*semver.Version, error) {
 	return semver.StrictNewVersion(strings.TrimPrefix(rawVersion, "v"))
 }

--- a/cmd/api/src/utils/util_test.go
+++ b/cmd/api/src/utils/util_test.go
@@ -65,7 +65,16 @@ func TestIsValidClientVersion(t *testing.T) {
 	_, err = utils.IsValidClientVersion("azurehound/0.0.0+notdocker")
 	require.ErrorIs(t, err, utils.ErrInvalidCollectorVersion)
 
-	_, err = utils.IsValidClientVersion("azurehound/0.0.0-rc1+docker")
+	azureHoundRCDockerVersion, err := utils.IsValidClientVersion("azurehound/0.0.0-rc1+docker")
+	require.Nil(t, err)
+	require.Equal(t, utils.ClientTypeAzureHound, azureHoundRCDockerVersion.ClientType)
+	require.Equal(t, 0, azureHoundRCDockerVersion.Major)
+	require.Equal(t, 0, azureHoundRCDockerVersion.Minor)
+	require.Equal(t, 0, azureHoundRCDockerVersion.Patch)
+	require.Equal(t, "rc1", azureHoundRCDockerVersion.Prerelease)
+	require.Equal(t, "docker", azureHoundRCDockerVersion.BuildMetadata)
+
+	_, err = utils.IsValidClientVersion("azurehound/0.0.0-rc1+notdocker")
 	require.ErrorIs(t, err, utils.ErrInvalidCollectorVersion)
 
 	_, err = utils.IsValidClientVersion("azurehound/0.0.0-rcfoo")
@@ -232,6 +241,16 @@ func TestParseClientVersion(t *testing.T) {
 	require.Equal(t, "docker", version.BuildMetadata)
 
 	version, err = utils.ParseClientVersion("azurehound/v1.0.1-rc1+docker")
+	require.Nil(t, err)
+	require.Equal(t, utils.ClientTypeAzureHound, version.ClientType)
+	require.Equal(t, 1, version.Major)
+	require.Equal(t, 0, version.Minor)
+	require.Equal(t, 1, version.Patch)
+	require.Equal(t, 0, version.Extra)
+	require.Equal(t, "rc1", version.Prerelease)
+	require.Equal(t, "docker", version.BuildMetadata)
+
+	version, err = utils.ParseClientVersion("azurehound/v1.0.1-rc1+notdocker")
 	require.Equal(t, utils.ErrInvalidCollectorVersion, err)
 
 	version, err = utils.ParseClientVersion("azurehound/v1.0.1+notdocker")


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

User agent parsing was not accounted for format `azurehound/vX.Y.Z-rc#+docker`. This made it so the collectors couldn't connect to BHE and jobs were stuck running

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-7980

## How Has This Been Tested?
Manual testing (instructions in [Manual Testing Instructions](https://specterops.atlassian.net/browse/BED-7980)) and added unit tests

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved client-version parsing and validation so AzureHound release-candidate versions with Docker build metadata (e.g., +docker) are accepted, while other invalid build metadata remain rejected. This yields more accurate client-type detection and fewer false negatives when reporting collector versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->