### PR TITLE
fix: cypher shortcut concatenation BED-6595

### DIFF
--- a/cmd/api/src/queries/rewriter.go
+++ b/cmd/api/src/queries/rewriter.go
@@ -20,6 +20,7 @@ import (
 	"github.com/specterops/bloodhound/packages/go/graphschema/azure"
 	"github.com/specterops/dawgs/cypher/models/cypher"
 	"github.com/specterops/dawgs/cypher/models/walk"
+	"github.com/specterops/dawgs/graph"
 )
 
 const (
@@ -57,17 +58,17 @@ func (s *Rewriter) Enter(node cypher.SyntaxNode) {
 				s.HasRelationshipTypeShortcut = true
 				typedNode.Kinds = append(azure.PathfindingRelationships(), ad.PathfindingRelationships()...)
 
+				return
+
 			case azureAttackPathsRelationshipShortcutType:
 				s.HasRelationshipTypeShortcut = true
-				typedNode.Kinds = azure.PathfindingRelationships()
+				typedNode.Kinds = typedNode.Kinds.Remove(graph.StringKind(azureAttackPathsRelationshipShortcutType))
+				typedNode.Kinds = typedNode.Kinds.Concatenate(azure.PathfindingRelationships())
 
 			case adAttackPathsRelationshipShortcutType:
 				s.HasRelationshipTypeShortcut = true
-				typedNode.Kinds = ad.PathfindingRelationships()
-			}
-
-			if s.HasRelationshipTypeShortcut {
-				break
+				typedNode.Kinds = typedNode.Kinds.Remove(graph.StringKind(adAttackPathsRelationshipShortcutType))
+				typedNode.Kinds = typedNode.Kinds.Concatenate(ad.PathfindingRelationships())
 			}
 		}
 	}

