### PR TITLE
fix: small bug in Cross Product BED-8034

### DIFF
--- a/cmd/api/src/test/integration/harnesses.go
+++ b/cmd/api/src/test/integration/harnesses.go
@@ -5613,6 +5613,48 @@ func (s *ShortcutHarnessEveryone2) Setup(graphTestContext *GraphTestContext) {
 	graphTestContext.UpdateNode(s.Everyone)
 }
 
+// ShortcutHarnessSharedMember models the scenario where a user is a member of two sub-groups that both
+// appear in the second node set, and both sub-groups are reachable through a common parent group in the
+// first node set. The shared user must not appear as an individual cross-product result because it is
+// already covered by both sub-groups.
+//
+// Graph shape:
+//
+//	SharedUser  -[MemberOf]-> SubGroup1 -[MemberOf]-> ParentGroup  (firstSet)
+//	SharedUser  -[MemberOf]-> SubGroup2 -[MemberOf]-> ParentGroup
+//	UniqueUser1 -[MemberOf]-> SubGroup1                             (secondSet contains SubGroup1, SubGroup2)
+//	UniqueUser2 -[MemberOf]-> SubGroup2
+type ShortcutHarnessSharedMember struct {
+	ParentGroup *graph.Node
+	SubGroup1   *graph.Node
+	SubGroup2   *graph.Node
+	SharedUser  *graph.Node
+	UniqueUser1 *graph.Node
+	UniqueUser2 *graph.Node
+}
+
+func (s *ShortcutHarnessSharedMember) Setup(graphTestContext *GraphTestContext) {
+	sid := RandomDomainSID()
+	s.ParentGroup = graphTestContext.NewActiveDirectoryGroup("PARENT GROUP", sid)
+	s.SubGroup1 = graphTestContext.NewActiveDirectoryGroup("SUB GROUP ONE", sid)
+	s.SubGroup2 = graphTestContext.NewActiveDirectoryGroup("SUB GROUP TWO", sid)
+	s.SharedUser = graphTestContext.NewActiveDirectoryUser("SHARED USER", sid)
+	s.UniqueUser1 = graphTestContext.NewActiveDirectoryUser("UNIQUE USER ONE", sid)
+	s.UniqueUser2 = graphTestContext.NewActiveDirectoryUser("UNIQUE USER TWO", sid)
+
+	// Both sub-groups are members of the parent group
+	graphTestContext.NewRelationship(s.SubGroup1, s.ParentGroup, ad.MemberOf)
+	graphTestContext.NewRelationship(s.SubGroup2, s.ParentGroup, ad.MemberOf)
+
+	// SharedUser is a member of both sub-groups
+	graphTestContext.NewRelationship(s.SharedUser, s.SubGroup1, ad.MemberOf)
+	graphTestContext.NewRelationship(s.SharedUser, s.SubGroup2, ad.MemberOf)
+
+	// Each unique user belongs to exactly one sub-group
+	graphTestContext.NewRelationship(s.UniqueUser1, s.SubGroup1, ad.MemberOf)
+	graphTestContext.NewRelationship(s.UniqueUser2, s.SubGroup2, ad.MemberOf)
+}
+
 type RootADHarness struct {
 	ActiveDirectoryDomainSID                string
 	ActiveDirectoryDomain                   *graph.Node
@@ -10182,6 +10224,7 @@ type HarnessDetails struct {
 	ShortcutHarnessAuthUsers                        ShortcutHarnessAuthUsers
 	ShortcutHarnessEveryone                         ShortcutHarnessEveryone
 	ShortcutHarnessEveryone2                        ShortcutHarnessEveryone2
+	ShortcutHarnessSharedMember                     ShortcutHarnessSharedMember
 	ADCSESC1Harness                                 ADCSESC1Harness
 	ADCSESC1HarnessAuthUsers                        ADCSESC1HarnessAuthUsers
 	EnrollOnBehalfOfHarness1                        EnrollOnBehalfOfHarness1

--- a/cmd/ui/public/mockServiceWorker.js
+++ b/cmd/ui/public/mockServiceWorker.js
@@ -17,7 +17,7 @@
 /* tslint:disable */
 
 /**
- * Mock Service Worker (1.3.3).
+ * Mock Service Worker (1.3.5).
  * @see https://github.com/mswjs/msw
  * - Please do NOT modify this file.
  * - Please do NOT serve this file on production.

--- a/packages/go/analysis/ad/ad.go
+++ b/packages/go/analysis/ad/ad.go
@@ -668,11 +668,19 @@ func CalculateCrossProductNodeSets(localGroupData *LocalGroupData, nodeSlices ..
 		}
 
 		if checkSet.Contains(groupId) {
-			// If this entity is a cross product, add it to result entities, remove the group id from the second set and xor the group's membership with the result set
+			// If this entity is a cross product, add it to result entities, remove the group id from the second set and remove the group's membership from the result set
 			resultEntities.Add(groupId)
 
 			unrolledRefSet.Remove(groupId)
-			localGroupData.GroupMembershipCache.XorReach(groupId, graph.DirectionInbound, unrolledRefSet)
+			// Use ReachSliceOfComponentContainingMember with iterative AndNot instead of XorReach.
+			// XorReach toggles bits, which re-adds members that were previously removed when they
+			// belong to multiple matching groups, causing false-positive result entries.
+			// Iterative AndNot only removes: A & ~(B₁|B₂|…|Bₖ) = A&~B₁&~B₂&…&~Bₖ
+			// This also avoids the two bitmap allocations XorReach requires (merge + clone),
+			// since ReachSliceOfComponentContainingMember returns shared component bitmaps directly.
+			for _, componentBitmap := range localGroupData.GroupMembershipCache.ReachSliceOfComponentContainingMember(groupId, graph.DirectionInbound) {
+				unrolledRefSet.AndNot(componentBitmap)
+			}
 		} else {
 			// If this isn't a match, remove it from the second set to ensure we don't check it again, but leave its membership
 			unrolledRefSet.Remove(groupId)

--- a/packages/go/analysis/ad/post_integration_test.go
+++ b/packages/go/analysis/ad/post_integration_test.go
@@ -102,6 +102,48 @@ func TestCrossProductEveryone2(t *testing.T) {
 	})
 }
 
+// TestCrossProductSharedMemberNotDuplicated ensures that a user who is a member of two sub-groups that
+// both qualify as cross-product results does not appear as an individual result entry. Prior to the fix,
+// the XorReach shortcutting toggled the shared member back into the candidate set when the second
+// matching sub-group was processed, causing a false-positive individual result edge.
+//
+// Graph shape:
+//
+//	firstSet  = [ParentGroup]
+//	secondSet = [SubGroup1, SubGroup2]
+//
+//	SharedUser  -[MemberOf]-> SubGroup1 -[MemberOf]-> ParentGroup
+//	SharedUser  -[MemberOf]-> SubGroup2 -[MemberOf]-> ParentGroup
+//	UniqueUser1 -[MemberOf]-> SubGroup1
+//	UniqueUser2 -[MemberOf]-> SubGroup2
+//
+// Expected results: SubGroup1 and SubGroup2 only. SharedUser is covered by both groups and must not
+// appear individually.
+func TestCrossProductSharedMemberNotDuplicated(t *testing.T) {
+	testContext := integration.NewGraphTestContext(t, schema.DefaultGraphSchema())
+	testContext.DatabaseTransactionTestWithSetup(func(harness *integration.HarnessDetails) error {
+		harness.ShortcutHarnessSharedMember.Setup(testContext)
+		return nil
+	}, func(harness integration.HarnessDetails, graphDB graph.Database, tx graph.Transaction) {
+		var (
+			firstSet  = []*graph.Node{testContext.Harness.ShortcutHarnessSharedMember.ParentGroup}
+			secondSet = []*graph.Node{testContext.Harness.ShortcutHarnessSharedMember.SubGroup1, testContext.Harness.ShortcutHarnessSharedMember.SubGroup2}
+		)
+
+		localGroupData, err := ad.FetchLocalGroupData(context.Background(), graphDB)
+		require.NoError(t, err)
+
+		results := ad.CalculateCrossProductNodeSets(localGroupData, firstSet, secondSet)
+
+		// Both sub-groups are valid cross-product results: each appears in both sets
+		require.True(t, results.Contains(harness.ShortcutHarnessSharedMember.SubGroup1.ID.Uint64()))
+		require.True(t, results.Contains(harness.ShortcutHarnessSharedMember.SubGroup2.ID.Uint64()))
+
+		// SharedUser is already covered by SubGroup1 and SubGroup2 and must not appear individually
+		require.False(t, results.Contains(harness.ShortcutHarnessSharedMember.SharedUser.ID.Uint64()))
+	})
+}
+
 func FetchCanRDPData(ctx context.Context, graphDB graph.Database) (*ad.CanRDPData, error) {
 	if localGroupData, err := ad.FetchLocalGroupData(ctx, graphDB); err != nil {
 		return nil, err

--- a/packages/go/analysis/ad/post_integration_test.go
+++ b/packages/go/analysis/ad/post_integration_test.go
@@ -138,6 +138,7 @@ func TestCrossProductSharedMemberNotDuplicated(t *testing.T) {
 		// Both sub-groups are valid cross-product results: each appears in both sets
 		require.True(t, results.Contains(harness.ShortcutHarnessSharedMember.SubGroup1.ID.Uint64()))
 		require.True(t, results.Contains(harness.ShortcutHarnessSharedMember.SubGroup2.ID.Uint64()))
+		require.Equal(t, 2, int(results.Cardinality()))
 
 		// SharedUser is already covered by SubGroup1 and SubGroup2 and must not appear individually
 		require.False(t, results.Contains(harness.ShortcutHarnessSharedMember.SharedUser.ID.Uint64()))


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description
An issue was identified in Cross Product that could lead to the creation of extra, unnecessary edges in very specific cirucmstances.

## Motivation and Context

https://specterops.atlassian.net/browse/BED-8034

## How Has This Been Tested?

Added a new integration test to cover the specific scenario. All existing tests pass.

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)


## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [ ] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicated results when entities belong to overlapping groups so cross-product analysis returns accurate, deduplicated outcomes.
* **Tests**
  * Added an integration test validating shared members are not reintroduced as individual candidates.
* **Chores**
  * Added a test harness to support the new integration scenario.
  * Updated service worker metadata/version comment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->