### PR TITLE
chore: Cleanup bad sourcekinds on AD/AZ nodes: BED-8158

### DIFF
--- a/cmd/api/src/migrations/graph.go
+++ b/cmd/api/src/migrations/graph.go
@@ -23,6 +23,7 @@ import (
 	"log/slog"
 	"sort"
 
+	"github.com/specterops/bloodhound/cmd/api/src/database"
 	"github.com/specterops/bloodhound/cmd/api/src/version"
 	"github.com/specterops/bloodhound/packages/go/bhlog/attr"
 	"github.com/specterops/bloodhound/packages/go/graphschema"
@@ -134,11 +135,29 @@ type GraphMigration interface {
 }
 
 type GraphMigrator struct {
-	db graph.Database
+	db              graph.Database
+	sourceKindsData database.SourceKindsData
 }
 
-func NewGraphMigrator(db graph.Database) *GraphMigrator {
-	return &GraphMigrator{db: db}
+// Option configures optional dependencies on a GraphMigrator. Most migrations
+// only need a graph.Database; a small number need access to the relational
+// database (e.g. to read source_kinds). Use functional options to inject those
+// dependencies without forcing every caller to acknowledge them.
+type Option func(*GraphMigrator)
+
+// WithSourceKinds wires a SourceKindsData provider into the migrator. Migrations
+// that depend on the source_kinds table will short-circuit when this option is
+// not supplied.
+func WithSourceKinds(sourceKindsData database.SourceKindsData) Option {
+	return func(m *GraphMigrator) { m.sourceKindsData = sourceKindsData }
+}
+
+func NewGraphMigrator(db graph.Database, opts ...Option) *GraphMigrator {
+	migrator := &GraphMigrator{db: db}
+	for _, opt := range opts {
+		opt(migrator)
+	}
+	return migrator
 }
 
 func (s *GraphMigrator) Migrate(ctx context.Context) error {
@@ -220,7 +239,7 @@ func (s *GraphMigrator) executeMigrations(ctx context.Context, originalVersion v
 
 func (s *GraphMigrator) GetMigrationsByVersion() MigrationsByVersion {
 	migrationsByVersion := make(MigrationsByVersion)
-	for _, migration := range Manifest {
+	for _, migration := range GetManifest(s.sourceKindsData) {
 		migrationsByVersion[migration.Version] = append(migrationsByVersion[migration.Version], migration)
 	}
 	return migrationsByVersion

--- a/cmd/api/src/migrations/manifest.go
+++ b/cmd/api/src/migrations/manifest.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/specterops/bloodhound/cmd/api/src/database"
 	"github.com/specterops/bloodhound/cmd/api/src/version"
 	"github.com/specterops/bloodhound/packages/go/analysis/ad/wellknown"
 	"github.com/specterops/bloodhound/packages/go/analysis/post"
@@ -48,6 +49,65 @@ func RequiresMigration(ctx context.Context, db graph.Database) (bool, error) {
 		}
 	} else {
 		return version.GetVersion().GreaterThan(currentMigration), nil
+	}
+}
+
+// Version_920_Migration returns a migration that removes any registered source kinds
+// (other than ad.Entity) from Active Directory nodes. It addresses cross-platform kind
+// pollution where AD nodes acquired foreign source kinds (e.g. azure.Entity, OpenGraph
+// custom kinds) via relationship ingest before BED-8158. The list of source kinds is
+// fetched from the relational database via sourceKinds; ad.Entity is excluded so AD
+// nodes retain their platform base kind alongside their type kinds (ad.User, ad.Group,
+// etc., which are not stored in the source_kinds table).
+func Version_920_Migration(sourceKindsData database.SourceKindsData) func(ctx context.Context, db graph.Database) error {
+	return func(ctx context.Context, db graph.Database) error {
+		defer measure.LogAndMeasureWithThreshold(slog.LevelInfo, "Migration to remove non-ad.Entity source kinds from Active Directory nodes")()
+
+		if sourceKindsData == nil {
+			slog.InfoContext(ctx, "Skipping Version_920_Migration: no SourceKindsData provider configured")
+			return nil
+		}
+
+		registeredSourceKinds, err := sourceKindsData.GetSourceKinds(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to fetch source kinds: %w", err)
+		}
+
+		removableSourceKinds := graph.Kinds{}
+		for _, sourceKind := range registeredSourceKinds {
+			kind := sourceKind.ToKind()
+			if kind == ad.Entity {
+				continue
+			}
+			removableSourceKinds = append(removableSourceKinds, kind)
+		}
+
+		if len(removableSourceKinds) == 0 {
+			return nil
+		}
+
+		return db.WriteTransaction(ctx, func(tx graph.Transaction) error {
+			if nodes, err := ops.FetchNodes(tx.Nodes().Filter(query.KindIn(query.Node(), ad.Nodes()...))); err != nil {
+				return err
+			} else {
+				for _, node := range nodes {
+					kindsToRemove := graph.Kinds{}
+					for _, kind := range removableSourceKinds {
+						if node.Kinds.ContainsOneOf(kind) {
+							kindsToRemove = append(kindsToRemove, kind)
+						}
+					}
+					if len(kindsToRemove) == 0 {
+						continue
+					}
+					node.DeleteKinds(kindsToRemove...)
+					if err := tx.UpdateNode(node); err != nil {
+						return err
+					}
+				}
+			}
+			return nil
+		})
 	}
 }
 
@@ -528,118 +588,127 @@ func Version_277_Migration(ctx context.Context, db graph.Database) error {
 	})
 }
 
-var Manifest = []Migration{
-	{
-		Version: version.Version{Major: 2, Minor: 3, Patch: 0},
-		Execute: func(ctx context.Context, db graph.Database) error {
-			defer measure.MeasureWithThreshold(slog.LevelInfo, "Deleting all existing role nodes")()
+// GetManifest returns the ordered list of graph migrations. Migrations that need
+// dependencies beyond the graph database (e.g. relational source kinds) capture
+// them via the provided arguments.
+func GetManifest(sourceKindsData database.SourceKindsData) []Migration {
+	return []Migration{
+		{
+			Version: version.Version{Major: 2, Minor: 3, Patch: 0},
+			Execute: func(ctx context.Context, db graph.Database) error {
+				defer measure.MeasureWithThreshold(slog.LevelInfo, "Deleting all existing role nodes")()
 
-			return db.WriteTransaction(ctx, func(tx graph.Transaction) error {
-				return tx.Nodes().Filterf(func() graph.Criteria {
-					return query.Kind(query.Node(), azure.Role)
-				}).Delete()
-			})
+				return db.WriteTransaction(ctx, func(tx graph.Transaction) error {
+					return tx.Nodes().Filterf(func() graph.Criteria {
+						return query.Kind(query.Node(), azure.Role)
+					}).Delete()
+				})
+			},
 		},
-	},
-	{
-		Version: version.Version{Major: 2, Minor: 6, Patch: 3},
-		Execute: func(ctx context.Context, db graph.Database) error {
-			defer measure.MeasureWithThreshold(slog.LevelInfo, "Deleting all LocalToComputer/RemoteInteractiveLogin edges and ADLocalGroup labels")()
+		{
+			Version: version.Version{Major: 2, Minor: 6, Patch: 3},
+			Execute: func(ctx context.Context, db graph.Database) error {
+				defer measure.MeasureWithThreshold(slog.LevelInfo, "Deleting all LocalToComputer/RemoteInteractiveLogin edges and ADLocalGroup labels")()
 
-			// This kind has long since gone missing from our schemas but the assert below reintroduces it for the
-			// purposes of running this migration
-			rilpKind := graph.StringKind("RemoteInteractiveLogonPrivilege")
+				// This kind has long since gone missing from our schemas but the assert below reintroduces it for the
+				// purposes of running this migration
+				rilpKind := graph.StringKind("RemoteInteractiveLogonPrivilege")
 
-			if err := db.AssertSchema(ctx, graph.Schema{
-				Graphs: []graph.Graph{{
-					Edges: graph.Kinds{rilpKind},
-				}},
-			}); err != nil {
-				return err
-			}
-
-			return db.WriteTransaction(ctx, func(tx graph.Transaction) error {
-				// Remove ADLocalGroup label from all nodes that also have the group label
-				if nodes, err := ops.FetchNodes(tx.Nodes().Filterf(func() graph.Criteria {
-					return query.And(
-						query.Kind(query.Node(), ad.LocalGroup),
-						query.Kind(query.Node(), ad.Group),
-					)
-				})); err != nil {
+				if err := db.AssertSchema(ctx, graph.Schema{
+					Graphs: []graph.Graph{{
+						Edges: graph.Kinds{rilpKind},
+					}},
+				}); err != nil {
 					return err
-				} else {
-					for _, node := range nodes {
-						node.DeleteKinds(ad.LocalGroup)
-						if err := tx.UpdateNode(node); err != nil {
-							return err
+				}
+
+				return db.WriteTransaction(ctx, func(tx graph.Transaction) error {
+					// Remove ADLocalGroup label from all nodes that also have the group label
+					if nodes, err := ops.FetchNodes(tx.Nodes().Filterf(func() graph.Criteria {
+						return query.And(
+							query.Kind(query.Node(), ad.LocalGroup),
+							query.Kind(query.Node(), ad.Group),
+						)
+					})); err != nil {
+						return err
+					} else {
+						for _, node := range nodes {
+							node.DeleteKinds(ad.LocalGroup)
+							if err := tx.UpdateNode(node); err != nil {
+								return err
+							}
 						}
 					}
-				}
 
-				// Delete all local group edges
-				if err := tx.Relationships().Filterf(func() graph.Criteria {
-					return query.And(
-						query.Or(
-							query.Kind(query.Relationship(), rilpKind),
-							query.Kind(query.Relationship(), ad.LocalToComputer),
-							query.Kind(query.Relationship(), ad.MemberOfLocalGroup),
-						),
-						query.Kind(query.Start(), ad.Entity),
-					)
-				}).Delete(); err != nil {
-					return err
-				}
+					// Delete all local group edges
+					if err := tx.Relationships().Filterf(func() graph.Criteria {
+						return query.And(
+							query.Or(
+								query.Kind(query.Relationship(), rilpKind),
+								query.Kind(query.Relationship(), ad.LocalToComputer),
+								query.Kind(query.Relationship(), ad.MemberOfLocalGroup),
+							),
+							query.Kind(query.Start(), ad.Entity),
+						)
+					}).Delete(); err != nil {
+						return err
+					}
 
-				return nil
-			})
+					return nil
+				})
+			},
 		},
-	},
-	{
-		Version: version.Version{Major: 2, Minor: 7, Patch: 7},
-		Execute: Version_277_Migration,
-	},
-	{
-		Version: version.Version{Major: 5, Minor: 0, Patch: 8},
-		Execute: Version_508_Migration,
-	},
-	{
-		Version: version.Version{Major: 5, Minor: 13, Patch: 0},
-		Execute: Version_513_Migration,
-	},
-	{
-		Version: version.Version{Major: 6, Minor: 2, Patch: 0},
-		Execute: Version_620_Migration,
-	},
-	{
-		Version: version.Version{Major: 7, Minor: 3, Patch: 0},
-		Execute: Version_730_Migration,
-	},
-	{
-		Version: version.Version{Major: 7, Minor: 4, Patch: 0},
-		Execute: Version_740_Migration,
-	},
-	{
-		Version: version.Version{Major: 8, Minor: 1, Patch: 3},
-		Execute: Version_813_Migration,
-	},
-	{
-		Version: version.Version{Major: 8, Minor: 3, Patch: 0},
-		Execute: Version_830_Migration,
-	},
-	{
-		Version: version.Version{Major: 8, Minor: 5, Patch: 2},
-		Execute: Version_852_Migration,
-	},
-	{
-		Version: version.Version{Major: 8, Minor: 6, Patch: 0},
-		Execute: Version_860_Migration,
-	},
-	{
-		Version: version.Version{Major: 9, Minor: 0, Patch: 0},
-		Execute: Version_900_Migration,
-	},
-	{
-		Version: version.Version{Major: 9, Minor: 1, Patch: 0},
-		Execute: Version_910_Migration,
-	},
+		{
+			Version: version.Version{Major: 2, Minor: 7, Patch: 7},
+			Execute: Version_277_Migration,
+		},
+		{
+			Version: version.Version{Major: 5, Minor: 0, Patch: 8},
+			Execute: Version_508_Migration,
+		},
+		{
+			Version: version.Version{Major: 5, Minor: 13, Patch: 0},
+			Execute: Version_513_Migration,
+		},
+		{
+			Version: version.Version{Major: 6, Minor: 2, Patch: 0},
+			Execute: Version_620_Migration,
+		},
+		{
+			Version: version.Version{Major: 7, Minor: 3, Patch: 0},
+			Execute: Version_730_Migration,
+		},
+		{
+			Version: version.Version{Major: 7, Minor: 4, Patch: 0},
+			Execute: Version_740_Migration,
+		},
+		{
+			Version: version.Version{Major: 8, Minor: 1, Patch: 3},
+			Execute: Version_813_Migration,
+		},
+		{
+			Version: version.Version{Major: 8, Minor: 3, Patch: 0},
+			Execute: Version_830_Migration,
+		},
+		{
+			Version: version.Version{Major: 8, Minor: 5, Patch: 2},
+			Execute: Version_852_Migration,
+		},
+		{
+			Version: version.Version{Major: 8, Minor: 6, Patch: 0},
+			Execute: Version_860_Migration,
+		},
+		{
+			Version: version.Version{Major: 9, Minor: 0, Patch: 0},
+			Execute: Version_900_Migration,
+		},
+		{
+			Version: version.Version{Major: 9, Minor: 1, Patch: 0},
+			Execute: Version_910_Migration,
+		},
+		{
+			Version: version.Version{Major: 9, Minor: 2, Patch: 0},
+			Execute: Version_920_Migration(sourceKindsData),
+		},
+	}
 }

--- a/cmd/api/src/migrations/manifest.go
+++ b/cmd/api/src/migrations/manifest.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/specterops/bloodhound/cmd/api/src/database"
+	"github.com/specterops/bloodhound/cmd/api/src/model"
 	"github.com/specterops/bloodhound/cmd/api/src/version"
 	"github.com/specterops/bloodhound/packages/go/analysis/ad/wellknown"
 	"github.com/specterops/bloodhound/packages/go/analysis/post"
@@ -52,16 +53,19 @@ func RequiresMigration(ctx context.Context, db graph.Database) (bool, error) {
 	}
 }
 
-// Version_920_Migration returns a migration that removes any registered source kinds
-// (other than ad.Entity) from Active Directory nodes. It addresses cross-platform kind
-// pollution where AD nodes acquired foreign source kinds (e.g. azure.Entity, OpenGraph
-// custom kinds) via relationship ingest before BED-8158. The list of source kinds is
-// fetched from the relational database via sourceKinds; ad.Entity is excluded so AD
-// nodes retain their platform base kind alongside their type kinds (ad.User, ad.Group,
-// etc., which are not stored in the source_kinds table).
+// Version_920_Migration returns a migration that removes cross-platform kind
+// pollution from Active Directory and Azure nodes. Before BED-8158, AD and
+// Azure nodes could acquire foreign source kinds (e.g. azure.Entity on AD
+// nodes, OpenGraph custom kinds) via relationship ingest. For each platform
+// the migration strips every registered source kind from in-scope nodes
+// except the platform's own base kind (ad.Entity for AD, azure.Entity for
+// Azure), so nodes retain their platform base kind alongside their type
+// kinds (ad.User, azure.User, etc., which are not stored in the
+// source_kinds table). The list of source kinds is fetched from the
+// relational database via sourceKindsData.
 func Version_920_Migration(sourceKindsData database.SourceKindsData) func(ctx context.Context, db graph.Database) error {
 	return func(ctx context.Context, db graph.Database) error {
-		defer measure.LogAndMeasureWithThreshold(slog.LevelInfo, "Migration to remove non-ad.Entity source kinds from Active Directory nodes")()
+		defer measure.LogAndMeasureWithThreshold(slog.LevelInfo, "Migration to remove cross-platform source kinds from AD and Azure nodes")()
 
 		if sourceKindsData == nil {
 			slog.InfoContext(ctx, "Skipping Version_920_Migration: no SourceKindsData provider configured")
@@ -73,42 +77,65 @@ func Version_920_Migration(sourceKindsData database.SourceKindsData) func(ctx co
 			return fmt.Errorf("failed to fetch source kinds: %w", err)
 		}
 
-		removableSourceKinds := graph.Kinds{}
-		for _, sourceKind := range registeredSourceKinds {
-			kind := sourceKind.ToKind()
-			if kind == ad.Entity {
-				continue
-			}
-			removableSourceKinds = append(removableSourceKinds, kind)
-		}
-
-		if len(removableSourceKinds) == 0 {
-			return nil
-		}
-
 		return db.WriteTransaction(ctx, func(tx graph.Transaction) error {
-			if nodes, err := ops.FetchNodes(tx.Nodes().Filter(query.KindIn(query.Node(), ad.Nodes()...))); err != nil {
+			var (
+				adKinds    graph.Kinds
+				azureKinds graph.Kinds
+			)
+			// Type kinds only — the base Entity kinds are exactly what may be polluted across platforms,
+			// so they can't be used to classify a node.
+			adKinds = ad.NodeKinds()
+			adKinds = adKinds.Remove(ad.Entity)
+			azureKinds = azure.NodeKinds()
+			azureKinds = azureKinds.Remove(azure.Entity)
+
+			if err := stripForeignSourceKinds(tx, ad.Entity, adKinds, registeredSourceKinds); err != nil {
 				return err
-			} else {
-				for _, node := range nodes {
-					kindsToRemove := graph.Kinds{}
-					for _, kind := range removableSourceKinds {
-						if node.Kinds.ContainsOneOf(kind) {
-							kindsToRemove = append(kindsToRemove, kind)
-						}
-					}
-					if len(kindsToRemove) == 0 {
-						continue
-					}
-					node.DeleteKinds(kindsToRemove...)
-					if err := tx.UpdateNode(node); err != nil {
-						return err
-					}
-				}
 			}
-			return nil
+			return stripForeignSourceKinds(tx, azure.Entity, azureKinds, registeredSourceKinds)
 		})
 	}
+}
+
+// stripForeignSourceKinds removes every registered source kind other than
+// preservedKind from each node whose kind is in platformNodeKinds. Type
+// kinds (e.g. ad.User, azure.User) are not stored in source_kinds and
+// therefore remain on the node.
+func stripForeignSourceKinds(tx graph.Transaction, preservedKind graph.Kind, platformNodeKinds []graph.Kind, registeredSourceKinds []model.SourceKind) error {
+	var removableSourceKinds graph.Kinds
+	for _, sourceKind := range registeredSourceKinds {
+		kind := sourceKind.ToKind()
+		if kind == preservedKind {
+			continue
+		}
+		removableSourceKinds = append(removableSourceKinds, kind)
+	}
+
+	if len(removableSourceKinds) == 0 {
+		return nil
+	}
+
+	nodes, err := ops.FetchNodes(tx.Nodes().Filter(query.KindIn(query.Node(), platformNodeKinds...)))
+	if err != nil {
+		return err
+	}
+
+	for _, node := range nodes {
+		var kindsToRemove graph.Kinds
+		for _, kind := range removableSourceKinds {
+			if node.Kinds.ContainsOneOf(kind) {
+				kindsToRemove = append(kindsToRemove, kind)
+			}
+		}
+		if len(kindsToRemove) == 0 {
+			continue
+		}
+		node.DeleteKinds(kindsToRemove...)
+		if err := tx.UpdateNode(node); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func Version_910_Migration(ctx context.Context, db graph.Database) error {

--- a/cmd/api/src/migrations/manifest_integration_test.go
+++ b/cmd/api/src/migrations/manifest_integration_test.go
@@ -1,0 +1,162 @@
+// Copyright 2026 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build integration
+
+package migrations_test
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/peterldowns/pgtestdb"
+	"github.com/specterops/bloodhound/cmd/api/src/auth"
+	"github.com/specterops/bloodhound/cmd/api/src/config"
+	"github.com/specterops/bloodhound/cmd/api/src/database"
+	"github.com/specterops/bloodhound/cmd/api/src/test/integration/utils"
+	"github.com/specterops/bloodhound/packages/go/graphschema"
+	"github.com/specterops/dawgs"
+	"github.com/specterops/dawgs/drivers/pg"
+	"github.com/specterops/dawgs/graph"
+	"github.com/stretchr/testify/require"
+)
+
+// IntegrationTestSuite carries only the fields needed to exercise
+// Version_920_Migration: a context, a graph database handle, and a
+// BloodhoundDB that satisfies database.SourceKindsData.
+type IntegrationTestSuite struct {
+	context    context.Context
+	graphDB    graph.Database
+	bhDatabase *database.BloodhoundDB
+}
+
+// setupIntegrationTestSuite stands up an isolated relational and graph
+// database for a single migration test. The BloodhoundDB SQL migrations
+// auto-register ad.Entity and azure.Entity as source kinds; tests that need
+// additional source kinds can call bhDatabase.RegisterSourceKind directly.
+func setupIntegrationTestSuite(t *testing.T) *IntegrationTestSuite {
+	t.Helper()
+
+	var (
+		ctx      = context.Background()
+		connConf = pgtestdb.Custom(t, getPostgresConfig(t), pgtestdb.NoopMigrator{})
+	)
+
+	cfg, err := config.NewDefaultConnectionConfiguration(connConf.URL())
+	require.NoError(t, err)
+
+	pool, err := pg.NewPool(cfg.Database)
+	require.NoError(t, err)
+
+	gormDB, dbPool, err := database.OpenDatabase(cfg.Database)
+	require.NoError(t, err)
+
+	bhDatabase := database.NewBloodhoundDB(gormDB, dbPool, auth.NewIdentityResolver(), cfg)
+	require.NoError(t, bhDatabase.Migrate(ctx))
+	require.NoError(t, bhDatabase.PopulateExtensionData(ctx))
+
+	graphDB, err := dawgs.Open(ctx, pg.DriverName, dawgs.Config{
+		GraphQueryMemoryLimit: 1024 * 1024 * 1024 * 2,
+		ConnectionString:      connConf.URL(),
+		Pool:                  pool,
+	})
+	require.NoError(t, err)
+
+	err = graphDB.AssertSchema(ctx, graphschema.DefaultGraphSchema())
+	require.NoError(t, err)
+
+	return &IntegrationTestSuite{
+		context:    ctx,
+		graphDB:    graphDB,
+		bhDatabase: bhDatabase,
+	}
+}
+
+func (s *IntegrationTestSuite) teardownIntegrationTestSuite(t *testing.T) {
+	t.Helper()
+
+	if s.graphDB != nil {
+		if err := s.graphDB.Close(s.context); err != nil {
+			t.Logf("failed to close GraphDB: %v", err)
+		}
+	}
+	if s.bhDatabase != nil {
+		s.bhDatabase.Close(s.context)
+	}
+}
+
+// createNodes writes each provided node to the graph and back-fills the node
+// ID so callers can reference the persisted nodes in assertions.
+func (s *IntegrationTestSuite) createNodes(t *testing.T, nodes ...*graph.Node) {
+	t.Helper()
+
+	for _, node := range nodes {
+		err := s.graphDB.WriteTransaction(s.context, func(tx graph.Transaction) error {
+			createdNode, err := tx.CreateNode(node.Properties, node.Kinds...)
+			if err != nil {
+				return err
+			}
+			node.ID = createdNode.ID
+			return nil
+		})
+		require.NoError(t, err, "unexpected error occurred while creating nodes")
+	}
+}
+
+// getPostgresConfig reads key/value pairs from the default integration
+// config file and creates a pgtestdb configuration object.
+func getPostgresConfig(t *testing.T) pgtestdb.Config {
+	t.Helper()
+
+	config, err := utils.LoadIntegrationTestConfig()
+	require.NoError(t, err)
+
+	environmentMap := make(map[string]string)
+	for _, entry := range strings.Fields(config.Database.Connection) {
+		if parts := strings.SplitN(entry, "=", 2); len(parts) == 2 {
+			environmentMap[parts[0]] = parts[1]
+		}
+	}
+
+	if strings.HasPrefix(environmentMap["host"], "/") {
+		return pgtestdb.Config{
+			DriverName: "pgx",
+			User:       environmentMap["user"],
+			Password:   environmentMap["password"],
+			Database:   environmentMap["dbname"],
+			Options:    fmt.Sprintf("host=%s", url.PathEscape(environmentMap["host"])),
+			TestRole: &pgtestdb.Role{
+				Username:     environmentMap["user"],
+				Password:     environmentMap["password"],
+				Capabilities: "NOSUPERUSER NOCREATEROLE",
+			},
+		}
+	}
+
+	return pgtestdb.Config{
+		DriverName:                "pgx",
+		Host:                      environmentMap["host"],
+		Port:                      environmentMap["port"],
+		User:                      environmentMap["user"],
+		Password:                  environmentMap["password"],
+		Database:                  environmentMap["dbname"],
+		Options:                   "sslmode=disable",
+		ForceTerminateConnections: true,
+	}
+}

--- a/cmd/api/src/migrations/migrations_integration_test.go
+++ b/cmd/api/src/migrations/migrations_integration_test.go
@@ -21,7 +21,6 @@ package migrations_test
 import (
 	"context"
 	"errors"
-	"fmt"
 	"testing"
 
 	"github.com/specterops/bloodhound/cmd/api/src/migrations"
@@ -243,13 +242,6 @@ func TestVersion_920_Migration(t *testing.T) {
 		suite.createNodes(t, azUserPolluted, azGroupPolluted, azTenantClean, adNodeUntouched, ogNodeUntouched)
 
 		require.NoError(t, suite.bhDatabase.RegisterSourceKind(suite.context)(graph.StringKind("CustomKind")))
-
-		suite.graphDB.ReadTransaction(suite.context, func(tx graph.Transaction) error {
-			azUser, err := ops.FetchNode(tx, azUserPolluted.ID)
-			require.NoError(t, err)
-			fmt.Println(azUser)
-			return nil
-		})
 
 		err := migrations.Version_920_Migration(suite.bhDatabase)(suite.context, suite.graphDB)
 		require.NoError(t, err)

--- a/cmd/api/src/migrations/migrations_integration_test.go
+++ b/cmd/api/src/migrations/migrations_integration_test.go
@@ -27,6 +27,8 @@ import (
 	"github.com/specterops/bloodhound/cmd/api/src/test/integration"
 	"github.com/specterops/bloodhound/packages/go/graphschema"
 	"github.com/specterops/bloodhound/packages/go/graphschema/ad"
+	"github.com/specterops/bloodhound/packages/go/graphschema/azure"
+	"github.com/specterops/bloodhound/packages/go/graphschema/common"
 	"github.com/specterops/dawgs/graph"
 	"github.com/specterops/dawgs/ops"
 	"github.com/specterops/dawgs/query"
@@ -125,5 +127,109 @@ func TestVersion_910_Migration(t *testing.T) {
 				return nil
 			})
 		})
+	})
+}
+
+// newADNode returns an unsaved AD-kinded node with the given name and type kind,
+// optionally polluted with extra kinds that the migration is expected to strip.
+func newADNode(name string, typeKind graph.Kind, extraKinds ...graph.Kind) *graph.Node {
+	kinds := graph.Kinds{ad.Entity, typeKind}
+	kinds = append(kinds, extraKinds...)
+	return &graph.Node{
+		Kinds: kinds,
+		Properties: graph.AsProperties(graph.PropertyMap{
+			common.Name:     name,
+			common.ObjectID: name,
+		}),
+	}
+}
+
+func TestVersion_920_Migration(t *testing.T) {
+	t.Run("strips non-ad.Entity source kinds from AD nodes", func(t *testing.T) {
+		suite := setupIntegrationTestSuite(t)
+		t.Cleanup(func() { suite.teardownIntegrationTestSuite(t) })
+
+		var (
+			adUserPolluted     = newADNode("PollutedUser", ad.User, azure.Entity, graph.StringKind("CustomKind"))
+			adComputerPolluted = newADNode("PollutedComputer", ad.Computer, graph.StringKind("CustomKind"))
+			adGroupClean       = newADNode("CleanGroup", ad.Group)
+			azNodeUntouched    = &graph.Node{
+				Kinds: graph.Kinds{azure.Entity, azure.User},
+				Properties: graph.AsProperties(graph.PropertyMap{
+					common.Name:     "AZUser",
+					common.ObjectID: "AZUser",
+				}),
+			}
+			ogNodeUntouched = &graph.Node{
+				Kinds: graph.Kinds{graph.StringKind("CustomKind")},
+				Properties: graph.AsProperties(graph.PropertyMap{
+					common.Name:     "OGNode",
+					common.ObjectID: "OGNode",
+				}),
+			}
+		)
+
+		suite.createNodes(t, adUserPolluted, adComputerPolluted, adGroupClean, azNodeUntouched, ogNodeUntouched)
+
+		// ad.Entity and azure.Entity are auto-registered as source kinds by the
+		// SQL migrations; only CustomKind needs to be registered explicitly.
+		require.NoError(t, suite.bhDatabase.RegisterSourceKind(suite.context)(graph.StringKind("CustomKind")))
+
+		err := migrations.Version_920_Migration(suite.bhDatabase)(suite.context, suite.graphDB)
+		require.NoError(t, err)
+
+		err = suite.graphDB.ReadTransaction(suite.context, func(tx graph.Transaction) error {
+			adUser, err := ops.FetchNode(tx, adUserPolluted.ID)
+			require.NoError(t, err)
+			require.True(t, adUser.Kinds.ContainsOneOf(ad.Entity), "ad.Entity must be preserved")
+			require.True(t, adUser.Kinds.ContainsOneOf(ad.User), "ad.User type kind must be preserved")
+			require.False(t, adUser.Kinds.ContainsOneOf(azure.Entity), "azure.Entity must be stripped")
+			require.False(t, adUser.Kinds.ContainsOneOf(graph.StringKind("CustomKind")), "CustomKind must be stripped")
+
+			adComputer, err := ops.FetchNode(tx, adComputerPolluted.ID)
+			require.NoError(t, err)
+			require.True(t, adComputer.Kinds.ContainsOneOf(ad.Entity))
+			require.True(t, adComputer.Kinds.ContainsOneOf(ad.Computer))
+			require.False(t, adComputer.Kinds.ContainsOneOf(graph.StringKind("CustomKind")))
+
+			adGroup, err := ops.FetchNode(tx, adGroupClean.ID)
+			require.NoError(t, err)
+			require.True(t, adGroup.Kinds.ContainsOneOf(ad.Entity))
+			require.True(t, adGroup.Kinds.ContainsOneOf(ad.Group))
+
+			azNode, err := ops.FetchNode(tx, azNodeUntouched.ID)
+			require.NoError(t, err)
+			require.True(t, azNode.Kinds.ContainsOneOf(azure.Entity), "non-AD nodes must not be touched")
+
+			ogNode, err := ops.FetchNode(tx, ogNodeUntouched.ID)
+			require.NoError(t, err)
+			require.True(t, ogNode.Kinds.ContainsOneOf(graph.StringKind("CustomKind")), "non-AD nodes must not be touched")
+
+			return nil
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("is a no-op when SourceKindsData is nil", func(t *testing.T) {
+		suite := setupIntegrationTestSuite(t)
+		t.Cleanup(func() { suite.teardownIntegrationTestSuite(t) })
+
+		require.NoError(t, suite.bhDatabase.RegisterSourceKind(suite.context)(graph.StringKind("CustomKind")))
+		require.NoError(t, suite.graphDB.RefreshKinds(suite.context))
+
+		adUserPolluted := newADNode("PollutedUser", ad.User, azure.Entity, graph.StringKind("CustomKind"))
+		suite.createNodes(t, adUserPolluted)
+
+		err := migrations.Version_920_Migration(nil)(suite.context, suite.graphDB)
+		require.NoError(t, err)
+
+		err = suite.graphDB.ReadTransaction(suite.context, func(tx graph.Transaction) error {
+			adUser, err := ops.FetchNode(tx, adUserPolluted.ID)
+			require.NoError(t, err)
+			require.True(t, adUser.Kinds.ContainsOneOf(azure.Entity), "azure.Entity should remain when migration is skipped")
+			require.True(t, adUser.Kinds.ContainsOneOf(graph.StringKind("CustomKind")), "CustomKind should remain when migration is skipped")
+			return nil
+		})
+		require.NoError(t, err)
 	})
 }

--- a/cmd/api/src/migrations/migrations_integration_test.go
+++ b/cmd/api/src/migrations/migrations_integration_test.go
@@ -292,7 +292,6 @@ func TestVersion_920_Migration(t *testing.T) {
 		t.Cleanup(func() { suite.teardownIntegrationTestSuite(t) })
 
 		require.NoError(t, suite.bhDatabase.RegisterSourceKind(suite.context)(graph.StringKind("CustomKind")))
-		require.NoError(t, suite.graphDB.RefreshKinds(suite.context))
 
 		adUserPolluted := newADNode("PollutedUser", ad.User, azure.Entity, graph.StringKind("CustomKind"))
 		suite.createNodes(t, adUserPolluted)

--- a/cmd/api/src/migrations/migrations_integration_test.go
+++ b/cmd/api/src/migrations/migrations_integration_test.go
@@ -21,6 +21,7 @@ package migrations_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/specterops/bloodhound/cmd/api/src/migrations"
@@ -133,7 +134,17 @@ func TestVersion_910_Migration(t *testing.T) {
 // newADNode returns an unsaved AD-kinded node with the given name and type kind,
 // optionally polluted with extra kinds that the migration is expected to strip.
 func newADNode(name string, typeKind graph.Kind, extraKinds ...graph.Kind) *graph.Node {
-	kinds := graph.Kinds{ad.Entity, typeKind}
+	return newPlatformNode(name, ad.Entity, typeKind, extraKinds...)
+}
+
+// newAzureNode returns an unsaved Azure-kinded node with the given name and type kind,
+// optionally polluted with extra kinds that the migration is expected to strip.
+func newAzureNode(name string, typeKind graph.Kind, extraKinds ...graph.Kind) *graph.Node {
+	return newPlatformNode(name, azure.Entity, typeKind, extraKinds...)
+}
+
+func newPlatformNode(name string, baseKind, typeKind graph.Kind, extraKinds ...graph.Kind) *graph.Node {
+	kinds := graph.Kinds{baseKind, typeKind}
 	kinds = append(kinds, extraKinds...)
 	return &graph.Node{
 		Kinds: kinds,
@@ -199,11 +210,77 @@ func TestVersion_920_Migration(t *testing.T) {
 
 			azNode, err := ops.FetchNode(tx, azNodeUntouched.ID)
 			require.NoError(t, err)
-			require.True(t, azNode.Kinds.ContainsOneOf(azure.Entity), "non-AD nodes must not be touched")
+			require.True(t, azNode.Kinds.ContainsOneOf(azure.Entity), "azure.Entity must be preserved on clean azure nodes")
+			require.True(t, azNode.Kinds.ContainsOneOf(azure.User), "azure type kinds must be preserved")
 
 			ogNode, err := ops.FetchNode(tx, ogNodeUntouched.ID)
 			require.NoError(t, err)
-			require.True(t, ogNode.Kinds.ContainsOneOf(graph.StringKind("CustomKind")), "non-AD nodes must not be touched")
+			require.True(t, ogNode.Kinds.ContainsOneOf(graph.StringKind("CustomKind")), "OpenGraph nodes must not be touched")
+
+			return nil
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("strips non-azure.Entity source kinds from Azure nodes", func(t *testing.T) {
+		suite := setupIntegrationTestSuite(t)
+		t.Cleanup(func() { suite.teardownIntegrationTestSuite(t) })
+
+		var (
+			azUserPolluted  = newAzureNode("PollutedAZUser", azure.User, ad.Entity, graph.StringKind("CustomKind"))
+			azGroupPolluted = newAzureNode("PollutedAZGroup", azure.Group, graph.StringKind("CustomKind"))
+			azTenantClean   = newAzureNode("CleanTenant", azure.Tenant)
+			adNodeUntouched = newADNode("ADUser", ad.User)
+			ogNodeUntouched = &graph.Node{
+				Kinds: graph.Kinds{graph.StringKind("CustomKind")},
+				Properties: graph.AsProperties(graph.PropertyMap{
+					common.Name:     "OGNode",
+					common.ObjectID: "OGNode",
+				}),
+			}
+		)
+
+		suite.createNodes(t, azUserPolluted, azGroupPolluted, azTenantClean, adNodeUntouched, ogNodeUntouched)
+
+		require.NoError(t, suite.bhDatabase.RegisterSourceKind(suite.context)(graph.StringKind("CustomKind")))
+
+		suite.graphDB.ReadTransaction(suite.context, func(tx graph.Transaction) error {
+			azUser, err := ops.FetchNode(tx, azUserPolluted.ID)
+			require.NoError(t, err)
+			fmt.Println(azUser)
+			return nil
+		})
+
+		err := migrations.Version_920_Migration(suite.bhDatabase)(suite.context, suite.graphDB)
+		require.NoError(t, err)
+
+		err = suite.graphDB.ReadTransaction(suite.context, func(tx graph.Transaction) error {
+			azUser, err := ops.FetchNode(tx, azUserPolluted.ID)
+			require.NoError(t, err)
+			require.True(t, azUser.Kinds.ContainsOneOf(azure.Entity), "azure.Entity must be preserved")
+			require.True(t, azUser.Kinds.ContainsOneOf(azure.User), "azure.User type kind must be preserved")
+			require.False(t, azUser.Kinds.ContainsOneOf(ad.Entity), "ad.Entity must be stripped")
+			require.False(t, azUser.Kinds.ContainsOneOf(graph.StringKind("CustomKind")), "CustomKind must be stripped")
+
+			azGroup, err := ops.FetchNode(tx, azGroupPolluted.ID)
+			require.NoError(t, err)
+			require.True(t, azGroup.Kinds.ContainsOneOf(azure.Entity))
+			require.True(t, azGroup.Kinds.ContainsOneOf(azure.Group))
+			require.False(t, azGroup.Kinds.ContainsOneOf(graph.StringKind("CustomKind")))
+
+			azTenant, err := ops.FetchNode(tx, azTenantClean.ID)
+			require.NoError(t, err)
+			require.True(t, azTenant.Kinds.ContainsOneOf(azure.Entity))
+			require.True(t, azTenant.Kinds.ContainsOneOf(azure.Tenant))
+
+			adNode, err := ops.FetchNode(tx, adNodeUntouched.ID)
+			require.NoError(t, err)
+			require.True(t, adNode.Kinds.ContainsOneOf(ad.Entity), "ad.Entity must be preserved on clean AD nodes")
+			require.True(t, adNode.Kinds.ContainsOneOf(ad.User), "AD type kinds must be preserved")
+
+			ogNode, err := ops.FetchNode(tx, ogNodeUntouched.ID)
+			require.NoError(t, err)
+			require.True(t, ogNode.Kinds.ContainsOneOf(graph.StringKind("CustomKind")), "OpenGraph nodes must not be touched")
 
 			return nil
 		})

--- a/cmd/api/src/services/entrypoint.go
+++ b/cmd/api/src/services/entrypoint.go
@@ -97,7 +97,7 @@ func Entrypoint(ctx context.Context, cfg config.Configuration, connections boots
 	if !cfg.DisableMigrations {
 		if err := bootstrap.MigrateDB(ctx, cfg, connections.RDMS, config.NewDefaultAdminConfiguration); err != nil {
 			return nil, fmt.Errorf("rdms migration error: %w", err)
-		} else if err := migrations.NewGraphMigrator(connections.Graph).Migrate(ctx); err != nil {
+		} else if err := migrations.NewGraphMigrator(connections.Graph, migrations.WithSourceKinds(connections.RDMS)).Migrate(ctx); err != nil {
 			return nil, fmt.Errorf("graph migration error: %w", err)
 		} else if err := bootstrap.PopulateExtensionData(ctx, connections.RDMS); err != nil {
 			return nil, fmt.Errorf("extensions data population error: %w", err)

--- a/packages/go/graphify/graph/graph.go
+++ b/packages/go/graphify/graph/graph.go
@@ -177,7 +177,7 @@ func (s *CommunityGraphService) InitializeService(ctx context.Context, cfg confi
 
 	if err := s.db.Migrate(ctx); err != nil {
 		return fmt.Errorf("error migrating database: %w", err)
-	} else if err := migrations.NewGraphMigrator(graphDB).Migrate(ctx); err != nil {
+	} else if err := migrations.NewGraphMigrator(graphDB, migrations.WithSourceKinds(s.db)).Migrate(ctx); err != nil {
 		return fmt.Errorf("error migrating graph schema: %w", err)
 	} else if err := s.db.PopulateExtensionData(ctx); err != nil {
 		return fmt.Errorf("error populating extension data: %w", err)


### PR DESCRIPTION
## Description
- This graph migration strips all AD nodes of any source kind that is NOT ad.Entity ("Base")
- It also strips all AZ nodes of any source kind that is NOT azure.Entity ("AZBase")


## Motivation and Context
This resolves a longstanding data integrity issue. OpenGraph ingest before BED-8030 (merged to main as of this week) allowed users to connect OpenGraph nodes to existing AD and Azure nodes, and due to the way the wire up worked, the AD/AZ node would be contaminated with whatever sourcekind came from the OpenGraph data file.


## How Has This Been Tested?
- Integration test for this migration
- Manual test: you can run BHCE or BHE, and manually change the graph migration node to anything LESS THAN 9.2.0. Mock up some dirty nodes, and then hot-reload your app, and you'll see the data get cleaned up.

## Screenshots (optional):

## Types of changes
- Chore (a change that does not modify the application functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [ ] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [ ] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [ ] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Migration added to remove incorrect cross-platform source-kind classifications from Active Directory and Azure nodes.

* **Chores**
  * Migration framework now supports optional relational source-kind data so manifests can be chosen based on available data.
  * Startup now wires the migrator with relational source-kind data when running migrations.

* **Tests**
  * Added integration tests and helpers validating the new migration behavior, including noop behavior when relational data is absent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->