### PR TITLE
fix: revert change to minItems for the kind array on OG node schema BED-8540

### DIFF
--- a/cmd/api/src/services/upload/jsonschema/node.json
+++ b/cmd/api/src/services/upload/jsonschema/node.json
@@ -63,7 +63,7 @@
       "items": {
         "type": "string"
       },
-      "minItems": 1,
+      "minItems": 0,
       "maxItems": 3,
       "description": "An array of kind labels for the node. The first element is treated as the node's primary kind and is used to determine which icon to display in the graph UI. This primary kind is only used for visual representation and has no semantic significance for data processing."
     }


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

This change needs to be reverted to avoid changing the API contract. It was made as part of BED-8080 (#2750)
 and changed by mistake. 

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves https://specterops.atlassian.net/browse/BED-8540

## Types of changes

<!-- Please remove any items that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Relaxed validation constraints to allow nodes with empty configuration arrays, enabling more flexible setup options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->