### PR TITLE
feat(preferences): add preferences JSONB column and custom type to User model - BED-7958

### DIFF
--- a/cmd/api/src/api/v2/auth/auth_test.go
+++ b/cmd/api/src/api/v2/auth/auth_test.go
@@ -2480,7 +2480,7 @@ func TestManagementResource_GetUser(t *testing.T) {
 			expected: expected{
 				responseCode:   http.StatusOK,
 				responseHeader: http.Header{"Content-Type": []string{"application/json"}},
-				responseBody:   `{"data":{"AuthSecret":null, "all_environments":false, "created_at":"0001-01-01T00:00:00Z", "deleted_at":{"Time":"0001-01-01T00:00:00Z", "Valid":false}, "email_address":"john.doe@example.com", "environment_targeted_access_control":null, "eula_accepted":false, "first_name":"John", "id":"00000000-0000-0000-0000-000000000001", "is_disabled":false, "last_login":"0001-01-01T00:00:00Z", "last_name":"Doe", "principal_name":"john.doe", "roles":null, "sso_provider_id":null, "updated_at":"0001-01-01T00:00:00Z"}}`,
+				responseBody:   `{"data":{"AuthSecret":null, "all_environments":false, "created_at":"0001-01-01T00:00:00Z", "deleted_at":{"Time":"0001-01-01T00:00:00Z", "Valid":false}, "email_address":"john.doe@example.com", "environment_targeted_access_control":null, "eula_accepted":false, "first_name":"John", "id":"00000000-0000-0000-0000-000000000001", "is_disabled":false, "last_login":"0001-01-01T00:00:00Z", "last_name":"Doe", "principal_name":"john.doe", "preferences":null, "roles":null, "sso_provider_id":null, "updated_at":"0001-01-01T00:00:00Z"}}`,
 			},
 		},
 	}
@@ -2563,7 +2563,7 @@ func TestManagementResource_GetSelf(t *testing.T) {
 			expected: expected{
 				responseCode:   http.StatusOK,
 				responseHeader: http.Header{"Content-Type": []string{"application/json"}},
-				responseBody:   `{"data":{"AuthSecret":null, "all_environments":false, "created_at":"0001-01-01T00:00:00Z", "deleted_at":{"Time":"0001-01-01T00:00:00Z", "Valid":false}, "email_address":"john.doe@example.com", "environment_targeted_access_control":null, "eula_accepted":false, "first_name":"John", "id":"00000000-0000-0000-0000-000000000000", "is_disabled":false, "last_login":"0001-01-01T00:00:00Z", "last_name":"Doe", "principal_name":"john.doe", "roles":[{"created_at":"0001-01-01T00:00:00Z", "deleted_at":{"Time":"0001-01-01T00:00:00Z", "Valid":false}, "description":"The big boy.", "id":0, "name":"Big Boy", "permissions":[], "updated_at":"0001-01-01T00:00:00Z"}], "sso_provider_id":null, "updated_at":"0001-01-01T00:00:00Z"}}`,
+				responseBody:   `{"data":{"AuthSecret":null, "all_environments":false, "created_at":"0001-01-01T00:00:00Z", "deleted_at":{"Time":"0001-01-01T00:00:00Z", "Valid":false}, "email_address":"john.doe@example.com", "environment_targeted_access_control":null, "eula_accepted":false, "first_name":"John", "id":"00000000-0000-0000-0000-000000000000", "is_disabled":false, "last_login":"0001-01-01T00:00:00Z", "last_name":"Doe", "principal_name":"john.doe", "preferences":null, "roles":[{"created_at":"0001-01-01T00:00:00Z", "deleted_at":{"Time":"0001-01-01T00:00:00Z", "Valid":false}, "description":"The big boy.", "id":0, "name":"Big Boy", "permissions":[], "updated_at":"0001-01-01T00:00:00Z"}], "sso_provider_id":null, "updated_at":"0001-01-01T00:00:00Z"}}`,
 			},
 		},
 		{
@@ -2585,7 +2585,7 @@ func TestManagementResource_GetSelf(t *testing.T) {
 			expected: expected{
 				responseCode:   http.StatusOK,
 				responseHeader: http.Header{"Content-Type": []string{"application/json"}},
-				responseBody:   `{"data":{"AuthSecret":null, "all_environments":false, "created_at":"0001-01-01T00:00:00Z", "deleted_at":{"Time":"0001-01-01T00:00:00Z", "Valid":false}, "email_address":null, "environment_targeted_access_control":null, "eula_accepted":false, "first_name":null, "id":"00000000-0000-0000-0000-000000000000", "is_disabled":false, "last_login":"0001-01-01T00:00:00Z", "last_name":null, "principal_name":"", "roles":null, "sso_provider_id":null, "updated_at":"0001-01-01T00:00:00Z"}}`,
+				responseBody:   `{"data":{"AuthSecret":null, "all_environments":false, "created_at":"0001-01-01T00:00:00Z", "deleted_at":{"Time":"0001-01-01T00:00:00Z", "Valid":false}, "email_address":null, "environment_targeted_access_control":null, "eula_accepted":false, "first_name":null, "id":"00000000-0000-0000-0000-000000000000", "is_disabled":false, "last_login":"0001-01-01T00:00:00Z", "last_name":null, "principal_name":"", "preferences":null, "roles":null, "sso_provider_id":null, "updated_at":"0001-01-01T00:00:00Z"}}`,
 			},
 		},
 	}

