### PR TITLE
refactor: centralize ingest and upload logic - BED-8313

### DIFF
--- a/cmd/api/src/services/graphify/ingest_storage.go
+++ b/cmd/api/src/services/graphify/ingest_storage.go
@@ -1,0 +1,194 @@
+// Copyright 2026 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package graphify
+
+import (
+	"archive/zip"
+	"context"
+	"errors"
+	"io"
+	"io/fs"
+	"log/slog"
+	"os"
+
+	"github.com/specterops/bloodhound/cmd/api/src/config"
+	"github.com/specterops/bloodhound/cmd/api/src/model"
+	"github.com/specterops/bloodhound/packages/go/bhlog/attr"
+	"github.com/specterops/bloodhound/packages/go/bhlog/measure"
+	"github.com/specterops/bloodhound/packages/go/bomenc"
+	"github.com/specterops/bloodhound/packages/go/errorlist"
+)
+
+type IngestFileData struct {
+	Name         string
+	ParentFile   string
+	Path         string
+	Errors       []string
+	UserDataErrs []string
+}
+
+// ExtractIngestFiles takes a stored ingest file path and extracts ZIP archives when necessary, returning the paths for
+// files to process. ZIP archives are deleted after extraction, and extracted files are written to the configured temp
+// directory with tempFilePrefix.
+func ExtractIngestFiles(ctx context.Context, configuration config.Configuration, storedFileName string, providedFileName string, fileType model.FileType, tempFilePrefix string) ([]IngestFileData, error) {
+	if fileType == model.FileTypeJson {
+		// If this isn't a zip file, just return a slice with the path in it and let stuff process as normal
+		return []IngestFileData{
+			{
+				Name:   providedFileName,
+				Path:   storedFileName,
+				Errors: []string{},
+			},
+		}, nil
+	} else if archive, err := zip.OpenReader(storedFileName); err != nil {
+		return []IngestFileData{}, err
+	} else {
+		var (
+			errs     = errorlist.NewBuilder()
+			fileData = make([]IngestFileData, 0)
+		)
+
+		defer func() {
+			if err := archive.Close(); err != nil {
+				slog.ErrorContext(
+					ctx,
+					"Error closing archive",
+					slog.String("path", storedFileName),
+					attr.Error(err),
+				)
+			}
+			if err := os.Remove(storedFileName); err != nil {
+				slog.ErrorContext(
+					ctx,
+					"Error deleting archive",
+					slog.String("path", storedFileName),
+					attr.Error(err),
+				)
+			}
+		}()
+
+		for _, file := range archive.File {
+			// skip directories
+			if file.FileInfo().IsDir() {
+				continue
+			}
+
+			fileName, err := extractToTempFile(configuration, file, tempFilePrefix)
+			if err != nil {
+				fileData = append(fileData, IngestFileData{
+					Name:       file.Name,
+					ParentFile: providedFileName,
+					Errors:     []string{err.Error()},
+				})
+
+				errs.Add(err)
+			} else {
+				fileData = append(fileData, IngestFileData{
+					Name:       file.Name,
+					ParentFile: providedFileName,
+					Path:       fileName,
+				})
+			}
+		}
+
+		return fileData, errs.Build()
+	}
+}
+
+func extractToTempFile(configuration config.Configuration, file *zip.File, tempFilePrefix string) (string, error) {
+	var (
+		tempFile            *os.File
+		tempFileName        string
+		sourceFile          io.ReadCloser
+		normalizedFile      io.Reader
+		extractionSucceeded bool
+		err                 error
+	)
+
+	if tempFile, err = os.CreateTemp(configuration.TempDirectory(), tempFilePrefix); err != nil {
+		return "", err
+	}
+
+	tempFileName = tempFile.Name()
+	defer func() {
+		if !extractionSucceeded {
+			tempFile.Close()
+			os.Remove(tempFileName)
+		}
+	}()
+
+	if sourceFile, err = file.Open(); err != nil {
+		return "", err
+	}
+	defer sourceFile.Close()
+
+	// this creates a normalized file to feed to the copy
+	if normalizedFile, err = bomenc.NormalizeToUTF8(sourceFile); err != nil {
+		return "", err
+		// and this is what actually copies it to disk
+	} else if _, err = io.Copy(tempFile, normalizedFile); err != nil {
+		return "", err
+		// try closing the temp file
+	} else if err = tempFile.Close(); err != nil {
+		return "", err
+	} else {
+		// let the deferred method above know we shouldn't delete it and return the filename
+		extractionSucceeded = true
+		return tempFileName, nil
+	}
+}
+
+func processSingleFile(ctx context.Context, fileData IngestFileData, ingestContext *IngestContext, readOpts ReadOptions) error {
+	defer measure.ContextLogAndMeasureWithThreshold(ctx, slog.LevelDebug, "processing single file for ingest", slog.String("filepath", fileData.Path))()
+
+	file, err := os.Open(fileData.Path)
+	if err != nil {
+		slog.ErrorContext(
+			ctx,
+			"Error opening ingest file",
+			slog.String("path", fileData.Path),
+			attr.Error(err),
+		)
+		return err
+	}
+
+	defer func() {
+		file.Close()
+
+		// Always remove the file after attempting to ingest it. Even if it failed
+		if err := os.Remove(fileData.Path); err != nil && !errors.Is(err, fs.ErrNotExist) {
+			slog.ErrorContext(
+				ctx,
+				"Error removing ingest file",
+				slog.String("path", fileData.Path),
+				attr.Error(err),
+			)
+		}
+	}()
+
+	if err := ReadFileForIngest(ingestContext, file, readOpts); err != nil {
+		slog.ErrorContext(
+			ctx,
+			"Error reading ingest file",
+			slog.String("storage_path", fileData.Path),
+			attr.Error(err),
+		)
+		return err
+	}
+
+	return nil
+}

