### PR TITLE
chore: removed tmp package as it passed age gate BED-8585

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -23,11 +23,6 @@ nodeLinker: node-modules
 
 npmMinimalAgeGate: 3d
 
-# tmp@0.2.6 is pinned in package.json for CVE-2026-44705.
-# TODO: this can be removed after the age gate passes.
-npmPreapprovedPackages:
-  - tmp
-
 npmAuditIgnoreAdvisories:
   - '1101851' # fix not currently available - https://github.com/advisories/GHSA-2p57-rm9w-gvfp
 


### PR DESCRIPTION
## Description

This removes the tmp package from the pre approved packages.

## Motivation and Context

Resolves [BED-8585](https://specterops.atlassian.net/browse/BED-8585)

The age gate has passed from this vulnerability and we should remove the tmp package.

## How Has This Been Tested?
Manually

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


[BED-8585]: https://specterops.atlassian.net/browse/BED-8585?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