### PR TITLE
chore: Edge endpoints no longer mutated with source kinds: Bed 8030

### DIFF
--- a/cmd/api/src/services/graphify/ingest.go
+++ b/cmd/api/src/services/graphify/ingest.go
@@ -247,7 +247,7 @@ func IngestGenericData(batch *IngestContext, sourceKind graph.Kind, converted Co
 		errs.Add(err)
 	}
 
-	if err := IngestRelationships(batch, sourceKind, converted.RelProps); err != nil {
+	if err := IngestRelationshipsKindless(batch, sourceKind, converted.RelProps); err != nil {
 		errs.Add(err)
 	}
 

--- a/cmd/api/src/services/graphify/ingest.go
+++ b/cmd/api/src/services/graphify/ingest.go
@@ -231,7 +231,7 @@ func IngestBasicData(batch *IngestContext, converted ConvertedData) error {
 		errs.Add(err)
 	}
 
-	if err := IngestRelationships(batch, converted.RelProps); err != nil {
+	if err := IngestRelationships(batch, ad.Entity, converted.RelProps); err != nil {
 		errs.Add(err)
 	}
 
@@ -247,7 +247,7 @@ func IngestGenericData(batch *IngestContext, sourceKind graph.Kind, converted Co
 		errs.Add(err)
 	}
 
-	if err := IngestRelationships(batch, converted.RelProps); err != nil {
+	if err := IngestRelationships(batch, sourceKind, converted.RelProps); err != nil {
 		errs.Add(err)
 	}
 
@@ -261,7 +261,7 @@ func IngestGroupData(batch *IngestContext, converted ConvertedGroupData) error {
 		errs.Add(err)
 	}
 
-	if err := IngestRelationships(batch, converted.RelProps); err != nil {
+	if err := IngestRelationships(batch, ad.Entity, converted.RelProps); err != nil {
 		errs.Add(err)
 	}
 
@@ -280,7 +280,7 @@ func IngestAzureData(batch *IngestContext, converted ConvertedAzureData) error {
 		errs.Add(err)
 	}
 
-	if err := IngestRelationships(batch, converted.RelProps); err != nil {
+	if err := IngestRelationships(batch, azure.Entity, converted.RelProps); err != nil {
 		errs.Add(err)
 	}
 

--- a/cmd/api/src/services/graphify/ingest.go
+++ b/cmd/api/src/services/graphify/ingest.go
@@ -231,7 +231,7 @@ func IngestBasicData(batch *IngestContext, converted ConvertedData) error {
 		errs.Add(err)
 	}
 
-	if err := IngestRelationships(batch, ad.Entity, converted.RelProps); err != nil {
+	if err := IngestRelationships(batch, converted.RelProps); err != nil {
 		errs.Add(err)
 	}
 
@@ -240,11 +240,6 @@ func IngestBasicData(batch *IngestContext, converted ConvertedData) error {
 
 // IngestGenericData writes generic graph data into the database using the provided batch.
 // It attempts to ingest all nodes and relationships from the ConvertedData object.
-//
-// Because generic entities do not have a predefined base kind (unlike AZ or AD), this function passes
-// graph.EmptyKind to the node and relationship ingestion functions. This indicates that no
-// base kind should be applied uniformly to all ingested entities, and instead the kind(s)
-// defined directly on each node or edge (if any) are used as-is.
 func IngestGenericData(batch *IngestContext, sourceKind graph.Kind, converted ConvertedData) error {
 	errs := errorlist.NewBuilder()
 
@@ -252,7 +247,7 @@ func IngestGenericData(batch *IngestContext, sourceKind graph.Kind, converted Co
 		errs.Add(err)
 	}
 
-	if err := IngestRelationships(batch, sourceKind, converted.RelProps); err != nil {
+	if err := IngestRelationships(batch, converted.RelProps); err != nil {
 		errs.Add(err)
 	}
 
@@ -266,7 +261,7 @@ func IngestGroupData(batch *IngestContext, converted ConvertedGroupData) error {
 		errs.Add(err)
 	}
 
-	if err := IngestRelationships(batch, ad.Entity, converted.RelProps); err != nil {
+	if err := IngestRelationships(batch, converted.RelProps); err != nil {
 		errs.Add(err)
 	}
 
@@ -285,7 +280,7 @@ func IngestAzureData(batch *IngestContext, converted ConvertedAzureData) error {
 		errs.Add(err)
 	}
 
-	if err := IngestRelationships(batch, azure.Entity, converted.RelProps); err != nil {
+	if err := IngestRelationships(batch, converted.RelProps); err != nil {
 		errs.Add(err)
 	}
 

--- a/cmd/api/src/services/graphify/ingestrelationships.go
+++ b/cmd/api/src/services/graphify/ingestrelationships.go
@@ -38,7 +38,7 @@ import (
 //
 // Each resolved relationship update is applied to the graph via batch.UpdateRelationshipBy.
 // Errors encountered during resolution or update are collected and returned as a single combined error.
-func IngestRelationships(ingestCtx *IngestContext, relationships []ein.IngestibleRelationship) error {
+func IngestRelationships(ingestCtx *IngestContext, sourceKind graph.Kind, relationships []ein.IngestibleRelationship) error {
 	var (
 		errs                                 = errorlist.NewBuilder()
 		resolvedRelationships, resolveErrors = endpoint.ResolveAll(ingestCtx.Ctx, ingestCtx.EndpointResolver, relationships)
@@ -48,7 +48,7 @@ func IngestRelationships(ingestCtx *IngestContext, relationships []ein.Ingestibl
 		errs.Add(resolveErrors)
 	}
 
-	for update := range ingestibleRelationshipsToUpdates(ingestCtx, resolvedRelationships) {
+	for update := range ingestibleRelationshipsToUpdates(ingestCtx, resolvedRelationships, sourceKind) {
 		if err := maybeSubmitRelationshipUpdate(ingestCtx, update); err != nil {
 			errs.Add(err)
 		}
@@ -196,7 +196,9 @@ func IngestSessions(batch *IngestContext, sessions []ein.IngestibleSession) erro
 // ingestibleRelationshipsToUpdates transforms a list of ingestible relationships into
 // graph.RelationshipUpdate objects as an iterator. Endpoint nodes are written without
 // any kind information; node kinds are managed exclusively by the node ingest path.
-func ingestibleRelationshipsToUpdates(batch *IngestContext, rels []ein.IngestibleRelationship) iter.Seq[graph.RelationshipUpdate] {
+// The sourceKind is propagated only to Start/EndIdentityKind so that Neo4j's label-scoped
+// MERGE can continue to use existing label-scoped indexes during endpoint resolution.
+func ingestibleRelationshipsToUpdates(batch *IngestContext, rels []ein.IngestibleRelationship, sourceKind graph.Kind) iter.Seq[graph.RelationshipUpdate] {
 	return func(yield func(graph.RelationshipUpdate) bool) {
 		for _, rel := range rels {
 			rel.RelProps[common.LastSeen.String()] = batch.IngestTime
@@ -211,12 +213,12 @@ func ingestibleRelationshipsToUpdates(batch *IngestContext, rels []ein.Ingestibl
 						common.LastSeen: batch.IngestTime,
 					})),
 					StartIdentityProperties: []string{common.ObjectID.String()},
-					StartIdentityKind:       graph.EmptyKind,
+					StartIdentityKind:       sourceKind,
 					End: graph.PrepareNode(graph.AsProperties(graph.PropertyMap{
 						common.ObjectID: endObjID,
 						common.LastSeen: batch.IngestTime,
 					})),
-					EndIdentityKind:       graph.EmptyKind,
+					EndIdentityKind:       sourceKind,
 					EndIdentityProperties: []string{common.ObjectID.String()},
 					Relationship:          graph.PrepareRelationship(graph.AsProperties(rel.RelProps), rel.RelType),
 				}

--- a/cmd/api/src/services/graphify/ingestrelationships.go
+++ b/cmd/api/src/services/graphify/ingestrelationships.go
@@ -32,13 +32,31 @@ import (
 	"github.com/specterops/dawgs/util"
 )
 
-// IngestRelationships resolves and writes a batch of ingestible relationships to the graph.
+// IngestRelationships resolves and writes a batch of ingestible relationships to the graph,
+// applying sourceKind to both endpoint nodes and to the dawgs RelationshipUpdate identity kind.
 //
-// This function first calls resolveRelationships to resolve node identifiers based on name and kind.
+// This is the legacy ingest path used by AD and Azure pipelines, where some endpoint nodes
+// are referenced only via relationship data (e.g. well-known SIDs, foreign principals, ACE
+// principals) and never appear in node payloads. Applying sourceKind here ensures those orphan
+// endpoint nodes receive a base kind.
 //
-// Each resolved relationship update is applied to the graph via batch.UpdateRelationshipBy.
-// Errors encountered during resolution or update are collected and returned as a single combined error.
+// For the kindless variant used by OpenGraph, see IngestRelationshipsKindless.
 func IngestRelationships(ingestCtx *IngestContext, sourceKind graph.Kind, relationships []ein.IngestibleRelationship) error {
+	return ingestRelationships(ingestCtx, sourceKind, relationships, true)
+}
+
+// IngestRelationshipsKindless resolves and writes a batch of ingestible relationships to the
+// graph WITHOUT applying sourceKind to endpoint nodes. sourceKind is propagated only to
+// Start/EndIdentityKind so that Neo4j's label-scoped MERGE can continue to use existing
+// label-scoped indexes during endpoint resolution.
+//
+// This is the OpenGraph (Generic) ingest path: endpoint kinds are managed exclusively by the
+// node ingest path; relationship ingest is forbidden from mutating endpoint node kinds.
+func IngestRelationshipsKindless(ingestCtx *IngestContext, sourceKind graph.Kind, relationships []ein.IngestibleRelationship) error {
+	return ingestRelationships(ingestCtx, sourceKind, relationships, false)
+}
+
+func ingestRelationships(ingestCtx *IngestContext, sourceKind graph.Kind, relationships []ein.IngestibleRelationship, applyKindToEndpoints bool) error {
 	var (
 		errs                                 = errorlist.NewBuilder()
 		resolvedRelationships, resolveErrors = endpoint.ResolveAll(ingestCtx.Ctx, ingestCtx.EndpointResolver, relationships)
@@ -48,7 +66,7 @@ func IngestRelationships(ingestCtx *IngestContext, sourceKind graph.Kind, relati
 		errs.Add(resolveErrors)
 	}
 
-	for update := range ingestibleRelationshipsToUpdates(ingestCtx, resolvedRelationships, sourceKind) {
+	for update := range ingestibleRelationshipsToUpdates(ingestCtx, resolvedRelationships, sourceKind, applyKindToEndpoints) {
 		if err := maybeSubmitRelationshipUpdate(ingestCtx, update); err != nil {
 			errs.Add(err)
 		}
@@ -194,11 +212,12 @@ func IngestSessions(batch *IngestContext, sessions []ein.IngestibleSession) erro
 }
 
 // ingestibleRelationshipsToUpdates transforms a list of ingestible relationships into
-// graph.RelationshipUpdate objects as an iterator. Endpoint nodes are written without
-// any kind information; node kinds are managed exclusively by the node ingest path.
-// The sourceKind is propagated only to Start/EndIdentityKind so that Neo4j's label-scoped
-// MERGE can continue to use existing label-scoped indexes during endpoint resolution.
-func ingestibleRelationshipsToUpdates(batch *IngestContext, rels []ein.IngestibleRelationship, sourceKind graph.Kind) iter.Seq[graph.RelationshipUpdate] {
+// graph.RelationshipUpdate objects as an iterator. sourceKind is always propagated to
+// Start/EndIdentityKind so that Neo4j's label-scoped MERGE can use existing label-scoped
+// indexes during endpoint resolution. When applyKindToEndpoints is true, sourceKind is
+// also applied to the endpoint nodes themselves (legacy AD/Azure behavior); when false,
+// endpoint nodes are written without any kind information (OpenGraph behavior).
+func ingestibleRelationshipsToUpdates(batch *IngestContext, rels []ein.IngestibleRelationship, sourceKind graph.Kind, applyKindToEndpoints bool) iter.Seq[graph.RelationshipUpdate] {
 	return func(yield func(graph.RelationshipUpdate) bool) {
 		for _, rel := range rels {
 			rel.RelProps[common.LastSeen.String()] = batch.IngestTime
@@ -206,23 +225,30 @@ func ingestibleRelationshipsToUpdates(batch *IngestContext, rels []ein.Ingestibl
 			var (
 				startObjID = strings.ToUpper(rel.Source.Value)
 				endObjID   = strings.ToUpper(rel.Target.Value)
-
-				update = graph.RelationshipUpdate{
-					Start: graph.PrepareNode(graph.AsProperties(graph.PropertyMap{
-						common.ObjectID: startObjID,
-						common.LastSeen: batch.IngestTime,
-					})),
-					StartIdentityProperties: []string{common.ObjectID.String()},
-					StartIdentityKind:       sourceKind,
-					End: graph.PrepareNode(graph.AsProperties(graph.PropertyMap{
-						common.ObjectID: endObjID,
-						common.LastSeen: batch.IngestTime,
-					})),
-					EndIdentityKind:       sourceKind,
-					EndIdentityProperties: []string{common.ObjectID.String()},
-					Relationship:          graph.PrepareRelationship(graph.AsProperties(rel.RelProps), rel.RelType),
-				}
+				startProps = graph.AsProperties(graph.PropertyMap{
+					common.ObjectID: startObjID,
+					common.LastSeen: batch.IngestTime,
+				})
+				endProps = graph.AsProperties(graph.PropertyMap{
+					common.ObjectID: endObjID,
+					common.LastSeen: batch.IngestTime,
+				})
+				endpointKinds []graph.Kind
 			)
+
+			if applyKindToEndpoints && sourceKind != graph.EmptyKind {
+				endpointKinds = []graph.Kind{sourceKind}
+			}
+
+			update := graph.RelationshipUpdate{
+				Start:                   graph.PrepareNode(startProps, endpointKinds...),
+				StartIdentityProperties: []string{common.ObjectID.String()},
+				StartIdentityKind:       sourceKind,
+				End:                     graph.PrepareNode(endProps, endpointKinds...),
+				EndIdentityKind:         sourceKind,
+				EndIdentityProperties:   []string{common.ObjectID.String()},
+				Relationship:            graph.PrepareRelationship(graph.AsProperties(rel.RelProps), rel.RelType),
+			}
 
 			if !yield(update) {
 				break

--- a/cmd/api/src/services/graphify/ingestrelationships.go
+++ b/cmd/api/src/services/graphify/ingestrelationships.go
@@ -215,7 +215,8 @@ func IngestSessions(batch *IngestContext, sessions []ein.IngestibleSession) erro
 // graph.RelationshipUpdate objects as an iterator. sourceKind is always propagated to
 // Start/EndIdentityKind so that Neo4j's label-scoped MERGE can use existing label-scoped
 // indexes during endpoint resolution. When applyKindToEndpoints is true, sourceKind is
-// also applied to the endpoint nodes themselves (legacy AD/Azure behavior); when false,
+// merged with each endpoint's per-relationship Kind (rel.Source.Kind / rel.Target.Kind)
+// and applied to the endpoint nodes themselves (legacy AD/Azure behavior); when false,
 // endpoint nodes are written without any kind information (OpenGraph behavior).
 func ingestibleRelationshipsToUpdates(batch *IngestContext, rels []ein.IngestibleRelationship, sourceKind graph.Kind, applyKindToEndpoints bool) iter.Seq[graph.RelationshipUpdate] {
 	return func(yield func(graph.RelationshipUpdate) bool) {
@@ -233,18 +234,20 @@ func ingestibleRelationshipsToUpdates(batch *IngestContext, rels []ein.Ingestibl
 					common.ObjectID: endObjID,
 					common.LastSeen: batch.IngestTime,
 				})
-				endpointKinds []graph.Kind
+				startEndpointKinds []graph.Kind
+				endEndpointKinds   []graph.Kind
 			)
 
-			if applyKindToEndpoints && sourceKind != graph.EmptyKind {
-				endpointKinds = []graph.Kind{sourceKind}
+			if applyKindToEndpoints {
+				startEndpointKinds = MergeNodeKinds(sourceKind, rel.Source.Kind)
+				endEndpointKinds = MergeNodeKinds(sourceKind, rel.Target.Kind)
 			}
 
 			update := graph.RelationshipUpdate{
-				Start:                   graph.PrepareNode(startProps, endpointKinds...),
+				Start:                   graph.PrepareNode(startProps, startEndpointKinds...),
 				StartIdentityProperties: []string{common.ObjectID.String()},
 				StartIdentityKind:       sourceKind,
-				End:                     graph.PrepareNode(endProps, endpointKinds...),
+				End:                     graph.PrepareNode(endProps, endEndpointKinds...),
 				EndIdentityKind:         sourceKind,
 				EndIdentityProperties:   []string{common.ObjectID.String()},
 				Relationship:            graph.PrepareRelationship(graph.AsProperties(rel.RelProps), rel.RelType),

--- a/cmd/api/src/services/graphify/ingestrelationships.go
+++ b/cmd/api/src/services/graphify/ingestrelationships.go
@@ -38,7 +38,7 @@ import (
 //
 // Each resolved relationship update is applied to the graph via batch.UpdateRelationshipBy.
 // Errors encountered during resolution or update are collected and returned as a single combined error.
-func IngestRelationships(ingestCtx *IngestContext, sourceKind graph.Kind, relationships []ein.IngestibleRelationship) error {
+func IngestRelationships(ingestCtx *IngestContext, relationships []ein.IngestibleRelationship) error {
 	var (
 		errs                                 = errorlist.NewBuilder()
 		resolvedRelationships, resolveErrors = endpoint.ResolveAll(ingestCtx.Ctx, ingestCtx.EndpointResolver, relationships)
@@ -48,7 +48,7 @@ func IngestRelationships(ingestCtx *IngestContext, sourceKind graph.Kind, relati
 		errs.Add(resolveErrors)
 	}
 
-	for update := range ingestibleRelationshipsToUpdates(ingestCtx, resolvedRelationships, sourceKind) {
+	for update := range ingestibleRelationshipsToUpdates(ingestCtx, resolvedRelationships) {
 		if err := maybeSubmitRelationshipUpdate(ingestCtx, update); err != nil {
 			errs.Add(err)
 		}
@@ -194,16 +194,14 @@ func IngestSessions(batch *IngestContext, sessions []ein.IngestibleSession) erro
 }
 
 // ingestibleRelationshipsToUpdates transforms a list of ingestible relationships into
-// graph.RelationshipUpdate objects as an iterator.
-func ingestibleRelationshipsToUpdates(batch *IngestContext, rels []ein.IngestibleRelationship, sourceKind graph.Kind) iter.Seq[graph.RelationshipUpdate] {
+// graph.RelationshipUpdate objects as an iterator. Endpoint nodes are written without
+// any kind information; node kinds are managed exclusively by the node ingest path.
+func ingestibleRelationshipsToUpdates(batch *IngestContext, rels []ein.IngestibleRelationship) iter.Seq[graph.RelationshipUpdate] {
 	return func(yield func(graph.RelationshipUpdate) bool) {
 		for _, rel := range rels {
 			rel.RelProps[common.LastSeen.String()] = batch.IngestTime
 
 			var (
-				startKinds = MergeNodeKinds(sourceKind, rel.Source.Kind)
-				endKinds   = MergeNodeKinds(sourceKind, rel.Target.Kind)
-
 				startObjID = strings.ToUpper(rel.Source.Value)
 				endObjID   = strings.ToUpper(rel.Target.Value)
 
@@ -211,14 +209,14 @@ func ingestibleRelationshipsToUpdates(batch *IngestContext, rels []ein.Ingestibl
 					Start: graph.PrepareNode(graph.AsProperties(graph.PropertyMap{
 						common.ObjectID: startObjID,
 						common.LastSeen: batch.IngestTime,
-					}), startKinds...),
+					})),
 					StartIdentityProperties: []string{common.ObjectID.String()},
-					StartIdentityKind:       sourceKind,
+					StartIdentityKind:       graph.EmptyKind,
 					End: graph.PrepareNode(graph.AsProperties(graph.PropertyMap{
 						common.ObjectID: endObjID,
 						common.LastSeen: batch.IngestTime,
-					}), endKinds...),
-					EndIdentityKind:       sourceKind,
+					})),
+					EndIdentityKind:       graph.EmptyKind,
 					EndIdentityProperties: []string{common.ObjectID.String()},
 					Relationship:          graph.PrepareRelationship(graph.AsProperties(rel.RelProps), rel.RelType),
 				}

--- a/cmd/api/src/services/graphify/ingestrelationships_integration_test.go
+++ b/cmd/api/src/services/graphify/ingestrelationships_integration_test.go
@@ -53,7 +53,7 @@ func Test_IngestRelationships(t *testing.T) {
 				err := db.BatchOperation(testContext.Context(), func(batch graph.Batch) error {
 					ingestContext := NewIngestContext(testContext.Context(), WithBatchUpdater(batch), WithEndpointResolver(endpoint.NewResolver(db)))
 
-					err := IngestRelationships(ingestContext, graph.EmptyKind, rels)
+					err := IngestRelationships(ingestContext, rels)
 					require.Nil(t, err)
 					return nil
 				})
@@ -100,7 +100,7 @@ func Test_IngestRelationships(t *testing.T) {
 				err := db.BatchOperation(testContext.Context(), func(batch graph.Batch) error {
 					ingestContext := NewIngestContext(testContext.Context(), WithBatchUpdater(batch), WithEndpointResolver(endpoint.NewResolver(db)))
 
-					err := IngestRelationships(ingestContext, graph.EmptyKind, rels)
+					err := IngestRelationships(ingestContext, rels)
 					require.Nil(t, err)
 					return nil
 				})
@@ -157,7 +157,7 @@ func Test_IngestRelationships(t *testing.T) {
 				err := db.BatchOperation(testContext.Context(), func(batch graph.Batch) error {
 					ingestContext := NewIngestContext(testContext.Context(), WithBatchUpdater(batch), WithEndpointResolver(endpoint.NewResolver(db)))
 
-					err := IngestRelationships(ingestContext, graph.EmptyKind, rels)
+					err := IngestRelationships(ingestContext, rels)
 					require.Nil(t, err)
 					return nil
 				})
@@ -176,6 +176,26 @@ func Test_IngestRelationships(t *testing.T) {
 
 					require.Equal(t, int64(1), count)
 					require.Nil(t, err)
+
+					// existing endpoint nodes must retain only the kinds they were created with
+					refetchedEndpoints := []*graph.Node{}
+					err = tx.Nodes().Filter(
+						query.Or(
+							query.Equals(query.NodeID(), harness.IngestRelationships.Node1.ID),
+							query.Equals(query.NodeID(), harness.IngestRelationships.Node2.ID),
+						),
+					).Fetch(func(cursor graph.Cursor[*graph.Node]) error {
+						for node := range cursor.Chan() {
+							refetchedEndpoints = append(refetchedEndpoints, node)
+						}
+						return nil
+					})
+					require.Nil(t, err)
+					require.Len(t, refetchedEndpoints, 2)
+					for _, node := range refetchedEndpoints {
+						objectid, _ := node.Properties.Get("objectid").String()
+						require.ElementsMatch(t, graph.Kinds{graph.StringKind("Computer")}, node.Kinds, "endpoint node %s kinds should be unchanged", objectid)
+					}
 
 					return nil
 				})
@@ -204,7 +224,7 @@ func Test_IngestRelationships(t *testing.T) {
 				err := db.BatchOperation(testContext.Context(), func(batch graph.Batch) error {
 					ingestContext := NewIngestContext(testContext.Context(), WithBatchUpdater(batch), WithEndpointResolver(endpoint.NewResolver(db)))
 
-					err := IngestRelationships(ingestContext, graph.EmptyKind, rels)
+					err := IngestRelationships(ingestContext, rels)
 					require.Nil(t, err)
 					return nil
 				})
@@ -261,7 +281,7 @@ func Test_IngestRelationships(t *testing.T) {
 				err := db.BatchOperation(testContext.Context(), func(batch graph.Batch) error {
 					ingestContext := NewIngestContext(testContext.Context(), WithBatchUpdater(batch), WithEndpointResolver(endpoint.NewResolver(db)))
 
-					err := IngestRelationships(ingestContext, graph.EmptyKind, rels)
+					err := IngestRelationships(ingestContext, rels)
 					require.Nil(t, err)
 					return nil
 				})
@@ -270,6 +290,7 @@ func Test_IngestRelationships(t *testing.T) {
 
 				err = db.ReadTransaction(testContext.Context(), func(tx graph.Transaction) error {
 					nodeIDs := map[string]graph.ID{}
+					createdNodes := []*graph.Node{}
 					// verify start and end nodes were created
 					_ = tx.Nodes().Filter(
 						query.Or(
@@ -281,12 +302,19 @@ func Test_IngestRelationships(t *testing.T) {
 							for node := range cursor.Chan() {
 								objectid, _ := node.Properties.Get("objectid").String()
 								nodeIDs[objectid] = node.ID
+								createdNodes = append(createdNodes, node)
 							}
 							return nil
 						},
 					)
 
 					require.Len(t, nodeIDs, 2)
+
+					// endpoint nodes implicitly created by IngestRelationships must not have any kinds appended
+					for _, node := range createdNodes {
+						objectid, _ := node.Properties.Get("objectid").String()
+						require.Empty(t, node.Kinds, "endpoint node %s should have no kinds", objectid)
+					}
 
 					// verify rel created
 					count, err := tx.Relationships().Filter(
@@ -327,7 +355,7 @@ func Test_IngestRelationships(t *testing.T) {
 				err := db.BatchOperation(testContext.Context(), func(batch graph.Batch) error {
 					ingestContext := NewIngestContext(testContext.Context(), WithBatchUpdater(batch), WithEndpointResolver(endpoint.NewResolver(db)))
 
-					err := IngestRelationships(ingestContext, graph.EmptyKind, rels)
+					err := IngestRelationships(ingestContext, rels)
 					require.ErrorContains(t, err, "unable to resolve")
 					return nil
 				})
@@ -372,7 +400,7 @@ func Test_IngestRelationships(t *testing.T) {
 				err := db.BatchOperation(testContext.Context(), func(batch graph.Batch) error {
 					ingestContext := NewIngestContext(testContext.Context(), WithBatchUpdater(batch), WithEndpointResolver(endpoint.NewResolver(db)))
 
-					err := IngestRelationships(ingestContext, graph.EmptyKind, rels)
+					err := IngestRelationships(ingestContext, rels)
 					require.Nil(t, err)
 					return nil
 				})
@@ -427,7 +455,7 @@ func Test_ResolveRelationships(t *testing.T) {
 					require.NoError(t, err)
 
 					updates := slices.Collect(
-						ingestibleRelationshipsToUpdates(ingestContext, updatedIngestibleRels, graph.EmptyKind),
+						ingestibleRelationshipsToUpdates(ingestContext, updatedIngestibleRels),
 					)
 
 					require.Len(t, updates, 1)
@@ -436,11 +464,9 @@ func Test_ResolveRelationships(t *testing.T) {
 
 					startObjectID, _ := startNode.Properties.Get(string(common.ObjectID)).String()
 					require.NotNil(t, startObjectID)
-					require.True(t, startNode.Kinds.ContainsOneOf(ad.Computer))
 
 					endObjectID, _ := endNode.Properties.Get(string(common.ObjectID)).String()
 					require.NotNil(t, endObjectID)
-					require.True(t, endNode.Kinds.ContainsOneOf(ad.Computer))
 
 					return nil
 				})
@@ -616,7 +642,7 @@ func Test_ResolveRelationships(t *testing.T) {
 					require.NoError(t, err)
 
 					updates := slices.Collect(
-						ingestibleRelationshipsToUpdates(ingestContext, updatedIngestibleRels, graph.EmptyKind),
+						ingestibleRelationshipsToUpdates(ingestContext, updatedIngestibleRels),
 					)
 
 					require.Nil(t, err)
@@ -626,11 +652,9 @@ func Test_ResolveRelationships(t *testing.T) {
 
 					startObjectID, _ := startNode.Properties.Get(string(common.ObjectID)).String()
 					require.NotNil(t, startObjectID)
-					require.True(t, startNode.Kinds.ContainsOneOf(graph.StringKind("KindA")))
 
 					endObjectID, _ := endNode.Properties.Get(string(common.ObjectID)).String()
 					require.NotNil(t, endObjectID)
-					require.True(t, endNode.Kinds.ContainsOneOf(graph.StringKind("KindB")))
 
 					return nil
 				})
@@ -661,7 +685,7 @@ func Test_ResolveRelationships(t *testing.T) {
 					require.NoError(t, err)
 
 					updates := slices.Collect(
-						ingestibleRelationshipsToUpdates(ingestContext, updatedIngestibleRels, graph.EmptyKind),
+						ingestibleRelationshipsToUpdates(ingestContext, updatedIngestibleRels),
 					)
 
 					require.Nil(t, err)
@@ -671,7 +695,6 @@ func Test_ResolveRelationships(t *testing.T) {
 
 					startObjectID, _ := startNode.Properties.Get(string(common.ObjectID)).String()
 					require.NotNil(t, startObjectID)
-					require.True(t, startNode.Kinds.ContainsOneOf(graph.StringKind("KindA")))
 
 					endObjectID, _ := endNode.Properties.Get(string(common.ObjectID)).String()
 					require.NotNil(t, endObjectID)
@@ -705,7 +728,7 @@ func Test_ResolveRelationships(t *testing.T) {
 					require.NoError(t, err)
 
 					updates := slices.Collect(
-						ingestibleRelationshipsToUpdates(ingestContext, updatedIngestibleRels, graph.EmptyKind),
+						ingestibleRelationshipsToUpdates(ingestContext, updatedIngestibleRels),
 					)
 
 					require.Nil(t, err)
@@ -748,7 +771,7 @@ func Test_ResolveRelationships(t *testing.T) {
 					require.NoError(t, err)
 
 					updates := slices.Collect(
-						ingestibleRelationshipsToUpdates(ingestContext, updatedIngestibleRels, graph.EmptyKind),
+						ingestibleRelationshipsToUpdates(ingestContext, updatedIngestibleRels),
 					)
 
 					require.Len(t, updates, 1)
@@ -848,7 +871,7 @@ func Test_ResolveRelationships(t *testing.T) {
 					require.NoError(t, err)
 
 					updates := slices.Collect(
-						ingestibleRelationshipsToUpdates(ingestContext, updatedIngestibleRels, graph.EmptyKind),
+						ingestibleRelationshipsToUpdates(ingestContext, updatedIngestibleRels),
 					)
 
 					require.Nil(t, err)
@@ -920,7 +943,7 @@ func Test_ResolveRelationships(t *testing.T) {
 					require.NoError(t, err)
 
 					updates := slices.Collect(
-						ingestibleRelationshipsToUpdates(ingestContext, updatedIngestibleRels, graph.EmptyKind),
+						ingestibleRelationshipsToUpdates(ingestContext, updatedIngestibleRels),
 					)
 
 					require.Nil(t, err)

--- a/cmd/api/src/services/graphify/ingestrelationships_integration_test.go
+++ b/cmd/api/src/services/graphify/ingestrelationships_integration_test.go
@@ -53,7 +53,7 @@ func Test_IngestRelationships(t *testing.T) {
 				err := db.BatchOperation(testContext.Context(), func(batch graph.Batch) error {
 					ingestContext := NewIngestContext(testContext.Context(), WithBatchUpdater(batch), WithEndpointResolver(endpoint.NewResolver(db)))
 
-					err := IngestRelationships(ingestContext, rels)
+					err := IngestRelationships(ingestContext, graph.EmptyKind, rels)
 					require.Nil(t, err)
 					return nil
 				})
@@ -100,7 +100,7 @@ func Test_IngestRelationships(t *testing.T) {
 				err := db.BatchOperation(testContext.Context(), func(batch graph.Batch) error {
 					ingestContext := NewIngestContext(testContext.Context(), WithBatchUpdater(batch), WithEndpointResolver(endpoint.NewResolver(db)))
 
-					err := IngestRelationships(ingestContext, rels)
+					err := IngestRelationships(ingestContext, graph.EmptyKind, rels)
 					require.Nil(t, err)
 					return nil
 				})
@@ -157,7 +157,7 @@ func Test_IngestRelationships(t *testing.T) {
 				err := db.BatchOperation(testContext.Context(), func(batch graph.Batch) error {
 					ingestContext := NewIngestContext(testContext.Context(), WithBatchUpdater(batch), WithEndpointResolver(endpoint.NewResolver(db)))
 
-					err := IngestRelationships(ingestContext, rels)
+					err := IngestRelationships(ingestContext, graph.EmptyKind, rels)
 					require.Nil(t, err)
 					return nil
 				})
@@ -224,7 +224,7 @@ func Test_IngestRelationships(t *testing.T) {
 				err := db.BatchOperation(testContext.Context(), func(batch graph.Batch) error {
 					ingestContext := NewIngestContext(testContext.Context(), WithBatchUpdater(batch), WithEndpointResolver(endpoint.NewResolver(db)))
 
-					err := IngestRelationships(ingestContext, rels)
+					err := IngestRelationships(ingestContext, graph.EmptyKind, rels)
 					require.Nil(t, err)
 					return nil
 				})
@@ -281,7 +281,7 @@ func Test_IngestRelationships(t *testing.T) {
 				err := db.BatchOperation(testContext.Context(), func(batch graph.Batch) error {
 					ingestContext := NewIngestContext(testContext.Context(), WithBatchUpdater(batch), WithEndpointResolver(endpoint.NewResolver(db)))
 
-					err := IngestRelationships(ingestContext, rels)
+					err := IngestRelationships(ingestContext, graph.EmptyKind, rels)
 					require.Nil(t, err)
 					return nil
 				})
@@ -355,7 +355,7 @@ func Test_IngestRelationships(t *testing.T) {
 				err := db.BatchOperation(testContext.Context(), func(batch graph.Batch) error {
 					ingestContext := NewIngestContext(testContext.Context(), WithBatchUpdater(batch), WithEndpointResolver(endpoint.NewResolver(db)))
 
-					err := IngestRelationships(ingestContext, rels)
+					err := IngestRelationships(ingestContext, graph.EmptyKind, rels)
 					require.ErrorContains(t, err, "unable to resolve")
 					return nil
 				})
@@ -400,7 +400,7 @@ func Test_IngestRelationships(t *testing.T) {
 				err := db.BatchOperation(testContext.Context(), func(batch graph.Batch) error {
 					ingestContext := NewIngestContext(testContext.Context(), WithBatchUpdater(batch), WithEndpointResolver(endpoint.NewResolver(db)))
 
-					err := IngestRelationships(ingestContext, rels)
+					err := IngestRelationships(ingestContext, graph.EmptyKind, rels)
 					require.Nil(t, err)
 					return nil
 				})
@@ -455,7 +455,7 @@ func Test_ResolveRelationships(t *testing.T) {
 					require.NoError(t, err)
 
 					updates := slices.Collect(
-						ingestibleRelationshipsToUpdates(ingestContext, updatedIngestibleRels),
+						ingestibleRelationshipsToUpdates(ingestContext, updatedIngestibleRels, graph.EmptyKind),
 					)
 
 					require.Len(t, updates, 1)
@@ -642,7 +642,7 @@ func Test_ResolveRelationships(t *testing.T) {
 					require.NoError(t, err)
 
 					updates := slices.Collect(
-						ingestibleRelationshipsToUpdates(ingestContext, updatedIngestibleRels),
+						ingestibleRelationshipsToUpdates(ingestContext, updatedIngestibleRels, graph.EmptyKind),
 					)
 
 					require.Nil(t, err)
@@ -685,7 +685,7 @@ func Test_ResolveRelationships(t *testing.T) {
 					require.NoError(t, err)
 
 					updates := slices.Collect(
-						ingestibleRelationshipsToUpdates(ingestContext, updatedIngestibleRels),
+						ingestibleRelationshipsToUpdates(ingestContext, updatedIngestibleRels, graph.EmptyKind),
 					)
 
 					require.Nil(t, err)
@@ -728,7 +728,7 @@ func Test_ResolveRelationships(t *testing.T) {
 					require.NoError(t, err)
 
 					updates := slices.Collect(
-						ingestibleRelationshipsToUpdates(ingestContext, updatedIngestibleRels),
+						ingestibleRelationshipsToUpdates(ingestContext, updatedIngestibleRels, graph.EmptyKind),
 					)
 
 					require.Nil(t, err)
@@ -771,7 +771,7 @@ func Test_ResolveRelationships(t *testing.T) {
 					require.NoError(t, err)
 
 					updates := slices.Collect(
-						ingestibleRelationshipsToUpdates(ingestContext, updatedIngestibleRels),
+						ingestibleRelationshipsToUpdates(ingestContext, updatedIngestibleRels, graph.EmptyKind),
 					)
 
 					require.Len(t, updates, 1)
@@ -871,7 +871,7 @@ func Test_ResolveRelationships(t *testing.T) {
 					require.NoError(t, err)
 
 					updates := slices.Collect(
-						ingestibleRelationshipsToUpdates(ingestContext, updatedIngestibleRels),
+						ingestibleRelationshipsToUpdates(ingestContext, updatedIngestibleRels, graph.EmptyKind),
 					)
 
 					require.Nil(t, err)
@@ -943,7 +943,7 @@ func Test_ResolveRelationships(t *testing.T) {
 					require.NoError(t, err)
 
 					updates := slices.Collect(
-						ingestibleRelationshipsToUpdates(ingestContext, updatedIngestibleRels),
+						ingestibleRelationshipsToUpdates(ingestContext, updatedIngestibleRels, graph.EmptyKind),
 					)
 
 					require.Nil(t, err)

--- a/cmd/api/src/services/graphify/ingestrelationships_integration_test.go
+++ b/cmd/api/src/services/graphify/ingestrelationships_integration_test.go
@@ -194,7 +194,7 @@ func Test_IngestRelationships(t *testing.T) {
 					require.Len(t, refetchedEndpoints, 2)
 					for _, node := range refetchedEndpoints {
 						objectid, _ := node.Properties.Get("objectid").String()
-						require.ElementsMatch(t, graph.Kinds{graph.StringKind("Computer")}, node.Kinds, "endpoint node %s kinds should be unchanged", objectid)
+						require.ElementsMatch(t, graph.Kinds{graph.StringKind("Computer"), graph.StringKind("SomeBase")}, node.Kinds, "endpoint node %s should retain its existing kind and gain the sourceKind", objectid)
 					}
 
 					return nil
@@ -310,10 +310,10 @@ func Test_IngestRelationships(t *testing.T) {
 
 					require.Len(t, nodeIDs, 2)
 
-					// endpoint nodes implicitly created by IngestRelationships must not have any kinds appended
+					// endpoint nodes implicitly created by IngestRelationships (legacy path) receive the sourceKind
 					for _, node := range createdNodes {
 						objectid, _ := node.Properties.Get("objectid").String()
-						require.Empty(t, node.Kinds, "endpoint node %s should have no kinds", objectid)
+						require.ElementsMatch(t, graph.Kinds{graph.StringKind("SomeBase")}, node.Kinds, "endpoint node %s should be created with the sourceKind", objectid)
 					}
 
 					// verify rel created
@@ -333,6 +333,145 @@ func Test_IngestRelationships(t *testing.T) {
 
 				require.Nil(t, err)
 
+			})
+	})
+
+	t.Run("IngestRelationshipsKindless. Existing endpoint nodes are NOT mutated by the relationship ingest.", func(t *testing.T) {
+		testContext := integration.NewGraphTestContext(t, graphschema.DefaultGraphSchema())
+
+		testContext.DatabaseTestWithSetup(
+			func(harness *integration.HarnessDetails) error {
+				harness.IngestRelationships.Setup(testContext)
+				return nil
+			},
+			func(harness integration.HarnessDetails, db graph.Database) {
+				// Endpoints reference the harness nodes by objectid (Node1=1234, Node2=5678, both kind Computer).
+				ingestibleRel := ein.NewIngestibleRelationship(
+					ein.IngestibleEndpoint{Value: "1234"},
+					ein.IngestibleEndpoint{Value: "5678"},
+					ein.IngestibleRel{RelType: graph.StringKind("related_to")},
+				)
+				rels := []ein.IngestibleRelationship{ingestibleRel}
+
+				err := db.BatchOperation(testContext.Context(), func(batch graph.Batch) error {
+					ingestContext := NewIngestContext(testContext.Context(), WithBatchUpdater(batch), WithEndpointResolver(endpoint.NewResolver(db)))
+
+					err := IngestRelationshipsKindless(ingestContext, graph.StringKind("SomeBase"), rels)
+					require.Nil(t, err)
+					return nil
+				})
+
+				require.Nil(t, err)
+
+				err = db.ReadTransaction(testContext.Context(), func(tx graph.Transaction) error {
+					// Verify the relationship was created.
+					count, err := tx.Relationships().Filter(
+						query.And(
+							query.Equals(query.StartID(), harness.IngestRelationships.Node1.ID),
+							query.Equals(query.EndID(), harness.IngestRelationships.Node2.ID),
+							query.Kind(query.Relationship(), graph.StringKind("related_to")),
+						),
+					).Count()
+					require.Nil(t, err)
+					require.Equal(t, int64(1), count)
+
+					// Existing endpoint nodes must retain ONLY their original kinds; the kindless
+					// path must not append sourceKind to endpoint nodes.
+					refetchedEndpoints := []*graph.Node{}
+					err = tx.Nodes().Filter(
+						query.Or(
+							query.Equals(query.NodeID(), harness.IngestRelationships.Node1.ID),
+							query.Equals(query.NodeID(), harness.IngestRelationships.Node2.ID),
+						),
+					).Fetch(func(cursor graph.Cursor[*graph.Node]) error {
+						for node := range cursor.Chan() {
+							refetchedEndpoints = append(refetchedEndpoints, node)
+						}
+						return nil
+					})
+					require.Nil(t, err)
+					require.Len(t, refetchedEndpoints, 2)
+					for _, node := range refetchedEndpoints {
+						objectid, _ := node.Properties.Get("objectid").String()
+						require.ElementsMatch(t, graph.Kinds{graph.StringKind("Computer")}, node.Kinds, "endpoint node %s kinds should be unchanged by kindless relationship ingest", objectid)
+					}
+
+					return nil
+				})
+
+				require.Nil(t, err)
+			})
+	})
+
+	t.Run("IngestRelationshipsKindless. New endpoint nodes are created without any kinds.", func(t *testing.T) {
+		testContext := integration.NewGraphTestContext(t, graphschema.DefaultGraphSchema())
+
+		testContext.DatabaseTestWithSetup(
+			func(harness *integration.HarnessDetails) error {
+				harness.IngestRelationships.Setup(testContext)
+				return nil
+			},
+			func(harness integration.HarnessDetails, db graph.Database) {
+				// Brand-new objectids that don't exist in the harness; nodes will be created by the ingest.
+				ingestibleRel := ein.NewIngestibleRelationship(
+					ein.IngestibleEndpoint{Value: "0001"},
+					ein.IngestibleEndpoint{Value: "0002"},
+					ein.IngestibleRel{RelType: graph.StringKind("related_to")},
+				)
+				rels := []ein.IngestibleRelationship{ingestibleRel}
+
+				err := db.BatchOperation(testContext.Context(), func(batch graph.Batch) error {
+					ingestContext := NewIngestContext(testContext.Context(), WithBatchUpdater(batch), WithEndpointResolver(endpoint.NewResolver(db)))
+
+					err := IngestRelationshipsKindless(ingestContext, graph.StringKind("SomeBase"), rels)
+					require.Nil(t, err)
+					return nil
+				})
+
+				require.Nil(t, err)
+
+				err = db.ReadTransaction(testContext.Context(), func(tx graph.Transaction) error {
+					nodeIDs := map[string]graph.ID{}
+					createdNodes := []*graph.Node{}
+					_ = tx.Nodes().Filter(
+						query.Or(
+							query.Equals(query.Property(query.Node(), "objectid"), "0001"),
+							query.Equals(query.Property(query.Node(), "objectid"), "0002"),
+						)).
+						OrderBy(query.Order(query.Property(query.Node(), "objectid"), query.Ascending())).Fetch(
+						func(cursor graph.Cursor[*graph.Node]) error {
+							for node := range cursor.Chan() {
+								objectid, _ := node.Properties.Get("objectid").String()
+								nodeIDs[objectid] = node.ID
+								createdNodes = append(createdNodes, node)
+							}
+							return nil
+						},
+					)
+					require.Len(t, nodeIDs, 2)
+
+					// Endpoint nodes implicitly created by the kindless path must have NO kinds:
+					// node kinding for OpenGraph is the exclusive responsibility of the node ingest path.
+					for _, node := range createdNodes {
+						objectid, _ := node.Properties.Get("objectid").String()
+						require.Empty(t, node.Kinds, "endpoint node %s should have no kinds when created via kindless relationship ingest", objectid)
+					}
+
+					// Verify the relationship was created.
+					count, err := tx.Relationships().Filter(
+						query.And(
+							query.Equals(query.StartID(), nodeIDs["0001"]),
+							query.Equals(query.EndID(), nodeIDs["0002"]),
+							query.Kind(query.Relationship(), graph.StringKind("related_to")),
+						),
+					).Count()
+					require.Nil(t, err)
+					require.Equal(t, int64(1), count)
+
+					return nil
+				})
+
+				require.Nil(t, err)
 			})
 	})
 
@@ -455,7 +594,7 @@ func Test_ResolveRelationships(t *testing.T) {
 					require.NoError(t, err)
 
 					updates := slices.Collect(
-						ingestibleRelationshipsToUpdates(ingestContext, updatedIngestibleRels, graph.EmptyKind),
+						ingestibleRelationshipsToUpdates(ingestContext, updatedIngestibleRels, graph.EmptyKind, true),
 					)
 
 					require.Len(t, updates, 1)
@@ -642,7 +781,7 @@ func Test_ResolveRelationships(t *testing.T) {
 					require.NoError(t, err)
 
 					updates := slices.Collect(
-						ingestibleRelationshipsToUpdates(ingestContext, updatedIngestibleRels, graph.EmptyKind),
+						ingestibleRelationshipsToUpdates(ingestContext, updatedIngestibleRels, graph.EmptyKind, true),
 					)
 
 					require.Nil(t, err)
@@ -685,7 +824,7 @@ func Test_ResolveRelationships(t *testing.T) {
 					require.NoError(t, err)
 
 					updates := slices.Collect(
-						ingestibleRelationshipsToUpdates(ingestContext, updatedIngestibleRels, graph.EmptyKind),
+						ingestibleRelationshipsToUpdates(ingestContext, updatedIngestibleRels, graph.EmptyKind, true),
 					)
 
 					require.Nil(t, err)
@@ -728,7 +867,7 @@ func Test_ResolveRelationships(t *testing.T) {
 					require.NoError(t, err)
 
 					updates := slices.Collect(
-						ingestibleRelationshipsToUpdates(ingestContext, updatedIngestibleRels, graph.EmptyKind),
+						ingestibleRelationshipsToUpdates(ingestContext, updatedIngestibleRels, graph.EmptyKind, true),
 					)
 
 					require.Nil(t, err)
@@ -771,7 +910,7 @@ func Test_ResolveRelationships(t *testing.T) {
 					require.NoError(t, err)
 
 					updates := slices.Collect(
-						ingestibleRelationshipsToUpdates(ingestContext, updatedIngestibleRels, graph.EmptyKind),
+						ingestibleRelationshipsToUpdates(ingestContext, updatedIngestibleRels, graph.EmptyKind, true),
 					)
 
 					require.Len(t, updates, 1)
@@ -871,7 +1010,7 @@ func Test_ResolveRelationships(t *testing.T) {
 					require.NoError(t, err)
 
 					updates := slices.Collect(
-						ingestibleRelationshipsToUpdates(ingestContext, updatedIngestibleRels, graph.EmptyKind),
+						ingestibleRelationshipsToUpdates(ingestContext, updatedIngestibleRels, graph.EmptyKind, true),
 					)
 
 					require.Nil(t, err)
@@ -943,7 +1082,7 @@ func Test_ResolveRelationships(t *testing.T) {
 					require.NoError(t, err)
 
 					updates := slices.Collect(
-						ingestibleRelationshipsToUpdates(ingestContext, updatedIngestibleRels, graph.EmptyKind),
+						ingestibleRelationshipsToUpdates(ingestContext, updatedIngestibleRels, graph.EmptyKind, true),
 					)
 
 					require.Nil(t, err)

--- a/cmd/api/src/services/graphify/ingestrelationships_integration_test.go
+++ b/cmd/api/src/services/graphify/ingestrelationships_integration_test.go
@@ -157,7 +157,7 @@ func Test_IngestRelationships(t *testing.T) {
 				err := db.BatchOperation(testContext.Context(), func(batch graph.Batch) error {
 					ingestContext := NewIngestContext(testContext.Context(), WithBatchUpdater(batch), WithEndpointResolver(endpoint.NewResolver(db)))
 
-					err := IngestRelationships(ingestContext, graph.EmptyKind, rels)
+					err := IngestRelationships(ingestContext, graph.StringKind("SomeBase"), rels)
 					require.Nil(t, err)
 					return nil
 				})
@@ -281,7 +281,7 @@ func Test_IngestRelationships(t *testing.T) {
 				err := db.BatchOperation(testContext.Context(), func(batch graph.Batch) error {
 					ingestContext := NewIngestContext(testContext.Context(), WithBatchUpdater(batch), WithEndpointResolver(endpoint.NewResolver(db)))
 
-					err := IngestRelationships(ingestContext, graph.EmptyKind, rels)
+					err := IngestRelationships(ingestContext, graph.StringKind("SomeBase"), rels)
 					require.Nil(t, err)
 					return nil
 				})


### PR DESCRIPTION
## Description
When we batch relationship updates in ingest, we no longer append the sourcekind to the start/end node.

## Motivation and Context
BED-8030
Generic-ingested edges are currently able to mutate the kinds of the nodes that they link. We want to remove that side-effect from relationship ingest because it creates buggy, hard to understand behavior, ESPECIALLY for hybrid paths.

## How Has This Been Tested?
`ingestRelationships()` is backed by many integration tests. I updated 2 that are specifically relevant to maintaining the invariant this changeset introduces. The two scenarios are as follows:

When you ingest a relationship; it can connect nodes that exist, or don't exist yet.
When the edge connects nodes that exist, the nodes' kinds should NOT be mutated.
When the edge connects nodes that don't exist, the nodes get created, and their kinds are NOT mutated. They get empty kinds.

## Screenshots (optional):
I ingested the following file with one edge:
```
{
  "metadata": {
    "source_kind": "HelloBase"
  },
  "graph": {
    "nodes": [
       
    ],
    "edges": [
    {
        "start": { "value": "1234" },
        "end": {  "value": "5678" },
        "kind": "HelloEdge",
        "properties": {
          "hello": "world"
        }
      }
    ]
  }
}
```
And confirmed that the nodes had no kinds in PG and could be searched on the explore page:
<img width="843" height="140" alt="Screenshot 2026-04-28 at 9 25 49 AM" src="https://github.com/user-attachments/assets/bc407f7f-c520-4ea5-ae59-fff39d73e759" />
<img width="1311" height="571" alt="Screenshot 2026-04-28 at 9 26 20 AM" src="https://github.com/user-attachments/assets/1465a293-29a0-4e1b-b1b4-2e5450969bb2" />


## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)
- Database Migrations

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [ ] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [ ] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [ ] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "kindless" relationship ingest mode that creates relationships without applying source kinds to endpoint nodes.

* **Bug Fixes**
  * Ensured legacy ingest continues to preserve and merge node kinds correctly while kindless ingest leaves endpoint kinds unchanged.

* **Tests**
  * Updated integration tests to cover both ingest modes and reduced coupling to exact kind contents.

* **Chores**
  * Removed internal explanatory comments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->