### PR TITLE
fix: Revert "chore: Edge endpoints no longer mutated with source kinds: Bed 8030" BED-8030

### DIFF
--- a/cmd/api/src/services/graphify/ingest.go
+++ b/cmd/api/src/services/graphify/ingest.go
@@ -240,6 +240,11 @@ func IngestBasicData(batch *IngestContext, converted ConvertedData) error {
 
 // IngestGenericData writes generic graph data into the database using the provided batch.
 // It attempts to ingest all nodes and relationships from the ConvertedData object.
+//
+// Because generic entities do not have a predefined base kind (unlike AZ or AD), this function passes
+// graph.EmptyKind to the node and relationship ingestion functions. This indicates that no
+// base kind should be applied uniformly to all ingested entities, and instead the kind(s)
+// defined directly on each node or edge (if any) are used as-is.
 func IngestGenericData(batch *IngestContext, sourceKind graph.Kind, converted ConvertedData) error {
 	errs := errorlist.NewBuilder()
 
@@ -247,7 +252,7 @@ func IngestGenericData(batch *IngestContext, sourceKind graph.Kind, converted Co
 		errs.Add(err)
 	}
 
-	if err := IngestRelationshipsKindless(batch, sourceKind, converted.RelProps); err != nil {
+	if err := IngestRelationships(batch, sourceKind, converted.RelProps); err != nil {
 		errs.Add(err)
 	}
 

--- a/cmd/api/src/services/graphify/ingestrelationships.go
+++ b/cmd/api/src/services/graphify/ingestrelationships.go
@@ -32,31 +32,13 @@ import (
 	"github.com/specterops/dawgs/util"
 )
 
-// IngestRelationships resolves and writes a batch of ingestible relationships to the graph,
-// applying sourceKind to both endpoint nodes and to the dawgs RelationshipUpdate identity kind.
+// IngestRelationships resolves and writes a batch of ingestible relationships to the graph.
 //
-// This is the legacy ingest path used by AD and Azure pipelines, where some endpoint nodes
-// are referenced only via relationship data (e.g. well-known SIDs, foreign principals, ACE
-// principals) and never appear in node payloads. Applying sourceKind here ensures those orphan
-// endpoint nodes receive a base kind.
+// This function first calls resolveRelationships to resolve node identifiers based on name and kind.
 //
-// For the kindless variant used by OpenGraph, see IngestRelationshipsKindless.
+// Each resolved relationship update is applied to the graph via batch.UpdateRelationshipBy.
+// Errors encountered during resolution or update are collected and returned as a single combined error.
 func IngestRelationships(ingestCtx *IngestContext, sourceKind graph.Kind, relationships []ein.IngestibleRelationship) error {
-	return ingestRelationships(ingestCtx, sourceKind, relationships, true)
-}
-
-// IngestRelationshipsKindless resolves and writes a batch of ingestible relationships to the
-// graph WITHOUT applying sourceKind to endpoint nodes. sourceKind is propagated only to
-// Start/EndIdentityKind so that Neo4j's label-scoped MERGE can continue to use existing
-// label-scoped indexes during endpoint resolution.
-//
-// This is the OpenGraph (Generic) ingest path: endpoint kinds are managed exclusively by the
-// node ingest path; relationship ingest is forbidden from mutating endpoint node kinds.
-func IngestRelationshipsKindless(ingestCtx *IngestContext, sourceKind graph.Kind, relationships []ein.IngestibleRelationship) error {
-	return ingestRelationships(ingestCtx, sourceKind, relationships, false)
-}
-
-func ingestRelationships(ingestCtx *IngestContext, sourceKind graph.Kind, relationships []ein.IngestibleRelationship, applyKindToEndpoints bool) error {
 	var (
 		errs                                 = errorlist.NewBuilder()
 		resolvedRelationships, resolveErrors = endpoint.ResolveAll(ingestCtx.Ctx, ingestCtx.EndpointResolver, relationships)
@@ -66,7 +48,7 @@ func ingestRelationships(ingestCtx *IngestContext, sourceKind graph.Kind, relati
 		errs.Add(resolveErrors)
 	}
 
-	for update := range ingestibleRelationshipsToUpdates(ingestCtx, resolvedRelationships, sourceKind, applyKindToEndpoints) {
+	for update := range ingestibleRelationshipsToUpdates(ingestCtx, resolvedRelationships, sourceKind) {
 		if err := maybeSubmitRelationshipUpdate(ingestCtx, update); err != nil {
 			errs.Add(err)
 		}
@@ -212,46 +194,35 @@ func IngestSessions(batch *IngestContext, sessions []ein.IngestibleSession) erro
 }
 
 // ingestibleRelationshipsToUpdates transforms a list of ingestible relationships into
-// graph.RelationshipUpdate objects as an iterator. sourceKind is always propagated to
-// Start/EndIdentityKind so that Neo4j's label-scoped MERGE can use existing label-scoped
-// indexes during endpoint resolution. When applyKindToEndpoints is true, sourceKind is
-// merged with each endpoint's per-relationship Kind (rel.Source.Kind / rel.Target.Kind)
-// and applied to the endpoint nodes themselves (legacy AD/Azure behavior); when false,
-// endpoint nodes are written without any kind information (OpenGraph behavior).
-func ingestibleRelationshipsToUpdates(batch *IngestContext, rels []ein.IngestibleRelationship, sourceKind graph.Kind, applyKindToEndpoints bool) iter.Seq[graph.RelationshipUpdate] {
+// graph.RelationshipUpdate objects as an iterator.
+func ingestibleRelationshipsToUpdates(batch *IngestContext, rels []ein.IngestibleRelationship, sourceKind graph.Kind) iter.Seq[graph.RelationshipUpdate] {
 	return func(yield func(graph.RelationshipUpdate) bool) {
 		for _, rel := range rels {
 			rel.RelProps[common.LastSeen.String()] = batch.IngestTime
 
 			var (
+				startKinds = MergeNodeKinds(sourceKind, rel.Source.Kind)
+				endKinds   = MergeNodeKinds(sourceKind, rel.Target.Kind)
+
 				startObjID = strings.ToUpper(rel.Source.Value)
 				endObjID   = strings.ToUpper(rel.Target.Value)
-				startProps = graph.AsProperties(graph.PropertyMap{
-					common.ObjectID: startObjID,
-					common.LastSeen: batch.IngestTime,
-				})
-				endProps = graph.AsProperties(graph.PropertyMap{
-					common.ObjectID: endObjID,
-					common.LastSeen: batch.IngestTime,
-				})
-				startEndpointKinds []graph.Kind
-				endEndpointKinds   []graph.Kind
+
+				update = graph.RelationshipUpdate{
+					Start: graph.PrepareNode(graph.AsProperties(graph.PropertyMap{
+						common.ObjectID: startObjID,
+						common.LastSeen: batch.IngestTime,
+					}), startKinds...),
+					StartIdentityProperties: []string{common.ObjectID.String()},
+					StartIdentityKind:       sourceKind,
+					End: graph.PrepareNode(graph.AsProperties(graph.PropertyMap{
+						common.ObjectID: endObjID,
+						common.LastSeen: batch.IngestTime,
+					}), endKinds...),
+					EndIdentityKind:       sourceKind,
+					EndIdentityProperties: []string{common.ObjectID.String()},
+					Relationship:          graph.PrepareRelationship(graph.AsProperties(rel.RelProps), rel.RelType),
+				}
 			)
-
-			if applyKindToEndpoints {
-				startEndpointKinds = MergeNodeKinds(sourceKind, rel.Source.Kind)
-				endEndpointKinds = MergeNodeKinds(sourceKind, rel.Target.Kind)
-			}
-
-			update := graph.RelationshipUpdate{
-				Start:                   graph.PrepareNode(startProps, startEndpointKinds...),
-				StartIdentityProperties: []string{common.ObjectID.String()},
-				StartIdentityKind:       sourceKind,
-				End:                     graph.PrepareNode(endProps, endEndpointKinds...),
-				EndIdentityKind:         sourceKind,
-				EndIdentityProperties:   []string{common.ObjectID.String()},
-				Relationship:            graph.PrepareRelationship(graph.AsProperties(rel.RelProps), rel.RelType),
-			}
 
 			if !yield(update) {
 				break

--- a/cmd/api/src/services/graphify/ingestrelationships_integration_test.go
+++ b/cmd/api/src/services/graphify/ingestrelationships_integration_test.go
@@ -157,7 +157,7 @@ func Test_IngestRelationships(t *testing.T) {
 				err := db.BatchOperation(testContext.Context(), func(batch graph.Batch) error {
 					ingestContext := NewIngestContext(testContext.Context(), WithBatchUpdater(batch), WithEndpointResolver(endpoint.NewResolver(db)))
 
-					err := IngestRelationships(ingestContext, graph.StringKind("SomeBase"), rels)
+					err := IngestRelationships(ingestContext, graph.EmptyKind, rels)
 					require.Nil(t, err)
 					return nil
 				})
@@ -176,26 +176,6 @@ func Test_IngestRelationships(t *testing.T) {
 
 					require.Equal(t, int64(1), count)
 					require.Nil(t, err)
-
-					// existing endpoint nodes must retain only the kinds they were created with
-					refetchedEndpoints := []*graph.Node{}
-					err = tx.Nodes().Filter(
-						query.Or(
-							query.Equals(query.NodeID(), harness.IngestRelationships.Node1.ID),
-							query.Equals(query.NodeID(), harness.IngestRelationships.Node2.ID),
-						),
-					).Fetch(func(cursor graph.Cursor[*graph.Node]) error {
-						for node := range cursor.Chan() {
-							refetchedEndpoints = append(refetchedEndpoints, node)
-						}
-						return nil
-					})
-					require.Nil(t, err)
-					require.Len(t, refetchedEndpoints, 2)
-					for _, node := range refetchedEndpoints {
-						objectid, _ := node.Properties.Get("objectid").String()
-						require.ElementsMatch(t, graph.Kinds{graph.StringKind("Computer"), graph.StringKind("SomeBase")}, node.Kinds, "endpoint node %s should retain its existing kind and gain the sourceKind", objectid)
-					}
 
 					return nil
 				})
@@ -281,7 +261,7 @@ func Test_IngestRelationships(t *testing.T) {
 				err := db.BatchOperation(testContext.Context(), func(batch graph.Batch) error {
 					ingestContext := NewIngestContext(testContext.Context(), WithBatchUpdater(batch), WithEndpointResolver(endpoint.NewResolver(db)))
 
-					err := IngestRelationships(ingestContext, graph.StringKind("SomeBase"), rels)
+					err := IngestRelationships(ingestContext, graph.EmptyKind, rels)
 					require.Nil(t, err)
 					return nil
 				})
@@ -290,7 +270,6 @@ func Test_IngestRelationships(t *testing.T) {
 
 				err = db.ReadTransaction(testContext.Context(), func(tx graph.Transaction) error {
 					nodeIDs := map[string]graph.ID{}
-					createdNodes := []*graph.Node{}
 					// verify start and end nodes were created
 					_ = tx.Nodes().Filter(
 						query.Or(
@@ -302,19 +281,12 @@ func Test_IngestRelationships(t *testing.T) {
 							for node := range cursor.Chan() {
 								objectid, _ := node.Properties.Get("objectid").String()
 								nodeIDs[objectid] = node.ID
-								createdNodes = append(createdNodes, node)
 							}
 							return nil
 						},
 					)
 
 					require.Len(t, nodeIDs, 2)
-
-					// endpoint nodes implicitly created by IngestRelationships (legacy path) receive the sourceKind
-					for _, node := range createdNodes {
-						objectid, _ := node.Properties.Get("objectid").String()
-						require.ElementsMatch(t, graph.Kinds{graph.StringKind("SomeBase")}, node.Kinds, "endpoint node %s should be created with the sourceKind", objectid)
-					}
 
 					// verify rel created
 					count, err := tx.Relationships().Filter(
@@ -333,145 +305,6 @@ func Test_IngestRelationships(t *testing.T) {
 
 				require.Nil(t, err)
 
-			})
-	})
-
-	t.Run("IngestRelationshipsKindless. Existing endpoint nodes are NOT mutated by the relationship ingest.", func(t *testing.T) {
-		testContext := integration.NewGraphTestContext(t, graphschema.DefaultGraphSchema())
-
-		testContext.DatabaseTestWithSetup(
-			func(harness *integration.HarnessDetails) error {
-				harness.IngestRelationships.Setup(testContext)
-				return nil
-			},
-			func(harness integration.HarnessDetails, db graph.Database) {
-				// Endpoints reference the harness nodes by objectid (Node1=1234, Node2=5678, both kind Computer).
-				ingestibleRel := ein.NewIngestibleRelationship(
-					ein.IngestibleEndpoint{Value: "1234"},
-					ein.IngestibleEndpoint{Value: "5678"},
-					ein.IngestibleRel{RelType: graph.StringKind("related_to")},
-				)
-				rels := []ein.IngestibleRelationship{ingestibleRel}
-
-				err := db.BatchOperation(testContext.Context(), func(batch graph.Batch) error {
-					ingestContext := NewIngestContext(testContext.Context(), WithBatchUpdater(batch), WithEndpointResolver(endpoint.NewResolver(db)))
-
-					err := IngestRelationshipsKindless(ingestContext, graph.StringKind("SomeBase"), rels)
-					require.Nil(t, err)
-					return nil
-				})
-
-				require.Nil(t, err)
-
-				err = db.ReadTransaction(testContext.Context(), func(tx graph.Transaction) error {
-					// Verify the relationship was created.
-					count, err := tx.Relationships().Filter(
-						query.And(
-							query.Equals(query.StartID(), harness.IngestRelationships.Node1.ID),
-							query.Equals(query.EndID(), harness.IngestRelationships.Node2.ID),
-							query.Kind(query.Relationship(), graph.StringKind("related_to")),
-						),
-					).Count()
-					require.Nil(t, err)
-					require.Equal(t, int64(1), count)
-
-					// Existing endpoint nodes must retain ONLY their original kinds; the kindless
-					// path must not append sourceKind to endpoint nodes.
-					refetchedEndpoints := []*graph.Node{}
-					err = tx.Nodes().Filter(
-						query.Or(
-							query.Equals(query.NodeID(), harness.IngestRelationships.Node1.ID),
-							query.Equals(query.NodeID(), harness.IngestRelationships.Node2.ID),
-						),
-					).Fetch(func(cursor graph.Cursor[*graph.Node]) error {
-						for node := range cursor.Chan() {
-							refetchedEndpoints = append(refetchedEndpoints, node)
-						}
-						return nil
-					})
-					require.Nil(t, err)
-					require.Len(t, refetchedEndpoints, 2)
-					for _, node := range refetchedEndpoints {
-						objectid, _ := node.Properties.Get("objectid").String()
-						require.ElementsMatch(t, graph.Kinds{graph.StringKind("Computer")}, node.Kinds, "endpoint node %s kinds should be unchanged by kindless relationship ingest", objectid)
-					}
-
-					return nil
-				})
-
-				require.Nil(t, err)
-			})
-	})
-
-	t.Run("IngestRelationshipsKindless. New endpoint nodes are created without any kinds.", func(t *testing.T) {
-		testContext := integration.NewGraphTestContext(t, graphschema.DefaultGraphSchema())
-
-		testContext.DatabaseTestWithSetup(
-			func(harness *integration.HarnessDetails) error {
-				harness.IngestRelationships.Setup(testContext)
-				return nil
-			},
-			func(harness integration.HarnessDetails, db graph.Database) {
-				// Brand-new objectids that don't exist in the harness; nodes will be created by the ingest.
-				ingestibleRel := ein.NewIngestibleRelationship(
-					ein.IngestibleEndpoint{Value: "0001"},
-					ein.IngestibleEndpoint{Value: "0002"},
-					ein.IngestibleRel{RelType: graph.StringKind("related_to")},
-				)
-				rels := []ein.IngestibleRelationship{ingestibleRel}
-
-				err := db.BatchOperation(testContext.Context(), func(batch graph.Batch) error {
-					ingestContext := NewIngestContext(testContext.Context(), WithBatchUpdater(batch), WithEndpointResolver(endpoint.NewResolver(db)))
-
-					err := IngestRelationshipsKindless(ingestContext, graph.StringKind("SomeBase"), rels)
-					require.Nil(t, err)
-					return nil
-				})
-
-				require.Nil(t, err)
-
-				err = db.ReadTransaction(testContext.Context(), func(tx graph.Transaction) error {
-					nodeIDs := map[string]graph.ID{}
-					createdNodes := []*graph.Node{}
-					_ = tx.Nodes().Filter(
-						query.Or(
-							query.Equals(query.Property(query.Node(), "objectid"), "0001"),
-							query.Equals(query.Property(query.Node(), "objectid"), "0002"),
-						)).
-						OrderBy(query.Order(query.Property(query.Node(), "objectid"), query.Ascending())).Fetch(
-						func(cursor graph.Cursor[*graph.Node]) error {
-							for node := range cursor.Chan() {
-								objectid, _ := node.Properties.Get("objectid").String()
-								nodeIDs[objectid] = node.ID
-								createdNodes = append(createdNodes, node)
-							}
-							return nil
-						},
-					)
-					require.Len(t, nodeIDs, 2)
-
-					// Endpoint nodes implicitly created by the kindless path must have NO kinds:
-					// node kinding for OpenGraph is the exclusive responsibility of the node ingest path.
-					for _, node := range createdNodes {
-						objectid, _ := node.Properties.Get("objectid").String()
-						require.Empty(t, node.Kinds, "endpoint node %s should have no kinds when created via kindless relationship ingest", objectid)
-					}
-
-					// Verify the relationship was created.
-					count, err := tx.Relationships().Filter(
-						query.And(
-							query.Equals(query.StartID(), nodeIDs["0001"]),
-							query.Equals(query.EndID(), nodeIDs["0002"]),
-							query.Kind(query.Relationship(), graph.StringKind("related_to")),
-						),
-					).Count()
-					require.Nil(t, err)
-					require.Equal(t, int64(1), count)
-
-					return nil
-				})
-
-				require.Nil(t, err)
 			})
 	})
 
@@ -594,7 +427,7 @@ func Test_ResolveRelationships(t *testing.T) {
 					require.NoError(t, err)
 
 					updates := slices.Collect(
-						ingestibleRelationshipsToUpdates(ingestContext, updatedIngestibleRels, graph.EmptyKind, true),
+						ingestibleRelationshipsToUpdates(ingestContext, updatedIngestibleRels, graph.EmptyKind),
 					)
 
 					require.Len(t, updates, 1)
@@ -603,9 +436,11 @@ func Test_ResolveRelationships(t *testing.T) {
 
 					startObjectID, _ := startNode.Properties.Get(string(common.ObjectID)).String()
 					require.NotNil(t, startObjectID)
+					require.True(t, startNode.Kinds.ContainsOneOf(ad.Computer))
 
 					endObjectID, _ := endNode.Properties.Get(string(common.ObjectID)).String()
 					require.NotNil(t, endObjectID)
+					require.True(t, endNode.Kinds.ContainsOneOf(ad.Computer))
 
 					return nil
 				})
@@ -781,7 +616,7 @@ func Test_ResolveRelationships(t *testing.T) {
 					require.NoError(t, err)
 
 					updates := slices.Collect(
-						ingestibleRelationshipsToUpdates(ingestContext, updatedIngestibleRels, graph.EmptyKind, true),
+						ingestibleRelationshipsToUpdates(ingestContext, updatedIngestibleRels, graph.EmptyKind),
 					)
 
 					require.Nil(t, err)
@@ -791,9 +626,11 @@ func Test_ResolveRelationships(t *testing.T) {
 
 					startObjectID, _ := startNode.Properties.Get(string(common.ObjectID)).String()
 					require.NotNil(t, startObjectID)
+					require.True(t, startNode.Kinds.ContainsOneOf(graph.StringKind("KindA")))
 
 					endObjectID, _ := endNode.Properties.Get(string(common.ObjectID)).String()
 					require.NotNil(t, endObjectID)
+					require.True(t, endNode.Kinds.ContainsOneOf(graph.StringKind("KindB")))
 
 					return nil
 				})
@@ -824,7 +661,7 @@ func Test_ResolveRelationships(t *testing.T) {
 					require.NoError(t, err)
 
 					updates := slices.Collect(
-						ingestibleRelationshipsToUpdates(ingestContext, updatedIngestibleRels, graph.EmptyKind, true),
+						ingestibleRelationshipsToUpdates(ingestContext, updatedIngestibleRels, graph.EmptyKind),
 					)
 
 					require.Nil(t, err)
@@ -834,6 +671,7 @@ func Test_ResolveRelationships(t *testing.T) {
 
 					startObjectID, _ := startNode.Properties.Get(string(common.ObjectID)).String()
 					require.NotNil(t, startObjectID)
+					require.True(t, startNode.Kinds.ContainsOneOf(graph.StringKind("KindA")))
 
 					endObjectID, _ := endNode.Properties.Get(string(common.ObjectID)).String()
 					require.NotNil(t, endObjectID)
@@ -867,7 +705,7 @@ func Test_ResolveRelationships(t *testing.T) {
 					require.NoError(t, err)
 
 					updates := slices.Collect(
-						ingestibleRelationshipsToUpdates(ingestContext, updatedIngestibleRels, graph.EmptyKind, true),
+						ingestibleRelationshipsToUpdates(ingestContext, updatedIngestibleRels, graph.EmptyKind),
 					)
 
 					require.Nil(t, err)
@@ -910,7 +748,7 @@ func Test_ResolveRelationships(t *testing.T) {
 					require.NoError(t, err)
 
 					updates := slices.Collect(
-						ingestibleRelationshipsToUpdates(ingestContext, updatedIngestibleRels, graph.EmptyKind, true),
+						ingestibleRelationshipsToUpdates(ingestContext, updatedIngestibleRels, graph.EmptyKind),
 					)
 
 					require.Len(t, updates, 1)
@@ -1010,7 +848,7 @@ func Test_ResolveRelationships(t *testing.T) {
 					require.NoError(t, err)
 
 					updates := slices.Collect(
-						ingestibleRelationshipsToUpdates(ingestContext, updatedIngestibleRels, graph.EmptyKind, true),
+						ingestibleRelationshipsToUpdates(ingestContext, updatedIngestibleRels, graph.EmptyKind),
 					)
 
 					require.Nil(t, err)
@@ -1082,7 +920,7 @@ func Test_ResolveRelationships(t *testing.T) {
 					require.NoError(t, err)
 
 					updates := slices.Collect(
-						ingestibleRelationshipsToUpdates(ingestContext, updatedIngestibleRels, graph.EmptyKind, true),
+						ingestibleRelationshipsToUpdates(ingestContext, updatedIngestibleRels, graph.EmptyKind),
 					)
 
 					require.Nil(t, err)


### PR DESCRIPTION
Reverts SpecterOps/BloodHound#2712

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified relationship ingestion logic by consolidating endpoint kind handling into a unified approach, removing legacy variant behavior and ensuring consistent kind application across all relationship processing paths.

* **Tests**
  * Updated relationship ingestion tests to reflect streamlined behavior and validate unified endpoint kind resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->