### PR TITLE
feat: add GET /display-kinds to enrich graph UI BED-7925

### DIFF
--- a/cmd/api/src/api/bloodhoundgraph/bloodhoundgraph_test.go
+++ b/cmd/api/src/api/bloodhoundgraph/bloodhoundgraph_test.go
@@ -76,7 +76,7 @@ func TestSetFontIcon(t *testing.T) {
 		nodeKindMap := graphschema.PrimaryDisplayKinds{
 			graph.StringKind("User"): graphschema.DisplayKind{
 				Name: "User",
-				Icon: graphschema.DisplayNodeIcon{
+				Icon: &graphschema.DisplayNodeIcon{
 					Name:  "user",
 					Color: "#17E625",
 					Type:  graphschema.DisplayNodeTypeFontAwesome,
@@ -117,7 +117,7 @@ func TestSetFontIcon(t *testing.T) {
 		nodeKindMap := graphschema.PrimaryDisplayKinds{
 			graph.StringKind("Meta"): graphschema.DisplayKind{
 				Name: "Meta",
-				Icon: graphschema.DisplayNodeIcon{
+				Icon: &graphschema.DisplayNodeIcon{
 					Name:  "star",
 					Color: "#FFF",
 				},

--- a/cmd/api/src/api/registration/v2.go
+++ b/cmd/api/src/api/registration/v2.go
@@ -204,6 +204,7 @@ func NewV2API(resources v2.Resources, routerInst *router.Router) {
 
 		routerInst.GET("/api/v2/pathfinding", resources.GetPathfindingResult).Queries("start_node", "{start_node}", "end_node", "{end_node}").RequirePermissions(permissions.GraphDBRead).RequireAllEnvironmentAccess(resources.DogTags),
 		routerInst.GET("/api/v2/graphs/kinds", resources.ListKinds).RequirePermissions(permissions.GraphDBRead),
+		routerInst.GET("/api/v2/graphs/display-kinds", resources.ListDisplayKinds).RequirePermissions(permissions.GraphDBRead),
 		routerInst.GET("/api/v2/graphs/source-kinds", resources.ListSourceKinds).RequirePermissions(permissions.GraphDBRead),
 		routerInst.GET("/api/v2/graphs/shortest-path", resources.GetShortestPath).Queries(params.StartNode.String(), params.StartNode.RouteMatcher(), params.EndNode.String(), params.EndNode.RouteMatcher()).RequirePermissions(permissions.GraphDBRead),
 		routerInst.GET("/api/v2/graphs/edge-composition", resources.GetEdgeComposition).RequirePermissions(permissions.GraphDBRead).RequireAllEnvironmentAccess(resources.DogTags),

--- a/cmd/api/src/api/v2/kinds.go
+++ b/cmd/api/src/api/v2/kinds.go
@@ -23,25 +23,115 @@ import (
 
 	"github.com/specterops/bloodhound/cmd/api/src/api"
 	"github.com/specterops/bloodhound/cmd/api/src/model"
+	"github.com/specterops/bloodhound/packages/go/graphschema"
+	"github.com/specterops/bloodhound/packages/go/graphschema/common"
 	"github.com/specterops/dawgs/graph"
 )
 
+func isExtendedNodeKind(kind graph.Kind) bool {
+	return strings.HasPrefix(kind.String(), model.AssetGroupTagKindPrefix) || kind.Is(graph.StringKind("Meta"), graph.StringKind("MetaDetails"), common.MigrationData)
+}
+
 type ListKindsResponse struct {
-	Kinds graph.Kinds `json:"kinds"`
+	Kinds     graph.Kinds `json:"kinds"`
+	NodeKinds graph.Kinds `json:"node_kinds"`
+	EdgeKinds graph.Kinds `json:"edge_kinds"`
 }
 
 // ListKinds returns all node kinds, edge kinds, and tier tags present in the system.
 // It is a comprehensive view of the various kinds the graph currently recognizes.
 func (s Resources) ListKinds(response http.ResponseWriter, request *http.Request) {
+	var (
+		resp = ListKindsResponse{}
+		err  error
+	)
+
+	if resp.Kinds, err = s.Graph.FetchKinds(request.Context()); err != nil {
+		api.HandleDatabaseError(request, response, err)
+	} else {
+		// Alpha sort kind list
+		slices.SortFunc(resp.Kinds, func(a, b graph.Kind) int {
+			return strings.Compare(a.String(), b.String())
+		})
+
+		// This gets both custom node kinds (schemaless) and schema based node kinds
+		// Note: currently this is not an exhaustive list until all the custom-node sync work is complete
+		if displayKinds, err := s.DB.GetPrimaryDisplayKinds(request.Context()); err != nil {
+			api.HandleDatabaseError(request, response, err)
+		} else {
+			// Add nodes and edge kinds for UI
+			for _, kind := range resp.Kinds {
+				if _, ok := displayKinds[kind]; ok {
+					resp.NodeKinds = append(resp.NodeKinds, kind)
+					// Asset group tags are node kinds as well as meta kinds
+				} else if isExtendedNodeKind(kind) {
+					resp.NodeKinds = append(resp.NodeKinds, kind)
+				} else {
+					resp.EdgeKinds = append(resp.EdgeKinds, kind)
+				}
+			}
+		}
+
+		api.WriteBasicResponse(request.Context(), resp, http.StatusOK, response)
+	}
+}
+
+type ListDisplayKindsResponse struct {
+	NodeKinds map[string]graphschema.DisplayKind `json:"node_kinds"`
+	EdgeKinds map[string]graphschema.DisplayKind `json:"edge_kinds"`
+}
+
+// ListDisplayKinds returns kinds to be mapped to enriched data like display name, icon, etc
+func (s Resources) ListDisplayKinds(response http.ResponseWriter, request *http.Request) {
+	var resp = ListDisplayKindsResponse{NodeKinds: make(map[string]graphschema.DisplayKind), EdgeKinds: make(map[string]graphschema.DisplayKind)}
+
 	if kinds, err := s.Graph.FetchKinds(request.Context()); err != nil {
 		api.HandleDatabaseError(request, response, err)
 	} else {
-		// Alpha sort
+		// Alpha sort kind list
 		slices.SortFunc(kinds, func(a, b graph.Kind) int {
 			return strings.Compare(a.String(), b.String())
 		})
 
-		api.WriteBasicResponse(request.Context(), ListKindsResponse{Kinds: kinds}, http.StatusOK, response)
+		// This gets both custom node kinds (schemaless) and schema based node kinds
+		// Note: currently this is not an exhaustive list until all the custom-node sync work is complete
+		if displayKinds, err := s.DB.GetPrimaryDisplayKinds(request.Context()); err != nil {
+			api.HandleDatabaseError(request, response, err)
+		} else if extensions, _, err := s.DB.GetGraphSchemaExtensions(request.Context(), model.Filters{}, model.Sort{}, 0, 0); err != nil {
+			api.HandleDatabaseError(request, response, err)
+		} else {
+			// Build map to link extension display name to id to enrich the display kind
+			extensionNameById := make(map[int]string)
+			for _, extension := range extensions {
+				extensionNameById[int(extension.ID)] = extension.DisplayName
+			}
+
+			// Sort nodes and edge kinds for UI
+			for _, kind := range kinds {
+				if nodeKind, ok := displayKinds[kind]; ok {
+					// Enrich display kind with extension display name so nodes can be labeled "ExtensionX | NodeKindY"
+					if extensionDisplayName, ok := extensionNameById[nodeKind.ExtensionId]; ok {
+						nodeKind.ExtensionDisplayName = extensionDisplayName
+					} else {
+						nodeKind.ExtensionDisplayName = "Open Graph" // Fallback to Open graph when schemaless
+					}
+					resp.NodeKinds[kind.String()] = nodeKind
+					// Asset group tags are node kinds as well as meta kinds, they do not have icons
+				} else if isExtendedNodeKind(kind) {
+					resp.NodeKinds[kind.String()] = graphschema.DisplayKind{
+						Name:        kind.String(),
+						DisplayName: kind.String(),
+					}
+				} else {
+					resp.EdgeKinds[kind.String()] = graphschema.DisplayKind{
+						Name:        kind.String(),
+						DisplayName: kind.String(),
+					}
+				}
+			}
+		}
+
+		api.WriteBasicResponse(request.Context(), resp, http.StatusOK, response)
 	}
 }
 

--- a/cmd/api/src/api/v2/pathfinding_test.go
+++ b/cmd/api/src/api/v2/pathfinding_test.go
@@ -1278,7 +1278,7 @@ func TestResources_GetSearchResult(t *testing.T) {
 						GetFlagByKey(gomock.Any(), appcfg.FeatureOpenGraphSearch).
 						Return(appcfg.FeatureFlag{Enabled: true}, nil)
 					mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any()).Return(graphschema.PrimaryDisplayKinds{
-						graph.StringKind("Person"): graphschema.DisplayKind{Name: "Person", Icon: graphschema.DisplayNodeIcon{Type: graphschema.DisplayNodeTypeFontAwesome, Name: "person-half-dress", Color: "#ff91af"}}}, nil)
+						graph.StringKind("Person"): graphschema.DisplayKind{Name: "Person", Icon: &graphschema.DisplayNodeIcon{Type: graphschema.DisplayNodeTypeFontAwesome, Name: "person-half-dress", Color: "#ff91af"}}}, nil)
 
 					nodeSet := graph.NewNodeSet()
 					personNode := &graph.Node{
@@ -1342,7 +1342,7 @@ func TestResources_GetSearchResult(t *testing.T) {
 
 					nodeSet.Add(personNode)
 					mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any()).Return(graphschema.PrimaryDisplayKinds{
-						graph.StringKind("Person"): graphschema.DisplayKind{Name: "Person", Icon: graphschema.DisplayNodeIcon{Type: graphschema.DisplayNodeTypeFontAwesome, Name: "person-half-dress", Color: "#ff91af"}}}, nil)
+						graph.StringKind("Person"): graphschema.DisplayKind{Name: "Person", Icon: &graphschema.DisplayNodeIcon{Type: graphschema.DisplayNodeTypeFontAwesome, Name: "person-half-dress", Color: "#ff91af"}}}, nil)
 					mockGraph.EXPECT().
 						SearchByNameOrObjectID(gomock.Any(), true, "some query", queries.SearchTypeFuzzy).
 						Return(nodeSet, nil)

--- a/cmd/api/src/api/v2/search_test.go
+++ b/cmd/api/src/api/v2/search_test.go
@@ -133,7 +133,7 @@ func TestResources_SearchHandler(t *testing.T) {
 							},
 						}, nil)
 					mockDB.EXPECT().GetPrimaryDisplayKinds(gomock.Any()).Return(graphschema.PrimaryDisplayKinds{
-						graph.StringKind("Person"): graphschema.DisplayKind{Name: "Person", Icon: graphschema.DisplayNodeIcon{Type: graphschema.DisplayNodeTypeFontAwesome, Name: "person-half-dress", Color: "#ff91af"}}}, nil)
+						graph.StringKind("Person"): graphschema.DisplayKind{Name: "Person", Icon: &graphschema.DisplayNodeIcon{Type: graphschema.DisplayNodeTypeFontAwesome, Name: "person-half-dress", Color: "#ff91af"}}}, nil)
 				},
 				Test: func(output apitest.Output) {
 					apitest.StatusCode(output, http.StatusOK)

--- a/cmd/api/src/database/graphschema.go
+++ b/cmd/api/src/database/graphschema.go
@@ -1361,18 +1361,22 @@ func (s *BloodhoundDB) GetPrimaryDisplayKinds(ctx context.Context) (graphschema.
 			for _, kind := range kinds {
 				customKind := customKindsByName[kind.Name]
 				primaryDisplayKinds[kind.ToKind()] = graphschema.DisplayKind{
-					Name: kind.Name,
-					Icon: graphschema.DisplayNodeIcon{
+					Name:        kind.Name,
+					DisplayName: kind.Name,
+					Icon: &graphschema.DisplayNodeIcon{
 						Name:  customKind.Config.Icon.Name,
 						Type:  customKind.Config.Icon.Type,
 						Color: customKind.Config.Icon.Color,
 					},
 				}
 			}
+			// Prioritize schema node kind definitions
 			for _, kind := range displaySchemaNodeKinds {
 				primaryDisplayKinds[kind.ToKind()] = graphschema.DisplayKind{
-					Name: kind.Name,
-					Icon: graphschema.DisplayNodeIcon{
+					Name:        kind.Name,
+					ExtensionId: int(kind.SchemaExtensionId),
+					DisplayName: kind.DisplayName,
+					Icon: &graphschema.DisplayNodeIcon{
 						Name:  kind.Icon,
 						Color: kind.IconColor,
 						Type:  graphschema.DisplayNodeTypeFontAwesome,

--- a/cmd/api/src/model/assetgrouptags.go
+++ b/cmd/api/src/model/assetgrouptags.go
@@ -85,8 +85,9 @@ const (
 )
 
 const (
-	TierZeroGlyph = "gem"
-	OwnedGlyph    = "skull"
+	TierZeroGlyph           = "gem"
+	OwnedGlyph              = "skull"
+	AssetGroupTagKindPrefix = "Tag_"
 )
 
 type AssetGroupTagCounts struct {
@@ -142,7 +143,7 @@ func (s AssetGroupTag) ToKind() graph.Kind {
 }
 
 func (s AssetGroupTag) KindName() string {
-	return fmt.Sprintf("Tag_%s", strings.ReplaceAll(s.Name, " ", "_"))
+	return fmt.Sprintf("%s%s", AssetGroupTagKindPrefix, strings.ReplaceAll(s.Name, " ", "_"))
 }
 
 func (s AssetGroupTag) IsStringColumn(filter string) bool {

--- a/packages/go/graphschema/primarykind.go
+++ b/packages/go/graphschema/primarykind.go
@@ -71,8 +71,11 @@ type DisplayNodeIcon struct {
 }
 
 type DisplayKind struct {
-	Name string
-	Icon DisplayNodeIcon
+	Name                 string           `json:"name"`
+	DisplayName          string           `json:"display_name"`
+	Icon                 *DisplayNodeIcon `json:"icon,omitempty"`
+	ExtensionId          int              `json:"extension_id,omitempty"`
+	ExtensionDisplayName string           `json:"extension_display_name,omitempty"`
 }
 
 type PrimaryDisplayKinds map[graph.Kind]DisplayKind
@@ -80,7 +83,7 @@ type PrimaryDisplayKinds map[graph.Kind]DisplayKind
 func (s PrimaryDisplayKinds) Add(kindName, iconName, iconColor string, iconType DisplayNodeType) {
 	s[graph.StringKind(kindName)] = DisplayKind{
 		Name: kindName,
-		Icon: DisplayNodeIcon{
+		Icon: &DisplayNodeIcon{
 			Type:  iconType,
 			Name:  iconName,
 			Color: iconColor,

--- a/packages/go/openapi/doc/openapi.json
+++ b/packages/go/openapi/doc/openapi.json
@@ -7039,6 +7039,114 @@
                           "items": {
                             "type": "string"
                           }
+                        },
+                        "node_kinds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "edge_kinds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/too-many-requests"
+          },
+          "500": {
+            "$ref": "#/components/responses/internal-server-error"
+          }
+        }
+      }
+    },
+    "/api/v2/graphs/display-kinds": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/header.prefer"
+        }
+      ],
+      "get": {
+        "operationId": "GetDisplayKinds",
+        "summary": "Get display kinds",
+        "description": "Gets display kinds",
+        "tags": [
+          "Graph",
+          "Community",
+          "Enterprise"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "node_kinds": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "display_name": {
+                                "type": "string"
+                              },
+                              "extension_display_name": {
+                                "type": "string"
+                              },
+                              "extension_id": {
+                                "type": "number"
+                              },
+                              "icon": {
+                                "type": "object",
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  },
+                                  "color": {
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "edge_kinds": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "display_name": {
+                                "type": "string"
+                              }
+                            }
+                          }
                         }
                       }
                     }

--- a/packages/go/openapi/src/openapi.yaml
+++ b/packages/go/openapi/src/openapi.yaml
@@ -368,6 +368,8 @@ paths:
   # graph
   /api/v2/graphs/kinds:
     $ref: './paths/graph.kinds.yaml'
+  /api/v2/graphs/display-kinds:
+    $ref: './paths/graph.display-kinds.yaml'
   /api/v2/pathfinding:
     $ref: './paths/graph.pathfinding.yaml'
   /api/v2/graph-search:

--- a/packages/go/openapi/src/paths/graph.display-kinds.yaml
+++ b/packages/go/openapi/src/paths/graph.display-kinds.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 Specter Ops, Inc.
+# Copyright 2026 Specter Ops, Inc.
 #
 # Licensed under the Apache License, Version 2.0
 # you may not use this file except in compliance with the License.
@@ -17,9 +17,9 @@
 parameters:
   - $ref: './../parameters/header.prefer.yaml'
 get:
-  operationId: GetKinds
-  summary: Get kinds
-  description: Gets kinds
+  operationId: GetDisplayKinds
+  summary: Get display kinds
+  description: Gets display kinds
   tags:
     - Graph
     - Community
@@ -35,18 +35,37 @@ get:
               data:
                 type: object
                 properties:
-                  kinds:
-                    type: array
-                    items:
-                      type: string
                   node_kinds:
-                    type: array
-                    items:
-                      type: string
+                    type: object
+                    additionalProperties:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        display_name:
+                          type: string
+                        extension_display_name:
+                          type: string
+                        extension_id:
+                          type: number
+                        icon:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                            type:
+                              type: string
+                            color:
+                              type: string
                   edge_kinds:
-                    type: array
-                    items:
-                      type: string
+                    type: object
+                    additionalProperties:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        display_name:
+                          type: string
 
     401:
       $ref: './../responses/unauthorized.yaml'


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

*Describe your changes in detail*
Extends `/kinds` with array for `node_kinds` and `edge_kinds`
Adds `/display-kinds` with `node_kinds` and `edge_kinds` map to provide icon / display name information to be used by the UI

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-7925

*Why is this change required? What problem does it solve?*

## How Has This Been Tested?

*Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc.*

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->
- New feature (non-breaking change which adds functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
