### PR TITLE
feat: REVERT- Highlight all direct inbound and outbound relationships of selected item - BED-7526

### DIFF
--- a/cmd/ui/src/components/SigmaChart/GraphEvents.tsx
+++ b/cmd/ui/src/components/SigmaChart/GraphEvents.tsx
@@ -15,9 +15,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { useRegisterEvents, useSetSettings, useSigma } from '@react-sigma/core';
-import { useTheme } from 'bh-shared-ui';
 import type { Attributes } from 'graphology-types';
-import { forwardRef, useCallback, useEffect, useImperativeHandle, useLayoutEffect, useMemo, useState } from 'react';
+import { forwardRef, useCallback, useEffect, useImperativeHandle, useLayoutEffect, useState } from 'react';
 import type { SigmaNodeEventPayload } from 'sigma/sigma';
 import type { Coordinates } from 'sigma/types';
 import {
@@ -31,7 +30,7 @@ import {
     resetCamera,
 } from 'src/ducks/graph/utils';
 import { bezier } from 'src/rendering/utils/bezier';
-import { blendHexColors, getNodeRadius } from 'src/rendering/utils/utils';
+import { getNodeRadius } from 'src/rendering/utils/utils';
 import { useAppSelector } from 'src/store';
 import { preventAllDefaults } from 'src/utils';
 import { sequentialLayout, standardLayout } from 'src/views/Explore/utils';
@@ -92,8 +91,6 @@ export const GraphEvents = forwardRef(function GraphEvents(
     ref
 ) {
     const exploreLayout = useAppSelector((state) => state.global.view.exploreLayout);
-    const darkMode = useAppSelector((state) => state.global.view.darkMode);
-    const theme = useTheme();
 
     const sigma = useSigma();
     const graph = sigma.getGraph();
@@ -277,75 +274,23 @@ export const GraphEvents = forwardRef(function GraphEvents(
         sigmaContainer,
     ]);
 
-    const isHighlightedItemInGraph = useMemo(() => {
-        if (!highlightedItem) return;
-        return graph.hasNode(highlightedItem) || graph.hasEdge(highlightedItem);
-    }, [graph, highlightedItem]);
-
-    // Compute which nodes and edges should remain fully visible when an item is selected.
-    // Nodes: the selected node itself + all its direct neighbors.
-    // Edges: all edges directly connected to the selected node/edge endpoints.
-    const { highlightedNodeIds, highlightedEdgeIds } = useMemo(() => {
-        const highlightedNodeIds = new Set<string>();
-        const highlightedEdgeIds = new Set<string>();
-
-        if (highlightedItem) {
-            if (graph.hasNode(highlightedItem)) {
-                highlightedNodeIds.add(highlightedItem);
-                graph.neighbors(highlightedItem).forEach((directNodes) => highlightedNodeIds.add(directNodes));
-                graph.edges(highlightedItem).forEach((directEdges) => highlightedEdgeIds.add(directEdges));
-            } else if (graph.hasEdge(highlightedItem)) {
-                highlightedEdgeIds.add(highlightedItem);
-                graph.extremities(highlightedItem).forEach((directNodes) => highlightedNodeIds.add(directNodes));
-            }
-        }
-
-        return { highlightedNodeIds, highlightedEdgeIds };
-    }, [graph, highlightedItem]);
-
     useEffect(() => {
-        const bgColor = theme.neutral.primary;
-        // dimFactor is how much of the original color shows through (1 = full, 0 = fully hidden).
-        // Equivalent to 1 - nodeBlend from the old CPU-blend approach: dark 1-0.5=0.5, light 1-0.8=0.2.
-        const nodeDimFactor = darkMode ? 0.5 : 0.2;
-        const edgeBlend = darkMode ? 0.6 : 0.9;
-        const labelDimFactor = darkMode ? 0.3 : 0.1;
-
         setSettings({
             nodeReducer: (node, data) => {
                 const camera = sigma.getCamera();
-                const isDimmed = !!highlightedItem && !highlightedNodeIds.has(node) && isHighlightedItemInGraph;
-
                 return {
                     ...data,
                     highlighted: node === highlightedItem,
                     inverseSqrtZoomRatio: 1 / Math.sqrt(camera.ratio),
-                    isDimmed,
-                    // Always pass the canvas background color so the shader can dim toward it.
-                    graphBgColor: bgColor,
-                    ...(isDimmed && {
-                        labelDimFactor,
-                        dimFactor: nodeDimFactor,
-                        // Keep label background dimmed — labels are rendered on canvas 2D, not by the shader.
-                        backgroundColor: blendHexColors(data.backgroundColor ?? bgColor, bgColor, 1 - nodeDimFactor),
-                    }),
                 };
             },
             edgeReducer: (edge, data) => {
                 const camera = sigma.getCamera();
-                const isDimmed = !!highlightedItem && !highlightedEdgeIds.has(edge);
-
                 const newData: Attributes = {
                     ...data,
                     hidden: false,
                     highlighted: edge === highlightedItem,
                     inverseSqrtZoomRatio: 1 / Math.sqrt(camera.ratio),
-                    isDimmed,
-                    backgroundColor: bgColor,
-                    ...(isDimmed && {
-                        labelDimFactor,
-                        color: blendHexColors(data.color, bgColor, edgeBlend),
-                    }),
                 };
 
                 if (data.type === 'curved') {
@@ -357,18 +302,7 @@ export const GraphEvents = forwardRef(function GraphEvents(
                 return newData;
             },
         });
-    }, [
-        curvedEdgeReducer,
-        darkMode,
-        highlightedEdgeIds,
-        highlightedItem,
-        highlightedNodeIds,
-        selfEdgeReducer,
-        setSettings,
-        sigma,
-        theme.neutral.primary,
-        isHighlightedItemInGraph,
-    ]);
+    }, [curvedEdgeReducer, highlightedItem, selfEdgeReducer, setSettings, sigma]);
 
     // Toggle off edge labels when dragging a node to avoid performance hit
     useLayoutEffect(() => {

--- a/cmd/ui/src/rendering/programs/node-label.ts
+++ b/cmd/ui/src/rendering/programs/node-label.ts
@@ -41,8 +41,7 @@ export default function drawLabel(context: CanvasRenderingContext2D, data: Graph
     const fillBackground = data.highlighted ? data.highlightedBackground : data.backgroundColor;
     const fillText = data.highlighted ? data.highlightedText : settings.labelColor.color;
 
-    const dimFactor = data.isDimmed ? data.labelDimFactor ?? 0.1 : 1;
-    context.globalAlpha = calculateLabelOpacity(inverseSqrtZoomRatio) * dimFactor;
+    context.globalAlpha = calculateLabelOpacity(inverseSqrtZoomRatio);
 
     // Edge labels: use original right-of-node positioning with center-alignment offset
     if (EDGE_TYPES.includes(data.type ?? '')) {
@@ -58,13 +57,9 @@ export default function drawLabel(context: CanvasRenderingContext2D, data: Graph
         const labelbounds = getLabelBoundsFromContext(context, labelParams);
         labelbounds[0] = labelbounds[0] - labelbounds[2] / 2 - EDGE_MIDDLE_ALIGN_OFFSET;
 
-        // Draw background at full opacity so it always masks the edge line behind it
-        context.globalAlpha = 1;
         context.fillStyle = fillBackground;
         context.fillRect(...labelbounds);
 
-        // Draw text with zoom/dim factor applied
-        context.globalAlpha = calculateLabelOpacity(inverseSqrtZoomRatio) * dimFactor;
         context.fillStyle = fillText;
         context.fillText(data.label, labelbounds[0] + LABEL_PADDING, labelbounds[1] + labelbounds[3] - LABEL_PADDING);
 
@@ -93,12 +88,9 @@ export default function drawLabel(context: CanvasRenderingContext2D, data: Graph
 
     const primaryBounds = getNodeLabelBoundsBelowFromContext(context, primaryParams);
 
-    // Draw background at full opacity to mask any edge lines passing through the label area
-    context.globalAlpha = 1;
     context.fillStyle = fillBackground;
     context.fillRect(...primaryBounds);
 
-    context.globalAlpha = calculateLabelOpacity(inverseSqrtZoomRatio) * dimFactor;
     context.fillStyle = fillText;
     context.fillText(
         primaryLabel,
@@ -122,11 +114,9 @@ export default function drawLabel(context: CanvasRenderingContext2D, data: Graph
 
         const sublabelBounds = getNodeLabelBoundsBelowFromContext(context, sublabelParams, primaryBounds[3]);
 
-        context.globalAlpha = 1;
         context.fillStyle = fillBackground;
         context.fillRect(...sublabelBounds);
 
-        context.globalAlpha = calculateLabelOpacity(inverseSqrtZoomRatio) * dimFactor;
         context.fillStyle = fillText;
         context.fillText(
             sublabelText,

--- a/cmd/ui/src/rendering/programs/node.combined.ts
+++ b/cmd/ui/src/rendering/programs/node.combined.ts
@@ -35,7 +35,6 @@ import { Coordinates, Dimensions, NodeDisplayData } from 'sigma/types';
 import { floatColor } from 'sigma/utils';
 import { fragmentShaderSource } from '../shaders/node.combined.frag';
 import { vertexShaderSource } from '../shaders/node.combined.vert';
-import { DEFAULT_BG_COLOR, DIM_FACTOR, NO_DIM_FACTOR } from '../utils/utils';
 
 const POINTS = 3,
     /*
@@ -47,7 +46,7 @@ const POINTS = 3,
       - angle (1xfloat)
       - borderColor (4xbyte = 1xfloat)
    */
-    ATTRIBUTES = 11,
+    ATTRIBUTES = 9,
     // maximum size of single texture in atlas
     MAX_TEXTURE_SIZE = 192,
     // maximum width of atlas texture (limited by browser)
@@ -257,8 +256,6 @@ export default function getNodeCombinedProgram(): typeof AbstractNodeCombinedPro
         correctionRatioLocation: WebGLUniformLocation;
         angleLocation: GLint;
         borderColorLocation: GLint;
-        dimLocation: GLint;
-        bgColorLocation: GLint;
         latestRenderParams?: RenderParams;
 
         constructor(gl: WebGLRenderingContext, renderer: Sigma) {
@@ -275,8 +272,6 @@ export default function getNodeCombinedProgram(): typeof AbstractNodeCombinedPro
             this.textureLocation = gl.getAttribLocation(this.program, 'a_texture');
             this.angleLocation = gl.getAttribLocation(this.program, 'a_angle');
             this.borderColorLocation = gl.getAttribLocation(this.program, 'a_borderColor');
-            this.dimLocation = gl.getAttribLocation(this.program, 'a_dim');
-            this.bgColorLocation = gl.getAttribLocation(this.program, 'a_bgColor');
 
             // Uniform Location
             const atlasLocation = gl.getUniformLocation(this.program, 'u_atlas');
@@ -313,8 +308,6 @@ export default function getNodeCombinedProgram(): typeof AbstractNodeCombinedPro
             gl.enableVertexAttribArray(this.textureLocation);
             gl.enableVertexAttribArray(this.angleLocation);
             gl.enableVertexAttribArray(this.borderColorLocation);
-            gl.enableVertexAttribArray(this.dimLocation);
-            gl.enableVertexAttribArray(this.bgColorLocation);
 
             gl.vertexAttribPointer(
                 this.textureLocation,
@@ -340,32 +333,10 @@ export default function getNodeCombinedProgram(): typeof AbstractNodeCombinedPro
                 this.attributes * Float32Array.BYTES_PER_ELEMENT,
                 32
             );
-            gl.vertexAttribPointer(
-                this.dimLocation,
-                1,
-                gl.FLOAT,
-                false,
-                this.attributes * Float32Array.BYTES_PER_ELEMENT,
-                36
-            );
-            gl.vertexAttribPointer(
-                this.bgColorLocation,
-                4,
-                gl.UNSIGNED_BYTE,
-                true,
-                this.attributes * Float32Array.BYTES_PER_ELEMENT,
-                40
-            );
         }
 
         process(
-            data: NodeDisplayData & {
-                image?: string;
-                isDimmed: boolean;
-                borderColor?: string;
-                dimFactor?: number;
-                graphBgColor?: string;
-            },
+            data: NodeDisplayData & { image?: string; borderColor?: string },
             hidden: boolean,
             offset: number
         ): void {
@@ -390,17 +361,11 @@ export default function getNodeCombinedProgram(): typeof AbstractNodeCombinedPro
                 array[i++] = 0;
                 // Border Color:
                 array[i++] = 0;
-                // Dim:
-                array[i++] = 0;
-                // BgColor:
-                array[i++] = 0;
                 return;
             }
 
             const color = floatColor(data.color);
             const borderColor = floatColor(data.borderColor ?? data.color);
-            const bgColor = floatColor(data.graphBgColor ?? DEFAULT_BG_COLOR);
-            const dim = data.dimFactor ?? (data.isDimmed ? DIM_FACTOR : NO_DIM_FACTOR);
             array[i++] = data.x;
             array[i++] = data.y;
             array[i++] = data.size;
@@ -421,8 +386,6 @@ export default function getNodeCombinedProgram(): typeof AbstractNodeCombinedPro
             }
             array[i++] = ANGLE_1;
             array[i++] = borderColor;
-            array[i++] = dim;
-            array[i++] = bgColor;
 
             array[i++] = data.x;
             array[i++] = data.y;
@@ -445,8 +408,6 @@ export default function getNodeCombinedProgram(): typeof AbstractNodeCombinedPro
             }
             array[i++] = ANGLE_2;
             array[i++] = borderColor;
-            array[i++] = dim;
-            array[i++] = bgColor;
 
             array[i++] = data.x;
             array[i++] = data.y;
@@ -465,8 +426,6 @@ export default function getNodeCombinedProgram(): typeof AbstractNodeCombinedPro
             }
             array[i++] = ANGLE_3;
             array[i++] = borderColor;
-            array[i++] = dim;
-            array[i++] = bgColor;
         }
 
         render(params: RenderParams): void {

--- a/cmd/ui/src/rendering/programs/node.glyphs.ts
+++ b/cmd/ui/src/rendering/programs/node.glyphs.ts
@@ -38,7 +38,6 @@ import { Coordinates, Dimensions, NodeDisplayData } from 'sigma/types';
 import { floatColor } from 'sigma/utils';
 import { fragmentShaderSource } from 'src/rendering/shaders/node.glyphs.frag';
 import { vertexShaderSource } from 'src/rendering/shaders/node.glyphs.vert';
-import { DEFAULT_BG_COLOR, DIM_FACTOR, NO_DIM_FACTOR } from '../utils/utils';
 
 const POINTS = 3,
     /*
@@ -50,7 +49,7 @@ const POINTS = 3,
       - angle (1xfloat)
       - borderColor (4xbyte = 1xfloat)
    */
-    ATTRIBUTES = 13,
+    ATTRIBUTES = 11,
     // Number of possible circles to be drawn -- 1 node + 4 glyphs
     CIRCLES = 5,
     // maximum size of single texture in atlas
@@ -272,8 +271,6 @@ export default function getNodeGlyphsProgram(): typeof AbstractNodeGlyphsProgram
         angleLocation: GLint;
         translationLocation: GLint;
         borderColorLocation: GLint;
-        dimLocation: GLint;
-        bgColorLocation: GLint;
         latestRenderParams?: RenderParams;
 
         constructor(gl: WebGLRenderingContext, renderer: Sigma) {
@@ -291,8 +288,6 @@ export default function getNodeGlyphsProgram(): typeof AbstractNodeGlyphsProgram
             this.angleLocation = gl.getAttribLocation(this.program, 'a_angle');
             this.borderColorLocation = gl.getAttribLocation(this.program, 'a_borderColor');
             this.translationLocation = gl.getAttribLocation(this.program, 'a_translation');
-            this.dimLocation = gl.getAttribLocation(this.program, 'a_dim');
-            this.bgColorLocation = gl.getAttribLocation(this.program, 'a_bgColor');
 
             // Uniform Location
             const atlasLocation = gl.getUniformLocation(this.program, 'u_atlas');
@@ -330,8 +325,6 @@ export default function getNodeGlyphsProgram(): typeof AbstractNodeGlyphsProgram
             gl.enableVertexAttribArray(this.angleLocation);
             gl.enableVertexAttribArray(this.translationLocation);
             gl.enableVertexAttribArray(this.borderColorLocation);
-            gl.enableVertexAttribArray(this.dimLocation);
-            gl.enableVertexAttribArray(this.bgColorLocation);
 
             gl.vertexAttribPointer(
                 this.textureLocation,
@@ -365,22 +358,6 @@ export default function getNodeGlyphsProgram(): typeof AbstractNodeGlyphsProgram
                 this.attributes * Float32Array.BYTES_PER_ELEMENT,
                 40
             );
-            gl.vertexAttribPointer(
-                this.dimLocation,
-                1,
-                gl.FLOAT,
-                false,
-                this.attributes * Float32Array.BYTES_PER_ELEMENT,
-                44
-            );
-            gl.vertexAttribPointer(
-                this.bgColorLocation,
-                4,
-                gl.UNSIGNED_BYTE,
-                true,
-                this.attributes * Float32Array.BYTES_PER_ELEMENT,
-                48
-            );
         }
 
         // We need to override this method to multiply the default array size by number of glyphs + 1 node
@@ -389,20 +366,11 @@ export default function getNodeGlyphsProgram(): typeof AbstractNodeGlyphsProgram
         }
 
         process(
-            data: NodeDisplayData & {
-                image?: string;
-                borderColor?: string;
-                glyphs?: Glyph[];
-                isDimmed?: boolean;
-                dimFactor?: number;
-                graphBgColor?: string;
-            },
+            data: NodeDisplayData & { image?: string; borderColor?: string; glyphs?: Glyph[] },
             hidden: boolean,
             offset: number
         ): void {
             let i = offset * POINTS * ATTRIBUTES * CIRCLES;
-            const dim = data.dimFactor ?? (data.isDimmed ? DIM_FACTOR : NO_DIM_FACTOR);
-            const bgColor = data.graphBgColor ?? DEFAULT_BG_COLOR;
 
             this.fillCircleAttributeBuffer(
                 this.array,
@@ -413,10 +381,7 @@ export default function getNodeGlyphsProgram(): typeof AbstractNodeGlyphsProgram
                 data.size,
                 data.color,
                 data.borderColor ?? data.color,
-                data.image,
-                undefined,
-                dim,
-                bgColor
+                data.image
             );
 
             i += POINTS * ATTRIBUTES;
@@ -443,9 +408,7 @@ export default function getNodeGlyphsProgram(): typeof AbstractNodeGlyphsProgram
                         glyph.backgroundColor, //fill
                         glyph.color, //border
                         glyph.image,
-                        { x, y },
-                        dim,
-                        bgColor
+                        { x, y }
                     );
                 }
                 i += POINTS * ATTRIBUTES;
@@ -462,9 +425,7 @@ export default function getNodeGlyphsProgram(): typeof AbstractNodeGlyphsProgram
             color: string,
             borderColor: string,
             image?: string,
-            translation?: Coordinates,
-            dim: number = 1.0,
-            bgColor: string = DEFAULT_BG_COLOR
+            translation?: Coordinates
         ): void {
             let i = currentIndex;
             const imageSource = image;
@@ -492,15 +453,10 @@ export default function getNodeGlyphsProgram(): typeof AbstractNodeGlyphsProgram
                 array[i++] = 0;
                 // Border Color:
                 array[i++] = 0;
-                // Dim:
-                array[i++] = 0;
-                // BgColor:
-                array[i++] = 0;
             }
 
             const fcolor = floatColor(color);
             const fborderColor = floatColor(borderColor ?? color);
-            const fbgColor = floatColor(bgColor);
 
             array[i++] = x;
             array[i++] = y;
@@ -524,8 +480,6 @@ export default function getNodeGlyphsProgram(): typeof AbstractNodeGlyphsProgram
             array[i++] = translateX;
             array[i++] = translateY;
             array[i++] = fborderColor;
-            array[i++] = dim;
-            array[i++] = fbgColor;
 
             array[i++] = x;
             array[i++] = y;
@@ -550,8 +504,6 @@ export default function getNodeGlyphsProgram(): typeof AbstractNodeGlyphsProgram
             array[i++] = translateX;
             array[i++] = translateY;
             array[i++] = fborderColor;
-            array[i++] = dim;
-            array[i++] = fbgColor;
 
             array[i++] = x;
             array[i++] = y;
@@ -572,8 +524,6 @@ export default function getNodeGlyphsProgram(): typeof AbstractNodeGlyphsProgram
             array[i++] = translateX;
             array[i++] = translateY;
             array[i++] = fborderColor;
-            array[i++] = dim;
-            array[i++] = fbgColor;
         }
 
         render(params: RenderParams): void {

--- a/cmd/ui/src/rendering/shaders/node.combined.frag.ts
+++ b/cmd/ui/src/rendering/shaders/node.combined.frag.ts
@@ -26,8 +26,6 @@ varying vec2 v_diffVector;
 varying float v_radius;
 varying float v_angle;
 varying vec2 v_position;
-varying float v_dim;
-varying vec4 v_bgColor;
 
 
 
@@ -69,10 +67,4 @@ void main(void) {
     gl_FragColor = mix(color, border_color, (dist - v_radius + v_border) / v_softborder);
   else
     gl_FragColor = color;
-
-  // Premultiplied alpha output required by Sigma's blend func (gl.ONE, gl.ONE_MINUS_SRC_ALPHA).
-  // Pre-multiplying v_bgColor.rgb by gl_FragColor.a before the mix avoids the double-alpha
-  // artifact that produces a grey ring at antialiased edges: without it the background colour
-  // leaks through at (1-t)^2 weight instead of (1-t), making the ring visibly too dark.
-  gl_FragColor.rgb = mix(v_bgColor.rgb * gl_FragColor.a, gl_FragColor.rgb, v_dim);
 }`;

--- a/cmd/ui/src/rendering/shaders/node.combined.vert.ts
+++ b/cmd/ui/src/rendering/shaders/node.combined.vert.ts
@@ -21,8 +21,6 @@ attribute vec4 a_color;
 attribute vec4 a_texture;
 attribute float a_angle;
 attribute vec4 a_borderColor;
-attribute float a_dim;
-attribute vec4 a_bgColor;
 
 uniform float u_ratio;
 uniform float u_scale;
@@ -37,8 +35,6 @@ varying float v_border;
 varying vec4 v_texture;
 varying vec2 v_diffVector;
 varying float v_radius;
-varying float v_dim;
-varying vec4 v_bgColor;
 
 const float bias = 255.0 / 254.0;
 const float marginRatio = 1.05;
@@ -68,6 +64,4 @@ void main() {
   v_texture = a_texture;
   v_borderColor = a_borderColor;
   v_borderColor.a *= bias;
-  v_dim = a_dim;
-  v_bgColor = a_bgColor;
 }`;

--- a/cmd/ui/src/rendering/shaders/node.glyphs.frag.ts
+++ b/cmd/ui/src/rendering/shaders/node.glyphs.frag.ts
@@ -26,8 +26,6 @@ varying vec2 v_diffVector;
 varying float v_radius;
 varying float v_angle;
 varying vec2 v_position;
-varying float v_dim;
-varying vec4 v_bgColor;
 
 
 
@@ -69,10 +67,4 @@ void main(void) {
     gl_FragColor = mix(color, border_color, (dist - v_radius + v_border) / v_softborder);
   else
     gl_FragColor = color;
-
-  // Premultiplied alpha output required by Sigma's blend func (gl.ONE, gl.ONE_MINUS_SRC_ALPHA).
-  // Pre-multiplying v_bgColor.rgb by gl_FragColor.a before the mix avoids the double-alpha
-  // artifact that produces a grey ring at antialiased edges: without it the background colour
-  // leaks through at (1-t)^2 weight instead of (1-t), making the ring visibly too dark.
-  gl_FragColor.rgb = mix(v_bgColor.rgb * gl_FragColor.a, gl_FragColor.rgb, v_dim);
 }`;

--- a/cmd/ui/src/rendering/shaders/node.glyphs.vert.ts
+++ b/cmd/ui/src/rendering/shaders/node.glyphs.vert.ts
@@ -22,8 +22,6 @@ attribute vec4 a_texture;
 attribute float a_angle;
 attribute vec2 a_translation;
 attribute vec4 a_borderColor;
-attribute float a_dim;
-attribute vec4 a_bgColor;
 
 uniform float u_ratio;
 uniform float u_scale;
@@ -38,8 +36,6 @@ varying float v_border;
 varying vec4 v_texture;
 varying vec2 v_diffVector;
 varying float v_radius;
-varying float v_dim;
-varying vec4 v_bgColor;
 
 const float bias = 255.0 / 254.0;
 const float marginRatio = 1.05;
@@ -70,6 +66,4 @@ void main() {
   v_texture = a_texture;
   v_borderColor = a_borderColor;
   v_borderColor.a *= bias;
-  v_dim = a_dim;
-  v_bgColor = a_bgColor;
 }`;

--- a/cmd/ui/src/rendering/utils/utils.ts
+++ b/cmd/ui/src/rendering/utils/utils.ts
@@ -29,11 +29,6 @@ export const NODE_PADDING = 2;
 /** Gap between the bottom of a node and the top of its label */
 export const LABEL_NODE_MARGIN = 4;
 
-/** Dimming values for fading the non highlighted nodes */
-export const DIM_FACTOR = 0.1;
-export const NO_DIM_FACTOR = 1.0;
-export const DEFAULT_BG_COLOR = '#ffffff';
-
 /**
  * While edge labels are drawn with a custom renderer, the mouse target for capturing clicks is
  * handled by a separate process, making its position slightly differ. This offset is applied
@@ -46,38 +41,9 @@ export const EDGE_TYPES = ['curved', 'arrow'];
 
 /** Type for node data passed to custom render programs */
 export type GraphItemData = PartialButFor<
-    NodeDisplayData & { inverseSqrtZoomRatio: number; sublabel?: string; isDimmed?: boolean },
+    NodeDisplayData & { inverseSqrtZoomRatio: number; sublabel?: string },
     'x' | 'y' | 'size' | 'label' | 'color'
 >;
-
-/**
- * Blend two 6-digit hex colors together by a given ratio.
- *
- * @param hex - The starting color in 6-digit hex format (e.g. `#4e9a4e`)
- * @param targetHex - The color to blend toward in 6-digit hex format (e.g. `#1a1a2e`)
- * @param amount - How far to blend toward `targetHex` (0 = original, 1 = full target)
- * @returns A 6-digit hex string of the blended color
- */
-export const blendHexColors = (hex: string, targetHex: string, amount: number): string => {
-    const parse = (h: string): [number, number, number] => {
-        // trim() handles the leading space that getComputedStyle returns for CSS custom property values
-        const cleaned = h.trim().replace('#', '');
-        return [
-            parseInt(cleaned.slice(0, 2), 16),
-            parseInt(cleaned.slice(2, 4), 16),
-            parseInt(cleaned.slice(4, 6), 16),
-        ];
-    };
-
-    const [r1, g1, b1] = parse(hex);
-    const [r2, g2, b2] = parse(targetHex);
-
-    const r = Math.round(r1 + (r2 - r1) * amount);
-    const g = Math.round(g1 + (g2 - g1) * amount);
-    const b = Math.round(b1 + (b2 - b1) * amount);
-
-    return `#${r.toString(16).padStart(2, '0')}${g.toString(16).padStart(2, '0')}${b.toString(16).padStart(2, '0')}`;
-};
 
 /**
  * Calculate a labels opacity relative to the current graph's zoom (to mimick ReGraph)


### PR DESCRIPTION
Used the github Revert button to create a PR that reverts all the changes in the previous PR as we don't want it out this release.

Reverts SpecterOps/BloodHound#2715

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Refactor

* Simplified graph node rendering system and WebGL pipeline
* Removed visual dimming effects from node display
* Optimized vertex shader attribute handling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SpecterOps/BloodHound/pull/2778)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->