### PR TITLE
feat(webhooks): event subscribe API BED-7949

### DIFF
--- a/cmd/api/src/services/pubsub/pubsub.go
+++ b/cmd/api/src/services/pubsub/pubsub.go
@@ -67,3 +67,9 @@ func (s *PubSubService) Publish(ctx context.Context, eventInput model.EventInput
 		}
 	}
 }
+
+// Subscribe registers an EventHandler for the given EventType. Multiple handlers
+// can be registered for the same EventType.
+func (s *PubSubService) Subscribe(eventType model.EventType, handler EventHandler) {
+	s.handlers[eventType] = append(s.handlers[eventType], handler)
+}

--- a/cmd/api/src/services/pubsub/pubsub_test.go
+++ b/cmd/api/src/services/pubsub/pubsub_test.go
@@ -30,7 +30,7 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
-func TestService_Publish(t *testing.T) {
+func TestPubSubService_Publish(t *testing.T) {
 
 	t.Run("error - empty message", func(t *testing.T) {
 		var (
@@ -95,7 +95,7 @@ func TestService_Publish(t *testing.T) {
 		assert.NotEmpty(t, createdEvent.ID)
 	})
 
-	t.Run("success - publishes event with minimal fields", func(t *testing.T) {
+	t.Run("success - publishes event with minimal fields (no data)", func(t *testing.T) {
 		var (
 			mockCtrl     = gomock.NewController(t)
 			mockDatabase = mocks.NewMockPubSubRepository(mockCtrl)
@@ -119,5 +119,59 @@ func TestService_Publish(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, string(eventInput.Type), createdEvent.Type)
 		assert.Equal(t, eventInput.Message, createdEvent.Message)
+	})
+}
+
+type testHandler struct {
+	called bool
+}
+
+func (s *testHandler) HandleEvent(_ context.Context, _ model.Event) error {
+	s.called = true
+	return nil
+}
+
+func TestPubSubService_Subscribe(t *testing.T) {
+	t.Run("success - subscribes a single handler", func(t *testing.T) {
+		var (
+			mockCtrl     = gomock.NewController(t)
+			mockDatabase = mocks.NewMockPubSubRepository(mockCtrl)
+			service      = pubsub.NewPubSubService(mockDatabase)
+		)
+
+		defer mockCtrl.Finish()
+
+		handler := &testHandler{}
+		service.Subscribe("ingest.started", handler)
+	})
+
+	t.Run("success - subscribes multiple handlers for the same event type", func(t *testing.T) {
+		var (
+			mockCtrl     = gomock.NewController(t)
+			mockDatabase = mocks.NewMockPubSubRepository(mockCtrl)
+			service      = pubsub.NewPubSubService(mockDatabase)
+		)
+
+		defer mockCtrl.Finish()
+
+		handlerOne := &testHandler{}
+		handlerTwo := &testHandler{}
+		service.Subscribe("ingest.started", handlerOne)
+		service.Subscribe("ingest.started", handlerTwo)
+	})
+
+	t.Run("success - subscribes handlers for different event types", func(t *testing.T) {
+		var (
+			mockCtrl     = gomock.NewController(t)
+			mockDatabase = mocks.NewMockPubSubRepository(mockCtrl)
+			service      = pubsub.NewPubSubService(mockDatabase)
+		)
+
+		defer mockCtrl.Finish()
+
+		handlerOne := &testHandler{}
+		handlerTwo := &testHandler{}
+		service.Subscribe("ingest.started", handlerOne)
+		service.Subscribe("analysis.completed", handlerTwo)
 	})
 }


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Adds a `Subscribe` function to the pubsub service that allows the caller to add an event handler for a specific event type.

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-7949

Enables further progress for the webhooks functionality.

## How Has This Been Tested?

Unit tests added.

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- New feature (non-breaking change which adds functionality)


## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
