### PR TITLE
feat(kinds): Upsert to the kinds table [BED-7921]

### DIFF
--- a/cmd/api/src/api/v2/customnode.go
+++ b/cmd/api/src/api/v2/customnode.go
@@ -81,6 +81,8 @@ func (s *Resources) CreateCustomNodeKind(response http.ResponseWriter, request *
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusConflict, fmt.Sprintf("%s: duplicate kind name", api.ErrorResponseConflict), request), response)
 	} else if err != nil {
 		api.HandleDatabaseError(request, response, err)
+	} else if err := s.Graph.RefreshKinds(request.Context()); err != nil {
+		api.HandleDatabaseError(request, response, err)
 	} else {
 		api.WriteBasicResponse(request.Context(), kinds, http.StatusCreated, response)
 	}

--- a/cmd/api/src/api/v2/customnode_test.go
+++ b/cmd/api/src/api/v2/customnode_test.go
@@ -27,6 +27,7 @@ import (
 	"testing"
 
 	"github.com/specterops/bloodhound/cmd/api/src/auth"
+	"github.com/specterops/bloodhound/cmd/api/src/database"
 	"github.com/specterops/bloodhound/packages/go/graphschema"
 	"github.com/specterops/bloodhound/packages/go/headers"
 
@@ -35,6 +36,7 @@ import (
 	dbmocks "github.com/specterops/bloodhound/cmd/api/src/database/mocks"
 	"github.com/specterops/bloodhound/cmd/api/src/model"
 	"github.com/specterops/bloodhound/cmd/api/src/utils/test"
+	graphmocks "github.com/specterops/bloodhound/cmd/api/src/vendormocks/dawgs/graph"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -45,6 +47,7 @@ func TestResources_CreateCustomNodeKindsTest(t *testing.T) {
 
 	type mock struct {
 		mockDatabase *dbmocks.MockDatabase
+		mockGraph    *graphmocks.MockDatabase
 	}
 	type expected struct {
 		responseBody   string
@@ -202,11 +205,56 @@ func TestResources_CreateCustomNodeKindsTest(t *testing.T) {
 						},
 					},
 				}, nil)
+				mocks.mockGraph.EXPECT().RefreshKinds(gomock.Any()).Return(nil)
 			},
 			expected: expected{
 				responseCode:   http.StatusCreated,
 				responseBody:   `{"data":[{"id":1,"kindName":"KindA","config":{"icon":{"type":"font-awesome","name":"coffee","color":"#FFFFFF"}}},{"id":2,"kindName":"KindB","config":{"icon":{"type":"font-awesome","name":"house","color":"#000"}}}]}`,
 				responseHeader: http.Header{"Content-Type": []string{"application/json"}},
+			},
+		},
+		{
+			name: "Error: duplicate kind name",
+			buildRequest: func() *http.Request {
+				request := &http.Request{
+					URL: &url.URL{
+						Path: "/api/v2/custom-nodes",
+					},
+					Method: http.MethodPost,
+					Header: http.Header{},
+				}
+
+				payload := &v2.CreateCustomNodeRequest{
+					CustomTypes: map[string]model.CustomNodeKindConfig{
+						"DuplicateKind": {
+							Icon: graphschema.DisplayNodeIcon{
+								Type:  graphschema.DisplayNodeTypeFontAwesome,
+								Name:  "coffee",
+								Color: "#FFFFFF",
+							},
+						},
+					},
+				}
+				jsonPayload, err := json.Marshal(payload)
+				if err != nil {
+					t.Fatalf("error occurred while marshaling payload necessary for test: %v", err)
+				}
+
+				request.Header.Add(headers.ContentType.String(), "application/json")
+				request.Body = io.NopCloser(bytes.NewReader(jsonPayload))
+
+				return request
+			},
+			setupMocks: func(t *testing.T, mocks *mock) {
+				t.Helper()
+				mocks.mockDatabase.EXPECT().
+					CreateCustomNodeKinds(gomock.Any(), gomock.Any()).
+					Return(model.CustomNodeKinds{}, database.ErrDuplicateCustomNodeKindName)
+			},
+			expected: expected{
+				responseCode:   http.StatusConflict,
+				responseHeader: http.Header{"Content-Type": []string{"application/json"}},
+				// responseBody intentionally omitted — status code is the contract under test
 			},
 		},
 		{
@@ -256,6 +304,7 @@ func TestResources_CreateCustomNodeKindsTest(t *testing.T) {
 
 			mocks := &mock{
 				mockDatabase: dbmocks.NewMockDatabase(ctrl),
+				mockGraph:    graphmocks.NewMockDatabase(ctrl),
 			}
 
 			request := testCase.buildRequest()
@@ -263,6 +312,7 @@ func TestResources_CreateCustomNodeKindsTest(t *testing.T) {
 
 			resources := v2.Resources{
 				DB:         mocks.mockDatabase,
+				Graph:      mocks.mockGraph,
 				Authorizer: auth.NewAuthorizer(mocks.mockDatabase),
 			}
 
@@ -276,7 +326,9 @@ func TestResources_CreateCustomNodeKindsTest(t *testing.T) {
 
 			require.Equal(t, testCase.expected.responseCode, status)
 			require.Equal(t, testCase.expected.responseHeader, header)
-			assert.JSONEq(t, testCase.expected.responseBody, body)
+			if testCase.expected.responseBody != "" {
+				assert.JSONEq(t, testCase.expected.responseBody, body)
+			}
 		})
 	}
 }

