### PR TITLE
chore: Cache AuthUsers, Everyone groups for lookup - BED-8363

### DIFF
--- a/packages/go/analysis/ad/adcscache.go
+++ b/packages/go/analysis/ad/adcscache.go
@@ -133,6 +133,13 @@ func (s *ADCSCache) BuildCache(ctx context.Context, db graph.Database, enterpris
 			s.enterpriseCertAuthorities = enterpriseCertAuthorities
 		}
 
+		// Fetch Auth. Users and Everyone groups once for the entire BuildCache transaction
+		// instead of re-fetching per cert template / enterprise CA.
+		specialGroups, err := FetchAuthUsersAndEveryoneGroups(tx)
+		if err != nil {
+			return fmt.Errorf("failed fetching auth users and everyone groups: %w", err)
+		}
+
 		certTemplateMeasure := measure.ContextMeasure(
 			ctx,
 			slog.LevelInfo,
@@ -154,7 +161,7 @@ func (s *ADCSCache) BuildCache(ctx context.Context, db graph.Database, enterpris
 				s.certTemplateEnrollers[ct.ID] = certTemplateEnrollers.Slice()
 
 				// Check if Auth. Users or Everyone has enroll
-				if authUsersOrEveryoneHasEnroll, err := containsAuthUsersOrEveryone(tx, certTemplateEnrollers.Slice()); err != nil {
+				if authUsersOrEveryoneHasEnroll, err := containsAuthUsersOrEveryone(tx, specialGroups, certTemplateEnrollers.Slice()); err != nil {
 					slog.ErrorContext(
 						ctx,
 						"Error fetching if auth. users or everyone has enroll on certtemplate",
@@ -201,7 +208,7 @@ func (s *ADCSCache) BuildCache(ctx context.Context, db graph.Database, enterpris
 				s.enterpriseCAEnrollers[eca.ID] = enterpriseCAEnrollers.Slice()
 
 				// Check if Auth. Users or Everyone has enroll
-				if authUsersOrEveryoneHasEnroll, err := containsAuthUsersOrEveryone(tx, enterpriseCAEnrollers.Slice()); err != nil {
+				if authUsersOrEveryoneHasEnroll, err := containsAuthUsersOrEveryone(tx, specialGroups, enterpriseCAEnrollers.Slice()); err != nil {
 					slog.ErrorContext(
 						ctx,
 						"Error fetching if auth. users or everyone has enroll on enterprise ca",

--- a/packages/go/analysis/ad/esc_shared.go
+++ b/packages/go/analysis/ad/esc_shared.go
@@ -332,31 +332,44 @@ func expandNodeSliceToBitmapWithoutGroups(nodes []*graph.Node, localGroupData *L
 	return nonGroupNodes
 }
 
-func containsAuthUsersOrEveryone(tx graph.Transaction, nodes []*graph.Node) (bool, error) {
-	if specialGroups, err := FetchAuthUsersAndEveryoneGroups(tx); err != nil {
-		return false, err
-	} else {
-		for _, node := range nodes {
-			if specialGroups.Contains(node) {
-				return true, nil
-			} else if node.Kinds.ContainsOneOf(ad.Group) {
-				for _, group := range specialGroups {
-					if path, err := ops.FetchRelationships(tx.Relationships().Filterf(func() graph.Criteria {
-						return query.And(
-							query.Equals(query.StartID(), group.ID),
-							query.KindIn(query.Relationship(), ad.MemberOf),
-							query.Equals(query.EndID(), node.ID),
-						)
-					})); err != nil {
-						return false, err
-					} else if len(path) > 0 {
-						return true, nil
-					}
-				}
-			}
+func containsAuthUsersOrEveryone(tx graph.Transaction, specialGroups graph.NodeSet, nodes []*graph.Node) (bool, error) {
+	// Collect IDs of special groups and group nodes for a single bulk query
+	var groupNodeIDs []graph.ID
+
+	for _, node := range nodes {
+		// Direct membership check — is this node itself a special group?
+		if specialGroups.Contains(node) {
+			return true, nil
+		}
+
+		if node.Kinds.ContainsOneOf(ad.Group) {
+			groupNodeIDs = append(groupNodeIDs, node.ID)
 		}
 	}
-	return false, nil
+
+	// No group nodes to check transitive membership for
+	if len(groupNodeIDs) == 0 {
+		return false, nil
+	}
+
+	// Build the list of special group IDs
+	specialGroupIDs := make([]graph.ID, 0, len(specialGroups))
+	for _, group := range specialGroups {
+		specialGroupIDs = append(specialGroupIDs, group.ID)
+	}
+
+	// Single bulk query: check if any special group is a MemberOf any of the group nodes
+	if rels, err := ops.FetchRelationships(tx.Relationships().Filterf(func() graph.Criteria {
+		return query.And(
+			query.InIDs(query.StartID(), specialGroupIDs...),
+			query.KindIn(query.Relationship(), ad.MemberOf),
+			query.InIDs(query.EndID(), groupNodeIDs...),
+		)
+	})); err != nil {
+		return false, err
+	} else {
+		return len(rels) > 0, nil
+	}
 }
 
 func certTemplateValidForUserVictim(certTemplate *graph.Node) bool {

--- a/packages/go/analysis/ad/esc_shared.go
+++ b/packages/go/analysis/ad/esc_shared.go
@@ -353,10 +353,7 @@ func containsAuthUsersOrEveryone(tx graph.Transaction, specialGroups graph.NodeS
 	}
 
 	// Build the list of special group IDs
-	specialGroupIDs := make([]graph.ID, 0, len(specialGroups))
-	for _, group := range specialGroups {
-		specialGroupIDs = append(specialGroupIDs, group.ID)
-	}
+	specialGroupIDs := specialGroups.IDs()
 
 	// Single bulk query: check if any special group is a MemberOf any of the group nodes
 	if rels, err := ops.FetchRelationships(tx.Relationships().Filterf(func() graph.Criteria {


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Centralizes the lookups for specialGroups to prevent recurring lookups during post-processing. In pathological environments, this yielded a 98% reduction in creating the ADCSCache ahead of post-processing.

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-8363

*Why is this change required? What problem does it solve?*

## How Has This Been Tested?

No changes have been made to existing test suites. Additionally, validated with multiple local datasets.

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [X] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [X] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [X] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Cache population now fetches authorization groups once per transaction and reuses them across checks.
  * Group-membership validation was streamlined to use bulk membership queries for improved efficiency and reliability.
  * Cache build will abort early if the initial authorization-group fetch fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->