### PR TITLE
fix(Dialog): prevent max-height overflow - BED-7580

### DIFF
--- a/packages/javascript/bh-shared-ui/src/components/FileDrop/FileDrop.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/FileDrop/FileDrop.tsx
@@ -62,7 +62,7 @@ const FileDrop: React.FC<{
     return (
         <div
             className={cn(
-                'cursor-pointer h-80 rounded font-bold text-center border-2 border-contrast px-32 relative flex flex-col items-center justify-center bg-neutral-2',
+                'cursor-pointer h-80 rounded font-bold text-center border-2 border-contrast px-32 py-4 relative flex flex-col items-center justify-center bg-neutral-2',
                 {
                     'cursor-default opacity-50': disabled,
                     'bg-neutral-3': isHoverActive || isDragActive || disabled,

--- a/packages/javascript/bh-shared-ui/src/components/FileDrop/FileDrop.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/FileDrop/FileDrop.tsx
@@ -25,7 +25,8 @@ const FileDrop: React.FC<{
     accept?: string[];
     multiple?: boolean;
     icon?: IconDefinition;
-}> = ({ onDrop, disabled, accept, multiple = true, icon = faInbox }) => {
+    className?: string;
+}> = ({ onDrop, disabled, accept, multiple = true, icon = faInbox, className }) => {
     const inputRef = useRef<HTMLInputElement>(null);
     const [isDragActive, setDragActive] = useState(false);
     const [isHoverActive, setHoverActive] = useState(false);
@@ -66,7 +67,8 @@ const FileDrop: React.FC<{
                 {
                     'cursor-default opacity-50': disabled,
                     'bg-neutral-3': isHoverActive || isDragActive || disabled,
-                }
+                },
+                className
             )}>
             <input
                 data-testid='ingest-file-upload'

--- a/packages/javascript/bh-shared-ui/src/hooks/useExecuteOnFileDrag.ts
+++ b/packages/javascript/bh-shared-ui/src/hooks/useExecuteOnFileDrag.ts
@@ -14,6 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import { useEffect } from 'react';
+import { isQuickUploadExcludedById } from '../utils/quickUpload';
 import type { AcceptedIngestType } from './useFileIngest';
 
 type ExecuteOnFileDragOptions = {
@@ -32,6 +33,13 @@ export const useExecuteOnFileDrag = (
         const onDragEnter = (e: DragEvent) => {
             // Hook only executes when provided condition returns true
             if (!condition()) {
+                return;
+            }
+
+            // Re-check exclusion ids against the live DOM at drag time. The condition closure
+            // above can hold a stale value when an excluded element (e.g. ImportQueryDialog)
+            // mounts without triggering a re-render of the consumer.
+            if (isQuickUploadExcludedById()) {
                 return;
             }
 

--- a/packages/javascript/bh-shared-ui/src/utils/quickUpload.ts
+++ b/packages/javascript/bh-shared-ui/src/utils/quickUpload.ts
@@ -28,7 +28,7 @@ export enum QuickUploadExclusionPaths {
     OpenGraphManagementPath = '/administration/opengraph-management',
 }
 
-const getExcludedIds = () => {
+export const isQuickUploadExcludedById = () => {
     const ids = Object.values(QuickUploadExclusionIds);
 
     for (const id of ids) {
@@ -44,7 +44,7 @@ export const useQuickUploadEnabled = () => {
     const { pathname } = useLocation();
     const { checkPermission } = usePermissions();
 
-    const isExcludedById = getExcludedIds();
+    const isExcludedById = isQuickUploadExcludedById();
     const isExcludedByPath = Object.values(QuickUploadExclusionPaths).includes(pathname as QuickUploadExclusionPaths);
     const hasPermissionToUpload = checkPermission(Permission.GRAPH_DB_INGEST);
 

--- a/packages/javascript/bh-shared-ui/src/views/Explore/ExploreSearch/SavedQueries/ImportQueryDialog.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/Explore/ExploreSearch/SavedQueries/ImportQueryDialog.tsx
@@ -31,7 +31,7 @@ import FileStatusListItem from '../../../../components/FileStatusListItem';
 import { FileForIngest, FileStatus, FileUploadStep } from '../../../../components/FileUploadDialog/types';
 import { useImportSavedQuery } from '../../../../hooks';
 import { useNotifications } from '../../../../providers';
-import { QuickUploadExclusionIds } from '../../../../utils';
+import { cn, QuickUploadExclusionIds } from '../../../../utils';
 
 const allowedFileTypes = ['application/json', 'application/zip', 'application/x-zip-compressed'];
 
@@ -200,14 +200,20 @@ const ImportQueryDialog: React.FC<{
                     }}
                     maxWidth='sm'
                     id={QuickUploadExclusionIds.ImportQueryDialog}>
-                    <DialogTitle>Upload Files</DialogTitle>
-
-                    {fileUploadStep === FileUploadStep.ADD_FILES && (
-                        <FileDrop onDrop={handleFileDrop} disabled={false} accept={allowedFileTypes} />
-                    )}
-                    {fileUploadStep === FileUploadStep.UPLOAD && uploadMessage && (
-                        <div className='text-lg mb-4'>{uploadMessage}</div>
-                    )}
+                    <DialogTitle className='flex flex-col gap-2'>
+                        <div>Upload Files</div>
+                        {fileUploadStep === FileUploadStep.ADD_FILES && (
+                            <FileDrop
+                                onDrop={handleFileDrop}
+                                disabled={false}
+                                accept={allowedFileTypes}
+                                className={cn({ 'h-40': filesForIngest.length > 0 })}
+                            />
+                        )}
+                        {fileUploadStep === FileUploadStep.UPLOAD && uploadMessage && (
+                            <div className='text-lg mb-4'>{uploadMessage}</div>
+                        )}
+                    </DialogTitle>
 
                     {filesForIngest.length > 0 && (
                         <>

--- a/packages/javascript/doodle-ui/src/components/Dialog/Dialog.stories.tsx
+++ b/packages/javascript/doodle-ui/src/components/Dialog/Dialog.stories.tsx
@@ -25,10 +25,16 @@ const meta = {
     component: DialogContent,
     parameters: {
         layout: 'centered',
+        docs: {
+            description: {
+                component:
+                    'A modal dialog that overlays the page to focus the user on a single, self-contained task. Use it to confirm destructive actions, request input that interrupts the current flow, or surface contextual information that the user must acknowledge before continuing.',
+            },
+        },
     },
     // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/writing-docs/autodocs
     tags: ['autodocs'],
-    // More on argTypes: https://storybook.js.org/docs/api/argtypes
+    // More on argTypes: https://storybook.js.org/docs/api/doc-blocks/doc-block-argtypes
     argTypes: {
         DialogOverlayProps: {
             control: 'select',
@@ -36,10 +42,35 @@ const meta = {
             mapping: {
                 blur: { blurBackground: true },
             },
+            description:
+                'Props forwarded to the underlying `DialogOverlay`. Use the `blur` option to enable a backdrop blur (`blurBackground: true`) behind the dialog.',
+            table: {
+                type: { summary: 'DialogOverlayProps' },
+                defaultValue: { summary: '{ blurBackground: false }' },
+            },
         },
         maxWidth: {
             control: 'select',
             options: ['xl', 'lg', 'md', 'sm', 'xs'],
+            description:
+                'Constrains the maximum width of the dialog. Values match the MUI breakpoint scale: `xs` (444px), `sm` (600px), `md` (900px), `lg` (1200px), `xl` (1536px).',
+            table: {
+                type: { summary: "'xl' | 'lg' | 'md' | 'sm' | 'xs'" },
+                defaultValue: { summary: 'sm' },
+            },
+        },
+        allowNav: {
+            control: 'boolean',
+            description:
+                'When `true`, lowers the overlay z-index and re-enables pointer events on the document body so the user can still interact with the surrounding application (for example, switching tabs) while the dialog is open.',
+            table: {
+                type: { summary: 'boolean' },
+                defaultValue: { summary: 'false' },
+            },
+        },
+        className: {
+            control: 'text',
+            description: 'Additional CSS class names to apply to the `DialogContent` container.',
         },
     },
     args: { DialogOverlayProps: { blurBackground: false }, maxWidth: 'sm' },
@@ -53,7 +84,7 @@ const meta = {
                     <DialogContent {...args}>
                         <DialogTitle>Are you absolutely sure?</DialogTitle>
                         <VisuallyHidden>
-                            something that we want to hide visually but still want in the DOM for accessibility
+                            Something that we want to hide visually but still want in the DOM for accessibility
                         </VisuallyHidden>
                         <DialogDescription>
                             This action cannot be undone. This will permanently delete your account and remove your data
@@ -75,4 +106,106 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const DefaultDialog: Story = {};
+export const DefaultDialog: Story = {
+    parameters: {
+        docs: {
+            description: {
+                story: 'A standard confirmation dialog composed of a `DialogTitle`, a `DialogDescription`, and a `DialogActions` footer. Clicking the trigger opens the dialog. Open dialogs may be dismissed either by clicking the `DialogClose` button or by clicking outside the dialog on the overlay. Use `VisuallyHidden` to provide accessible content (such as an alternate description) that should not appear visually.',
+            },
+            source: {
+                code: `
+<Dialog>
+    <DialogTrigger asChild>
+        <Button variant='primary'>Default Dialog</Button>
+    </DialogTrigger>
+    <DialogPortal>
+        <DialogContent>
+            <DialogTitle>Are you absolutely sure?</DialogTitle>
+            <VisuallyHidden>
+                Something that we want to hide visually but still want in the DOM for accessibility
+            </VisuallyHidden>
+            <DialogDescription>
+                This action cannot be undone. This will permanently delete your account and remove your data
+                from our servers.
+            </DialogDescription>
+            <DialogActions className='flex justify-end gap-4'>
+                <DialogClose asChild>
+                    <Button variant='secondary'>Cancel</Button>
+                </DialogClose>
+                <Button>Submit</Button>
+            </DialogActions>
+        </DialogContent>
+    </DialogPortal>
+</Dialog>`,
+                language: 'tsx',
+                type: 'code',
+            },
+        },
+    },
+};
+
+const loremParagraph =
+    'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.';
+
+export const OverflowingContent: Story = {
+    parameters: {
+        docs: {
+            description: {
+                story: 'When the body content exceeds the available height, only the middle section scrolls — the `DialogTitle` stays pinned to the top of the dialog and the `DialogActions` footer stays pinned to the bottom. The dialog is constrained by `max-h-[calc(100vh-32px)]` and any children other than the title and actions are placed inside an internal scrollable container. This works for both `DialogDescription` and arbitrary JSX children.',
+            },
+            source: {
+                code: `
+<Dialog>
+    <DialogTrigger asChild>
+        <Button variant='primary'>Overflowing Dialog</Button>
+    </DialogTrigger>
+    <DialogPortal>
+        <DialogContent>
+            <DialogTitle>Terms and Conditions</DialogTitle>
+            <DialogDescription>A bunch of repeating text</DialogDescription>
+            {Array.from({ length: 25 }, (_, index) => (
+                <p key={index} className='mb-4'>
+                    {loremParagraph}
+                </p>
+            ))}
+            <DialogActions className='flex justify-end gap-4'>
+                <DialogClose asChild>
+                    <Button variant='secondary'>Cancel</Button>
+                </DialogClose>
+                <Button>Accept</Button>
+            </DialogActions>
+        </DialogContent>
+    </DialogPortal>
+</Dialog>`,
+                language: 'tsx',
+                type: 'code',
+            },
+        },
+    },
+    render: (args) => {
+        return (
+            <Dialog>
+                <DialogTrigger asChild>
+                    <Button variant='primary'>Overflowing Dialog</Button>
+                </DialogTrigger>
+                <DialogPortal>
+                    <DialogContent {...args}>
+                        <DialogTitle>Terms and Conditions</DialogTitle>
+                        <DialogDescription>A bunch of repeating text</DialogDescription>
+                        {Array.from({ length: 25 }, (_, index) => (
+                            <p key={index} className='mb-4'>
+                                {loremParagraph}
+                            </p>
+                        ))}
+                        <DialogActions className='flex justify-end gap-4'>
+                            <DialogClose asChild>
+                                <Button variant='secondary'>Cancel</Button>
+                            </DialogClose>
+                            <Button>Accept</Button>
+                        </DialogActions>
+                    </DialogContent>
+                </DialogPortal>
+            </Dialog>
+        );
+    },
+};

--- a/packages/javascript/doodle-ui/src/components/Dialog/Dialog.stories.tsx
+++ b/packages/javascript/doodle-ui/src/components/Dialog/Dialog.stories.tsx
@@ -49,6 +49,15 @@ const meta = {
                 defaultValue: { summary: '{ blurBackground: false }' },
             },
         },
+        disableStickyLayout: {
+            control: 'boolean',
+            description:
+                'When `true`, opts out of the default sticky layout. By default, `DialogTitle` and `DialogActions` are pinned to the top and bottom of `DialogContent` and any other children are placed inside an internal scrollable container, so the title and actions remain in view while the middle content scrolls. With this prop enabled, all children render in source order and the entire dialog scrolls as a single block — a difference that only becomes visible when the content overflows.',
+            table: {
+                type: { summary: 'boolean' },
+                defaultValue: { summary: 'false' },
+            },
+        },
         maxWidth: {
             control: 'select',
             options: ['xl', 'lg', 'md', 'sm', 'xs'],
@@ -187,6 +196,70 @@ export const OverflowingContent: Story = {
             <Dialog>
                 <DialogTrigger asChild>
                     <Button variant='primary'>Overflowing Dialog</Button>
+                </DialogTrigger>
+                <DialogPortal>
+                    <DialogContent {...args}>
+                        <DialogTitle>Terms and Conditions</DialogTitle>
+                        <DialogDescription>A bunch of repeating text</DialogDescription>
+                        {Array.from({ length: 25 }, (_, index) => (
+                            <p key={index} className='mb-4'>
+                                {loremParagraph}
+                            </p>
+                        ))}
+                        <DialogActions className='flex justify-end gap-4'>
+                            <DialogClose asChild>
+                                <Button variant='secondary'>Cancel</Button>
+                            </DialogClose>
+                            <Button>Accept</Button>
+                        </DialogActions>
+                    </DialogContent>
+                </DialogPortal>
+            </Dialog>
+        );
+    },
+};
+
+export const OverflowingContentWithDisabledStickyLayout: Story = {
+    parameters: {
+        docs: {
+            description: {
+                story: 'Setting `disableStickyLayout` to `true` opts out of the default sticky layout behavior. The `DialogTitle` and `DialogActions` are no longer pinned to the top and bottom of the dialog, and children are rendered in source order without an internal scrollable container. When the body content exceeds the available height the entire `DialogContent` scrolls as a single block, so the title and actions scroll out of view along with the rest of the content. Use this when you need full control over the dialog layout.',
+            },
+            source: {
+                code: `
+<Dialog>
+    <DialogTrigger asChild>
+        <Button variant='primary'>Overflowing Dialog</Button>
+    </DialogTrigger>
+    <DialogPortal>
+        <DialogContent disableStickyLayout>
+            <DialogTitle>Terms and Conditions</DialogTitle>
+            <DialogDescription>A bunch of repeating text</DialogDescription>
+            {Array.from({ length: 25 }, (_, index) => (
+                <p key={index} className='mb-4'>
+                    {loremParagraph}
+                </p>
+            ))}
+            <DialogActions className='flex justify-end gap-4'>
+                <DialogClose asChild>
+                    <Button variant='secondary'>Cancel</Button>
+                </DialogClose>
+                <Button>Accept</Button>
+            </DialogActions>
+        </DialogContent>
+    </DialogPortal>
+</Dialog>`,
+                language: 'tsx',
+                type: 'code',
+            },
+        },
+    },
+    args: { disableStickyLayout: true },
+    render: (args) => {
+        return (
+            <Dialog>
+                <DialogTrigger asChild>
+                    <Button variant='primary'>Overflowing Dialog without auto </Button>
                 </DialogTrigger>
                 <DialogPortal>
                     <DialogContent {...args}>

--- a/packages/javascript/doodle-ui/src/components/Dialog/Dialog.tsx
+++ b/packages/javascript/doodle-ui/src/components/Dialog/Dialog.tsx
@@ -63,16 +63,28 @@ DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 
 export const DialogMaxWidth = ['xl', 'lg', 'md', 'sm', 'xs'] as const;
 interface DialogContentProps extends React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> {
-    maxWidth?: (typeof DialogMaxWidth)[number];
     allowNav?: boolean;
     DialogOverlayProps?: DialogOverlayProps;
+    maxWidth?: (typeof DialogMaxWidth)[number];
+    disableStickyLayout?: boolean;
 }
 
 /**
  * See documentation: [DialogContent](https://www.radix-ui.com/primitives/docs/components/dialog#content)
  */
 const DialogContent = React.forwardRef<React.ElementRef<typeof DialogPrimitive.Content>, DialogContentProps>(
-    ({ DialogOverlayProps, allowNav = false, maxWidth = 'sm', className, children, ...props }, ref) => {
+    (
+        {
+            allowNav = false,
+            children,
+            className,
+            DialogOverlayProps,
+            disableStickyLayout = false,
+            maxWidth = 'sm',
+            ...props
+        },
+        ref
+    ) => {
         // Where do these magic values come from? They match MUIs maxWidth values
         const maxWidthMap: Record<(typeof DialogMaxWidth)[number], string> = {
             xl: 'max-w-[1536px]',
@@ -90,15 +102,16 @@ const DialogContent = React.forwardRef<React.ElementRef<typeof DialogPrimitive.C
         // Title and Actions are separated from other content so that they may be "stickied" to top/bottom.
         // All other content is added to its own container so that if it causes overflow, the content is
         // scrollable, but Title and Actions are always visible.
-        React.Children.toArray(children).forEach((child) => {
-            if (React.isValidElement(child) && child.type === DialogTitle) {
-                titleChildren.push(child);
-            } else if (React.isValidElement(child) && child.type === DialogActions) {
-                actionsChildren.push(child);
-            } else {
-                middleChildren.push(child);
-            }
-        });
+        !disableStickyLayout &&
+            React.Children.toArray(children).forEach((child) => {
+                if (React.isValidElement(child) && child.type === DialogTitle) {
+                    titleChildren.push(child);
+                } else if (React.isValidElement(child) && child.type === DialogActions) {
+                    actionsChildren.push(child);
+                } else {
+                    middleChildren.push(child);
+                }
+            });
 
         return (
             <>
@@ -111,6 +124,7 @@ const DialogContent = React.forwardRef<React.ElementRef<typeof DialogPrimitive.C
                         'duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%]',
                         'rounded-md bg-neutral-light-2 dark:bg-neutral-dark-2 dark:text-neutral-light-1 z-[1500]',
                         maxWidthClass,
+                        { 'overflow-y-auto': disableStickyLayout },
                         className
                     )}
                     onOpenAutoFocus={() => {
@@ -120,11 +134,19 @@ const DialogContent = React.forwardRef<React.ElementRef<typeof DialogPrimitive.C
                         }
                     }}
                     {...props}>
-                    {titleChildren}
-                    {middleChildren.length > 0 && (
-                        <div className='flex flex-col gap-4 flex-auto min-h-0 overflow-y-auto'>{middleChildren}</div>
+                    {disableStickyLayout ? (
+                        children
+                    ) : (
+                        <>
+                            {titleChildren}
+                            {middleChildren.length > 0 && (
+                                <div className='flex flex-col gap-4 flex-auto min-h-0 overflow-y-auto'>
+                                    {middleChildren}
+                                </div>
+                            )}
+                            {actionsChildren}
+                        </>
                     )}
-                    {actionsChildren}
                 </DialogPrimitive.Content>
             </>
         );

--- a/packages/javascript/doodle-ui/src/components/Dialog/Dialog.tsx
+++ b/packages/javascript/doodle-ui/src/components/Dialog/Dialog.tsx
@@ -83,13 +83,33 @@ const DialogContent = React.forwardRef<React.ElementRef<typeof DialogPrimitive.C
         };
         const maxWidthClass = maxWidth ? maxWidthMap[maxWidth] : '';
 
+        const titleChildren: React.ReactNode[] = [];
+        const actionsChildren: React.ReactNode[] = [];
+        const middleChildren: React.ReactNode[] = [];
+
+        // Title and Actions are separated from other content so that they may be "stickied" to top/bottom.
+        // All other content is added to its own container so that if it causes overflow, the content is
+        // scrollable, but Title and Actions are always visible.
+        React.Children.toArray(children).forEach((child) => {
+            if (React.isValidElement(child) && child.type === DialogTitle) {
+                titleChildren.push(child);
+            } else if (React.isValidElement(child) && child.type === DialogActions) {
+                actionsChildren.push(child);
+            } else {
+                middleChildren.push(child);
+            }
+        });
+
         return (
             <>
                 <DialogOverlay {...DialogOverlayProps} allowNav={allowNav} />
                 <DialogPrimitive.Content
                     ref={ref}
                     className={cn(
-                        'fixed left-[50%] top-[50%] grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] rounded-md bg-neutral-light-2 dark:bg-neutral-dark-2 dark:text-neutral-light-1 z-[1500]',
+                        'flex flex-col overflow-hidden fixed gap-4 p-6 w-full shadow-lg max-w-lg max-h-[calc(100vh-32px)]',
+                        'left-[50%] top-[50%] translate-x-[-50%] translate-y-[-50%]',
+                        'duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%]',
+                        'rounded-md bg-neutral-light-2 dark:bg-neutral-dark-2 dark:text-neutral-light-1 z-[1500]',
                         maxWidthClass,
                         className
                     )}
@@ -100,7 +120,11 @@ const DialogContent = React.forwardRef<React.ElementRef<typeof DialogPrimitive.C
                         }
                     }}
                     {...props}>
-                    {children}
+                    {titleChildren}
+                    {middleChildren.length > 0 && (
+                        <div className='flex flex-col gap-4 flex-auto min-h-0 overflow-y-auto'>{middleChildren}</div>
+                    )}
+                    {actionsChildren}
                 </DialogPrimitive.Content>
             </>
         );


### PR DESCRIPTION
## Description

* Updates Doodle Dialog to prevent overflow when content would exceed browser window height.
* Updates FileDrop dialog to specifically scroll file list

## Motivation and Context

Resolves BED-7580
Resolves BED-7308

## How Has This Been Tested?

Added storybook height overflow story. Manual testing for FileDrop

## Screenshots (optional):
| Before | After |
| ------ | ----- |
| <img width="1319" height="720" alt="image" src="https://github.com/user-attachments/assets/09142b8c-0777-4962-a5db-bcce2bbae5f4" /> | <img width="1319" height="720" alt="image" src="https://github.com/user-attachments/assets/abefae58-fd8e-4a09-98db-aef5843b8d2e" /> |

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Dialog title and actions remain pinned while overflow scrolls in the middle.
  * Drag-to-upload is suppressed when excluded areas are present to prevent accidental uploads.

* **New Features**
  * FileDrop accepts an optional className prop for easier styling.
  * Dialog supports an optional non-sticky layout that lets the entire content scroll.

* **Documentation**
  * Expanded Dialog stories showing overflowing content and the non-sticky layout.

* **Style**
  * FileDrop vertical padding adjusted for improved spacing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->