### PR TITLE
chore: pre-cache computers with localgroup data - BED-8365

### DIFF
--- a/packages/go/analysis/ad/local_groups.go
+++ b/packages/go/analysis/ad/local_groups.go
@@ -174,7 +174,7 @@ func PostCanRDP(parentCtx context.Context, graphDB graph.Database, localGroupDat
 		}(workerID)
 	}
 
-	localGroupData.Computers.Each(func(nextComputer uint64) bool {
+	localGroupData.ComputersWithLocalGroups.Each(func(nextComputer uint64) bool {
 		return channels.Submit(ctx, workC, nextComputer)
 	})
 
@@ -367,7 +367,7 @@ func PostLocalGroups(parentCtx context.Context, graphDB graph.Database, localGro
 		}(workerID)
 	}
 
-	localGroupData.Computers.Each(func(value uint64) bool {
+	localGroupData.ComputersWithLocalGroups.Each(func(value uint64) bool {
 		return channels.Submit(ctx, computerC, value)
 	})
 

--- a/packages/go/analysis/ad/post.go
+++ b/packages/go/analysis/ad/post.go
@@ -279,7 +279,9 @@ func FetchComputerIDsWithLocalToComputer(tx graph.Transaction) (cardinality.Dupl
 		attr.Scope("routine"),
 	)()
 
-	computers := cardinality.NewBitmap64()
+	var (
+		computers = cardinality.NewBitmap64()
+	)
 
 	if err := tx.Relationships().Filterf(func() graph.Criteria {
 		return query.Kind(query.Relationship(), ad.LocalToComputer)

--- a/packages/go/analysis/ad/post.go
+++ b/packages/go/analysis/ad/post.go
@@ -268,6 +268,34 @@ func FetchNodeIDsByKind(tx graph.Transaction, targetKind graph.Kind) (cardinalit
 	return nodes, nil
 }
 
+// FetchComputerIDsWithLocalToComputer fetches a bitmap of Computer node IDs that have at least one
+// inbound LocalToComputer edge.
+func FetchComputerIDsWithLocalToComputer(tx graph.Transaction) (cardinality.Duplex[uint64], error) {
+	defer measure.LogAndMeasure(
+		slog.LevelInfo,
+		"FetchComputerIDsWithLocalToComputer",
+		attr.Namespace("analysis"),
+		attr.Function("FetchComputerIDsWithLocalToComputer"),
+		attr.Scope("routine"),
+	)()
+
+	computers := cardinality.NewBitmap64()
+
+	if err := tx.Relationships().Filterf(func() graph.Criteria {
+		return query.Kind(query.Relationship(), ad.LocalToComputer)
+	}).FetchKinds(func(cursor graph.Cursor[graph.RelationshipKindsResult]) error {
+		for result := range cursor.Chan() {
+			computers.Add(result.EndID.Uint64())
+		}
+
+		return cursor.Error()
+	}); err != nil {
+		return nil, err
+	}
+
+	return computers, nil
+}
+
 func FetchNodesByKind(ctx context.Context, db graph.Database, kinds ...graph.Kind) ([]*graph.Node, error) {
 	var nodes []*graph.Node
 	return nodes, db.ReadTransaction(ctx, func(tx graph.Transaction) error {
@@ -634,6 +662,9 @@ type LocalGroupData struct {
 	// All computer IDs in all domains
 	Computers cardinality.Duplex[uint64]
 
+	// All computer IDs in all domains that have at least one inbound LocalToComputer edge
+	ComputersWithLocalGroups cardinality.Duplex[uint64]
+
 	// All group IDs in all domains
 	Groups cardinality.Duplex[uint64]
 
@@ -675,6 +706,12 @@ func FetchLocalGroupData(ctx context.Context, graphDB graph.Database) (*LocalGro
 			return err
 		} else {
 			localGroupData.Computers = computerIDs
+		}
+
+		if computersWithLocalGroups, err := FetchComputerIDsWithLocalToComputer(tx); err != nil {
+			return err
+		} else {
+			localGroupData.ComputersWithLocalGroups = computersWithLocalGroups
 		}
 
 		if allGroupIDs, err := FetchNodeIDsByKind(tx, ad.Group); err != nil {

--- a/packages/go/analysis/ad/post.go
+++ b/packages/go/analysis/ad/post.go
@@ -284,7 +284,10 @@ func FetchComputerIDsWithLocalToComputer(tx graph.Transaction) (cardinality.Dupl
 	)
 
 	if err := tx.Relationships().Filterf(func() graph.Criteria {
-		return query.Kind(query.Relationship(), ad.LocalToComputer)
+		return query.And(
+			query.Kind(query.Relationship(), ad.LocalToComputer),
+			query.Kind(query.End(), ad.Computer),
+		)
 	}).FetchKinds(func(cursor graph.Cursor[graph.RelationshipKindsResult]) error {
 		for result := range cursor.Chan() {
 			computers.Add(result.EndID.Uint64())


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

PostCanRDP and PostLocalGroups iterate over localGroupData.Computers — the set of all computer node IDs in the graph. For each computer, they check local group membership to determine RDP/DCOM/PSRemote access. However, computers that have no LocalToComputer edges have no local group data and produce no results, making their processing pure overhead. This will reduce the local edge (AdminTo, CanRDP, etc) post-processing time universally by whatever percentage of computers have local privilege data; in certain cases, this will reduce local post-processing by 100%.

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-8365

*Why is this change required? What problem does it solve?*

## How Has This Been Tested?

Test suites have remained unchanged. Multiple datasets were validated locally.

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [X] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [X] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [X] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Local group analysis now only processes computers that actually have local group data, reducing unnecessary work and lowering compute overhead.
* **Reliability**
  * Relationship generation for local admin/remote/DCOM groups is restricted to relevant hosts, improving consistency and reducing spurious outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->