### PR TITLE
chore: update bhce checkout for pg IAM connection string fixes - BED-8293

### DIFF
--- a/cmd/api/src/api/dbpool/dbpool.go
+++ b/cmd/api/src/api/dbpool/dbpool.go
@@ -42,7 +42,7 @@ func newPoolCfg(cfg config.DatabaseConfiguration) (*pgxpool.Config, error) {
 	if cfg.EnableRDSIAMAuth {
 		// Only enable the BeforeConnect handler if RDS IAM Auth is enabled
 		poolCfg.BeforeConnect = func(ctx context.Context, connCfg *pgx.ConnConfig) error {
-			if newPoolCfg, err := pgxpool.ParseConfig(cfg.RDSIAMAuthConnectionString()); err != nil {
+			if newPoolCfg, err := pgxpool.ParseConfig(cfg.PostgreSQLConnectionString()); err != nil {
 				return err
 			} else {
 				connCfg.Host = newPoolCfg.ConnConfig.Host

--- a/cmd/api/src/config/config.go
+++ b/cmd/api/src/config/config.go
@@ -66,7 +66,60 @@ type DatabaseConfiguration struct {
 	EnableRDSIAMAuth      bool   `json:"enable_rds_iam_auth"`
 }
 
+// missingRDSIAMAuthFields returns structured database fields required to build an RDS IAM auth token connection string.
+func (s DatabaseConfiguration) missingRDSIAMAuthFields() []string {
+	var missingFields []string
+
+	if strings.TrimSpace(s.Address) == "" {
+		missingFields = append(missingFields, "addr")
+	}
+
+	if strings.TrimSpace(s.Username) == "" {
+		missingFields = append(missingFields, "username")
+	}
+
+	if strings.TrimSpace(s.Database) == "" {
+		missingFields = append(missingFields, "database")
+	}
+
+	return missingFields
+}
+
+// PostgreSQLConnectionString returns the PostgreSQL connection string represented by this configuration.
+//
+// Control-flow gotchas:
+//   - When RDS IAM auth is enabled, this method is not a pure formatter. It loads AWS configuration,
+//     resolves the database endpoint, and attempts to generate a fresh IAM auth token before considering
+//     the raw Connection override.
+//   - The IAM path requires Address, Username, and Database to be populated because it does not parse those
+//     values out of Connection.
+//   - If IAM token generation fails, the method falls back to the non-IAM behavior: Connection when set,
+//     otherwise a DSN assembled from Username, Secret, Address, and Database.
 func (s DatabaseConfiguration) PostgreSQLConnectionString() string {
+	if s.EnableRDSIAMAuth {
+		if missingConfigFields := s.missingRDSIAMAuthFields(); len(missingConfigFields) > 0 {
+			slog.Error("RDS IAM auth is enabled but required database configuration fields are missing",
+				slog.Any("missing_fields", missingConfigFields),
+				slog.Bool("database_connection_set", s.Connection != ""))
+		} else if awsConfig, err := awsConfig.LoadDefaultConfig(context.TODO()); err != nil {
+			slog.Error("AWS Config Loading Error", slog.String("err", err.Error()))
+		} else {
+			// Must use instance awsInstanceEndpoint with IAM auth
+			awsInstanceEndpoint := s.awsEndpointLookup()
+
+			slog.Debug("Requesting RDS IAM Auth Token")
+
+			if awsAuthenticationToken, err := auth.BuildAuthToken(context.TODO(), awsInstanceEndpoint, awsConfig.Region, s.Username, awsConfig.Credentials); err != nil {
+				slog.Error("RDS IAM Auth Token Request Error", slog.String("err", err.Error()))
+			} else {
+				slog.Debug("RDS IAM Auth Token Created")
+				return fmt.Sprintf("postgresql://%s:%s@%s/%s", s.Username, url.QueryEscape(awsAuthenticationToken), awsInstanceEndpoint, s.Database)
+			}
+		}
+
+		slog.Error("Failed to create IAM auth token. Falling back to default Postgres connection string")
+	}
+
 	if s.Connection != "" {
 		return s.Connection
 	}
@@ -82,28 +135,7 @@ func (s DatabaseConfiguration) Neo4JConnectionString() string {
 	return fmt.Sprintf("neo4j://%s:%s@%s/%s", s.Username, s.Secret, s.Address, s.Database)
 }
 
-func (s DatabaseConfiguration) RDSIAMAuthConnectionString() string {
-	if cfg, err := awsConfig.LoadDefaultConfig(context.TODO()); err != nil {
-		slog.Error("AWS Config Loading Error", slog.String("err", err.Error()))
-	} else {
-		// Must use instance endpoint with IAM auth
-		endpoint := s.LookupEndpoint()
-
-		slog.Info("Requesting RDS IAM Auth Token")
-
-		if authenticationToken, err := auth.BuildAuthToken(context.TODO(), endpoint, cfg.Region, s.Username, cfg.Credentials); err != nil {
-			slog.Error("RDS IAM Auth Token Request Error", slog.String("err", err.Error()))
-		} else {
-			slog.Info("RDS IAM Auth Token Created")
-			return fmt.Sprintf("postgresql://%s:%s@%s/%s", s.Username, url.QueryEscape(authenticationToken), endpoint, s.Database)
-		}
-	}
-
-	slog.Warn("Failed to create IAM auth token. Falling back to default Postgres connection string")
-	return s.PostgreSQLConnectionString()
-}
-
-func (s DatabaseConfiguration) LookupEndpoint() string {
+func (s DatabaseConfiguration) awsEndpointLookup() string {
 	host, port, err := net.SplitHostPort(s.Address)
 	if err != nil {
 		slog.Warn("Missing port in address. Using default port 5432.", slog.String("err", err.Error()))


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Replaced pg.NewPool with standard pgxpool.New in OpenDatabase() since the relational database doesn't need graph-specific type handling

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-8293

BHCE API logs were flooded with `nodecomposite does not exist` and `edgecomposite does not exist` errors.  Updated the connection pool type that checks for these graph types.

## How Has This Been Tested?

Existing tests run.  Application runs as expected.  Logs are no longer flooded with nodecomposite and edgecomposite errors 

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
