### PR TITLE
chore: Bump examples, test fixtures to use PG18 - BED-8581

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -35,7 +35,7 @@ services:
       - debug-api
       - pg-only
       - sso
-    image: docker.io/library/postgres:16
+    image: docker.io/library/postgres:18
     command: -c config_file=/etc/postgresql.conf
     shm_size: 1gb
     environment:
@@ -46,7 +46,7 @@ services:
     ports:
       - ${BH_POSTGRES_PORT:-127.0.0.1:5432}:5432
     volumes:
-      - ${BH_POSTGRES_VOLUME:-postgres-data}:/var/lib/postgresql/data
+      - ${BH_POSTGRES_VOLUME:-postgres-data}:/var/lib/postgresql
       - ${BH_POSTGRES_CONFIG:-./local-harnesses/postgresql.conf}:/etc/postgresql.conf
     healthcheck:
       test:

--- a/docker-compose.testing.yml
+++ b/docker-compose.testing.yml
@@ -17,7 +17,7 @@
 services:
   testdb:
     restart: unless-stopped
-    image: docker.io/library/postgres:16
+    image: docker.io/library/postgres:18
     command: -c config_file=/etc/postgresql.conf
     shm_size: 1gb
     environment:
@@ -27,7 +27,7 @@ services:
     ports:
       - 127.0.0.1:65432:5432
     volumes:
-      - test-postgres-data:/var/lib/postgresql/data
+      - test-postgres-data:/var/lib/postgresql
       - ${BH_POSTGRES_CONFIG:-./local-harnesses/postgresql.conf}:/etc/postgresql.conf
 
   testgraph:

--- a/examples/docker-compose/docker-compose.yml
+++ b/examples/docker-compose/docker-compose.yml
@@ -16,7 +16,7 @@
 
 services:
   app-db:
-    image: docker.io/library/postgres:16
+    image: docker.io/library/postgres:18
     environment:
       - PGUSER=${POSTGRES_USER:-bloodhound}
       - POSTGRES_USER=${POSTGRES_USER:-bloodhound}
@@ -26,7 +26,7 @@ services:
     # ports:
     #   - 127.0.0.1:${POSTGRES_PORT:-5432}:5432
     volumes:
-      - postgres-data:/var/lib/postgresql/data
+      - postgres-data:/var/lib/postgresql
     healthcheck:
       test:
         [

--- a/examples/helm/templates/deployappdb.yaml
+++ b/examples/helm/templates/deployappdb.yaml
@@ -60,7 +60,7 @@ spec:
         {{- if .Values.appdb.volumes.pvcEnabled }}
         volumeMounts:
         - name: postgres-data
-          mountPath: /var/lib/postgresql/data
+          mountPath: /var/lib/postgresql
         {{- end }}
       {{- if .Values.appdb.volumes.pvcEnabled }}
       volumes:

--- a/examples/helm/values.yaml
+++ b/examples/helm/values.yaml
@@ -22,7 +22,7 @@ appdb:
   appName: postgres
   container:
     name: postgres
-    image: docker.io/library/postgres:16
+    image: docker.io/library/postgres:18
     env:
       POSTGRES_USER: "bloodhound"
       POSTGRES_PASSWORD: "bloodhoundcommunityedition"


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Bumps example docs to utilize PG18.

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-8581

*Why is this change required? What problem does it solve?*

## How Has This Been Tested?

BHE hosted fleet utilizes PG18. Additionally, re-an `bh-dev` stacks, and ran/completed full local test runs.

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [X] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [X] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [X] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded PostgreSQL across development, testing, Helm, and example deployments from version 16 to version 18.
  * Adjusted database volume mount paths across all deployment and example configurations to match PostgreSQL 18 expectations.
  * Aligned deployment and example manifests to ensure consistent runtime behavior with the updated database image.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->