### PR TITLE
feat: enforce lowercase opengraph property names BED-8071

### DIFF
--- a/cmd/api/src/services/upload/jsonschema/edge.json
+++ b/cmd/api/src/services/upload/jsonschema/edge.json
@@ -20,6 +20,9 @@
             ]
           }
         ]
+      },
+      "propertyNames": {
+        "pattern": "^[a-z0-9_-]+$"
       }
     },
     "endpoint": {

--- a/cmd/api/src/services/upload/jsonschema/edge.json
+++ b/cmd/api/src/services/upload/jsonschema/edge.json
@@ -22,7 +22,7 @@
         ]
       },
       "propertyNames": {
-        "pattern": "^[a-z0-9_-]+$"
+        "pattern": "^[a-z0-9_-]{1,128}$"
       }
     },
     "endpoint": {

--- a/cmd/api/src/services/upload/jsonschema/edge.json
+++ b/cmd/api/src/services/upload/jsonschema/edge.json
@@ -41,7 +41,8 @@
             "type": "object",
             "properties": {
               "key": {
-                "type": "string"
+                "type": "string",
+                "pattern": "^[a-z0-9_-]{1,128}$"
               },
               "operator": {
                 "type": "string",

--- a/cmd/api/src/services/upload/jsonschema/node.json
+++ b/cmd/api/src/services/upload/jsonschema/node.json
@@ -43,7 +43,7 @@
         ]
       },
       "propertyNames": {
-        "pattern": "^[a-z0-9_-]+$"
+        "pattern": "^[a-z0-9_-]{1,128}$"
       },
       "not": {
         "required": [

--- a/cmd/api/src/services/upload/jsonschema/node.json
+++ b/cmd/api/src/services/upload/jsonschema/node.json
@@ -42,6 +42,9 @@
           }
         ]
       },
+      "propertyNames": {
+        "pattern": "^[a-z0-9_-]+$"
+      },
       "not": {
         "required": [
           "objectid"

--- a/cmd/api/src/services/upload/streamdecoder_test.go
+++ b/cmd/api/src/services/upload/streamdecoder_test.go
@@ -1202,6 +1202,74 @@ func edgeSchemaFailureCases() []genericIngestAssertion {
 				{"edges[0] schema validation failed with 1 error(s)", "invalid propertyName 'aaaaaaaaaaa", "aaaaaaaaaaa' does not match pattern"},
 			},
 		},
+		{
+			name: "edge validation: property_matchers key values cannot use uppercase characters",
+			payload: &testPayload{
+				Edges: []testEdge{
+					{
+						Kind:  "test",
+						Start: &edgePiece{Value: "1234"},
+						End: &edgePiece{MatchBy: "property", PropertyMatchers: []propertyMatcher{
+							propertyMatcher{Key: "TESTKey", Operator: "equals", Value: "asdf"},
+						}},
+					},
+				},
+			},
+			validationErrContains: [][]string{
+				{"edges[0] schema validation failed with 1 error(s)", "at '/end/property_matchers/0/key': 'TESTKey' does not match pattern"},
+			},
+		},
+		{
+			name: "edge validation: property_matchers key values cannot be empty",
+			payload: &testPayload{
+				Edges: []testEdge{
+					{
+						Kind:  "test",
+						Start: &edgePiece{Value: "1234"},
+						End: &edgePiece{MatchBy: "property", PropertyMatchers: []propertyMatcher{
+							propertyMatcher{Key: "", Operator: "equals", Value: "asdf"},
+						}},
+					},
+				},
+			},
+			validationErrContains: [][]string{
+				{"edges[0] schema validation failed with 1 error(s)", "at '/end/property_matchers/0/key': '' does not match pattern"},
+			},
+		},
+		{
+			name: "edge validation: property_matchers key values cannot contain spaces",
+			payload: &testPayload{
+				Edges: []testEdge{
+					{
+						Kind:  "test",
+						Start: &edgePiece{Value: "1234"},
+						End: &edgePiece{MatchBy: "property", PropertyMatchers: []propertyMatcher{
+							propertyMatcher{Key: "test prop", Operator: "equals", Value: "asdf"},
+						}},
+					},
+				},
+			},
+			validationErrContains: [][]string{
+				{"edges[0] schema validation failed with 1 error(s)", "at '/end/property_matchers/0/key': 'test prop' does not match pattern"},
+			},
+		},
+		{
+			name: "edge validation: property_matchers key values cannot be longer than 128 chars",
+			payload: &testPayload{
+				Edges: []testEdge{
+					{
+						Kind:  "test",
+						Start: &edgePiece{Value: "1234"},
+						End: &edgePiece{MatchBy: "property", PropertyMatchers: []propertyMatcher{
+							propertyMatcher{Key: strings.Repeat("a", 129), Operator: "equals", Value: "asdf"},
+						}},
+					},
+				},
+			},
+			validationErrContains: [][]string{
+				{"edges[0] schema validation failed with 1 error(s)", "at '/end/property_matchers/0/key': 'aaaaaaaaaaa", "aaaaaaaaaaa' does not match pattern"},
+			},
+		},
 	}
 }
 

