### PR TITLE
chore: Optimize ADCS post-processing to reduce GC pressure and CPU overhead - BED-8361

### DIFF
--- a/packages/go/analysis/ad/ad.go
+++ b/packages/go/analysis/ad/ad.go
@@ -512,8 +512,8 @@ func createOrUpdateWellKnownLink(
 
 // CalculateCrossProductNodeSets finds the intersection of the given sets of nodes.
 // See CalculateCrossProductNodeSetsDoc.md for explaination of the specialGroups (Authenticated Users and Everyone) and why we treat them the way we do
-func CalculateCrossProductNodeSets(localGroupData *LocalGroupData, nodeSlices ...[]*graph.Node) cardinality.Duplex[uint64] {
-	if len(nodeSlices) < 2 {
+func CalculateCrossProductNodeSets(localGroupData *LocalGroupData, principalSets ...CachedPrincipalSet) cardinality.Duplex[uint64] {
+	if len(principalSets) < 2 {
 		slog.Error("Cross products require at least 2 nodesets")
 		return cardinality.NewBitmap64()
 	}
@@ -532,7 +532,7 @@ func CalculateCrossProductNodeSets(localGroupData *LocalGroupData, nodeSlices ..
 	)
 
 	// Unroll all nodesets
-	for _, nodeSlice := range nodeSlices {
+	for _, principalSet := range principalSets {
 		var (
 			// Skip sets containing Auth. Users or Everyone
 			nodeExcluded = false
@@ -542,15 +542,13 @@ func CalculateCrossProductNodeSets(localGroupData *LocalGroupData, nodeSlices ..
 			entityReachBitmaps = []cardinality.Duplex[uint64]{entityReachBitmap}
 		)
 
-		for _, entity := range nodeSlice {
-			entityID := entity.ID.Uint64()
-
+		principalSet.AllIDs.Each(func(entityID uint64) bool {
 			firstDegreeSet.Add(entityID)
 			entityReachBitmap.Add(entityID)
 
 			// When encountering a node that is a group or a local group, the algorithm here must expand all of the members
 			// of the group or local group
-			if entity.Kinds.ContainsOneOf(ad.Group, ad.LocalGroup) {
+			if principalSet.GroupOrLocalGroupIDs.Contains(entityID) {
 				// If this group is one of the excluded groups
 				if localGroupData.ExcludedShortcutGroups.Contains(entityID) {
 					// If this group is excluded, do not continue expanding the rest of the nodes in the set
@@ -574,16 +572,14 @@ func CalculateCrossProductNodeSets(localGroupData *LocalGroupData, nodeSlices ..
 						}
 
 						if nodeExcluded {
-							break
+							return false
 						}
 					}
 				}
 			}
 
-			if nodeExcluded {
-				break
-			}
-		}
+			return !nodeExcluded
+		})
 
 		// If the node is not excluded, include all group members
 		if !nodeExcluded {
@@ -594,10 +590,8 @@ func CalculateCrossProductNodeSets(localGroupData *LocalGroupData, nodeSlices ..
 
 	// If every nodeset (unrolled) includes Auth. Users/Everyone then return all nodesets (first degree)
 	if len(firstDegreeSets) == 0 {
-		for _, nodeSet := range nodeSlices {
-			for _, entity := range nodeSet {
-				resultEntities.Add(entity.ID.Uint64())
-			}
+		for _, principalSet := range principalSets {
+			resultEntities.Or(principalSet.AllIDs)
 		}
 
 		return resultEntities

--- a/packages/go/analysis/ad/adcs_integration_test.go
+++ b/packages/go/analysis/ad/adcs_integration_test.go
@@ -315,6 +315,14 @@ func TestEnrollOnBehalfOf(t *testing.T) {
 			return nil
 		}, func(harness integration.HarnessDetails, db graph.Database) {
 			certTemplates, err := adAnalysis.FetchNodesByKind(context.Background(), db, ad.CertTemplate)
+			require.Nil(t, err)
+
+			enterpriseCAs, err := adAnalysis.FetchNodesByKind(context.Background(), db, ad.EnterpriseCA)
+			require.Nil(t, err)
+
+			cache := adAnalysis.NewADCSCache()
+			require.Nil(t, cache.BuildCache(context.Background(), db, enterpriseCAs, certTemplates))
+
 			v1Templates := make([]*graph.Node, 0)
 			v2Templates := make([]*graph.Node, 0)
 
@@ -328,43 +336,31 @@ func TestEnrollOnBehalfOf(t *testing.T) {
 				}
 			}
 
-			require.Nil(t, err)
+			results := adAnalysis.EnrollOnBehalfOfVersionOne(cache, v1Templates, certTemplates, harness.EnrollOnBehalfOfHarness1.Domain1.ID)
 
-			db.ReadTransaction(context.Background(), func(tx graph.Transaction) error {
-				results, err := adAnalysis.EnrollOnBehalfOfVersionOne(tx, v1Templates, certTemplates, harness.EnrollOnBehalfOfHarness1.Domain1.ID)
-				require.Nil(t, err)
+			require.Len(t, results, 3)
 
-				require.Len(t, results, 3)
-
-				require.Contains(t, results, post.EnsureRelationshipJob{
-					FromID: harness.EnrollOnBehalfOfHarness1.CertTemplate11.ID,
-					ToID:   harness.EnrollOnBehalfOfHarness1.CertTemplate12.ID,
-					Kind:   ad.EnrollOnBehalfOf,
-				})
-
-				require.Contains(t, results, post.EnsureRelationshipJob{
-					FromID: harness.EnrollOnBehalfOfHarness1.CertTemplate13.ID,
-					ToID:   harness.EnrollOnBehalfOfHarness1.CertTemplate12.ID,
-					Kind:   ad.EnrollOnBehalfOf,
-				})
-
-				require.Contains(t, results, post.EnsureRelationshipJob{
-					FromID: harness.EnrollOnBehalfOfHarness1.CertTemplate12.ID,
-					ToID:   harness.EnrollOnBehalfOfHarness1.CertTemplate12.ID,
-					Kind:   ad.EnrollOnBehalfOf,
-				})
-
-				return nil
+			require.Contains(t, results, post.EnsureRelationshipJob{
+				FromID: harness.EnrollOnBehalfOfHarness1.CertTemplate11.ID,
+				ToID:   harness.EnrollOnBehalfOfHarness1.CertTemplate12.ID,
+				Kind:   ad.EnrollOnBehalfOf,
 			})
 
-			db.ReadTransaction(context.Background(), func(tx graph.Transaction) error {
-				results, err := adAnalysis.EnrollOnBehalfOfVersionTwo(tx, v2Templates, certTemplates, harness.EnrollOnBehalfOfHarness1.Domain1.ID)
-				require.Nil(t, err)
-
-				require.Len(t, results, 0)
-
-				return nil
+			require.Contains(t, results, post.EnsureRelationshipJob{
+				FromID: harness.EnrollOnBehalfOfHarness1.CertTemplate13.ID,
+				ToID:   harness.EnrollOnBehalfOfHarness1.CertTemplate12.ID,
+				Kind:   ad.EnrollOnBehalfOf,
 			})
+
+			require.Contains(t, results, post.EnsureRelationshipJob{
+				FromID: harness.EnrollOnBehalfOfHarness1.CertTemplate12.ID,
+				ToID:   harness.EnrollOnBehalfOfHarness1.CertTemplate12.ID,
+				Kind:   ad.EnrollOnBehalfOf,
+			})
+
+			resultsV2 := adAnalysis.EnrollOnBehalfOfVersionTwo(cache, v2Templates, certTemplates, harness.EnrollOnBehalfOfHarness1.Domain1.ID)
+
+			require.Len(t, resultsV2, 0)
 		})
 	})
 
@@ -375,6 +371,14 @@ func TestEnrollOnBehalfOf(t *testing.T) {
 			return nil
 		}, func(harness integration.HarnessDetails, db graph.Database) {
 			certTemplates, err := adAnalysis.FetchNodesByKind(context.Background(), db, ad.CertTemplate)
+			require.Nil(t, err)
+
+			enterpriseCAs, err := adAnalysis.FetchNodesByKind(context.Background(), db, ad.EnterpriseCA)
+			require.Nil(t, err)
+
+			cache := adAnalysis.NewADCSCache()
+			require.Nil(t, cache.BuildCache(context.Background(), db, enterpriseCAs, certTemplates))
+
 			v1Templates := make([]*graph.Node, 0)
 			v2Templates := make([]*graph.Node, 0)
 
@@ -388,27 +392,17 @@ func TestEnrollOnBehalfOf(t *testing.T) {
 				}
 			}
 
-			require.Nil(t, err)
+			results := adAnalysis.EnrollOnBehalfOfVersionOne(cache, v1Templates, certTemplates, harness.EnrollOnBehalfOfHarness2.Domain2.ID)
 
-			db.ReadTransaction(context.Background(), func(tx graph.Transaction) error {
-				results, err := adAnalysis.EnrollOnBehalfOfVersionOne(tx, v1Templates, certTemplates, harness.EnrollOnBehalfOfHarness2.Domain2.ID)
-				require.Nil(t, err)
+			require.Len(t, results, 0)
 
-				require.Len(t, results, 0)
-				return nil
-			})
+			resultsV2 := adAnalysis.EnrollOnBehalfOfVersionTwo(cache, v2Templates, certTemplates, harness.EnrollOnBehalfOfHarness2.Domain2.ID)
 
-			db.ReadTransaction(context.Background(), func(tx graph.Transaction) error {
-				results, err := adAnalysis.EnrollOnBehalfOfVersionTwo(tx, v2Templates, certTemplates, harness.EnrollOnBehalfOfHarness2.Domain2.ID)
-				require.Nil(t, err)
-
-				require.Len(t, results, 1)
-				require.Contains(t, results, post.EnsureRelationshipJob{
-					FromID: harness.EnrollOnBehalfOfHarness2.CertTemplate21.ID,
-					ToID:   harness.EnrollOnBehalfOfHarness2.CertTemplate23.ID,
-					Kind:   ad.EnrollOnBehalfOf,
-				})
-				return nil
+			require.Len(t, resultsV2, 1)
+			require.Contains(t, resultsV2, post.EnsureRelationshipJob{
+				FromID: harness.EnrollOnBehalfOfHarness2.CertTemplate21.ID,
+				ToID:   harness.EnrollOnBehalfOfHarness2.CertTemplate23.ID,
+				Kind:   ad.EnrollOnBehalfOf,
 			})
 		})
 	})

--- a/packages/go/analysis/ad/adcscache.go
+++ b/packages/go/analysis/ad/adcscache.go
@@ -76,8 +76,6 @@ type ADCSCache struct {
 	publishedTemplateCache          map[graph.ID][]*graph.Node              // cert templates that are published to an enterprise ca
 	authUsersByDomain               map[graph.ID]graph.ID                   // domain node ID → Authenticated Users group node ID
 	ecasWithHostingComputers        cardinality.Duplex[uint64]              // enterprise CAs with at least one hosting computer where the computer is enabled
-	hasUPNCertMappingInForest       cardinality.Duplex[uint64]              // domains where at least one DC in the forest has Schannel UPN cert mapping enabled
-	hasWeakCertBindingInForest      cardinality.Duplex[uint64]              // domains where at least one DC in the forest has Kerberos weak cert binding enabled
 	authStoreForChainValid          map[graph.ID]cardinality.Duplex[uint64] //Auth stores with a valid chain to the domain, key is domain ID
 	rootCAForChainValid             map[graph.ID]cardinality.Duplex[uint64] //Root CA with a valid chain to the domain, key is domain ID
 	hasHostingComputer              map[graph.ID]bool
@@ -87,6 +85,8 @@ type ADCSCache struct {
 	certTemplateEnrollOrAllExtendedRighters map[graph.ID][]*graph.Node // principals with Enroll or AllExtendedRights on a cert template
 	certTemplateWritePKINameFlaggers        map[graph.ID][]*graph.Node // principals with WritePKINameFlag on a cert template
 	certTemplateWritePKIEnrollmentFlaggers  map[graph.ID][]*graph.Node // principals with WritePKIEnrollmentFlag on a cert template
+	hasUPNCertMappingInForest               cardinality.Duplex[uint64] // domains where at least one DC in the forest has Schannel UPN cert mapping enabled
+	hasWeakCertBindingInForest              cardinality.Duplex[uint64] // domains where at least one DC in the forest has Kerberos weak cert binding enabled
 }
 
 func NewADCSCache() *ADCSCache {

--- a/packages/go/analysis/ad/adcscache.go
+++ b/packages/go/analysis/ad/adcscache.go
@@ -222,7 +222,8 @@ func (s *ADCSCache) BuildCache(ctx context.Context, db graph.Database, enterpris
 			}
 
 			if principals, err := FetchPrincipalsWithWritePKIEnrollmentFlagOnCertTemplate(tx, ct); err != nil {
-				slog.ErrorContext(ctx,
+				slog.ErrorContext(
+					ctx,
 					"Error fetching principals with WritePKIEnrollmentFlag on cert template",
 					slog.Uint64("cert_template", uint64(ct.ID)),
 					attr.Error(err),

--- a/packages/go/analysis/ad/adcscache.go
+++ b/packages/go/analysis/ad/adcscache.go
@@ -49,8 +49,8 @@ type EnterpriseCAChainedDomains struct {
 
 // NewEnterpriseCAChainedDomains creates an EnterpriseCAChainedDomains for the
 // given Enterprise CA node, seeded with a single domain node ID.
-func NewEnterpriseCAChainedDomains(enterpriseCA *graph.Node, domainID uint64) *EnterpriseCAChainedDomains {
-	return &EnterpriseCAChainedDomains{EnterpriseCA: enterpriseCA, Domains: cardinality.NewBitmap64With(domainID)}
+func NewEnterpriseCAChainedDomains(enterpriseCA *graph.Node) *EnterpriseCAChainedDomains {
+	return &EnterpriseCAChainedDomains{EnterpriseCA: enterpriseCA, Domains: cardinality.NewBitmap64()}
 }
 
 // AddDomain adds a domain node ID to the set of domains reachable from this
@@ -59,40 +59,35 @@ func (s *EnterpriseCAChainedDomains) AddDomain(domainID uint64) {
 	s.Domains.CheckedAdd(domainID)
 }
 
-// Clone returns a deep copy of the EnterpriseCAChainedDomains. The EnterpriseCA
-// pointer is shared (graph nodes are immutable after construction), but the
-// Domains bitmap is cloned so callers cannot mutate the cache's internal state.
-func (s *EnterpriseCAChainedDomains) Clone() *EnterpriseCAChainedDomains {
-	return &EnterpriseCAChainedDomains{
-		EnterpriseCA: s.EnterpriseCA,
-		Domains:      s.Domains.Clone(),
-	}
-}
-
 type ADCSCache struct {
 	mutex *sync.RWMutex
 
 	enterpriseCertAuthorities []*graph.Node
 	certTemplates             []*graph.Node
+	domains                   []*graph.Node
 
 	// To discourage direct access without getting a read lock, these are private
-	chainedDomainsByEnterpriseCA    map[uint64]*EnterpriseCAChainedDomains // chainedDomainsByEnterpriseCA maps each Enterprise CA node ID to the domains reachable from it through a valid certificate chain (RootCAFor ∩ TrustedForNTAuth).
-	certTemplateHasSpecialEnrollers map[graph.ID]bool                      // whether Auth. Users or Everyone has enrollment rights on templates
-	enterpriseCAHasSpecialEnrollers map[graph.ID]bool                      // whether Auth. Users or Everyone has enrollment rights on enterprise CAs
-	certTemplateEnrollers           map[graph.ID][]*graph.Node             // principals that have enrollment on a cert template via `enroll`, `generic all`, `all extended rights` edges
-	certTemplateControllers         map[graph.ID][]*graph.Node             // principals that have privileges on a cert template via `owner`, `generic all`, `write dacl`, `write owner` edges
-	enterpriseCAEnrollers           map[graph.ID][]*graph.Node             // principals that have enrollment rights on an enterprise ca via `enroll` edge
-	publishedTemplateCache          map[graph.ID][]*graph.Node             // cert templates that are published to an enterprise ca
-	authUsersByDomain               map[graph.ID]graph.ID                  // domain node ID → Authenticated Users group node ID
-	ecasWithHostingComputers        cardinality.Duplex[uint64]             // enterprise CAs with at least one hosting computer where the computer is enabled
-	hasUPNCertMappingInForest       cardinality.Duplex[uint64]             // domains where at least one DC in the forest has Schannel UPN cert mapping enabled
-	hasWeakCertBindingInForest      cardinality.Duplex[uint64]             // domains where at least one DC in the forest has Kerberos weak cert binding enabled
+	authStoreForChainValid          map[graph.ID]cardinality.Duplex[uint64] //Auth stores with a valid chain to the domain, key is domain ID
+	rootCAForChainValid             map[graph.ID]cardinality.Duplex[uint64] //Root CA with a valid chain to the domain, key is domain ID
+	hasHostingComputer              map[graph.ID]bool
+	certTemplateHasSpecialEnrollers map[graph.ID]bool          // whether Auth. Users or Everyone has enrollment rights on templates
+	enterpriseCAHasSpecialEnrollers map[graph.ID]bool          // whether Auth. Users or Everyone has enrollment rights on enterprise CAs
+	certTemplateEnrollers           map[graph.ID][]*graph.Node // principals that have enrollment on a cert template via `enroll`, `generic all`, `all extended rights` edges
+	certTemplateControllers         map[graph.ID][]*graph.Node // principals that have privileges on a cert template via `owner`, `generic all`, `write dacl`, `write owner` edges
+	enterpriseCAEnrollers           map[graph.ID][]*graph.Node // principals that have enrollment rights on an enterprise ca via `enroll` edge
+	publishedTemplateCache          map[graph.ID][]*graph.Node // cert templates that are published to an enterprise ca
+	authUsersByDomain               map[graph.ID]graph.ID      // domain node ID → Authenticated Users group node ID
+	ecasWithHostingComputers        cardinality.Duplex[uint64] // enterprise CAs with at least one hosting computer where the computer is enabled
+	hasUPNCertMappingInForest       cardinality.Duplex[uint64] // domains where at least one DC in the forest has Schannel UPN cert mapping enabled
+	hasWeakCertBindingInForest      cardinality.Duplex[uint64] // domains where at least one DC in the forest has Kerberos weak cert binding enabled
 }
 
 func NewADCSCache() *ADCSCache {
 	return &ADCSCache{
 		mutex:                           &sync.RWMutex{},
-		chainedDomainsByEnterpriseCA:    make(map[uint64]*EnterpriseCAChainedDomains),
+		authStoreForChainValid:          make(map[graph.ID]cardinality.Duplex[uint64]),
+		rootCAForChainValid:             make(map[graph.ID]cardinality.Duplex[uint64]),
+		hasHostingComputer:              make(map[graph.ID]bool),
 		certTemplateHasSpecialEnrollers: make(map[graph.ID]bool),
 		enterpriseCAHasSpecialEnrollers: make(map[graph.ID]bool),
 		certTemplateEnrollers:           make(map[graph.ID][]*graph.Node),
@@ -121,16 +116,12 @@ func (s *ADCSCache) BuildCache(ctx context.Context, db graph.Database, enterpris
 
 	err := db.ReadTransaction(ctx, func(tx graph.Transaction) error {
 
-		var (
-			domains []*graph.Node
-			err     error
-		)
-
-		if domains, err = FetchNodesByKind(ctx, db, ad.Domain); err != nil {
+		if domains, err := FetchNodesByKind(ctx, db, ad.Domain); err != nil {
 			return fmt.Errorf("failed fetching domain nodes: %w", err)
 		} else {
 			s.certTemplates = certTemplates
 			s.enterpriseCertAuthorities = enterpriseCertAuthorities
+			s.domains = domains
 		}
 
 		// Fetch Auth. Users and Everyone groups once for the entire BuildCache transaction
@@ -249,10 +240,8 @@ func (s *ADCSCache) BuildCache(ctx context.Context, db graph.Database, enterpris
 						break
 					}
 				}
+				s.hasHostingComputer[eca.ID] = hasHostingComputer
 
-				if hasHostingComputer {
-					s.ecasWithHostingComputers.Add(eca.ID.Uint64())
-				}
 			}
 		}
 
@@ -267,7 +256,7 @@ func (s *ADCSCache) BuildCache(ctx context.Context, db graph.Database, enterpris
 			attr.Scope("routine"),
 		)
 
-		for _, domain := range domains {
+		for _, domain := range s.domains {
 			if rootCaForNodes, err := FetchEnterpriseCAsRootCAForPathToDomain(tx, domain); err != nil {
 				slog.ErrorContext(
 					ctx,
@@ -283,19 +272,8 @@ func (s *ADCSCache) BuildCache(ctx context.Context, db graph.Database, enterpris
 					attr.Error(err),
 				)
 			} else {
-				var ecas = graph.NodeSetToDuplex(authStoreForNodes)
-				ecas.And(graph.NodeSetToDuplex((rootCaForNodes)))
-
-				ecas.Each(func(ecaID uint64) bool {
-					if ecaNode, ok := authStoreForNodes[graph.ID(ecaID)]; !ok {
-						return true
-					} else if _, ok := s.chainedDomainsByEnterpriseCA[ecaID]; !ok {
-						s.chainedDomainsByEnterpriseCA[ecaID] = NewEnterpriseCAChainedDomains(ecaNode, domain.ID.Uint64())
-					} else {
-						s.chainedDomainsByEnterpriseCA[ecaID].AddDomain((domain.ID.Uint64()))
-					}
-					return true
-				})
+				s.authStoreForChainValid[domain.ID] = graph.NodeSetToDuplex(authStoreForNodes)
+				s.rootCAForChainValid[domain.ID] = graph.NodeSetToDuplex(rootCaForNodes)
 			}
 
 			// Check for weak cert config on DCs
@@ -349,16 +327,49 @@ func (s *ADCSCache) BuildCache(ctx context.Context, db graph.Database, enterpris
 	return err
 }
 
+func (s *ADCSCache) DoesCAChainProperlyToDomain(enterpriseCA, domain *graph.Node) bool {
+	var domainID = domain.ID
+	var caID = enterpriseCA.ID.Uint64()
+
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+	if _, ok := s.rootCAForChainValid[domainID]; !ok {
+		return false
+	} else if _, ok := s.authStoreForChainValid[domainID]; !ok {
+		return false
+	} else {
+		return s.rootCAForChainValid[domainID].Contains(caID) && s.authStoreForChainValid[domainID].Contains(caID)
+	}
+}
+
+func (s *ADCSCache) DoesCAHaveHostingComputer(enterpriseCA *graph.Node) bool {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+	if hasHost, ok := s.hasHostingComputer[enterpriseCA.ID]; !ok {
+		return false
+	} else {
+		return hasHost
+	}
+}
+
 func (s *ADCSCache) GetECAHostedChainedDomains() map[uint64]*EnterpriseCAChainedDomains {
 	s.mutex.RLock()
 	defer s.mutex.RUnlock()
 
 	filtered := make(map[uint64]*EnterpriseCAChainedDomains)
 
-	for ecaID, chainedDomains := range s.chainedDomainsByEnterpriseCA {
-		if s.ecasWithHostingComputers.Contains(ecaID) {
-			filtered[ecaID] = chainedDomains.Clone()
+	for _, enterpriseCA := range s.enterpriseCertAuthorities {
+		innerEnterpriseCA := enterpriseCA
+
+		targetDomains := NewEnterpriseCAChainedDomains(enterpriseCA)
+		for _, domain := range s.domains {
+			innerDomain := domain
+
+			if s.DoesCAChainProperlyToDomain(innerEnterpriseCA, innerDomain) && s.DoesCAHaveHostingComputer(innerEnterpriseCA) {
+				targetDomains.AddDomain(innerDomain.ID.Uint64())
+			}
 		}
+		filtered[enterpriseCA.ID.Uint64()] = targetDomains
 	}
 
 	return filtered
@@ -368,13 +379,23 @@ func (s *ADCSCache) GetChainedDomains() map[uint64]*EnterpriseCAChainedDomains {
 	s.mutex.RLock()
 	defer s.mutex.RUnlock()
 
-	result := make(map[uint64]*EnterpriseCAChainedDomains, len(s.chainedDomainsByEnterpriseCA))
+	filtered := make(map[uint64]*EnterpriseCAChainedDomains)
 
-	for ecaID, chainedDomains := range s.chainedDomainsByEnterpriseCA {
-		result[ecaID] = chainedDomains.Clone()
+	for _, enterpriseCA := range s.enterpriseCertAuthorities {
+		innerEnterpriseCA := enterpriseCA
+
+		targetDomains := NewEnterpriseCAChainedDomains(enterpriseCA)
+		for _, domain := range s.domains {
+			innerDomain := domain
+
+			if s.DoesCAChainProperlyToDomain(innerEnterpriseCA, innerDomain) {
+				targetDomains.AddDomain(innerDomain.ID.Uint64())
+			}
+		}
+		filtered[enterpriseCA.ID.Uint64()] = targetDomains
 	}
 
-	return result
+	return filtered
 }
 
 func (s *ADCSCache) GetCertTemplateHasSpecialEnrollers(id graph.ID) bool {

--- a/packages/go/analysis/ad/adcscache.go
+++ b/packages/go/analysis/ad/adcscache.go
@@ -327,31 +327,6 @@ func (s *ADCSCache) BuildCache(ctx context.Context, db graph.Database, enterpris
 	return err
 }
 
-func (s *ADCSCache) DoesCAChainProperlyToDomain(enterpriseCA, domain *graph.Node) bool {
-	var domainID = domain.ID
-	var caID = enterpriseCA.ID.Uint64()
-
-	s.mutex.RLock()
-	defer s.mutex.RUnlock()
-	if _, ok := s.rootCAForChainValid[domainID]; !ok {
-		return false
-	} else if _, ok := s.authStoreForChainValid[domainID]; !ok {
-		return false
-	} else {
-		return s.rootCAForChainValid[domainID].Contains(caID) && s.authStoreForChainValid[domainID].Contains(caID)
-	}
-}
-
-func (s *ADCSCache) DoesCAHaveHostingComputer(enterpriseCA *graph.Node) bool {
-	s.mutex.RLock()
-	defer s.mutex.RUnlock()
-	if hasHost, ok := s.hasHostingComputer[enterpriseCA.ID]; !ok {
-		return false
-	} else {
-		return hasHost
-	}
-}
-
 func (s *ADCSCache) GetECAHostedChainedDomains() map[uint64]*EnterpriseCAChainedDomains {
 	s.mutex.RLock()
 	defer s.mutex.RUnlock()
@@ -365,11 +340,22 @@ func (s *ADCSCache) GetECAHostedChainedDomains() map[uint64]*EnterpriseCAChained
 		for _, domain := range s.domains {
 			innerDomain := domain
 
-			if s.DoesCAChainProperlyToDomain(innerEnterpriseCA, innerDomain) && s.DoesCAHaveHostingComputer(innerEnterpriseCA) {
+			if hasHost, ok := s.hasHostingComputer[innerEnterpriseCA.ID]; !ok {
+				continue
+			} else if !hasHost {
+				continue
+			} else if _, ok := s.rootCAForChainValid[innerDomain.ID]; !ok {
+				continue
+			} else if _, ok := s.authStoreForChainValid[innerDomain.ID]; !ok {
+				continue
+			} else if s.rootCAForChainValid[innerDomain.ID].Contains(innerEnterpriseCA.ID.Uint64()) && s.authStoreForChainValid[innerDomain.ID].Contains(innerEnterpriseCA.ID.Uint64()) {
 				targetDomains.AddDomain(innerDomain.ID.Uint64())
 			}
+
 		}
-		filtered[enterpriseCA.ID.Uint64()] = targetDomains
+		if targetDomains.Domains.Cardinality() > 0 {
+			filtered[enterpriseCA.ID.Uint64()] = targetDomains
+		}
 	}
 
 	return filtered
@@ -388,11 +374,18 @@ func (s *ADCSCache) GetChainedDomains() map[uint64]*EnterpriseCAChainedDomains {
 		for _, domain := range s.domains {
 			innerDomain := domain
 
-			if s.DoesCAChainProperlyToDomain(innerEnterpriseCA, innerDomain) {
+			if _, ok := s.rootCAForChainValid[innerDomain.ID]; !ok {
+				continue
+			} else if _, ok := s.authStoreForChainValid[innerDomain.ID]; !ok {
+				continue
+			} else if s.rootCAForChainValid[innerDomain.ID].Contains(innerEnterpriseCA.ID.Uint64()) && s.authStoreForChainValid[innerDomain.ID].Contains(innerEnterpriseCA.ID.Uint64()) {
 				targetDomains.AddDomain(innerDomain.ID.Uint64())
 			}
+
 		}
-		filtered[enterpriseCA.ID.Uint64()] = targetDomains
+		if targetDomains.Domains.Cardinality() > 0 {
+			filtered[enterpriseCA.ID.Uint64()] = targetDomains
+		}
 	}
 
 	return filtered

--- a/packages/go/analysis/ad/adcscache.go
+++ b/packages/go/analysis/ad/adcscache.go
@@ -140,12 +140,13 @@ type ADCSCache struct {
 	hasHostingComputer              map[graph.ID]bool
 
 	// ESC4-specific caches: principals with specific rights on cert templates, pre-computed to avoid per-ECA DB queries
-	certTemplateGenericWriters              map[graph.ID]CachedPrincipalSet // principals with GenericWrite on a cert template
-	certTemplateEnrollOrAllExtendedRighters map[graph.ID]CachedPrincipalSet // principals with Enroll or AllExtendedRights on a cert template
-	certTemplateWritePKINameFlaggers        map[graph.ID]CachedPrincipalSet // principals with WritePKINameFlag on a cert template
-	certTemplateWritePKIEnrollmentFlaggers  map[graph.ID]CachedPrincipalSet // principals with WritePKIEnrollmentFlag on a cert template
-	hasUPNCertMappingInForest               cardinality.Duplex[uint64]      // domains where at least one DC in the forest has Schannel UPN cert mapping enabled
-	hasWeakCertBindingInForest              cardinality.Duplex[uint64]      // domains where at least one DC in the forest has Kerberos weak cert binding enabled
+	certTemplateGenericWriters              map[graph.ID]CachedPrincipalSet         // principals with GenericWrite on a cert template
+	certTemplateEnrollOrAllExtendedRighters map[graph.ID]CachedPrincipalSet         // principals with Enroll or AllExtendedRights on a cert template
+	certTemplateWritePKINameFlaggers        map[graph.ID]CachedPrincipalSet         // principals with WritePKINameFlag on a cert template
+	certTemplateWritePKIEnrollmentFlaggers  map[graph.ID]CachedPrincipalSet         // principals with WritePKIEnrollmentFlag on a cert template
+	hasUPNCertMappingInForest               cardinality.Duplex[uint64]              // domains where at least one DC in the forest has Schannel UPN cert mapping enabled
+	hasWeakCertBindingInForest              cardinality.Duplex[uint64]              // domains where at least one DC in the forest has Kerberos weak cert binding enabled
+	certTemplateLinkedDomains               map[graph.ID]cardinality.Duplex[uint64] // cert template ID → bitmap of domain IDs reachable via PublishedTo→RootCAFor chain
 }
 
 func NewADCSCache() *ADCSCache {
@@ -169,6 +170,7 @@ func NewADCSCache() *ADCSCache {
 		certTemplateWritePKINameFlaggers:        make(map[graph.ID]CachedPrincipalSet),
 		certTemplateWritePKIEnrollmentFlaggers:  make(map[graph.ID]CachedPrincipalSet),
 		hasWeakCertBindingInForest:              cardinality.NewBitmap64(),
+		certTemplateLinkedDomains:               make(map[graph.ID]cardinality.Duplex[uint64]),
 	}
 }
 
@@ -408,6 +410,37 @@ func (s *ADCSCache) BuildCache(ctx context.Context, db graph.Database, enterpris
 
 		domainMeasure()
 
+		// Pre-compute cert template → domain linkage by combining rootCAForChainValid
+		// and publishedTemplateCache. A cert template links to a domain if it is
+		// published to any ECA that has a valid RootCAFor chain to that domain. This
+		// eliminates per-pair shortest-path queries in EnrollOnBehalfOf processing.
+		linkMeasure := measure.ContextMeasure(
+			ctx,
+			slog.LevelInfo,
+			"BuildCache cert template domain linkage",
+			attr.Namespace("analysis"),
+			attr.Function("BuildCache.CertTemplateDomainLinkage"),
+			attr.Scope("routine"),
+		)
+
+		for domainID, validECAs := range s.rootCAForChainValid {
+			validECAs.Each(func(ecaID uint64) bool {
+				if publishedTemplates, ok := s.publishedTemplateCache[graph.ID(ecaID)]; ok {
+					for _, certTemplate := range publishedTemplates {
+						domains, exists := s.certTemplateLinkedDomains[certTemplate.ID]
+						if !exists {
+							domains = cardinality.NewBitmap64()
+							s.certTemplateLinkedDomains[certTemplate.ID] = domains
+						}
+						domains.Add(domainID.Uint64())
+					}
+				}
+				return true
+			})
+		}
+
+		linkMeasure()
+
 		return nil
 	})
 
@@ -491,6 +524,20 @@ func (s *ADCSCache) GetCertTemplateHasSpecialEnrollers(id graph.ID) bool {
 	defer s.mutex.RUnlock()
 
 	return s.certTemplateHasSpecialEnrollers[id]
+}
+
+// CertTemplateLinksToDomain returns true if the given cert template can reach the
+// given domain through a PublishedTo → RootCAFor chain (via any Enterprise CA).
+// This is a pre-computed O(1) bitmap lookup that replaces the per-pair
+// DoesCertTemplateLinkToDomain shortest-path DB query.
+func (s *ADCSCache) CertTemplateLinksToDomain(certTemplateID, domainID graph.ID) bool {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
+	if domains, ok := s.certTemplateLinkedDomains[certTemplateID]; ok {
+		return domains.Contains(domainID.Uint64())
+	}
+	return false
 }
 
 func (s *ADCSCache) GetEnterpriseCAHasSpecialEnrollers(id graph.ID) bool {

--- a/packages/go/analysis/ad/adcscache.go
+++ b/packages/go/analysis/ad/adcscache.go
@@ -153,84 +153,63 @@ func (s *ADCSCache) BuildCache(ctx context.Context, db graph.Database, enterpris
 		)
 
 		for _, ct := range s.certTemplates {
-			if certTemplateEnrollers, err := fetchFirstDegreeNodes(tx, ct, ad.Enroll, ad.GenericAll, ad.AllExtendedRights); err != nil {
+			// Single consolidated query fetches all first-degree principals partitioned by relationship kind,
+			// replacing 6 separate fetchFirstDegreeNodes calls per cert template.
+			nodesByRelKind, err := fetchFirstDegreeNodesByRelKind(tx, ct,
+				ad.Enroll, ad.GenericAll, ad.AllExtendedRights,
+				ad.Owns, ad.WriteDACL, ad.WriteOwner,
+				ad.GenericWrite, ad.WritePKINameFlag, ad.WritePKIEnrollmentFlag,
+			)
+			if err != nil {
 				slog.ErrorContext(
 					ctx,
-					"Error fetching enrollers for cert template",
+					"Error fetching first degree nodes for cert template",
+					slog.Uint64("cert_template", uint64(ct.ID)),
+					attr.Error(err),
+				)
+				continue
+			}
+
+			// certTemplateEnrollers = Enroll ∪ GenericAll ∪ AllExtendedRights
+			certTemplateEnrollers := graph.MergeNodeSets(
+				nodesByRelKind[ad.Enroll],
+				nodesByRelKind[ad.GenericAll],
+				nodesByRelKind[ad.AllExtendedRights],
+			)
+			s.certTemplateEnrollers[ct.ID] = certTemplateEnrollers.Slice()
+
+			// Check if Auth. Users or Everyone has enroll
+			if authUsersOrEveryoneHasEnroll, err := containsAuthUsersOrEveryone(tx, specialGroups, certTemplateEnrollers.Slice()); err != nil {
+				slog.ErrorContext(
+					ctx,
+					"Error fetching if auth. users or everyone has enroll on certtemplate",
 					slog.Uint64("cert_template", uint64(ct.ID)),
 					attr.Error(err),
 				)
 			} else {
-				s.certTemplateEnrollers[ct.ID] = certTemplateEnrollers.Slice()
-
-				// Check if Auth. Users or Everyone has enroll
-				if authUsersOrEveryoneHasEnroll, err := containsAuthUsersOrEveryone(tx, specialGroups, certTemplateEnrollers.Slice()); err != nil {
-					slog.ErrorContext(
-						ctx,
-						"Error fetching if auth. users or everyone has enroll on certtemplate",
-						slog.Uint64("cert_template", uint64(ct.ID)),
-						attr.Error(err),
-					)
-				} else {
-					s.certTemplateHasSpecialEnrollers[ct.ID] = authUsersOrEveryoneHasEnroll
-				}
+				s.certTemplateHasSpecialEnrollers[ct.ID] = authUsersOrEveryoneHasEnroll
 			}
 
-			if certTemplateControllers, err := fetchFirstDegreeNodes(tx, ct, ad.Owns, ad.GenericAll, ad.WriteDACL, ad.WriteOwner); err != nil {
-				slog.ErrorContext(
-					ctx,
-					"Error fetching controllers for cert template",
-					slog.Uint64("cert_template", uint64(ct.ID)),
-					attr.Error(err),
-				)
-			} else {
-				s.certTemplateControllers[ct.ID] = certTemplateControllers.Slice()
-			}
+			// certTemplateControllers = Owns ∪ GenericAll ∪ WriteDACL ∪ WriteOwner
+			certTemplateControllers := graph.MergeNodeSets(
+				nodesByRelKind[ad.Owns],
+				nodesByRelKind[ad.GenericAll],
+				nodesByRelKind[ad.WriteDACL],
+				nodesByRelKind[ad.WriteOwner],
+			)
+			s.certTemplateControllers[ct.ID] = certTemplateControllers.Slice()
 
 			// ESC4-specific principal caches
-			if principals, err := fetchFirstDegreeNodes(tx, ct, ad.GenericWrite); err != nil {
-				slog.ErrorContext(
-					ctx,
-					"Error fetching principals with GenericWrite on cert template",
-					slog.Uint64("cert_template", uint64(ct.ID)),
-					attr.Error(err),
-				)
-			} else {
-				s.certTemplateGenericWriters[ct.ID] = principals.Slice()
-			}
+			s.certTemplateGenericWriters[ct.ID] = nodesByRelKind[ad.GenericWrite].Slice()
 
-			if principals, err := fetchFirstDegreeNodes(tx, ct, ad.Enroll, ad.AllExtendedRights); err != nil {
-				slog.ErrorContext(
-					ctx,
-					"Error fetching principals with Enroll/AllExtendedRights on cert template",
-					slog.Uint64("cert_template", uint64(ct.ID)),
-					attr.Error(err),
-				)
-			} else {
-				s.certTemplateEnrollOrAllExtendedRighters[ct.ID] = principals.Slice()
-			}
+			enrollOrAllExtendedRighters := graph.MergeNodeSets(
+				nodesByRelKind[ad.Enroll],
+				nodesByRelKind[ad.AllExtendedRights],
+			)
+			s.certTemplateEnrollOrAllExtendedRighters[ct.ID] = enrollOrAllExtendedRighters.Slice()
 
-			if principals, err := fetchFirstDegreeNodes(tx, ct, ad.WritePKINameFlag); err != nil {
-				slog.ErrorContext(
-					ctx,
-					"Error fetching principals with WritePKINameFlag on cert template",
-					slog.Uint64("cert_template", uint64(ct.ID)),
-					attr.Error(err),
-				)
-			} else {
-				s.certTemplateWritePKINameFlaggers[ct.ID] = principals.Slice()
-			}
-
-			if principals, err := fetchFirstDegreeNodes(tx, ct, ad.WritePKIEnrollmentFlag); err != nil {
-				slog.ErrorContext(
-					ctx,
-					"Error fetching principals with WritePKIEnrollmentFlag on cert template",
-					slog.Uint64("cert_template", uint64(ct.ID)),
-					attr.Error(err),
-				)
-			} else {
-				s.certTemplateWritePKIEnrollmentFlaggers[ct.ID] = principals.Slice()
-			}
+			s.certTemplateWritePKINameFlaggers[ct.ID] = nodesByRelKind[ad.WritePKINameFlag].Slice()
+			s.certTemplateWritePKIEnrollmentFlaggers[ct.ID] = nodesByRelKind[ad.WritePKIEnrollmentFlag].Slice()
 		}
 
 		certTemplateMeasure()

--- a/packages/go/analysis/ad/adcscache.go
+++ b/packages/go/analysis/ad/adcscache.go
@@ -59,6 +59,65 @@ func (s *EnterpriseCAChainedDomains) AddDomain(domainID uint64) {
 	s.Domains.CheckedAdd(domainID)
 }
 
+// CachedPrincipalSet stores principal IDs in a GC-friendly bitmap format instead of []*graph.Node pointers.
+// It separates group/local-group IDs so that cross-product and expansion functions can perform group expansion
+// without needing the original node objects.
+type CachedPrincipalSet struct {
+	AllIDs               cardinality.Duplex[uint64] // all principal IDs in the set
+	GroupOrLocalGroupIDs cardinality.Duplex[uint64] // subset that are ad.Group or ad.LocalGroup
+}
+
+// IsEmpty returns true when the set contains no principals.
+func (s CachedPrincipalSet) IsEmpty() bool {
+	return s.AllIDs == nil || s.AllIDs.Cardinality() == 0
+}
+
+// EmptyCachedPrincipalSet returns a CachedPrincipalSet backed by empty bitmaps.
+func EmptyCachedPrincipalSet() CachedPrincipalSet {
+	return CachedPrincipalSet{
+		AllIDs:               cardinality.NewBitmap64(),
+		GroupOrLocalGroupIDs: cardinality.NewBitmap64(),
+	}
+}
+
+// NewCachedPrincipalSet converts a node slice into a GC-friendly bitmap representation.
+func NewCachedPrincipalSet(nodes []*graph.Node) CachedPrincipalSet {
+	allIDs := cardinality.NewBitmap64()
+	groupOrLocalGroupIDs := cardinality.NewBitmap64()
+
+	for _, node := range nodes {
+		id := node.ID.Uint64()
+		allIDs.Add(id)
+		if node.Kinds.ContainsOneOf(ad.Group, ad.LocalGroup) {
+			groupOrLocalGroupIDs.Add(id)
+		}
+	}
+
+	return CachedPrincipalSet{
+		AllIDs:               allIDs,
+		GroupOrLocalGroupIDs: groupOrLocalGroupIDs,
+	}
+}
+
+// NewCachedPrincipalSetFromNodeSet converts a NodeSet into a GC-friendly bitmap representation.
+func NewCachedPrincipalSetFromNodeSet(nodes graph.NodeSet) CachedPrincipalSet {
+	allIDs := cardinality.NewBitmap64()
+	groupOrLocalGroupIDs := cardinality.NewBitmap64()
+
+	for _, node := range nodes {
+		id := node.ID.Uint64()
+		allIDs.Add(id)
+		if node.Kinds.ContainsOneOf(ad.Group, ad.LocalGroup) {
+			groupOrLocalGroupIDs.Add(id)
+		}
+	}
+
+	return CachedPrincipalSet{
+		AllIDs:               allIDs,
+		GroupOrLocalGroupIDs: groupOrLocalGroupIDs,
+	}
+}
+
 type ADCSCache struct {
 	mutex *sync.RWMutex
 
@@ -70,10 +129,10 @@ type ADCSCache struct {
 	chainedDomainsByEnterpriseCA    map[uint64]*EnterpriseCAChainedDomains  // chainedDomainsByEnterpriseCA maps each Enterprise CA node ID to the domains reachable from it through a valid certificate chain (RootCAFor ∩ TrustedForNTAuth).
 	certTemplateHasSpecialEnrollers map[graph.ID]bool                       // whether Auth. Users or Everyone has enrollment rights on templates
 	enterpriseCAHasSpecialEnrollers map[graph.ID]bool                       // whether Auth. Users or Everyone has enrollment rights on enterprise CAs
-	certTemplateEnrollers           map[graph.ID][]*graph.Node              // principals that have enrollment on a cert template via `enroll`, `generic all`, `all extended rights` edges
-	certTemplateControllers         map[graph.ID][]*graph.Node              // principals that have privileges on a cert template via `owner`, `generic all`, `write dacl`, `write owner` edges
-	enterpriseCAEnrollers           map[graph.ID][]*graph.Node              // principals that have enrollment rights on an enterprise ca via `enroll` edge
-	publishedTemplateCache          map[graph.ID][]*graph.Node              // cert templates that are published to an enterprise ca
+	certTemplateEnrollers           map[graph.ID]CachedPrincipalSet         // principals that have enrollment on a cert template via `enroll`, `generic all`, `all extended rights` edges
+	certTemplateControllers         map[graph.ID]CachedPrincipalSet         // principals that have privileges on a cert template via `owner`, `generic all`, `write dacl`, `write owner` edges
+	enterpriseCAEnrollers           map[graph.ID]CachedPrincipalSet         // principals that have enrollment rights on an enterprise ca via `enroll` edge
+	publishedTemplateCache          map[graph.ID][]*graph.Node              // cert templates that are published to an enterprise ca (needs property access)
 	authUsersByDomain               map[graph.ID]graph.ID                   // domain node ID → Authenticated Users group node ID
 	ecasWithHostingComputers        cardinality.Duplex[uint64]              // enterprise CAs with at least one hosting computer where the computer is enabled
 	authStoreForChainValid          map[graph.ID]cardinality.Duplex[uint64] //Auth stores with a valid chain to the domain, key is domain ID
@@ -81,12 +140,12 @@ type ADCSCache struct {
 	hasHostingComputer              map[graph.ID]bool
 
 	// ESC4-specific caches: principals with specific rights on cert templates, pre-computed to avoid per-ECA DB queries
-	certTemplateGenericWriters              map[graph.ID][]*graph.Node // principals with GenericWrite on a cert template
-	certTemplateEnrollOrAllExtendedRighters map[graph.ID][]*graph.Node // principals with Enroll or AllExtendedRights on a cert template
-	certTemplateWritePKINameFlaggers        map[graph.ID][]*graph.Node // principals with WritePKINameFlag on a cert template
-	certTemplateWritePKIEnrollmentFlaggers  map[graph.ID][]*graph.Node // principals with WritePKIEnrollmentFlag on a cert template
-	hasUPNCertMappingInForest               cardinality.Duplex[uint64] // domains where at least one DC in the forest has Schannel UPN cert mapping enabled
-	hasWeakCertBindingInForest              cardinality.Duplex[uint64] // domains where at least one DC in the forest has Kerberos weak cert binding enabled
+	certTemplateGenericWriters              map[graph.ID]CachedPrincipalSet // principals with GenericWrite on a cert template
+	certTemplateEnrollOrAllExtendedRighters map[graph.ID]CachedPrincipalSet // principals with Enroll or AllExtendedRights on a cert template
+	certTemplateWritePKINameFlaggers        map[graph.ID]CachedPrincipalSet // principals with WritePKINameFlag on a cert template
+	certTemplateWritePKIEnrollmentFlaggers  map[graph.ID]CachedPrincipalSet // principals with WritePKIEnrollmentFlag on a cert template
+	hasUPNCertMappingInForest               cardinality.Duplex[uint64]      // domains where at least one DC in the forest has Schannel UPN cert mapping enabled
+	hasWeakCertBindingInForest              cardinality.Duplex[uint64]      // domains where at least one DC in the forest has Kerberos weak cert binding enabled
 }
 
 func NewADCSCache() *ADCSCache {
@@ -98,17 +157,17 @@ func NewADCSCache() *ADCSCache {
 		authStoreForChainValid:                  make(map[graph.ID]cardinality.Duplex[uint64]),
 		rootCAForChainValid:                     make(map[graph.ID]cardinality.Duplex[uint64]),
 		hasHostingComputer:                      make(map[graph.ID]bool),
-		certTemplateEnrollers:                   make(map[graph.ID][]*graph.Node),
-		certTemplateControllers:                 make(map[graph.ID][]*graph.Node),
-		enterpriseCAEnrollers:                   make(map[graph.ID][]*graph.Node),
+		certTemplateEnrollers:                   make(map[graph.ID]CachedPrincipalSet),
+		certTemplateControllers:                 make(map[graph.ID]CachedPrincipalSet),
+		enterpriseCAEnrollers:                   make(map[graph.ID]CachedPrincipalSet),
 		publishedTemplateCache:                  make(map[graph.ID][]*graph.Node),
 		authUsersByDomain:                       make(map[graph.ID]graph.ID),
 		ecasWithHostingComputers:                cardinality.NewBitmap64(),
 		hasUPNCertMappingInForest:               cardinality.NewBitmap64(),
-		certTemplateGenericWriters:              make(map[graph.ID][]*graph.Node),
-		certTemplateEnrollOrAllExtendedRighters: make(map[graph.ID][]*graph.Node),
-		certTemplateWritePKINameFlaggers:        make(map[graph.ID][]*graph.Node),
-		certTemplateWritePKIEnrollmentFlaggers:  make(map[graph.ID][]*graph.Node),
+		certTemplateGenericWriters:              make(map[graph.ID]CachedPrincipalSet),
+		certTemplateEnrollOrAllExtendedRighters: make(map[graph.ID]CachedPrincipalSet),
+		certTemplateWritePKINameFlaggers:        make(map[graph.ID]CachedPrincipalSet),
+		certTemplateWritePKIEnrollmentFlaggers:  make(map[graph.ID]CachedPrincipalSet),
 		hasWeakCertBindingInForest:              cardinality.NewBitmap64(),
 	}
 }
@@ -176,7 +235,7 @@ func (s *ADCSCache) BuildCache(ctx context.Context, db graph.Database, enterpris
 				nodesByRelKind[ad.GenericAll],
 				nodesByRelKind[ad.AllExtendedRights],
 			)
-			s.certTemplateEnrollers[ct.ID] = certTemplateEnrollers.Slice()
+			s.certTemplateEnrollers[ct.ID] = NewCachedPrincipalSetFromNodeSet(certTemplateEnrollers)
 
 			// Check if Auth. Users or Everyone has enroll
 			if authUsersOrEveryoneHasEnroll, err := containsAuthUsersOrEveryone(tx, specialGroups, certTemplateEnrollers.Slice()); err != nil {
@@ -197,19 +256,19 @@ func (s *ADCSCache) BuildCache(ctx context.Context, db graph.Database, enterpris
 				nodesByRelKind[ad.WriteDACL],
 				nodesByRelKind[ad.WriteOwner],
 			)
-			s.certTemplateControllers[ct.ID] = certTemplateControllers.Slice()
+			s.certTemplateControllers[ct.ID] = NewCachedPrincipalSetFromNodeSet(certTemplateControllers)
 
 			// ESC4-specific principal caches
-			s.certTemplateGenericWriters[ct.ID] = nodesByRelKind[ad.GenericWrite].Slice()
+			s.certTemplateGenericWriters[ct.ID] = NewCachedPrincipalSetFromNodeSet(nodesByRelKind[ad.GenericWrite])
 
 			enrollOrAllExtendedRighters := graph.MergeNodeSets(
 				nodesByRelKind[ad.Enroll],
 				nodesByRelKind[ad.AllExtendedRights],
 			)
-			s.certTemplateEnrollOrAllExtendedRighters[ct.ID] = enrollOrAllExtendedRighters.Slice()
+			s.certTemplateEnrollOrAllExtendedRighters[ct.ID] = NewCachedPrincipalSetFromNodeSet(enrollOrAllExtendedRighters)
 
-			s.certTemplateWritePKINameFlaggers[ct.ID] = nodesByRelKind[ad.WritePKINameFlag].Slice()
-			s.certTemplateWritePKIEnrollmentFlaggers[ct.ID] = nodesByRelKind[ad.WritePKIEnrollmentFlag].Slice()
+			s.certTemplateWritePKINameFlaggers[ct.ID] = NewCachedPrincipalSetFromNodeSet(nodesByRelKind[ad.WritePKINameFlag])
+			s.certTemplateWritePKIEnrollmentFlaggers[ct.ID] = NewCachedPrincipalSetFromNodeSet(nodesByRelKind[ad.WritePKIEnrollmentFlag])
 		}
 
 		certTemplateMeasure()
@@ -232,7 +291,7 @@ func (s *ADCSCache) BuildCache(ctx context.Context, db graph.Database, enterpris
 					attr.Error(err),
 				)
 			} else {
-				s.enterpriseCAEnrollers[eca.ID] = enterpriseCAEnrollers.Slice()
+				s.enterpriseCAEnrollers[eca.ID] = NewCachedPrincipalSetFromNodeSet(enterpriseCAEnrollers)
 
 				// Check if Auth. Users or Everyone has enroll
 				if authUsersOrEveryoneHasEnroll, err := containsAuthUsersOrEveryone(tx, specialGroups, enterpriseCAEnrollers.Slice()); err != nil {
@@ -441,53 +500,74 @@ func (s *ADCSCache) GetEnterpriseCAHasSpecialEnrollers(id graph.ID) bool {
 	return s.enterpriseCAHasSpecialEnrollers[id]
 }
 
-func (s *ADCSCache) GetCertTemplateEnrollers(id graph.ID) []*graph.Node {
+func (s *ADCSCache) GetCertTemplateEnrollers(id graph.ID) CachedPrincipalSet {
 	s.mutex.RLock()
 	defer s.mutex.RUnlock()
 
-	return s.certTemplateEnrollers[id]
+	if cached, ok := s.certTemplateEnrollers[id]; ok {
+		return cached
+	}
+	return EmptyCachedPrincipalSet()
 }
 
-func (s *ADCSCache) GetCertTemplateControllers(id graph.ID) []*graph.Node {
+func (s *ADCSCache) GetCertTemplateControllers(id graph.ID) CachedPrincipalSet {
 	s.mutex.RLock()
 	defer s.mutex.RUnlock()
 
-	return s.certTemplateControllers[id]
+	if cached, ok := s.certTemplateControllers[id]; ok {
+		return cached
+	}
+	return EmptyCachedPrincipalSet()
 }
 
-func (s *ADCSCache) GetCertTemplateGenericWriters(id graph.ID) []*graph.Node {
+func (s *ADCSCache) GetCertTemplateGenericWriters(id graph.ID) CachedPrincipalSet {
 	s.mutex.RLock()
 	defer s.mutex.RUnlock()
 
-	return s.certTemplateGenericWriters[id]
+	if cached, ok := s.certTemplateGenericWriters[id]; ok {
+		return cached
+	}
+	return EmptyCachedPrincipalSet()
 }
 
-func (s *ADCSCache) GetCertTemplateEnrollOrAllExtendedRighters(id graph.ID) []*graph.Node {
+func (s *ADCSCache) GetCertTemplateEnrollOrAllExtendedRighters(id graph.ID) CachedPrincipalSet {
 	s.mutex.RLock()
 	defer s.mutex.RUnlock()
 
-	return s.certTemplateEnrollOrAllExtendedRighters[id]
+	if cached, ok := s.certTemplateEnrollOrAllExtendedRighters[id]; ok {
+		return cached
+	}
+	return EmptyCachedPrincipalSet()
 }
 
-func (s *ADCSCache) GetCertTemplateWritePKINameFlaggers(id graph.ID) []*graph.Node {
+func (s *ADCSCache) GetCertTemplateWritePKINameFlaggers(id graph.ID) CachedPrincipalSet {
 	s.mutex.RLock()
 	defer s.mutex.RUnlock()
 
-	return s.certTemplateWritePKINameFlaggers[id]
+	if cached, ok := s.certTemplateWritePKINameFlaggers[id]; ok {
+		return cached
+	}
+	return EmptyCachedPrincipalSet()
 }
 
-func (s *ADCSCache) GetCertTemplateWritePKIEnrollmentFlaggers(id graph.ID) []*graph.Node {
+func (s *ADCSCache) GetCertTemplateWritePKIEnrollmentFlaggers(id graph.ID) CachedPrincipalSet {
 	s.mutex.RLock()
 	defer s.mutex.RUnlock()
 
-	return s.certTemplateWritePKIEnrollmentFlaggers[id]
+	if cached, ok := s.certTemplateWritePKIEnrollmentFlaggers[id]; ok {
+		return cached
+	}
+	return EmptyCachedPrincipalSet()
 }
 
-func (s *ADCSCache) GetEnterpriseCAEnrollers(id graph.ID) []*graph.Node {
+func (s *ADCSCache) GetEnterpriseCAEnrollers(id graph.ID) CachedPrincipalSet {
 	s.mutex.RLock()
 	defer s.mutex.RUnlock()
 
-	return s.enterpriseCAEnrollers[id]
+	if cached, ok := s.enterpriseCAEnrollers[id]; ok {
+		return cached
+	}
+	return EmptyCachedPrincipalSet()
 }
 
 func (s *ADCSCache) GetPublishedTemplateCache(id graph.ID) []*graph.Node {

--- a/packages/go/analysis/ad/adcscache.go
+++ b/packages/go/analysis/ad/adcscache.go
@@ -188,7 +188,7 @@ func (s *ADCSCache) BuildCache(ctx context.Context, db graph.Database, enterpris
 			}
 
 			// ESC4-specific principal caches
-			if principals, err := FetchPrincipalsWithGenericWriteOnCertTemplate(tx, ct); err != nil {
+			if principals, err := fetchFirstDegreeNodes(tx, ct, ad.GenericWrite); err != nil {
 				slog.ErrorContext(
 					ctx,
 					"Error fetching principals with GenericWrite on cert template",
@@ -199,7 +199,7 @@ func (s *ADCSCache) BuildCache(ctx context.Context, db graph.Database, enterpris
 				s.certTemplateGenericWriters[ct.ID] = principals.Slice()
 			}
 
-			if principals, err := FetchPrincipalsWithEnrollOrAllExtendedRightsOnCertTemplate(tx, ct); err != nil {
+			if principals, err := fetchFirstDegreeNodes(tx, ct, ad.Enroll, ad.AllExtendedRights); err != nil {
 				slog.ErrorContext(
 					ctx,
 					"Error fetching principals with Enroll/AllExtendedRights on cert template",
@@ -210,7 +210,7 @@ func (s *ADCSCache) BuildCache(ctx context.Context, db graph.Database, enterpris
 				s.certTemplateEnrollOrAllExtendedRighters[ct.ID] = principals.Slice()
 			}
 
-			if principals, err := FetchPrincipalsWithWritePKINameFlagOnCertTemplate(tx, ct); err != nil {
+			if principals, err := fetchFirstDegreeNodes(tx, ct, ad.WritePKINameFlag); err != nil {
 				slog.ErrorContext(
 					ctx,
 					"Error fetching principals with WritePKINameFlag on cert template",
@@ -221,7 +221,7 @@ func (s *ADCSCache) BuildCache(ctx context.Context, db graph.Database, enterpris
 				s.certTemplateWritePKINameFlaggers[ct.ID] = principals.Slice()
 			}
 
-			if principals, err := FetchPrincipalsWithWritePKIEnrollmentFlagOnCertTemplate(tx, ct); err != nil {
+			if principals, err := fetchFirstDegreeNodes(tx, ct, ad.WritePKIEnrollmentFlag); err != nil {
 				slog.ErrorContext(
 					ctx,
 					"Error fetching principals with WritePKIEnrollmentFlag on cert template",

--- a/packages/go/analysis/ad/adcscache.go
+++ b/packages/go/analysis/ad/adcscache.go
@@ -67,37 +67,49 @@ type ADCSCache struct {
 	domains                   []*graph.Node
 
 	// To discourage direct access without getting a read lock, these are private
+	chainedDomainsByEnterpriseCA    map[uint64]*EnterpriseCAChainedDomains  // chainedDomainsByEnterpriseCA maps each Enterprise CA node ID to the domains reachable from it through a valid certificate chain (RootCAFor ∩ TrustedForNTAuth).
+	certTemplateHasSpecialEnrollers map[graph.ID]bool                       // whether Auth. Users or Everyone has enrollment rights on templates
+	enterpriseCAHasSpecialEnrollers map[graph.ID]bool                       // whether Auth. Users or Everyone has enrollment rights on enterprise CAs
+	certTemplateEnrollers           map[graph.ID][]*graph.Node              // principals that have enrollment on a cert template via `enroll`, `generic all`, `all extended rights` edges
+	certTemplateControllers         map[graph.ID][]*graph.Node              // principals that have privileges on a cert template via `owner`, `generic all`, `write dacl`, `write owner` edges
+	enterpriseCAEnrollers           map[graph.ID][]*graph.Node              // principals that have enrollment rights on an enterprise ca via `enroll` edge
+	publishedTemplateCache          map[graph.ID][]*graph.Node              // cert templates that are published to an enterprise ca
+	authUsersByDomain               map[graph.ID]graph.ID                   // domain node ID → Authenticated Users group node ID
+	ecasWithHostingComputers        cardinality.Duplex[uint64]              // enterprise CAs with at least one hosting computer where the computer is enabled
+	hasUPNCertMappingInForest       cardinality.Duplex[uint64]              // domains where at least one DC in the forest has Schannel UPN cert mapping enabled
+	hasWeakCertBindingInForest      cardinality.Duplex[uint64]              // domains where at least one DC in the forest has Kerberos weak cert binding enabled
 	authStoreForChainValid          map[graph.ID]cardinality.Duplex[uint64] //Auth stores with a valid chain to the domain, key is domain ID
 	rootCAForChainValid             map[graph.ID]cardinality.Duplex[uint64] //Root CA with a valid chain to the domain, key is domain ID
 	hasHostingComputer              map[graph.ID]bool
-	certTemplateHasSpecialEnrollers map[graph.ID]bool          // whether Auth. Users or Everyone has enrollment rights on templates
-	enterpriseCAHasSpecialEnrollers map[graph.ID]bool          // whether Auth. Users or Everyone has enrollment rights on enterprise CAs
-	certTemplateEnrollers           map[graph.ID][]*graph.Node // principals that have enrollment on a cert template via `enroll`, `generic all`, `all extended rights` edges
-	certTemplateControllers         map[graph.ID][]*graph.Node // principals that have privileges on a cert template via `owner`, `generic all`, `write dacl`, `write owner` edges
-	enterpriseCAEnrollers           map[graph.ID][]*graph.Node // principals that have enrollment rights on an enterprise ca via `enroll` edge
-	publishedTemplateCache          map[graph.ID][]*graph.Node // cert templates that are published to an enterprise ca
-	authUsersByDomain               map[graph.ID]graph.ID      // domain node ID → Authenticated Users group node ID
-	ecasWithHostingComputers        cardinality.Duplex[uint64] // enterprise CAs with at least one hosting computer where the computer is enabled
-	hasUPNCertMappingInForest       cardinality.Duplex[uint64] // domains where at least one DC in the forest has Schannel UPN cert mapping enabled
-	hasWeakCertBindingInForest      cardinality.Duplex[uint64] // domains where at least one DC in the forest has Kerberos weak cert binding enabled
+
+	// ESC4-specific caches: principals with specific rights on cert templates, pre-computed to avoid per-ECA DB queries
+	certTemplateGenericWriters              map[graph.ID][]*graph.Node // principals with GenericWrite on a cert template
+	certTemplateEnrollOrAllExtendedRighters map[graph.ID][]*graph.Node // principals with Enroll or AllExtendedRights on a cert template
+	certTemplateWritePKINameFlaggers        map[graph.ID][]*graph.Node // principals with WritePKINameFlag on a cert template
+	certTemplateWritePKIEnrollmentFlaggers  map[graph.ID][]*graph.Node // principals with WritePKIEnrollmentFlag on a cert template
 }
 
 func NewADCSCache() *ADCSCache {
 	return &ADCSCache{
-		mutex:                           &sync.RWMutex{},
-		authStoreForChainValid:          make(map[graph.ID]cardinality.Duplex[uint64]),
-		rootCAForChainValid:             make(map[graph.ID]cardinality.Duplex[uint64]),
-		hasHostingComputer:              make(map[graph.ID]bool),
-		certTemplateHasSpecialEnrollers: make(map[graph.ID]bool),
-		enterpriseCAHasSpecialEnrollers: make(map[graph.ID]bool),
-		certTemplateEnrollers:           make(map[graph.ID][]*graph.Node),
-		certTemplateControllers:         make(map[graph.ID][]*graph.Node),
-		enterpriseCAEnrollers:           make(map[graph.ID][]*graph.Node),
-		publishedTemplateCache:          make(map[graph.ID][]*graph.Node),
-		authUsersByDomain:               make(map[graph.ID]graph.ID),
-		ecasWithHostingComputers:        cardinality.NewBitmap64(),
-		hasUPNCertMappingInForest:       cardinality.NewBitmap64(),
-		hasWeakCertBindingInForest:      cardinality.NewBitmap64(),
+		mutex:                                   &sync.RWMutex{},
+		chainedDomainsByEnterpriseCA:            make(map[uint64]*EnterpriseCAChainedDomains),
+		certTemplateHasSpecialEnrollers:         make(map[graph.ID]bool),
+		enterpriseCAHasSpecialEnrollers:         make(map[graph.ID]bool),
+		authStoreForChainValid:                  make(map[graph.ID]cardinality.Duplex[uint64]),
+		rootCAForChainValid:                     make(map[graph.ID]cardinality.Duplex[uint64]),
+		hasHostingComputer:                      make(map[graph.ID]bool),
+		certTemplateEnrollers:                   make(map[graph.ID][]*graph.Node),
+		certTemplateControllers:                 make(map[graph.ID][]*graph.Node),
+		enterpriseCAEnrollers:                   make(map[graph.ID][]*graph.Node),
+		publishedTemplateCache:                  make(map[graph.ID][]*graph.Node),
+		authUsersByDomain:                       make(map[graph.ID]graph.ID),
+		ecasWithHostingComputers:                cardinality.NewBitmap64(),
+		hasUPNCertMappingInForest:               cardinality.NewBitmap64(),
+		certTemplateGenericWriters:              make(map[graph.ID][]*graph.Node),
+		certTemplateEnrollOrAllExtendedRighters: make(map[graph.ID][]*graph.Node),
+		certTemplateWritePKINameFlaggers:        make(map[graph.ID][]*graph.Node),
+		certTemplateWritePKIEnrollmentFlaggers:  make(map[graph.ID][]*graph.Node),
+		hasWeakCertBindingInForest:              cardinality.NewBitmap64(),
 	}
 }
 
@@ -173,6 +185,50 @@ func (s *ADCSCache) BuildCache(ctx context.Context, db graph.Database, enterpris
 				)
 			} else {
 				s.certTemplateControllers[ct.ID] = certTemplateControllers.Slice()
+			}
+
+			// ESC4-specific principal caches
+			if principals, err := FetchPrincipalsWithGenericWriteOnCertTemplate(tx, ct); err != nil {
+				slog.ErrorContext(
+					ctx,
+					"Error fetching principals with GenericWrite on cert template",
+					slog.Uint64("cert_template", uint64(ct.ID)),
+					attr.Error(err),
+				)
+			} else {
+				s.certTemplateGenericWriters[ct.ID] = principals.Slice()
+			}
+
+			if principals, err := FetchPrincipalsWithEnrollOrAllExtendedRightsOnCertTemplate(tx, ct); err != nil {
+				slog.ErrorContext(
+					ctx,
+					"Error fetching principals with Enroll/AllExtendedRights on cert template",
+					slog.Uint64("cert_template", uint64(ct.ID)),
+					attr.Error(err),
+				)
+			} else {
+				s.certTemplateEnrollOrAllExtendedRighters[ct.ID] = principals.Slice()
+			}
+
+			if principals, err := FetchPrincipalsWithWritePKINameFlagOnCertTemplate(tx, ct); err != nil {
+				slog.ErrorContext(
+					ctx,
+					"Error fetching principals with WritePKINameFlag on cert template",
+					slog.Uint64("cert_template", uint64(ct.ID)),
+					attr.Error(err),
+				)
+			} else {
+				s.certTemplateWritePKINameFlaggers[ct.ID] = principals.Slice()
+			}
+
+			if principals, err := FetchPrincipalsWithWritePKIEnrollmentFlagOnCertTemplate(tx, ct); err != nil {
+				slog.ErrorContext(ctx,
+					"Error fetching principals with WritePKIEnrollmentFlag on cert template",
+					slog.Uint64("cert_template", uint64(ct.ID)),
+					attr.Error(err),
+				)
+			} else {
+				s.certTemplateWritePKIEnrollmentFlaggers[ct.ID] = principals.Slice()
 			}
 		}
 
@@ -417,6 +473,34 @@ func (s *ADCSCache) GetCertTemplateControllers(id graph.ID) []*graph.Node {
 	defer s.mutex.RUnlock()
 
 	return s.certTemplateControllers[id]
+}
+
+func (s *ADCSCache) GetCertTemplateGenericWriters(id graph.ID) []*graph.Node {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
+	return s.certTemplateGenericWriters[id]
+}
+
+func (s *ADCSCache) GetCertTemplateEnrollOrAllExtendedRighters(id graph.ID) []*graph.Node {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
+	return s.certTemplateEnrollOrAllExtendedRighters[id]
+}
+
+func (s *ADCSCache) GetCertTemplateWritePKINameFlaggers(id graph.ID) []*graph.Node {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
+	return s.certTemplateWritePKINameFlaggers[id]
+}
+
+func (s *ADCSCache) GetCertTemplateWritePKIEnrollmentFlaggers(id graph.ID) []*graph.Node {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
+	return s.certTemplateWritePKIEnrollmentFlaggers[id]
 }
 
 func (s *ADCSCache) GetEnterpriseCAEnrollers(id graph.ID) []*graph.Node {

--- a/packages/go/analysis/ad/esc10.go
+++ b/packages/go/analysis/ad/esc10.go
@@ -36,7 +36,7 @@ import (
 func PostADCSESC10a(ctx context.Context, tx graph.Transaction, outC chan<- post.EnsureRelationshipJob, localGroupData *LocalGroupData, certChains *EnterpriseCAChainedDomains, cache *ADCSCache) error {
 	if publishedCertTemplates := cache.GetPublishedTemplateCache(certChains.EnterpriseCA.ID); len(publishedCertTemplates) == 0 {
 		return nil
-	} else if ecaEnrollers := cache.GetEnterpriseCAEnrollers(certChains.EnterpriseCA.ID); len(ecaEnrollers) == 0 {
+	} else if ecaEnrollers := cache.GetEnterpriseCAEnrollers(certChains.EnterpriseCA.ID); ecaEnrollers.IsEmpty() {
 		return nil
 	} else {
 		results := cardinality.NewBitmap64()
@@ -44,7 +44,7 @@ func PostADCSESC10a(ctx context.Context, tx graph.Transaction, outC chan<- post.
 		for _, template := range publishedCertTemplates {
 			if !isCertTemplateValidForESC10(ctx, template, false) {
 				continue
-			} else if certTemplateEnrollers := cache.GetCertTemplateEnrollers(template.ID); len(certTemplateEnrollers) == 0 {
+			} else if certTemplateEnrollers := cache.GetCertTemplateEnrollers(template.ID); certTemplateEnrollers.IsEmpty() {
 				slog.DebugContext(
 					ctx,
 					"Failed to retrieve enrollers for cert template from cache",
@@ -93,7 +93,7 @@ func PostADCSESC10a(ctx context.Context, tx graph.Transaction, outC chan<- post.
 func PostADCSESC10b(ctx context.Context, tx graph.Transaction, outC chan<- post.EnsureRelationshipJob, localGroupData *LocalGroupData, chains *EnterpriseCAChainedDomains, cache *ADCSCache) error {
 	if publishedCertTemplates := cache.GetPublishedTemplateCache(chains.EnterpriseCA.ID); len(publishedCertTemplates) == 0 {
 		return nil
-	} else if ecaEnrollers := cache.GetEnterpriseCAEnrollers(chains.EnterpriseCA.ID); len(ecaEnrollers) == 0 {
+	} else if ecaEnrollers := cache.GetEnterpriseCAEnrollers(chains.EnterpriseCA.ID); ecaEnrollers.IsEmpty() {
 		return nil
 	} else {
 		results := cardinality.NewBitmap64()
@@ -101,7 +101,7 @@ func PostADCSESC10b(ctx context.Context, tx graph.Transaction, outC chan<- post.
 		for _, template := range publishedCertTemplates {
 			if !isCertTemplateValidForESC10(ctx, template, true) {
 				continue
-			} else if certTemplateEnrollers := cache.GetCertTemplateEnrollers(template.ID); len(certTemplateEnrollers) == 0 {
+			} else if certTemplateEnrollers := cache.GetCertTemplateEnrollers(template.ID); certTemplateEnrollers.IsEmpty() {
 				slog.DebugContext(
 					ctx,
 					"Failed to retrieve enrollers for cert template from cache",

--- a/packages/go/analysis/ad/esc3.go
+++ b/packages/go/analysis/ad/esc3.go
@@ -113,7 +113,7 @@ func PostADCSESC3(ctx context.Context, tx graph.Transaction, outC chan<- post.En
 									certTemplateEnrollersTwo,
 									cache.GetEnterpriseCAEnrollers(eca1.ID),
 									ecaEnrollersTwo,
-									delegatedAgents.Slice())
+									NewCachedPrincipalSet(delegatedAgents.Slice()))
 
 								// Add principals to result set unless it's a user and DNS is required
 								if filteredResults, err := filterUserDNSResults(tx, tempResults, certTemplateOne); err != nil {

--- a/packages/go/analysis/ad/esc3.go
+++ b/packages/go/analysis/ad/esc3.go
@@ -204,30 +204,22 @@ func PostEnrollOnBehalfOf(cache *ADCSCache, operation post.StatTrackedOperation[
 		} else {
 			chains.Domains.Each(func(domain uint64) bool {
 
-				operation.Operation.SubmitReader(func(ctx context.Context, tx graph.Transaction, outC chan<- post.EnsureRelationshipJob) error {
-					if results, err := EnrollOnBehalfOfVersionTwo(tx, versionTwoTemplates, publishedCertTemplates, graph.ID(domain)); err != nil {
-						return err
-					} else {
-						for _, result := range results {
-							if !channels.Submit(ctx, outC, result) {
-								return nil
-							}
+				operation.Operation.SubmitReader(func(ctx context.Context, _ graph.Transaction, outC chan<- post.EnsureRelationshipJob) error {
+					for _, result := range EnrollOnBehalfOfVersionTwo(cache, versionTwoTemplates, publishedCertTemplates, graph.ID(domain)) {
+						if !channels.Submit(ctx, outC, result) {
+							return nil
 						}
-						return nil
 					}
+					return nil
 				})
 
-				operation.Operation.SubmitReader(func(ctx context.Context, tx graph.Transaction, outC chan<- post.EnsureRelationshipJob) error {
-					if results, err := EnrollOnBehalfOfVersionOne(tx, versionOneTemplates, publishedCertTemplates, graph.ID(domain)); err != nil {
-						return err
-					} else {
-						for _, result := range results {
-							if !channels.Submit(ctx, outC, result) {
-								return nil
-							}
+				operation.Operation.SubmitReader(func(ctx context.Context, _ graph.Transaction, outC chan<- post.EnsureRelationshipJob) error {
+					for _, result := range EnrollOnBehalfOfVersionOne(cache, versionOneTemplates, publishedCertTemplates, graph.ID(domain)) {
+						if !channels.Submit(ctx, outC, result) {
+							return nil
 						}
-						return nil
 					}
+					return nil
 				})
 
 				return true
@@ -238,7 +230,7 @@ func PostEnrollOnBehalfOf(cache *ADCSCache, operation post.StatTrackedOperation[
 	return nil
 }
 
-func EnrollOnBehalfOfVersionOne(tx graph.Transaction, versionOneCertTemplates []*graph.Node, publishedTemplates []*graph.Node, domainID graph.ID) ([]post.EnsureRelationshipJob, error) {
+func EnrollOnBehalfOfVersionOne(cache *ADCSCache, versionOneCertTemplates []*graph.Node, publishedTemplates []*graph.Node, domainID graph.ID) []post.EnsureRelationshipJob {
 	results := make([]post.EnsureRelationshipJob, 0)
 
 	for _, certTemplateOne := range publishedTemplates {
@@ -259,29 +251,23 @@ func EnrollOnBehalfOfVersionOne(tx graph.Transaction, versionOneCertTemplates []
 			continue
 		} else {
 			for _, certTemplateTwo := range versionOneCertTemplates {
-				if hasPath, err := DoesCertTemplateLinkToDomain(tx, certTemplateTwo.ID, domainID); err != nil {
-					slog.Error(
-						"Error getting domain node for certtemplate",
-						slog.Uint64("cert_template_id", uint64(certTemplateTwo.ID)),
-						attr.Error(err),
-					)
-				} else if !hasPath {
+				if !cache.CertTemplateLinksToDomain(certTemplateTwo.ID, domainID) {
 					continue
-				} else {
-					results = append(results, post.EnsureRelationshipJob{
-						FromID: certTemplateOne.ID,
-						ToID:   certTemplateTwo.ID,
-						Kind:   ad.EnrollOnBehalfOf,
-					})
 				}
+
+				results = append(results, post.EnsureRelationshipJob{
+					FromID: certTemplateOne.ID,
+					ToID:   certTemplateTwo.ID,
+					Kind:   ad.EnrollOnBehalfOf,
+				})
 			}
 		}
 	}
 
-	return results, nil
+	return results
 }
 
-func EnrollOnBehalfOfVersionTwo(tx graph.Transaction, versionTwoCertTemplates, publishedTemplates []*graph.Node, domainID graph.ID) ([]post.EnsureRelationshipJob, error) {
+func EnrollOnBehalfOfVersionTwo(cache *ADCSCache, versionTwoCertTemplates, publishedTemplates []*graph.Node, domainID graph.ID) []post.EnsureRelationshipJob {
 	results := make([]post.EnsureRelationshipJob, 0)
 	for _, certTemplateOne := range publishedTemplates {
 		if hasBadEku, err := certTemplateHasEku(certTemplateOne, EkuAnyPurpose); errors.Is(err, graph.ErrPropertyNotFound) {
@@ -332,13 +318,7 @@ func EnrollOnBehalfOfVersionTwo(tx graph.Transaction, versionTwoCertTemplates, p
 					)
 				} else if !slices.Contains(applicationPolicies, EkuCertRequestAgent) {
 					continue
-				} else if isLinked, err := DoesCertTemplateLinkToDomain(tx, certTemplateTwo.ID, domainID); err != nil {
-					slog.Error(
-						"Error fetch paths from cert template to domain",
-						slog.Uint64("cert_template_id", uint64(certTemplateTwo.ID)),
-						attr.Error(err),
-					)
-				} else if !isLinked {
+				} else if !cache.CertTemplateLinksToDomain(certTemplateTwo.ID, domainID) {
 					continue
 				} else {
 					results = append(results, post.EnsureRelationshipJob{
@@ -351,7 +331,7 @@ func EnrollOnBehalfOfVersionTwo(tx graph.Transaction, versionTwoCertTemplates, p
 		}
 	}
 
-	return results, nil
+	return results
 }
 
 func certTemplateHasEku(certTemplate *graph.Node, targetEkus ...string) (bool, error) {

--- a/packages/go/analysis/ad/esc4.go
+++ b/packages/go/analysis/ad/esc4.go
@@ -160,8 +160,6 @@ func isCertTemplateValidForESC4(ctx context.Context, ct *graph.Node) bool {
 	}
 }
 
-
-
 // composition: p1
 func findPathsToDomainThroughCertTemplateWithGenericAll(
 	ctx context.Context,

--- a/packages/go/analysis/ad/esc4.go
+++ b/packages/go/analysis/ad/esc4.go
@@ -160,71 +160,7 @@ func isCertTemplateValidForESC4(ctx context.Context, ct *graph.Node) bool {
 	}
 }
 
-func FetchPrincipalsWithGenericWriteOnCertTemplate(tx graph.Transaction, certTemplate *graph.Node) (graph.NodeSet, error) {
-	if nodes, err := ops.FetchStartNodes(tx.Relationships().Filterf(
-		func() graph.Criteria {
-			return query.And(
-				query.Equals(query.EndID(), certTemplate.ID),
-				query.Kind(query.Relationship(), ad.GenericWrite),
-			)
-		},
-	)); err != nil {
-		return nil, err
-	} else {
-		return nodes, nil
-	}
-}
 
-func FetchPrincipalsWithEnrollOrAllExtendedRightsOnCertTemplate(tx graph.Transaction, certTemplate *graph.Node) (graph.NodeSet, error) {
-	if nodes, err := ops.FetchStartNodes(
-		tx.Relationships().Filterf(
-			func() graph.Criteria {
-				return query.And(
-					query.Equals(query.EndID(), certTemplate.ID),
-					query.Or(
-						query.Kind(query.Relationship(), ad.Enroll),
-						query.Kind(query.Relationship(), ad.AllExtendedRights),
-					),
-				)
-			},
-		)); err != nil {
-		return nil, err
-	} else {
-		return nodes, nil
-	}
-}
-
-func FetchPrincipalsWithWritePKINameFlagOnCertTemplate(tx graph.Transaction, certTemplate *graph.Node) (graph.NodeSet, error) {
-	if nodes, err := ops.FetchStartNodes(
-		tx.Relationships().Filterf(
-			func() graph.Criteria {
-				return query.And(
-					query.Equals(query.EndID(), certTemplate.ID),
-					query.Kind(query.Relationship(), ad.WritePKINameFlag),
-				)
-			},
-		)); err != nil {
-		return nil, err
-	} else {
-		return nodes, nil
-	}
-}
-
-func FetchPrincipalsWithWritePKIEnrollmentFlagOnCertTemplate(tx graph.Transaction, certTemplate *graph.Node) (graph.NodeSet, error) {
-	if nodes, err := ops.FetchStartNodes(
-		tx.Relationships().Filterf(
-			func() graph.Criteria {
-				return query.And(
-					query.Equals(query.EndID(), certTemplate.ID),
-					query.Kind(query.Relationship(), ad.WritePKIEnrollmentFlag),
-				)
-			},
-		)); err != nil {
-		return nil, err
-	} else {
-		return nodes, nil
-	}
-}
 
 // composition: p1
 func findPathsToDomainThroughCertTemplateWithGenericAll(

--- a/packages/go/analysis/ad/esc4.go
+++ b/packages/go/analysis/ad/esc4.go
@@ -41,35 +41,14 @@ func PostADCSESC4(ctx context.Context, tx graph.Transaction, outC chan<- post.En
 
 	// 2. iterate certtemplates that have an outbound `PublishedTo` edge to eca
 	for _, certTemplate := range publishedTemplates {
-		if principalsWithGenericWrite, err := FetchPrincipalsWithGenericWriteOnCertTemplate(tx, certTemplate); err != nil {
-			slog.WarnContext(
-				ctx,
-				"Error fetching principals with GenericWrite on cert template",
-				slog.Uint64("cert_template_id", uint64(certTemplate.ID)),
-				attr.Error(err),
-			)
-		} else if principalsWithEnrollOrAllExtendedRights, err := FetchPrincipalsWithEnrollOrAllExtendedRightsOnCertTemplate(tx, certTemplate); err != nil {
-			slog.WarnContext(
-				ctx,
-				"Error fetching principals with Enroll or AllExtendedRights on cert template",
-				slog.Uint64("cert_template_id", uint64(certTemplate.ID)),
-				attr.Error(err),
-			)
-		} else if principalsWithPKINameFlag, err := FetchPrincipalsWithWritePKINameFlagOnCertTemplate(tx, certTemplate); err != nil {
-			slog.WarnContext(
-				ctx,
-				"Error fetching principals with WritePKINameFlag on cert template",
-				slog.Uint64("cert_template_id", uint64(certTemplate.ID)),
-				attr.Error(err),
-			)
-		} else if principalsWithPKIEnrollmentFlag, err := FetchPrincipalsWithWritePKIEnrollmentFlagOnCertTemplate(tx, certTemplate); err != nil {
-			slog.WarnContext(
-				ctx,
-				"Error fetching principals with WritePKIEnrollmentFlag on cert template",
-				slog.Uint64("cert_template_id", uint64(certTemplate.ID)),
-				attr.Error(err),
-			)
-		} else if enrolleeSuppliesSubject, err := certTemplate.Properties.Get(string(ad.EnrolleeSuppliesSubject)).Bool(); err != nil {
+		var (
+			principalsWithGenericWrite              = cache.GetCertTemplateGenericWriters(certTemplate.ID)
+			principalsWithEnrollOrAllExtendedRights = cache.GetCertTemplateEnrollOrAllExtendedRighters(certTemplate.ID)
+			principalsWithPKINameFlag               = cache.GetCertTemplateWritePKINameFlaggers(certTemplate.ID)
+			principalsWithPKIEnrollmentFlag         = cache.GetCertTemplateWritePKIEnrollmentFlaggers(certTemplate.ID)
+		)
+
+		if enrolleeSuppliesSubject, err := certTemplate.Properties.Get(string(ad.EnrolleeSuppliesSubject)).Bool(); err != nil {
 			slog.WarnContext(
 				ctx,
 				"Error fetching EnrolleeSuppliesSubject property on cert template",
@@ -103,8 +82,8 @@ func PostADCSESC4(ctx context.Context, tx graph.Transaction, outC chan<- post.En
 				CalculateCrossProductNodeSets(
 					localGroupData,
 					enterpriseCAEnrollers,
-					principalsWithGenericWrite.Slice(),
-					principalsWithEnrollOrAllExtendedRights.Slice(),
+					principalsWithGenericWrite,
+					principalsWithEnrollOrAllExtendedRights,
 				),
 			)
 
@@ -117,9 +96,9 @@ func PostADCSESC4(ctx context.Context, tx graph.Transaction, outC chan<- post.En
 			principals.Or(CalculateCrossProductNodeSets(
 				localGroupData,
 				enterpriseCAEnrollers,
-				principalsWithEnrollOrAllExtendedRights.Slice(),
-				principalsWithPKINameFlag.Slice(),
-				principalsWithPKIEnrollmentFlag.Slice(),
+				principalsWithEnrollOrAllExtendedRights,
+				principalsWithPKINameFlag,
+				principalsWithPKIEnrollmentFlag,
 			))
 
 			// 2e.
@@ -128,8 +107,8 @@ func PostADCSESC4(ctx context.Context, tx graph.Transaction, outC chan<- post.En
 					CalculateCrossProductNodeSets(
 						localGroupData,
 						enterpriseCAEnrollers,
-						principalsWithEnrollOrAllExtendedRights.Slice(),
-						principalsWithPKIEnrollmentFlag.Slice(),
+						principalsWithEnrollOrAllExtendedRights,
+						principalsWithPKIEnrollmentFlag,
 					),
 				)
 			}
@@ -140,8 +119,8 @@ func PostADCSESC4(ctx context.Context, tx graph.Transaction, outC chan<- post.En
 					CalculateCrossProductNodeSets(
 						localGroupData,
 						enterpriseCAEnrollers,
-						principalsWithEnrollOrAllExtendedRights.Slice(),
-						principalsWithPKINameFlag.Slice(),
+						principalsWithEnrollOrAllExtendedRights,
+						principalsWithPKINameFlag,
 					),
 				)
 			}

--- a/packages/go/analysis/ad/esc9.go
+++ b/packages/go/analysis/ad/esc9.go
@@ -37,13 +37,13 @@ func PostADCSESC9a(ctx context.Context, tx graph.Transaction, outC chan<- post.E
 
 	if publishedCertTemplates := cache.GetPublishedTemplateCache(chains.EnterpriseCA.ID); len(publishedCertTemplates) == 0 {
 		return nil
-	} else if ecaEnrollers := cache.GetEnterpriseCAEnrollers(chains.EnterpriseCA.ID); len(ecaEnrollers) == 0 {
+	} else if ecaEnrollers := cache.GetEnterpriseCAEnrollers(chains.EnterpriseCA.ID); ecaEnrollers.IsEmpty() {
 		return nil
 	} else {
 		for _, template := range publishedCertTemplates {
 			if !isCertTemplateValidForESC9(ctx, template, false) {
 				continue
-			} else if certTemplateEnrollers := cache.GetCertTemplateEnrollers(template.ID); len(certTemplateEnrollers) == 0 {
+			} else if certTemplateEnrollers := cache.GetCertTemplateEnrollers(template.ID); certTemplateEnrollers.IsEmpty() {
 				continue
 			} else {
 				victimBitmap := getVictimBitmap(localGroupData, certTemplateEnrollers, ecaEnrollers, cache.GetCertTemplateHasSpecialEnrollers(template.ID), cache.GetEnterpriseCAHasSpecialEnrollers(chains.EnterpriseCA.ID))
@@ -90,13 +90,13 @@ func PostADCSESC9b(ctx context.Context, tx graph.Transaction, outC chan<- post.E
 
 	if publishedCertTemplates := cache.GetPublishedTemplateCache(chains.EnterpriseCA.ID); len(publishedCertTemplates) == 0 {
 		return nil
-	} else if ecaEnrollers := cache.GetEnterpriseCAEnrollers(chains.EnterpriseCA.ID); len(ecaEnrollers) == 0 {
+	} else if ecaEnrollers := cache.GetEnterpriseCAEnrollers(chains.EnterpriseCA.ID); ecaEnrollers.IsEmpty() {
 		return nil
 	} else {
 		for _, template := range publishedCertTemplates {
 			if !isCertTemplateValidForESC9(ctx, template, true) {
 				continue
-			} else if certTemplateEnrollers := cache.GetCertTemplateEnrollers(template.ID); len(certTemplateEnrollers) == 0 {
+			} else if certTemplateEnrollers := cache.GetCertTemplateEnrollers(template.ID); certTemplateEnrollers.IsEmpty() {
 				slog.DebugContext(
 					ctx,
 					"Failed to retrieve enrollers for cert template from cache",

--- a/packages/go/analysis/ad/esc_shared.go
+++ b/packages/go/analysis/ad/esc_shared.go
@@ -310,14 +310,14 @@ func findNodesByCertThumbprint(certThumbprint string, tx graph.Transaction, kind
 	}))
 }
 
-func expandNodeSliceToBitmapWithoutGroups(nodes []*graph.Node, localGroupData *LocalGroupData) cardinality.Duplex[uint64] {
+func expandCachedPrincipalsToBitmapWithoutGroups(principals CachedPrincipalSet, localGroupData *LocalGroupData) cardinality.Duplex[uint64] {
 	var (
 		nonGroupNodes = cardinality.NewBitmap64()
 	)
 
-	for _, controller := range nodes {
-		if controller.Kinds.ContainsOneOf(ad.Group) {
-			localGroupData.GroupMembershipCache.ReachOfComponentContainingMember(controller.ID.Uint64(), graph.DirectionInbound).Each(func(memberID uint64) bool {
+	principals.AllIDs.Each(func(entityID uint64) bool {
+		if principals.GroupOrLocalGroupIDs.Contains(entityID) {
+			localGroupData.GroupMembershipCache.ReachOfComponentContainingMember(entityID, graph.DirectionInbound).Each(func(memberID uint64) bool {
 				if !localGroupData.Groups.Contains(memberID) {
 					nonGroupNodes.Add(memberID)
 				}
@@ -325,9 +325,11 @@ func expandNodeSliceToBitmapWithoutGroups(nodes []*graph.Node, localGroupData *L
 				return true
 			})
 		} else {
-			nonGroupNodes.Add(controller.ID.Uint64())
+			nonGroupNodes.Add(entityID)
 		}
-	}
+
+		return true
+	})
 
 	return nonGroupNodes
 }
@@ -411,11 +413,11 @@ func filterUserDNSResults(tx graph.Transaction, bitmap cardinality.Duplex[uint64
 	return bitmap, nil
 }
 
-func getVictimBitmap(localGroupData *LocalGroupData, certTemplateControllers, ecaControllers []*graph.Node, specialGroupHasTemplateEnroll, specialGroupHasECAEnroll bool) cardinality.Duplex[uint64] {
+func getVictimBitmap(localGroupData *LocalGroupData, certTemplateControllers, ecaControllers CachedPrincipalSet, specialGroupHasTemplateEnroll, specialGroupHasECAEnroll bool) cardinality.Duplex[uint64] {
 	// Expand controllers for the eca + template completely because we don't do group shortcutting here
 	var (
-		templateBitmap = expandNodeSliceToBitmapWithoutGroups(certTemplateControllers, localGroupData)
-		ecaBitmap      = expandNodeSliceToBitmapWithoutGroups(ecaControllers, localGroupData)
+		templateBitmap = expandCachedPrincipalsToBitmapWithoutGroups(certTemplateControllers, localGroupData)
+		ecaBitmap      = expandCachedPrincipalsToBitmapWithoutGroups(ecaControllers, localGroupData)
 		victimBitmap   = cardinality.NewBitmap64()
 	)
 

--- a/packages/go/analysis/ad/ntlm.go
+++ b/packages/go/analysis/ad/ntlm.go
@@ -390,7 +390,7 @@ func PostCoerceAndRelayNTLMToADCS(ctx context.Context, operation post.StatTracke
 				// Verify cert template enables authentication and get cert template enrollers
 				if valid := isCertTemplateValidForADCSRelay(ctx, certTemplate); !valid {
 					continue
-				} else if certTemplateEnrollers := adcsCache.GetCertTemplateEnrollers(certTemplate.ID); len(certTemplateEnrollers) == 0 {
+				} else if certTemplateEnrollers := adcsCache.GetCertTemplateEnrollers(certTemplate.ID); certTemplateEnrollers.IsEmpty() {
 					continue
 				} else {
 					victims := getVictimBitmap(

--- a/packages/go/analysis/ad/post.go
+++ b/packages/go/analysis/ad/post.go
@@ -384,7 +384,7 @@ func getLAPSSyncers(tx graph.Transaction, domain *graph.Node, localGroupData *Lo
 	} else if getChangesFilteredNodes, err := ops.FetchStartNodes(getChangesFilteredQuery); err != nil {
 		return nil, err
 	} else {
-		results := CalculateCrossProductNodeSets(localGroupData, getChangesNodes.Slice(), getChangesFilteredNodes.Slice())
+		results := CalculateCrossProductNodeSets(localGroupData, NewCachedPrincipalSet(getChangesNodes.Slice()), NewCachedPrincipalSet(getChangesFilteredNodes.Slice()))
 
 		return results, nil
 	}
@@ -401,7 +401,7 @@ func getDCSyncers(tx graph.Transaction, domain *graph.Node, localGroupData *Loca
 	} else if getChangesAllNodes, err := ops.FetchStartNodes(getChangesAllQuery); err != nil {
 		return nil, err
 	} else {
-		results := CalculateCrossProductNodeSets(localGroupData, getChangesNodes.Slice(), getChangesAllNodes.Slice())
+		results := CalculateCrossProductNodeSets(localGroupData, NewCachedPrincipalSet(getChangesNodes.Slice()), NewCachedPrincipalSet(getChangesAllNodes.Slice()))
 
 		return results, nil
 	}
@@ -606,10 +606,10 @@ func FetchCanRDPEntityBitmapForComputer(computerData *CanRDPComputerData, enforc
 
 		if !uraEnabled {
 			// In cases where we do not need to check for the existence of the RIL privilege, return the cross product of both groups
-			return CalculateCrossProductNodeSets(&computerData.LocalGroupData, []*graph.Node{computerData.RemoteDesktopUsersLocalGroup}, []*graph.Node{computerData.DAUGroup}), nil
+			return CalculateCrossProductNodeSets(&computerData.LocalGroupData, NewCachedPrincipalSet([]*graph.Node{computerData.RemoteDesktopUsersLocalGroup}), NewCachedPrincipalSet([]*graph.Node{computerData.DAUGroup})), nil
 		} else {
 			// Otherwise, return the cross product of all three criteria
-			return CalculateCrossProductNodeSets(&computerData.LocalGroupData, []*graph.Node{computerData.RemoteDesktopUsersLocalGroup}, []*graph.Node{computerData.DAUGroup}, computerData.RemoteInteractiveLogonRightEntities.Slice()), nil
+			return CalculateCrossProductNodeSets(&computerData.LocalGroupData, NewCachedPrincipalSet([]*graph.Node{computerData.RemoteDesktopUsersLocalGroup}), NewCachedPrincipalSet([]*graph.Node{computerData.DAUGroup}), NewCachedPrincipalSet(computerData.RemoteInteractiveLogonRightEntities.Slice())), nil
 		}
 	} else if canSkipURAProcessing {
 		return FetchRemoteDesktopUsersBitmapForComputerWithoutURA(computerData), nil

--- a/packages/go/analysis/ad/post_integration_test.go
+++ b/packages/go/analysis/ad/post_integration_test.go
@@ -39,8 +39,8 @@ func TestCrossProduct(t *testing.T) {
 		harness.ShortcutHarness.Setup(testContext)
 		return nil
 	}, func(harness integration.HarnessDetails, graphDB graph.Database, tx graph.Transaction) {
-		firstSet := []*graph.Node{testContext.Harness.ShortcutHarness.Group1}
-		secondSet := []*graph.Node{testContext.Harness.ShortcutHarness.Group2}
+		firstSet := ad.NewCachedPrincipalSet([]*graph.Node{testContext.Harness.ShortcutHarness.Group1})
+		secondSet := ad.NewCachedPrincipalSet([]*graph.Node{testContext.Harness.ShortcutHarness.Group2})
 
 		excludedGroups, err := ad.FetchLocalGroupData(context.Background(), graphDB)
 		require.NoError(t, err)
@@ -56,8 +56,8 @@ func TestCrossProductAuthUsers(t *testing.T) {
 		harness.ShortcutHarnessAuthUsers.Setup(testContext)
 		return nil
 	}, func(harness integration.HarnessDetails, graphDB graph.Database, tx graph.Transaction) {
-		firstSet := []*graph.Node{testContext.Harness.ShortcutHarnessAuthUsers.Group1}
-		secondSet := []*graph.Node{testContext.Harness.ShortcutHarnessAuthUsers.Group2}
+		firstSet := ad.NewCachedPrincipalSet([]*graph.Node{testContext.Harness.ShortcutHarnessAuthUsers.Group1})
+		secondSet := ad.NewCachedPrincipalSet([]*graph.Node{testContext.Harness.ShortcutHarnessAuthUsers.Group2})
 
 		excludedGroups, err := ad.FetchLocalGroupData(context.Background(), graphDB)
 		require.NoError(t, err)
@@ -73,8 +73,8 @@ func TestCrossProductEveryone(t *testing.T) {
 		harness.ShortcutHarnessEveryone.Setup(testContext)
 		return nil
 	}, func(harness integration.HarnessDetails, graphDB graph.Database, tx graph.Transaction) {
-		firstSet := []*graph.Node{testContext.Harness.ShortcutHarnessEveryone.Group1}
-		secondSet := []*graph.Node{testContext.Harness.ShortcutHarnessEveryone.Group2}
+		firstSet := ad.NewCachedPrincipalSet([]*graph.Node{testContext.Harness.ShortcutHarnessEveryone.Group1})
+		secondSet := ad.NewCachedPrincipalSet([]*graph.Node{testContext.Harness.ShortcutHarnessEveryone.Group2})
 
 		excludedGroups, err := ad.FetchLocalGroupData(context.Background(), graphDB)
 		require.NoError(t, err)
@@ -90,8 +90,8 @@ func TestCrossProductEveryone2(t *testing.T) {
 		harness.ShortcutHarnessEveryone2.Setup(testContext)
 		return nil
 	}, func(harness integration.HarnessDetails, graphDB graph.Database, tx graph.Transaction) {
-		firstSet := []*graph.Node{testContext.Harness.ShortcutHarnessEveryone2.Group1}
-		secondSet := []*graph.Node{testContext.Harness.ShortcutHarnessEveryone2.Group2}
+		firstSet := ad.NewCachedPrincipalSet([]*graph.Node{testContext.Harness.ShortcutHarnessEveryone2.Group1})
+		secondSet := ad.NewCachedPrincipalSet([]*graph.Node{testContext.Harness.ShortcutHarnessEveryone2.Group2})
 
 		excludedGroups, err := ad.FetchLocalGroupData(context.Background(), graphDB)
 		require.NoError(t, err)
@@ -126,8 +126,8 @@ func TestCrossProductSharedMemberNotDuplicated(t *testing.T) {
 		return nil
 	}, func(harness integration.HarnessDetails, graphDB graph.Database, tx graph.Transaction) {
 		var (
-			firstSet  = []*graph.Node{testContext.Harness.ShortcutHarnessSharedMember.ParentGroup}
-			secondSet = []*graph.Node{testContext.Harness.ShortcutHarnessSharedMember.SubGroup1, testContext.Harness.ShortcutHarnessSharedMember.SubGroup2}
+			firstSet  = ad.NewCachedPrincipalSet([]*graph.Node{testContext.Harness.ShortcutHarnessSharedMember.ParentGroup})
+			secondSet = ad.NewCachedPrincipalSet([]*graph.Node{testContext.Harness.ShortcutHarnessSharedMember.SubGroup1, testContext.Harness.ShortcutHarnessSharedMember.SubGroup2})
 		)
 
 		localGroupData, err := ad.FetchLocalGroupData(context.Background(), graphDB)

--- a/packages/go/analysis/ad/queries.go
+++ b/packages/go/analysis/ad/queries.go
@@ -1867,6 +1867,30 @@ func fetchFirstDegreeNodes(tx graph.Transaction, targetNode *graph.Node, relKind
 	))
 }
 
+// fetchFirstDegreeNodesByRelKind fetches all entities connected to targetNode in a single database query,
+// then partitions the results by relationship kind. This avoids issuing separate queries per edge kind.
+func fetchFirstDegreeNodesByRelKind(tx graph.Transaction, targetNode *graph.Node, relKinds ...graph.Kind) (map[graph.Kind]graph.NodeSet, error) {
+	nodesByKind := make(map[graph.Kind]graph.NodeSet, len(relKinds))
+	for _, kind := range relKinds {
+		nodesByKind[kind] = graph.NewNodeSet()
+	}
+
+	err := ops.ForEachStartNode(tx.Relationships().Filter(
+		query.And(
+			query.Kind(query.Start(), ad.Entity),
+			query.KindIn(query.Relationship(), relKinds...),
+			query.Equals(query.EndID(), targetNode.ID),
+		),
+	), func(relationship *graph.Relationship, node *graph.Node) error {
+		if nodeSet, ok := nodesByKind[relationship.Kind]; ok {
+			nodeSet.Add(node)
+		}
+		return nil
+	})
+
+	return nodesByKind, err
+}
+
 func FetchAttackersForEscalations9and10(tx graph.Transaction, victimBitmap cardinality.Duplex[uint64], scenarioB bool) ([]graph.ID, error) {
 	if attackers, err := ops.FetchStartNodeIDs(tx.Relationships().Filterf(func() graph.Criteria {
 		criteria := query.And(

--- a/packages/go/analysis/ad/queries.go
+++ b/packages/go/analysis/ad/queries.go
@@ -1828,34 +1828,6 @@ func FetchEnterpriseCAsRootCAForPathToDomainFull(tx graph.Transaction, domain *g
 	})
 }
 
-func DoesCertTemplateLinkToDomain(tx graph.Transaction, certTemplate, domainNode graph.ID) (bool, error) {
-	if pathSet, err := FetchCertTemplatePathToDomain(tx, certTemplate, domainNode); err != nil {
-		return false, err
-	} else {
-		return pathSet.Len() > 0, nil
-	}
-}
-
-func FetchCertTemplatePathToDomain(tx graph.Transaction, certTemplate, domain graph.ID) (graph.PathSet, error) {
-	var (
-		paths = graph.NewPathSet()
-	)
-
-	return paths, tx.Relationships().Filter(
-		query.And(
-			query.Equals(query.StartID(), certTemplate),
-			query.KindIn(query.Relationship(), ad.PublishedTo, ad.IssuedSignedBy, ad.EnterpriseCAFor, ad.RootCAFor),
-			query.Equals(query.EndID(), domain),
-		),
-	).FetchAllShortestPaths(func(cursor graph.Cursor[graph.Path]) error {
-		for path := range cursor.Chan() {
-			paths.AddPath(path)
-		}
-
-		return cursor.Error()
-	})
-}
-
 // fetchFirstDegreeNodes fetches all entities that are connected to the provided targetNode with a relationship kind that matches any of the provided relKinds
 func fetchFirstDegreeNodes(tx graph.Transaction, targetNode *graph.Node, relKinds ...graph.Kind) (graph.NodeSet, error) {
 	return ops.FetchStartNodes(tx.Relationships().Filter(


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

ADCS post-processing spends ~44% of CPU in GC scanning due to pointer-heavy caches, ~29% in per-pair shortest-path queries during EnrollOnBehalfOf, and issues redundant per-cert-template DB queries in both BuildCache and ESC4 processing. This ticket consolidates queries, replaces pointer-dense maps with bitmap representations, and pre-computes reachability data to eliminate these bottlenecks.

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-8361

*Why is this change required? What problem does it solve?*

## How Has This Been Tested?

Existing test suites are thorough and unchanged. Additionally, validated manually using several local datasets.

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [X] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [X] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [X] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reworked AD CS caching to use compact principal sets, improving performance and memory for certificate-template and enterprise-CA analyses and making ESC checks more efficient.
  * ESC rules and cross-product computations now use the new cached principal sets for faster evaluation.
* **Tests**
  * Integration and unit tests updated to use the new cached principal set inputs.
* **Chores**
  * Cache-build failures now log clearer per-template diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->