--- a/cmd/api/src/database/customnode.go
+++ b/cmd/api/src/database/customnode.go
@@ -44,6 +44,14 @@ func (s *BloodhoundDB) CreateCustomNodeKinds(ctx context.Context, customNodeKind
 	)
 
 	err := s.AuditableTransaction(ctx, auditEntry, func(tx *gorm.DB) error {
+		bhdb := NewBloodhoundDB(tx, s.pool, s.idResolver, s.config)
+
+		for _, kind := range customNodeKinds {
+			if _, err := bhdb.UpsertKind(ctx, kind.KindName); err != nil {
+				return fmt.Errorf("failed to upsert kind %q: %w", kind.KindName, err)
+			}
+		}
+
 		err := tx.Create(&customNodeKinds).Error
 
 		if err != nil {

--- a/cmd/api/src/database/customnode_integration_test.go
+++ b/cmd/api/src/database/customnode_integration_test.go
@@ -382,6 +382,96 @@ func TestUpdateCustomNodeKind(t *testing.T) {
 	}
 }
 
+func TestCreateCustomNodeKinds_UpsertsToKindTable(t *testing.T) {
+	testSuite := setupIntegrationTestSuite(t)
+	defer teardownIntegrationTestSuite(t, &testSuite)
+
+	_, err := testSuite.BHDatabase.CreateCustomNodeKinds(testSuite.Context, model.CustomNodeKinds{
+		{
+			KindName: "TestUpsertKindA",
+			Config: model.CustomNodeKindConfig{
+				Icon: graphschema.DisplayNodeIcon{Type: graphschema.DisplayNodeTypeFontAwesome, Name: "coffee", Color: "#FFFFFF"},
+			},
+		},
+		{
+			KindName: "TestUpsertKindB",
+			Config: model.CustomNodeKindConfig{
+				Icon: graphschema.DisplayNodeIcon{Type: graphschema.DisplayNodeTypeFontAwesome, Name: "house", Color: "#000000"},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	kinds, err := testSuite.BHDatabase.GetKindsByNames(testSuite.Context, "TestUpsertKindA", "TestUpsertKindB")
+	require.NoError(t, err)
+	assert.Len(t, kinds, 2)
+}
+
+func TestCreateCustomNodeKinds_ReusesExistingKindRow(t *testing.T) {
+	testSuite := setupIntegrationTestSuite(t)
+	defer teardownIntegrationTestSuite(t, &testSuite)
+
+	// Simulate a kind that already exists in the registry (e.g. from prior ingest
+	// or the BED-7926 backfill) but has no custom_node_kinds row yet.
+	existing, err := testSuite.BHDatabase.UpsertKind(testSuite.Context, "PreExistingKind")
+	require.NoError(t, err)
+
+	_, err = testSuite.BHDatabase.CreateCustomNodeKinds(testSuite.Context, model.CustomNodeKinds{
+		{
+			KindName: "PreExistingKind",
+			Config: model.CustomNodeKindConfig{
+				Icon: graphschema.DisplayNodeIcon{Type: graphschema.DisplayNodeTypeFontAwesome, Name: "star", Color: "#FF0000"},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	kinds, err := testSuite.BHDatabase.GetKindsByNames(testSuite.Context, "PreExistingKind")
+	require.NoError(t, err)
+	require.Len(t, kinds, 1)
+	assert.Equal(t, existing.ID, kinds[0].ID, "expected the pre-existing kind row to be reused, not duplicated")
+}
+
+func TestCreateCustomNodeKinds_TxAtomicity(t *testing.T) {
+	testSuite := setupIntegrationTestSuite(t)
+	defer teardownIntegrationTestSuite(t, &testSuite)
+
+	// Pre-create a custom_node_kinds row so the second item in the batch below
+	// will conflict on the unique constraint.
+	_, err := testSuite.BHDatabase.CreateCustomNodeKinds(testSuite.Context, model.CustomNodeKinds{
+		{
+			KindName: "AlreadyRegistered",
+			Config: model.CustomNodeKindConfig{
+				Icon: graphschema.DisplayNodeIcon{Type: graphschema.DisplayNodeTypeFontAwesome, Name: "coffee", Color: "#FFFFFF"},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	// Submit a batch where one kind is brand new and the other will conflict.
+	_, err = testSuite.BHDatabase.CreateCustomNodeKinds(testSuite.Context, model.CustomNodeKinds{
+		{
+			KindName: "NewKindShouldRollBack",
+			Config: model.CustomNodeKindConfig{
+				Icon: graphschema.DisplayNodeIcon{Type: graphschema.DisplayNodeTypeFontAwesome, Name: "fire", Color: "#FF5733"},
+			},
+		},
+		{
+			KindName: "AlreadyRegistered",
+			Config: model.CustomNodeKindConfig{
+				Icon: graphschema.DisplayNodeIcon{Type: graphschema.DisplayNodeTypeFontAwesome, Name: "coffee", Color: "#FFFFFF"},
+			},
+		},
+	})
+	require.ErrorIs(t, err, database.ErrDuplicateCustomNodeKindName)
+
+	// The new kind upsert into `kind` must have been rolled back along with the
+	// failed custom_node_kinds insert. If `kind` is written outside the tx, the
+	// row will still exist and this assertion will fail.
+	_, err = testSuite.BHDatabase.GetKindsByNames(testSuite.Context, "NewKindShouldRollBack")
+	require.ErrorIs(t, err, database.ErrNotFound, "kind row should have been rolled back when custom_node_kinds insert failed")
+}
+
 func TestDeleteCustomNodeKind(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
## Description

When a custom node kind is created via POST /api/v2/custom-nodes, also upsert each kind name into the kind table in the same transaction. After commit, refresh the in-memory kind map.

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-7921

## How Has This Been Tested?

Additional tests added to test functionality

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- New feature (non-breaking change which adds functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Custom node kind creation now properly returns HTTP 409 Conflict status when duplicate names are provided, preventing ambiguous error responses.

* **Improvements**
  * Increased transactional reliability for custom node kind database operations.
  * Automatic synchronization of custom node kinds in system memory following creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->