### PR TITLE
fix: return kinds array during db getKinds method BED-8155

### DIFF
--- a/cmd/api/src/database/kind.go
+++ b/cmd/api/src/database/kind.go
@@ -38,9 +38,9 @@ func (s *BloodhoundDB) GetKindsByNames(ctx context.Context, names ...string) ([]
 
 	var kinds []model.Kind
 	if result := s.db.WithContext(ctx).Raw(query, uniqueNames).Scan(&kinds); result.Error != nil {
-		return nil, result.Error
+		return kinds, result.Error
 	} else if len(kinds) != len(uniqueNames) {
-		return nil, ErrNotFound
+		return kinds, ErrNotFound
 	}
 
 	return kinds, nil
@@ -66,11 +66,11 @@ func (s *BloodhoundDB) GetKindsByIDs(ctx context.Context, ids ...int32) ([]model
 	result := s.db.WithContext(ctx).Raw(query, uniqueIDs).Scan(&kinds)
 
 	if err := result.Error; err != nil {
-		return nil, fmt.Errorf("failed to fetch kinds by IDs: %w", err)
+		return kinds, fmt.Errorf("failed to fetch kinds by IDs: %w", err)
 	}
 
 	if len(kinds) != len(uniqueIDs) {
-		return nil, ErrNotFound
+		return kinds, ErrNotFound
 	}
 
 	return kinds, nil


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

*Describe your changes in detail*
- Return kinds found regardless to allow callers to decide

## Motivation and Context
The notfound error wasn't necessary for internal primary kind calls, but by ignoring it and not returning kinds, existing custom kinds are also ignored. This gives callers the ability to decide if / when they wish to consider the notfound case.

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-8155

*Why is this change required? What problem does it solve?*

## How Has This Been Tested?

*Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc.*

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
