### PR TITLE
feat(webhooks): Add migration + model layer for webhook tables BED-7965

### DIFF
--- a/cmd/api/src/database/migration/migrations/v9.2.0.sql
+++ b/cmd/api/src/database/migration/migrations/v9.2.0.sql
@@ -90,9 +90,9 @@ CREATE TABLE IF NOT EXISTS webhook_events
     webhook_id       text                     NOT NULL,
     event_id         text                     NOT NULL,
     created_at       timestamp with time zone NOT NULL DEFAULT current_timestamp,
-    last_status_code integer                  NOT NULL DEFAULT 0,
+    last_status_code integer,
     last_error       text,
-    attempts         integer                  NOT NULL DEFAULT 0,
+    attempts         integer                  NOT NULL DEFAULT 1,
     PRIMARY KEY (webhook_id, event_id),
     CONSTRAINT fk_webhook_events_webhooks
         FOREIGN KEY (webhook_id) REFERENCES webhooks (id) ON DELETE CASCADE,

--- a/cmd/api/src/database/migration/migrations/v9.2.0.sql
+++ b/cmd/api/src/database/migration/migrations/v9.2.0.sql
@@ -16,9 +16,7 @@
 
 -- Webhooks subsystem tables
 
--- events carries the domain events that may be delivered to subscribed webhooks.
--- id is stored as text holding the canonical string form of a UUIDv7 so events
--- remain naturally time-ordered. Event ingestion is owned by a separate changeset.
+-- events
 CREATE TABLE IF NOT EXISTS events
 (
     id           text                     NOT NULL,
@@ -30,8 +28,7 @@ CREATE TABLE IF NOT EXISTS events
     PRIMARY KEY (id)
 );
 
