### PR TITLE
fix: escape backslashes and quotes in UI-built Cypher queries - BED-8162

### DIFF
--- a/packages/javascript/bh-shared-ui/src/utils/cypher.test.ts
+++ b/packages/javascript/bh-shared-ui/src/utils/cypher.test.ts
@@ -1,0 +1,59 @@
+// Copyright 2026 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { escapeCypherString } from './cypher';
+
+describe('escapeCypherString', () => {
+    it('wraps a plain value in single quotes', () => {
+        expect(escapeCypherString('S-1-5-21-1234')).toBe("'S-1-5-21-1234'");
+    });
+
+    it('escapes a single quote', () => {
+        expect(escapeCypherString("a'b")).toBe("'a\\'b'");
+    });
+
+    it('escapes multiple single quotes', () => {
+        expect(escapeCypherString("'''")).toBe("'\\'\\'\\''");
+    });
+
+    it('escapes a backslash', () => {
+        expect(escapeCypherString('a\\b')).toBe("'a\\\\b'");
+    });
+
+    it('escapes backslashes before quotes so they do not combine', () => {
+        // Input: a\'b  (backslash + single quote)
+        // Backslash must be escaped first to \\, then the quote to \'.
+        // Result must be 'a\\\'b' so the parser reads literal `\` then literal `'`,
+        // not an escaped quote that swallows the closing delimiter.
+        expect(escapeCypherString("a\\'b")).toBe("'a\\\\\\'b'");
+    });
+
+    it('leaves double quotes untouched', () => {
+        expect(escapeCypherString('a"b')).toBe("'a\"b'");
+    });
+
+    it('handles an empty string', () => {
+        expect(escapeCypherString('')).toBe("''");
+    });
+
+    it('handles only escapable characters', () => {
+        expect(escapeCypherString("\\'")).toBe("'\\\\\\''");
+    });
+
+    it('preserves unicode characters', () => {
+        expect(escapeCypherString('ézoë')).toBe("'ézoë'");
+    });
+});

--- a/packages/javascript/bh-shared-ui/src/utils/cypher.ts
+++ b/packages/javascript/bh-shared-ui/src/utils/cypher.ts
@@ -1,0 +1,27 @@
+// Copyright 2026 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Wraps a value as a Cypher single-quoted string literal, escaping any
+ * embedded backslashes and single quotes so the result is safe to interpolate
+ * directly into a Cypher query. The returned value includes the surrounding
+ * single quotes.
+ *
+ * @example
+ *   escapeCypherString("a'b")       // "'a\\'b'"
+ *   escapeCypherString('S-1-5\\21') // "'S-1-5\\\\21'"
+ */
+export const escapeCypherString = (value: string): string => `'${value.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`;

--- a/packages/javascript/bh-shared-ui/src/utils/parseItemId.ts
+++ b/packages/javascript/bh-shared-ui/src/utils/parseItemId.ts
@@ -14,6 +14,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+import { escapeCypherString } from './cypher';
+
 interface ParsedQueryItem {
     itemType: 'edge' | 'node';
     cypherQuery: string;
@@ -52,7 +54,7 @@ export const parseItemId = (itemId: string): ParsedQueryItem => {
     if (match) {
         return {
             itemType: 'node',
-            cypherQuery: `MATCH (n) WHERE n.objectid = '${match[1]}' RETURN n LIMIT 1`,
+            cypherQuery: `MATCH (n) WHERE n.objectid = ${escapeCypherString(match[1])} RETURN n LIMIT 1`,
         };
     }
 
@@ -62,7 +64,7 @@ export const parseItemId = (itemId: string): ParsedQueryItem => {
         const [, sourceObjectId, edgeType, targetObjectId] = match;
         return {
             itemType: 'edge',
-            cypherQuery: `MATCH p=(s)-[r:${edgeType}]->(t) WHERE s.objectid = '${sourceObjectId}' AND t.objectid = '${targetObjectId}'  RETURN p LIMIT 1`,
+            cypherQuery: `MATCH p=(s)-[r:${edgeType}]->(t) WHERE s.objectid = ${escapeCypherString(sourceObjectId)} AND t.objectid = ${escapeCypherString(targetObjectId)}  RETURN p LIMIT 1`,
         };
     }
 

--- a/packages/javascript/bh-shared-ui/src/views/Explore/ContextMenu/CopyMenuItem.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/Explore/ContextMenu/CopyMenuItem.tsx
@@ -19,6 +19,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { MenuItem, Tooltip, TooltipProps, styled, tooltipClasses } from '@mui/material';
 import { NodeResponse, useExploreSelectedItem } from '../../../hooks';
 import { useNotifications } from '../../../providers';
+import { escapeCypherString } from '../../../utils/cypher';
 
 const StyledTooltip = styled(({ className, ...props }: TooltipProps) => (
     <Tooltip {...props} classes={{ popper: className }} />
@@ -55,7 +56,7 @@ const CopyMenuItem = () => {
 
     const handleCopyCypher = () => {
         if (selectedItemQuery.data) {
-            const cypher = `MATCH (n:${selectedItemQuery.data.kind}) WHERE n.objectid = '${(selectedItemQuery.data as NodeResponse).objectId}' RETURN n`;
+            const cypher = `MATCH (n:${selectedItemQuery.data.kind}) WHERE n.objectid = ${escapeCypherString((selectedItemQuery.data as NodeResponse).objectId)} RETURN n`;
             navigator.clipboard.writeText(cypher);
             addNotification(`Cypher copied to clipboard`, 'copyToClipboard');
         }


### PR DESCRIPTION
## Description

Adds an escapeCypherString function to the front end to ensure some searches via objectIDs are properly escaped before being passed to the backend. 

## Motivation and Context
Resolves: BED-8162

Fixes two bugs affecting the UI's ability to build cypher queries containing escaped characters. 

## How Has This Been Tested?

- Added new unit tests
- Manually tested locally 

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added proper escaping for special characters in Cypher query string handling.

* **Bug Fixes**
  * Updated query generation for item identifiers and clipboard copy functionality to correctly escape special characters, preventing query failures when values contain quotes or backslashes.

* **Tests**
  * Added comprehensive test coverage for the new escaping functionality.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SpecterOps/BloodHound/pull/2761)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->