### PR TITLE
feat: add type filter to GET /kinds endpoint BED-7925

### DIFF
--- a/cmd/api/src/api/v2/kinds.go
+++ b/cmd/api/src/api/v2/kinds.go
@@ -17,14 +17,20 @@
 package v2
 
 import (
+	"fmt"
 	"net/http"
 	"slices"
 	"strings"
 
 	"github.com/specterops/bloodhound/cmd/api/src/api"
 	"github.com/specterops/bloodhound/cmd/api/src/model"
+	"github.com/specterops/bloodhound/packages/go/graphschema/common"
 	"github.com/specterops/dawgs/graph"
 )
+
+func isExtendedNodeKind(kind graph.Kind) bool {
+	return strings.HasPrefix(kind.String(), model.AssetGroupTagKindPrefix) || kind.Is(graph.StringKind("Meta"), graph.StringKind("MetaDetail"), common.MigrationData)
+}
 
 type ListKindsResponse struct {
 	Kinds graph.Kinds `json:"kinds"`
@@ -35,7 +41,70 @@ type ListKindsResponse struct {
 func (s Resources) ListKinds(response http.ResponseWriter, request *http.Request) {
 	if kinds, err := s.Graph.FetchKinds(request.Context()); err != nil {
 		api.HandleDatabaseError(request, response, err)
+	} else if queryFilters, err := model.NewQueryParameterFilterParser().ParseQueryParameterFilters(request); err != nil {
+		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, api.ErrorResponseDetailsBadQueryParameterFilters, request), response)
 	} else {
+		for name, filters := range queryFilters {
+			if validPredicates, err := api.GetValidFilterPredicatesAsStrings(model.Kind{}, name); err != nil {
+				api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, fmt.Sprintf("%s: %s", api.ErrorResponseDetailsColumnNotFilterable, name), request), response)
+				return
+			} else {
+				for _, filter := range filters {
+					if !slices.Contains(validPredicates, string(filter.Operator)) {
+						api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, fmt.Sprintf("%s: %s %s", api.ErrorResponseDetailsFilterPredicateNotSupported, filter.Name, filter.Operator), request), response)
+						return
+					}
+				}
+			}
+		}
+
+		if len(queryFilters) > 0 {
+			if filters, ok := queryFilters["type"]; ok {
+				// This gets both custom node kinds (schemaless) and schema based node kinds
+				// Only kinds that have been synced to the kinds table will be included in this.
+				displayKinds, err := s.DB.GetPrimaryDisplayKinds(request.Context())
+				if err != nil {
+					api.HandleDatabaseError(request, response, err)
+					return
+				}
+
+				// Source kinds are node kinds
+				sourceKindsByKind := make(map[graph.Kind]bool)
+				if sourceKinds, err := s.DB.GetSourceKinds(request.Context()); err != nil {
+					api.HandleDatabaseError(request, response, err)
+					return
+				} else {
+					for _, kind := range sourceKinds {
+						sourceKindsByKind[kind.ToKind()] = true
+					}
+				}
+
+				// Filter down kinds
+				var filteredKinds = graph.Kinds{}
+				for _, filter := range filters {
+					for _, kind := range kinds {
+						var isNodeKind bool
+						// Asset group tags are node kinds as well as meta / migrationData kinds
+						if _, ok := displayKinds[kind]; ok || sourceKindsByKind[kind] || isExtendedNodeKind(kind) {
+							isNodeKind = true
+						}
+
+						switch filter.Value {
+						case "node":
+							if (isNodeKind && filter.Operator == model.Equals) || (!isNodeKind && filter.Operator == model.NotEquals) {
+								filteredKinds = append(filteredKinds, kind)
+							}
+						case "edge":
+							if (!isNodeKind && filter.Operator == model.Equals) || (isNodeKind && filter.Operator == model.NotEquals) {
+								filteredKinds = append(filteredKinds, kind)
+							}
+						}
+					}
+				}
+				kinds = filteredKinds
+			}
+		}
+
 		// Alpha sort
 		slices.SortFunc(kinds, func(a, b graph.Kind) int {
 			return strings.Compare(a.String(), b.String())

--- a/cmd/api/src/api/v2/kinds.go
+++ b/cmd/api/src/api/v2/kinds.go
@@ -64,7 +64,6 @@ func (s Resources) ListKinds(response http.ResponseWriter, request *http.Request
 				validNodeKinds := make(map[graph.Kind]bool)
 
 				// Schema based node kinds
-				// Only kinds that have been synced to the kinds table will be included in this.
 				if schemaNodeKinds, _, err := s.DB.GetGraphSchemaNodeKinds(ctx, model.Filters{}, model.Sort{}, 0, 0); err != nil {
 					api.HandleDatabaseError(request, response, err)
 					return
@@ -95,7 +94,7 @@ func (s Resources) ListKinds(response http.ResponseWriter, request *http.Request
 				}
 
 				// Source kinds
-				if sourceKinds, err := s.DB.GetSourceKinds(request.Context()); err != nil {
+				if sourceKinds, err := s.DB.GetSourceKinds(ctx); err != nil {
 					api.HandleDatabaseError(request, response, err)
 					return
 				} else {
@@ -106,6 +105,7 @@ func (s Resources) ListKinds(response http.ResponseWriter, request *http.Request
 
 				// Filter down kinds
 				var filteredKinds = graph.Kinds{}
+				var kindsSeen = make(map[graph.Kind]bool)
 				for _, filter := range filters {
 					for _, kind := range kinds {
 						var isNodeKind bool
@@ -117,11 +117,17 @@ func (s Resources) ListKinds(response http.ResponseWriter, request *http.Request
 						switch filter.Value {
 						case "node":
 							if (isNodeKind && filter.Operator == model.Equals) || (!isNodeKind && filter.Operator == model.NotEquals) {
-								filteredKinds = append(filteredKinds, kind)
+								if !kindsSeen[kind] {
+									filteredKinds = append(filteredKinds, kind)
+									kindsSeen[kind] = true
+								}
 							}
 						case "edge":
 							if (!isNodeKind && filter.Operator == model.Equals) || (isNodeKind && filter.Operator == model.NotEquals) {
-								filteredKinds = append(filteredKinds, kind)
+								if !kindsSeen[kind] {
+									filteredKinds = append(filteredKinds, kind)
+									kindsSeen[kind] = true
+								}
 							}
 						}
 					}

--- a/cmd/api/src/api/v2/kinds.go
+++ b/cmd/api/src/api/v2/kinds.go
@@ -39,19 +39,20 @@ type ListKindsResponse struct {
 // ListKinds returns all node kinds, edge kinds, and tier tags present in the system.
 // It is a comprehensive view of the various kinds the graph currently recognizes.
 func (s Resources) ListKinds(response http.ResponseWriter, request *http.Request) {
-	if kinds, err := s.Graph.FetchKinds(request.Context()); err != nil {
+	ctx := request.Context()
+	if kinds, err := s.Graph.FetchKinds(ctx); err != nil {
 		api.HandleDatabaseError(request, response, err)
 	} else if queryFilters, err := model.NewQueryParameterFilterParser().ParseQueryParameterFilters(request); err != nil {
-		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, api.ErrorResponseDetailsBadQueryParameterFilters, request), response)
+		api.WriteErrorResponse(ctx, api.BuildErrorResponse(http.StatusBadRequest, api.ErrorResponseDetailsBadQueryParameterFilters, request), response)
 	} else {
 		for name, filters := range queryFilters {
 			if validPredicates, err := api.GetValidFilterPredicatesAsStrings(model.Kind{}, name); err != nil {
-				api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, fmt.Sprintf("%s: %s", api.ErrorResponseDetailsColumnNotFilterable, name), request), response)
+				api.WriteErrorResponse(ctx, api.BuildErrorResponse(http.StatusBadRequest, fmt.Sprintf("%s: %s", api.ErrorResponseDetailsColumnNotFilterable, name), request), response)
 				return
 			} else {
 				for _, filter := range filters {
 					if !slices.Contains(validPredicates, string(filter.Operator)) {
-						api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, fmt.Sprintf("%s: %s %s", api.ErrorResponseDetailsFilterPredicateNotSupported, filter.Name, filter.Operator), request), response)
+						api.WriteErrorResponse(ctx, api.BuildErrorResponse(http.StatusBadRequest, fmt.Sprintf("%s: %s %s", api.ErrorResponseDetailsFilterPredicateNotSupported, filter.Name, filter.Operator), request), response)
 						return
 					}
 				}
@@ -60,22 +61,46 @@ func (s Resources) ListKinds(response http.ResponseWriter, request *http.Request
 
 		if len(queryFilters) > 0 {
 			if filters, ok := queryFilters["type"]; ok {
-				// This gets both custom node kinds (schemaless) and schema based node kinds
+				validNodeKinds := make(map[graph.Kind]bool)
+
+				// Schema based node kinds
 				// Only kinds that have been synced to the kinds table will be included in this.
-				displayKinds, err := s.DB.GetPrimaryDisplayKinds(request.Context())
-				if err != nil {
+				if schemaNodeKinds, _, err := s.DB.GetGraphSchemaNodeKinds(ctx, model.Filters{}, model.Sort{}, 0, 0); err != nil {
 					api.HandleDatabaseError(request, response, err)
 					return
+				} else {
+					for _, kind := range schemaNodeKinds {
+						validNodeKinds[kind.ToKind()] = true
+					}
 				}
 
-				// Source kinds are node kinds
-				sourceKindsByKind := make(map[graph.Kind]bool)
+				// Schemaless customnode kinds
+				if customNodeKinds, err := s.DB.GetCustomNodeKinds(ctx, nil); err != nil {
+					api.HandleDatabaseError(request, response, err)
+					return
+				} else {
+					var customNames []string
+					for _, kind := range customNodeKinds {
+						customNames = append(customNames, kind.KindName)
+					}
+					// Until work is complete to ensure custom_node_kinds are properly kind backed, this will filter out invalid kinds
+					if kinds, err := s.DB.GetKindsByNames(ctx, customNames...); err != nil {
+						api.HandleDatabaseError(request, response, err)
+						return
+					} else {
+						for _, kind := range kinds {
+							validNodeKinds[kind.ToKind()] = true
+						}
+					}
+				}
+
+				// Source kinds
 				if sourceKinds, err := s.DB.GetSourceKinds(request.Context()); err != nil {
 					api.HandleDatabaseError(request, response, err)
 					return
 				} else {
 					for _, kind := range sourceKinds {
-						sourceKindsByKind[kind.ToKind()] = true
+						validNodeKinds[kind.ToKind()] = true
 					}
 				}
 
@@ -85,7 +110,7 @@ func (s Resources) ListKinds(response http.ResponseWriter, request *http.Request
 					for _, kind := range kinds {
 						var isNodeKind bool
 						// Asset group tags are node kinds as well as meta / migrationData kinds
-						if _, ok := displayKinds[kind]; ok || sourceKindsByKind[kind] || isExtendedNodeKind(kind) {
+						if validNodeKinds[kind] || isExtendedNodeKind(kind) {
 							isNodeKind = true
 						}
 

--- a/cmd/api/src/api/v2/kinds_test.go
+++ b/cmd/api/src/api/v2/kinds_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/specterops/bloodhound/cmd/api/src/utils/test"
 	graphmocks "github.com/specterops/bloodhound/cmd/api/src/vendormocks/dawgs/graph"
 	"github.com/specterops/bloodhound/packages/go/analysis/tiering"
-	"github.com/specterops/bloodhound/packages/go/graphschema"
 	"github.com/specterops/bloodhound/packages/go/graphschema/ad"
 	"github.com/specterops/bloodhound/packages/go/graphschema/azure"
 	"github.com/specterops/bloodhound/packages/go/graphschema/common"
@@ -58,20 +57,21 @@ func TestResources_ListKinds(t *testing.T) {
 	}
 
 	var (
-		mockKindsResp = graph.Kinds{
+		customNodeKind = graph.StringKind("Villain")
+		mockKindsResp  = graph.Kinds{
 			ad.User,
 			ad.DCSync,
 			tiering.KindTagTierZero,
 			common.MigrationData,
 			azure.Entity,
 			azure.HasRole,
+			customNodeKind,
 		}
 
-		mockDispKindsResp = graphschema.PrimaryDisplayKinds{
-			ad.User: graphschema.DisplayKind{Name: ad.User.String()},
-		}
-
-		mockSrcKindsResp = []model.SourceKind{{ID: 1, Name: azure.Entity.String()}}
+		mockSchemaNodeKindsResp = model.GraphSchemaNodeKinds{{Name: ad.User.String()}}
+		mockCustomNodeKindsResp = []model.CustomNodeKind{{KindName: customNodeKind.String()}}
+		mockKindsByNamesResp    = []model.Kind{{Name: customNodeKind.String()}}
+		mockSrcKindsResp        = []model.SourceKind{{ID: 1, Name: azure.Entity.String()}}
 	)
 
 	tt := []testData{
@@ -153,7 +153,7 @@ func TestResources_ListKinds(t *testing.T) {
 			},
 		},
 		{
-			name: "Error: GetPrimaryDisplayKinds database error - Internal Server Error",
+			name: "Error: GetGraphSchemaNodeKinds database error - Internal Server Error",
 			buildRequest: func() *http.Request {
 				return &http.Request{
 					URL: &url.URL{
@@ -165,7 +165,52 @@ func TestResources_ListKinds(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mock *mock) {
 				mock.mockGraph.EXPECT().FetchKinds(gomock.Any())
-				mock.mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any()).Return(nil, errors.New("error"))
+				mock.mockDB.EXPECT().GetGraphSchemaNodeKinds(gomock.Any(), model.Filters{}, model.Sort{}, 0, 0).Return(nil, 0, errors.New("error"))
+			},
+			expected: expected{
+				responseCode:   http.StatusInternalServerError,
+				responseHeader: http.Header{"Content-Type": []string{"application/json"}},
+				responseBody:   `{"errors":[{"context":"","message":"an internal error has occurred that is preventing the service from servicing this request"}],"http_status":500,"request_id":"","timestamp":"0001-01-01T00:00:00Z"}`,
+			},
+		},
+		{
+			name: "Error: GetCustomNodeKinds database error - Internal Server Error",
+			buildRequest: func() *http.Request {
+				return &http.Request{
+					URL: &url.URL{
+						Path:     "/api/v2/graphs/kinds",
+						RawQuery: "type=eq:node",
+					},
+					Method: http.MethodGet,
+				}
+			},
+			setupMocks: func(t *testing.T, mock *mock) {
+				mock.mockGraph.EXPECT().FetchKinds(gomock.Any())
+				mock.mockDB.EXPECT().GetGraphSchemaNodeKinds(gomock.Any(), model.Filters{}, model.Sort{}, 0, 0)
+				mock.mockDB.EXPECT().GetCustomNodeKinds(gomock.Any(), nil).Return(nil, errors.New("error"))
+			},
+			expected: expected{
+				responseCode:   http.StatusInternalServerError,
+				responseHeader: http.Header{"Content-Type": []string{"application/json"}},
+				responseBody:   `{"errors":[{"context":"","message":"an internal error has occurred that is preventing the service from servicing this request"}],"http_status":500,"request_id":"","timestamp":"0001-01-01T00:00:00Z"}`,
+			},
+		},
+		{
+			name: "Error: GetKindsByNames database error - Internal Server Error",
+			buildRequest: func() *http.Request {
+				return &http.Request{
+					URL: &url.URL{
+						Path:     "/api/v2/graphs/kinds",
+						RawQuery: "type=eq:node",
+					},
+					Method: http.MethodGet,
+				}
+			},
+			setupMocks: func(t *testing.T, mock *mock) {
+				mock.mockGraph.EXPECT().FetchKinds(gomock.Any())
+				mock.mockDB.EXPECT().GetGraphSchemaNodeKinds(gomock.Any(), model.Filters{}, model.Sort{}, 0, 0)
+				mock.mockDB.EXPECT().GetCustomNodeKinds(gomock.Any(), nil)
+				mock.mockDB.EXPECT().GetKindsByNames(gomock.Any()).Return(nil, errors.New("error"))
 			},
 			expected: expected{
 				responseCode:   http.StatusInternalServerError,
@@ -186,7 +231,9 @@ func TestResources_ListKinds(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mock *mock) {
 				mock.mockGraph.EXPECT().FetchKinds(gomock.Any())
-				mock.mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
+				mock.mockDB.EXPECT().GetGraphSchemaNodeKinds(gomock.Any(), model.Filters{}, model.Sort{}, 0, 0)
+				mock.mockDB.EXPECT().GetCustomNodeKinds(gomock.Any(), nil)
+				mock.mockDB.EXPECT().GetKindsByNames(gomock.Any())
 				mock.mockDB.EXPECT().GetSourceKinds(gomock.Any()).Return(nil, errors.New("error"))
 			},
 			expected: expected{
@@ -209,7 +256,7 @@ func TestResources_ListKinds(t *testing.T) {
 			expected: expected{
 				responseCode:   http.StatusOK,
 				responseHeader: http.Header{"Content-Type": []string{"application/json"}},
-				responseBody:   `{"data":{"kinds":["AZBase", "AZHasRole", "DCSync", "MigrationData", "Tag_Tier_Zero", "User"]}}`,
+				responseBody:   `{"data":{"kinds":["AZBase", "AZHasRole", "DCSync", "MigrationData", "Tag_Tier_Zero", "User", "Villain"]}}`,
 			},
 		},
 		{
@@ -225,13 +272,15 @@ func TestResources_ListKinds(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mock *mock) {
 				mock.mockGraph.EXPECT().FetchKinds(gomock.Any()).Return(mockKindsResp, nil)
-				mock.mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any()).Return(mockDispKindsResp, nil)
+				mock.mockDB.EXPECT().GetGraphSchemaNodeKinds(gomock.Any(), model.Filters{}, model.Sort{}, 0, 0).Return(mockSchemaNodeKindsResp, 0, nil)
+				mock.mockDB.EXPECT().GetCustomNodeKinds(gomock.Any(), nil).Return(mockCustomNodeKindsResp, nil)
+				mock.mockDB.EXPECT().GetKindsByNames(gomock.Any(), []string{customNodeKind.String()}).Return(mockKindsByNamesResp, nil)
 				mock.mockDB.EXPECT().GetSourceKinds(gomock.Any()).Return(mockSrcKindsResp, nil)
 			},
 			expected: expected{
 				responseCode:   http.StatusOK,
 				responseHeader: http.Header{"Content-Type": []string{"application/json"}},
-				responseBody:   `{"data":{"kinds":["AZBase","MigrationData","Tag_Tier_Zero","User"]}}`,
+				responseBody:   `{"data":{"kinds":["AZBase","MigrationData","Tag_Tier_Zero","User","Villain"]}}`,
 			},
 		},
 		{
@@ -247,7 +296,9 @@ func TestResources_ListKinds(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mock *mock) {
 				mock.mockGraph.EXPECT().FetchKinds(gomock.Any()).Return(mockKindsResp, nil)
-				mock.mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any()).Return(mockDispKindsResp, nil)
+				mock.mockDB.EXPECT().GetGraphSchemaNodeKinds(gomock.Any(), model.Filters{}, model.Sort{}, 0, 0).Return(mockSchemaNodeKindsResp, 0, nil)
+				mock.mockDB.EXPECT().GetCustomNodeKinds(gomock.Any(), nil).Return(mockCustomNodeKindsResp, nil)
+				mock.mockDB.EXPECT().GetKindsByNames(gomock.Any(), []string{customNodeKind.String()}).Return(mockKindsByNamesResp, nil)
 				mock.mockDB.EXPECT().GetSourceKinds(gomock.Any()).Return(mockSrcKindsResp, nil)
 			},
 			expected: expected{
@@ -269,7 +320,9 @@ func TestResources_ListKinds(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mock *mock) {
 				mock.mockGraph.EXPECT().FetchKinds(gomock.Any()).Return(mockKindsResp, nil)
-				mock.mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any()).Return(mockDispKindsResp, nil)
+				mock.mockDB.EXPECT().GetGraphSchemaNodeKinds(gomock.Any(), model.Filters{}, model.Sort{}, 0, 0).Return(mockSchemaNodeKindsResp, 0, nil)
+				mock.mockDB.EXPECT().GetCustomNodeKinds(gomock.Any(), nil).Return(mockCustomNodeKindsResp, nil)
+				mock.mockDB.EXPECT().GetKindsByNames(gomock.Any(), []string{customNodeKind.String()}).Return(mockKindsByNamesResp, nil)
 				mock.mockDB.EXPECT().GetSourceKinds(gomock.Any()).Return(mockSrcKindsResp, nil)
 			},
 			expected: expected{
@@ -291,7 +344,9 @@ func TestResources_ListKinds(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mock *mock) {
 				mock.mockGraph.EXPECT().FetchKinds(gomock.Any()).Return(mockKindsResp, nil)
-				mock.mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any()).Return(mockDispKindsResp, nil)
+				mock.mockDB.EXPECT().GetGraphSchemaNodeKinds(gomock.Any(), model.Filters{}, model.Sort{}, 0, 0).Return(mockSchemaNodeKindsResp, 0, nil)
+				mock.mockDB.EXPECT().GetCustomNodeKinds(gomock.Any(), nil).Return(mockCustomNodeKindsResp, nil)
+				mock.mockDB.EXPECT().GetKindsByNames(gomock.Any(), []string{customNodeKind.String()}).Return(mockKindsByNamesResp, nil)
 				mock.mockDB.EXPECT().GetSourceKinds(gomock.Any()).Return(mockSrcKindsResp, nil)
 			},
 			expected: expected{

--- a/cmd/api/src/api/v2/kinds_test.go
+++ b/cmd/api/src/api/v2/kinds_test.go
@@ -274,7 +274,7 @@ func TestResources_ListKinds(t *testing.T) {
 				mock.mockGraph.EXPECT().FetchKinds(gomock.Any()).Return(mockKindsResp, nil)
 				mock.mockDB.EXPECT().GetGraphSchemaNodeKinds(gomock.Any(), model.Filters{}, model.Sort{}, 0, 0).Return(mockSchemaNodeKindsResp, 0, nil)
 				mock.mockDB.EXPECT().GetCustomNodeKinds(gomock.Any(), nil).Return(mockCustomNodeKindsResp, nil)
-				mock.mockDB.EXPECT().GetKindsByNames(gomock.Any(), []string{customNodeKind.String()}).Return(mockKindsByNamesResp, nil)
+				mock.mockDB.EXPECT().GetKindsByNames(gomock.Any(), customNodeKind.String()).Return(mockKindsByNamesResp, nil)
 				mock.mockDB.EXPECT().GetSourceKinds(gomock.Any()).Return(mockSrcKindsResp, nil)
 			},
 			expected: expected{
@@ -298,7 +298,7 @@ func TestResources_ListKinds(t *testing.T) {
 				mock.mockGraph.EXPECT().FetchKinds(gomock.Any()).Return(mockKindsResp, nil)
 				mock.mockDB.EXPECT().GetGraphSchemaNodeKinds(gomock.Any(), model.Filters{}, model.Sort{}, 0, 0).Return(mockSchemaNodeKindsResp, 0, nil)
 				mock.mockDB.EXPECT().GetCustomNodeKinds(gomock.Any(), nil).Return(mockCustomNodeKindsResp, nil)
-				mock.mockDB.EXPECT().GetKindsByNames(gomock.Any(), []string{customNodeKind.String()}).Return(mockKindsByNamesResp, nil)
+				mock.mockDB.EXPECT().GetKindsByNames(gomock.Any(), customNodeKind.String()).Return(mockKindsByNamesResp, nil)
 				mock.mockDB.EXPECT().GetSourceKinds(gomock.Any()).Return(mockSrcKindsResp, nil)
 			},
 			expected: expected{
@@ -322,7 +322,7 @@ func TestResources_ListKinds(t *testing.T) {
 				mock.mockGraph.EXPECT().FetchKinds(gomock.Any()).Return(mockKindsResp, nil)
 				mock.mockDB.EXPECT().GetGraphSchemaNodeKinds(gomock.Any(), model.Filters{}, model.Sort{}, 0, 0).Return(mockSchemaNodeKindsResp, 0, nil)
 				mock.mockDB.EXPECT().GetCustomNodeKinds(gomock.Any(), nil).Return(mockCustomNodeKindsResp, nil)
-				mock.mockDB.EXPECT().GetKindsByNames(gomock.Any(), []string{customNodeKind.String()}).Return(mockKindsByNamesResp, nil)
+				mock.mockDB.EXPECT().GetKindsByNames(gomock.Any(), customNodeKind.String()).Return(mockKindsByNamesResp, nil)
 				mock.mockDB.EXPECT().GetSourceKinds(gomock.Any()).Return(mockSrcKindsResp, nil)
 			},
 			expected: expected{
@@ -346,7 +346,7 @@ func TestResources_ListKinds(t *testing.T) {
 				mock.mockGraph.EXPECT().FetchKinds(gomock.Any()).Return(mockKindsResp, nil)
 				mock.mockDB.EXPECT().GetGraphSchemaNodeKinds(gomock.Any(), model.Filters{}, model.Sort{}, 0, 0).Return(mockSchemaNodeKindsResp, 0, nil)
 				mock.mockDB.EXPECT().GetCustomNodeKinds(gomock.Any(), nil).Return(mockCustomNodeKindsResp, nil)
-				mock.mockDB.EXPECT().GetKindsByNames(gomock.Any(), []string{customNodeKind.String()}).Return(mockKindsByNamesResp, nil)
+				mock.mockDB.EXPECT().GetKindsByNames(gomock.Any(), customNodeKind.String()).Return(mockKindsByNamesResp, nil)
 				mock.mockDB.EXPECT().GetSourceKinds(gomock.Any()).Return(mockSrcKindsResp, nil)
 			},
 			expected: expected{

--- a/cmd/api/src/api/v2/kinds_test.go
+++ b/cmd/api/src/api/v2/kinds_test.go
@@ -1,0 +1,424 @@
+// Copyright 2026 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package v2_test
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/gorilla/mux"
+	v2 "github.com/specterops/bloodhound/cmd/api/src/api/v2"
+	"github.com/specterops/bloodhound/cmd/api/src/database/mocks"
+	"github.com/specterops/bloodhound/cmd/api/src/model"
+	"github.com/specterops/bloodhound/cmd/api/src/utils/test"
+	graphmocks "github.com/specterops/bloodhound/cmd/api/src/vendormocks/dawgs/graph"
+	"github.com/specterops/bloodhound/packages/go/analysis/tiering"
+	"github.com/specterops/bloodhound/packages/go/graphschema"
+	"github.com/specterops/bloodhound/packages/go/graphschema/ad"
+	"github.com/specterops/bloodhound/packages/go/graphschema/azure"
+	"github.com/specterops/bloodhound/packages/go/graphschema/common"
+	"github.com/specterops/dawgs/graph"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+)
+
+func TestResources_ListKinds(t *testing.T) {
+	t.Parallel()
+	type mock struct {
+		mockGraph *graphmocks.MockDatabase
+		mockDB    *mocks.MockDatabase
+	}
+	type expected struct {
+		responseBody   string
+		responseCode   int
+		responseHeader http.Header
+	}
+	type testData struct {
+		name         string
+		buildRequest func() *http.Request
+		setupMocks   func(t *testing.T, mock *mock)
+		expected     expected
+	}
+
+	var (
+		mockKindsResp = graph.Kinds{
+			ad.User,
+			ad.DCSync,
+			tiering.KindTagTierZero,
+			common.MigrationData,
+			azure.Entity,
+			azure.HasRole,
+		}
+
+		mockDispKindsResp = graphschema.PrimaryDisplayKinds{
+			ad.User: graphschema.DisplayKind{Name: ad.User.String()},
+		}
+
+		mockSrcKindsResp = []model.SourceKind{{ID: 1, Name: azure.Entity.String()}}
+	)
+
+	tt := []testData{
+		{
+			name: "Error: FetchKinds database error - Internal Server Error",
+			buildRequest: func() *http.Request {
+				return &http.Request{
+					URL:    &url.URL{Path: "/api/v2/graphs/kinds"},
+					Method: http.MethodGet,
+				}
+			},
+			setupMocks: func(t *testing.T, mock *mock) {
+				mock.mockGraph.EXPECT().FetchKinds(gomock.Any()).Return(nil, errors.New("error"))
+			},
+			expected: expected{
+				responseCode:   http.StatusInternalServerError,
+				responseHeader: http.Header{"Content-Type": []string{"application/json"}},
+				responseBody:   `{"errors":[{"context":"","message":"an internal error has occurred that is preventing the service from servicing this request"}],"http_status":500,"request_id":"","timestamp":"0001-01-01T00:00:00Z"}`,
+			},
+		},
+		{
+			name: "Error: bad query parameter filter - Bad Request",
+			buildRequest: func() *http.Request {
+				return &http.Request{
+					URL: &url.URL{
+						Path:     "/api/v2/graphs/kinds",
+						RawQuery: "type=unknown:bad",
+					},
+					Method: http.MethodGet,
+				}
+			},
+			setupMocks: func(t *testing.T, mock *mock) {
+				mock.mockGraph.EXPECT().FetchKinds(gomock.Any())
+			},
+			expected: expected{
+				responseCode:   http.StatusBadRequest,
+				responseHeader: http.Header{"Content-Type": []string{"application/json"}},
+				responseBody:   `{"errors":[{"context":"","message":"there are errors in the query parameter filters specified"}],"http_status":400,"request_id":"","timestamp":"0001-01-01T00:00:00Z"}`,
+			},
+		},
+		{
+			name: "Error: column not filterable - Bad Request",
+			buildRequest: func() *http.Request {
+				return &http.Request{
+					URL: &url.URL{
+						Path:     "/api/v2/graphs/kinds",
+						RawQuery: "badqueryparam=eq:bad",
+					},
+					Method: http.MethodGet,
+				}
+			},
+			setupMocks: func(t *testing.T, mock *mock) {
+				mock.mockGraph.EXPECT().FetchKinds(gomock.Any())
+			},
+			expected: expected{
+				responseCode:   http.StatusBadRequest,
+				responseHeader: http.Header{"Content-Type": []string{"application/json"}},
+				responseBody:   `{"errors":[{"context":"","message":"the specified column cannot be filtered: badqueryparam"}],"http_status":400,"request_id":"","timestamp":"0001-01-01T00:00:00Z"}`,
+			},
+		},
+		{
+			name: "Error: predicate not supported - Bad Request",
+			buildRequest: func() *http.Request {
+				return &http.Request{
+					URL: &url.URL{
+						Path:     "/api/v2/graphs/kinds",
+						RawQuery: "type=gt:node",
+					},
+					Method: http.MethodGet,
+				}
+			},
+			setupMocks: func(t *testing.T, mock *mock) {
+				mock.mockGraph.EXPECT().FetchKinds(gomock.Any())
+			},
+			expected: expected{
+				responseCode:   http.StatusBadRequest,
+				responseHeader: http.Header{"Content-Type": []string{"application/json"}},
+				responseBody:   `{"errors":[{"context":"","message":"the specified filter predicate is not supported for this column: type gt"}],"http_status":400,"request_id":"","timestamp":"0001-01-01T00:00:00Z"}`,
+			},
+		},
+		{
+			name: "Error: GetPrimaryDisplayKinds database error - Internal Server Error",
+			buildRequest: func() *http.Request {
+				return &http.Request{
+					URL: &url.URL{
+						Path:     "/api/v2/graphs/kinds",
+						RawQuery: "type=eq:node",
+					},
+					Method: http.MethodGet,
+				}
+			},
+			setupMocks: func(t *testing.T, mock *mock) {
+				mock.mockGraph.EXPECT().FetchKinds(gomock.Any())
+				mock.mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any()).Return(nil, errors.New("error"))
+			},
+			expected: expected{
+				responseCode:   http.StatusInternalServerError,
+				responseHeader: http.Header{"Content-Type": []string{"application/json"}},
+				responseBody:   `{"errors":[{"context":"","message":"an internal error has occurred that is preventing the service from servicing this request"}],"http_status":500,"request_id":"","timestamp":"0001-01-01T00:00:00Z"}`,
+			},
+		},
+		{
+			name: "Error: GetSourceKinds database error - Internal Server Error",
+			buildRequest: func() *http.Request {
+				return &http.Request{
+					URL: &url.URL{
+						Path:     "/api/v2/graphs/kinds",
+						RawQuery: "type=eq:node",
+					},
+					Method: http.MethodGet,
+				}
+			},
+			setupMocks: func(t *testing.T, mock *mock) {
+				mock.mockGraph.EXPECT().FetchKinds(gomock.Any())
+				mock.mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any())
+				mock.mockDB.EXPECT().GetSourceKinds(gomock.Any()).Return(nil, errors.New("error"))
+			},
+			expected: expected{
+				responseCode:   http.StatusInternalServerError,
+				responseHeader: http.Header{"Content-Type": []string{"application/json"}},
+				responseBody:   `{"errors":[{"context":"","message":"an internal error has occurred that is preventing the service from servicing this request"}],"http_status":500,"request_id":"","timestamp":"0001-01-01T00:00:00Z"}`,
+			},
+		},
+		{
+			name: "Success: no filters returns all kinds alpha sorted - OK",
+			buildRequest: func() *http.Request {
+				return &http.Request{
+					URL:    &url.URL{Path: "/api/v2/graphs/kinds"},
+					Method: http.MethodGet,
+				}
+			},
+			setupMocks: func(t *testing.T, mock *mock) {
+				mock.mockGraph.EXPECT().FetchKinds(gomock.Any()).Return(mockKindsResp, nil)
+			},
+			expected: expected{
+				responseCode:   http.StatusOK,
+				responseHeader: http.Header{"Content-Type": []string{"application/json"}},
+				responseBody:   `{"data":{"kinds":["AZBase", "AZHasRole", "DCSync", "MigrationData", "Tag_Tier_Zero", "User"]}}`,
+			},
+		},
+		{
+			name: "Success: filter type=eq:node returns only node kinds - OK",
+			buildRequest: func() *http.Request {
+				return &http.Request{
+					URL: &url.URL{
+						Path:     "/api/v2/graphs/kinds",
+						RawQuery: "type=eq:node",
+					},
+					Method: http.MethodGet,
+				}
+			},
+			setupMocks: func(t *testing.T, mock *mock) {
+				mock.mockGraph.EXPECT().FetchKinds(gomock.Any()).Return(mockKindsResp, nil)
+				mock.mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any()).Return(mockDispKindsResp, nil)
+				mock.mockDB.EXPECT().GetSourceKinds(gomock.Any()).Return(mockSrcKindsResp, nil)
+			},
+			expected: expected{
+				responseCode:   http.StatusOK,
+				responseHeader: http.Header{"Content-Type": []string{"application/json"}},
+				responseBody:   `{"data":{"kinds":["AZBase","MigrationData","Tag_Tier_Zero","User"]}}`,
+			},
+		},
+		{
+			name: "Success: filter type=eq:edge returns only edge kinds - OK",
+			buildRequest: func() *http.Request {
+				return &http.Request{
+					URL: &url.URL{
+						Path:     "/api/v2/graphs/kinds",
+						RawQuery: "type=eq:edge",
+					},
+					Method: http.MethodGet,
+				}
+			},
+			setupMocks: func(t *testing.T, mock *mock) {
+				mock.mockGraph.EXPECT().FetchKinds(gomock.Any()).Return(mockKindsResp, nil)
+				mock.mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any()).Return(mockDispKindsResp, nil)
+				mock.mockDB.EXPECT().GetSourceKinds(gomock.Any()).Return(mockSrcKindsResp, nil)
+			},
+			expected: expected{
+				responseCode:   http.StatusOK,
+				responseHeader: http.Header{"Content-Type": []string{"application/json"}},
+				responseBody:   `{"data":{"kinds":["AZHasRole", "DCSync"]}}`,
+			},
+		},
+		{
+			name: "Success: filter type=neq:node returns edges - OK",
+			buildRequest: func() *http.Request {
+				return &http.Request{
+					URL: &url.URL{
+						Path:     "/api/v2/graphs/kinds",
+						RawQuery: "type=neq:node",
+					},
+					Method: http.MethodGet,
+				}
+			},
+			setupMocks: func(t *testing.T, mock *mock) {
+				mock.mockGraph.EXPECT().FetchKinds(gomock.Any()).Return(mockKindsResp, nil)
+				mock.mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any()).Return(mockDispKindsResp, nil)
+				mock.mockDB.EXPECT().GetSourceKinds(gomock.Any()).Return(mockSrcKindsResp, nil)
+			},
+			expected: expected{
+				responseCode:   http.StatusOK,
+				responseHeader: http.Header{"Content-Type": []string{"application/json"}},
+				responseBody:   `{"data":{"kinds":["AZHasRole","DCSync"]}}`,
+			},
+		},
+		{
+			name: "Success: unknown filter value returns empty list - OK",
+			buildRequest: func() *http.Request {
+				return &http.Request{
+					URL: &url.URL{
+						Path:     "/api/v2/graphs/kinds",
+						RawQuery: "type=eq:bupkis",
+					},
+					Method: http.MethodGet,
+				}
+			},
+			setupMocks: func(t *testing.T, mock *mock) {
+				mock.mockGraph.EXPECT().FetchKinds(gomock.Any()).Return(mockKindsResp, nil)
+				mock.mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any()).Return(mockDispKindsResp, nil)
+				mock.mockDB.EXPECT().GetSourceKinds(gomock.Any()).Return(mockSrcKindsResp, nil)
+			},
+			expected: expected{
+				responseCode:   http.StatusOK,
+				responseHeader: http.Header{"Content-Type": []string{"application/json"}},
+				responseBody:   `{"data":{"kinds":[]}}`,
+			},
+		},
+	}
+
+	for _, testCase := range tt {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+
+			mock := &mock{
+				mockGraph: graphmocks.NewMockDatabase(ctrl),
+				mockDB:    mocks.NewMockDatabase(ctrl),
+			}
+
+			request := testCase.buildRequest()
+			testCase.setupMocks(t, mock)
+
+			resources := v2.Resources{
+				Graph: mock.mockGraph,
+				DB:    mock.mockDB,
+			}
+
+			response := httptest.NewRecorder()
+
+			router := mux.NewRouter()
+			router.HandleFunc("/api/v2/graphs/kinds", resources.ListKinds).Methods("GET")
+
+			router.ServeHTTP(response, request)
+
+			status, header, body := test.ProcessResponse(t, response)
+
+			assert.Equal(t, testCase.expected.responseCode, status)
+			assert.Equal(t, testCase.expected.responseHeader, header)
+			assert.JSONEq(t, testCase.expected.responseBody, body)
+		})
+	}
+}
+
+func TestResources_ListSourceKinds(t *testing.T) {
+	t.Parallel()
+	type mock struct {
+		mockDB *mocks.MockDatabase
+	}
+	type expected struct {
+		responseBody   string
+		responseCode   int
+		responseHeader http.Header
+	}
+	type testData struct {
+		name         string
+		buildRequest func() *http.Request
+		setupMocks   func(t *testing.T, mock *mock)
+		expected     expected
+	}
+
+	tt := []testData{
+		{
+			name: "Error: GetSourceKinds database error - Internal Server Error",
+			buildRequest: func() *http.Request {
+				return &http.Request{
+					URL:    &url.URL{Path: "/api/v2/graphs/source-kinds"},
+					Method: http.MethodGet,
+				}
+			},
+			setupMocks: func(t *testing.T, mock *mock) {
+				mock.mockDB.EXPECT().GetSourceKinds(gomock.Any()).Return(nil, errors.New("error"))
+			},
+			expected: expected{
+				responseCode:   http.StatusInternalServerError,
+				responseHeader: http.Header{"Content-Type": []string{"application/json"}},
+				responseBody:   `{"errors":[{"context":"","message":"an internal error has occurred that is preventing the service from servicing this request"}],"http_status":500,"request_id":"","timestamp":"0001-01-01T00:00:00Z"}`,
+			},
+		},
+		{
+			name: "Success: returns kinds with Sourceless appended - OK",
+			buildRequest: func() *http.Request {
+				return &http.Request{
+					URL:    &url.URL{Path: "/api/v2/graphs/source-kinds"},
+					Method: http.MethodGet,
+				}
+			},
+			setupMocks: func(t *testing.T, mock *mock) {
+				mock.mockDB.EXPECT().GetSourceKinds(gomock.Any()).Return([]model.SourceKind{
+					{ID: 1, Name: ad.Entity.String()},
+					{ID: 2, Name: azure.Entity.String()},
+				}, nil)
+			},
+			expected: expected{
+				responseCode:   http.StatusOK,
+				responseHeader: http.Header{"Content-Type": []string{"application/json"}},
+				responseBody:   `{"data":{"kinds":[{"id":1,"name":"Base"},{"id":2,"name":"AZBase"},{"id":0,"name":"Sourceless"}]}}`,
+			},
+		},
+	}
+
+	for _, testCase := range tt {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+
+			mock := &mock{
+				mockDB: mocks.NewMockDatabase(ctrl),
+			}
+
+			request := testCase.buildRequest()
+			testCase.setupMocks(t, mock)
+
+			resources := v2.Resources{DB: mock.mockDB}
+
+			response := httptest.NewRecorder()
+
+			router := mux.NewRouter()
+			router.HandleFunc("/api/v2/graphs/source-kinds", resources.ListSourceKinds).Methods("GET")
+
+			router.ServeHTTP(response, request)
+
+			status, header, body := test.ProcessResponse(t, response)
+
+			assert.Equal(t, testCase.expected.responseCode, status)
+			assert.Equal(t, testCase.expected.responseHeader, header)
+			assert.JSONEq(t, testCase.expected.responseBody, body)
+		})
+	}
+}

--- a/cmd/api/src/model/assetgrouptags.go
+++ b/cmd/api/src/model/assetgrouptags.go
@@ -85,8 +85,9 @@ const (
 )
 
 const (
-	TierZeroGlyph = "gem"
-	OwnedGlyph    = "skull"
+	TierZeroGlyph           = "gem"
+	OwnedGlyph              = "skull"
+	AssetGroupTagKindPrefix = "Tag_"
 )
 
 type AssetGroupTagCounts struct {
@@ -142,7 +143,7 @@ func (s AssetGroupTag) ToKind() graph.Kind {
 }
 
 func (s AssetGroupTag) KindName() string {
-	return fmt.Sprintf("Tag_%s", strings.ReplaceAll(s.Name, " ", "_"))
+	return fmt.Sprintf("%s%s", AssetGroupTagKindPrefix, strings.ReplaceAll(s.Name, " ", "_"))
 }
 
 func (s AssetGroupTag) IsStringColumn(filter string) bool {

--- a/cmd/api/src/model/kind.go
+++ b/cmd/api/src/model/kind.go
@@ -13,6 +13,7 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
+
 package model
 
 import "github.com/specterops/dawgs/graph"
@@ -28,4 +29,10 @@ func (k Kind) TableName() string {
 
 func (k Kind) ToKind() graph.Kind {
 	return graph.StringKind(k.Name)
+}
+
+func (k Kind) ValidFilters() map[string][]FilterOperator {
+	return map[string][]FilterOperator{
+		"type": {Equals, NotEquals},
+	}
 }

--- a/packages/go/openapi/doc/openapi.json
+++ b/packages/go/openapi/doc/openapi.json
@@ -7027,7 +7027,7 @@
           {
             "name": "type",
             "in": "query",
-            "description": "Filter by type, valid types are \"node\" or \"edge\".",
+            "description": "Filter by type, valid types are node or edge, e.g. \"eq:node\"",
             "required": false,
             "schema": {
               "$ref": "#/components/schemas/api.params.predicate.filter.string-strict"

--- a/packages/go/openapi/doc/openapi.json
+++ b/packages/go/openapi/doc/openapi.json
@@ -7023,6 +7023,17 @@
           "Community",
           "Enterprise"
         ],
+        "parameters": [
+          {
+            "name": "type",
+            "in": "query",
+            "description": "Filter by type, valid types are \"node\" or \"edge\".",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/api.params.predicate.filter.string-strict"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -7046,6 +7057,9 @@
                 }
               }
             }
+          },
+          "400": {
+            "$ref": "#/components/responses/bad-request"
           },
           "401": {
             "$ref": "#/components/responses/unauthorized"

--- a/packages/go/openapi/src/paths/graph.kinds.yaml
+++ b/packages/go/openapi/src/paths/graph.kinds.yaml
@@ -24,6 +24,13 @@ get:
     - Graph
     - Community
     - Enterprise
+  parameters:
+    - name: type
+      in: query
+      description: Filter by type, valid types are "node" or "edge".
+      required: false
+      schema:
+        $ref: './../schemas/api.params.predicate.filter.string-strict.yaml'
   responses:
     200:
       description: OK
@@ -39,6 +46,8 @@ get:
                     type: array
                     items:
                       type: string
+    400:
+      $ref: './../responses/bad-request.yaml'
     401:
       $ref: './../responses/unauthorized.yaml'
     403:

--- a/packages/go/openapi/src/paths/graph.kinds.yaml
+++ b/packages/go/openapi/src/paths/graph.kinds.yaml
@@ -27,7 +27,7 @@ get:
   parameters:
     - name: type
       in: query
-      description: Filter by type, valid types are "node" or "edge".
+      description: Filter by type, valid types are node or edge, e.g. "eq:node"
       required: false
       schema:
         $ref: './../schemas/api.params.predicate.filter.string-strict.yaml'


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

*Describe your changes in detail*
Extends `/kinds` with type filter (node / edge) to be used by the UI in cypher label autocomplete

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-7925

*Why is this change required? What problem does it solve?*

## How Has This Been Tested?

*Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc.*

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->
- New feature (non-breaking change which adds functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Kinds API supports an optional `type` query parameter to filter results to node or edge kinds; results are alpha-sorted.
  * Source kinds listing returns simplified {id,name} entries and appends a "Sourceless" kind.
  * Tag-kind naming prefix standardized for consistent kind names.

* **Bug Fixes**
  * API returns clear 400 Bad Request for invalid, non-filterable, or unsupported filter inputs.

* **Documentation**
  * OpenAPI updated to document the `type` filter and 400 response.

* **Tests**
  * Added tests covering filtering, error cases, and source-kind listing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->