--- a/cmd/api/src/services/upload/streamdecoder_test.go
+++ b/cmd/api/src/services/upload/streamdecoder_test.go
@@ -774,6 +774,66 @@ func nodeSchemaFailureCases() []genericIngestAssertion {
 				{"nodes[0] validation failed with 1 error(s)", "kind 'tag' uses reserved namespace 'tag'"},
 			},
 		},
+		{
+			name: "node validation: property keys cannot use uppercase characters",
+			payload: &testPayload{
+				Nodes: []testNode{
+					{
+						ID:         "1234",
+						Kinds:      []string{"test"},
+						Properties: map[string]any{"TESTKey": "asdf"},
+					},
+				},
+			},
+			validationErrContains: [][]string{
+				{"nodes[0] schema validation failed with 1 error(s)", "invalid propertyName 'TESTKey'\n- at '': 'TESTKey' does not match pattern"},
+			},
+		},
+		{
+			name: "node validation: property keys cannot be empty",
+			payload: &testPayload{
+				Nodes: []testNode{
+					{
+						ID:         "1234",
+						Kinds:      []string{"test"},
+						Properties: map[string]any{"": "asdf"},
+					},
+				},
+			},
+			validationErrContains: [][]string{
+				{"nodes[0] schema validation failed with 1 error(s)", "invalid propertyName ''\n- at '': '' does not match pattern"},
+			},
+		},
+		{
+			name: "node validation: property keys cannot contain spaces",
+			payload: &testPayload{
+				Nodes: []testNode{
+					{
+						ID:         "1234",
+						Kinds:      []string{"test"},
+						Properties: map[string]any{"test prop": "asdf"},
+					},
+				},
+			},
+			validationErrContains: [][]string{
+				{"nodes[0] schema validation failed with 1 error(s)", "invalid propertyName 'test prop'\n- at '': 'test prop' does not match pattern"},
+			},
+		},
+		{
+			name: "node validation: property keys cannot be longer than 128 chars",
+			payload: &testPayload{
+				Nodes: []testNode{
+					{
+						ID:         "1234",
+						Kinds:      []string{"test"},
+						Properties: map[string]any{strings.Repeat("a", 129): "asdf"},
+					},
+				},
+			},
+			validationErrContains: [][]string{
+				{"nodes[0] schema validation failed with 1 error(s)", "invalid propertyName 'aaaaaaaaaaa", "aaaaaaaaaaa' does not match pattern"},
+			},
+		},
 	}
 }
 
