### PR TITLE
fix: removed API expiration column BED-8228

### DIFF
--- a/packages/javascript/bh-shared-ui/src/views/Users/UsersTable.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/Users/UsersTable.tsx
@@ -21,7 +21,7 @@ import { DateTime } from 'luxon';
 import { FC } from 'react';
 import { useQuery } from 'react-query';
 import { DataTable, Header } from '../../components';
-import { useAPITokenExpirationConfiguration, usePermissions, useTheme } from '../../hooks';
+import { usePermissions, useTheme } from '../../hooks';
 import { useBloodHoundUsers, useSelf } from '../../hooks/useBloodHoundUsers';
 import { LuxonFormat, Permission, apiClient } from '../../utils';
 import UserActionsMenu from './UserActionsMenu';
@@ -60,7 +60,6 @@ const UsersTable: FC<UsersTableProps> = ({
     setSelectedUserId,
 }) => {
     const theme = useTheme();
-    const { enabled: apiTokenExpirationEnabled } = useAPITokenExpirationConfiguration();
 
     const usersTableHeaders: Header[] = [
         { label: 'Username' },
@@ -69,7 +68,6 @@ const UsersTable: FC<UsersTableProps> = ({
         { label: 'Created' },
         { label: 'Role' },
         { label: 'Status' },
-        ...(apiTokenExpirationEnabled ? [{ label: 'API Expiration Date' }] : []),
         { label: 'Auth Method' },
         { label: '', alignment: 'right' as const },
     ];
@@ -98,21 +96,6 @@ const UsersTable: FC<UsersTableProps> = ({
         if (user.AuthSecret?.totp_activated)
             return <span style={{ whiteSpace: 'pre-wrap' }}>{'Username / Password\nMFA Enabled'}</span>;
         return <span>Username / Password</span>;
-    };
-
-    const getAPIExpirationDate = (expiresAt?: string): React.ReactNode => {
-        if (!expiresAt) return null;
-        const date = DateTime.fromISO(expiresAt);
-        if (!date.isValid) return null;
-        const daysUntilExpiry = date.diff(DateTime.now(), 'days').days;
-        if (daysUntilExpiry < 0) return <span className='text-error'>Expired</span>;
-        const isExpiringSoon = daysUntilExpiry < 10;
-        return (
-            <>
-                <span>{date.toFormat('yyyy-MM-dd')}</span>
-                {isExpiringSoon && <div className='text-error'>&lt;10 Days to Expire</div>}
-            </>
-        );
     };
 
     const usersTableRows = listUsersQuery.data?.map((user, index) => {
@@ -145,7 +128,6 @@ const UsersTable: FC<UsersTableProps> = ({
             </span>,
             user.roles?.[0]?.name,
             getUserStatusText(user),
-            ...(apiTokenExpirationEnabled ? [getAPIExpirationDate(user.AuthSecret?.expires_at)] : []),
             getAuthMethodText(user),
             <UserActionsMenu
                 userId={user.id}


### PR DESCRIPTION
## Description

This changeset removes the API Key Expiration column from Manage Users.

## Motivation and Context

Resolves [BED-8228](https://specterops.atlassian.net/browse/BED-8228)

## How Has This Been Tested?
Manual testing

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


[BED-8228]: https://specterops.atlassian.net/browse/BED-8228?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed the API token expiration date column from the Users table interface. The user management view no longer displays API token expiration information or related warnings. All other table functionality, user actions, and authentication method controls remain fully intact and operational.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SpecterOps/BloodHound/pull/2762)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->