### PR TITLE
fix(api): correct type coercion when filtering string properties on graph DB  - BED-8252

### DIFF
--- a/cmd/api/src/api/v2/search_test.go
+++ b/cmd/api/src/api/v2/search_test.go
@@ -525,6 +525,130 @@ func TestResources_ListAvailableEnvironments(t *testing.T) {
 				responseBody:   `{"data":[{"type":"HeeHaw","name":"HeeHaw Name","id":"1","collected":true}]}`,
 			},
 		},
+		{
+			name: "success - filter by name",
+			buildRequest: func() *http.Request {
+				return &http.Request{
+					URL: &url.URL{
+						Path:     "/api/v2/available-domains",
+						RawQuery: "name=eq:basic",
+					},
+					Method: http.MethodGet,
+				}
+			},
+			setupMocks: func(t *testing.T, mock *mock) {
+				mock.mockDatabase.EXPECT().GetFlagByKey(gomock.Any(), appcfg.FeatureOpenGraphFindings).Return(appcfg.FeatureFlag{Enabled: false}, nil)
+				mock.mockOpenGraphSchemaService.EXPECT().GetEnvironmentKindsAndEnvironmentExtensionDisplayNames(gomock.Any(), true).
+					Return(graph.Kinds{ad.Domain}, map[string]string{ad.Domain.String(): "Active Directory"}, nil)
+				mock.mockGraphQuery.EXPECT().GetFilteredAndSortedNodes(gomock.Any(), gomock.Any()).
+					Return([]*graph.Node{{
+						Properties: graph.AsProperties(map[string]any{
+							common.Name.String():      "basic",
+							common.ObjectID.String():  "99",
+							common.Collected.String(): false,
+						}),
+						Kinds: graph.Kinds{ad.Domain},
+					}}, nil)
+			},
+			expected: expected{
+				responseCode:   http.StatusOK,
+				responseHeader: http.Header{"Content-Type": []string{"application/json"}},
+				responseBody:   `{"data":[{"type":"active-directory","name":"basic","id":"99","collected":false}]}`,
+			},
+		},
+		{
+			name: "success - boolean-like string filter",
+			buildRequest: func() *http.Request {
+				return &http.Request{
+					URL: &url.URL{
+						Path:     "/api/v2/available-domains",
+						RawQuery: "name=eq:true",
+					},
+					Method: http.MethodGet,
+				}
+			},
+			setupMocks: func(t *testing.T, mock *mock) {
+				mock.mockDatabase.EXPECT().GetFlagByKey(gomock.Any(), appcfg.FeatureOpenGraphFindings).Return(appcfg.FeatureFlag{Enabled: false}, nil)
+				mock.mockOpenGraphSchemaService.EXPECT().GetEnvironmentKindsAndEnvironmentExtensionDisplayNames(gomock.Any(), true).
+					Return(graph.Kinds{ad.Domain}, map[string]string{ad.Domain.String(): "Active Directory"}, nil)
+				mock.mockGraphQuery.EXPECT().GetFilteredAndSortedNodes(gomock.Any(), gomock.Any()).
+					Return([]*graph.Node{{
+						Properties: graph.AsProperties(map[string]any{
+							common.Name.String():      "true",
+							common.ObjectID.String():  "100",
+							common.Collected.String(): false,
+						}),
+						Kinds: graph.Kinds{ad.Domain},
+					}}, nil)
+			},
+			expected: expected{
+				responseCode:   http.StatusOK,
+				responseHeader: http.Header{"Content-Type": []string{"application/json"}},
+				responseBody:   `{"data":[{"type":"active-directory","name":"true","id":"100","collected":false}]}`,
+			},
+		},
+		{
+			name: "success - numeric string filter",
+			buildRequest: func() *http.Request {
+				return &http.Request{
+					URL: &url.URL{
+						Path:     "/api/v2/available-domains",
+						RawQuery: "name=eq:123",
+					},
+					Method: http.MethodGet,
+				}
+			},
+			setupMocks: func(t *testing.T, mock *mock) {
+				mock.mockDatabase.EXPECT().GetFlagByKey(gomock.Any(), appcfg.FeatureOpenGraphFindings).Return(appcfg.FeatureFlag{Enabled: false}, nil)
+				mock.mockOpenGraphSchemaService.EXPECT().GetEnvironmentKindsAndEnvironmentExtensionDisplayNames(gomock.Any(), true).
+					Return(graph.Kinds{ad.Domain}, map[string]string{ad.Domain.String(): "Active Directory"}, nil)
+				mock.mockGraphQuery.EXPECT().GetFilteredAndSortedNodes(gomock.Any(), gomock.Any()).
+					Return([]*graph.Node{{
+						Properties: graph.AsProperties(map[string]any{
+							common.Name.String():      "123",
+							common.ObjectID.String():  "101",
+							common.Collected.String(): false,
+						}),
+						Kinds: graph.Kinds{ad.Domain},
+					}}, nil)
+			},
+			expected: expected{
+				responseCode:   http.StatusOK,
+				responseHeader: http.Header{"Content-Type": []string{"application/json"}},
+				responseBody:   `{"data":[{"type":"active-directory","name":"123","id":"101","collected":false}]}`,
+			},
+		},
+		{
+			name: "success - boolean filter",
+			buildRequest: func() *http.Request {
+				return &http.Request{
+					URL: &url.URL{
+						Path:     "/api/v2/available-domains",
+						RawQuery: "collected=eq:true",
+					},
+					Method: http.MethodGet,
+				}
+			},
+			setupMocks: func(t *testing.T, mock *mock) {
+				mock.mockDatabase.EXPECT().GetFlagByKey(gomock.Any(), appcfg.FeatureOpenGraphFindings).Return(appcfg.FeatureFlag{Enabled: false}, nil)
+				mock.mockOpenGraphSchemaService.EXPECT().GetEnvironmentKindsAndEnvironmentExtensionDisplayNames(gomock.Any(), true).
+					Return(graph.Kinds{ad.Domain}, map[string]string{ad.Domain.String(): "Active Directory"}, nil)
+				mock.mockGraphQuery.EXPECT().GetFilteredAndSortedNodes(gomock.Any(), gomock.Any()).
+					Return([]*graph.Node{{
+						Properties: graph.AsProperties(map[string]any{
+							common.Name.String():      "domain1",
+							common.ObjectID.String():  "102",
+							common.Collected.String(): true,
+						}),
+						Kinds: graph.Kinds{ad.Domain},
+					}}, nil)
+			},
+			expected: expected{
+				responseCode:   http.StatusOK,
+				responseHeader: http.Header{"Content-Type": []string{"application/json"}},
+				responseBody:   `{"data":[{"type":"active-directory","name":"domain1","id":"102","collected":true}]}`,
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/cmd/api/src/model/filter.go
+++ b/cmd/api/src/model/filter.go
@@ -116,7 +116,7 @@ type QueryParameterFilters []QueryParameterFilter
 func (s QueryParameterFilter) BuildGDBNodeFilter() graph.Criteria {
 	var (
 		propertyRef = query.NodeProperty(s.Name)
-		value       = guessFilterValueType(s.Value)
+		value       = guessFilterValueType(s.Value, s.IsStringData)
 	)
 
 	// TODO: Investigate whether we can set the collected property for domains that originate from trusts in ParseDomainTrusts
@@ -320,7 +320,12 @@ func (s QueryParameterFilterMap) BuildSQLFilter() (SQLFilter, error) {
 	return s.BuildAliasedSQLFilter(models.EmptyOptional[string]())
 }
 
-func guessFilterValueType(raw string) any {
+func guessFilterValueType(raw string, isPropertyString bool) any {
+	// GDB node property corresponds to a string value
+	if isPropertyString {
+		return raw
+	}
+
 	if strings.ToLower(raw) == TrueString {
 		return true
 	}

--- a/cmd/api/src/model/filter.go
+++ b/cmd/api/src/model/filter.go
@@ -46,19 +46,9 @@ const (
 	NotEquals           FilterOperator = "neq"
 	ApproximatelyEquals FilterOperator = "~eq"
 
-	GreaterThanSymbol         string = ">"
-	GreaterThanOrEqualsSymbol string = ">="
-	LessThanSymbol            string = "<"
-	LessThanOrEqualsSymbol    string = "<="
-	EqualsSymbol              string = "="
-	NotEqualsSymbol           string = "<>"
-	ApproximatelyEqualSymbol  string = "ILIKE"
-
-	NullString     = "null"
-	TrueString     = "true"
-	FalseString    = "false"
-	IdString       = "id"
-	ObjectIdString = "objectid"
+	NullString  = "null"
+	TrueString  = "true"
+	FalseString = "false"
 )
 
 var (
@@ -358,66 +348,6 @@ func (s QueryParameterFilterMap) BuildGDBNodeFilter() graph.Criteria {
 	}
 
 	return query.And(criteria...)
-}
-
-func (s QueryParameterFilterMap) BuildNeo4jFilter() (string, error) {
-	var (
-		result      = ""
-		firstFilter = true
-		predicate   string
-	)
-
-	for _, filters := range s {
-		for _, filter := range filters {
-			if !firstFilter {
-				result = result + " AND "
-			}
-
-			switch filter.Operator {
-			case GreaterThan:
-				predicate = GreaterThanSymbol
-			case GreaterThanOrEquals:
-				predicate = GreaterThanOrEqualsSymbol
-			case LessThan:
-				predicate = LessThanSymbol
-			case LessThanOrEquals:
-				predicate = LessThanOrEqualsSymbol
-			case Equals:
-				predicate = EqualsSymbol
-			case NotEquals:
-				predicate = NotEqualsSymbol
-			default:
-				return "", fmt.Errorf("invalid filter predicate specified")
-			}
-
-			// our structs hold the data as id but the cypher column is actually objectid
-			if filter.Name == IdString {
-				filter.Name = ObjectIdString
-			}
-
-			filter.Name = fmt.Sprintf("n.%s", filter.Name)
-
-			if filter.IsStringData {
-				// for strings, add single quotes
-				result = result + fmt.Sprintf("%s %s '%s'", filter.Name, predicate, filter.Value)
-			} else {
-				// for booleans, change the predicate to IS or IS NOT
-				if (filter.Value == TrueString || filter.Value == FalseString) && !filter.IsStringData {
-					if predicate == "=" {
-						predicate = "IS"
-					} else {
-						predicate = "IS NOT"
-					}
-				}
-
-				result = result + fmt.Sprintf("%s %s %s", filter.Name, predicate, filter.Value)
-			}
-
-			firstFilter = false
-		}
-	}
-
-	return result, nil
 }
 
 func (s QueryParameterFilterMap) FirstFilter(name string) (QueryParameterFilter, bool) {

--- a/cmd/api/src/model/filter.go
+++ b/cmd/api/src/model/filter.go
@@ -320,8 +320,11 @@ func (s QueryParameterFilterMap) BuildSQLFilter() (SQLFilter, error) {
 	return s.BuildAliasedSQLFilter(models.EmptyOptional[string]())
 }
 
+// guessFilterValueType takes a raw string filter value and attempts to guess its Go type.
+// If isPropertyString is true, the raw value is returned as is. Otherwise, it
+// attempts boolean, integer, or float parsing before defaulting to string.
 func guessFilterValueType(raw string, isPropertyString bool) any {
-	// GDB node property corresponds to a string value
+	// skip type guessing when the node property is a string type
 	if isPropertyString {
 		return raw
 	}

--- a/cmd/api/src/model/filter_test.go
+++ b/cmd/api/src/model/filter_test.go
@@ -399,47 +399,72 @@ func TestBuildGDBNodeFilter(t *testing.T) {
 		output graph.Criteria
 	}{
 		{
-			name: "equals string", //TODO
+			name: "equals string",
 			input: model.QueryParameterFilter{
-				Name:     "name",
-				Operator: model.Equals,
-				Value:    "abc",
+				Name:         "name",
+				Operator:     model.Equals,
+				Value:        "abc",
+				IsStringData: true,
 			},
 			output: query.Equals(query.NodeProperty("name"), "abc"),
 		},
 		{
-			name: "not equals string", //TODO
+			name: "not equals string",
 			input: model.QueryParameterFilter{
-				Name:     "name",
-				Operator: model.NotEquals,
-				Value:    "xyz",
+				Name:         "name",
+				Operator:     model.NotEquals,
+				Value:        "xyz",
+				IsStringData: true,
 			},
 			output: query.Not(query.Equals(query.NodeProperty("name"), "xyz")),
 		},
 		{
-			name: "equals integer",
+			name: "greater than integer",
 			input: model.QueryParameterFilter{
-				Name:     "name",
-				Operator: model.Equals,
-				Value:    "007",
+				Name:         "integer_property",
+				Operator:     model.GreaterThan,
+				Value:        "550",
+				IsStringData: false,
 			},
-			output: query.Equals(query.NodeProperty("name"), int64(007)),
+			output: query.GreaterThan(query.NodeProperty("integer_property"), int64(550)),
+		},
+		{
+			name: "less than integer",
+			input: model.QueryParameterFilter{
+				Name:         "integer_property",
+				Operator:     model.LessThan,
+				Value:        "5",
+				IsStringData: false,
+			},
+			output: query.LessThan(query.NodeProperty("integer_property"), int64(5)),
+		},
+		{
+			name: "less than float",
+			input: model.QueryParameterFilter{
+				Name:         "float_property",
+				Operator:     model.LessThan,
+				Value:        "9.99999",
+				IsStringData: false,
+			},
+			output: query.LessThan(query.NodeProperty("float_property"), float64(9.99999)),
 		},
 		{
 			name: "equals boolean true",
 			input: model.QueryParameterFilter{
-				Name:     "collected",
-				Operator: model.Equals,
-				Value:    "true",
+				Name:         "collected",
+				Operator:     model.Equals,
+				Value:        "true",
+				IsStringData: false,
 			},
 			output: query.Equals(query.NodeProperty("collected"), true),
 		},
 		{
 			name: "equals boolean false",
 			input: model.QueryParameterFilter{
-				Name:     "collected",
-				Operator: model.Equals,
-				Value:    "false",
+				Name:         "collected",
+				Operator:     model.Equals,
+				Value:        "false",
+				IsStringData: false,
 			},
 			output: query.Or(
 				query.Equals(query.NodeProperty("collected"), false),
@@ -447,31 +472,14 @@ func TestBuildGDBNodeFilter(t *testing.T) {
 			),
 		},
 		{
-			name: "not equals",
+			name: "not equals boolean false",
 			input: model.QueryParameterFilter{
-				Name:     "some_property",
-				Operator: model.NotEquals,
-				Value:    "42",
+				Name:         "collected",
+				Operator:     model.NotEquals,
+				Value:        "false",
+				IsStringData: false,
 			},
-			output: query.Not(query.Equals(query.NodeProperty("some_property"), int64(42))),
-		},
-		{
-			name: "greater than",
-			input: model.QueryParameterFilter{
-				Name:     "some_property",
-				Operator: model.GreaterThan,
-				Value:    "7",
-			},
-			output: query.GreaterThan(query.NodeProperty("some_property"), int64(7)),
-		},
-		{
-			name: "less than",
-			input: model.QueryParameterFilter{
-				Name:     "abcd",
-				Operator: model.LessThan,
-				Value:    "5",
-			},
-			output: query.LessThan(query.NodeProperty("abcd"), int64(5)),
+			output: query.Not(query.Equals(query.NodeProperty("collected"), false)),
 		},
 		{
 			name: "equals boolean-like string",
@@ -514,11 +522,32 @@ func TestBuildGDBNodeFilter(t *testing.T) {
 			output: query.Not(query.Equals(query.NodeProperty("name"), "5.6")),
 		},
 		{
+			name: "empty value defaults to raw string",
+			input: model.QueryParameterFilter{
+				Name:         "abc",
+				Operator:     model.Equals,
+				Value:        "",
+				IsStringData: true,
+			},
+			output: query.Equals(query.NodeProperty("abc"), ""),
+		},
+		{
+			name: "empty value on bool defaults to raw string - edge case",
+			input: model.QueryParameterFilter{
+				Name:         "collected",
+				Operator:     model.Equals,
+				Value:        "",
+				IsStringData: false,
+			},
+			output: query.Equals(query.NodeProperty("collected"), ""),
+		},
+		{
 			name: "unsupported operator returns nil",
 			input: model.QueryParameterFilter{
-				Name:     "some_property",
-				Operator: model.ApproximatelyEquals,
-				Value:    "test",
+				Name:         "some_property",
+				Operator:     model.ApproximatelyEquals,
+				Value:        "test",
+				IsStringData: true,
 			},
 			output: nil,
 		},

--- a/cmd/api/src/model/filter_test.go
+++ b/cmd/api/src/model/filter_test.go
@@ -21,6 +21,9 @@ import (
 
 	"github.com/specterops/bloodhound/cmd/api/src/model"
 	"github.com/specterops/dawgs/cypher/models"
+	"github.com/specterops/dawgs/graph"
+	"github.com/specterops/dawgs/query"
+	"github.com/stretchr/testify/require"
 )
 
 func TestBuildSQLFilter(t *testing.T) {
@@ -385,6 +388,146 @@ func TestBuildSQLFilter(t *testing.T) {
 			if actualOutput.SQLString != tc.output.SQLString {
 				t.Errorf("incorrect SQL string: got %q, want %q", actualOutput.SQLString, tc.output.SQLString)
 			}
+		})
+	}
+}
+
+func TestBuildGDBNodeFilter(t *testing.T) {
+	testCases := []struct {
+		name   string
+		input  model.QueryParameterFilter
+		output graph.Criteria
+	}{
+		{
+			name: "equals string", //TODO
+			input: model.QueryParameterFilter{
+				Name:     "name",
+				Operator: model.Equals,
+				Value:    "abc",
+			},
+			output: query.Equals(query.NodeProperty("name"), "abc"),
+		},
+		{
+			name: "not equals string", //TODO
+			input: model.QueryParameterFilter{
+				Name:     "name",
+				Operator: model.NotEquals,
+				Value:    "xyz",
+			},
+			output: query.Not(query.Equals(query.NodeProperty("name"), "xyz")),
+		},
+		{
+			name: "equals integer",
+			input: model.QueryParameterFilter{
+				Name:     "name",
+				Operator: model.Equals,
+				Value:    "007",
+			},
+			output: query.Equals(query.NodeProperty("name"), int64(007)),
+		},
+		{
+			name: "equals boolean true",
+			input: model.QueryParameterFilter{
+				Name:     "collected",
+				Operator: model.Equals,
+				Value:    "true",
+			},
+			output: query.Equals(query.NodeProperty("collected"), true),
+		},
+		{
+			name: "equals boolean false",
+			input: model.QueryParameterFilter{
+				Name:     "collected",
+				Operator: model.Equals,
+				Value:    "false",
+			},
+			output: query.Or(
+				query.Equals(query.NodeProperty("collected"), false),
+				query.Not(query.Exists(query.NodeProperty("collected"))),
+			),
+		},
+		{
+			name: "not equals",
+			input: model.QueryParameterFilter{
+				Name:     "some_property",
+				Operator: model.NotEquals,
+				Value:    "42",
+			},
+			output: query.Not(query.Equals(query.NodeProperty("some_property"), int64(42))),
+		},
+		{
+			name: "greater than",
+			input: model.QueryParameterFilter{
+				Name:     "some_property",
+				Operator: model.GreaterThan,
+				Value:    "7",
+			},
+			output: query.GreaterThan(query.NodeProperty("some_property"), int64(7)),
+		},
+		{
+			name: "less than",
+			input: model.QueryParameterFilter{
+				Name:     "abcd",
+				Operator: model.LessThan,
+				Value:    "5",
+			},
+			output: query.LessThan(query.NodeProperty("abcd"), int64(5)),
+		},
+		{
+			name: "equals boolean-like string",
+			input: model.QueryParameterFilter{
+				Name:         "name",
+				Operator:     model.Equals,
+				Value:        "true",
+				IsStringData: true,
+			},
+			output: query.Equals(query.NodeProperty("name"), "true"),
+		},
+		{
+			name: "not equals boolean-like string",
+			input: model.QueryParameterFilter{
+				Name:         "name",
+				Operator:     model.NotEquals,
+				Value:        "false",
+				IsStringData: true,
+			},
+			output: query.Not(query.Equals(query.NodeProperty("name"), "false")),
+		},
+		{
+			name: "equals numeric string",
+			input: model.QueryParameterFilter{
+				Name:         "name",
+				Operator:     model.Equals,
+				Value:        "1",
+				IsStringData: true,
+			},
+			output: query.Equals(query.NodeProperty("name"), "1"),
+		},
+		{
+			name: "not equals float-like string",
+			input: model.QueryParameterFilter{
+				Name:         "name",
+				Operator:     model.NotEquals,
+				Value:        "5.6",
+				IsStringData: true,
+			},
+			output: query.Not(query.Equals(query.NodeProperty("name"), "5.6")),
+		},
+		{
+			name: "unsupported operator returns nil",
+			input: model.QueryParameterFilter{
+				Name:     "some_property",
+				Operator: model.ApproximatelyEquals,
+				Value:    "test",
+			},
+			output: nil,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			result := testCase.input.BuildGDBNodeFilter()
+			require.Equal(t, testCase.output, result)
 		})
 	}
 }

--- a/cmd/api/src/model/search.go
+++ b/cmd/api/src/model/search.go
@@ -72,9 +72,10 @@ func (s EnvironmentSelectors) ValidFilters() map[string][]FilterOperator {
 func (s EnvironmentSelectors) IsString(column string) bool {
 	switch column {
 	case "name",
-		"objectid",
-		"collected":
+		"objectid":
 		return true
+	case "collected":
+		return false
 	default:
 		return false
 	}


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Relates to [BED-8218](https://specterops.atlassian.net/browse/BED-8218).

This fixes a similar bug in the graph DB filtering path used by the Search `available-domains` endpoint. 
Unlike the SQL path (which returned a 500), this graph DB filter path returned no data when filtering string properties with boolean-like or numeric string values. 

Also fixes a bug where the `collected` boolean property was incorrectly classified as a string in EnvironmentSelectors.IsString().

This also removes the unused `BuildNeo4jFilter` function and any unused constants.

#### Details
- modifies guessFilterValueType to accept an isPropertyString flag; if the property is a string, we skip bool/int/float parsing and return the raw string
- fixes EnvironmentSelectors.IsString() to correctly identify the `collected` as a boolean, not a string
- removes unused BuildNeo4jFilter function and associated/now unused constants (GreaterThanSymbol, EqualsSymbol, etc.)
- adds missing unit test coverage for BuildGDBNodeFilter + adds bug-specific test cases
- adds endpoint tests in search_test.go for ListAvailableEnvironments
- runs pfc

## Motivation and Context

Resolves [BED-8252](https://specterops.atlassian.net/browse/BED-8252).
As mentioned above, this relates to [BED-8218](https://specterops.atlassian.net/browse/BED-8218). Similar bug affecting the graph DB filtering path, only affecting the /api/v2/available-domains endpoint.

## How Has This Been Tested?
- added table unit tests covering string, integer, float, boolean, boolean-like string, numeric string, float-like string, empty value, and unsupported operator cases
- added endpoint tests for ListAvailableEnviroments
- verified non-string properties (int, float, bool) still parse correctly
- verified the removed BuildNeo4jFilter function is not called anywhere
- manually tested the endpoint with various filters (see screenshots)

## Screenshots:
**Before fix: numeric string filter on name (`name=eq:1`):**
<img width="900" height="228" alt="before numeric string call" src="https://github.com/user-attachments/assets/37de86a6-d267-464d-88b2-a56ebfbcbf97" />
<img width="620" height="54" alt="before numeric string print" src="https://github.com/user-attachments/assets/07c5b4fb-7c64-4f5b-8e34-b9c4135b0843" />

**After fix: numeric string filter on name (`name=eq:1`):**
<img width="1275" height="225" alt="after numeric string call" src="https://github.com/user-attachments/assets/771460a5-ae98-45fa-8eaf-ee4b89ae9e2d" />
<img width="677" height="113" alt="after numeric string print" src="https://github.com/user-attachments/assets/75c8ce8f-c00a-49bb-9adb-a992a928fe91" />


**Before fix: boolean-like string filter on name (`name=eq:true`):**
<img width="945" height="173" alt="before boolean string call" src="https://github.com/user-attachments/assets/aed09057-d2ec-405d-ac94-0f875fc47391" />
<img width="636" height="59" alt="before boolean string print" src="https://github.com/user-attachments/assets/1ac15851-dd95-4670-871b-18fb2d2b1ec3" />

**After fix: boolean-like string filter on name (`name=eq:true`):**
<img width="697" height="93" alt="after boolean string print" src="https://github.com/user-attachments/assets/d018fe11-5811-438a-924f-0dd54ed56bc1" />

**Boolean filter on collected still works:**
<img width="1134" height="469" alt="after collected 200" src="https://github.com/user-attachments/assets/7779978e-9ea6-4091-9eab-2128815a6876" />



## Testing Instructions

1. run BHE
2. hit GET /api/v2/available-domains?name=eq:123 (or any numeric string)
            before fix: empty results
            after fix: returns domains whose name matches "123"
3. hit GET /api/v2/available-domains?name=eq:true (or false, t, f)
            before fix: empty results
            after fix: returns domains whose name matches the string "true"
4. hit GET /api/v2/available-domains?collected=eq:true
5. verify boolean filtering on collected still works correctly
6. hit GET /api/v2/available-domains?name=eq:some_normal_string
7. verify normal string filtering is unaffected

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


[BED-8218]: https://specterops.atlassian.net/browse/BED-8218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BED-8252]: https://specterops.atlassian.net/browse/BED-8252?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filter parsing so string, numeric, and boolean-like values are handled correctly; the "collected" attribute is now treated consistently during filtering.
* **Tests**
  * Expanded test coverage for search/filtering, including additional cases for available-domains queries and varied operator/value combinations to validate results.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SpecterOps/BloodHound/pull/2781)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->