### PR TITLE
chore: Cache ESC4 principal lookups in ADCSCache - BED-8361

### DIFF
--- a/packages/go/analysis/ad/adcscache.go
+++ b/packages/go/analysis/ad/adcscache.go
@@ -51,6 +51,12 @@ type ADCSCache struct {
 	certTemplateControllers         map[graph.ID][]*graph.Node // principals that have privileges on a cert template via `owner`, `generic all`, `write dacl`, `write owner` edges
 	enterpriseCAEnrollers           map[graph.ID][]*graph.Node // principals that have enrollment rights on an enterprise ca via `enroll` edge
 	publishedTemplateCache          map[graph.ID][]*graph.Node // cert templates that are published to an enterprise ca
+
+	// ESC4-specific caches: principals with specific rights on cert templates, pre-computed to avoid per-ECA DB queries
+	certTemplateGenericWriters              map[graph.ID][]*graph.Node // principals with GenericWrite on a cert template
+	certTemplateEnrollOrAllExtendedRighters map[graph.ID][]*graph.Node // principals with Enroll or AllExtendedRights on a cert template
+	certTemplateWritePKINameFlaggers        map[graph.ID][]*graph.Node // principals with WritePKINameFlag on a cert template
+	certTemplateWritePKIEnrollmentFlaggers  map[graph.ID][]*graph.Node // principals with WritePKIEnrollmentFlag on a cert template
 	hasUPNCertMappingInForest       cardinality.Duplex[uint64] // domains where at least one DC in the forest has Schannel UPN cert mapping enabled
 	hasWeakCertBindingInForest      cardinality.Duplex[uint64] // domains where at least one DC in the forest has Kerberos weak cert binding enabled
 }
@@ -66,9 +72,13 @@ func NewADCSCache() ADCSCache {
 		enterpriseCAHasSpecialEnrollers: make(map[graph.ID]bool),
 		certTemplateEnrollers:           make(map[graph.ID][]*graph.Node),
 		certTemplateControllers:         make(map[graph.ID][]*graph.Node),
-		enterpriseCAEnrollers:           make(map[graph.ID][]*graph.Node),
-		publishedTemplateCache:          make(map[graph.ID][]*graph.Node),
-		hasUPNCertMappingInForest:       cardinality.NewBitmap64(),
+		enterpriseCAEnrollers:                  make(map[graph.ID][]*graph.Node),
+		publishedTemplateCache:                 make(map[graph.ID][]*graph.Node),
+		certTemplateGenericWriters:             make(map[graph.ID][]*graph.Node),
+		certTemplateEnrollOrAllExtendedRighters: make(map[graph.ID][]*graph.Node),
+		certTemplateWritePKINameFlaggers:        make(map[graph.ID][]*graph.Node),
+		certTemplateWritePKIEnrollmentFlaggers:  make(map[graph.ID][]*graph.Node),
+		hasUPNCertMappingInForest:              cardinality.NewBitmap64(),
 		hasWeakCertBindingInForest:      cardinality.NewBitmap64(),
 	}
 }
@@ -138,6 +148,35 @@ func (s *ADCSCache) BuildCache(ctx context.Context, db graph.Database, enterpris
 				)
 			} else {
 				s.certTemplateControllers[ct.ID] = firstDegreePrincipals.Slice()
+			}
+
+			// ESC4-specific principal caches
+			if principals, err := FetchPrincipalsWithGenericWriteOnCertTemplate(tx, ct); err != nil {
+				slog.ErrorContext(ctx, "Error fetching principals with GenericWrite on cert template",
+					slog.Uint64("cert_template", uint64(ct.ID)), attr.Error(err))
+			} else {
+				s.certTemplateGenericWriters[ct.ID] = principals.Slice()
+			}
+
+			if principals, err := FetchPrincipalsWithEnrollOrAllExtendedRightsOnCertTemplate(tx, ct); err != nil {
+				slog.ErrorContext(ctx, "Error fetching principals with Enroll/AllExtendedRights on cert template",
+					slog.Uint64("cert_template", uint64(ct.ID)), attr.Error(err))
+			} else {
+				s.certTemplateEnrollOrAllExtendedRighters[ct.ID] = principals.Slice()
+			}
+
+			if principals, err := FetchPrincipalsWithWritePKINameFlagOnCertTemplate(tx, ct); err != nil {
+				slog.ErrorContext(ctx, "Error fetching principals with WritePKINameFlag on cert template",
+					slog.Uint64("cert_template", uint64(ct.ID)), attr.Error(err))
+			} else {
+				s.certTemplateWritePKINameFlaggers[ct.ID] = principals.Slice()
+			}
+
+			if principals, err := FetchPrincipalsWithWritePKIEnrollmentFlagOnCertTemplate(tx, ct); err != nil {
+				slog.ErrorContext(ctx, "Error fetching principals with WritePKIEnrollmentFlag on cert template",
+					slog.Uint64("cert_template", uint64(ct.ID)), attr.Error(err))
+			} else {
+				s.certTemplateWritePKIEnrollmentFlaggers[ct.ID] = principals.Slice()
 			}
 		}
 
