### PR TITLE
fix: Last Analysis Run At not updating on every analysis BED-8136

### DIFF
--- a/cmd/api/src/api/tools/analysis_schedule.go
+++ b/cmd/api/src/api/tools/analysis_schedule.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/specterops/bloodhound/cmd/api/src/api"
 	"github.com/specterops/bloodhound/cmd/api/src/database/types"
@@ -45,35 +46,30 @@ func (s ToolContainer) GetScheduledAnalysisConfiguration(response http.ResponseW
 
 func (s ToolContainer) SetScheduledAnalysisConfiguration(response http.ResponseWriter, request *http.Request) {
 	var config ScheduledAnalysisConfiguration
+	ctx := request.Context()
 
 	if err := api.ReadJSONRequestPayloadLimited(&config, request); err != nil {
-		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, api.ErrorParseParams, request), response)
+		api.WriteErrorResponse(ctx, api.BuildErrorResponse(http.StatusBadRequest, api.ErrorParseParams, request), response)
 	} else if !config.Enabled {
 		nextParameter := appcfg.ScheduledAnalysisParameter{
 			Enabled: false,
 		}
 
 		if val, err := types.NewJSONBObject(nextParameter); err != nil {
-			api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusInternalServerError, fmt.Sprintf("failed to convert value to JSONBObject: %v", err), request), response)
+			api.WriteErrorResponse(ctx, api.BuildErrorResponse(http.StatusInternalServerError, fmt.Sprintf("failed to convert value to JSONBObject: %v", err), request), response)
 		} else {
 			updatedParameter := appcfg.Parameter{
 				Key:   appcfg.ScheduledAnalysis,
 				Value: val,
 			}
 
-			if err := s.db.SetConfigurationParameter(request.Context(), updatedParameter); err != nil {
-				api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusInternalServerError, fmt.Sprintf("error updating database: %v", api.FormatDatabaseError(err)), request), response)
+			if err := s.db.SetConfigurationParameter(ctx, updatedParameter); err != nil {
+				api.WriteErrorResponse(ctx, api.BuildErrorResponse(http.StatusInternalServerError, fmt.Sprintf("error updating database: %v", api.FormatDatabaseError(err)), request), response)
 			}
 		}
 	} else {
-		//Validate that the rrule is a good rule. We're going to require a DTSTART to keep scheduling consistent.
-		//We're also going to reject UNTIL/COUNT because it will most likely break the pipeline once it's hit without being invalid
-		if _, err := rrule.StrToRRule(config.RRule); err != nil {
-			api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, fmt.Sprintf(ErrInvalidRrule, err), request), response)
-		} else if strings.Contains(strings.ToUpper(config.RRule), "UNTIL") || strings.Contains(strings.ToUpper(config.RRule), "COUNT") {
-			api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, fmt.Sprintf(ErrInvalidRrule, "count/until not supported"), request), response)
-		} else if !strings.Contains(strings.ToUpper(config.RRule), "DTSTART") {
-			api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, fmt.Sprintf(ErrInvalidRrule, "dtstart is required"), request), response)
+		if rule, err := validateRRule(config.RRule); err != nil {
+			api.WriteErrorResponse(ctx, api.BuildErrorResponse(http.StatusBadRequest, err.Error(), request), response)
 		} else {
 			nextParameter := appcfg.ScheduledAnalysisParameter{
 				Enabled: true,
@@ -81,17 +77,37 @@ func (s ToolContainer) SetScheduledAnalysisConfiguration(response http.ResponseW
 			}
 
 			if val, err := types.NewJSONBObject(nextParameter); err != nil {
-				api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusInternalServerError, fmt.Sprintf("failed to convert value to JSONBObject: %v", err), request), response)
+				api.WriteErrorResponse(ctx, api.BuildErrorResponse(http.StatusInternalServerError, fmt.Sprintf("failed to convert value to JSONBObject: %v", err), request), response)
 			} else {
 				updatedParameter := appcfg.Parameter{
 					Key:   appcfg.ScheduledAnalysis,
 					Value: val,
 				}
 
-				if err := s.db.SetConfigurationParameter(request.Context(), updatedParameter); err != nil {
-					api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusInternalServerError, fmt.Sprintf("error updating database: %v", api.FormatDatabaseError(err)), request), response)
+				if err := s.db.SetConfigurationParameter(ctx, updatedParameter); err != nil {
+					api.WriteErrorResponse(ctx, api.BuildErrorResponse(http.StatusInternalServerError, fmt.Sprintf("error setting analysis schedule: %v", api.FormatDatabaseError(err)), request), response)
+				} else if err = s.db.SetNextScheduledAnalysisStartTime(ctx, rule.After(time.Now(), true)); err != nil {
+					api.WriteErrorResponse(ctx, api.BuildErrorResponse(http.StatusInternalServerError, fmt.Sprintf("scheduled analysis updated, but there was an error updating the next scheduled analysis start time: %v", api.FormatDatabaseError(err)), request), response)
 				}
+
 			}
+		}
+	}
+}
+
+// Validates that the rrule is valid. Valid rules require a DTSTART to keep scheduling consistent.
+// Valid rules do not contain UNTIL/COUNT because it will most likely break the pipeline once it's hit without being invalid.
+func validateRRule(RRuleParam string) (*rrule.RRule, error) {
+	if rule, err := rrule.StrToRRule(RRuleParam); err != nil {
+		return rule, fmt.Errorf(ErrInvalidRrule, err)
+	} else {
+		RRuleParam = strings.ToUpper(RRuleParam)
+		if strings.Contains(RRuleParam, "UNTIL") || strings.Contains(RRuleParam, "COUNT") {
+			return rule, fmt.Errorf(ErrInvalidRrule, "count/until not supported")
+		} else if !strings.Contains(RRuleParam, "DTSTART") {
+			return rule, fmt.Errorf(ErrInvalidRrule, "dtstart is required")
+		} else {
+			return rule, nil
 		}
 	}
 }

--- a/cmd/api/src/api/tools/analysis_schedule.go
+++ b/cmd/api/src/api/tools/analysis_schedule.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/specterops/bloodhound/cmd/api/src/api"
 	"github.com/specterops/bloodhound/cmd/api/src/database/types"
+	"github.com/specterops/bloodhound/cmd/api/src/database/types/null"
 	"github.com/specterops/bloodhound/cmd/api/src/model/appcfg"
 	"github.com/specterops/bloodhound/cmd/api/src/utils/validation"
 )
