### PR TITLE
feat: Add OpenHound collector link to Downloads page - BED-8032

### DIFF
--- a/cmd/ui/src/views/DownloadCollectors/DownloadCollectors.tsx
+++ b/cmd/ui/src/views/DownloadCollectors/DownloadCollectors.tsx
@@ -14,8 +14,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { Alert, Box, Paper, Skeleton, Typography } from '@mui/material';
-import { CollectorCardList, DocumentationLinks, PageWithTitle, apiClient } from 'bh-shared-ui';
+import { Alert, Box, Link, Paper, Skeleton, Typography } from '@mui/material';
+import { CollectorCardList, DocumentationLinks, PageWithTitle, apiClient, useFeatureFlag } from 'bh-shared-ui';
 import { CommunityCollectorType } from 'js-client-library';
 import fileDownload from 'js-file-download';
 import { addSnackbar } from 'src/ducks/global/actions';
@@ -27,6 +27,9 @@ const DownloadCollectors = () => {
     const dispatch = useAppDispatch();
     const sharpHoundCollectorsQuery = useGetCollectorsByType('sharphound');
     const azureHoundCollectorsQuery = useGetCollectorsByType('azurehound');
+    const { data: openHoundEnabled } = useFeatureFlag('openhound_support');
+
+    const openHoundHref = 'https://hub.docker.com/r/specterops/openhound';
 
     /* Event Handlers */
     const downloadCollector = (collectorType: CommunityCollectorType, version: string) => {
@@ -75,12 +78,28 @@ const DownloadCollectors = () => {
             title='Download Collectors'
             data-testid='download-collectors'
             pageDescription={
-                <Typography variant='body2' paragraph>
-                    To get started, collect data using SharpHound or AzureHound.
-                    <br />
-                    BloodHound CE supports both {DocumentationLinks.sharpHoundCELink} and{' '}
-                    {DocumentationLinks.azureHoundCELink} collectors.
-                </Typography>
+                openHoundEnabled?.enabled ? (
+                    <Typography variant='body2' paragraph>
+                        To get started, collect data using SharpHound, AzureHound, or OpenHound.
+                        <br />
+                        BloodHound CE supports {DocumentationLinks.sharpHoundCELink},{' '}
+                        {DocumentationLinks.azureHoundCELink}, and{' '}
+                        <Link
+                            target='_blank'
+                            data-testid='download-collectors-openhound-link'
+                            href={openHoundHref}>
+                            OpenHound
+                        </Link>
+                        .
+                    </Typography>
+                ) : (
+                    <Typography variant='body2' paragraph>
+                        To get started, collect data using SharpHound or AzureHound.
+                        <br />
+                        BloodHound CE supports both {DocumentationLinks.sharpHoundCELink} and{' '}
+                        {DocumentationLinks.azureHoundCELink} collectors.
+                    </Typography>
+                )
             }>
             <div className='grid gap-8'>
                 {(sharpHoundCollectorsQuery.isError ||
@@ -160,6 +179,20 @@ const DownloadCollectors = () => {
                         />
                     )}
                 </Box>
+                {openHoundEnabled?.enabled && (
+                    <Box>
+                        <Typography variant='h2'>OpenHound</Typography>
+                        <Paper>
+                            <Box p={2}>
+                                <Typography variant='body1'>
+                                    <Link href={openHoundHref} target='_blank'>
+                                        Download OpenHound on Docker Hub
+                                    </Link>
+                                </Typography>
+                            </Box>
+                        </Paper>
+                    </Box>
+                )}
             </div>
         </PageWithTitle>
     );

--- a/cmd/ui/src/views/DownloadCollectors/DownloadCollectors.tsx
+++ b/cmd/ui/src/views/DownloadCollectors/DownloadCollectors.tsx
@@ -84,10 +84,7 @@ const DownloadCollectors = () => {
                         <br />
                         BloodHound CE supports {DocumentationLinks.sharpHoundCELink},{' '}
                         {DocumentationLinks.azureHoundCELink}, and{' '}
-                        <Link
-                            target='_blank'
-                            data-testid='download-collectors-openhound-link'
-                            href={openHoundHref}>
+                        <Link target='_blank' data-testid='download-collectors-openhound-link' href={openHoundHref}>
                             OpenHound
                         </Link>
                         .


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Adding OpenHound download link to CE collector downloads page.

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-8032

## How Has This Been Tested?
just bh-dev

## Screenshots (optional):
<img width="625" height="497" alt="image" src="https://github.com/user-attachments/assets/6c4fe6ac-ba93-477d-a0b1-d7caca0b57d5" />

## Types of changes

<!-- Please remove any items that do not apply. -->

- New feature (non-breaking change which adds functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