@@ -368,6 +407,34 @@ func (s *ADCSCache) GetCertTemplateControllers(id graph.ID) []*graph.Node {
 	defer s.mu.RUnlock()
 
 	return s.certTemplateControllers[id]
+}
+
+func (s *ADCSCache) GetCertTemplateGenericWriters(id graph.ID) []*graph.Node {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.certTemplateGenericWriters[id]
+}
+
+func (s *ADCSCache) GetCertTemplateEnrollOrAllExtendedRighters(id graph.ID) []*graph.Node {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.certTemplateEnrollOrAllExtendedRighters[id]
+}
+
+func (s *ADCSCache) GetCertTemplateWritePKINameFlaggers(id graph.ID) []*graph.Node {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.certTemplateWritePKINameFlaggers[id]
+}
+
+func (s *ADCSCache) GetCertTemplateWritePKIEnrollmentFlaggers(id graph.ID) []*graph.Node {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.certTemplateWritePKIEnrollmentFlaggers[id]
 }
 
 func (s *ADCSCache) GetEnterpriseCAEnrollers(id graph.ID) []*graph.Node {

--- a/packages/go/analysis/ad/adcscache.go
+++ b/packages/go/analysis/ad/adcscache.go
@@ -57,29 +57,29 @@ type ADCSCache struct {
 	certTemplateEnrollOrAllExtendedRighters map[graph.ID][]*graph.Node // principals with Enroll or AllExtendedRights on a cert template
 	certTemplateWritePKINameFlaggers        map[graph.ID][]*graph.Node // principals with WritePKINameFlag on a cert template
 	certTemplateWritePKIEnrollmentFlaggers  map[graph.ID][]*graph.Node // principals with WritePKIEnrollmentFlag on a cert template
-	hasUPNCertMappingInForest       cardinality.Duplex[uint64] // domains where at least one DC in the forest has Schannel UPN cert mapping enabled
-	hasWeakCertBindingInForest      cardinality.Duplex[uint64] // domains where at least one DC in the forest has Kerberos weak cert binding enabled
+	hasUPNCertMappingInForest               cardinality.Duplex[uint64] // domains where at least one DC in the forest has Schannel UPN cert mapping enabled
+	hasWeakCertBindingInForest              cardinality.Duplex[uint64] // domains where at least one DC in the forest has Kerberos weak cert binding enabled
 }
 
 func NewADCSCache() ADCSCache {
 	return ADCSCache{
-		mu:                              &sync.RWMutex{},
-		authStoreForChainValid:          make(map[graph.ID]cardinality.Duplex[uint64]),
-		rootCAForChainValid:             make(map[graph.ID]cardinality.Duplex[uint64]),
-		hasHostingComputer:              make(map[graph.ID]bool),
-		expandedCertTemplateControllers: make(map[graph.ID]cardinality.Duplex[uint64]),
-		certTemplateHasSpecialEnrollers: make(map[graph.ID]bool),
-		enterpriseCAHasSpecialEnrollers: make(map[graph.ID]bool),
-		certTemplateEnrollers:           make(map[graph.ID][]*graph.Node),
-		certTemplateControllers:         make(map[graph.ID][]*graph.Node),
-		enterpriseCAEnrollers:                  make(map[graph.ID][]*graph.Node),
-		publishedTemplateCache:                 make(map[graph.ID][]*graph.Node),
-		certTemplateGenericWriters:             make(map[graph.ID][]*graph.Node),
+		mu:                                      &sync.RWMutex{},
+		authStoreForChainValid:                  make(map[graph.ID]cardinality.Duplex[uint64]),
+		rootCAForChainValid:                     make(map[graph.ID]cardinality.Duplex[uint64]),
+		hasHostingComputer:                      make(map[graph.ID]bool),
+		expandedCertTemplateControllers:         make(map[graph.ID]cardinality.Duplex[uint64]),
+		certTemplateHasSpecialEnrollers:         make(map[graph.ID]bool),
+		enterpriseCAHasSpecialEnrollers:         make(map[graph.ID]bool),
+		certTemplateEnrollers:                   make(map[graph.ID][]*graph.Node),
+		certTemplateControllers:                 make(map[graph.ID][]*graph.Node),
+		enterpriseCAEnrollers:                   make(map[graph.ID][]*graph.Node),
+		publishedTemplateCache:                  make(map[graph.ID][]*graph.Node),
+		certTemplateGenericWriters:              make(map[graph.ID][]*graph.Node),
 		certTemplateEnrollOrAllExtendedRighters: make(map[graph.ID][]*graph.Node),
 		certTemplateWritePKINameFlaggers:        make(map[graph.ID][]*graph.Node),
 		certTemplateWritePKIEnrollmentFlaggers:  make(map[graph.ID][]*graph.Node),
-		hasUPNCertMappingInForest:              cardinality.NewBitmap64(),
-		hasWeakCertBindingInForest:      cardinality.NewBitmap64(),
+		hasUPNCertMappingInForest:               cardinality.NewBitmap64(),
+		hasWeakCertBindingInForest:              cardinality.NewBitmap64(),
 	}
 }
 

--- a/packages/go/analysis/ad/adcscache.go
+++ b/packages/go/analysis/ad/adcscache.go
@@ -152,29 +152,45 @@ func (s *ADCSCache) BuildCache(ctx context.Context, db graph.Database, enterpris
 
 			// ESC4-specific principal caches
 			if principals, err := FetchPrincipalsWithGenericWriteOnCertTemplate(tx, ct); err != nil {
-				slog.ErrorContext(ctx, "Error fetching principals with GenericWrite on cert template",
-					slog.Uint64("cert_template", uint64(ct.ID)), attr.Error(err))
+				slog.ErrorContext(
+					ctx,
+					"Error fetching principals with GenericWrite on cert template",
+					slog.Uint64("cert_template", uint64(ct.ID)),
+					attr.Error(err),
+				)
 			} else {
 				s.certTemplateGenericWriters[ct.ID] = principals.Slice()
 			}
 
 			if principals, err := FetchPrincipalsWithEnrollOrAllExtendedRightsOnCertTemplate(tx, ct); err != nil {
-				slog.ErrorContext(ctx, "Error fetching principals with Enroll/AllExtendedRights on cert template",
-					slog.Uint64("cert_template", uint64(ct.ID)), attr.Error(err))
+				slog.ErrorContext(
+					ctx,
+					"Error fetching principals with Enroll/AllExtendedRights on cert template",
+					slog.Uint64("cert_template", uint64(ct.ID)),
+					attr.Error(err),
+				)
 			} else {
 				s.certTemplateEnrollOrAllExtendedRighters[ct.ID] = principals.Slice()
 			}
 
 			if principals, err := FetchPrincipalsWithWritePKINameFlagOnCertTemplate(tx, ct); err != nil {
-				slog.ErrorContext(ctx, "Error fetching principals with WritePKINameFlag on cert template",
-					slog.Uint64("cert_template", uint64(ct.ID)), attr.Error(err))
+				slog.ErrorContext(
+					ctx,
+					"Error fetching principals with WritePKINameFlag on cert template",
+					slog.Uint64("cert_template", uint64(ct.ID)),
+					attr.Error(err),
+				)
 			} else {
 				s.certTemplateWritePKINameFlaggers[ct.ID] = principals.Slice()
 			}
 
 			if principals, err := FetchPrincipalsWithWritePKIEnrollmentFlagOnCertTemplate(tx, ct); err != nil {
-				slog.ErrorContext(ctx, "Error fetching principals with WritePKIEnrollmentFlag on cert template",
-					slog.Uint64("cert_template", uint64(ct.ID)), attr.Error(err))
+				slog.ErrorContext(
+					ctx,
+					"Error fetching principals with WritePKIEnrollmentFlag on cert template",
+					slog.Uint64("cert_template", uint64(ct.ID)),
+					attr.Error(err),
+				)
 			} else {
 				s.certTemplateWritePKIEnrollmentFlaggers[ct.ID] = principals.Slice()
 			}

--- a/packages/go/analysis/ad/esc4.go
+++ b/packages/go/analysis/ad/esc4.go
@@ -39,35 +39,14 @@ func PostADCSESC4(ctx context.Context, tx graph.Transaction, outC chan<- post.En
 
 	// 2. iterate certtemplates that have an outbound `PublishedTo` edge to eca
 	for _, certTemplate := range publishedTemplates {
-		if principalsWithGenericWrite, err := FetchPrincipalsWithGenericWriteOnCertTemplate(tx, certTemplate); err != nil {
-			slog.WarnContext(
-				ctx,
-				"Error fetching principals with GenericWrite on cert template",
-				slog.Uint64("cert_template_id", uint64(certTemplate.ID)),
-				attr.Error(err),
-			)
-		} else if principalsWithEnrollOrAllExtendedRights, err := FetchPrincipalsWithEnrollOrAllExtendedRightsOnCertTemplate(tx, certTemplate); err != nil {
-			slog.WarnContext(
-				ctx,
-				"Error fetching principals with Enroll or AllExtendedRights on cert template",
-				slog.Uint64("cert_template_id", uint64(certTemplate.ID)),
-				attr.Error(err),
-			)
-		} else if principalsWithPKINameFlag, err := FetchPrincipalsWithWritePKINameFlagOnCertTemplate(tx, certTemplate); err != nil {
-			slog.WarnContext(
-				ctx,
-				"Error fetching principals with WritePKINameFlag on cert template",
-				slog.Uint64("cert_template_id", uint64(certTemplate.ID)),
-				attr.Error(err),
-			)
-		} else if principalsWithPKIEnrollmentFlag, err := FetchPrincipalsWithWritePKIEnrollmentFlagOnCertTemplate(tx, certTemplate); err != nil {
-			slog.WarnContext(
-				ctx,
-				"Error fetching principals with WritePKIEnrollmentFlag on cert template",
-				slog.Uint64("cert_template_id", uint64(certTemplate.ID)),
-				attr.Error(err),
-			)
-		} else if enrolleeSuppliesSubject, err := certTemplate.Properties.Get(string(ad.EnrolleeSuppliesSubject)).Bool(); err != nil {
+		var (
+			principalsWithGenericWrite              = cache.GetCertTemplateGenericWriters(certTemplate.ID)
+			principalsWithEnrollOrAllExtendedRights = cache.GetCertTemplateEnrollOrAllExtendedRighters(certTemplate.ID)
+			principalsWithPKINameFlag               = cache.GetCertTemplateWritePKINameFlaggers(certTemplate.ID)
+			principalsWithPKIEnrollmentFlag         = cache.GetCertTemplateWritePKIEnrollmentFlaggers(certTemplate.ID)
+		)
+
+		if enrolleeSuppliesSubject, err := certTemplate.Properties.Get(string(ad.EnrolleeSuppliesSubject)).Bool(); err != nil {
 			slog.WarnContext(
 				ctx,
 				"Error fetching EnrolleeSuppliesSubject property on cert template",
@@ -101,8 +80,8 @@ func PostADCSESC4(ctx context.Context, tx graph.Transaction, outC chan<- post.En
 				CalculateCrossProductNodeSets(
 					localGroupData,
 					enterpriseCAEnrollers,
-					principalsWithGenericWrite.Slice(),
-					principalsWithEnrollOrAllExtendedRights.Slice(),
+					principalsWithGenericWrite,
+					principalsWithEnrollOrAllExtendedRights,
 				),
 			)
 
@@ -123,9 +102,9 @@ func PostADCSESC4(ctx context.Context, tx graph.Transaction, outC chan<- post.En
 			principals.Or(CalculateCrossProductNodeSets(
 				localGroupData,
 				enterpriseCAEnrollers,
-				principalsWithEnrollOrAllExtendedRights.Slice(),
-				principalsWithPKINameFlag.Slice(),
-				principalsWithPKIEnrollmentFlag.Slice(),
+				principalsWithEnrollOrAllExtendedRights,
+				principalsWithPKINameFlag,
+				principalsWithPKIEnrollmentFlag,
 			))
 
 			// 2e.
@@ -134,8 +113,8 @@ func PostADCSESC4(ctx context.Context, tx graph.Transaction, outC chan<- post.En
 					CalculateCrossProductNodeSets(
 						localGroupData,
 						enterpriseCAEnrollers,
-						principalsWithEnrollOrAllExtendedRights.Slice(),
-						principalsWithPKIEnrollmentFlag.Slice(),
+						principalsWithEnrollOrAllExtendedRights,
+						principalsWithPKIEnrollmentFlag,
 					),
 				)
 			}
@@ -146,8 +125,8 @@ func PostADCSESC4(ctx context.Context, tx graph.Transaction, outC chan<- post.En
 					CalculateCrossProductNodeSets(
 						localGroupData,
 						enterpriseCAEnrollers,
-						principalsWithEnrollOrAllExtendedRights.Slice(),
-						principalsWithPKINameFlag.Slice(),
+						principalsWithEnrollOrAllExtendedRights,
+						principalsWithPKINameFlag,
 					),
 				)
 			}


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Caches per-cert-template fields used repeatedly during ADCSESC4 post-processing, reducing DB churn, and improving performance. In worst-case scenario environments, this provided a _14% reduction_ in ADCS post-processing duration.

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-8361

*Why is this change required? What problem does it solve?*

## How Has This Been Tested?

Existing test suites are thorough and unchanged. Additionally, validated manually using several local datasets.

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [X] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [X] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [X] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * ESC4 certificate-template analysis now uses four precomputed in-memory principal caches (generic writers, enroll/all-extended-rights, WritePKIName flaggers, WritePKIEnrollment flaggers) instead of per-template DB queries.
  * Results in faster, more efficient security scans with fewer runtime warnings and more consistent principal lookups.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SpecterOps/BloodHound/pull/2819?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->