--- webhooks is the top-level registration of an outbound delivery target.
--- id is stored as text holding the canonical string form of a UUIDv4.
+-- webhooks
 CREATE TABLE IF NOT EXISTS webhooks
 (
     id          text                     NOT NULL,
@@ -50,9 +47,7 @@ CREATE TABLE IF NOT EXISTS webhooks
 
 CREATE UNIQUE INDEX IF NOT EXISTS webhooks_url_unique_index ON webhooks (url);
 
--- webhook_secrets stores the HMAC signing secret for a webhook (1:1 with webhooks).
--- Kept in a separate table so the secret can be protected independently of the
--- record that is regularly selected by the UI.
+-- webhook_secrets
 CREATE TABLE IF NOT EXISTS webhook_secrets
 (
     webhook_id  text                     NOT NULL,
@@ -63,7 +58,7 @@ CREATE TABLE IF NOT EXISTS webhook_secrets
         FOREIGN KEY (webhook_id) REFERENCES webhooks (id) ON DELETE CASCADE
 );
 
--- webhook_metadata tracks rolling delivery health per webhook (1:1 with webhooks).
+-- webhook_metadata
 CREATE TABLE IF NOT EXISTS webhook_metadata
 (
     webhook_id        text                     NOT NULL,
@@ -78,9 +73,7 @@ CREATE TABLE IF NOT EXISTS webhook_metadata
         FOREIGN KEY (webhook_id) REFERENCES webhooks (id) ON DELETE CASCADE
 );
 
--- webhook_subscriptions maps a webhook to the event types it consumes.
--- version is a payload attribute, not part of identity: a webhook can subscribe
--- to any given event_type exactly once.
+-- webhook_subscriptions
 CREATE TABLE IF NOT EXISTS webhook_subscriptions
 (
     webhook_id text NOT NULL,
@@ -91,7 +84,7 @@ CREATE TABLE IF NOT EXISTS webhook_subscriptions
         FOREIGN KEY (webhook_id) REFERENCES webhooks (id) ON DELETE CASCADE
 );
 
--- webhook_events records the delivery state of a single event to a single webhook.
+-- webhook_events
 CREATE TABLE IF NOT EXISTS webhook_events
 (
     webhook_id       text                     NOT NULL,

--- a/cmd/api/src/database/migration/migrations/v9.2.0.sql
+++ b/cmd/api/src/database/migration/migrations/v9.2.0.sql
@@ -1,0 +1,109 @@
+-- Copyright 2026 Specter Ops, Inc.
+--
+-- Licensed under the Apache License, Version 2.0
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- SPDX-License-Identifier: Apache-2.0
+
+-- Webhooks subsystem tables
+
+-- events carries the domain events that may be delivered to subscribed webhooks.
+-- id is stored as text holding the canonical string form of a UUIDv7 so events
+-- remain naturally time-ordered. Event ingestion is owned by a separate changeset.
+CREATE TABLE IF NOT EXISTS events
+(
+    id           text                     NOT NULL,
+    type         text                     NOT NULL,
+    message      text                     NOT NULL DEFAULT '',
+    data         jsonb                    NOT NULL DEFAULT '{}'::jsonb,
+    created_at   timestamp with time zone NOT NULL DEFAULT current_timestamp,
+    processed_at timestamp with time zone,
+    PRIMARY KEY (id)
+);
+
+-- webhooks is the top-level registration of an outbound delivery target.
+-- id is stored as text holding the canonical string form of a UUIDv4.
+CREATE TABLE IF NOT EXISTS webhooks
+(
+    id          text                     NOT NULL,
+    type        text                     NOT NULL,
+    name        text                     NOT NULL,
+    description text                     NOT NULL DEFAULT '',
+    url         text                     NOT NULL,
+    created_at  timestamp with time zone NOT NULL DEFAULT current_timestamp,
+    created_by  text                     NOT NULL,
+    updated_at  timestamp with time zone NOT NULL DEFAULT current_timestamp,
+    updated_by  text                     NOT NULL,
+    disabled_at timestamp with time zone,
+    disabled_by text,
+    PRIMARY KEY (id)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS webhooks_url_unique_index ON webhooks (url);
+
+-- webhook_secrets stores the HMAC signing secret for a webhook (1:1 with webhooks).
+-- Kept in a separate table so the secret can be protected independently of the
+-- record that is regularly selected by the UI.
+CREATE TABLE IF NOT EXISTS webhook_secrets
+(
+    webhook_id  text                     NOT NULL,
+    hmac_secret text                     NOT NULL,
+    created_at  timestamp with time zone NOT NULL DEFAULT current_timestamp,
+    PRIMARY KEY (webhook_id),
+    CONSTRAINT fk_webhook_secrets_webhooks
+        FOREIGN KEY (webhook_id) REFERENCES webhooks (id) ON DELETE CASCADE
+);
+
+-- webhook_metadata tracks rolling delivery health per webhook (1:1 with webhooks).
+CREATE TABLE IF NOT EXISTS webhook_metadata
+(
+    webhook_id        text                     NOT NULL,
+    health            double precision         NOT NULL DEFAULT 1.0,
+    attempts          integer                  NOT NULL DEFAULT 0,
+    failures          integer                  NOT NULL DEFAULT 0,
+    last_error        text,
+    last_errored_at   timestamp with time zone,
+    last_succeeded_at timestamp with time zone,
+    PRIMARY KEY (webhook_id),
+    CONSTRAINT fk_webhook_metadata_webhooks
+        FOREIGN KEY (webhook_id) REFERENCES webhooks (id) ON DELETE CASCADE
+);
+
+-- webhook_subscriptions maps a webhook to the event types it consumes.
+-- version is a payload attribute, not part of identity: a webhook can subscribe
+-- to any given event_type exactly once.
+CREATE TABLE IF NOT EXISTS webhook_subscriptions
+(
+    webhook_id text NOT NULL,
+    event_type text NOT NULL,
+    version    text NOT NULL,
+    PRIMARY KEY (webhook_id, event_type),
+    CONSTRAINT fk_webhook_subscriptions_webhooks
+        FOREIGN KEY (webhook_id) REFERENCES webhooks (id) ON DELETE CASCADE
+);
+
+-- webhook_events records the delivery state of a single event to a single webhook.
+CREATE TABLE IF NOT EXISTS webhook_events
+(
+    webhook_id       text                     NOT NULL,
+    event_id         text                     NOT NULL,
+    created_at       timestamp with time zone NOT NULL DEFAULT current_timestamp,
+    last_status_code integer                  NOT NULL DEFAULT 0,
+    last_error       text,
+    attempts         integer                  NOT NULL DEFAULT 0,
+    PRIMARY KEY (webhook_id, event_id),
+    CONSTRAINT fk_webhook_events_webhooks
+        FOREIGN KEY (webhook_id) REFERENCES webhooks (id) ON DELETE CASCADE,
+    CONSTRAINT fk_webhook_events_events
+        FOREIGN KEY (event_id) REFERENCES events (id) ON DELETE CASCADE
+);
+

--- a/cmd/api/src/model/webhooks.go
+++ b/cmd/api/src/model/webhooks.go
@@ -150,7 +150,7 @@ type WebhookEvent struct {
 	WebhookId      uuid.UUID   `json:"webhook_id" gorm:"type:text;primaryKey"`
 	EventId        uuid.UUID   `json:"event_id" gorm:"type:text;primaryKey"`
 	CreatedAt      time.Time   `json:"created_at"`
-	LastStatusCode int         `json:"last_status_code"`
+	LastStatusCode null.Int32  `json:"last_status_code"`
 	LastError      null.String `json:"last_error"`
 	Attempts       int         `json:"attempts"`
 }

--- a/cmd/api/src/model/webhooks.go
+++ b/cmd/api/src/model/webhooks.go
@@ -136,14 +136,6 @@ func (s WebhookSubscription) AuditData() AuditData {
 	}
 }
 
-func (s WebhookSubscription) ValidFilters() map[string][]FilterOperator {
-	return map[string][]FilterOperator{
-		"webhook_id": {Equals, NotEquals},
-		"event_type": {Equals, NotEquals, ApproximatelyEquals},
-		"version":    {Equals, NotEquals},
-	}
-}
-
 type WebhookEvents []WebhookEvent
 
 type WebhookEvent struct {

--- a/cmd/api/src/model/webhooks.go
+++ b/cmd/api/src/model/webhooks.go
@@ -1,0 +1,160 @@
+// Copyright 2026 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package model
+
+import (
+	"time"
+
+	"github.com/gofrs/uuid"
+	"github.com/specterops/bloodhound/cmd/api/src/database/types/null"
+)
+
+type Webhooks []Webhook
+
+type Webhook struct {
+	ID          uuid.UUID   `json:"id" gorm:"type:text;primaryKey"`
+	Type        string      `json:"type" validate:"required"`
+	Name        string      `json:"name" validate:"required"`
+	Description string      `json:"description"`
+	URL         string      `json:"url" validate:"required"`
+	CreatedAt   time.Time   `json:"created_at"`
+	CreatedBy   string      `json:"created_by"`
+	UpdatedAt   time.Time   `json:"updated_at"`
+	UpdatedBy   string      `json:"updated_by"`
+	DisabledAt  null.Time   `json:"disabled_at"`
+	DisabledBy  null.String `json:"disabled_by"`
+}
+
+func (Webhook) TableName() string {
+	return "webhooks"
+}
+
+func (s Webhook) AuditData() AuditData {
+	return AuditData{
+		"id":          s.ID,
+		"type":        s.Type,
+		"name":        s.Name,
+		"description": s.Description,
+		"url":         s.URL,
+		"created_at":  s.CreatedAt,
+		"created_by":  s.CreatedBy,
+		"updated_at":  s.UpdatedAt,
+		"updated_by":  s.UpdatedBy,
+		"disabled_at": s.DisabledAt,
+		"disabled_by": s.DisabledBy,
+	}
+}
+
+func (s Webhook) IsStringColumn(filter string) bool {
+	switch filter {
+	case "type", "name", "description", "url", "created_by", "updated_by", "disabled_by":
+		return true
+	default:
+		return false
+	}
+}
+
+func (s Webhook) ValidFilters() map[string][]FilterOperator {
+	return map[string][]FilterOperator{
+		"type":        {Equals, NotEquals, ApproximatelyEquals},
+		"name":        {Equals, NotEquals, ApproximatelyEquals},
+		"description": {Equals, NotEquals, ApproximatelyEquals},
+		"url":         {Equals, NotEquals, ApproximatelyEquals},
+		"created_at":  {Equals, GreaterThan, GreaterThanOrEquals, LessThan, LessThanOrEquals, NotEquals},
+		"created_by":  {Equals, NotEquals},
+		"updated_at":  {Equals, GreaterThan, GreaterThanOrEquals, LessThan, LessThanOrEquals, NotEquals},
+		"updated_by":  {Equals, NotEquals},
+		"disabled_at": {Equals, GreaterThan, GreaterThanOrEquals, LessThan, LessThanOrEquals, NotEquals},
+		"disabled_by": {Equals, NotEquals},
+	}
+}
+
+func (s Webhooks) IsSortable(column string) bool {
+	switch column {
+	case "id", "type", "name", "url", "created_at", "updated_at", "disabled_at":
+		return true
+	default:
+		return false
+	}
+}
+
+type WebhookSecret struct {
+	WebhookId  uuid.UUID `json:"webhook_id" gorm:"type:text;primaryKey"`
+	HmacSecret string    `json:"hmac_secret"`
+	CreatedAt  time.Time `json:"created_at"`
+}
+
+func (WebhookSecret) TableName() string {
+	return "webhook_secrets"
+}
+
+type WebhookMetadata struct {
+	WebhookId       uuid.UUID   `json:"webhook_id" gorm:"type:text;primaryKey"`
+	Health          float64     `json:"health"`
+	Attempts        int         `json:"attempts"`
+	Failures        int         `json:"failures"`
+	LastError       null.String `json:"last_error"`
+	LastErroredAt   null.Time   `json:"last_errored_at"`
+	LastSucceededAt null.Time   `json:"last_succeeded_at"`
+}
+
+func (WebhookMetadata) TableName() string {
+	return "webhook_metadata"
+}
+
+type WebhookSubscriptions []WebhookSubscription
+
+type WebhookSubscription struct {
+	WebhookId uuid.UUID `json:"webhook_id" gorm:"type:text;primaryKey"`
+	EventType string    `json:"event_type" gorm:"primaryKey" validate:"required"`
+	Version   string    `json:"version" validate:"required"`
+}
+
+func (WebhookSubscription) TableName() string {
+	return "webhook_subscriptions"
+}
+
+func (s WebhookSubscription) AuditData() AuditData {
+	return AuditData{
+		"webhook_id": s.WebhookId,
+		"event_type": s.EventType,
+		"version":    s.Version,
+	}
+}
+
+func (s WebhookSubscription) ValidFilters() map[string][]FilterOperator {
+	return map[string][]FilterOperator{
+		"webhook_id": {Equals, NotEquals},
+		"event_type": {Equals, NotEquals, ApproximatelyEquals},
+		"version":    {Equals, NotEquals},
+	}
+}
+
+type WebhookEvents []WebhookEvent
+
+type WebhookEvent struct {
+	WebhookId      uuid.UUID   `json:"webhook_id" gorm:"type:text;primaryKey"`
+	EventId        uuid.UUID   `json:"event_id" gorm:"type:text;primaryKey"`
+	CreatedAt      time.Time   `json:"created_at"`
+	LastStatusCode int         `json:"last_status_code"`
+	LastError      null.String `json:"last_error"`
+	Attempts       int         `json:"attempts"`
+}
+
+func (WebhookEvent) TableName() string {
+	return "webhook_events"
+}


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

*Describe your changes in detail*
Adds migration v9.2.0 which creates the required webhook tables
Adds model structs to be used in future webhook work

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-7965
Resolves BED-7966
Resolves BED-7967

*Why is this change required? What problem does it solve?*

## How Has This Been Tested?

*Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc.*

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)
- Database Migrations

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a webhooks subsystem for registering webhooks and subscribing to event types.
  * Added persistent event storage with per-webhook delivery tracking (attempts, last status, last error).
  * Added webhook secret storage, delivery health/metrics, and unique-URL enforcement for webhook endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->