### PR TITLE
chore(webhooks): add getEvents with filters and pagination BED-7952

### DIFF
--- a/cmd/api/src/database/events.go
+++ b/cmd/api/src/database/events.go
@@ -18,6 +18,8 @@ package database
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	"github.com/gofrs/uuid"
 	"github.com/specterops/bloodhound/cmd/api/src/model"
@@ -25,12 +27,69 @@ import (
 
 type EventData interface {
 	CreateEvent(ctx context.Context, event model.Event) (model.Event, error)
+	GetEvents(ctx context.Context, filter model.SQLFilter, sort model.Sort, skip, limit int) (model.Events, int, error)
 	GetEvent(ctx context.Context, eventId uuid.UUID) (model.Event, error)
 }
 
 func (s *BloodhoundDB) CreateEvent(ctx context.Context, event model.Event) (model.Event, error) {
 	result := s.db.WithContext(ctx).Create(&event)
 	return event, CheckError(result)
+}
+
+func (s *BloodhoundDB) GetEvents(ctx context.Context, filter model.SQLFilter, sort model.Sort, skip, limit int) (model.Events, int, error) {
+	var (
+		events          = model.Events{}
+		skipLimitString string
+		orderSQL        string
+		sortColumns     []string
+		totalRowCount   int
+	)
+
+	if filter.SQLString != "" {
+		filter.SQLString = " WHERE " + filter.SQLString
+	}
+
+	if len(sort) == 0 {
+		sort = append(sort, model.SortItem{Column: "created_at", Direction: model.DescendingSortDirection})
+	}
+
+	for _, item := range sort {
+		dirString := "ASC"
+		if item.Direction == model.DescendingSortDirection {
+			dirString = "DESC"
+		}
+		sortColumns = append(sortColumns, fmt.Sprintf("%s %s", item.Column, dirString))
+	}
+
+	orderSQL = "ORDER BY " + strings.Join(sortColumns, ", ")
+
+	if limit > 0 {
+		skipLimitString += fmt.Sprintf(" LIMIT %d", limit)
+	}
+
+	if skip > 0 {
+		skipLimitString += fmt.Sprintf(" OFFSET %d", skip)
+	}
+
+	sqlString := fmt.Sprintf(`SELECT * FROM %s%s %s %s`, model.Event{}.TableName(), filter.SQLString, orderSQL, skipLimitString)
+
+	if result := s.db.WithContext(ctx).Raw(sqlString, filter.Params...).Find(&events); result.Error != nil {
+		return events, 0, CheckError(result)
+	}
+
+	if limit > 0 || skip > 0 {
+		sqlCountStr := fmt.Sprintf(
+			"SELECT COUNT(*) FROM %s%s",
+			(model.Event{}).TableName(),
+			filter.SQLString)
+		if result := s.db.WithContext(ctx).Raw(sqlCountStr, filter.Params...).Scan(&totalRowCount); result.Error != nil {
+			return []model.Event{}, 0, CheckError(result)
+		}
+	} else {
+		totalRowCount = len(events)
+	}
+
+	return events, totalRowCount, nil
 }
 
 func (s *BloodhoundDB) GetEvent(ctx context.Context, eventId uuid.UUID) (model.Event, error) {

--- a/cmd/api/src/database/events_integration_test.go
+++ b/cmd/api/src/database/events_integration_test.go
@@ -122,3 +122,124 @@ func TestDatabase_GetEvent(t *testing.T) {
 		})
 	}
 }