--- a/cmd/api/src/queries/rewriter_test.go
+++ b/cmd/api/src/queries/rewriter_test.go
@@ -1,0 +1,162 @@
+// Copyright 2026 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package queries_test
+
+import (
+	"testing"
+
+	"github.com/specterops/bloodhound/cmd/api/src/queries"
+	"github.com/specterops/bloodhound/packages/go/graphschema/ad"
+	"github.com/specterops/bloodhound/packages/go/graphschema/azure"
+	"github.com/specterops/dawgs/cypher/models/cypher"
+	"github.com/specterops/dawgs/graph"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewRewriter(t *testing.T) {
+	rewriter := queries.NewRewriter()
+
+	require.NotNil(t, rewriter)
+	require.NotNil(t, rewriter.Visitor)
+	require.False(t, rewriter.HasMutation)
+	require.False(t, rewriter.HasRelationshipTypeShortcut)
+}
+
+func TestRewriter_Enter_UpdatingClauseSetsHasMutation(t *testing.T) {
+	rewriter := queries.NewRewriter()
+
+	rewriter.Enter(&cypher.UpdatingClause{})
+
+	require.True(t, rewriter.HasMutation)
+	require.False(t, rewriter.HasRelationshipTypeShortcut)
+}
+
+func TestRewriter_Enter_ADAttackPathsShortcut_ReplacesKinds(t *testing.T) {
+	var (
+		rewriter            = queries.NewRewriter()
+		relationshipPattern = &cypher.RelationshipPattern{
+			Kinds: graph.Kinds{graph.StringKind("AD_ATTACK_PATHS")},
+		}
+	)
+
+	rewriter.Enter(relationshipPattern)
+
+	require.True(t, rewriter.HasRelationshipTypeShortcut)
+	require.False(t, rewriter.HasMutation)
+	require.Equal(t, graph.Kinds(ad.PathfindingRelationships()), relationshipPattern.Kinds)
+}
+
+func TestRewriter_Enter_AzureAttackPathsShortcut_ReplacesKinds(t *testing.T) {
+	var (
+		rewriter            = queries.NewRewriter()
+		relationshipPattern = &cypher.RelationshipPattern{
+			Kinds: graph.Kinds{graph.StringKind("AZ_ATTACK_PATHS")},
+		}
+	)
+
+	rewriter.Enter(relationshipPattern)
+
+	require.True(t, rewriter.HasRelationshipTypeShortcut)
+	require.False(t, rewriter.HasMutation)
+	require.Equal(t, graph.Kinds(azure.PathfindingRelationships()), relationshipPattern.Kinds)
+}
+
+func TestRewriter_Enter_CombinedAzureAndADShortcut_ConcatenatesKinds(t *testing.T) {
+	var (
+		rewriter            = queries.NewRewriter()
+		relationshipPattern = &cypher.RelationshipPattern{
+			Kinds: graph.Kinds{
+				graph.StringKind("AZ_ATTACK_PATHS"),
+				graph.StringKind("AD_ATTACK_PATHS"),
+			},
+		}
+		expectedKinds = graph.Kinds(append(azure.PathfindingRelationships(), ad.PathfindingRelationships()...))
+	)
+
+	rewriter.Enter(relationshipPattern)
+
+	require.True(t, rewriter.HasRelationshipTypeShortcut)
+	require.Equal(t, expectedKinds, relationshipPattern.Kinds)
+}
+
+func TestRewriter_Enter_CombinedADAndAzureShortcut_PreservesOrder(t *testing.T) {
+	var (
+		rewriter            = queries.NewRewriter()
+		relationshipPattern = &cypher.RelationshipPattern{
+			Kinds: graph.Kinds{
+				graph.StringKind("AD_ATTACK_PATHS"),
+				graph.StringKind("AZ_ATTACK_PATHS"),
+			},
+		}
+		expectedKinds = graph.Kinds(append(ad.PathfindingRelationships(), azure.PathfindingRelationships()...))
+	)
+
+	rewriter.Enter(relationshipPattern)
+
+	require.True(t, rewriter.HasRelationshipTypeShortcut)
+	require.Equal(t, expectedKinds, relationshipPattern.Kinds)
+}
+
+func TestRewriter_Enter_AllAttackPathsShortcut_ReplacesKinds(t *testing.T) {
+	var (
+		rewriter            = queries.NewRewriter()
+		relationshipPattern = &cypher.RelationshipPattern{
+			Kinds: graph.Kinds{graph.StringKind("ALL_ATTACK_PATHS")},
+		}
+		expectedKinds = graph.Kinds(append(azure.PathfindingRelationships(), ad.PathfindingRelationships()...))
+	)
+
+	rewriter.Enter(relationshipPattern)
+
+	require.True(t, rewriter.HasRelationshipTypeShortcut)
+	require.Equal(t, expectedKinds, relationshipPattern.Kinds)
+}
+
+func TestRewriter_Enter_AllAttackPathsShortcut_TakesPrecedenceOverOtherShortcuts(t *testing.T) {
+	var (
+		rewriter            = queries.NewRewriter()
+		relationshipPattern = &cypher.RelationshipPattern{
+			Kinds: graph.Kinds{
+				graph.StringKind("ALL_ATTACK_PATHS"),
+				graph.StringKind("AZ_ATTACK_PATHS"),
+				graph.StringKind("AD_ATTACK_PATHS"),
+			},
+		}
+		expectedKinds = graph.Kinds(append(azure.PathfindingRelationships(), ad.PathfindingRelationships()...))
+	)
+
+	rewriter.Enter(relationshipPattern)
+
+	require.True(t, rewriter.HasRelationshipTypeShortcut)
+	require.Equal(t, expectedKinds, relationshipPattern.Kinds)
+}
+
+func TestRewriter_Enter_NoShortcut_PreservesKinds(t *testing.T) {
+	var (
+		rewriter            = queries.NewRewriter()
+		originalKind        = graph.StringKind("MemberOf")
+		relationshipPattern = &cypher.RelationshipPattern{
+			Kinds: graph.Kinds{originalKind},
+		}
+	)
+
+	rewriter.Enter(relationshipPattern)
+
+	require.False(t, rewriter.HasRelationshipTypeShortcut)
+	require.False(t, rewriter.HasMutation)
+	require.Equal(t, graph.Kinds{originalKind}, relationshipPattern.Kinds)
+}


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

An update is made so that using the existing Active Directory and Azure cypher edge shortcuts work when using the pipe character for concatenating the sets of edges associated with the shortcuts.

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-6595

*Why is this change required? What problem does it solve?*

## How Has This Been Tested?

New set of unit tests for the rewriter have been added. 

## Screenshots (optional):

Example showing both AD and AZ edges in the result set when using concatenation with the edge shortcuts.

<img width="3024" height="1674" alt="image" src="https://github.com/user-attachments/assets/4bc7d3e3-bd65-48c9-9c9c-137a1aea38cc" />


## Types of changes

<!-- Please remove any items that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed query-rewriter handling of attack-path relationship shortcuts: combined shortcuts are accumulated (not overwritten), input order is preserved, the universal shortcut (ALL_ATTACK_PATHS) takes precedence and halts further processing after appending Azure+AD relationships, and shortcut kinds are removed from existing kind sets rather than replaced.

* **Tests**
  * Added tests covering individual, combined, order-sensitive, precedence, immediate-return, and non-shortcut scenarios to validate rewrite behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->