### PR TITLE
fix: Re-add legacy CSS variable for light mode graph highlights BED-6410

### DIFF
--- a/packages/javascript/doodle-ui/src/tailwind/plugin.ts
+++ b/packages/javascript/doodle-ui/src/tailwind/plugin.ts
@@ -192,6 +192,8 @@ const plugin: PluginCreator = ({ addBase, addUtilities }) => {
             '--neutral-4': '#dadee1',
             '--neutral-5': '#cacfd3',
 
+            '--link': '#1a30ff',
+
             '--error': '#b44641',
 
             '--neutral-light-1': '#ffffff',


### PR DESCRIPTION
## Description
During the recent color token migration, we inadvertently removed a CSS variable that is used to highlight nodes in the graph in light mode. This change is a quick fix that re-adds the original legacy variable to match our dark mode palette.

When we come back to clean this up fully, we should address the CSS variables that are being read directly in `useTheme.tsx` and make sure those are pulling in the intended tokens. We may also end up ditching this hook altogether once MUI is gone.

## Motivation and Context

Resolves BED-6410

I just attached this to the original palette ticket, I can create another if needed.

## How Has This Been Tested?
- Tested manually, before/after videos below

## Screenshots (optional):
Before:
https://github.com/user-attachments/assets/44b85548-174e-42aa-a8db-099cdce0fbf4

After:
https://github.com/user-attachments/assets/4896ed7d-2b8b-482e-bf76-593cdf14e27f

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved link color styling with enhanced theme support. Links now display optimized colors for light and dark modes, providing better visual consistency and readability throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->