+
+func TestDatabase_GetEvents(t *testing.T) {
+	t.Run("success - returns empty list when none exist", func(t *testing.T) {
+		testSuite := setupIntegrationTestSuite(t)
+		defer teardownIntegrationTestSuite(t, &testSuite)
+
+		events, count, err := testSuite.BHDatabase.GetEvents(testSuite.Context, model.SQLFilter{}, nil, 0, 0)
+		require.NoError(t, err)
+		assert.Equal(t, 0, count)
+		assert.Empty(t, events)
+	})
+
+	t.Run("success - returns all created events", func(t *testing.T) {
+		testSuite := setupIntegrationTestSuite(t)
+		defer teardownIntegrationTestSuite(t, &testSuite)
+
+		for i := 0; i < 3; i++ {
+			_, err := testSuite.BHDatabase.CreateEvent(testSuite.Context, model.Event{
+				ID:      uuid.Must(uuid.NewV7()),
+				Type:    "test_event",
+				Message: "event message",
+			})
+			require.NoError(t, err)
+		}
+
+		events, count, err := testSuite.BHDatabase.GetEvents(testSuite.Context, model.SQLFilter{}, nil, 0, 0)
+		require.NoError(t, err)
+		assert.Equal(t, 3, count)
+		assert.Len(t, events, 3)
+	})
+
+	t.Run("success - default sort is created_at descending", func(t *testing.T) {
+		testSuite := setupIntegrationTestSuite(t)
+		defer teardownIntegrationTestSuite(t, &testSuite)
+
+		for _, eventType := range []string{"first", "second", "third"} {
+			_, err := testSuite.BHDatabase.CreateEvent(testSuite.Context, model.Event{
+				ID:      uuid.Must(uuid.NewV7()),
+				Type:    eventType,
+				Message: eventType,
+			})
+			require.NoError(t, err)
+		}
+
+		events, _, err := testSuite.BHDatabase.GetEvents(testSuite.Context, model.SQLFilter{}, nil, 0, 0)
+		require.NoError(t, err)
+		require.Len(t, events, 3)
+		assert.Equal(t, "third", events[0].Type)
+		assert.Equal(t, "second", events[1].Type)
+		assert.Equal(t, "first", events[2].Type)
+	})
+
+	t.Run("success - pagination with skip and limit", func(t *testing.T) {
+		testSuite := setupIntegrationTestSuite(t)
+		defer teardownIntegrationTestSuite(t, &testSuite)
+
+		for i := 0; i < 5; i++ {
+			_, err := testSuite.BHDatabase.CreateEvent(testSuite.Context, model.Event{
+				ID:      uuid.Must(uuid.NewV7()),
+				Type:    "paginated_event",
+				Message: "event message",
+			})
+			require.NoError(t, err)
+		}
+
+		events, count, err := testSuite.BHDatabase.GetEvents(testSuite.Context, model.SQLFilter{}, nil, 2, 2)
+		require.NoError(t, err)
+		assert.Equal(t, 5, count)
+		assert.Len(t, events, 2)
+	})
+
+	t.Run("success - filter by type", func(t *testing.T) {
+		testSuite := setupIntegrationTestSuite(t)
+		defer teardownIntegrationTestSuite(t, &testSuite)
+
+		for _, eventType := range []string{"analysis_complete", "ingest_started", "analysis_complete"} {
+			_, err := testSuite.BHDatabase.CreateEvent(testSuite.Context, model.Event{
+				ID:   uuid.Must(uuid.NewV7()),
+				Type: eventType,
+			})
+			require.NoError(t, err)
+		}
+
+		filter := model.SQLFilter{
+			SQLString: "type = ?",
+			Params:    []any{"analysis_complete"},
+		}
+
+		events, count, err := testSuite.BHDatabase.GetEvents(testSuite.Context, filter, nil, 0, 0)
+		require.NoError(t, err)
+		assert.Equal(t, 2, count)
+		assert.Len(t, events, 2)
+		for _, event := range events {
+			assert.Equal(t, "analysis_complete", event.Type)
+		}
+	})
+
+	t.Run("success - custom sort ascending", func(t *testing.T) {
+		testSuite := setupIntegrationTestSuite(t)
+		defer teardownIntegrationTestSuite(t, &testSuite)
+
+		for _, eventType := range []string{"charlie", "alpha", "bravo"} {
+			_, err := testSuite.BHDatabase.CreateEvent(testSuite.Context, model.Event{
+				ID:   uuid.Must(uuid.NewV4()),
+				Type: eventType,
+			})
+			require.NoError(t, err)
+		}
+
+		sortItems := model.Sort{
+			{Column: "type", Direction: model.AscendingSortDirection},
+		}
+
+		events, _, err := testSuite.BHDatabase.GetEvents(testSuite.Context, model.SQLFilter{}, sortItems, 0, 0)
+		require.NoError(t, err)
+		require.Len(t, events, 3)
+		assert.Equal(t, "alpha", events[0].Type)
+		assert.Equal(t, "bravo", events[1].Type)
+		assert.Equal(t, "charlie", events[2].Type)
+	})
+}

--- a/cmd/api/src/database/mocks/db.go
+++ b/cmd/api/src/database/mocks/db.go
@@ -1870,6 +1870,22 @@ func (mr *MockDatabaseMockRecorder) GetEvent(ctx, eventId any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEvent", reflect.TypeOf((*MockDatabase)(nil).GetEvent), ctx, eventId)
 }
 
+// GetEvents mocks base method.
+func (m *MockDatabase) GetEvents(ctx context.Context, filter model.SQLFilter, sort model.Sort, skip, limit int) (model.Events, int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetEvents", ctx, filter, sort, skip, limit)
+	ret0, _ := ret[0].(model.Events)
+	ret1, _ := ret[1].(int)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetEvents indicates an expected call of GetEvents.
+func (mr *MockDatabaseMockRecorder) GetEvents(ctx, filter, sort, skip, limit any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEvents", reflect.TypeOf((*MockDatabase)(nil).GetEvents), ctx, filter, sort, skip, limit)
+}
+
 // GetFlag mocks base method.
 func (m *MockDatabase) GetFlag(ctx context.Context, id int32) (appcfg.FeatureFlag, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Adds a function to get events from the database with filters and pagination capabilities.

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-7952

We want to be able to get events from the database.

## How Has This Been Tested?

Integration Tests Added

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)


## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
