### PR TITLE
chore: Update feature flag key to "findings_table" BED-7775

### DIFF
--- a/cmd/api/src/database/migration/migrations/v9.1.0.sql
+++ b/cmd/api/src/database/migration/migrations/v9.1.0.sql
@@ -71,13 +71,13 @@ DO $$
     END IF;
   END $$;
 
--- Add Attack Paths Table feature flag
+-- Add Findings Table feature flag
 INSERT INTO feature_flags (created_at, updated_at, key, name, description, enabled, user_updatable)
 VALUES (current_timestamp,
         current_timestamp,
-        'attack_paths_table',
-        'Attack Paths Table',
-        'Enables a new table view for attack paths.',
+        'findings_table',
+        'Findings Table',
+        'Enables a new table view for findings.',
         false,
         false)
 ON CONFLICT DO NOTHING;


### PR DESCRIPTION
## Description
Changes the key of a recently added feature flag from `attack_paths_table` to `findings_table`.

## Motivation and Context

Resolves BED-7775

The name of the project as a whole is changing and we wanted to update this key accordingly before it gets pulled into a release.

## How Has This Been Tested?

## Screenshots (optional):

## Types of changes
- Chore (a change that does not modify the application functionality)
- Database Migrations

## Checklist:
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Findings table feature is now available.

* **Chores**
  * Attack paths table feature has been removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->