### PR TITLE
fix(api): prevent 500 when filtering text fields with numeric strings or boolean-like values - BED-8218

### DIFF
--- a/cmd/api/src/api/v2/assetgrouptags_test.go
+++ b/cmd/api/src/api/v2/assetgrouptags_test.go
@@ -61,7 +61,10 @@ import (
 )
 
 func TestResources_GetAssetGroupTags(t *testing.T) {
-	const queryParamTagType = "type"
+	const (
+		queryParamTagType = "type"
+		queryParamName    = "name"
+	)
 	var (
 		mockCtrl      = gomock.NewController(t)
 		mockDB        = mocks_db.NewMockDatabase(mockCtrl)
@@ -207,6 +210,50 @@ func TestResources_GetAssetGroupTags(t *testing.T) {
 						}
 					}
 					apitest.Equal(output, 2, tierCount)
+				},
+			},
+			{
+				Name: "NumericStringName",
+				Input: func(input *apitest.Input) {
+					apitest.AddQueryParam(input, queryParamName, "eq:123")
+				},
+				Setup: func() {
+					mockDB.EXPECT().
+						GetAssetGroupTags(gomock.Any(), model.SQLFilter{
+							SQLString: queryParamName + " = '123'",
+						}).
+						Return(model.AssetGroupTags{
+							model.AssetGroupTag{ID: 1, Name: "123"},
+						}, nil)
+				},
+				Test: func(output apitest.Output) {
+					resp := v2.GetAssetGroupTagsResponse{}
+					apitest.StatusCode(output, http.StatusOK)
+					apitest.UnmarshalData(output, &resp)
+					apitest.Equal(output, "123", resp.Tags[0].Name)
+
+				},
+			},
+			{
+				Name: "Bool-likeName",
+				Input: func(input *apitest.Input) {
+					apitest.AddQueryParam(input, queryParamName, "eq:t")
+				},
+				Setup: func() {
+					mockDB.EXPECT().
+						GetAssetGroupTags(gomock.Any(), model.SQLFilter{
+							SQLString: queryParamName + " = 't'",
+						}).
+						Return(model.AssetGroupTags{
+							model.AssetGroupTag{ID: 1, Name: "t"},
+						}, nil)
+				},
+				Test: func(output apitest.Output) {
+					resp := v2.GetAssetGroupTagsResponse{}
+					apitest.StatusCode(output, http.StatusOK)
+					apitest.UnmarshalData(output, &resp)
+					apitest.Equal(output, "t", resp.Tags[0].Name)
+
 				},
 			},
 			{

--- a/cmd/api/src/api/v2/assetgrouptags_test.go
+++ b/cmd/api/src/api/v2/assetgrouptags_test.go
@@ -230,8 +230,8 @@ func TestResources_GetAssetGroupTags(t *testing.T) {
 					resp := v2.GetAssetGroupTagsResponse{}
 					apitest.StatusCode(output, http.StatusOK)
 					apitest.UnmarshalData(output, &resp)
+					require.Len(t, resp.Tags, 1)
 					apitest.Equal(output, "123", resp.Tags[0].Name)
-
 				},
 			},
 			{
@@ -252,8 +252,8 @@ func TestResources_GetAssetGroupTags(t *testing.T) {
 					resp := v2.GetAssetGroupTagsResponse{}
 					apitest.StatusCode(output, http.StatusOK)
 					apitest.UnmarshalData(output, &resp)
+					require.Len(t, resp.Tags, 1)
 					apitest.Equal(output, "t", resp.Tags[0].Name)
-
 				},
 			},
 			{

--- a/cmd/api/src/api/v2/fileingest_test.go
+++ b/cmd/api/src/api/v2/fileingest_test.go
@@ -103,7 +103,7 @@ func TestResources_ListFileUploadJobs(t *testing.T) {
 					apitest.AddQueryParam(input, "user_id", "eq:123")
 				},
 				Setup: func() {
-					mockDB.EXPECT().GetAllIngestJobs(gomock.Any(), 1, 2, "start_time", model.SQLFilter{SQLString: "user_id = 123"}).Return([]model.IngestJob{}, 0, nil)
+					mockDB.EXPECT().GetAllIngestJobs(gomock.Any(), 1, 2, "start_time", model.SQLFilter{SQLString: "user_id = '123'"}).Return([]model.IngestJob{}, 0, nil)
 				},
 				Test: func(output apitest.Output) {
 					apitest.StatusCode(output, http.StatusOK)

--- a/cmd/api/src/api/v2/graphschema_test.go
+++ b/cmd/api/src/api/v2/graphschema_test.go
@@ -138,9 +138,10 @@ func TestResources_ListEdgeTypes(t *testing.T) {
 			setupMocks: func(t *testing.T, mock *mock) {
 				mock.mockDatabase.EXPECT().GetGraphSchemaRelationshipKindsWithSchemaName(gomock.Any(), model.Filters{
 					"schema.name": []model.Filter{{
-						Operator:    model.Equals,
-						Value:       "extension_a",
-						SetOperator: model.FilterOr,
+						Operator:     model.Equals,
+						Value:        "extension_a",
+						SetOperator:  model.FilterOr,
+						IsStringData: true,
 					}}, "is_traversable": []model.Filter{{
 						Operator: model.Equals,
 						Value:    "true",

--- a/cmd/api/src/database/helper.go
+++ b/cmd/api/src/database/helper.go
@@ -72,11 +72,13 @@ func buildSQLFilter(filters model.Filters) (sqlFilter, error) {
 
 		for _, filter := range filterOperations {
 			var (
-				operator     pgsql.Operator
-				filterValue  = filter.Value
-				isNullValue  = filterValue == model.NullString
-				literalValue pgsql.Literal
-				setOperator  = pgsql.OperatorAnd
+				operator             pgsql.Operator
+				filterValue          = filter.Value
+				isNullValue          = filterValue == model.NullString
+				isFilterColumnString = filter.IsStringData
+				literalValue         pgsql.Literal
+				setOperator          = pgsql.OperatorAnd
+				err                  error
 			)
 
 			switch filter.Operator {
@@ -116,6 +118,11 @@ func buildSQLFilter(filters model.Filters) (sqlFilter, error) {
 
 			if isNullValue {
 				literalValue = pgsql.NullLiteral()
+			} else if isFilterColumnString {
+				literalValue, err = pgsql.AsLiteral(filterValue)
+				if err != nil {
+					return sqlFilter{}, fmt.Errorf(model.FmtErrFilterValueConversion, name, err)
+				}
 			} else if valueInt64, err := strconv.ParseInt(filterValue, 10, 64); err == nil {
 				literalValue = pgsql.NewLiteral(valueInt64, pgsql.Int8)
 			} else if valueFloat64, err := strconv.ParseFloat(filterValue, 64); err == nil {
@@ -123,7 +130,7 @@ func buildSQLFilter(filters model.Filters) (sqlFilter, error) {
 			} else if valueBool, err := strconv.ParseBool(filterValue); err == nil {
 				literalValue = pgsql.NewLiteral(valueBool, pgsql.Boolean)
 			} else if val, err := pgsql.AsLiteral(filterValue); err != nil {
-				return sqlFilter{}, fmt.Errorf("invalid filter value specified for %s: %w", name, err)
+				return sqlFilter{}, fmt.Errorf(model.FmtErrFilterValueConversion, name, err)
 			} else {
 				literalValue = val
 			}

--- a/cmd/api/src/model/filter.go
+++ b/cmd/api/src/model/filter.go
@@ -160,9 +160,10 @@ func (s QueryParameterFilterMap) ToFiltersModel() Filters {
 		newModelFilters := make([]Filter, len(oldModelFilters))
 		for idx, oldModelFilter := range oldModelFilters {
 			newModelFilters[idx] = Filter{
-				Operator:    oldModelFilter.Operator,
-				Value:       oldModelFilter.Value,
-				SetOperator: oldModelFilter.SetOperator,
+				Operator:     oldModelFilter.Operator,
+				Value:        oldModelFilter.Value,
+				SetOperator:  oldModelFilter.SetOperator,
+				IsStringData: oldModelFilter.IsStringData,
 			}
 		}
 
@@ -175,9 +176,13 @@ func (s QueryParameterFilterMap) ToFiltersModel() Filters {
 // filterValueAsPGLiteral takes a string value and returns a PG SQL literal that represents the value in the form of a
 // Go struct. This function will attempt to parse the string value into different types but otherwise defaults to the
 // given string value as a wrapped literal.
-func filterValueAsPGLiteral(valueStr string, isNullValue bool) (pgsql.Literal, error) {
+func filterValueAsPGLiteral(valueStr string, isNullValue bool, isColumnString bool) (pgsql.Literal, error) {
 	if isNullValue {
 		return pgsql.NullLiteral(), nil
+	}
+
+	if isColumnString {
+		return pgsql.AsLiteral(valueStr)
 	}
 
 	if valueInt64, err := strconv.ParseInt(valueStr, 10, 64); err == nil {
@@ -215,9 +220,10 @@ func BuildSQLFilter(filters Filters, tableAlias models.Optional[string]) (SQLFil
 
 		for _, filter := range filterOperations {
 			var (
-				operator    pgsql.Operator
-				filterValue = filter.Value
-				isNullValue = filterValue == NullString
+				operator             pgsql.Operator
+				filterValue          = filter.Value
+				isNullValue          = filterValue == NullString
+				isFilterColumnString = filter.IsStringData
 			)
 
 			switch filter.Operator {
@@ -255,7 +261,7 @@ func BuildSQLFilter(filters Filters, tableAlias models.Optional[string]) (SQLFil
 				return SQLFilter{}, fmt.Errorf("invalid operator specified")
 			}
 
-			if literalValue, err := filterValueAsPGLiteral(filterValue, isNullValue); err != nil {
+			if literalValue, err := filterValueAsPGLiteral(filterValue, isNullValue, isFilterColumnString); err != nil {
 				return SQLFilter{}, fmt.Errorf("invalid filter value specified for %s: %w", name, err)
 			} else {
 				setOperator := pgsql.OperatorAnd
@@ -477,9 +483,10 @@ func NewQueryParameterFilterParser() QueryParameterFilterParser {
 }
 
 type Filter struct {
-	Operator    FilterOperator
-	Value       string
-	SetOperator FilterSetOperator
+	Operator     FilterOperator
+	Value        string
+	SetOperator  FilterSetOperator
+	IsStringData bool
 }
 
 type Filters map[string][]Filter

--- a/cmd/api/src/model/filter.go
+++ b/cmd/api/src/model/filter.go
@@ -61,7 +61,10 @@ const (
 	ObjectIdString = "objectid"
 )
 
-var ErrNotFiltered = errors.New("parameter value is not filtered")
+var (
+	ErrNotFiltered              = errors.New("parameter value is not filtered")
+	FmtErrFilterValueConversion = "unable to convert filter value to SQL literal for %s: %w"
+)
 
 type Filtered interface {
 	ValidFilters() map[string][]FilterOperator
@@ -174,7 +177,8 @@ func (s QueryParameterFilterMap) ToFiltersModel() Filters {
 }
 
 // filterValueAsPGLiteral takes a string value and returns a PG SQL literal that represents the value in the form of a
-// Go struct. This function will attempt to parse the string value into different types but otherwise defaults to the
+// Go struct. If the filter column is a string type, the value is returned directly as a string literal.
+// Otherwise, this function will attempt to parse the string value into different types but defaults to the
 // given string value as a wrapped literal.
 func filterValueAsPGLiteral(valueStr string, isNullValue bool, isColumnString bool) (pgsql.Literal, error) {
 	if isNullValue {
@@ -262,7 +266,7 @@ func BuildSQLFilter(filters Filters, tableAlias models.Optional[string]) (SQLFil
 			}
 
 			if literalValue, err := filterValueAsPGLiteral(filterValue, isNullValue, isFilterColumnString); err != nil {
-				return SQLFilter{}, fmt.Errorf("invalid filter value specified for %s: %w", name, err)
+				return SQLFilter{}, fmt.Errorf(FmtErrFilterValueConversion, name, err)
 			} else {
 				setOperator := pgsql.OperatorAnd
 				if filter.SetOperator == FilterOr {

--- a/cmd/api/src/model/filter_test.go
+++ b/cmd/api/src/model/filter_test.go
@@ -191,6 +191,19 @@ func TestBuildSQLFilter(t *testing.T) {
 			},
 		},
 		{
+			name: "not equals boolean-like string",
+			input: model.Filters{
+				"foo": []model.Filter{{
+					Operator:     "neq",
+					Value:        "f",
+					IsStringData: true,
+				}},
+			},
+			output: model.SQLFilter{
+				SQLString: "foo != 'f'",
+			},
+		},
+		{
 			name: "equals boolean",
 			input: model.Filters{
 				"foo": []model.Filter{{
@@ -204,7 +217,7 @@ func TestBuildSQLFilter(t *testing.T) {
 			},
 		},
 		{
-			name: "equals 1-letter boolean",
+			name: "equals one-letter boolean",
 			input: model.Filters{
 				"foo": []model.Filter{{
 					Operator:     "eq",
@@ -243,7 +256,7 @@ func TestBuildSQLFilter(t *testing.T) {
 			},
 		},
 		{
-			name: "not equals boolean-like string",
+			name: "not equals one-letter boolean",
 			input: model.Filters{
 				"foo": []model.Filter{{
 					Operator:     "neq",

--- a/cmd/api/src/model/filter_test.go
+++ b/cmd/api/src/model/filter_test.go
@@ -35,8 +35,9 @@ func TestBuildSQLFilter(t *testing.T) {
 			name: "greater than",
 			input: model.Filters{
 				"foo": []model.Filter{{
-					Operator: "gt",
-					Value:    "12",
+					Operator:     "gt",
+					Value:        "12",
+					IsStringData: false,
 				}},
 			},
 			alias: models.OptionalValue("f"),
@@ -49,8 +50,9 @@ func TestBuildSQLFilter(t *testing.T) {
 			name: "greater than or equals",
 			input: model.Filters{
 				"foo": []model.Filter{{
-					Operator: "gte",
-					Value:    "12",
+					Operator:     "gte",
+					Value:        "12",
+					IsStringData: false,
 				}},
 			},
 			alias: models.OptionalValue("f"),
@@ -62,8 +64,9 @@ func TestBuildSQLFilter(t *testing.T) {
 			name: "greater than",
 			input: model.Filters{
 				"foo": []model.Filter{{
-					Operator: "gt",
-					Value:    "12",
+					Operator:     "gt",
+					Value:        "12",
+					IsStringData: false,
 				}},
 			},
 			output: model.SQLFilter{
@@ -74,8 +77,9 @@ func TestBuildSQLFilter(t *testing.T) {
 			name: "greater than or equals",
 			input: model.Filters{
 				"foo": []model.Filter{{
-					Operator: "gte",
-					Value:    "12",
+					Operator:     "gte",
+					Value:        "12",
+					IsStringData: false,
 				}},
 			},
 			output: model.SQLFilter{
@@ -86,8 +90,9 @@ func TestBuildSQLFilter(t *testing.T) {
 			name: "less than",
 			input: model.Filters{
 				"foo": []model.Filter{{
-					Operator: "lt",
-					Value:    "12",
+					Operator:     "lt",
+					Value:        "12",
+					IsStringData: false,
 				}},
 			},
 			output: model.SQLFilter{
@@ -98,8 +103,9 @@ func TestBuildSQLFilter(t *testing.T) {
 			name: "less than or equals",
 			input: model.Filters{
 				"foo": []model.Filter{{
-					Operator: "lte",
-					Value:    "12",
+					Operator:     "lte",
+					Value:        "12",
+					IsStringData: false,
 				}},
 			},
 			output: model.SQLFilter{
@@ -110,8 +116,9 @@ func TestBuildSQLFilter(t *testing.T) {
 			name: "equals int",
 			input: model.Filters{
 				"foo": []model.Filter{{
-					Operator: "eq",
-					Value:    "12",
+					Operator:     "eq",
+					Value:        "12",
+					IsStringData: false,
 				}},
 			},
 			output: model.SQLFilter{
@@ -122,8 +129,9 @@ func TestBuildSQLFilter(t *testing.T) {
 			name: "equals float",
 			input: model.Filters{
 				"foo": []model.Filter{{
-					Operator: "eq",
-					Value:    "12.215",
+					Operator:     "eq",
+					Value:        "12.215",
+					IsStringData: false,
 				}},
 			},
 			output: model.SQLFilter{
@@ -134,8 +142,9 @@ func TestBuildSQLFilter(t *testing.T) {
 			name: "equals string",
 			input: model.Filters{
 				"foo": []model.Filter{{
-					Operator: "eq",
-					Value:    "1notanumber2",
+					Operator:     "eq",
+					Value:        "1notanumber2",
+					IsStringData: true,
 				}},
 			},
 			output: model.SQLFilter{
@@ -143,11 +152,51 @@ func TestBuildSQLFilter(t *testing.T) {
 			},
 		},
 		{
+			name: "equals numeric string",
+			input: model.Filters{
+				"foo": []model.Filter{{
+					Operator:     "eq",
+					Value:        "1",
+					IsStringData: true,
+				}},
+			},
+			output: model.SQLFilter{
+				SQLString: "foo = '1'",
+			},
+		},
+		{
+			name: "equals float-like string",
+			input: model.Filters{
+				"foo": []model.Filter{{
+					Operator:     "eq",
+					Value:        "1.1",
+					IsStringData: true,
+				}},
+			},
+			output: model.SQLFilter{
+				SQLString: "foo = '1.1'",
+			},
+		},
+		{
+			name: "equals boolean-like string",
+			input: model.Filters{
+				"foo": []model.Filter{{
+					Operator:     "eq",
+					Value:        "t",
+					IsStringData: true,
+				}},
+			},
+			output: model.SQLFilter{
+				SQLString: "foo = 't'",
+			},
+		},
+		{
 			name: "equals boolean",
 			input: model.Filters{
 				"foo": []model.Filter{{
-					Operator: "eq",
-					Value:    "false",
+					Operator:     "eq",
+					Value:        "false",
+					IsStringData: false,
 				}},
 			},
 			output: model.SQLFilter{
@@ -155,11 +204,25 @@ func TestBuildSQLFilter(t *testing.T) {
 			},
 		},
 		{
+			name: "equals 1-letter boolean",
+			input: model.Filters{
+				"foo": []model.Filter{{
+					Operator:     "eq",
+					Value:        "t",
+					IsStringData: false,
+				}},
+			},
+			output: model.SQLFilter{
+				SQLString: "foo = true",
+			},
+		},
+		{
 			name: "equals null",
 			input: model.Filters{
 				"foo": []model.Filter{{
-					Operator: "eq",
-					Value:    "null",
+					Operator:     "eq",
+					Value:        "null",
+					IsStringData: false,
 				}},
 			},
 			output: model.SQLFilter{
@@ -170,8 +233,9 @@ func TestBuildSQLFilter(t *testing.T) {
 			name: "not equals int",
 			input: model.Filters{
 				"foo": []model.Filter{{
-					Operator: "neq",
-					Value:    "12",
+					Operator:     "neq",
+					Value:        "12",
+					IsStringData: false,
 				}},
 			},
 			output: model.SQLFilter{
@@ -179,11 +243,25 @@ func TestBuildSQLFilter(t *testing.T) {
 			},
 		},
 		{
+			name: "not equals boolean-like string",
+			input: model.Filters{
+				"foo": []model.Filter{{
+					Operator:     "neq",
+					Value:        "f",
+					IsStringData: false,
+				}},
+			},
+			output: model.SQLFilter{
+				SQLString: "foo != false",
+			},
+		},
+		{
 			name: "not equals null",
 			input: model.Filters{
 				"foo": []model.Filter{{
-					Operator: "neq",
-					Value:    "null",
+					Operator:     "neq",
+					Value:        "null",
+					IsStringData: false,
 				}},
 			},
 			output: model.SQLFilter{
@@ -191,11 +269,12 @@ func TestBuildSQLFilter(t *testing.T) {
 			},
 		},
 		{
-			name: "aprox equals",
+			name: "approx equals",
 			input: model.Filters{
 				"foo": []model.Filter{{
-					Operator: "~eq",
-					Value:    "12",
+					Operator:     "~eq",
+					Value:        "12",
+					IsStringData: false,
 				}},
 			},
 			output: model.SQLFilter{
@@ -206,13 +285,15 @@ func TestBuildSQLFilter(t *testing.T) {
 			name: "or equals",
 			input: model.Filters{
 				"z": []model.Filter{{
-					SetOperator: model.FilterOr,
-					Operator:    "eq",
-					Value:       "6",
+					Operator:     "eq",
+					Value:        "6",
+					SetOperator:  model.FilterOr,
+					IsStringData: false,
 				}, {
-					SetOperator: model.FilterOr,
-					Operator:    "eq",
-					Value:       "7",
+					Operator:     "eq",
+					Value:        "7",
+					SetOperator:  model.FilterOr,
+					IsStringData: false,
 				}},
 			},
 			output: model.SQLFilter{
@@ -220,11 +301,50 @@ func TestBuildSQLFilter(t *testing.T) {
 			},
 		},
 		{
+			name: "combined and equals numeric strings",
+			input: model.Filters{
+				"some_column": []model.Filter{{
+					Operator:     "eq",
+					Value:        "6",
+					SetOperator:  model.FilterAnd,
+					IsStringData: true,
+				}, {
+					Operator:     "eq",
+					Value:        "7",
+					SetOperator:  model.FilterAnd,
+					IsStringData: true,
+				}},
+			},
+			output: model.SQLFilter{
+				SQLString: "some_column = '6' and some_column = '7'",
+			},
+		},
+		{
+			name: "combined or equals boolean-like strings",
+			input: model.Filters{
+				"some_column": []model.Filter{{
+					Operator:     "eq",
+					Value:        "t",
+					SetOperator:  model.FilterOr,
+					IsStringData: true,
+				}, {
+					Operator:     "eq",
+					Value:        "false",
+					SetOperator:  model.FilterOr,
+					IsStringData: true,
+				}},
+			},
+			output: model.SQLFilter{
+				SQLString: "(some_column = 't' or some_column = 'false')",
+			},
+		},
+		{
 			name: "broken operator",
 			input: model.Filters{
 				"foo": []model.Filter{{
-					Operator: "NOT OPERATOR",
-					Value:    "12",
+					Operator:     "NOT OPERATOR",
+					Value:        "12",
+					IsStringData: false,
 				}},
 			},
 			wantErr: true,

--- a/cmd/api/src/model/filter_test.go
+++ b/cmd/api/src/model/filter_test.go
@@ -301,7 +301,7 @@ func TestBuildSQLFilter(t *testing.T) {
 			},
 		},
 		{
-			name: "combined and equals numeric strings",
+			name: "combined AND equals numeric strings",
 			input: model.Filters{
 				"some_column": []model.Filter{{
 					Operator:     "eq",
@@ -320,7 +320,7 @@ func TestBuildSQLFilter(t *testing.T) {
 			},
 		},
 		{
-			name: "combined or equals boolean-like strings",
+			name: "combined OR equals boolean-like strings",
 			input: model.Filters{
 				"some_column": []model.Filter{{
 					Operator:     "eq",


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Fixes a bug where filtering text-based columns (eg: name, first_name) with numeric strings ("123") or boolean-like values ("t", "false") causes a 500 due to a type mismatch at the database level.

- adds IsStringData field to the model.Filter struct
- when a filter column is a string type, `filterValueAsPGLiteral` and `buildSQLFilter` skip the int/float/bool type guessing and treat the value as a string literal directly
- modifies `filterValueAsPGLiteral`'s signature to accept isColumnString bool
- passes IsStringData through ToFiltersModel() and both BuildSQLFilter (exported, in model/filter.go) and buildSQLFilter (unexported, in database/helper.go)
- adds FmtErrFilterValueConversion error format constant
- adds unit tests in filter_test.go for numeric string, float-like string, boolean-like string, combined AND/OR set operator cases
- adds endpoint-level tests in assetgrouptags_test.go for numeric string and boolean-like string name filtering
- updates pre-existing tests in filter_test.go, fileingest_test.go, and graphschema_test.go to include the new IsStringData field
- runs pfc

**Note**: There are 2 remaining SQL filter paths that do not explicitly set IsStringData, `GetAssetGroupCollections` and the `selectorSeedsQueryFilter` path in `GetAssetGroupTagSelectors`. Neither has text columns, and IsStringData correctly defaults to false. If either path adds string filters later, we should set IsStringData there too.

The same issue with graph path filtering will be tackled in [BED-8252](https://specterops.atlassian.net/browse/BED-8252) 

## Motivation and Context

Resolves [BED-8218](https://specterops.atlassian.net/browse/BED-8218)

When filtering by text-based fields (eg name, first_name) on API endpoints, values like "123", "t", or "false" are incorrectly parsed as integers or booleans. This causes a type mismatch at the database level, resulting in a 500. This affects every endpoint that has a string column in its ValidFilters(): asset group tags, users, saved queries, SSO providers, etc.

## How Has This Been Tested?

I tested this with:
- numeric string filter values (e.g. "123")
- float-like string filter values (e.g. "1.1")
- boolean-like string filter values (e.g. "t", "f", "true", "false")
- combined AND/OR set operator filters with string columns
- non-string columns to verify existing int/float/bool parsing still works
- endpoint-level test for asset group tags filtering by name with numeric and boolean-like values
- verified pre-existing tests still pass after adding IsStringData field

## Testing Instructions
1. run BHE
2. choose any endpoint with a text-based filter column (for example: asset group tags with name, users with first_name). For example, you can create a new resource with a name like "001", whether it's a user or an asset tag. Or you can validate with empty results. 

_Note: for users, first_name and other text fields don't allow single character names, so `t` won't work, whereas `true` or `123` will._ 
3. filter with a numeric string value and valid predicate: ?name=eq:123
               before fix: 500
               after fix: 200, correct results
4. filter with a boolean-like string value: ?name=eq:t
              before fix: 500
              after fix: 200, correct results
5. filter with a float-like string value: ?name=eq:1.1
              before fix: 500
              after fix: 200, correct results
6. verify that non-string columns (e.g. integer, boolean) still filter correctly and are not affected by this change

## Screenshots:

**Before fix — numeric string filter (`name=eq:123`):**
<img width="962" height="450" alt="client_name_1_bad_type" src="https://github.com/user-attachments/assets/c8e341c8-0438-4383-ae75-a2a886529fbe" />

**After fix — numeric string filter:
<img width="958" height="586" alt="client_name_1_exists" src="https://github.com/user-attachments/assets/0996586a-4e11-4879-9f49-0a8e72752579" />

(list all - "1" exists)
<img width="958" height="586" alt="client_name_1_exists" src="https://github.com/user-attachments/assets/085c56a5-f46a-4ec1-b2fc-0841aa027790" />

**After fix — float-like string filter (`name=eq:1.5`):**
(does not exist, but 200s)
<img width="957" height="411" alt="client_name_1 5_200_doesntexist" src="https://github.com/user-attachments/assets/4fd4cf78-b666-4794-9353-c3f005d22dda" />

**Before fix — boolean-like string filter (`name=eq:f`):**
<img width="957" height="433" alt="client_name_f_fail" src="https://github.com/user-attachments/assets/89e44aa6-c9eb-478e-8d95-e1beb82f03a7" />

**After fix — boolean-like string filter:**
<img width="945" height="610" alt="client_name_f_success" src="https://github.com/user-attachments/assets/61c10075-c889-4703-b13e-62f317078d49" />


## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


[BED-8218]: https://specterops.atlassian.net/browse/BED-8218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of string-typed filters for more accurate query results.
  * Clearer error messages when filter value conversion fails.

* **Tests**
  * Expanded coverage for string, numeric, and boolean-like filter scenarios.
  * Added tests for combined AND/OR filter behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SpecterOps/BloodHound/pull/2759)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[BED-8252]: https://specterops.atlassian.net/browse/BED-8252?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