--- a/cmd/api/src/database/migration/migrations/v9.1.0.sql
+++ b/cmd/api/src/database/migration/migrations/v9.1.0.sql
@@ -83,4 +83,5 @@ VALUES (current_timestamp,
 ON CONFLICT DO NOTHING;
 
 -- Add preferences column to users table
-ALTER TABLE users ADD COLUMN IF NOT EXISTS preferences JSONB NOT NULL DEFAULT '{}'::jsonb;
+ALTER TABLE users
+  ADD COLUMN IF NOT EXISTS preferences JSONB NOT NULL DEFAULT '{}'::jsonb;

--- a/cmd/api/src/database/migration/migrations/v9.1.0.sql
+++ b/cmd/api/src/database/migration/migrations/v9.1.0.sql
@@ -81,3 +81,6 @@ VALUES (current_timestamp,
         false,
         false)
 ON CONFLICT DO NOTHING;
+
+-- Add preferences column to users table
+ALTER TABLE users ADD COLUMN IF NOT EXISTS preferences JSONB NOT NULL DEFAULT '{}'::jsonb;

--- a/cmd/api/src/model/auth.go
+++ b/cmd/api/src/model/auth.go
@@ -452,6 +452,7 @@ type User struct {
 	IsDisabled                       bool                               `json:"is_disabled"`
 	AllEnvironments                  bool                               `json:"all_environments"`
 	EnvironmentTargetedAccessControl []EnvironmentTargetedAccessControl `json:"environment_targeted_access_control"`
+	Preferences                      Preferences                        `json:"preferences"`
 
 	// SupportAccount should never be settable by a user. It is used to determine if a user is a support account.
 	SupportAccount bool `json:"-"`

--- a/cmd/api/src/model/preferences.go
+++ b/cmd/api/src/model/preferences.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/cmd/api/src/model/preferences.go
+++ b/cmd/api/src/model/preferences.go
@@ -13,6 +13,7 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
+
 package model
 
 import (

--- a/cmd/api/src/model/preferences.go
+++ b/cmd/api/src/model/preferences.go
@@ -1,3 +1,18 @@
+// Copyright 2026 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 package model
 
 import (

--- a/cmd/api/src/model/preferences.go
+++ b/cmd/api/src/model/preferences.go
@@ -25,10 +25,10 @@ import (
 	"gorm.io/gorm/schema"
 )
 
-// PreferenceItem represents a single user preference with its value and an enterprise flag.
+// PreferenceItem represents a single user preference with its value and a community flag.
 type PreferenceItem struct {
-	Value      any  `json:"value"`
-	Enterprise bool `json:"enterprise"`
+	Value     any  `json:"value"`
+	Community bool `json:"community"`
 }
 
 // Preferences represents a map of preference names to their PreferenceItem values, stored as JSONB in the database.

--- a/cmd/api/src/model/preferences.go
+++ b/cmd/api/src/model/preferences.go
@@ -25,13 +25,12 @@ import (
 	"gorm.io/gorm/schema"
 )
 
-// PreferenceItem represents a single user preference with its value and a community flag.
+// PreferenceItem represents a single user preference.
 type PreferenceItem struct {
-	Value     any  `json:"value"`
-	Community bool `json:"community"`
+	Value any `json:"value"`
 }
 
-// Preferences represents a map of preference names to their PreferenceItem values, stored as JSONB in the database.
+// Preferences represents a map of preference names to their PreferenceItem objects, stored as JSONB in the database.
 type Preferences map[string]PreferenceItem
 
 // Scan verifies that the input value is []byte (the Go representation of JSONB) and unmarshals it into the receiver.

--- a/cmd/api/src/model/preferences.go
+++ b/cmd/api/src/model/preferences.go
@@ -35,6 +35,7 @@ type PreferenceItem struct {
 type Preferences map[string]PreferenceItem
 
 // Scan verifies that the input value is []byte (the Go representation of JSONB) and unmarshals it into the receiver.
+// Uses a pointer receiver because it must modify the map. This matches the pattern in types.JSONUntypedObject.
 // sql.Scanner implementation
 func (s *Preferences) Scan(value any) error {
 	var (
@@ -50,13 +51,16 @@ func (s *Preferences) Scan(value any) error {
 
 // Value marshals the Preferences map into []byte for storage as JSONB.
 // driver.Valuer implementation
-func (s *Preferences) Value() (driver.Value, error) {
+func (s Preferences) Value() (driver.Value, error) {
+	if len(s) == 0 {
+		return []byte("{}"), nil
+	}
 	return json.Marshal(s)
 }
 
 // GormDBDataType returns JSONB if postgres, otherwise panics due to lack of DB type support.
 // GORM schema.DataTypeInterface implementation
-func (s *Preferences) GormDBDataType(db *gorm.DB, _ *schema.Field) string {
+func (s Preferences) GormDBDataType(db *gorm.DB, _ *schema.Field) string {
 	switch dbDialect := db.Name(); dbDialect {
 	case "postgres":
 		return "JSONB"

--- a/cmd/api/src/model/preferences.go
+++ b/cmd/api/src/model/preferences.go
@@ -1,0 +1,51 @@
+package model
+
+import (
+	"database/sql/driver"
+	"encoding/json"
+	"fmt"
+
+	"gorm.io/gorm"
+	"gorm.io/gorm/schema"
+)
+
+// PreferenceItem represents a single user preference with its value and an enterprise flag.
+type PreferenceItem struct {
+	Value      any  `json:"value"`
+	Enterprise bool `json:"enterprise"`
+}
+
+// Preferences represents a map of preference names to their PreferenceItem values, stored as JSONB in the database.
+type Preferences map[string]PreferenceItem
+
+// Scan verifies that the input value is []byte (the Go representation of JSONB) and unmarshals it into the receiver.
+// sql.Scanner implementation
+func (s *Preferences) Scan(value any) error {
+	var (
+		bytes  []byte
+		typeOK bool
+	)
+	if bytes, typeOK = value.([]byte); !typeOK {
+		return fmt.Errorf("expected []byte representation of JSONB, received %T", value)
+	}
+
+	return json.Unmarshal(bytes, s)
+}
+
+// Value marshals the Preferences map into []byte for storage as JSONB.
+// driver.Valuer implementation
+func (s *Preferences) Value() (driver.Value, error) {
+	return json.Marshal(s)
+}
+
+// GormDBDataType returns JSONB if postgres, otherwise panics due to lack of DB type support.
+// GORM schema.DataTypeInterface implementation
+func (s *Preferences) GormDBDataType(db *gorm.DB, _ *schema.Field) string {
+	switch dbDialect := db.Name(); dbDialect {
+	case "postgres":
+		return "JSONB"
+
+	default:
+		panic(fmt.Sprintf("Unsupported database dialect for JSON datatype: %s", dbDialect))
+	}
+}

--- a/cmd/api/src/model/preferences_test.go
+++ b/cmd/api/src/model/preferences_test.go
@@ -26,21 +26,21 @@ import (
 
 func TestPreferences_Scan_InvalidInput(t *testing.T) {
 	preferences := model.Preferences{}
-	err := preferences.Scan("not bytes")
-	require.NotNil(t, err)
+	err := preferences.Scan(json.RawMessage(`{"random":"random"}`))
+	require.Error(t, err)
 	require.Contains(t, err.Error(), "expected []byte representation of JSONB")
 }
 
 func TestPreferences_Scan_InvalidJSON(t *testing.T) {
 	preferences := model.Preferences{}
-	err := preferences.Scan(json.RawMessage(`{"random":"random"}`))
-	require.NotNil(t, err)
+	err := preferences.Scan([]byte(`{not valid json}`))
+	require.Error(t, err)
 }
 
 func TestPreferences_Scan_EmptyObject(t *testing.T) {
 	preferences := model.Preferences{}
 	err := preferences.Scan([]byte(`{}`))
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Empty(t, preferences)
 }
 
@@ -58,7 +58,7 @@ func TestPreferences_Scan_Success(t *testing.T) {
 	}`)
 
 	err := preferences.Scan(jsonbInput)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Len(t, preferences, 2)
 
 	darkMode, exists := preferences["dark_mode"]
@@ -81,11 +81,11 @@ func TestPreferences_Value_Success(t *testing.T) {
 	}
 
 	value, err := preferences.Value()
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	var result model.Preferences
 	err = json.Unmarshal(value.([]byte), &result)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Len(t, result, 1)
 
 	darkMode, exists := result["dark_mode"]
@@ -98,8 +98,16 @@ func TestPreferences_Value_EmptyPreferences(t *testing.T) {
 	preferences := model.Preferences{}
 
 	value, err := preferences.Value()
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, []byte(`{}`), value)
+}
+
+func TestPreferences_Value_NilPreferences(t *testing.T) {
+	var preferences model.Preferences
+
+	value, err := preferences.Value()
+	require.NoError(t, err)
+	require.Equal(t, []byte("{}"), value)
 }
 
 func TestPreferences_Scan_Value_RoundTrip(t *testing.T) {
@@ -117,16 +125,16 @@ func TestPreferences_Scan_Value_RoundTrip(t *testing.T) {
 
 	// unmarshal original jsonb into preferences
 	err := preferences.Scan(originalJSONB)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// marshal newly-created preferences map back to jsonb
 	value, err := preferences.Value()
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// final unmarshaling after roundtrip to verify success
 	var roundTrip model.Preferences
 	err = json.Unmarshal(value.([]byte), &roundTrip)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	require.Equal(t, preferences, roundTrip)
 }

--- a/cmd/api/src/model/preferences_test.go
+++ b/cmd/api/src/model/preferences_test.go
@@ -48,12 +48,10 @@ func TestPreferences_Scan_Success(t *testing.T) {
 	preferences := model.Preferences{}
 	jsonbInput := []byte(`{
 		"dark_mode": {
-			"value": true,
-			"community": true
+			"value": true
 		},
 		"preferred_domain": {
-			"value": "S-1-5-24-1234567890",
-			"community": false
+			"value": "S-1-5-24-1234567890"
 		}
 	}`)
 
@@ -64,19 +62,16 @@ func TestPreferences_Scan_Success(t *testing.T) {
 	darkMode, exists := preferences["dark_mode"]
 	require.True(t, exists)
 	require.Equal(t, true, darkMode.Value)
-	require.Equal(t, true, darkMode.Community)
 
 	preferredDomain, exists := preferences["preferred_domain"]
 	require.True(t, exists)
 	require.Equal(t, "S-1-5-24-1234567890", preferredDomain.Value)
-	require.Equal(t, false, preferredDomain.Community)
 }
 
 func TestPreferences_Value_Success(t *testing.T) {
 	preferences := model.Preferences{
 		"dark_mode": model.PreferenceItem{
-			Value:     true,
-			Community: true,
+			Value: true,
 		},
 	}
 
@@ -91,7 +86,6 @@ func TestPreferences_Value_Success(t *testing.T) {
 	darkMode, exists := result["dark_mode"]
 	require.True(t, exists)
 	require.Equal(t, true, darkMode.Value)
-	require.Equal(t, true, darkMode.Community)
 }
 
 func TestPreferences_Value_EmptyPreferences(t *testing.T) {
@@ -113,12 +107,10 @@ func TestPreferences_Value_NilPreferences(t *testing.T) {
 func TestPreferences_Scan_Value_RoundTrip(t *testing.T) {
 	originalJSONB := []byte(`{
 		"dark_mode": {
-			"value": true,
-			"community": true
+			"value": true
 		},
 		"preferred_domain": {
-			"value": "S-1-5-24-1234567890",
-			"community": false
+			"value": "S-1-5-24-1234567890"
 		}
 	}`)
 	preferences := model.Preferences{}

--- a/cmd/api/src/model/preferences_test.go
+++ b/cmd/api/src/model/preferences_test.go
@@ -1,0 +1,132 @@
+// Copyright 2023 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package model_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/specterops/bloodhound/cmd/api/src/model"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPreferences_Scan_InvalidInput(t *testing.T) {
+	preferences := model.Preferences{}
+	err := preferences.Scan("not bytes")
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "expected []byte representation of JSONB")
+}
+
+func TestPreferences_Scan_InvalidJSON(t *testing.T) {
+	preferences := model.Preferences{}
+	err := preferences.Scan(json.RawMessage(`{"random":"random"}`))
+	require.NotNil(t, err)
+}
+
+func TestPreferences_Scan_EmptyObject(t *testing.T) {
+	preferences := model.Preferences{}
+	err := preferences.Scan([]byte(`{}`))
+	require.Nil(t, err)
+	require.Empty(t, preferences)
+}
+
+func TestPreferences_Scan_Success(t *testing.T) {
+	preferences := model.Preferences{}
+	jsonbInput := []byte(`{
+		"dark_mode": {
+			"value": true,
+			"enterprise": false
+		},
+		"preferred_domain": {
+			"value": "S-1-5-24-1234567890",
+			"enterprise": true
+		}
+	}`)
+
+	err := preferences.Scan(jsonbInput)
+	require.Nil(t, err)
+	require.Len(t, preferences, 2)
+
+	darkMode, exists := preferences["dark_mode"]
+	require.True(t, exists)
+	require.Equal(t, true, darkMode.Value)
+	require.Equal(t, false, darkMode.Enterprise)
+
+	preferredDomain, exists := preferences["preferred_domain"]
+	require.True(t, exists)
+	require.Equal(t, "S-1-5-24-1234567890", preferredDomain.Value)
+	require.Equal(t, true, preferredDomain.Enterprise)
+}
+
+func TestPreferences_Value_Success(t *testing.T) {
+	preferences := model.Preferences{
+		"dark_mode": model.PreferenceItem{
+			Value:      true,
+			Enterprise: false,
+		},
+	}
+
+	value, err := preferences.Value()
+	require.Nil(t, err)
+
+	var result model.Preferences
+	err = json.Unmarshal(value.([]byte), &result)
+	require.Nil(t, err)
+	require.Len(t, result, 1)
+
+	darkMode, exists := result["dark_mode"]
+	require.True(t, exists)
+	require.Equal(t, true, darkMode.Value)
+	require.Equal(t, false, darkMode.Enterprise)
+}
+
+func TestPreferences_Value_EmptyPreferences(t *testing.T) {
+	preferences := model.Preferences{}
+
+	value, err := preferences.Value()
+	require.Nil(t, err)
+	require.Equal(t, []byte(`{}`), value)
+}
+
+func TestPreferences_Scan_Value_RoundTrip(t *testing.T) {
+	originalJSONB := []byte(`{
+		"dark_mode": {
+			"value": true,
+			"enterprise": false
+		},
+		"preferred_domain": {
+			"value": "S-1-5-24-1234567890",
+			"enterprise": true
+		}
+	}`)
+	preferences := model.Preferences{}
+
+	// unmarshal original jsonb into preferences
+	err := preferences.Scan(originalJSONB)
+	require.Nil(t, err)
+
+	// marshal newly-created preferences map back to jsonb
+	value, err := preferences.Value()
+	require.Nil(t, err)
+
+	// final unmarshaling after roundtrip to verify success
+	var roundTrip model.Preferences
+	err = json.Unmarshal(value.([]byte), &roundTrip)
+	require.Nil(t, err)
+
+	require.Equal(t, preferences, roundTrip)
+}

--- a/cmd/api/src/model/preferences_test.go
+++ b/cmd/api/src/model/preferences_test.go
@@ -49,11 +49,11 @@ func TestPreferences_Scan_Success(t *testing.T) {
 	jsonbInput := []byte(`{
 		"dark_mode": {
 			"value": true,
-			"enterprise": false
+			"community": true
 		},
 		"preferred_domain": {
 			"value": "S-1-5-24-1234567890",
-			"enterprise": true
+			"community": false
 		}
 	}`)
 
@@ -64,19 +64,19 @@ func TestPreferences_Scan_Success(t *testing.T) {
 	darkMode, exists := preferences["dark_mode"]
 	require.True(t, exists)
 	require.Equal(t, true, darkMode.Value)
-	require.Equal(t, false, darkMode.Enterprise)
+	require.Equal(t, true, darkMode.Community)
 
 	preferredDomain, exists := preferences["preferred_domain"]
 	require.True(t, exists)
 	require.Equal(t, "S-1-5-24-1234567890", preferredDomain.Value)
-	require.Equal(t, true, preferredDomain.Enterprise)
+	require.Equal(t, false, preferredDomain.Community)
 }
 
 func TestPreferences_Value_Success(t *testing.T) {
 	preferences := model.Preferences{
 		"dark_mode": model.PreferenceItem{
-			Value:      true,
-			Enterprise: false,
+			Value:     true,
+			Community: true,
 		},
 	}
 
@@ -91,7 +91,7 @@ func TestPreferences_Value_Success(t *testing.T) {
 	darkMode, exists := result["dark_mode"]
 	require.True(t, exists)
 	require.Equal(t, true, darkMode.Value)
-	require.Equal(t, false, darkMode.Enterprise)
+	require.Equal(t, true, darkMode.Community)
 }
 
 func TestPreferences_Value_EmptyPreferences(t *testing.T) {
@@ -114,11 +114,11 @@ func TestPreferences_Scan_Value_RoundTrip(t *testing.T) {
 	originalJSONB := []byte(`{
 		"dark_mode": {
 			"value": true,
-			"enterprise": false
+			"community": true
 		},
 		"preferred_domain": {
 			"value": "S-1-5-24-1234567890",
-			"enterprise": true
+			"community": false
 		}
 	}`)
 	preferences := model.Preferences{}

--- a/go.sum
+++ b/go.sum
@@ -320,8 +320,8 @@ github.com/jackc/pgx/v4 v4.0.0-pre1.0.20190824185557-6972a5742186/go.mod h1:X+GQ
 github.com/jackc/pgx/v4 v4.12.1-0.20210724153913-640aa07df17c/go.mod h1:1QD0+tgSXP7iUjYm9C1NxKhny7lq6ee99u/z+IHFcgs=
 github.com/jackc/pgx/v4 v4.18.2 h1:xVpYkNR5pk5bMCZGfClbO962UIqVABcAGt7ha1s/FeU=
 github.com/jackc/pgx/v4 v4.18.2/go.mod h1:Ey4Oru5tH5sB6tV7hDmfWFahwF15Eb7DNXlRKx2CkVw=
-github.com/jackc/pgx/v5 v5.8.0 h1:TYPDoleBBme0xGSAX3/+NujXXtpZn9HBONkQC7IEZSo=
-github.com/jackc/pgx/v5 v5.8.0/go.mod h1:QVeDInX2m9VyzvNeiCJVjCkNFqzsNb43204HshNSZKw=
+github.com/jackc/pgx/v5 v5.9.0 h1:T/dI+2TvmI2H8s/KH1/lXIbz1CUFk3gn5oTjr0/mBsE=
+github.com/jackc/pgx/v5 v5.9.0/go.mod h1:mal1tBGAFfLHvZzaYh77YS/eC6IX9OWbRV1QIIM0Jn4=
 github.com/jackc/puddle v0.0.0-20190413234325-e4ced69a3a2b/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v0.0.0-20190608224051-11cab39313c9/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v1.1.3/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=

--- a/go.sum
+++ b/go.sum
@@ -320,8 +320,8 @@ github.com/jackc/pgx/v4 v4.0.0-pre1.0.20190824185557-6972a5742186/go.mod h1:X+GQ
 github.com/jackc/pgx/v4 v4.12.1-0.20210724153913-640aa07df17c/go.mod h1:1QD0+tgSXP7iUjYm9C1NxKhny7lq6ee99u/z+IHFcgs=
 github.com/jackc/pgx/v4 v4.18.2 h1:xVpYkNR5pk5bMCZGfClbO962UIqVABcAGt7ha1s/FeU=
 github.com/jackc/pgx/v4 v4.18.2/go.mod h1:Ey4Oru5tH5sB6tV7hDmfWFahwF15Eb7DNXlRKx2CkVw=
-github.com/jackc/pgx/v5 v5.9.0 h1:T/dI+2TvmI2H8s/KH1/lXIbz1CUFk3gn5oTjr0/mBsE=
-github.com/jackc/pgx/v5 v5.9.0/go.mod h1:mal1tBGAFfLHvZzaYh77YS/eC6IX9OWbRV1QIIM0Jn4=
+github.com/jackc/pgx/v5 v5.8.0 h1:TYPDoleBBme0xGSAX3/+NujXXtpZn9HBONkQC7IEZSo=
+github.com/jackc/pgx/v5 v5.8.0/go.mod h1:QVeDInX2m9VyzvNeiCJVjCkNFqzsNb43204HshNSZKw=
 github.com/jackc/puddle v0.0.0-20190413234325-e4ced69a3a2b/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v0.0.0-20190608224051-11cab39313c9/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v1.1.3/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=

--- a/packages/go/openapi/doc/openapi.json
+++ b/packages/go/openapi/doc/openapi.json
@@ -19216,10 +19216,7 @@
                 "additionalProperties": {
                   "type": "object",
                   "properties": {
-                    "value": {},
-                    "enterprise": {
-                      "type": "boolean"
-                    }
+                    "value": {}
                   }
                 }
               }

--- a/packages/go/openapi/doc/openapi.json
+++ b/packages/go/openapi/doc/openapi.json
@@ -19221,8 +19221,7 @@
                       "type": "boolean"
                     }
                   }
-                },
-                "readOnly": false
+                }
               }
             }
           }

--- a/packages/go/openapi/doc/openapi.json
+++ b/packages/go/openapi/doc/openapi.json
@@ -19209,6 +19209,20 @@
               "eula_accepted": {
                 "type": "boolean",
                 "readOnly": true
+              },
+              "preferences": {
+                "type": "object",
+                "description": "User preferences stored as a map of preference names to their values",
+                "additionalProperties": {
+                  "type": "object",
+                  "properties": {
+                    "value": {},
+                    "enterprise": {
+                      "type": "boolean"
+                    }
+                  }
+                },
+                "readOnly": false
               }
             }
           }

--- a/packages/go/openapi/src/schemas/model.user.yaml
+++ b/packages/go/openapi/src/schemas/model.user.yaml
@@ -71,5 +71,3 @@ allOf:
               value: {}
               enterprise:
                 type: boolean
-
-        readOnly: false

--- a/packages/go/openapi/src/schemas/model.user.yaml
+++ b/packages/go/openapi/src/schemas/model.user.yaml
@@ -62,3 +62,14 @@ allOf:
       eula_accepted:
         type: boolean
         readOnly: true
+      preferences:
+        type: object
+        description: User preferences stored as a map of preference names to their values
+        additionalProperties:
+          type: object
+          properties:
+              value: {}
+              enterprise:
+                type: boolean
+
+        readOnly: false

--- a/packages/go/openapi/src/schemas/model.user.yaml
+++ b/packages/go/openapi/src/schemas/model.user.yaml
@@ -69,5 +69,3 @@ allOf:
           type: object
           properties:
               value: {}
-              enterprise:
-                type: boolean


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Currently, we don't have a way to save user preferences in one place. This PR (subtask of https://specterops.atlassian.net/browse/BED-7619) adds a preferences JSONB column to the `users` table and a corresponding Preferences custom type to the User model. This will enable users to store settings like dark mode and preferred domain.

- adds Preferences field to the User struct
- adds Preferences custom type (map[string]PreferenceItem) with sql.Scanner, driver.Valuer, and GORM DataTypeInterface implementations for JSONB read/write
- adds PreferenceItem struct with value (any) field
- adds preferences JSONB column to the users table via migration
- adds unit tests for Preferences.Scan and Preferences.Value
- updates existing integration tests to include preferences in expected response bodies
- updates OpenAPI schema for the user model to include preferences
- runs pfc

## Motivation and Context
Resolves [BED-7958](https://specterops.atlassian.net/browse/BED-7958)

## How Has This Been Tested?

- Added unit tests for Preferences.Scan and Preferences.Value 
- Existing tests pass (updated GetUser and GetSelf unit tests), existing integration tests pass
- Verified migration applies and preferences column appears in the users table
- Manually verified that an empty preferences object is returned in the GET /api/v2/users/{id} and GET /api/v2/self responses (Bruno, Swagger)

## Types of changes

<!-- Please remove any items that do not apply. -->
- New feature (non-breaking change which adds functionality)
- Database Migrations

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


[BED-7958]: https://specterops.atlassian.net/browse/BED-7958?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can store/manage flexible per-user preferences; preferences are now included in user responses.

* **Database**
  * Persisted JSON preferences added for users, defaulting to an empty object.

* **Documentation**
  * API/OpenAPI schemas updated to document the new preferences structure.

* **Tests**
  * Added/updated tests covering preferences serialization, deserialization, and API responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->