### PR TITLE
fix(SubNav): address Safari GPU rendering bug - BED-8283

### DIFF
--- a/packages/javascript/bh-shared-ui/src/components/Navigation/SubNav.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/Navigation/SubNav.tsx
@@ -80,6 +80,7 @@ const SubNav: React.FC<{
                 'bottom-2 py-2 rounded-lg cursor-default z-subNav',
                 'flex flex-col gap-8 absolute shadow-md',
                 'bg-[#F2F2F2] dark:bg-[#1F1F1F]',
+                'transform-gpu translate-z-[0px]', // This line addresses a Safari hardware rendering bug
                 'transition-all duration-300 ease-out',
                 {
                     'opacity-100': visible,


### PR DESCRIPTION
## Description

Updates SubNav styling to address a Safari hardware rendering bug that causes the Administration subnav menu to sometimes disappear.

## Motivation and Context

Resolves BED-8283

## How Has This Been Tested?

Manually tested in Safari

## Screenshots:

| Before | After |
|--------|-------|
| <img width="529" height="442" alt="image" src="https://github.com/user-attachments/assets/768b94b5-c0b0-4314-a575-85c1454cb32e" /> | <img width="529" height="442" alt="image" src="https://github.com/user-attachments/assets/61e53882-2413-41be-979e-e8f1f3dc8d35" /> |

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed visual glitches in the navigation submenu’s slide-in animation on Safari by enabling GPU-backed rendering, improving smoothness and transition fidelity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SpecterOps/BloodHound/pull/2773)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->