### PR TITLE
fix: exclude UI static assets from rate limiting BED-8327

### DIFF
--- a/cmd/api/src/api/registration/registration.go
+++ b/cmd/api/src/api/registration/registration.go
@@ -83,10 +83,11 @@ func RegisterFossRoutes(
 		routerInst.GET("/", func(response http.ResponseWriter, request *http.Request) {
 			http.Redirect(response, request, "/ui", http.StatusMovedPermanently)
 		}),
-
-		// Static asset handling for the UI
-		routerInst.PathPrefix("/ui", static.AssetHandler),
 	)
+
+	// Static asset handling for the UI. This route intentionally sits outside the default API rate limiter
+	// because a single page load can request many static HTML, JavaScript, CSS, and media assets.
+	routerInst.PathPrefix(api.UserInterfacePath, static.AssetHandler)
 
 	var resources = v2.NewResources(rdms, graphDB, cfg, apiCache, graphQuery, collectorManifests, authorizer, authenticator, ingestSchema, dogtagsService, openGraphSchemaService)
 	NewV2API(resources, routerInst)

--- a/cmd/api/src/api/registration/registration.go
+++ b/cmd/api/src/api/registration/registration.go
@@ -81,7 +81,7 @@ func RegisterFossRoutes(
 
 		// Redirect root resource to the UI
 		routerInst.GET("/", func(response http.ResponseWriter, request *http.Request) {
-			http.Redirect(response, request, "/ui", http.StatusMovedPermanently)
+			http.Redirect(response, request, api.UserInterfacePath, http.StatusMovedPermanently)
 		}),
 	)
 


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->

## Description

Move the `/ui` static asset prefix out of the `DefaultRateLimitMiddleware` group in `RegisterFossRoutes` so a single UI page load — which can request many HTML/JS/CSS/media assets — is not throttled by the per-IP API rate limiter. While reordering, also switch the literal `"/ui"` to the existing `api.UserInterfacePath` constant to keep the path defined in one place.

Auth and other global middleware (panic handler, auth middleware, compression, logging) continue to apply, since those are registered via `UsePrerouting` / `UsePostrouting` rather than the per-route `router.With(...)` rate-limiter wrapper.

## Motivation and Context

Resolves BED-8327

Users have reported intermittent missing images and 429s on remediation pages with heavy screenshots (e.g. ESC1 documentation). The static asset route was previously inside the default rate-limited group, which trips the limiter whenever the UI fetches many assets at once — especially when react-query refetches on tab focus.

This PR handles the static asset / UI path. The companion change in `bloodhound-enterprise` covers the `/api/v2/assets` BHE finding-asset prefix and the UI-side `refetchOnWindowFocus` / memoization fixes.

## How Has This Been Tested?

- Existing unit tests in `cmd/api/src/api/middleware/rate_limit_test.go` already cover the rate-limiter middleware itself (`TestRateLimitMiddleware`, `TestDefaultRateLimitMiddleware`). This PR only changes route registration, not the middleware, so no new middleware tests were added.
- Ran `just prepare-for-codereview` — clean tree, no codegen / license / format drift.

## Screenshots (optional):

n/a

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: BED-8327
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs — n/a (no API surface change)
  - Code comments — added a comment on the route explaining why it sits outside the rate-limited group
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes — n/a, see "How Has This Been Tested?"
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated routing for user interface static resources.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SpecterOps/BloodHound/pull/2816?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->