### PR TITLE
feat: explore page search results returns selected node 

### DIFF
--- a/cmd/ui/src/hooks/useSigmaExploreGraph/useSigmaExploreGraph.tsx
+++ b/cmd/ui/src/hooks/useSigmaExploreGraph/useSigmaExploreGraph.tsx
@@ -14,7 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { isGraphResponse, transformFlatGraphResponse, useExploreGraph } from 'bh-shared-ui';
+import { ExploreGraphQueryOptions, isGraphResponse, transformFlatGraphResponse, useExploreGraph } from 'bh-shared-ui';
 import { FlatGraphResponse, GraphData, GraphResponse } from 'js-client-library';
 import { useMemo } from 'react';
 
@@ -30,8 +30,8 @@ export const normalizeGraphDataForSigma = (
     }
 };
 
-export const useSigmaExploreGraph = () => {
-    const graphQuery = useExploreGraph();
+export const useSigmaExploreGraph = (options: ExploreGraphQueryOptions) => {
+    const graphQuery = useExploreGraph(options);
     const normalizedGraphData = useMemo(() => normalizeGraphDataForSigma(graphQuery.data), [graphQuery.data]);
     // return the full query so we can know loading/error state, and use react-query tools. But override the data field with the normalized value
     return {

--- a/cmd/ui/src/views/Explore/GraphView.test.tsx
+++ b/cmd/ui/src/views/Explore/GraphView.test.tsx
@@ -19,8 +19,21 @@ import { cypherTestResponse, mockKindsHandler } from 'bh-shared-ui';
 import { GraphEdge } from 'js-client-library';
 import { rest } from 'msw';
 import { setupServer } from 'msw/node';
-import { render, screen, waitFor } from 'src/test-utils';
+import { render, screen, waitFor, within } from 'src/test-utils';
 import GraphView from './GraphView';
+
+const searchedNode = {
+    label: 'Searched Node',
+    kind: 'User',
+    kinds: ['User'],
+    objectId: 'testing-node-123',
+    isTierZero: false,
+    isOwnedObject: false,
+    lastSeen: '',
+};
+const graphSearchResponse = {
+    data: { data: { nodes: { '42': searchedNode }, edges: [] } },
+};
 
 const server = setupServer(
     rest.post('/api/v2/graphs/cypher', (req, res, ctx) => {
@@ -43,6 +56,9 @@ const server = setupServer(
     }),
     rest.get('/api/v2/saved-queries', async (_, res, ctx) => {
         return res(ctx.status(200));
+    }),
+    rest.get('/api/v2/graph-search', (_req, res, ctx) => {
+        return res(ctx.json(graphSearchResponse));
     }),
     mockKindsHandler(),
     rest.get(`/api/v2/roles`, (req, res, ctx) => {
@@ -161,6 +177,61 @@ describe('GraphView', () => {
         expect(sigma).toBeInTheDocument();
         expect(table).not.toBeInTheDocument();
     });
+
+    const autoSelectRoute = `/explore?searchType=node&primarySearch=${searchedNode.objectId}`;
+
+    it('auto-selects when a search result has a matching objectId', async () => {
+        render(<GraphView />, { route: autoSelectRoute });
+
+        await waitFor(() => expect(window.location.search).toContain('selectedItem=42'));
+    });
+
+    it('does not auto-select when no search result has a matching objectId', async () => {
+        let requestHandled = false;
+        server.use(
+            rest.get('/api/v2/graph-search', (_req, res, ctx) => {
+                requestHandled = true;
+                return res(
+                    ctx.json({
+                        data: {
+                            data: {
+                                nodes: { '42': { ...searchedNode, objectId: 'non-matching-object-id' } },
+                                edges: [],
+                            },
+                        },
+                    })
+                );
+            })
+        );
+
+        render(<GraphView />, { route: autoSelectRoute });
+
+        await waitFor(() => expect(requestHandled).toBe(true));
+        expect(window.location.search).not.toContain('selectedItem=');
+    });
+
+    it('opens the entity information panel for the auto-selected node', async () => {
+        server.use(
+            rest.post('/api/v2/graphs/cypher', (_req, res, ctx) =>
+                res(
+                    ctx.json({
+                        data: {
+                            nodes: { '42': searchedNode },
+                            edges: [],
+                        },
+                    })
+                )
+            )
+        );
+
+        render(<GraphView />, { route: autoSelectRoute });
+
+        await waitFor(() => expect(window.location.search).toContain('selectedItem=42'));
+
+        const panel = await screen.findByTestId('explore_entity-information-panel');
+        expect(within(panel).getByText('Searched Node')).toBeInTheDocument();
+    });
+
     it('renders correct search elements after keypresses', async () => {
         render(<GraphView />, { route: `/explore` });
         const user = userEvent.setup();

--- a/cmd/ui/src/views/Explore/GraphView.tsx
+++ b/cmd/ui/src/views/Explore/GraphView.tsx
@@ -45,6 +45,7 @@ import {
 } from 'bh-shared-ui';
 import { MultiDirectedGraph } from 'graphology';
 import { Attributes } from 'graphology-types';
+import { FlatGraphResponse, GraphResponse } from 'js-client-library';
 import { FC, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { SigmaNodeEventPayload } from 'sigma/sigma';
 import { NoDataFileUploadDialogWithLinks } from 'src/components/NoDataFileUploadDialogWithLinks';
@@ -55,7 +56,7 @@ import {
     setPinnedExploreTableColumns,
     setSelectedExploreTableColumns,
 } from 'src/ducks/global/actions';
-import { useSigmaExploreGraph } from 'src/hooks/useSigmaExploreGraph';
+import { normalizeGraphDataForSigma, useSigmaExploreGraph } from 'src/hooks/useSigmaExploreGraph';
 import { useAppDispatch, useAppSelector } from 'src/store';
 import { initGraph } from 'src/views/Explore/utils';
 import ContextMenu from './ContextMenu/ContextMenu';
@@ -70,11 +71,28 @@ const GraphView: FC = () => {
     const theme = useTheme();
 
     const graphHasDataQuery = useGraphHasData();
-    const graphQuery = useSigmaExploreGraph();
 
-    const { searchType } = useExploreParams();
+    const { searchType, primarySearch } = useExploreParams();
     const { selectedItem, setSelectedItem, selectedItemQuery, clearSelectedItem, previousSelectedItem } =
         useExploreSelectedItem();
+
+    // Auto-select the searched node so it is highlighted and its information panel is displayed
+    const handleNodeAutoSelect = useCallback(
+        (data: GraphResponse | FlatGraphResponse) => {
+            if (searchType !== 'node' || !primarySearch) return;
+
+            const nodes = normalizeGraphDataForSigma(data)?.nodes;
+            if (!nodes) return;
+
+            if (selectedItem && nodes[selectedItem]) return;
+
+            const matchedEntry = Object.entries(nodes).find(([, node]) => node.objectId === primarySearch);
+            if (matchedEntry) setSelectedItem(matchedEntry[0]);
+        },
+        [searchType, primarySearch, selectedItem, setSelectedItem]
+    );
+
+    const graphQuery = useSigmaExploreGraph({ onSuccess: handleNodeAutoSelect });
 
     const [graphologyGraph, setGraphologyGraph] = useState<MultiDirectedGraph<Attributes, Attributes, Attributes>>();
     const [contextMenu, setContextMenu] = useState<{ mouseX: number; mouseY: number } | null>(null);


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

*Describe your changes in detail*

On Explore page, Search menu, when user searches for a node and clicks one, node is automatically selected and entity panel is displayed (with selected node's information)

Testing Instructions:
1. Navigate to explore page
2. Navigate to search tab
3. Search for a node and select a node
4. Selected node should be selected (highlighted) and entity panel should be opened with selected node’s information 

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves https://specterops.atlassian.net/browse/BED-8159

*Why is this change required? What problem does it solve?*

## How Has This Been Tested?

*Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc.*

Locally tested and added unit tests

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)
- Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)
- Database Migrations

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [ ] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
