### PR TITLE
chore: Migrate cross-product lookups to use bitmask isntead of CommutativeDuplex - BED-8362

### DIFF
--- a/packages/go/analysis/ad/ad.go
+++ b/packages/go/analysis/ad/ad.go
@@ -607,10 +607,10 @@ func CalculateCrossProductNodeSets(localGroupData *LocalGroupData, nodeSlices ..
 	}
 
 	// This means that len(firstDegreeSets) must be greater than or equal to 2 i.e. we have at least two nodesets (unrolled) without Auth. Users/Everyone
-	// Materialize the check set as a single bitmap by Or-ing all component bitmaps within each set, then And-ing across sets.
+	// Materialize the check set as a single bitmap from the union of all component bitmaps (`Or`) within each set, then intersecting (`And`) across sets.
 	materializedCheckSet := cardinality.NewBitmap64()
-	for _, bm := range unrolledSets[1] {
-		materializedCheckSet.Or(bm)
+	for _, set := range unrolledSets[1] {
+		materializedCheckSet.Or(set)
 	}
 
 	for _, unrolledSet := range unrolledSets[2:] {

--- a/packages/go/analysis/ad/ad.go
+++ b/packages/go/analysis/ad/ad.go
@@ -607,9 +607,7 @@ func CalculateCrossProductNodeSets(localGroupData *LocalGroupData, nodeSlices ..
 	}
 
 	// This means that len(firstDegreeSets) must be greater than or equal to 2 i.e. we have at least two nodesets (unrolled) without Auth. Users/Everyone
-	// Materialize the check set as a single bitmap by Or-ing all component bitmaps within each set,
-	// then And-ing across sets. This replaces the lazy CommutativeDuplexes approach which required
-	// per-element binary searches and was the dominant bottleneck (86.9% of CPU in profiling).
+	// Materialize the check set as a single bitmap by Or-ing all component bitmaps within each set, then And-ing across sets.
 	materializedCheckSet := cardinality.NewBitmap64()
 	for _, bm := range unrolledSets[1] {
 		materializedCheckSet.Or(bm)
@@ -694,9 +692,7 @@ func CalculateCrossProductNodeSets(localGroupData *LocalGroupData, nodeSlices ..
 		}
 	}
 
-	// Use bitmap-level intersection instead of per-element Contains checks.
-	// The previous approach iterated every member in unrolledRefSet calling checkSet.Contains()
-	// which did per-element binary searches across component bitmaps — this was 86.9% of CPU.
+	// Use bitmap-level intersection to confirm membership in check set.
 	unrolledRefSet.And(materializedCheckSet)
 	resultEntities.Or(unrolledRefSet)
 

--- a/packages/go/analysis/ad/ad.go
+++ b/packages/go/analysis/ad/ad.go
@@ -613,8 +613,9 @@ func CalculateCrossProductNodeSets(localGroupData *LocalGroupData, nodeSlices ..
 		materializedCheckSet.Or(set)
 	}
 
+	setUnion := cardinality.NewBitmap64()
 	for _, unrolledSet := range unrolledSets[2:] {
-		setUnion := cardinality.NewBitmap64()
+		setUnion.Clear()
 		for _, bm := range unrolledSet {
 			setUnion.Or(bm)
 		}

--- a/packages/go/analysis/ad/ad.go
+++ b/packages/go/analysis/ad/ad.go
@@ -524,11 +524,8 @@ func CalculateCrossProductNodeSets(localGroupData *LocalGroupData, nodeSlices ..
 		firstDegreeSets []cardinality.Duplex[uint64]
 		unrolledSets    [][]cardinality.Duplex[uint64]
 
-		// This is the set we use as a reference set to check against checkset
+		// This is the set we use as a reference set to check against the materialized check set
 		unrolledRefSet = cardinality.NewBitmap64()
-
-		// This is the set we use to aggregate multiple sets together it should have all the valid principals from all other sets at this point
-		checkSet = cardinality.CommutativeDuplexes[uint64]{}
 
 		// This is our set of entities that have the complete cross product of permissions
 		resultEntities = cardinality.NewBitmap64()
@@ -610,15 +607,25 @@ func CalculateCrossProductNodeSets(localGroupData *LocalGroupData, nodeSlices ..
 	}
 
 	// This means that len(firstDegreeSets) must be greater than or equal to 2 i.e. we have at least two nodesets (unrolled) without Auth. Users/Everyone
-	checkSet.Or(cardinality.CommutativeOr(unrolledSets[1]...))
+	// Materialize the check set as a single bitmap by Or-ing all component bitmaps within each set,
+	// then And-ing across sets. This replaces the lazy CommutativeDuplexes approach which required
+	// per-element binary searches and was the dominant bottleneck (86.9% of CPU in profiling).
+	materializedCheckSet := cardinality.NewBitmap64()
+	for _, bm := range unrolledSets[1] {
+		materializedCheckSet.Or(bm)
+	}
 
 	for _, unrolledSet := range unrolledSets[2:] {
-		checkSet.And(cardinality.CommutativeOr(unrolledSet...))
+		setUnion := cardinality.NewBitmap64()
+		for _, bm := range unrolledSet {
+			setUnion.Or(bm)
+		}
+		materializedCheckSet.And(setUnion)
 	}
 
 	// Check first degree principals in our reference set (firstDegreeSets[0]) first
 	firstDegreeSets[0].Each(func(id uint64) bool {
-		if checkSet.Contains(id) {
+		if materializedCheckSet.Contains(id) {
 			resultEntities.Add(id)
 		} else {
 			localGroupData.GroupMembershipCache.OrReach(id, graph.DirectionInbound, unrolledRefSet)
@@ -667,7 +674,7 @@ func CalculateCrossProductNodeSets(localGroupData *LocalGroupData, nodeSlices ..
 			continue
 		}
 
-		if checkSet.Contains(groupId) {
+		if materializedCheckSet.Contains(groupId) {
 			// If this entity is a cross product, add it to result entities, remove the group id from the second set and remove the group's membership from the result set
 			resultEntities.Add(groupId)
 
@@ -687,13 +694,11 @@ func CalculateCrossProductNodeSets(localGroupData *LocalGroupData, nodeSlices ..
 		}
 	}
 
-	unrolledRefSet.Each(func(remainder uint64) bool {
-		if checkSet.Contains(remainder) {
-			resultEntities.Add(remainder)
-		}
-
-		return true
-	})
+	// Use bitmap-level intersection instead of per-element Contains checks.
+	// The previous approach iterated every member in unrolledRefSet calling checkSet.Contains()
+	// which did per-element binary searches across component bitmaps — this was 86.9% of CPU.
+	unrolledRefSet.And(materializedCheckSet)
+	resultEntities.Or(unrolledRefSet)
 
 	return resultEntities
 }


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Migrates `CalculateCrossProductNodeSets` to utilize a bitmap instead of `CommutativeDuplex` for performance optimization. In pathological cases, this resulted in a _98% reduction_ in post-processing time for ADCS.

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-8362

*Why is this change required? What problem does it solve?*

## How Has This Been Tested?

Existing test suites are unchanged. Additionally, performed manual validation utilizing several local datasets.

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [X] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [X] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [X] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Optimized cross-product computation by switching to an aggregated set representation for membership checks.
  * Replaced per-item iteration with bulk set intersections and unions, reducing iteration overhead and CPU work.
  * Improved reference-set handling and remainder merging for lower runtime and memory usage, yielding faster and more predictable set operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->