### PR TITLE
feat: add HTTP request and labeled response size metrics BED-8498

### DIFF
--- a/cmd/api/src/api/middleware/metrics.go
+++ b/cmd/api/src/api/middleware/metrics.go
@@ -69,18 +69,28 @@ var (
 		},
 		[]string{"code", "method", "handler"},
 	)
-
-	// ApiResponseSize is a zero-dimensional ObserverVec. If ever extended,
-	// follow the same "handler"-label rules rather than adding a path label.
-	ApiResponseSize = prometheus.NewHistogramVec(
-		prometheus.HistogramOpts{
+	// ApiResponseSize is partitioned by HTTP method and response code. It records
+  	// response size observations and exports count and sum without quantile objectives.
+	ApiResponseSize = prometheus.NewSummaryVec(
+		prometheus.SummaryOpts{
 			Namespace: model.Namespace,
 			Subsystem: "api",
 			Name:      "response_size_bytes",
-			Help:      "A histogram of response sizes for requests.",
-			Buckets:   []float64{200, 500, 900, 1500},
+			Help:      "Tracks the size of HTTP response.",
 		},
-		[]string{},
+		[]string{"method", "code"},
+	)
+
+	// ApiRequestSize is partitioned by HTTP method and response code. It records
+  	// request size observations and exports count and sum without quantile objectives.
+	ApiRequestSize = prometheus.NewSummaryVec(
+		prometheus.SummaryOpts{
+			Namespace: model.Namespace,
+			Subsystem: "api",
+			Name:      "request_size_bytes",
+			Help:      "Tracks the size of HTTP requests.",
+		},
+		[]string{"method", "code"},
 	)
 )
 
@@ -94,6 +104,8 @@ func RegisterApiMiddlewareMetrics(registry prometheus.Registerer) error {
 	} else if err = registry.Register(ApiRequestDuration); err != nil {
 		return err
 	} else if err = registry.Register(ApiResponseSize); err != nil {
+		return err
+	} else if err = registry.Register(ApiRequestSize); err != nil {
 		return err
 	}
 	return nil

--- a/cmd/api/src/api/middleware/metrics.go
+++ b/cmd/api/src/api/middleware/metrics.go
@@ -70,7 +70,7 @@ var (
 		[]string{"code", "method", "handler"},
 	)
 	// ApiResponseSize is partitioned by HTTP method and response code. It records
-  	// response size observations and exports count and sum without quantile objectives.
+	// response size observations and exports count and sum without quantile objectives.
 	ApiResponseSize = prometheus.NewSummaryVec(
 		prometheus.SummaryOpts{
 			Namespace: model.Namespace,
@@ -82,7 +82,7 @@ var (
 	)
 
 	// ApiRequestSize is partitioned by HTTP method and response code. It records
-  	// request size observations and exports count and sum without quantile objectives.
+	// request size observations and exports count and sum without quantile objectives.
 	ApiRequestSize = prometheus.NewSummaryVec(
 		prometheus.SummaryOpts{
 			Namespace: model.Namespace,

--- a/cmd/api/src/api/middleware/middleware.go
+++ b/cmd/api/src/api/middleware/middleware.go
@@ -406,7 +406,9 @@ func MetricsMiddleware(muxRouter *mux.Router) mux.MiddlewareFunc {
 			promhttp.InstrumentHandlerInFlight(ApiInFlightGauge,
 				promhttp.InstrumentHandlerDuration(curriedDuration,
 					promhttp.InstrumentHandlerCounter(ApiTotalRequests,
-						promhttp.InstrumentHandlerResponseSize(ApiResponseSize, next),
+						promhttp.InstrumentHandlerRequestSize(ApiRequestSize,
+							promhttp.InstrumentHandlerResponseSize(ApiResponseSize, next),
+						),
 					),
 				),
 			).ServeHTTP(w, r)


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

This change adds Prometheus tracking for HTTP request sizes and updates response size tracking to report method and status code labels. It wires the new request size instrumentation into the API middleware and registers the `request_size_bytes` metric alongside the existing API middleware metrics.

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves: BED-8498

## How Has This Been Tested?
Tested locally, users should be able to query `_count` & `_sum` on both metrics.

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)
- Database Migrations

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced API metrics: request body sizes are now tracked and response size metrics were upgraded to provide per-endpoint visibility.
  * Metrics are labeled by HTTP method and response code, improving monitoring granularity and observability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->