### PR TITLE
fix: populate custom node kinds with existing schemaless node kinds BED-7926

### DIFF
--- a/cmd/api/src/database/customnode.go
+++ b/cmd/api/src/database/customnode.go
@@ -58,14 +58,6 @@ func (s *BloodhoundDB) EnsureStubbedCustomNodeKindForIngest(ctx context.Context,
 	return nil
 }
 
-// SchemalessNodeKindBackfillData is a narrow interface used by the graph migration Version_930_Migration()
-// to read display metadata from Postgres and write backfilled custom_node_kinds entries.
-type SchemalessNodeKindBackfillData interface {
-	GetCustomNodeKinds(ctx context.Context, filters model.Filters) ([]model.CustomNodeKind, error)
-	GetGraphSchemaNodeKinds(ctx context.Context, filters model.Filters, sort model.Sort, skip, limit int) (model.GraphSchemaNodeKinds, int, error)
-	CreateCustomNodeKinds(ctx context.Context, customNodeKinds model.CustomNodeKinds) (model.CustomNodeKinds, error)
-}
-
 func (s *BloodhoundDB) CreateCustomNodeKinds(ctx context.Context, customNodeKinds model.CustomNodeKinds) (model.CustomNodeKinds, error) {
 	var (
 		auditEntry = model.AuditEntry{

--- a/cmd/api/src/database/customnode.go
+++ b/cmd/api/src/database/customnode.go
@@ -58,6 +58,14 @@ func (s *BloodhoundDB) EnsureStubbedCustomNodeKindForIngest(ctx context.Context,
 	return nil
 }
 
+// SchemalessNodeKindBackfillData is a narrow interface used by the graph migration Version_930_Migration()
+// to read display metadata from Postgres and write backfilled custom_node_kinds entries.
+type SchemalessNodeKindBackfillData interface {
+	GetCustomNodeKinds(ctx context.Context, filters model.Filters) ([]model.CustomNodeKind, error)
+	GetGraphSchemaNodeKinds(ctx context.Context, filters model.Filters, sort model.Sort, skip, limit int) (model.GraphSchemaNodeKinds, int, error)
+	CreateCustomNodeKinds(ctx context.Context, customNodeKinds model.CustomNodeKinds) (model.CustomNodeKinds, error)
+}
+
 func (s *BloodhoundDB) CreateCustomNodeKinds(ctx context.Context, customNodeKinds model.CustomNodeKinds) (model.CustomNodeKinds, error) {
 	var (
 		auditEntry = model.AuditEntry{

--- a/cmd/api/src/database/customnode.go
+++ b/cmd/api/src/database/customnode.go
@@ -29,7 +29,7 @@ import (
 	"gorm.io/gorm"
 )
 
-var ingestCustomNodeKindStubConfig = model.CustomNodeKindConfig{
+var CustomNodeKindStubConfig = model.CustomNodeKindConfig{
 	Icon: graphschema.DisplayNodeIcon{
 		Name:  "question",
 		Type:  graphschema.DisplayNodeTypeFontAwesome,
@@ -51,7 +51,7 @@ func (s *BloodhoundDB) EnsureStubbedCustomNodeKindForIngest(ctx context.Context,
 		return errors.New("invalid kind name")
 	}
 
-	if result := s.db.WithContext(ctx).Exec("SELECT ensure_stubbed_custom_node_kind_for_ingest(?, ?);", name, ingestCustomNodeKindStubConfig); result.Error != nil {
+	if result := s.db.WithContext(ctx).Exec("SELECT ensure_stubbed_custom_node_kind_for_ingest(?, ?);", name, CustomNodeKindStubConfig); result.Error != nil {
 		return fmt.Errorf("failed to ensure custom node kind stub %q: %w", name, result.Error)
 	}
 

--- a/cmd/api/src/migrations/graph.go
+++ b/cmd/api/src/migrations/graph.go
@@ -23,7 +23,7 @@ import (
 	"log/slog"
 	"sort"
 
-	"github.com/specterops/bloodhound/cmd/api/src/database"
+	"github.com/specterops/bloodhound/cmd/api/src/model"
 	"github.com/specterops/bloodhound/cmd/api/src/version"
 	"github.com/specterops/bloodhound/packages/go/bhlog/attr"
 	"github.com/specterops/bloodhound/packages/go/graphschema"
@@ -134,9 +134,18 @@ type GraphMigration interface {
 	executeMigrations(ctx context.Context, originalVersion version.Version, migrationsByVersion MigrationsByVersion) error
 }
 
+// SchemalessNodeKindBackfillData is the narrow interface consumed by Version_930_Migration to read
+// display metadata from Postgres and write backfilled custom_node_kinds entries. It is intended to
+// be satisfied by database.Database
+type SchemalessNodeKindBackfillData interface {
+	GetCustomNodeKinds(ctx context.Context, filters model.Filters) ([]model.CustomNodeKind, error)
+	GetGraphSchemaNodeKinds(ctx context.Context, filters model.Filters, sort model.Sort, skip, limit int) (model.GraphSchemaNodeKinds, int, error)
+	CreateCustomNodeKinds(ctx context.Context, customNodeKinds model.CustomNodeKinds) (model.CustomNodeKinds, error)
+}
+
 type GraphMigrator struct {
 	db                             graph.Database
-	schemalessNodeKindBackfillData database.SchemalessNodeKindBackfillData
+	schemalessNodeKindBackfillData SchemalessNodeKindBackfillData
 }
 
 // Option configures optional dependencies on a GraphMigrator. Most migrations
@@ -148,8 +157,8 @@ type Option func(*GraphMigrator)
 // WithSchemalessKindBackfill wires a SchemalessNodeKindBackfillData provider into the migrator.
 // Migrations that backfill custom_node_kinds for orphaned schemaless ingest kinds will
 // short-circuit when this option is not supplied.
-func WithSchemalessKindBackfill(backfillData database.SchemalessNodeKindBackfillData) Option {
-	return func(m *GraphMigrator) { m.schemalessNodeKindBackfillData = backfillData }
+func WithSchemalessKindBackfill(nodeKindData SchemalessNodeKindBackfillData) Option {
+	return func(m *GraphMigrator) { m.schemalessNodeKindBackfillData = nodeKindData }
 }
 
 func NewGraphMigrator(db graph.Database, opts ...Option) *GraphMigrator {

--- a/cmd/api/src/migrations/graph.go
+++ b/cmd/api/src/migrations/graph.go
@@ -23,6 +23,7 @@ import (
 	"log/slog"
 	"sort"
 
+	"github.com/specterops/bloodhound/cmd/api/src/database"
 	"github.com/specterops/bloodhound/cmd/api/src/version"
 	"github.com/specterops/bloodhound/packages/go/bhlog/attr"
 	"github.com/specterops/bloodhound/packages/go/graphschema"
@@ -134,11 +135,29 @@ type GraphMigration interface {
 }
 
 type GraphMigrator struct {
-	db graph.Database
+	db                             graph.Database
+	schemalessNodeKindBackfillData database.SchemalessNodeKindBackfillData
 }
 
-func NewGraphMigrator(db graph.Database) *GraphMigrator {
-	return &GraphMigrator{db: db}
+// Option configures optional dependencies on a GraphMigrator. Most migrations
+// only need a graph.Database; a small number need access to the relational
+// database (e.g. to read source_kinds). Use functional options to inject those
+// dependencies without forcing every caller to acknowledge them.
+type Option func(*GraphMigrator)
+
+// WithSchemalessKindBackfill wires a SchemalessNodeKindBackfillData provider into the migrator.
+// Migrations that backfill custom_node_kinds for orphaned schemaless ingest kinds will
+// short-circuit when this option is not supplied.
+func WithSchemalessKindBackfill(backfillData database.SchemalessNodeKindBackfillData) Option {
+	return func(m *GraphMigrator) { m.schemalessNodeKindBackfillData = backfillData }
+}
+
+func NewGraphMigrator(db graph.Database, opts ...Option) *GraphMigrator {
+	migrator := &GraphMigrator{db: db}
+	for _, opt := range opts {
+		opt(migrator)
+	}
+	return migrator
 }
 
 func (s *GraphMigrator) Migrate(ctx context.Context) error {
@@ -220,7 +239,7 @@ func (s *GraphMigrator) executeMigrations(ctx context.Context, originalVersion v
 
 func (s *GraphMigrator) GetMigrationsByVersion() MigrationsByVersion {
 	migrationsByVersion := make(MigrationsByVersion)
-	for _, migration := range Manifest {
+	for _, migration := range GetManifest(s.schemalessNodeKindBackfillData) {
 		migrationsByVersion[migration.Version] = append(migrationsByVersion[migration.Version], migration)
 	}
 	return migrationsByVersion

--- a/cmd/api/src/migrations/graph.go
+++ b/cmd/api/src/migrations/graph.go
@@ -134,10 +134,10 @@ type GraphMigration interface {
 	executeMigrations(ctx context.Context, originalVersion version.Version, migrationsByVersion MigrationsByVersion) error
 }
 
-// SchemalessNodeKindBackfillData is the narrow interface consumed by Version_930_Migration to read
+// schemalessNodeKindBackfillData is the narrow interface consumed by Version_930_Migration to read
 // display metadata from Postgres and write backfilled custom_node_kinds entries. It is intended to
 // be satisfied by database.Database
-type SchemalessNodeKindBackfillData interface {
+type schemalessNodeKindBackfillData interface {
 	GetCustomNodeKinds(ctx context.Context, filters model.Filters) ([]model.CustomNodeKind, error)
 	GetGraphSchemaNodeKinds(ctx context.Context, filters model.Filters, sort model.Sort, skip, limit int) (model.GraphSchemaNodeKinds, int, error)
 	CreateCustomNodeKinds(ctx context.Context, customNodeKinds model.CustomNodeKinds) (model.CustomNodeKinds, error)
@@ -145,7 +145,7 @@ type SchemalessNodeKindBackfillData interface {
 
 type GraphMigrator struct {
 	db                             graph.Database
-	schemalessNodeKindBackfillData SchemalessNodeKindBackfillData
+	schemalessNodeKindBackfillData schemalessNodeKindBackfillData
 }
 
 // Option configures optional dependencies on a GraphMigrator. Most migrations
@@ -157,7 +157,7 @@ type Option func(*GraphMigrator)
 // WithSchemalessKindBackfill wires a SchemalessNodeKindBackfillData provider into the migrator.
 // Migrations that backfill custom_node_kinds for orphaned schemaless ingest kinds will
 // short-circuit when this option is not supplied.
-func WithSchemalessKindBackfill(nodeKindData SchemalessNodeKindBackfillData) Option {
+func WithSchemalessKindBackfill(nodeKindData schemalessNodeKindBackfillData) Option {
 	return func(m *GraphMigrator) { m.schemalessNodeKindBackfillData = nodeKindData }
 }
 

--- a/cmd/api/src/migrations/manifest.go
+++ b/cmd/api/src/migrations/manifest.go
@@ -56,11 +56,11 @@ func RequiresMigration(ctx context.Context, db graph.Database) (bool, error) {
 // that exists in the graph but has no corresponding entry in either custom_node_kinds or schema_node_kinds.
 // This covers node kinds that entered the graph through schemaless Open Graph ingest, which were never written
 // to custom_node_kinds.
-func Version_930_Migration(backfillData SchemalessNodeKindBackfillData) func(ctx context.Context, db graph.Database) error {
+func Version_930_Migration(nodeKindData SchemalessNodeKindBackfillData) func(ctx context.Context, db graph.Database) error {
 	return func(ctx context.Context, db graph.Database) error {
 		defer measure.LogAndMeasureWithThreshold(slog.LevelInfo, "Migration to backfill custom_node_kinds for schemaless ingest kinds")()
 
-		if backfillData == nil {
+		if nodeKindData == nil {
 			return fmt.Errorf("Version_930_Migration requires a SchemalessNodeKindBackfillData provider but none was configured")
 		}
 
@@ -71,7 +71,7 @@ func Version_930_Migration(backfillData SchemalessNodeKindBackfillData) func(ctx
 		}
 
 		// Build a set of kind names already covered by custom_node_kinds.
-		existingCustomNodeKinds, err := backfillData.GetCustomNodeKinds(ctx, nil)
+		existingCustomNodeKinds, err := nodeKindData.GetCustomNodeKinds(ctx, nil)
 		if err != nil {
 			return fmt.Errorf("failed to fetch custom node kinds: %w", err)
 		}
@@ -82,7 +82,7 @@ func Version_930_Migration(backfillData SchemalessNodeKindBackfillData) func(ctx
 		}
 
 		// Extend the covered set with kind names present in schema_node_kinds.
-		schemaNodeKinds, _, err := backfillData.GetGraphSchemaNodeKinds(ctx, nil, model.Sort{}, 0, 0)
+		schemaNodeKinds, _, err := nodeKindData.GetGraphSchemaNodeKinds(ctx, nil, model.Sort{}, 0, 0)
 		if err != nil {
 			return fmt.Errorf("failed to fetch schema node kinds: %w", err)
 		}
@@ -124,7 +124,7 @@ func Version_930_Migration(backfillData SchemalessNodeKindBackfillData) func(ctx
 			return nil
 		}
 
-		if _, err := backfillData.CreateCustomNodeKinds(ctx, kindsToCreate); err != nil {
+		if _, err := nodeKindData.CreateCustomNodeKinds(ctx, kindsToCreate); err != nil {
 			return fmt.Errorf("failed to create custom node kinds during backfill: %w", err)
 		}
 
@@ -631,7 +631,7 @@ func Version_277_Migration(ctx context.Context, db graph.Database) error {
 // GetManifest returns the ordered list of graph migrations. Migrations that need
 // dependencies beyond the graph database (e.g. relational source kinds) capture
 // them via the provided arguments.
-func GetManifest(backfillData SchemalessNodeKindBackfillData) []Migration {
+func GetManifest(nodeKindData SchemalessNodeKindBackfillData) []Migration {
 	return []Migration{
 		{
 			Version: version.Version{Major: 2, Minor: 3, Patch: 0},
@@ -748,7 +748,7 @@ func GetManifest(backfillData SchemalessNodeKindBackfillData) []Migration {
 		},
 		{
 			Version: version.Version{Major: 9, Minor: 3, Patch: 0},
-			Execute: Version_930_Migration(backfillData),
+			Execute: Version_930_Migration(nodeKindData),
 		},
 	}
 }

--- a/cmd/api/src/migrations/manifest.go
+++ b/cmd/api/src/migrations/manifest.go
@@ -24,6 +24,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/specterops/bloodhound/cmd/api/src/database"
+	"github.com/specterops/bloodhound/cmd/api/src/model"
 	"github.com/specterops/bloodhound/cmd/api/src/version"
 	"github.com/specterops/bloodhound/packages/go/analysis/ad/wellknown"
 	"github.com/specterops/bloodhound/packages/go/analysis/post"
@@ -49,6 +51,112 @@ func RequiresMigration(ctx context.Context, db graph.Database) (bool, error) {
 	} else {
 		return version.GetVersion().GreaterThan(currentMigration), nil
 	}
+}
+
+// Version_930_Migration returns a migration that backfills custom_node_kinds rows for any node kind
+// that exists in the graph but has no corresponding entry in either custom_node_kinds or schema_node_kinds.
+// This covers node kinds that entered the graph through schemaless Open Graph ingest, which were never written
+// to custom_node_kinds.
+func Version_930_Migration(backfillData database.SchemalessNodeKindBackfillData) func(ctx context.Context, db graph.Database) error {
+	return func(ctx context.Context, db graph.Database) error {
+		defer measure.LogAndMeasureWithThreshold(slog.LevelInfo, "Migration to backfill custom_node_kinds for schemaless ingest kinds")()
+
+		if backfillData == nil {
+			slog.InfoContext(ctx, "Skipping Version_930_Migration: no SchemalessNodeKindBackfillData provider configured")
+			return nil
+		}
+
+		// Fetch all kinds registered in the graph / kind table.
+		allKinds, err := db.FetchKinds(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to fetch kinds from graph: %w", err)
+		}
+
+		// Build a set of kind names already covered by custom_node_kinds.
+		existingCustomNodeKinds, err := backfillData.GetCustomNodeKinds(ctx, nil)
+		if err != nil {
+			return fmt.Errorf("failed to fetch custom node kinds: %w", err)
+		}
+
+		coveredKindNames := make(map[string]struct{}, len(existingCustomNodeKinds))
+		for _, customNodeKind := range existingCustomNodeKinds {
+			coveredKindNames[customNodeKind.KindName] = struct{}{}
+		}
+
+		// Extend the covered set with kind names present in schema_node_kinds.
+		schemaNodeKinds, _, err := backfillData.GetGraphSchemaNodeKinds(ctx, nil, model.Sort{}, 0, 0)
+		if err != nil {
+			return fmt.Errorf("failed to fetch schema node kinds: %w", err)
+		}
+		for _, schemaNodeKind := range schemaNodeKinds {
+			coveredKindNames[schemaNodeKind.Name] = struct{}{}
+		}
+
+		var kindsToCreate model.CustomNodeKinds
+		for _, kind := range allKinds {
+			// skip meta kinds, tier tags, etc.
+			if isInternalGraphKind(kind) {
+				continue
+			}
+			// skip kinds that are already covered by custom_node_kinds or schema_node_kinds
+			if _, alreadyCovered := coveredKindNames[kind.String()]; alreadyCovered {
+				continue
+			}
+
+			nodeFound, err := graphKindHasNodes(ctx, db, kind)
+			if err != nil {
+				return fmt.Errorf("failed to check graph for nodes of kind %q: %w", kind.String(), err)
+			}
+			if nodeFound {
+				kindsToCreate = append(kindsToCreate, model.CustomNodeKind{
+					KindName: kind.String(),
+					Config: model.CustomNodeKindConfig{
+						Icon: graphschema.DisplayNodeIcon{
+							Type:  graphschema.DisplayNodeTypeFontAwesome,
+							Color: "#FFFFFF",
+						},
+					},
+				})
+			}
+		}
+
+		if len(kindsToCreate) == 0 {
+			slog.InfoContext(ctx, "No schemaless node kinds require backfilling into custom_node_kinds")
+			return nil
+		}
+
+		if _, err := backfillData.CreateCustomNodeKinds(ctx, kindsToCreate); err != nil {
+			return fmt.Errorf("failed to create custom node kinds during backfill: %w", err)
+		}
+
+		slog.InfoContext(ctx, "Backfilled custom_node_kinds for schemaless ingest kinds",
+			slog.Int("count", len(kindsToCreate)),
+		)
+		return nil
+	}
+}
+
+// isInternalGraphKind reports whether a kind is an internal implementation detail that would
+// never have been ingested as user data (e.g. migration tracking nodes, meta nodes, tier tags).
+func isInternalGraphKind(kind graph.Kind) bool {
+	return strings.HasPrefix(kind.String(), model.AssetGroupTagKindPrefix) ||
+		kind.Is(common.MigrationData, graph.StringKind("Meta"), graph.StringKind("MetaDetail"))
+}
+
+// graphKindHasNodes returns true if at least one node with the kind exists in the graph.
+func graphKindHasNodes(ctx context.Context, db graph.Database, kind graph.Kind) (bool, error) {
+	var nodeFound bool
+	err := db.ReadTransaction(ctx, func(tx graph.Transaction) error {
+		if _, err := tx.Nodes().Filter(query.Kind(query.Node(), kind)).First(); err != nil {
+			if errors.Is(err, graph.ErrNoResultsFound) {
+				return nil
+			}
+			return err
+		}
+		nodeFound = true
+		return nil
+	})
+	return nodeFound, err
 }
 
 func Version_910_Migration(ctx context.Context, db graph.Database) error {
@@ -528,118 +636,127 @@ func Version_277_Migration(ctx context.Context, db graph.Database) error {
 	})
 }
 
-var Manifest = []Migration{
-	{
-		Version: version.Version{Major: 2, Minor: 3, Patch: 0},
-		Execute: func(ctx context.Context, db graph.Database) error {
-			defer measure.MeasureWithThreshold(slog.LevelInfo, "Deleting all existing role nodes")()
+// GetManifest returns the ordered list of graph migrations. Migrations that need
+// dependencies beyond the graph database (e.g. relational source kinds) capture
+// them via the provided arguments.
+func GetManifest(backfillData database.SchemalessNodeKindBackfillData) []Migration {
+	return []Migration{
+		{
+			Version: version.Version{Major: 2, Minor: 3, Patch: 0},
+			Execute: func(ctx context.Context, db graph.Database) error {
+				defer measure.MeasureWithThreshold(slog.LevelInfo, "Deleting all existing role nodes")()
 
-			return db.WriteTransaction(ctx, func(tx graph.Transaction) error {
-				return tx.Nodes().Filterf(func() graph.Criteria {
-					return query.Kind(query.Node(), azure.Role)
-				}).Delete()
-			})
+				return db.WriteTransaction(ctx, func(tx graph.Transaction) error {
+					return tx.Nodes().Filterf(func() graph.Criteria {
+						return query.Kind(query.Node(), azure.Role)
+					}).Delete()
+				})
+			},
 		},
-	},
-	{
-		Version: version.Version{Major: 2, Minor: 6, Patch: 3},
-		Execute: func(ctx context.Context, db graph.Database) error {
-			defer measure.MeasureWithThreshold(slog.LevelInfo, "Deleting all LocalToComputer/RemoteInteractiveLogin edges and ADLocalGroup labels")()
+		{
+			Version: version.Version{Major: 2, Minor: 6, Patch: 3},
+			Execute: func(ctx context.Context, db graph.Database) error {
+				defer measure.MeasureWithThreshold(slog.LevelInfo, "Deleting all LocalToComputer/RemoteInteractiveLogin edges and ADLocalGroup labels")()
 
-			// This kind has long since gone missing from our schemas but the assert below reintroduces it for the
-			// purposes of running this migration
-			rilpKind := graph.StringKind("RemoteInteractiveLogonPrivilege")
+				// This kind has long since gone missing from our schemas but the assert below reintroduces it for the
+				// purposes of running this migration
+				rilpKind := graph.StringKind("RemoteInteractiveLogonPrivilege")
 
-			if err := db.AssertSchema(ctx, graph.Schema{
-				Graphs: []graph.Graph{{
-					Edges: graph.Kinds{rilpKind},
-				}},
-			}); err != nil {
-				return err
-			}
-
-			return db.WriteTransaction(ctx, func(tx graph.Transaction) error {
-				// Remove ADLocalGroup label from all nodes that also have the group label
-				if nodes, err := ops.FetchNodes(tx.Nodes().Filterf(func() graph.Criteria {
-					return query.And(
-						query.Kind(query.Node(), ad.LocalGroup),
-						query.Kind(query.Node(), ad.Group),
-					)
-				})); err != nil {
+				if err := db.AssertSchema(ctx, graph.Schema{
+					Graphs: []graph.Graph{{
+						Edges: graph.Kinds{rilpKind},
+					}},
+				}); err != nil {
 					return err
-				} else {
-					for _, node := range nodes {
-						node.DeleteKinds(ad.LocalGroup)
-						if err := tx.UpdateNode(node); err != nil {
-							return err
+				}
+
+				return db.WriteTransaction(ctx, func(tx graph.Transaction) error {
+					// Remove ADLocalGroup label from all nodes that also have the group label
+					if nodes, err := ops.FetchNodes(tx.Nodes().Filterf(func() graph.Criteria {
+						return query.And(
+							query.Kind(query.Node(), ad.LocalGroup),
+							query.Kind(query.Node(), ad.Group),
+						)
+					})); err != nil {
+						return err
+					} else {
+						for _, node := range nodes {
+							node.DeleteKinds(ad.LocalGroup)
+							if err := tx.UpdateNode(node); err != nil {
+								return err
+							}
 						}
 					}
-				}
 
-				// Delete all local group edges
-				if err := tx.Relationships().Filterf(func() graph.Criteria {
-					return query.And(
-						query.Or(
-							query.Kind(query.Relationship(), rilpKind),
-							query.Kind(query.Relationship(), ad.LocalToComputer),
-							query.Kind(query.Relationship(), ad.MemberOfLocalGroup),
-						),
-						query.Kind(query.Start(), ad.Entity),
-					)
-				}).Delete(); err != nil {
-					return err
-				}
+					// Delete all local group edges
+					if err := tx.Relationships().Filterf(func() graph.Criteria {
+						return query.And(
+							query.Or(
+								query.Kind(query.Relationship(), rilpKind),
+								query.Kind(query.Relationship(), ad.LocalToComputer),
+								query.Kind(query.Relationship(), ad.MemberOfLocalGroup),
+							),
+							query.Kind(query.Start(), ad.Entity),
+						)
+					}).Delete(); err != nil {
+						return err
+					}
 
-				return nil
-			})
+					return nil
+				})
+			},
 		},
-	},
-	{
-		Version: version.Version{Major: 2, Minor: 7, Patch: 7},
-		Execute: Version_277_Migration,
-	},
-	{
-		Version: version.Version{Major: 5, Minor: 0, Patch: 8},
-		Execute: Version_508_Migration,
-	},
-	{
-		Version: version.Version{Major: 5, Minor: 13, Patch: 0},
-		Execute: Version_513_Migration,
-	},
-	{
-		Version: version.Version{Major: 6, Minor: 2, Patch: 0},
-		Execute: Version_620_Migration,
-	},
-	{
-		Version: version.Version{Major: 7, Minor: 3, Patch: 0},
-		Execute: Version_730_Migration,
-	},
-	{
-		Version: version.Version{Major: 7, Minor: 4, Patch: 0},
-		Execute: Version_740_Migration,
-	},
-	{
-		Version: version.Version{Major: 8, Minor: 1, Patch: 3},
-		Execute: Version_813_Migration,
-	},
-	{
-		Version: version.Version{Major: 8, Minor: 3, Patch: 0},
-		Execute: Version_830_Migration,
-	},
-	{
-		Version: version.Version{Major: 8, Minor: 5, Patch: 2},
-		Execute: Version_852_Migration,
-	},
-	{
-		Version: version.Version{Major: 8, Minor: 6, Patch: 0},
-		Execute: Version_860_Migration,
-	},
-	{
-		Version: version.Version{Major: 9, Minor: 0, Patch: 0},
-		Execute: Version_900_Migration,
-	},
-	{
-		Version: version.Version{Major: 9, Minor: 1, Patch: 0},
-		Execute: Version_910_Migration,
-	},
+		{
+			Version: version.Version{Major: 2, Minor: 7, Patch: 7},
+			Execute: Version_277_Migration,
+		},
+		{
+			Version: version.Version{Major: 5, Minor: 0, Patch: 8},
+			Execute: Version_508_Migration,
+		},
+		{
+			Version: version.Version{Major: 5, Minor: 13, Patch: 0},
+			Execute: Version_513_Migration,
+		},
+		{
+			Version: version.Version{Major: 6, Minor: 2, Patch: 0},
+			Execute: Version_620_Migration,
+		},
+		{
+			Version: version.Version{Major: 7, Minor: 3, Patch: 0},
+			Execute: Version_730_Migration,
+		},
+		{
+			Version: version.Version{Major: 7, Minor: 4, Patch: 0},
+			Execute: Version_740_Migration,
+		},
+		{
+			Version: version.Version{Major: 8, Minor: 1, Patch: 3},
+			Execute: Version_813_Migration,
+		},
+		{
+			Version: version.Version{Major: 8, Minor: 3, Patch: 0},
+			Execute: Version_830_Migration,
+		},
+		{
+			Version: version.Version{Major: 8, Minor: 5, Patch: 2},
+			Execute: Version_852_Migration,
+		},
+		{
+			Version: version.Version{Major: 8, Minor: 6, Patch: 0},
+			Execute: Version_860_Migration,
+		},
+		{
+			Version: version.Version{Major: 9, Minor: 0, Patch: 0},
+			Execute: Version_900_Migration,
+		},
+		{
+			Version: version.Version{Major: 9, Minor: 1, Patch: 0},
+			Execute: Version_910_Migration,
+		},
+		{
+			Version: version.Version{Major: 9, Minor: 3, Patch: 0},
+			Execute: Version_930_Migration(backfillData),
+		},
+	}
 }

--- a/cmd/api/src/migrations/manifest.go
+++ b/cmd/api/src/migrations/manifest.go
@@ -56,7 +56,7 @@ func RequiresMigration(ctx context.Context, db graph.Database) (bool, error) {
 // that exists in the graph but has no corresponding entry in either custom_node_kinds or schema_node_kinds.
 // This covers node kinds that entered the graph through schemaless Open Graph ingest, which were never written
 // to custom_node_kinds.
-func Version_930_Migration(nodeKindData SchemalessNodeKindBackfillData) func(ctx context.Context, db graph.Database) error {
+func Version_930_Migration(nodeKindData schemalessNodeKindBackfillData) func(ctx context.Context, db graph.Database) error {
 	return func(ctx context.Context, db graph.Database) error {
 		defer measure.LogAndMeasureWithThreshold(slog.LevelInfo, "Migration to backfill custom_node_kinds for schemaless ingest kinds")()
 
@@ -631,7 +631,7 @@ func Version_277_Migration(ctx context.Context, db graph.Database) error {
 // GetManifest returns the ordered list of graph migrations. Migrations that need
 // dependencies beyond the graph database (e.g. relational source kinds) capture
 // them via the provided arguments.
-func GetManifest(nodeKindData SchemalessNodeKindBackfillData) []Migration {
+func GetManifest(nodeKindData schemalessNodeKindBackfillData) []Migration {
 	return []Migration{
 		{
 			Version: version.Version{Major: 2, Minor: 3, Patch: 0},

--- a/cmd/api/src/migrations/manifest.go
+++ b/cmd/api/src/migrations/manifest.go
@@ -24,7 +24,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/specterops/bloodhound/cmd/api/src/database"
 	"github.com/specterops/bloodhound/cmd/api/src/model"
 	"github.com/specterops/bloodhound/cmd/api/src/version"
 	"github.com/specterops/bloodhound/packages/go/analysis/ad/wellknown"
@@ -57,7 +56,7 @@ func RequiresMigration(ctx context.Context, db graph.Database) (bool, error) {
 // that exists in the graph but has no corresponding entry in either custom_node_kinds or schema_node_kinds.
 // This covers node kinds that entered the graph through schemaless Open Graph ingest, which were never written
 // to custom_node_kinds.
-func Version_930_Migration(backfillData database.SchemalessNodeKindBackfillData) func(ctx context.Context, db graph.Database) error {
+func Version_930_Migration(backfillData SchemalessNodeKindBackfillData) func(ctx context.Context, db graph.Database) error {
 	return func(ctx context.Context, db graph.Database) error {
 		defer measure.LogAndMeasureWithThreshold(slog.LevelInfo, "Migration to backfill custom_node_kinds for schemaless ingest kinds")()
 
@@ -633,7 +632,7 @@ func Version_277_Migration(ctx context.Context, db graph.Database) error {
 // GetManifest returns the ordered list of graph migrations. Migrations that need
 // dependencies beyond the graph database (e.g. relational source kinds) capture
 // them via the provided arguments.
-func GetManifest(backfillData database.SchemalessNodeKindBackfillData) []Migration {
+func GetManifest(backfillData SchemalessNodeKindBackfillData) []Migration {
 	return []Migration{
 		{
 			Version: version.Version{Major: 2, Minor: 3, Patch: 0},

--- a/cmd/api/src/migrations/manifest.go
+++ b/cmd/api/src/migrations/manifest.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/specterops/bloodhound/cmd/api/src/database"
 	"github.com/specterops/bloodhound/cmd/api/src/model"
 	"github.com/specterops/bloodhound/cmd/api/src/version"
 	"github.com/specterops/bloodhound/packages/go/analysis/ad/wellknown"
@@ -108,13 +109,7 @@ func Version_930_Migration(nodeKindData schemalessNodeKindBackfillData) func(ctx
 			if nodeFound {
 				kindsToCreate = append(kindsToCreate, model.CustomNodeKind{
 					KindName: kind.String(),
-					Config: model.CustomNodeKindConfig{
-						Icon: graphschema.DisplayNodeIcon{
-							Type:  graphschema.DisplayNodeTypeFontAwesome,
-							Color: "#FFFFFF",
-							Name:  "question",
-						},
-					},
+					Config:   database.CustomNodeKindStubConfig,
 				})
 			}
 		}

--- a/cmd/api/src/migrations/manifest.go
+++ b/cmd/api/src/migrations/manifest.go
@@ -95,7 +95,7 @@ func Version_930_Migration(backfillData database.SchemalessNodeKindBackfillData)
 		var kindsToCreate model.CustomNodeKinds
 		for _, kind := range allKinds {
 			// skip meta kinds, tier tags, etc.
-			if isInternalGraphKind(kind) {
+			if model.IsExtendedNodeKind(kind) {
 				continue
 			}
 			// skip kinds that are already covered by custom_node_kinds or schema_node_kinds
@@ -114,6 +114,7 @@ func Version_930_Migration(backfillData database.SchemalessNodeKindBackfillData)
 						Icon: graphschema.DisplayNodeIcon{
 							Type:  graphschema.DisplayNodeTypeFontAwesome,
 							Color: "#FFFFFF",
+							Name:  "question",
 						},
 					},
 				})
@@ -134,13 +135,6 @@ func Version_930_Migration(backfillData database.SchemalessNodeKindBackfillData)
 		)
 		return nil
 	}
-}
-
-// isInternalGraphKind reports whether a kind is an internal implementation detail that would
-// never have been ingested as user data (e.g. migration tracking nodes, meta nodes, tier tags).
-func isInternalGraphKind(kind graph.Kind) bool {
-	return strings.HasPrefix(kind.String(), model.AssetGroupTagKindPrefix) ||
-		kind.Is(common.MigrationData, graph.StringKind("Meta"), graph.StringKind("MetaDetail"))
 }
 
 // graphKindHasNodes returns true if at least one node with the kind exists in the graph.

--- a/cmd/api/src/migrations/manifest.go
+++ b/cmd/api/src/migrations/manifest.go
@@ -61,8 +61,7 @@ func Version_930_Migration(backfillData SchemalessNodeKindBackfillData) func(ctx
 		defer measure.LogAndMeasureWithThreshold(slog.LevelInfo, "Migration to backfill custom_node_kinds for schemaless ingest kinds")()
 
 		if backfillData == nil {
-			slog.InfoContext(ctx, "Skipping Version_930_Migration: no SchemalessNodeKindBackfillData provider configured")
-			return nil
+			return fmt.Errorf("Version_930_Migration requires a SchemalessNodeKindBackfillData provider but none was configured")
 		}
 
 		// Fetch all kinds registered in the graph / kind table.

--- a/cmd/api/src/migrations/manifest_integration_test.go
+++ b/cmd/api/src/migrations/manifest_integration_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 
 	"github.com/peterldowns/pgtestdb"
+	"github.com/specterops/bloodhound/cmd/api/src/api/dbpool"
 	"github.com/specterops/bloodhound/cmd/api/src/auth"
 	"github.com/specterops/bloodhound/cmd/api/src/config"
 	"github.com/specterops/bloodhound/cmd/api/src/database"
@@ -61,7 +62,7 @@ func setupIntegrationTestSuite(t *testing.T) *IntegrationTestSuite {
 	cfg, err := config.NewDefaultConnectionConfiguration(connConf.URL())
 	require.NoError(t, err)
 
-	pool, err := pg.NewPool(cfg.Database)
+	pool, err := dbpool.NewDawgsPool(cfg.Database)
 	require.NoError(t, err)
 
 	gormDB, dbPool, err := database.OpenDatabase(cfg.Database)

--- a/cmd/api/src/migrations/manifest_integration_test.go
+++ b/cmd/api/src/migrations/manifest_integration_test.go
@@ -1,0 +1,162 @@
+// Copyright 2026 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build integration
+
+package migrations_test
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/peterldowns/pgtestdb"
+	"github.com/specterops/bloodhound/cmd/api/src/auth"
+	"github.com/specterops/bloodhound/cmd/api/src/config"
+	"github.com/specterops/bloodhound/cmd/api/src/database"
+	"github.com/specterops/bloodhound/cmd/api/src/test/integration/utils"
+	"github.com/specterops/bloodhound/packages/go/graphschema"
+	"github.com/specterops/dawgs"
+	"github.com/specterops/dawgs/drivers/pg"
+	"github.com/specterops/dawgs/graph"
+	"github.com/stretchr/testify/require"
+)
+
+// IntegrationTestSuite carries only the fields needed to exercise
+// Version_930_Migration: a context, a graph database handle, and a
+// BloodhoundDB that satisfies SchemalessNodeKindBackfillData.
+type IntegrationTestSuite struct {
+	context    context.Context
+	graphDB    graph.Database
+	bhDatabase *database.BloodhoundDB
+}
+
+// setupIntegrationTestSuite stands up an isolated relational and graph
+// database for a single migration test. The BloodhoundDB SQL migrations
+// auto-register ad.Entity and azure.Entity as source kinds; tests that need
+// additional source kinds can call bhDatabase.RegisterSourceKind directly.
+func setupIntegrationTestSuite(t *testing.T) *IntegrationTestSuite {
+	t.Helper()
+
+	var (
+		ctx      = context.Background()
+		connConf = pgtestdb.Custom(t, getPostgresConfig(t), pgtestdb.NoopMigrator{})
+	)
+
+	cfg, err := config.NewDefaultConnectionConfiguration(connConf.URL())
+	require.NoError(t, err)
+
+	pool, err := pg.NewPool(cfg.Database)
+	require.NoError(t, err)
+
+	gormDB, dbPool, err := database.OpenDatabase(cfg.Database)
+	require.NoError(t, err)
+
+	bhDatabase := database.NewBloodhoundDB(gormDB, dbPool, auth.NewIdentityResolver(), cfg)
+	require.NoError(t, bhDatabase.Migrate(ctx))
+	require.NoError(t, bhDatabase.PopulateExtensionData(ctx))
+
+	graphDB, err := dawgs.Open(ctx, pg.DriverName, dawgs.Config{
+		GraphQueryMemoryLimit: 1024 * 1024 * 1024 * 2,
+		ConnectionString:      connConf.URL(),
+		Pool:                  pool,
+	})
+	require.NoError(t, err)
+
+	err = graphDB.AssertSchema(ctx, graphschema.DefaultGraphSchema())
+	require.NoError(t, err)
+
+	return &IntegrationTestSuite{
+		context:    ctx,
+		graphDB:    graphDB,
+		bhDatabase: bhDatabase,
+	}
+}
+
+func (s *IntegrationTestSuite) teardownIntegrationTestSuite(t *testing.T) {
+	t.Helper()
+
+	if s.graphDB != nil {
+		if err := s.graphDB.Close(s.context); err != nil {
+			t.Logf("failed to close GraphDB: %v", err)
+		}
+	}
+	if s.bhDatabase != nil {
+		s.bhDatabase.Close(s.context)
+	}
+}
+
+// createNodes writes each provided node to the graph and back-fills the node
+// ID so callers can reference the persisted nodes in assertions.
+func (s *IntegrationTestSuite) createNodes(t *testing.T, nodes ...*graph.Node) {
+	t.Helper()
+
+	for _, node := range nodes {
+		err := s.graphDB.WriteTransaction(s.context, func(tx graph.Transaction) error {
+			createdNode, err := tx.CreateNode(node.Properties, node.Kinds...)
+			if err != nil {
+				return err
+			}
+			node.ID = createdNode.ID
+			return nil
+		})
+		require.NoError(t, err, "unexpected error occurred while creating nodes")
+	}
+}
+
+// getPostgresConfig reads key/value pairs from the default integration
+// config file and creates a pgtestdb configuration object.
+func getPostgresConfig(t *testing.T) pgtestdb.Config {
+	t.Helper()
+
+	config, err := utils.LoadIntegrationTestConfig()
+	require.NoError(t, err)
+
+	environmentMap := make(map[string]string)
+	for _, entry := range strings.Fields(config.Database.Connection) {
+		if parts := strings.SplitN(entry, "=", 2); len(parts) == 2 {
+			environmentMap[parts[0]] = parts[1]
+		}
+	}
+
+	if strings.HasPrefix(environmentMap["host"], "/") {
+		return pgtestdb.Config{
+			DriverName: "pgx",
+			User:       environmentMap["user"],
+			Password:   environmentMap["password"],
+			Database:   environmentMap["dbname"],
+			Options:    fmt.Sprintf("host=%s", url.PathEscape(environmentMap["host"])),
+			TestRole: &pgtestdb.Role{
+				Username:     environmentMap["user"],
+				Password:     environmentMap["password"],
+				Capabilities: "NOSUPERUSER NOCREATEROLE",
+			},
+		}
+	}
+
+	return pgtestdb.Config{
+		DriverName:                "pgx",
+		Host:                      environmentMap["host"],
+		Port:                      environmentMap["port"],
+		User:                      environmentMap["user"],
+		Password:                  environmentMap["password"],
+		Database:                  environmentMap["dbname"],
+		Options:                   "sslmode=disable",
+		ForceTerminateConnections: true,
+	}
+}

--- a/cmd/api/src/migrations/migrations_integration_test.go
+++ b/cmd/api/src/migrations/migrations_integration_test.go
@@ -24,9 +24,11 @@ import (
 	"testing"
 
 	"github.com/specterops/bloodhound/cmd/api/src/migrations"
+	"github.com/specterops/bloodhound/cmd/api/src/model"
 	"github.com/specterops/bloodhound/cmd/api/src/test/integration"
 	"github.com/specterops/bloodhound/packages/go/graphschema"
 	"github.com/specterops/bloodhound/packages/go/graphschema/ad"
+	"github.com/specterops/bloodhound/packages/go/graphschema/common"
 	"github.com/specterops/dawgs/graph"
 	"github.com/specterops/dawgs/ops"
 	"github.com/specterops/dawgs/query"
@@ -125,5 +127,158 @@ func TestVersion_910_Migration(t *testing.T) {
 				return nil
 			})
 		})
+	})
+}
+
+func TestVersion_930_Migration(t *testing.T) {
+	t.Run("backfills custom_node_kinds for a schemaless node kind that isn't in custom_node_kinds or schema_node_kinds", func(t *testing.T) {
+		suite := setupIntegrationTestSuite(t)
+		t.Cleanup(func() { suite.teardownIntegrationTestSuite(t) })
+
+		schemalessNode := &graph.Node{
+			Kinds: graph.Kinds{graph.StringKind("SchemalessKind")},
+			Properties: graph.AsProperties(graph.PropertyMap{
+				common.Name:     "SchemalessNode",
+				common.ObjectID: "SchemalessNode",
+			}),
+		}
+		suite.createNodes(t, schemalessNode)
+
+		err := migrations.Version_930_Migration(suite.bhDatabase)(suite.context, suite.graphDB)
+		require.NoError(t, err)
+
+		customNodeKinds, err := suite.bhDatabase.GetCustomNodeKinds(suite.context, nil)
+		require.NoError(t, err)
+
+		var kindNames []string
+		for _, customNodeKind := range customNodeKinds {
+			kindNames = append(kindNames, customNodeKind.KindName)
+		}
+		require.Contains(t, kindNames, "SchemalessKind")
+	})
+
+	t.Run("does not backfill a kind already present in custom_node_kinds", func(t *testing.T) {
+		suite := setupIntegrationTestSuite(t)
+		t.Cleanup(func() { suite.teardownIntegrationTestSuite(t) })
+
+		_, err := suite.bhDatabase.CreateCustomNodeKinds(suite.context, model.CustomNodeKinds{
+			{
+				KindName: "PreExistingCustomNodeKind",
+				Config: model.CustomNodeKindConfig{
+					Icon: graphschema.DisplayNodeIcon{
+						Type:  graphschema.DisplayNodeTypeFontAwesome,
+						Color: "#FF0000",
+					},
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		preExistingNode := &graph.Node{
+			Kinds: graph.Kinds{graph.StringKind("PreExistingCustomNodeKind")},
+			Properties: graph.AsProperties(graph.PropertyMap{
+				common.Name:     "PreExistingNode",
+				common.ObjectID: "PreExistingNode",
+			}),
+		}
+		suite.createNodes(t, preExistingNode)
+
+		err = migrations.Version_930_Migration(suite.bhDatabase)(suite.context, suite.graphDB)
+		require.NoError(t, err)
+
+		customNodeKinds, err := suite.bhDatabase.GetCustomNodeKinds(suite.context, nil)
+		require.NoError(t, err)
+
+		var preExistingCount int
+		for _, customNodeKind := range customNodeKinds {
+			if customNodeKind.KindName == "PreExistingCustomNodeKind" {
+				preExistingCount++
+			}
+		}
+		require.Equal(t, 1, preExistingCount, "PreExistingCustomNodeKind must appear exactly once in custom_node_kinds")
+	})
+
+	t.Run("does not backfill a kind already present in schema_node_kinds", func(t *testing.T) {
+		suite := setupIntegrationTestSuite(t)
+		t.Cleanup(func() { suite.teardownIntegrationTestSuite(t) })
+
+		schemaExtension, err := suite.bhDatabase.CreateGraphSchemaExtension(suite.context, "test-ext", "Test Extension", "1.0.0", "test")
+		require.NoError(t, err)
+
+		_, err = suite.bhDatabase.CreateGraphSchemaNodeKind(suite.context, "SchemaNodeKind", schemaExtension.ID, "Schema Kind", "", false, "fa-circle", "#FFFFFF")
+		require.NoError(t, err)
+
+		// RefreshKinds so that dawgs can resolve the new kind ID when creating the graph node.
+		require.NoError(t, suite.graphDB.RefreshKinds(suite.context))
+
+		schemaNode := &graph.Node{
+			Kinds: graph.Kinds{graph.StringKind("SchemaNodeKind")},
+			Properties: graph.AsProperties(graph.PropertyMap{
+				common.Name:     "SchemaNode",
+				common.ObjectID: "SchemaNode",
+			}),
+		}
+		suite.createNodes(t, schemaNode)
+
+		err = migrations.Version_930_Migration(suite.bhDatabase)(suite.context, suite.graphDB)
+		require.NoError(t, err)
+
+		customNodeKinds, err := suite.bhDatabase.GetCustomNodeKinds(suite.context, nil)
+		require.NoError(t, err)
+
+		for _, customNodeKind := range customNodeKinds {
+			require.NotEqual(t, "SchemaNodeKind", customNodeKind.KindName, "schema_node_kinds entries must not be duplicated in custom_node_kinds")
+		}
+	})
+
+	t.Run("does not backfill a kind that has no nodes in the graph", func(t *testing.T) {
+		suite := setupIntegrationTestSuite(t)
+		t.Cleanup(func() { suite.teardownIntegrationTestSuite(t) })
+
+		// Create a node to register the kind in the kinds table, then immediately delete it.
+		ephemeralNode := &graph.Node{
+			Kinds: graph.Kinds{graph.StringKind("EphemeralKind")},
+			Properties: graph.AsProperties(graph.PropertyMap{
+				common.Name:     "EphemeralNode",
+				common.ObjectID: "EphemeralNode",
+			}),
+		}
+		suite.createNodes(t, ephemeralNode)
+
+		err := suite.graphDB.BatchOperation(suite.context, func(batch graph.Batch) error {
+			return batch.DeleteNode(ephemeralNode.ID)
+		})
+		require.NoError(t, err)
+
+		err = migrations.Version_930_Migration(suite.bhDatabase)(suite.context, suite.graphDB)
+		require.NoError(t, err)
+
+		customNodeKinds, err := suite.bhDatabase.GetCustomNodeKinds(suite.context, nil)
+		require.NoError(t, err)
+
+		for _, customNodeKind := range customNodeKinds {
+			require.NotEqual(t, "EphemeralKind", customNodeKind.KindName, "kinds with no nodes in the graph must not be backfilled")
+		}
+	})
+
+	t.Run("is a no-op when backfillData is nil", func(t *testing.T) {
+		suite := setupIntegrationTestSuite(t)
+		t.Cleanup(func() { suite.teardownIntegrationTestSuite(t) })
+
+		nilTestNode := &graph.Node{
+			Kinds: graph.Kinds{graph.StringKind("NilTestKind")},
+			Properties: graph.AsProperties(graph.PropertyMap{
+				common.Name:     "NilTestNode",
+				common.ObjectID: "NilTestNode",
+			}),
+		}
+		suite.createNodes(t, nilTestNode)
+
+		err := migrations.Version_930_Migration(nil)(suite.context, suite.graphDB)
+		require.NoError(t, err)
+
+		customNodeKinds, err := suite.bhDatabase.GetCustomNodeKinds(suite.context, nil)
+		require.NoError(t, err)
+		require.Empty(t, customNodeKinds, "no custom_node_kinds rows should be created when backfillData is nil")
 	})
 }

--- a/cmd/api/src/migrations/migrations_integration_test.go
+++ b/cmd/api/src/migrations/migrations_integration_test.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/specterops/bloodhound/cmd/api/src/database"
 	"github.com/specterops/bloodhound/cmd/api/src/migrations"
 	"github.com/specterops/bloodhound/cmd/api/src/model"
 	"github.com/specterops/bloodhound/cmd/api/src/test/integration"
@@ -159,8 +160,8 @@ func TestVersion_930_Migration(t *testing.T) {
 		}
 		require.NotNil(t, backfilledKind, "SchemalessKind must be present in custom_node_kinds after backfill")
 		require.Equal(t, graphschema.DisplayNodeTypeFontAwesome, backfilledKind.Config.Icon.Type)
-		require.Equal(t, "question", backfilledKind.Config.Icon.Name)
-		require.Equal(t, "#FFFFFF", backfilledKind.Config.Icon.Color)
+		require.Equal(t, database.CustomNodeKindStubConfig.Icon.Name, backfilledKind.Config.Icon.Name)
+		require.Equal(t, database.CustomNodeKindStubConfig.Icon.Color, backfilledKind.Config.Icon.Color)
 	})
 
 	t.Run("does not backfill a kind already present in custom_node_kinds", func(t *testing.T) {

--- a/cmd/api/src/migrations/migrations_integration_test.go
+++ b/cmd/api/src/migrations/migrations_integration_test.go
@@ -261,26 +261,11 @@ func TestVersion_930_Migration(t *testing.T) {
 		}
 	})
 
-	t.Run("is a no-op when backfillData is nil", func(t *testing.T) {
+	t.Run("returns an error when backfillData is nil", func(t *testing.T) {
 		suite := setupIntegrationTestSuite(t)
 		t.Cleanup(func() { suite.teardownIntegrationTestSuite(t) })
 
-		nilTestNode := &graph.Node{
-			Kinds: graph.Kinds{graph.StringKind("NilTestKind")},
-			Properties: graph.AsProperties(graph.PropertyMap{
-				common.Name:     "NilTestNode",
-				common.ObjectID: "NilTestNode",
-			}),
-		}
-		suite.createNodes(t, nilTestNode)
-
 		err := migrations.Version_930_Migration(nil)(suite.context, suite.graphDB)
-		require.NoError(t, err)
-
-		customNodeKinds, err := suite.bhDatabase.GetCustomNodeKinds(suite.context, nil)
-		require.NoError(t, err)
-		for _, customNodeKind := range customNodeKinds {
-			require.NotEqual(t, "NilTestKind", customNodeKind.KindName, "NilTestKind must not be backfilled when backfillData is nil")
-		}
+		require.Error(t, err)
 	})
 }

--- a/cmd/api/src/migrations/migrations_integration_test.go
+++ b/cmd/api/src/migrations/migrations_integration_test.go
@@ -150,11 +150,17 @@ func TestVersion_930_Migration(t *testing.T) {
 		customNodeKinds, err := suite.bhDatabase.GetCustomNodeKinds(suite.context, nil)
 		require.NoError(t, err)
 
-		var kindNames []string
-		for _, customNodeKind := range customNodeKinds {
-			kindNames = append(kindNames, customNodeKind.KindName)
+		var backfilledKind *model.CustomNodeKind
+		for i, customNodeKind := range customNodeKinds {
+			if customNodeKind.KindName == "SchemalessKind" {
+				backfilledKind = &customNodeKinds[i]
+				break
+			}
 		}
-		require.Contains(t, kindNames, "SchemalessKind")
+		require.NotNil(t, backfilledKind, "SchemalessKind must be present in custom_node_kinds after backfill")
+		require.Equal(t, graphschema.DisplayNodeTypeFontAwesome, backfilledKind.Config.Icon.Type)
+		require.Equal(t, "question", backfilledKind.Config.Icon.Name)
+		require.Equal(t, "#FFFFFF", backfilledKind.Config.Icon.Color)
 	})
 
 	t.Run("does not backfill a kind already present in custom_node_kinds", func(t *testing.T) {
@@ -261,7 +267,7 @@ func TestVersion_930_Migration(t *testing.T) {
 		}
 	})
 
-	t.Run("returns an error when backfillData is nil", func(t *testing.T) {
+	t.Run("returns an error when nodeKindData is nil", func(t *testing.T) {
 		suite := setupIntegrationTestSuite(t)
 		t.Cleanup(func() { suite.teardownIntegrationTestSuite(t) })
 

--- a/cmd/api/src/migrations/migrations_integration_test.go
+++ b/cmd/api/src/migrations/migrations_integration_test.go
@@ -279,6 +279,8 @@ func TestVersion_930_Migration(t *testing.T) {
 
 		customNodeKinds, err := suite.bhDatabase.GetCustomNodeKinds(suite.context, nil)
 		require.NoError(t, err)
-		require.Empty(t, customNodeKinds, "no custom_node_kinds rows should be created when backfillData is nil")
+		for _, customNodeKind := range customNodeKinds {
+			require.NotEqual(t, "NilTestKind", customNodeKind.KindName, "NilTestKind must not be backfilled when backfillData is nil")
+		}
 	})
 }

--- a/cmd/api/src/services/entrypoint.go
+++ b/cmd/api/src/services/entrypoint.go
@@ -97,7 +97,7 @@ func Entrypoint(ctx context.Context, cfg config.Configuration, connections boots
 	if !cfg.DisableMigrations {
 		if err := bootstrap.MigrateDB(ctx, cfg, connections.RDMS, config.NewDefaultAdminConfiguration); err != nil {
 			return nil, fmt.Errorf("rdms migration error: %w", err)
-		} else if err := migrations.NewGraphMigrator(connections.Graph).Migrate(ctx); err != nil {
+		} else if err := migrations.NewGraphMigrator(connections.Graph, migrations.WithSchemalessKindBackfill(connections.RDMS)).Migrate(ctx); err != nil {
 			return nil, fmt.Errorf("graph migration error: %w", err)
 		} else if err := bootstrap.PopulateExtensionData(ctx, connections.RDMS); err != nil {
 			return nil, fmt.Errorf("extensions data population error: %w", err)

--- a/packages/go/graphify/graph/graph.go
+++ b/packages/go/graphify/graph/graph.go
@@ -178,7 +178,7 @@ func (s *CommunityGraphService) InitializeService(ctx context.Context, cfg confi
 
 	if err := s.db.Migrate(ctx); err != nil {
 		return fmt.Errorf("error migrating database: %w", err)
-	} else if err := migrations.NewGraphMigrator(graphDB).Migrate(ctx); err != nil {
+	} else if err := migrations.NewGraphMigrator(graphDB, migrations.WithSchemalessKindBackfill(s.db)).Migrate(ctx); err != nil {
 		return fmt.Errorf("error migrating graph schema: %w", err)
 	} else if err := s.db.PopulateExtensionData(ctx); err != nil {
 		return fmt.Errorf("error populating extension data: %w", err)


### PR DESCRIPTION
## Description

Schemaless ingest has occurred for months now. 

There exists a possibility that there are node kinds assigned to nodes which do not have records in `custom_node_kinds` nor `schema_node_kinds`. This fix inserts those node kinds into the `custom_node_kinds` table. 

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves https://specterops.atlassian.net/browse/BED-7926

*Why is this change required? What problem does it solve?*

## How Has This Been Tested?

Integration tests for the migration are included in this PR. 

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)
- Database Migrations

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * v9.3.0 migration: automatically backfills missing custom node kinds for schemaless kinds found in the graph; applied during migration runs.

* **Tests**
  * Added integration tests validating backfill behavior, idempotency, skip conditions, and error on missing backfill provider.
  * Added migration integration test utilities for isolated DB/graph test runs.

* **Refactor**
  * Centralized extended-node-kind detection for consistent kind classification across APIs.

* **Chore**
  * Startup now wires the backfill provider into the migration process so backfills run during initialization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SpecterOps/BloodHound/pull/2766)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->