### PR TITLE
chore: Add Attack Paths Table feature flag BED-7775

### DIFF
--- a/cmd/api/src/database/migration/migrations/v9.1.0.sql
+++ b/cmd/api/src/database/migration/migrations/v9.1.0.sql
@@ -70,3 +70,14 @@ DO $$
             REFERENCES users(id);
     END IF;
   END $$;
+
+-- Add Attack Paths Table feature flag
+INSERT INTO feature_flags (created_at, updated_at, key, name, description, enabled, user_updatable)
+VALUES (current_timestamp,
+        current_timestamp,
+        'attack_paths_table',
+        'Attack Paths Table',
+        'Enables a new table view for attack paths.',
+        false,
+        false)
+ON CONFLICT DO NOTHING;


### PR DESCRIPTION
## Description
Adds a disabled, non user-updateable feature flag with the key `attack_paths_table` to the v9.1.0 migration file.

## Motivation and Context

Resolves BED-7775

We want to gate the table view work on the Attack Paths page behind a feature flag.

## How Has This Been Tested?

## Screenshots (optional):

## Types of changes
- Chore (a change that does not modify the application functionality)
- Database Migrations

## Checklist:
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added database configuration for feature flag management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->