--- a/cmd/api/src/services/graphify/ingest_storage_test.go
+++ b/cmd/api/src/services/graphify/ingest_storage_test.go
@@ -1,0 +1,125 @@
+// Copyright 2026 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package graphify_test
+
+import (
+	"archive/zip"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/specterops/bloodhound/cmd/api/src/config"
+	"github.com/specterops/bloodhound/cmd/api/src/model"
+	"github.com/specterops/bloodhound/cmd/api/src/services/graphify"
+	"github.com/stretchr/testify/require"
+)
+
+type zipTestFile struct {
+	name    string
+	content []byte
+}
+
+func writeZipFile(t *testing.T, archivePath string, files []zipTestFile) {
+	var (
+		archiveFile *os.File
+		zipWriter   *zip.Writer
+		err         error
+	)
+
+	archiveFile, err = os.Create(archivePath)
+	require.NoError(t, err)
+	defer archiveFile.Close()
+
+	zipWriter = zip.NewWriter(archiveFile)
+	defer zipWriter.Close()
+
+	for _, file := range files {
+		fileWriter, err := zipWriter.Create(file.name)
+		require.NoError(t, err)
+
+		_, err = fileWriter.Write(file.content)
+		require.NoError(t, err)
+	}
+
+	_, err = zipWriter.Create("empty-directory/")
+	require.NoError(t, err)
+}
+
+func TestExtractIngestFilesReturnsJSONFile(t *testing.T) {
+	var (
+		ctx              = context.Background()
+		configuration    = config.Configuration{WorkDir: t.TempDir()}
+		storedFileName   = filepath.Join(configuration.WorkDir, "ingest.json")
+		providedFileName = "provided.json"
+	)
+
+	fileData, err := graphify.ExtractIngestFiles(ctx, configuration, storedFileName, providedFileName, model.FileTypeJson, "unused")
+	require.NoError(t, err)
+	require.Equal(t, []graphify.IngestFileData{
+		{
+			Name:   providedFileName,
+			Path:   storedFileName,
+			Errors: []string{},
+		},
+	}, fileData)
+}
+
+func TestExtractIngestFilesExpandsZIPIntoTempDirectory(t *testing.T) {
+	var (
+		ctx              = context.Background()
+		configuration    = config.Configuration{WorkDir: t.TempDir()}
+		archivePath      = filepath.Join(configuration.WorkDir, "archive.zip")
+		providedFileName = "archive.zip"
+		tempFilePrefix   = "file_upload_job7_"
+		bomFileContent   = append([]byte{0xEF, 0xBB, 0xBF}, []byte(`{"meta":{"type":"domains","version":5,"count":0},"data":[]}`)...)
+		plainFileContent = []byte(`{"meta":{"type":"users","version":5,"count":0},"data":[]}`)
+	)
+
+	require.NoError(t, os.MkdirAll(configuration.TempDirectory(), 0o755))
+	writeZipFile(t, archivePath, []zipTestFile{
+		{
+			name:    "domains.json",
+			content: bomFileContent,
+		},
+		{
+			name:    "users.json",
+			content: plainFileContent,
+		},
+	})
+
+	fileData, err := graphify.ExtractIngestFiles(ctx, configuration, archivePath, providedFileName, model.FileTypeZip, tempFilePrefix)
+	require.NoError(t, err)
+	require.Len(t, fileData, 2)
+	require.NoFileExists(t, archivePath)
+
+	for _, file := range fileData {
+		require.Equal(t, providedFileName, file.ParentFile)
+		require.Empty(t, file.Errors)
+		require.DirExists(t, filepath.Dir(file.Path))
+		require.FileExists(t, file.Path)
+		require.Contains(t, filepath.Base(file.Path), tempFilePrefix)
+	}
+
+	domainsContent, err := os.ReadFile(fileData[0].Path)
+	require.NoError(t, err)
+	require.Equal(t, []byte(`{"meta":{"type":"domains","version":5,"count":0},"data":[]}`), domainsContent)
+
+	usersContent, err := os.ReadFile(fileData[1].Path)
+	require.NoError(t, err)
+	require.Equal(t, plainFileContent, usersContent)
+}