@@ -63,7 +64,10 @@ func (s ToolContainer) SetScheduledAnalysisConfiguration(response http.ResponseW
 
 			if err := s.db.SetConfigurationParameter(ctx, updatedParameter); err != nil {
 				api.WriteErrorResponse(ctx, api.BuildErrorResponse(http.StatusInternalServerError, fmt.Sprintf("error updating database: %v", api.FormatDatabaseError(err)), request), response)
+			} else if err = s.db.SetNextScheduledAnalysisStartTime(ctx, null.Time{}); err != nil {
+				api.WriteErrorResponse(ctx, api.BuildErrorResponse(http.StatusInternalServerError, fmt.Sprintf("scheduled analysis disabled, but there was an error updating the next scheduled analysis start time: %v", api.FormatDatabaseError(err)), request), response)
 			}
+
 		}
 	} else {
 		if rule, err := validation.ValidateRRule(config.RRule); err != nil {
@@ -84,7 +88,7 @@ func (s ToolContainer) SetScheduledAnalysisConfiguration(response http.ResponseW
 
 				if err := s.db.SetConfigurationParameter(ctx, updatedParameter); err != nil {
 					api.WriteErrorResponse(ctx, api.BuildErrorResponse(http.StatusInternalServerError, fmt.Sprintf("error setting analysis schedule: %v", api.FormatDatabaseError(err)), request), response)
-				} else if err = s.db.SetNextScheduledAnalysisStartTime(ctx, rule.After(time.Now(), true)); err != nil {
+				} else if err = s.db.SetNextScheduledAnalysisStartTime(ctx, null.TimeFrom(rule.After(time.Now(), true))); err != nil {
 					api.WriteErrorResponse(ctx, api.BuildErrorResponse(http.StatusInternalServerError, fmt.Sprintf("scheduled analysis updated, but there was an error updating the next scheduled analysis start time: %v", api.FormatDatabaseError(err)), request), response)
 				}
 

--- a/cmd/api/src/api/tools/analysis_schedule.go
+++ b/cmd/api/src/api/tools/analysis_schedule.go
@@ -19,13 +19,12 @@ package tools
 import (
 	"fmt"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/specterops/bloodhound/cmd/api/src/api"
 	"github.com/specterops/bloodhound/cmd/api/src/database/types"
 	"github.com/specterops/bloodhound/cmd/api/src/model/appcfg"
-	"github.com/teambition/rrule-go"
+	"github.com/specterops/bloodhound/cmd/api/src/utils/validation"
 )
 
 type ScheduledAnalysisConfiguration struct {
@@ -33,7 +32,6 @@ type ScheduledAnalysisConfiguration struct {
 	RRule   string `json:"rrule"`
 }
 
-const ErrInvalidRrule = "invalid rrule specified: %v"
 const ErrFailedRetrievingData = "error retrieving configuration data: %v"
 
 func (s ToolContainer) GetScheduledAnalysisConfiguration(response http.ResponseWriter, request *http.Request) {
@@ -68,7 +66,7 @@ func (s ToolContainer) SetScheduledAnalysisConfiguration(response http.ResponseW
 			}
 		}
 	} else {
-		if rule, err := validateRRule(config.RRule); err != nil {
+		if rule, err := validation.ValidateRRule(config.RRule); err != nil {
 			api.WriteErrorResponse(ctx, api.BuildErrorResponse(http.StatusBadRequest, err.Error(), request), response)
 		} else {
 			nextParameter := appcfg.ScheduledAnalysisParameter{
@@ -91,23 +89,6 @@ func (s ToolContainer) SetScheduledAnalysisConfiguration(response http.ResponseW
 				}
 
 			}
-		}
-	}
-}
-
-// Validates that the rrule is valid. Valid rules require a DTSTART to keep scheduling consistent.
-// Valid rules do not contain UNTIL/COUNT because it will most likely break the pipeline once it's hit without being invalid.
-func validateRRule(RRuleParam string) (*rrule.RRule, error) {
-	if rule, err := rrule.StrToRRule(RRuleParam); err != nil {
-		return rule, fmt.Errorf(ErrInvalidRrule, err)
-	} else {
-		RRuleParam = strings.ToUpper(RRuleParam)
-		if strings.Contains(RRuleParam, "UNTIL") || strings.Contains(RRuleParam, "COUNT") {
-			return rule, fmt.Errorf(ErrInvalidRrule, "count/until not supported")
-		} else if !strings.Contains(RRuleParam, "DTSTART") {
-			return rule, fmt.Errorf(ErrInvalidRrule, "dtstart is required")
-		} else {
-			return rule, nil
 		}
 	}
 }

--- a/cmd/api/src/api/tools/analysis_schedule_test.go
+++ b/cmd/api/src/api/tools/analysis_schedule_test.go
@@ -24,13 +24,13 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
-	"time"
 
 	"github.com/gorilla/mux"
 	"github.com/specterops/bloodhound/cmd/api/src/api/tools"
 	"github.com/specterops/bloodhound/cmd/api/src/ctx"
 	"github.com/specterops/bloodhound/cmd/api/src/database/mocks"
 	"github.com/specterops/bloodhound/cmd/api/src/database/types"
+	"github.com/specterops/bloodhound/cmd/api/src/database/types/null"
 	"github.com/specterops/bloodhound/cmd/api/src/model/appcfg"
 	"github.com/specterops/bloodhound/packages/go/headers"
 	"github.com/specterops/bloodhound/packages/go/mediatypes"
@@ -179,7 +179,7 @@ func TestToolContainer_SetScheduledAnalysisConfiguration(t *testing.T) {
 		reqBody, _ := json.Marshal(scheduledAnalysisRequest)
 
 		mockDB.EXPECT().SetConfigurationParameter(gomock.Any(), parameterConfig).Return(nil)
-		mockDB.EXPECT().SetNextScheduledAnalysisStartTime(gomock.Any(), time.Time{}).Return(nil)
+		mockDB.EXPECT().SetNextScheduledAnalysisStartTime(gomock.Any(), null.Time{}).Return(nil)
 
 		if req, err := http.NewRequestWithContext(requestCtx, http.MethodPut, endpoint, bytes.NewBuffer(reqBody)); err != nil {
 			t.Fatal(err)

--- a/cmd/api/src/api/tools/analysis_schedule_test.go
+++ b/cmd/api/src/api/tools/analysis_schedule_test.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/gorilla/mux"
 	"github.com/specterops/bloodhound/cmd/api/src/api/tools"
@@ -40,7 +41,7 @@ import (
 func TestToolContainer_GetScheduledAnalysisConfiguration(t *testing.T) {
 	endpoint := "/analysis/schedule"
 
-	t.Run("happy path", func(t *testing.T) {
+	t.Run("success getting scheduled analysis", func(t *testing.T) {
 		var (
 			ctrl     = gomock.NewController(t)
 			mockDB   = mocks.NewMockDatabase(ctrl)
@@ -108,7 +109,7 @@ func TestToolContainer_SetScheduledAnalysisConfiguration(t *testing.T) {
 	endpoint := "/analysis/schedule"
 	validRRule := "FREQ=DAILY;INTERVAL=1;DTSTART=20230101T100000Z"
 
-	t.Run("happy path", func(t *testing.T) {
+	t.Run("success enabling scheduled analysis", func(t *testing.T) {
 		var (
 			ctrl     = gomock.NewController(t)
 			mockDB   = mocks.NewMockDatabase(ctrl)
@@ -137,6 +138,48 @@ func TestToolContainer_SetScheduledAnalysisConfiguration(t *testing.T) {
 
 		mockDB.EXPECT().SetConfigurationParameter(gomock.Any(), parameterConfig).Return(nil)
 		mockDB.EXPECT().SetNextScheduledAnalysisStartTime(gomock.Any(), gomock.Any()).Return(nil)
+
+		if req, err := http.NewRequestWithContext(requestCtx, http.MethodPut, endpoint, bytes.NewBuffer(reqBody)); err != nil {
+			t.Fatal(err)
+		} else {
+			req.Header.Set(headers.ContentType.String(), mediatypes.ApplicationJson.String())
+
+			router := mux.NewRouter()
+			router.HandleFunc(endpoint, handlers.SetScheduledAnalysisConfiguration).Methods(http.MethodPut)
+
+			response := httptest.NewRecorder()
+			router.ServeHTTP(response, req)
+
+			require.Equal(t, http.StatusOK, response.Code)
+		}
+	})
+
+	t.Run("success -- disable scheduled analysis", func(t *testing.T) {
+		var (
+			ctrl     = gomock.NewController(t)
+			mockDB   = mocks.NewMockDatabase(ctrl)
+			handlers = tools.NewToolContainer(mockDB)
+		)
+
+		defer ctrl.Finish()
+
+		requestCtx := context.WithValue(context.Background(), ctx.ValueKey, &ctx.Context{})
+		scheduledAnalysisRequest := tools.ScheduledAnalysisConfiguration{
+			Enabled: false,
+		}
+
+		jsonValue, _ := types.NewJSONBObject(appcfg.ScheduledAnalysisParameter{
+			Enabled: false})
+
+		parameterConfig := appcfg.Parameter{
+			Key:   appcfg.ScheduledAnalysis,
+			Value: jsonValue,
+		}
+
+		reqBody, _ := json.Marshal(scheduledAnalysisRequest)
+
+		mockDB.EXPECT().SetConfigurationParameter(gomock.Any(), parameterConfig).Return(nil)
+		mockDB.EXPECT().SetNextScheduledAnalysisStartTime(gomock.Any(), time.Time{}).Return(nil)
 
 		if req, err := http.NewRequestWithContext(requestCtx, http.MethodPut, endpoint, bytes.NewBuffer(reqBody)); err != nil {
 			t.Fatal(err)

--- a/cmd/api/src/api/tools/analysis_schedule_test.go
+++ b/cmd/api/src/api/tools/analysis_schedule_test.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -27,13 +28,131 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/specterops/bloodhound/cmd/api/src/api/tools"
 	"github.com/specterops/bloodhound/cmd/api/src/ctx"
+	"github.com/specterops/bloodhound/cmd/api/src/database/mocks"
+	"github.com/specterops/bloodhound/cmd/api/src/database/types"
+	"github.com/specterops/bloodhound/cmd/api/src/model/appcfg"
 	"github.com/specterops/bloodhound/packages/go/headers"
 	"github.com/specterops/bloodhound/packages/go/mediatypes"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 )
 
-func TestToolContainer_GetScheduledAnalysisConfiguration_Errors(t *testing.T) {
+func TestToolContainer_GetScheduledAnalysisConfiguration(t *testing.T) {
+	endpoint := "/analysis/schedule"
+
+	t.Run("happy path", func(t *testing.T) {
+		var (
+			ctrl     = gomock.NewController(t)
+			mockDB   = mocks.NewMockDatabase(ctrl)
+			handlers = tools.NewToolContainer(mockDB)
+		)
+
+		defer ctrl.Finish()
+
+		requestCtx := context.WithValue(context.Background(), ctx.ValueKey, &ctx.Context{})
+
+		scheduledAnalysisValue, _ := types.NewJSONBObject(map[string]any{
+			"enabled": true,
+			"rrule":   "FREQ=DAILY;INTERVAL=1;DTSTART=20230101T100000Z",
+		})
+
+		mockDB.EXPECT().GetConfigurationParameter(gomock.Any(), appcfg.ScheduledAnalysis).Return(appcfg.Parameter{
+			Key:   appcfg.ScheduledAnalysis,
+			Value: scheduledAnalysisValue,
+		}, nil)
+
+		if req, err := http.NewRequestWithContext(requestCtx, http.MethodGet, endpoint, nil); err != nil {
+			t.Fatal(err)
+		} else {
+			router := mux.NewRouter()
+			router.HandleFunc(endpoint, handlers.GetScheduledAnalysisConfiguration).Methods(http.MethodGet)
+
+			response := httptest.NewRecorder()
+			router.ServeHTTP(response, req)
+
+			require.Equal(t, http.StatusOK, response.Code)
+			require.Contains(t, response.Body.String(), `"enabled":true`)
+			require.Contains(t, response.Body.String(), `"rrule":"FREQ=DAILY;INTERVAL=1;DTSTART=20230101T100000Z"`)
+		}
+	})
+
+	t.Run("returns error when GetConfigurationParameter fails", func(t *testing.T) {
+		var (
+			ctrl     = gomock.NewController(t)
+			mockDB   = mocks.NewMockDatabase(ctrl)
+			handlers = tools.NewToolContainer(mockDB)
+		)
+
+		defer ctrl.Finish()
+
+		requestCtx := context.WithValue(context.Background(), ctx.ValueKey, &ctx.Context{})
+
+		mockDB.EXPECT().GetConfigurationParameter(gomock.Any(), appcfg.ScheduledAnalysis).Return(appcfg.Parameter{}, fmt.Errorf("database connection lost"))
+
+		if req, err := http.NewRequestWithContext(requestCtx, http.MethodGet, endpoint, nil); err != nil {
+			t.Fatal(err)
+		} else {
+			router := mux.NewRouter()
+			router.HandleFunc(endpoint, handlers.GetScheduledAnalysisConfiguration).Methods(http.MethodGet)
+
+			response := httptest.NewRecorder()
+			router.ServeHTTP(response, req)
+
+			require.Equal(t, http.StatusInternalServerError, response.Code)
+			require.Contains(t, response.Body.String(), "error retrieving configuration data")
+		}
+	})
+}
+
+func TestToolContainer_SetScheduledAnalysisConfiguration(t *testing.T) {
+	endpoint := "/analysis/schedule"
+	validRRule := "FREQ=DAILY;INTERVAL=1;DTSTART=20230101T100000Z"
+
+	t.Run("happy path", func(t *testing.T) {
+		var (
+			ctrl     = gomock.NewController(t)
+			mockDB   = mocks.NewMockDatabase(ctrl)
+			handlers = tools.NewToolContainer(mockDB)
+		)
+
+		defer ctrl.Finish()
+
+		requestCtx := context.WithValue(context.Background(), ctx.ValueKey, &ctx.Context{})
+		scheduledAnalysisRequest := tools.ScheduledAnalysisConfiguration{
+			Enabled: true,
+			RRule:   validRRule,
+		}
+
+		jsonValue, _ := types.NewJSONBObject(appcfg.ScheduledAnalysisParameter{
+			Enabled: true,
+			RRule:   validRRule,
+		})
+
+		parameterConfig := appcfg.Parameter{
+			Key:   appcfg.ScheduledAnalysis,
+			Value: jsonValue,
+		}
+
+		reqBody, _ := json.Marshal(scheduledAnalysisRequest)
+
+		mockDB.EXPECT().SetConfigurationParameter(gomock.Any(), parameterConfig).Return(nil)
+		mockDB.EXPECT().SetNextScheduledAnalysisStartTime(gomock.Any(), gomock.Any()).Return(nil)
+
+		if req, err := http.NewRequestWithContext(requestCtx, http.MethodPut, endpoint, bytes.NewBuffer(reqBody)); err != nil {
+			t.Fatal(err)
+		} else {
+			req.Header.Set(headers.ContentType.String(), mediatypes.ApplicationJson.String())
+
+			router := mux.NewRouter()
+			router.HandleFunc(endpoint, handlers.SetScheduledAnalysisConfiguration).Methods(http.MethodPut)
+
+			response := httptest.NewRecorder()
+			router.ServeHTTP(response, req)
+
+			require.Equal(t, http.StatusOK, response.Code)
+		}
+	})
+
 	t.Run("returns error on invalid rrule", func(t *testing.T) {
 		var (
 			ctrl     = gomock.NewController(t)
@@ -42,7 +161,6 @@ func TestToolContainer_GetScheduledAnalysisConfiguration_Errors(t *testing.T) {
 
 		defer ctrl.Finish()
 
-		endpoint := "/analysis/schedule"
 		requestCtx := context.WithValue(context.Background(), ctx.ValueKey, &ctx.Context{})
 		scheduledAnalysisRequest := tools.ScheduledAnalysisConfiguration{
 			Enabled: true,
@@ -63,7 +181,7 @@ func TestToolContainer_GetScheduledAnalysisConfiguration_Errors(t *testing.T) {
 			router.ServeHTTP(response, req)
 
 			require.Equal(t, http.StatusBadRequest, response.Code)
-			require.Contains(t, response.Body.String(), "invalid rrule specified: wrong")
+			require.Contains(t, response.Body.String(), "invalid rrule specified")
 		}
 	})
 
@@ -75,7 +193,6 @@ func TestToolContainer_GetScheduledAnalysisConfiguration_Errors(t *testing.T) {
 
 		defer ctrl.Finish()
 
-		endpoint := "/analysis/schedule"
 		requestCtx := context.WithValue(context.Background(), ctx.ValueKey, &ctx.Context{})
 		scheduledAnalysisRequest := tools.ScheduledAnalysisConfiguration{
 			Enabled: true,
@@ -108,7 +225,6 @@ func TestToolContainer_GetScheduledAnalysisConfiguration_Errors(t *testing.T) {
 
 		defer ctrl.Finish()
 
-		endpoint := "/analysis/schedule"
 		requestCtx := context.WithValue(context.Background(), ctx.ValueKey, &ctx.Context{})
 		scheduledAnalysisRequest := tools.ScheduledAnalysisConfiguration{
 			Enabled: true,
@@ -133,6 +249,77 @@ func TestToolContainer_GetScheduledAnalysisConfiguration_Errors(t *testing.T) {
 		}
 	})
 
+	t.Run("returns error when SetConfigurationParameter fails", func(t *testing.T) {
+		var (
+			ctrl     = gomock.NewController(t)
+			mockDB   = mocks.NewMockDatabase(ctrl)
+			handlers = tools.NewToolContainer(mockDB)
+		)
+
+		defer ctrl.Finish()
+
+		requestCtx := context.WithValue(context.Background(), ctx.ValueKey, &ctx.Context{})
+		scheduledAnalysisRequest := tools.ScheduledAnalysisConfiguration{
+			Enabled: true,
+			RRule:   "FREQ=DAILY;INTERVAL=1;DTSTART=20230101T100000Z",
+		}
+
+		reqBody, _ := json.Marshal(scheduledAnalysisRequest)
+
+		mockDB.EXPECT().SetConfigurationParameter(gomock.Any(), gomock.Any()).Return(fmt.Errorf("database connection lost"))
+
+		if req, err := http.NewRequestWithContext(requestCtx, http.MethodPut, endpoint, bytes.NewBuffer(reqBody)); err != nil {
+			t.Fatal(err)
+		} else {
+			req.Header.Set(headers.ContentType.String(), mediatypes.ApplicationJson.String())
+
+			router := mux.NewRouter()
+			router.HandleFunc(endpoint, handlers.SetScheduledAnalysisConfiguration).Methods(http.MethodPut)
+
+			response := httptest.NewRecorder()
+			router.ServeHTTP(response, req)
+
+			require.Equal(t, http.StatusInternalServerError, response.Code)
+			require.Contains(t, response.Body.String(), "error setting analysis schedule")
+		}
+	})
+
+	t.Run("returns error when SetNextScheduledAnalysisStartTime fails", func(t *testing.T) {
+		var (
+			ctrl     = gomock.NewController(t)
+			mockDB   = mocks.NewMockDatabase(ctrl)
+			handlers = tools.NewToolContainer(mockDB)
+		)
+
+		defer ctrl.Finish()
+
+		requestCtx := context.WithValue(context.Background(), ctx.ValueKey, &ctx.Context{})
+		scheduledAnalysisRequest := tools.ScheduledAnalysisConfiguration{
+			Enabled: true,
+			RRule:   "FREQ=DAILY;INTERVAL=1;DTSTART=20230101T100000Z",
+		}
+
+		reqBody, _ := json.Marshal(scheduledAnalysisRequest)
+
+		mockDB.EXPECT().SetConfigurationParameter(gomock.Any(), gomock.Any()).Return(nil)
+		mockDB.EXPECT().SetNextScheduledAnalysisStartTime(gomock.Any(), gomock.Any()).Return(fmt.Errorf("database connection lost"))
+
+		if req, err := http.NewRequestWithContext(requestCtx, http.MethodPut, endpoint, bytes.NewBuffer(reqBody)); err != nil {
+			t.Fatal(err)
+		} else {
+			req.Header.Set(headers.ContentType.String(), mediatypes.ApplicationJson.String())
+
+			router := mux.NewRouter()
+			router.HandleFunc(endpoint, handlers.SetScheduledAnalysisConfiguration).Methods(http.MethodPut)
+
+			response := httptest.NewRecorder()
+			router.ServeHTTP(response, req)
+
+			require.Equal(t, http.StatusInternalServerError, response.Code)
+			require.Contains(t, response.Body.String(), "scheduled analysis updated, but there was an error updating the next scheduled analysis start time")
+		}
+	})
+
 	t.Run("returns error on rrule without dtstart", func(t *testing.T) {
 		var (
 			ctrl     = gomock.NewController(t)
@@ -141,7 +328,6 @@ func TestToolContainer_GetScheduledAnalysisConfiguration_Errors(t *testing.T) {
 
 		defer ctrl.Finish()
 
-		endpoint := "/analysis/schedule"
 		requestCtx := context.WithValue(context.Background(), ctx.ValueKey, &ctx.Context{})
 		scheduledAnalysisRequest := tools.ScheduledAnalysisConfiguration{
 			Enabled: true,
@@ -165,4 +351,5 @@ func TestToolContainer_GetScheduledAnalysisConfiguration_Errors(t *testing.T) {
 			require.Contains(t, response.Body.String(), "invalid rrule specified: dtstart is required")
 		}
 	})
+
 }

--- a/cmd/api/src/api/tools/analysis_schedule_test.go
+++ b/cmd/api/src/api/tools/analysis_schedule_test.go
@@ -213,7 +213,7 @@ func TestToolContainer_SetScheduledAnalysisConfiguration(t *testing.T) {
 			router.ServeHTTP(response, req)
 
 			require.Equal(t, http.StatusBadRequest, response.Code)
-			require.Contains(t, response.Body.String(), "invalid rrule specified: count/until not supported")
+			require.Contains(t, response.Body.String(), "invalid rrule specified: count not supported")
 		}
 	})
 
@@ -245,7 +245,7 @@ func TestToolContainer_SetScheduledAnalysisConfiguration(t *testing.T) {
 			router.ServeHTTP(response, req)
 
 			require.Equal(t, http.StatusBadRequest, response.Code)
-			require.Contains(t, response.Body.String(), "invalid rrule specified: count/until not supported")
+			require.Contains(t, response.Body.String(), "invalid rrule specified: until not supported")
 		}
 	})
 

--- a/cmd/api/src/api/v2/app_config.go
+++ b/cmd/api/src/api/v2/app_config.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/specterops/bloodhound/cmd/api/src/api"
 	"github.com/specterops/bloodhound/cmd/api/src/database"
+	"github.com/specterops/bloodhound/cmd/api/src/database/types/null"
 	"github.com/specterops/bloodhound/cmd/api/src/model"
 	"github.com/specterops/bloodhound/cmd/api/src/model/appcfg"
 	"github.com/specterops/bloodhound/packages/go/bhlog/attr"
@@ -94,8 +95,12 @@ func updateNextScheduledAnalysisStartTime(ctx context.Context, db database.Datap
 	} else if scheduledAnalysis.Enabled {
 		if rule, err := rrule.StrToRRule(scheduledAnalysis.RRule); err != nil {
 			slog.ErrorContext(ctx, "Error parsing scheduled analysis rrule", attr.Error(err))
-		} else if err := db.SetNextScheduledAnalysisStartTime(ctx, rule.After(time.Now(), true)); err != nil {
+		} else if err := db.SetNextScheduledAnalysisStartTime(ctx, null.TimeFrom(rule.After(time.Now(), true))); err != nil {
 			slog.ErrorContext(ctx, "Error setting next scheduled analysis start time", attr.Error(err))
+		}
+	} else {
+		if err := db.SetNextScheduledAnalysisStartTime(ctx, null.Time{}); err != nil {
+			slog.ErrorContext(ctx, "Error clearing the next scheduled analysis start time", attr.Error(err))
 		}
 	}
 }

--- a/cmd/api/src/api/v2/app_config.go
+++ b/cmd/api/src/api/v2/app_config.go
@@ -19,11 +19,16 @@ package v2
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"net/http"
+	"time"
 
 	"github.com/specterops/bloodhound/cmd/api/src/api"
+	"github.com/specterops/bloodhound/cmd/api/src/database"
 	"github.com/specterops/bloodhound/cmd/api/src/model"
 	"github.com/specterops/bloodhound/cmd/api/src/model/appcfg"
+	"github.com/specterops/bloodhound/packages/go/bhlog/attr"
+	"github.com/teambition/rrule-go"
 )
 
 type ListAppConfigParametersResponse struct {
@@ -58,22 +63,40 @@ func (s Resources) GetApplicationConfigurations(response http.ResponseWriter, re
 func (s Resources) SetApplicationConfiguration(response http.ResponseWriter, request *http.Request) {
 	var (
 		appConfig appcfg.AppConfigUpdateRequest
+		ctx       = request.Context()
 	)
 
 	if err := api.ReadJSONRequestPayloadLimited(&appConfig, request); err != nil {
-		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, api.ErrorResponsePayloadUnmarshalError, request), response)
+		api.WriteErrorResponse(ctx, api.BuildErrorResponse(http.StatusBadRequest, api.ErrorResponsePayloadUnmarshalError, request), response)
 	} else if parameter, err := appcfg.ConvertAppConfigUpdateRequestToParameter(appConfig); err != nil {
-		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, fmt.Sprintf("Configuration update request not converted to a parameter: %s", appConfig), request), response)
+		api.WriteErrorResponse(ctx, api.BuildErrorResponse(http.StatusBadRequest, fmt.Sprintf("Configuration update request not converted to a parameter: %s", appConfig), request), response)
 	} else if !parameter.IsValidKey(parameter.Key) {
-		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, fmt.Sprintf("Configuration parameter %s is not valid.", parameter.Key), request), response)
+		api.WriteErrorResponse(ctx, api.BuildErrorResponse(http.StatusBadRequest, fmt.Sprintf("Configuration parameter %s is not valid.", parameter.Key), request), response)
 	} else if errs := parameter.Validate(); errs != nil {
-		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, errs.Error(), request), response)
+		api.WriteErrorResponse(ctx, api.BuildErrorResponse(http.StatusBadRequest, errs.Error(), request), response)
 	} else if !checkApiKeyExpirationParamAvailable(request.Context(), parameter, s.DB) {
-		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusForbidden, fmt.Sprintf("Configuration parameter %s is not available.", parameter.Key), request), response)
-	} else if err := s.DB.SetConfigurationParameter(request.Context(), parameter); err != nil {
+		api.WriteErrorResponse(ctx, api.BuildErrorResponse(http.StatusForbidden, fmt.Sprintf("Configuration parameter %s is not available.", parameter.Key), request), response)
+	} else if err := s.DB.SetConfigurationParameter(ctx, parameter); err != nil {
 		api.HandleDatabaseError(request, response, err)
 	} else {
+		if parameter.Key == appcfg.ScheduledAnalysis {
+			updateNextScheduledAnalysisStartTime(ctx, s.DB, parameter)
+		}
+
 		api.WriteBasicResponse(request.Context(), appConfig, http.StatusOK, response)
+	}
+}
+
+func updateNextScheduledAnalysisStartTime(ctx context.Context, db database.DatapipeStatusData, parameter appcfg.Parameter) {
+	var scheduledAnalysis appcfg.ScheduledAnalysisParameter
+	if err := parameter.Map(&scheduledAnalysis); err != nil {
+		slog.ErrorContext(ctx, "Error mapping scheduled analysis parameter", attr.Error(err))
+	} else if scheduledAnalysis.Enabled {
+		if rule, err := rrule.StrToRRule(scheduledAnalysis.RRule); err != nil {
+			slog.ErrorContext(ctx, "Error parsing scheduled analysis rrule", attr.Error(err))
+		} else if err := db.SetNextScheduledAnalysisStartTime(ctx, rule.After(time.Now(), true)); err != nil {
+			slog.ErrorContext(ctx, "Error setting next scheduled analysis start time", attr.Error(err))
+		}
 	}
 }
 

--- a/cmd/api/src/api/v2/app_config_test.go
+++ b/cmd/api/src/api/v2/app_config_test.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	v2 "github.com/specterops/bloodhound/cmd/api/src/api/v2"
 	"github.com/specterops/bloodhound/cmd/api/src/database/mocks"
@@ -31,6 +32,7 @@ import (
 	"github.com/specterops/bloodhound/cmd/api/src/model/appcfg"
 	"github.com/specterops/bloodhound/cmd/api/src/test/must"
 	"github.com/specterops/bloodhound/cmd/api/src/utils/test"
+	"github.com/teambition/rrule-go"
 	"go.uber.org/mock/gomock"
 )
 
@@ -215,6 +217,51 @@ func Test_SetApplicationConfiguration(t *testing.T) {
 			Return(nil)
 
 		reqBody, _ := json.Marshal(appConfigRequest)
+		req := httptest.NewRequest(http.MethodPost, "/api/v2/config", bytes.NewBuffer(reqBody))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+
+		resources.SetApplicationConfiguration(rec, req)
+
+		if status := rec.Code; status != http.StatusOK {
+			t.Errorf("handler returned wrong status code: got %v want %v",
+				status, http.StatusOK)
+		}
+	})
+
+	t.Run("Scheduled Analysis updates next scheduled analysis start time", func(t *testing.T) {
+		var (
+			validRRule = "RRULE:FREQ=DAILY;INTERVAL=1;DTSTART=20240101T100000Z"
+
+			scheduledAnalysisRequest = appcfg.AppConfigUpdateRequest{
+				Key: string(appcfg.ScheduledAnalysis),
+				Value: map[string]any{
+					"enabled": true,
+					"rrule":   validRRule,
+				},
+			}
+
+			expectedParameter = appcfg.Parameter{
+				Key:   appcfg.ScheduledAnalysis,
+				Value: must.NewJSONBObject(map[string]any{"enabled": true, "rrule": validRRule}),
+			}
+		)
+
+		rule, err := rrule.StrToRRule(validRRule)
+		if err != nil {
+			t.Fatalf("failed to parse rrule: %v", err)
+		}
+		expectedNextAnalysis := rule.After(time.Now(), true)
+
+		mockDB.EXPECT().
+			SetConfigurationParameter(gomock.Any(), expectedParameter).
+			Return(nil)
+
+		mockDB.EXPECT().
+			SetNextScheduledAnalysisStartTime(gomock.Any(), expectedNextAnalysis).
+			Return(nil)
+
+		reqBody, _ := json.Marshal(scheduledAnalysisRequest)
 		req := httptest.NewRequest(http.MethodPost, "/api/v2/config", bytes.NewBuffer(reqBody))
 		req.Header.Set("Content-Type", "application/json")
 		rec := httptest.NewRecorder()

--- a/cmd/api/src/api/v2/app_config_test.go
+++ b/cmd/api/src/api/v2/app_config_test.go
@@ -274,4 +274,41 @@ func Test_SetApplicationConfiguration(t *testing.T) {
 				status, http.StatusOK)
 		}
 	})
+
+	t.Run("Disabling Scheduled Analysis removes the next scheduled analysis start time", func(t *testing.T) {
+		var (
+			scheduledAnalysisRequest = appcfg.AppConfigUpdateRequest{
+				Key: string(appcfg.ScheduledAnalysis),
+				Value: map[string]any{
+					"enabled": false,
+					"rrule":   "",
+				},
+			}
+
+			expectedParameter = appcfg.Parameter{
+				Key:   appcfg.ScheduledAnalysis,
+				Value: must.NewJSONBObject(map[string]any{"enabled": false, "rrule": ""}),
+			}
+		)
+
+		mockDB.EXPECT().
+			SetConfigurationParameter(gomock.Any(), expectedParameter).
+			Return(nil)
+
+		mockDB.EXPECT().
+			SetNextScheduledAnalysisStartTime(gomock.Any(), time.Time{}).
+			Return(nil)
+
+		reqBody, _ := json.Marshal(scheduledAnalysisRequest)
+		req := httptest.NewRequest(http.MethodPost, "/api/v2/config", bytes.NewBuffer(reqBody))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+
+		resources.SetApplicationConfiguration(rec, req)
+
+		if status := rec.Code; status != http.StatusOK {
+			t.Errorf("handler returned wrong status code: got %v want %v",
+				status, http.StatusOK)
+		}
+	})
 }

--- a/cmd/api/src/api/v2/app_config_test.go
+++ b/cmd/api/src/api/v2/app_config_test.go
@@ -28,6 +28,7 @@ import (
 
 	v2 "github.com/specterops/bloodhound/cmd/api/src/api/v2"
 	"github.com/specterops/bloodhound/cmd/api/src/database/mocks"
+	"github.com/specterops/bloodhound/cmd/api/src/database/types/null"
 	"github.com/specterops/bloodhound/cmd/api/src/model"
 	"github.com/specterops/bloodhound/cmd/api/src/model/appcfg"
 	"github.com/specterops/bloodhound/cmd/api/src/test/must"
@@ -252,7 +253,7 @@ func Test_SetApplicationConfiguration(t *testing.T) {
 		if err != nil {
 			t.Fatalf("failed to parse rrule: %v", err)
 		}
-		expectedNextAnalysis := rule.After(time.Now(), true)
+		expectedNextAnalysis := null.TimeFrom(rule.After(time.Now(), true))
 
 		mockDB.EXPECT().
 			SetConfigurationParameter(gomock.Any(), expectedParameter).
@@ -296,7 +297,7 @@ func Test_SetApplicationConfiguration(t *testing.T) {
 			Return(nil)
 
 		mockDB.EXPECT().
-			SetNextScheduledAnalysisStartTime(gomock.Any(), time.Time{}).
+			SetNextScheduledAnalysisStartTime(gomock.Any(), null.Time{}).
 			Return(nil)
 
 		reqBody, _ := json.Marshal(scheduledAnalysisRequest)

--- a/cmd/api/src/api/v2/app_config_test.go
+++ b/cmd/api/src/api/v2/app_config_test.go
@@ -231,7 +231,8 @@ func Test_SetApplicationConfiguration(t *testing.T) {
 
 	t.Run("Scheduled Analysis updates next scheduled analysis start time", func(t *testing.T) {
 		var (
-			validRRule = "RRULE:FREQ=DAILY;INTERVAL=1;DTSTART=20240101T100000Z"
+			futureTime = time.Now().Add(48 * time.Hour).Format("20060102T150405Z")
+			validRRule = fmt.Sprintf("FREQ=DAILY;INTERVAL=1;DTSTART=%s", futureTime)
 
 			scheduledAnalysisRequest = appcfg.AppConfigUpdateRequest{
 				Key: string(appcfg.ScheduledAnalysis),

--- a/cmd/api/src/daemons/datapipe/datapipe_integration_test.go
+++ b/cmd/api/src/daemons/datapipe/datapipe_integration_test.go
@@ -115,13 +115,16 @@ func setupIntegrationTestSuite(t *testing.T, fixturesPath string) IntegrationTes
 
 	cl := changelog.NewChangelog(graphDB, db, changelog.DefaultOptions())
 
+	cache, err := cache.NewCache(cache.Config{MaxSize: 1})
+	require.NoError(t, err)
+
 	return IntegrationTestSuite{
 		Context:         ctx,
 		GraphifyService: graphify.NewGraphifyService(ctx, db, graphDB, cfg, ingestSchema, cl),
 		GraphDB:         graphDB,
 		BHDatabase:      db,
 		WorkDir:         workDir,
-		Daemon:          datapipe.NewPipeline(ctx, cfg, db, graphDB, cache.Cache{}, ingestSchema, cl),
+		Daemon:          datapipe.NewPipeline(ctx, cfg, db, graphDB, cache, ingestSchema, cl),
 	}
 }
 

--- a/cmd/api/src/daemons/datapipe/pipeline.go
+++ b/cmd/api/src/daemons/datapipe/pipeline.go
@@ -263,7 +263,7 @@ func (s *BHCEPipeline) Analyze(ctx context.Context) error {
 		)()
 
 		if err := s.db.SetLastAnalysisStartTime(ctx); err != nil {
-			slog.ErrorContext(ctx, "error setting last analysis start time", attr.Error(err))
+			slog.ErrorContext(ctx, "Error setting last analysis start time", attr.Error(err))
 		}
 
 		if err := analysis.RunAnalysisOperations(ctx, s.db, s.graphdb, s.cfg); err != nil {

--- a/cmd/api/src/daemons/datapipe/pipeline.go
+++ b/cmd/api/src/daemons/datapipe/pipeline.go
@@ -262,6 +262,10 @@ func (s *BHCEPipeline) Analyze(ctx context.Context) error {
 			attr.Scope("summary"),
 		)()
 
+		if err := s.db.SetLastAnalysisStartTime(ctx); err != nil {
+			slog.ErrorContext(ctx, "error setting last analysis start time", attr.Error(err))
+		}
+
 		if err := analysis.RunAnalysisOperations(ctx, s.db, s.graphdb, s.cfg); err != nil {
 			if errors.Is(err, analysis.ErrAnalysisFailed) {
 				s.jobService.FailAnalyzedIngestJobs()

--- a/cmd/api/src/daemons/datapipe/pipeline_integration_test.go
+++ b/cmd/api/src/daemons/datapipe/pipeline_integration_test.go
@@ -248,4 +248,16 @@ func TestAnalyze_LastAnalysisTimestampUpdated(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, updatedDatapipeStatus.LastAnalysisRunAt.IsZero())
 	require.Greater(t, updatedDatapipeStatus.LastAnalysisRunAt, datapipeStatus.LastAnalysisRunAt)
+
+	// request analysis again
+	err = testSuite.BHDatabase.RequestAnalysis(ctx, "test")
+	require.NoError(t, err)
+
+	err = testSuite.Daemon.Analyze(ctx)
+	require.NoError(t, err)
+
+	// confirm that the last analysis run timestamp is updated again
+	finalDataPipeStatus, err := testSuite.BHDatabase.GetDatapipeStatus(ctx)
+	require.NoError(t, err)
+	require.Greater(t, finalDataPipeStatus.LastAnalysisRunAt, updatedDatapipeStatus.LastAnalysisRunAt)
 }

--- a/cmd/api/src/daemons/datapipe/pipeline_integration_test.go
+++ b/cmd/api/src/daemons/datapipe/pipeline_integration_test.go
@@ -222,3 +222,30 @@ func TestPartialIngest(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, edgeCount, "THIS_EDGE_GETS_CREATED was not created")
 }
+
+func TestAnalyze_LastAnalysisTimestampUpdated(t *testing.T) {
+	var (
+		ctx              = context.Background()
+		ingestedFilePath = path.Join("fixtures", "OpenGraphJSON", "raw")
+		testSuite        = setupIntegrationTestSuite(t, ingestedFilePath)
+	)
+
+	defer teardownIntegrationTestSuite(t, &testSuite)
+
+	datapipeStatus, err := testSuite.BHDatabase.GetDatapipeStatus(ctx)
+	require.NoError(t, err)
+	require.True(t, datapipeStatus.LastAnalysisRunAt.IsZero())
+
+	// request analysis so that Analyze will run
+	err = testSuite.BHDatabase.RequestAnalysis(ctx, "test")
+	require.NoError(t, err)
+
+	err = testSuite.Daemon.Analyze(ctx)
+	require.NoError(t, err)
+
+	// confirm that the last analysis run timestamp is updated
+	updatedDatapipeStatus, err := testSuite.BHDatabase.GetDatapipeStatus(ctx)
+	require.NoError(t, err)
+	require.False(t, updatedDatapipeStatus.LastAnalysisRunAt.IsZero())
+	require.Greater(t, updatedDatapipeStatus.LastAnalysisRunAt, datapipeStatus.LastAnalysisRunAt)
+}

--- a/cmd/api/src/database/datapipestatus.go
+++ b/cmd/api/src/database/datapipestatus.go
@@ -18,32 +18,49 @@ package database
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/specterops/bloodhound/cmd/api/src/model"
 )
 
 type DatapipeStatusData interface {
+	SetLastAnalysisStartTime(ctx context.Context) error
 	UpdateLastAnalysisCompleteTime(ctx context.Context) error
 	SetDatapipeStatus(ctx context.Context, status model.DatapipeStatus) error
 	GetDatapipeStatus(ctx context.Context) (model.DatapipeStatusWrapper, error)
+	SetNextScheduledAnalysisStartTime(ctx context.Context, time time.Time) error
+}
+
+// This should be called at the start of analysis processing (not every datapipe tick, but start of real work)
+func (s *BloodhoundDB) SetLastAnalysisStartTime(ctx context.Context) error {
+	var datapipeStatus model.DatapipeStatus
+	return s.db.WithContext(ctx).Exec(fmt.Sprintf(`UPDATE %s SET updated_at = current_timestamp, last_analysis_run_at = current_timestamp`, datapipeStatus.TableName())).Error
 }
 
 // This should be called at the end of a successful analysis run (not always every analysis)
 func (s *BloodhoundDB) UpdateLastAnalysisCompleteTime(ctx context.Context) error {
-	now := time.Now().UTC()
-	return s.db.WithContext(ctx).Exec("UPDATE datapipe_status SET updated_at = ?, last_complete_analysis_at = ?", now, now).Error
+	var datapipeStatus model.DatapipeStatus
+	return s.db.WithContext(ctx).Exec(fmt.Sprintf("UPDATE %s SET updated_at = current_timestamp, last_complete_analysis_at = current_timestamp", datapipeStatus.TableName())).Error
 }
 
 func (s *BloodhoundDB) SetDatapipeStatus(ctx context.Context, status model.DatapipeStatus) error {
-	now := time.Now().UTC()
-	return s.db.WithContext(ctx).Exec("UPDATE datapipe_status SET status = ?, updated_at = ?;", status, now).Error
+	var datapipeStatus model.DatapipeStatus
+	return s.db.WithContext(ctx).Exec(fmt.Sprintf("UPDATE %s SET status = ?, updated_at = current_timestamp", datapipeStatus.TableName()), status).Error
 }
 
 func (s *BloodhoundDB) GetDatapipeStatus(ctx context.Context) (model.DatapipeStatusWrapper, error) {
-	var datapipeStatus model.DatapipeStatusWrapper
+	var (
+		datapipeStatusWrapper model.DatapipeStatusWrapper
+		datapipeStatus        model.DatapipeStatus
+	)
 
-	tx := s.db.WithContext(ctx).Select("status, updated_at, last_complete_analysis_at, last_analysis_run_at").Table("datapipe_status").First(&datapipeStatus)
+	tx := s.db.WithContext(ctx).Select("status, updated_at, last_complete_analysis_at, last_analysis_run_at, next_scheduled_analysis_at").Table(datapipeStatus.TableName()).First(&datapipeStatusWrapper)
 
-	return datapipeStatus, CheckError(tx)
+	return datapipeStatusWrapper, CheckError(tx)
+}
+
+// No-op in BHCE
+func (s *BloodhoundDB) SetNextScheduledAnalysisStartTime(ctx context.Context, time time.Time) error {
+	return nil
 }

--- a/cmd/api/src/database/datapipestatus.go
+++ b/cmd/api/src/database/datapipestatus.go
@@ -19,8 +19,8 @@ package database
 import (
 	"context"
 	"fmt"
-	"time"
 
+	"github.com/specterops/bloodhound/cmd/api/src/database/types/null"
 	"github.com/specterops/bloodhound/cmd/api/src/model"
 )
 
@@ -29,7 +29,7 @@ type DatapipeStatusData interface {
 	UpdateLastAnalysisCompleteTime(ctx context.Context) error
 	SetDatapipeStatus(ctx context.Context, status model.DatapipeStatus) error
 	GetDatapipeStatus(ctx context.Context) (model.DatapipeStatusWrapper, error)
-	SetNextScheduledAnalysisStartTime(ctx context.Context, time time.Time) error
+	SetNextScheduledAnalysisStartTime(ctx context.Context, time null.Time) error
 }
 
 // This should be called at the start of analysis processing (not every datapipe tick, but start of real work)
@@ -61,6 +61,6 @@ func (s *BloodhoundDB) GetDatapipeStatus(ctx context.Context) (model.DatapipeSta
 }
 
 // No-op in BHCE
-func (s *BloodhoundDB) SetNextScheduledAnalysisStartTime(ctx context.Context, time time.Time) error {
+func (s *BloodhoundDB) SetNextScheduledAnalysisStartTime(ctx context.Context, time null.Time) error {
 	return nil
 }

--- a/cmd/api/src/database/datapipestatus_integration_test.go
+++ b/cmd/api/src/database/datapipestatus_integration_test.go
@@ -19,30 +19,61 @@
 package database_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/specterops/bloodhound/cmd/api/src/model"
-	"github.com/specterops/bloodhound/cmd/api/src/test/integration"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestDatapipeStatus(t *testing.T) {
-	var (
-		testCtx = context.Background()
-		db      = integration.SetupDB(t)
-	)
+func TestDatabase_GetDatapipeStatus(t *testing.T) {
+	testSuite := setupIntegrationTestSuite(t)
+	defer teardownIntegrationTestSuite(t, &testSuite)
 
-	status, err := db.GetDatapipeStatus(testCtx)
-	require.Nil(t, err)
-	assert.Equal(t, model.DatapipeStatusIdle, status.Status)
+	status, err := testSuite.BHDatabase.GetDatapipeStatus(testSuite.Context)
+	require.NoError(t, err)
+	require.Equal(t, model.DatapipeStatusIdle, status.Status)
+}
 
-	err = db.SetDatapipeStatus(testCtx, model.DatapipeStatusIdle)
-	require.Nil(t, err)
-	err = db.UpdateLastAnalysisCompleteTime(testCtx)
-	require.Nil(t, err)
-	status, err = db.GetDatapipeStatus(testCtx)
-	require.Nil(t, err)
-	assert.True(t, !status.LastCompleteAnalysisAt.IsZero())
+func TestDatabase_SetDatapipeStatus(t *testing.T) {
+	testSuite := setupIntegrationTestSuite(t)
+	defer teardownIntegrationTestSuite(t, &testSuite)
+
+	err := testSuite.BHDatabase.SetDatapipeStatus(testSuite.Context, model.DatapipeStatusAnalyzing)
+	require.NoError(t, err)
+
+	status, err := testSuite.BHDatabase.GetDatapipeStatus(testSuite.Context)
+	require.NoError(t, err)
+	require.Equal(t, model.DatapipeStatusAnalyzing, status.Status)
+}
+
+func TestDatabase_SetLastAnalysisStartTime(t *testing.T) {
+	testSuite := setupIntegrationTestSuite(t)
+	defer teardownIntegrationTestSuite(t, &testSuite)
+
+	status, err := testSuite.BHDatabase.GetDatapipeStatus(testSuite.Context)
+	require.NoError(t, err)
+	require.True(t, status.LastAnalysisRunAt.IsZero())
+
+	err = testSuite.BHDatabase.SetLastAnalysisStartTime(testSuite.Context)
+	require.NoError(t, err)
+
+	status, err = testSuite.BHDatabase.GetDatapipeStatus(testSuite.Context)
+	require.NoError(t, err)
+	require.False(t, status.LastAnalysisRunAt.IsZero())
+}
+
+func TestDatabase_UpdateLastAnalysisCompleteTime(t *testing.T) {
+	testSuite := setupIntegrationTestSuite(t)
+	defer teardownIntegrationTestSuite(t, &testSuite)
+
+	status, err := testSuite.BHDatabase.GetDatapipeStatus(testSuite.Context)
+	require.NoError(t, err)
+	require.True(t, status.LastCompleteAnalysisAt.IsZero())
+
+	err = testSuite.BHDatabase.UpdateLastAnalysisCompleteTime(testSuite.Context)
+	require.NoError(t, err)
+
+	status, err = testSuite.BHDatabase.GetDatapipeStatus(testSuite.Context)
+	require.NoError(t, err)
+	require.False(t, status.LastCompleteAnalysisAt.IsZero())
 }

--- a/cmd/api/src/database/migration/migrations/20260508204725_bed_8136_last_analysis_run_at.sql
+++ b/cmd/api/src/database/migration/migrations/20260508204725_bed_8136_last_analysis_run_at.sql
@@ -1,0 +1,6 @@
+-- +goose Up
+ALTER TABLE datapipe_status 
+ADD COLUMN last_scheduled_analysis_run_at 
+
+-- +goose Down
+SELECT 'down SQL query';

--- a/cmd/api/src/database/migration/migrations/20260508204725_bed_8136_last_analysis_run_at.sql
+++ b/cmd/api/src/database/migration/migrations/20260508204725_bed_8136_last_analysis_run_at.sql
@@ -1,6 +1,0 @@
--- +goose Up
-ALTER TABLE datapipe_status 
-ADD COLUMN last_scheduled_analysis_run_at 
-
--- +goose Down
-SELECT 'down SQL query';

--- a/cmd/api/src/database/migration/migrations/20260514224346_v9_add_analysis_timestamps_bed_8136.sql
+++ b/cmd/api/src/database/migration/migrations/20260514224346_v9_add_analysis_timestamps_bed_8136.sql
@@ -1,0 +1,22 @@
+-- Copyright 2026 Specter Ops, Inc.
+--
+-- Licensed under the Apache License, Version 2.0
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- SPDX-License-Identifier: Apache-2.0
+
+-- +goose Up
+ALTER TABLE datapipe_status ADD COLUMN IF NOT EXISTS next_scheduled_analysis_at timestamp with time zone;
+
+
+-- +goose Down
+ALTER TABLE datapipe_status DROP COLUMN IF EXISTS next_scheduled_analysis_at;

--- a/cmd/api/src/database/mocks/db.go
+++ b/cmd/api/src/database/mocks/db.go
@@ -3030,6 +3030,34 @@ func (mr *MockDatabaseMockRecorder) SetFlag(ctx, value any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetFlag", reflect.TypeOf((*MockDatabase)(nil).SetFlag), ctx, value)
 }
 
+// SetLastAnalysisStartTime mocks base method.
+func (m *MockDatabase) SetLastAnalysisStartTime(ctx context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetLastAnalysisStartTime", ctx)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetLastAnalysisStartTime indicates an expected call of SetLastAnalysisStartTime.
+func (mr *MockDatabaseMockRecorder) SetLastAnalysisStartTime(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetLastAnalysisStartTime", reflect.TypeOf((*MockDatabase)(nil).SetLastAnalysisStartTime), ctx)
+}
+
+// SetNextScheduledAnalysisStartTime mocks base method.
+func (m *MockDatabase) SetNextScheduledAnalysisStartTime(ctx context.Context, arg1 time.Time) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetNextScheduledAnalysisStartTime", ctx, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetNextScheduledAnalysisStartTime indicates an expected call of SetNextScheduledAnalysisStartTime.
+func (mr *MockDatabaseMockRecorder) SetNextScheduledAnalysisStartTime(ctx, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetNextScheduledAnalysisStartTime", reflect.TypeOf((*MockDatabase)(nil).SetNextScheduledAnalysisStartTime), ctx, arg1)
+}
+
 // SetUserSessionFlag mocks base method.
 func (m *MockDatabase) SetUserSessionFlag(ctx context.Context, userSession *model.UserSession, key model.SessionFlagKey, state bool) error {
 	m.ctrl.T.Helper()

--- a/cmd/api/src/database/mocks/db.go
+++ b/cmd/api/src/database/mocks/db.go
@@ -3045,7 +3045,7 @@ func (mr *MockDatabaseMockRecorder) SetLastAnalysisStartTime(ctx any) *gomock.Ca
 }
 
 // SetNextScheduledAnalysisStartTime mocks base method.
-func (m *MockDatabase) SetNextScheduledAnalysisStartTime(ctx context.Context, arg1 time.Time) error {
+func (m *MockDatabase) SetNextScheduledAnalysisStartTime(ctx context.Context, arg1 null.Time) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetNextScheduledAnalysisStartTime", ctx, arg1)
 	ret0, _ := ret[0].(error)

--- a/cmd/api/src/model/datapipestatus.go
+++ b/cmd/api/src/model/datapipestatus.go
@@ -16,7 +16,11 @@
 
 package model
 
-import "time"
+import (
+	"time"
+
+	"github.com/specterops/bloodhound/cmd/api/src/database/types/null"
+)
 
 type DatapipeStatus string
 
@@ -34,7 +38,7 @@ type DatapipeStatusWrapper struct {
 	UpdatedAt               time.Time      `json:"updated_at"`
 	LastCompleteAnalysisAt  time.Time      `json:"last_complete_analysis_at"`
 	LastAnalysisRunAt       time.Time      `json:"last_analysis_run_at"`
-	NextScheduledAnalysisAt time.Time      `json:"next_scheduled_analysis_at"`
+	NextScheduledAnalysisAt null.Time      `json:"next_scheduled_analysis_at"`
 }
 
 func (DatapipeStatus) TableName() string {

--- a/cmd/api/src/model/datapipestatus.go
+++ b/cmd/api/src/model/datapipestatus.go
@@ -30,10 +30,11 @@ const (
 )
 
 type DatapipeStatusWrapper struct {
-	Status                     DatapipeStatus `json:"status"`
-	UpdatedAt                  time.Time      `json:"updated_at"`
-	LastCompleteAnalysisAt     time.Time      `json:"last_complete_analysis_at"`
-	LastScheduledAnalysisRunAt time.Time      `json:"last_analysis_run_at" gorm:"column:last_analysis_run_at"`
+	Status                  DatapipeStatus `json:"status"`
+	UpdatedAt               time.Time      `json:"updated_at"`
+	LastCompleteAnalysisAt  time.Time      `json:"last_complete_analysis_at"`
+	LastAnalysisRunAt       time.Time      `json:"last_analysis_run_at"`
+	NextScheduledAnalysisAt time.Time      `json:"next_scheduled_analysis_at"`
 }
 
 func (DatapipeStatus) TableName() string {

--- a/cmd/api/src/utils/validation/rrule_validator.go
+++ b/cmd/api/src/utils/validation/rrule_validator.go
@@ -49,19 +49,32 @@ func (s RRuleValidator) Validate(value any) utils.Errors {
 		return append(errs, fmt.Errorf(ErrInvalidRrule, value))
 	}
 
-	//Validate that the rrule is a good rule. We're going to require a DTSTART to keep scheduling consistent.
-	//We're also going to reject UNTIL/COUNT because it will most likely break the pipeline once it's hit without being invalid
 	if rruleStr == "" {
 		return nil
-	} else if _, err := rrule.StrToRRule(rruleStr); err != nil {
-		return append(errs, fmt.Errorf(ErrInvalidRrule, err))
-	} else if strings.Contains(strings.ToUpper(rruleStr), "UNTIL") {
-		return append(errs, fmt.Errorf(ErrInvalidRrule, "until not supported"))
-	} else if strings.Contains(strings.ToUpper(rruleStr), "COUNT") {
-		return append(errs, fmt.Errorf(ErrInvalidRrule, "count not supported"))
-	} else if !strings.Contains(strings.ToUpper(rruleStr), "DTSTART") {
-		return append(errs, fmt.Errorf(ErrInvalidRrule, "dtstart is required"))
+	}
+
+	if _, err := ValidateRRule(rruleStr); err != nil {
+		return append(errs, err)
 	}
 
 	return nil
+}
+
+// ValidateRRule validates that the rrule string is parseable and conforms to scheduling constraints.
+// Valid rules require a DTSTART to keep scheduling consistent.
+// Valid rules must not contain UNTIL or COUNT because they will break the pipeline once exhausted.
+func ValidateRRule(rruleStr string) (*rrule.RRule, error) {
+	var upperRRule = strings.ToUpper(rruleStr)
+
+	if rule, err := rrule.StrToRRule(rruleStr); err != nil {
+		return nil, fmt.Errorf(ErrInvalidRrule, err)
+	} else if strings.Contains(upperRRule, "UNTIL") {
+		return nil, fmt.Errorf(ErrInvalidRrule, "until not supported")
+	} else if strings.Contains(upperRRule, "COUNT") {
+		return nil, fmt.Errorf(ErrInvalidRrule, "count not supported")
+	} else if !strings.Contains(upperRRule, "DTSTART") {
+		return nil, fmt.Errorf(ErrInvalidRrule, "dtstart is required")
+	} else {
+		return rule, nil
+	}
 }

--- a/packages/go/openapi/doc/openapi.json
+++ b/packages/go/openapi/doc/openapi.json
@@ -13983,7 +13983,8 @@
                         },
                         "next_scheduled_analysis_at": {
                           "type": "string",
-                          "format": "date-time"
+                          "format": "date-time",
+                          "description": "The next time a scheduled analysis will run. Note this field is Enterprise-Only."
                         }
                       }
                     }

--- a/packages/go/openapi/doc/openapi.json
+++ b/packages/go/openapi/doc/openapi.json
@@ -13976,6 +13976,14 @@
                         "last_complete_analysis_at": {
                           "type": "string",
                           "format": "date-time"
+                        },
+                        "last_analysis_run_at": {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        "next_scheduled_analysis_at": {
+                          "type": "string",
+                          "format": "date-time"
                         }
                       }
                     }

--- a/packages/go/openapi/src/paths/datapipe.datapipe.status.yaml
+++ b/packages/go/openapi/src/paths/datapipe.datapipe.status.yaml
@@ -49,6 +49,7 @@ get:
                   next_scheduled_analysis_at:
                     type: string
                     format: date-time
+                    description: The next time a scheduled analysis will run. Note this field is Enterprise-Only.
     401:
       $ref: './../responses/unauthorized.yaml'
     429:

--- a/packages/go/openapi/src/paths/datapipe.datapipe.status.yaml
+++ b/packages/go/openapi/src/paths/datapipe.datapipe.status.yaml
@@ -43,6 +43,12 @@ get:
                   last_complete_analysis_at:
                     type: string
                     format: date-time
+                  last_analysis_run_at: 
+                    type: string
+                    format: date-time
+                  next_scheduled_analysis_at:
+                    type: string
+                    format: date-time
     401:
       $ref: './../responses/unauthorized.yaml'
     429:


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

We decided to change the `last_analysis_run_at` field to update every time analysis runs, instead of only using it to track scheduled analysis in BHE. This required a re-work of how scheduled analysis works, but since the `datapipe_status` table lives in both BHE and BHCE, some changes had to be made here as well. 

We also want to make sure we are updating the `next_scheduled_analysis_at` timestamp every time we set the `analysis.scheduled` parameter. Because this handler lives in BHCE, we needed to do some interesting things here with the database interface (since there is no concept of scheduled analysis in BHCE). The real implementation lives on the BHE side, but must be called from BHCE. 

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-8136

Updates `last_analysis_run_at` every time analysis starts.

## How Has This Been Tested?

Tested manually by running analysis and ensuring the timestamp is updated. Also added some more unit & integration tests.

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)
- Database Migrations

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Validates scheduled-analysis recurrence rules, persists configuration, and stores the next scheduled run time
  * Records analysis start timestamps and exposes last/next analysis times in API responses
* **Documentation**
  * OpenAPI schema updated to include last/next analysis timestamp fields
* **Tests**
  * Expanded coverage for scheduled-analysis handlers, configuration updates, datapipe status, and timestamp behavior
* **Chores**
  * Database migration adds a next-scheduled-analysis timestamp column
<!-- end of auto-generated comment: release notes by coderabbit.ai -->