### PR TITLE
fix: azure post processing failing with postgres BED-8031

### DIFF
--- a/packages/go/graphschema/schema.go
+++ b/packages/go/graphschema/schema.go
@@ -150,6 +150,28 @@ func ActiveDirectoryGraphSchema(name string) graph.Graph {
 	}
 }
 
+func MetaGraphDefinition() graph.Graph {
+	return graph.Graph{
+		Name:  "meta",
+		Nodes: []graph.Kind{meta, metaDetail},
+		Edges: []graph.Kind{metaIncludes},
+		NodeIndexes: []graph.Index{
+			{
+				Field: common.SystemTags.String(),
+				Type:  graph.TextSearchIndex,
+			},
+			{
+				Field: common.UserTags.String(),
+				Type:  graph.TextSearchIndex,
+			},
+			{
+				Field: common.OwnerObjectID.String(),
+				Type:  graph.TextSearchIndex,
+			},
+		},
+	}
+}
+
 func DefaultGraph() graph.Graph {
 	return CombinedGraphSchema("default")
 }
@@ -160,6 +182,7 @@ func DefaultGraphSchema() graph.Schema {
 	return graph.Schema{
 		Graphs: []graph.Graph{
 			defaultGraph,
+			MetaGraphDefinition(),
 		},
 
 		DefaultGraph: defaultGraph,


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

This PR adds the meta kinds to the CE graphschema. This prevents Azure post processing from failing when postgres is the graphDB since the meta kinds are referenced in Azure post processing. 

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves [BED-8031](https://specterops.atlassian.net/browse/BED-8031)

*Why is this change required? What problem does it solve?*

## How Has This Been Tested?

1. On a clean BHCE instance
3. Switch DB to Postgres (this can be done by sending a PUT to http://bloodhound.localhost:2112/graph-db/switch/pg)
5. [Upload Azure sample data](https://bloodhound.specterops.io/get-started/quickstart/ce-ingest-sample-data#azure)
7. Azure post processing successfully completes and analysis successfully completes as a whole

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [X] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [X] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [X] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


[BED-8031]: https://specterops.atlassian.net/browse/BED-8031?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