@@ -1076,6 +1136,70 @@ func edgeSchemaFailureCases() []genericIngestAssertion {
 			},
 			validationErrContains: [][]string{
 				{"edges[0]", "at '/start/match_by'", "value must be one of 'id', 'name'"},
+			},
+		},
+		{
+			name: "edge validation: property keys cannot use uppercase characters",
+			payload: &testPayload{
+				Edges: []testEdge{
+					{
+						Kind:       "test",
+						Start:      &edgePiece{Value: "1234"},
+						End:        &edgePiece{Value: "5678"},
+						Properties: map[string]any{"TESTKey": "asdf"},
+					},
+				},
+			},
+			validationErrContains: [][]string{
+				{"edges[0] schema validation failed with 1 error(s)", "invalid propertyName 'TESTKey'\n- at '': 'TESTKey' does not match pattern"},
+			},
+		},
+		{
+			name: "edge validation: property keys cannot be empty",
+			payload: &testPayload{
+				Edges: []testEdge{
+					{
+						Kind:       "test",
+						Start:      &edgePiece{Value: "1234"},
+						End:        &edgePiece{Value: "5678"},
+						Properties: map[string]any{"": "asdf"},
+					},
+				},
+			},
+			validationErrContains: [][]string{
+				{"edges[0] schema validation failed with 1 error(s)", "invalid propertyName ''\n- at '': '' does not match pattern"},
+			},
+		},
+		{
+			name: "edge validation: property keys cannot contain spaces",
+			payload: &testPayload{
+				Edges: []testEdge{
+					{
+						Kind:       "test",
+						Start:      &edgePiece{Value: "1234"},
+						End:        &edgePiece{Value: "5678"},
+						Properties: map[string]any{"test prop": "asdf"},
+					},
+				},
+			},
+			validationErrContains: [][]string{
+				{"edges[0] schema validation failed with 1 error(s)", "invalid propertyName 'test prop'\n- at '': 'test prop' does not match pattern"},
+			},
+		},
+		{
+			name: "edge validation: property keys cannot be longer than 128 chars",
+			payload: &testPayload{
+				Edges: []testEdge{
+					{
+						Kind:       "test",
+						Start:      &edgePiece{Value: "1234"},
+						End:        &edgePiece{Value: "5678"},
+						Properties: map[string]any{strings.Repeat("a", 129): "asdf"},
+					},
+				},
+			},
+			validationErrContains: [][]string{
+				{"edges[0] schema validation failed with 1 error(s)", "invalid propertyName 'aaaaaaaaaaa", "aaaaaaaaaaa' does not match pattern"},
 			},
 		},
 	}


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

- Updated the OpenGraph node and edge schemas to enforce property key names with a regex pattern
- Updated the OpenGraph edge schema to enforce `property_matchers[].key` values with a regex pattern

### Character Set
It is not realistic to implement this solely by checking for and rejecting uppercase characters, especially if enforcement is done via the schema files. Since enforcing lowercase will be a breaking change anyway, we decided to go with a character set that only allows lowercase Latin letters, numbers, dash, and underscore (`a-z0-9_-`). We also set the maximum length as 128 characters.

### UI Error Discoverability
These changes use the same mechanism for reporting errors that all the other OpenGraph validation code uses. As such, the validation errors appear in the API logs and the HTTP response body. The UI however does not always surface these errors to the user. It did not seem logical to special-case this error to make it appear in the UI, and seemed more appropriate to create a separate ticket to surface all validation errors in the UI regardless of cause.

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-8071

Not all systems that OpenGraph will interact with are case sensitive, so we are standardizing on lowercase property names.

## How Has This Been Tested?

Uploaded some test data to verify it was rejected, and ran created tests locally.

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened validation for property names in uploaded data: keys must be 1–128 chars, lowercase letters, digits, hyphens or underscores. Uploads with invalid property names are now rejected during validation.

* **Tests**
  * Added negative test cases to ensure invalid property keys (uppercase, empty, spaces, overly long) are rejected for both node and edge data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->