### PR TITLE
chore: exclude mockServiceWorker.js from production builds BED-7993

### DIFF
--- a/cmd/ui/vite.config.ts
+++ b/cmd/ui/vite.config.ts
@@ -16,8 +16,9 @@
 
 /// <reference types="vitest" />
 import react from '@vitejs/plugin-react';
+import fs from 'fs';
 import path from 'path';
-import { defineConfig, loadEnv, searchForWorkspaceRoot } from 'vite';
+import { defineConfig, loadEnv, Plugin, searchForWorkspaceRoot } from 'vite';
 import glsl from 'vite-plugin-glsl';
 
 // https://vitejs.dev/config/
@@ -25,7 +26,7 @@ export default defineConfig(({ mode }) => {
     const env = loadEnv(mode, process.cwd(), '');
 
     return {
-        plugins: [react(), glsl()],
+        plugins: [react(), glsl(), excludeMockServiceWorker()],
         resolve: {
             alias: {
                 src: path.resolve(__dirname, './src'),
@@ -110,3 +111,23 @@ export default defineConfig(({ mode }) => {
         },
     };
 });
+
+/**
+ * Exclude mockServiceWorker.js from production builds
+ * MSW service worker should only be available in development mode
+ */
+function excludeMockServiceWorker(): Plugin {
+    return {
+        name: 'exclude-mock-service-worker',
+        apply: 'build', // Only apply during build (production)
+        closeBundle() {
+            // Remove mockServiceWorker.js from the output directory after build
+            const outDir = process.env.BUILD_PATH || './dist';
+            const mockServiceWorkerPath = path.resolve(__dirname, outDir, 'mockServiceWorker.js');
+
+            if (fs.existsSync(mockServiceWorkerPath)) {
+                fs.unlinkSync(mockServiceWorkerPath);
+            }
+        },
+    };
+}

--- a/cmd/ui/vite.config.ts
+++ b/cmd/ui/vite.config.ts
@@ -107,7 +107,7 @@ export default defineConfig(({ mode }) => {
             ],
         },
         build: {
-            outDir: env.BUILD_PATH || './dist',
+            outDir: './dist',
         },
     };
 });
@@ -122,8 +122,7 @@ function excludeMockServiceWorker(): Plugin {
         apply: 'build', // Only apply during build (production)
         closeBundle() {
             // Remove mockServiceWorker.js from the output directory after build
-            const outDir = process.env.BUILD_PATH || './dist';
-            const mockServiceWorkerPath = path.resolve(__dirname, outDir, 'mockServiceWorker.js');
+            const mockServiceWorkerPath = path.resolve(__dirname, 'dist', 'mockServiceWorker.js');
 
             if (fs.existsSync(mockServiceWorkerPath)) {
                 fs.unlinkSync(mockServiceWorkerPath);

--- a/cmd/ui/vite.config.ts
+++ b/cmd/ui/vite.config.ts
@@ -26,7 +26,7 @@ export default defineConfig(({ mode }) => {
     const env = loadEnv(mode, process.cwd(), '');
 
     return {
-        plugins: [react(), glsl(), excludeMockServiceWorker()],
+        plugins: [react(), glsl(), excludeMockServiceWorker(env)],
         resolve: {
             alias: {
                 src: path.resolve(__dirname, './src'),
@@ -107,7 +107,7 @@ export default defineConfig(({ mode }) => {
             ],
         },
         build: {
-            outDir: './dist',
+            outDir: env.BUILD_PATH || './dist',
         },
     };
 });
@@ -116,13 +116,15 @@ export default defineConfig(({ mode }) => {
  * Exclude mockServiceWorker.js from production builds
  * MSW service worker should only be available in development mode
  */
-function excludeMockServiceWorker(): Plugin {
+function excludeMockServiceWorker(env: ReturnType<typeof loadEnv>): Plugin {
     return {
         name: 'exclude-mock-service-worker',
         apply: 'build', // Only apply during build (production)
         closeBundle() {
             // Remove mockServiceWorker.js from the output directory after build
-            const mockServiceWorkerPath = path.resolve(__dirname, 'dist', 'mockServiceWorker.js');
+            const mockServiceWorkerPath = env.BUILD_PATH
+                ? path.resolve(env.BUILD_PATH, 'mockServiceWorker.js')
+                : path.resolve(__dirname, 'dist', 'mockServiceWorker.js');
 
             if (fs.existsSync(mockServiceWorkerPath)) {
                 fs.unlinkSync(mockServiceWorkerPath);


### PR DESCRIPTION
## Description

Excludes `mockServiceWorker.js` from production builds while keeping it available for development mode.

MSW (Mock Service Worker) requires the service worker file to be served from the public directory to function properly in development. However, this file should not be included in production builds as it's only needed for local mocking during development.

This PR adds a custom Vite plugin that automatically removes `mockServiceWorker.js` from the build output after Vite copies public assets to the dist folder.

## Motivation and Context

Resolves BED-7993

The mockServiceWorker.js file was being included in production builds, adding unnecessary development-only code to the production bundle. This change ensures that MSW artifacts are excluded from production while maintaining full functionality in development mode.

## How Has This Been Tested?

- Built the BHCE UI with `yarn build`
- Verified build output and dist folder contents (to ensure mockServiceWorker.js is not present)

## Screenshots (optional):

N/A

## Types of changes

- Chore (a change that does not modify the application functionality)

## Checklist:

- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Remove mock service worker from production builds to streamline output and avoid shipping test artifacts.
  * Ensure build reliably locates the output directory for consistent deployment artifacts.
  * Add a build-only step that detects and removes unwanted mock assets during production packaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->