### PR TITLE
chore: add architecture models ahead of OpenFeature work BHADR-2

### DIFF
--- a/architecture/model/api-server.c4
+++ b/architecture/model/api-server.c4
@@ -111,6 +111,14 @@ model {
       technology 'Go'
     }
 
+    // ─── Feature Flags ─────────────────────────────────────────
+
+    featureFlagClient = component 'Feature Flag Client' {
+      #go #featureFlags
+      description 'OpenFeature SDK client used by application code to evaluate feature flags. The active provider is selected at build time, decoupling flag evaluation call sites from the backend. In BHCE the from-env provider reads flag defaults from environment variables; BHE swaps in LaunchDarkly (Fleet) or a Replicated-license-backed InMemoryProvider (On-Prem).'
+      technology 'Go / OpenFeature SDK'
+    }
+
     // ─── Data Access ───────────────────────────────────────────
 
     databaseClient = library 'Database Client' {

--- a/architecture/model/relationships.c4
+++ b/architecture/model/relationships.c4
@@ -109,5 +109,9 @@ model {
   bloodhound.apiServer.databaseClient -[sync]-> bloodhound.postgresql 'SQL queries'
   bloodhound.apiServer.graphClient -[sync]-> bloodhound.postgresqlGraph 'Graph operations (DAWGS)'
   bloodhound.apiServer.graphClient -[sync]-> bloodhound.neo4j 'Cypher queries'
+
+  // Feature flag evaluation
+  bloodhound.apiServer.restApi -[uses]-> bloodhound.apiServer.featureFlagClient 'Evaluates feature flags'
+  bloodhound.apiServer.analysisService -[uses]-> bloodhound.apiServer.featureFlagClient 'Evaluates feature flags'
 }
 

--- a/architecture/specification.c4
+++ b/architecture/specification.c4
@@ -101,5 +101,6 @@ specification {
   tag react
   tag graphdb
   tag relationaldb
+  tag featureFlags
 }
 

--- a/architecture/views/api-server.c4
+++ b/architecture/views/api-server.c4
@@ -26,6 +26,11 @@ views {
       notation "Data access layer"
       color muted
     }
+
+    style bloodhound.apiServer.featureFlagClient {
+      notation "Feature flag client"
+      color slate
+    }
   }
 }
 

--- a/rfc/bh-rfc-6.md
+++ b/rfc/bh-rfc-6.md
@@ -3,7 +3,7 @@ bh-rfc: 6
 title: Dogtags - SKU-Based Feature Entitlements
 authors: |
     [Pomeroy, Kaleb](kpomeroy@specterops.io)
-status: DRAFT
+status: SUPERSEDED BY BHADR-2
 created: 2025-01-07
 ---
 


### PR DESCRIPTION
Adds the `featureFlagClient` (OpenFeature SDK) component to the BHCE architecture model and wires it to its consumers.

## Motivation and Context

BHADR-2 documents the decision to replace DogTags with OpenFeature. This PR captures the BHCE side of that change in the architecture diagrams.

Resolves: BHADR-2

## How Has This Been Tested?

Ran `likec4 validate bhce/architecture` — passes cleanly.

## Screenshots (if appropriate):

## Types of changes
- [x] Chore (a change that does not modify the application functionality)

## Checklist:
- [x] Documentation updates are needed, and have been made accordingly.
- [ ] I have added and/or updated tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My changes include a database migration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated system architecture to document a feature-flag client used by the API and analysis services, with support for different provider implementations selected per build.
  * Added a dedicated visual style and a new "featureFlags" tag to clarify where feature-flag evaluation occurs.
  * RFC metadata updated: one RFC marked as superseded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->