--- a/cmd/api/src/services/graphify/tasks.go
+++ b/cmd/api/src/services/graphify/tasks.go
@@ -17,21 +17,16 @@
 package graphify
 
 import (
-	"archive/zip"
 	"context"
 	"errors"
-	"io"
 	"io/fs"
 	"log/slog"
-	"os"
 	"time"
 
 	"github.com/specterops/bloodhound/cmd/api/src/model"
 	"github.com/specterops/bloodhound/cmd/api/src/model/appcfg"
 	"github.com/specterops/bloodhound/cmd/api/src/services/graphify/endpoint"
 	"github.com/specterops/bloodhound/packages/go/bhlog/attr"
-	"github.com/specterops/bloodhound/packages/go/bhlog/measure"
-	"github.com/specterops/bloodhound/packages/go/bomenc"
 	"github.com/specterops/bloodhound/packages/go/errorlist"
 	"github.com/specterops/dawgs/graph"
 )
@@ -49,122 +44,11 @@ func (s *GraphifyService) clearFileTask(ingestTask model.IngestTask) {
 	}
 }
 
-type IngestFileData struct {
-	Name         string
-	ParentFile   string
-	Path         string
-	Errors       []string
-	UserDataErrs []string
-}
-
-// extractIngestFiles will take a path and extract zips if necessary, returning the paths for files to process
-// along with any errors and the number of failed files (in the case of a zip archive)
-func (s *GraphifyService) extractIngestFiles(path string, providedFileName string, fileType model.FileType) ([]IngestFileData, error) {
-	if fileType == model.FileTypeJson {
-		// If this isn't a zip file, just return a slice with the path in it and let stuff process as normal
-		return []IngestFileData{
-			{
-				Name:   providedFileName,
-				Path:   path,
-				Errors: []string{},
-			},
-		}, nil
-	} else if archive, err := zip.OpenReader(path); err != nil {
-		return []IngestFileData{}, err
-	} else {
-		var (
-			errs     = errorlist.NewBuilder()
-			fileData = make([]IngestFileData, 0)
-		)
-
-		defer func() {
-			if err := archive.Close(); err != nil {
-				slog.ErrorContext(
-					s.ctx,
-					"Error closing archive",
-					slog.String("path", path),
-					attr.Error(err),
-				)
-			}
-			if err := os.Remove(path); err != nil {
-				slog.ErrorContext(
-					s.ctx,
-					"Error deleting archive",
-					slog.String("path", path),
-					attr.Error(err),
-				)
-			}
-		}()
-
-		for _, f := range archive.File {
-			// skip directories
-			if f.FileInfo().IsDir() {
-				continue
-			}
-
-			fileName, err := s.extractToTempFile(f)
-			if err != nil {
-				fileData = append(fileData, IngestFileData{
-					Name:       f.Name,
-					ParentFile: providedFileName,
-					Errors:     []string{err.Error()},
-				})
-
-				errs.Add(err)
-			} else {
-				fileData = append(fileData, IngestFileData{
-					Name:       f.Name,
-					ParentFile: providedFileName,
-					Path:       fileName,
-				})
-			}
-		}
-
-		return fileData, errs.Build()
-	}
-}
-
-func (s *GraphifyService) extractToTempFile(f *zip.File) (string, error) {
-	// Given a single artifact in an archive, extract it out to a temporary file
-	tempFile, err := os.CreateTemp(s.cfg.TempDirectory(), "bh")
-	if err != nil {
-		return "", err
-	}
-
-	success := false
-	defer func() {
-		// Always close the tempFile, but...
-		tempFile.Close()
-		if !success {
-			// ... only delete if it wasn't successful. Otherwise we leave it around to be processed
-			os.Remove(tempFile.Name())
-		}
-	}()
-
-	srcFile, err := f.Open()
-	if err != nil {
-		return "", err
-	}
-	defer srcFile.Close()
-
-	// this creates a normalized file to feed to the copy
-	if normFile, err := bomenc.NormalizeToUTF8(srcFile); err != nil {
-		return "", err
-		// and this is what actually copies it to disk
-	} else if _, err := io.Copy(tempFile, normFile); err != nil {
-		return "", err
-	} else {
-		// let the deferred method above know we shouldn't delete it and return the filename
-		success = true
-		return tempFile.Name(), nil
-	}
-}
-
 // ProcessIngestFile reads the files at the path supplied, and returns the total number of files in the
 // archive, the number of files that failed to ingest as JSON, and an error
 func (s *GraphifyService) ProcessIngestFile(ic *IngestContext, task model.IngestTask) ([]IngestFileData, error) {
 	// Try to pre-process the file. If any of them fail, stop processing and return the error
-	if fileData, err := s.extractIngestFiles(task.StoredFileName, task.OriginalFileName, task.FileType); err != nil {
+	if fileData, err := ExtractIngestFiles(s.ctx, s.cfg, task.StoredFileName, task.OriginalFileName, task.FileType, "bh"); err != nil {
 		return []IngestFileData{}, err
 	} else {
 		errs := errorlist.NewBuilder()
@@ -222,47 +106,6 @@ func (s *GraphifyService) NewIngestContext(ctx context.Context, ingestTime time.
 	}
 
 	return NewIngestContext(ctx, opts...)
-}
-
-func processSingleFile(ctx context.Context, fileData IngestFileData, ingestContext *IngestContext, readOpts ReadOptions) error {
-	defer measure.ContextLogAndMeasureWithThreshold(ctx, slog.LevelDebug, "processing single file for ingest", slog.String("filepath", fileData.Path))()
-
-	file, err := os.Open(fileData.Path)
-	if err != nil {
-		slog.ErrorContext(
-			ctx,
-			"Error opening ingest file",
-			slog.String("filepath", fileData.Path),
-			attr.Error(err),
-		)
-		return err
-	}
-
-	defer func() {
-		file.Close()
-
-		// Always remove the file after attempting to ingest it. Even if it failed
-		if err := os.Remove(fileData.Path); err != nil && !errors.Is(err, fs.ErrNotExist) {
-			slog.ErrorContext(
-				ctx,
-				"Error removing ingest file",
-				slog.String("filepath", fileData.Path),
-				attr.Error(err),
-			)
-		}
-	}()
-
-	if err := ReadFileForIngest(ingestContext, file, readOpts); err != nil {
-		slog.ErrorContext(
-			ctx,
-			"Error reading ingest file",
-			slog.String("filepath", fileData.Path),
-			attr.Error(err),
-		)
-		return err
-	}
-
-	return nil
 }
 
 func (s *GraphifyService) getAllTasks() model.IngestTasks {

--- a/cmd/api/src/services/upload/upload.go
+++ b/cmd/api/src/services/upload/upload.go
@@ -53,7 +53,7 @@ func SaveIngestFile(location string, request *http.Request, validator IngestVali
 		return IngestTaskParams{}, fmt.Errorf("invalid content type for ingest file")
 	}
 
-	if tempFileName, err := WriteAndValidateFile(fileData, location, jobID, validationFn); err != nil {
+	if tempFileName, err := WriteAndValidateFileWithPrefix(fileData, location, ingestFileTempPrefix(jobID), validationFn); err != nil {
 		return IngestTaskParams{}, err
 	} else {
 		return IngestTaskParams{
@@ -64,18 +64,32 @@ func SaveIngestFile(location string, request *http.Request, validator IngestVali
 
 }
 
+func ingestFileTempPrefix(jobID int64) string {
+	return fmt.Sprintf("file_upload_job%d_", jobID)
+}
+
 func WriteAndValidateFile(fileData io.Reader, location string, jobID int64, validationFunc FileValidator) (string, error) {
+	return WriteAndValidateFileWithPrefix(fileData, location, ingestFileTempPrefix(jobID), validationFunc)
+}
+
+func WriteAndValidateFileWithPrefix(fileData io.Reader, location string, tempFilePrefix string, validationFunc FileValidator) (string, error) {
+	var (
+		tempFile      *os.File
+		tempFileName  string
+		err           error
+		validationErr error
+	)
+
 	// Write a temp file. If it passes validation, keep it around and return the filename. Otherwise destroy it.
-	tempFile, err := os.CreateTemp(location, fmt.Sprintf("file_upload_job%d_", jobID))
-	if err != nil {
+	if tempFile, err = os.CreateTemp(location, tempFilePrefix); err != nil {
 		return "", fmt.Errorf("error creating ingest file: %w", err)
 	}
 
 	// Save this for later
-	tempFileName := tempFile.Name()
+	tempFileName = tempFile.Name()
 
 	// Run validation on the file to see if we even want to keep it
-	_, validationErr := validationFunc(fileData, tempFile)
+	_, validationErr = validationFunc(fileData, tempFile)
 
 	// We close the file next, not last. We can't defer this if we might want to delete it.
 	// Note: fileData does not need to be closed because the HTTP server manages it's lifecyle

--- a/cmd/api/src/services/upload/upload_test.go
+++ b/cmd/api/src/services/upload/upload_test.go
@@ -22,12 +22,29 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/specterops/bloodhound/cmd/api/src/model/ingest"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func buildValidator(t *testing.T, expectedContent string, validationErr error) FileValidator {
+	t.Helper()
+
+	return func(src io.Reader, dst io.Writer) (ingest.OriginalMetadata, error) {
+		content, err := io.ReadAll(src)
+		require.NoError(t, err)
+		require.Equal(t, expectedContent, string(content))
+
+		_, err = dst.Write(content)
+		require.NoError(t, err)
+
+		return ingest.OriginalMetadata{}, validationErr
+	}
+}
 
 func TestWriteAndValidateZip(t *testing.T) {
 	t.Run("valid zip file is ok", func(t *testing.T) {
@@ -137,6 +154,41 @@ func TestWriteAndValidateJSON_NormalizationError(t *testing.T) {
 
 	assert.Error(t, err)
 	assert.ErrorIs(t, err, ErrInvalidJSON)
+}
+
+func TestWriteAndValidateFileWithPrefix(t *testing.T) {
+	t.Parallel()
+
+	var (
+		errValidation  = errors.New("validation failed")
+		tempFilePrefix = "custom_prefix_"
+	)
+
+	t.Run("writes validated file using caller supplied prefix", func(t *testing.T) {
+		t.Parallel()
+
+		tempDirectory := t.TempDir()
+		fileName, err := WriteAndValidateFileWithPrefix(strings.NewReader("content"), tempDirectory, tempFilePrefix, buildValidator(t, "content", nil))
+		require.NoError(t, err)
+		require.Contains(t, filepath.Base(fileName), tempFilePrefix)
+
+		fileContent, err := os.ReadFile(fileName)
+		require.NoError(t, err)
+		require.Equal(t, "content", string(fileContent))
+	})
+
+	t.Run("validation error deletes temp file", func(t *testing.T) {
+		t.Parallel()
+
+		tempDirectory := t.TempDir()
+		fileName, err := WriteAndValidateFileWithPrefix(strings.NewReader("content"), tempDirectory, tempFilePrefix, buildValidator(t, "content", errValidation))
+		require.ErrorIs(t, err, errValidation)
+		require.Empty(t, fileName)
+
+		files, err := filepath.Glob(filepath.Join(tempDirectory, tempFilePrefix+"*"))
+		require.NoError(t, err)
+		require.Empty(t, files)
+	})
 }
 
 // ErrorReader is a mock reader that always returns an error


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

This change refactors the ingest and upload logic to centralize some of the functions to be able to create a new file service in the future. 

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves: BED-8313


## How Has This Been Tested?
This has been tested by running the application and doing an upload. 

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Ingests JSON files and expands uploaded archives into staged temp files with per-file error tracking and automatic cleanup
  * Upload/validation flow now uses a configurable temp-file prefix for organized temporary filenames

* **Tests**
  * Unit tests added for archive extraction, JSON handling (including BOM stripping), temp-file-prefix behavior, validation success, and cleanup on failure

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SpecterOps/BloodHound/pull/2800?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->