### PR TITLE
fix: ignore not found errors for primary kinds BED-8155

### DIFF
--- a/cmd/api/src/database/graphschema.go
+++ b/cmd/api/src/database/graphschema.go
@@ -18,6 +18,7 @@ package database
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -1355,7 +1356,7 @@ func (s *BloodhoundDB) GetPrimaryDisplayKinds(ctx context.Context) (graphschema.
 			customKindsByName[kind.KindName] = kind
 		}
 		// Until work is complete to ensure custom_node_kinds are properly kind backed, this will filter out invalid kinds
-		if kinds, err := s.GetKindsByNames(ctx, customNames...); err != nil {
+		if kinds, err := s.GetKindsByNames(ctx, customNames...); err != nil && !errors.Is(err, ErrNotFound) {
 			return nil, err
 		} else {
 			var primaryDisplayKinds = make(graphschema.PrimaryDisplayKinds)


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description
- Handle not found error during primary kinds resolution

*Describe your changes in detail*

## Motivation and Context
As of today custom-node-kinds table is not backed by kinds, meaning records exist that may not have a kind record in the kind table. A helper function, PrimaryKinds, serves to determine the "representative" kind of a node. It was discovered that custom nodes were not included in the primary kinds function and an effort was made to add it. 

Because custom nodes kinds is not kind backed, a quick filter was applied, but that filter fails 404 if not all kinds supplied are found. This bubbled up across the endpoints as primarykind function is utilized across a number of vital systems, analysis, graph search, attack-paths, etc. A quick fix was to ignore the 404 db error


<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-8155

*Why is this change required? What problem does it solve?*

## How Has This Been Tested?

*Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc.*

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->
- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
