### PR TITLE
chore: update onstart migration to push node kinds to cnk table BED-8533

### DIFF
--- a/cmd/api/src/database/customnode_integration_test.go
+++ b/cmd/api/src/database/customnode_integration_test.go
@@ -147,24 +147,21 @@ func TestCreateCustomNodeKinds(t *testing.T) {
 
 func TestGetCustomNodeKinds(t *testing.T) {
 	tests := []struct {
-		name    string
-		setup   func() IntegrationTestSuite
-		wantLen int
-		wantErr error
+		name        string
+		setup       func() (IntegrationTestSuite, int)
+		baselineLen int
+		wantLen     int
+		wantErr     error
 	}{
 		{
-			name: "success - returns empty list when none exist",
-			setup: func() IntegrationTestSuite {
-				return setupIntegrationTestSuite(t)
-			},
-			wantLen: 0,
-			wantErr: nil,
-		},
-		{
 			name: "success - returns all created kinds",
-			setup: func() IntegrationTestSuite {
+			setup: func() (IntegrationTestSuite, int) {
 				testSuite := setupIntegrationTestSuite(t)
-				_, err := testSuite.BHDatabase.CreateCustomNodeKinds(testSuite.Context, model.CustomNodeKinds{
+
+				baselineKinds, err := testSuite.BHDatabase.GetCustomNodeKinds(testSuite.Context, nil)
+				require.NoError(t, err)
+
+				_, err = testSuite.BHDatabase.CreateCustomNodeKinds(testSuite.Context, model.CustomNodeKinds{
 					{
 						KindName: "KindOne",
 						Config: model.CustomNodeKindConfig{
@@ -179,7 +176,7 @@ func TestGetCustomNodeKinds(t *testing.T) {
 					},
 				})
 				require.NoError(t, err)
-				return testSuite
+				return testSuite, len(baselineKinds)
 			},
 			wantLen: 2,
 			wantErr: nil,
@@ -188,7 +185,7 @@ func TestGetCustomNodeKinds(t *testing.T) {
 
 	for _, testCase := range tests {
 		t.Run(testCase.name, func(t *testing.T) {
-			testSuite := testCase.setup()
+			testSuite, baselineLen := testCase.setup()
 			defer teardownIntegrationTestSuite(t, &testSuite)
 
 			kinds, err := testSuite.BHDatabase.GetCustomNodeKinds(testSuite.Context, nil)
@@ -196,7 +193,7 @@ func TestGetCustomNodeKinds(t *testing.T) {
 				assert.EqualError(t, err, testCase.wantErr.Error())
 			} else {
 				require.NoError(t, err)
-				assert.Len(t, kinds, testCase.wantLen)
+				assert.Len(t, kinds, testCase.wantLen+baselineLen)
 			}
 		})
 	}

--- a/cmd/api/src/database/migration/extensions/ad_graph_schema.sql
+++ b/cmd/api/src/database/migration/extensions/ad_graph_schema.sql
@@ -63,6 +63,26 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
+CREATE OR REPLACE FUNCTION genscript_upsert_custom_node_kind(v_kind_name VARCHAR(256), v_config JSONB) RETURNS void AS $$
+DECLARE
+	retrieved_kind_id SMALLINT;
+	retrieved_schema_node_kind_id INTEGER;
+BEGIN
+	SELECT id INTO retrieved_kind_id FROM kind WHERE name = v_kind_name;
+	IF retrieved_kind_id IS NULL THEN
+		SELECT genscript_upsert_kind(v_kind_name) INTO retrieved_kind_id;
+	END IF;
+
+	SELECT id INTO retrieved_schema_node_kind_id FROM schema_node_kinds WHERE kind_id = retrieved_kind_id;
+
+	IF NOT EXISTS (SELECT id FROM custom_node_kinds cnk WHERE cnk.kind_id = retrieved_kind_id) THEN
+		INSERT INTO custom_node_kinds (kind_id, config, schema_node_kind_id, created_at, updated_at) VALUES (retrieved_kind_id, v_config, retrieved_schema_node_kind_id, NOW(), NOW());
+	ELSE
+		UPDATE custom_node_kinds SET config = v_config, schema_node_kind_id = retrieved_schema_node_kind_id, updated_at = NOW() WHERE kind_id = retrieved_kind_id;
+	END IF;
+END;
+$$ LANGUAGE plpgsql;
+
 CREATE OR REPLACE FUNCTION genscript_upsert_schema_relationship_kind(v_extension_id INT, v_kind_name VARCHAR(256), v_description TEXT, v_is_traversable BOOLEAN) RETURNS void AS $$
 DECLARE
 	retrieved_kind_id SMALLINT;
@@ -257,6 +277,21 @@ BEGIN
 	PERFORM genscript_upsert_schema_node_kind(extension_id, 'CertTemplate', 'CertTemplate', '', true, 'id-card', '#B153F3');
 	PERFORM genscript_upsert_schema_node_kind(extension_id, 'IssuancePolicy', 'IssuancePolicy', '', true, 'clipboard-check', '#99B2DD');
 
+	-- Keep custom_node_kinds in sync with node kinds
+	PERFORM genscript_upsert_custom_node_kind('User', '{"icon": {"name": "user", "type": "font-awesome", "color": "#17E625"}}');
+	PERFORM genscript_upsert_custom_node_kind('Computer', '{"icon": {"name": "desktop", "type": "font-awesome", "color": "#E67873"}}');
+	PERFORM genscript_upsert_custom_node_kind('Group', '{"icon": {"name": "users", "type": "font-awesome", "color": "#DBE617"}}');
+	PERFORM genscript_upsert_custom_node_kind('GPO', '{"icon": {"name": "list", "type": "font-awesome", "color": "#998EFD"}}');
+	PERFORM genscript_upsert_custom_node_kind('OU', '{"icon": {"name": "sitemap", "type": "font-awesome", "color": "#FFAA00"}}');
+	PERFORM genscript_upsert_custom_node_kind('Container', '{"icon": {"name": "box", "type": "font-awesome", "color": "#F79A78"}}');
+	PERFORM genscript_upsert_custom_node_kind('Domain', '{"icon": {"name": "globe", "type": "font-awesome", "color": "#17E6B9"}}');
+	PERFORM genscript_upsert_custom_node_kind('AIACA', '{"icon": {"name": "arrows-left-right-to-line", "type": "font-awesome", "color": "#9769F0"}}');
+	PERFORM genscript_upsert_custom_node_kind('RootCA', '{"icon": {"name": "landmark", "type": "font-awesome", "color": "#6968E8"}}');
+	PERFORM genscript_upsert_custom_node_kind('EnterpriseCA', '{"icon": {"name": "building", "type": "font-awesome", "color": "#4696E9"}}');
+	PERFORM genscript_upsert_custom_node_kind('NTAuthStore', '{"icon": {"name": "store", "type": "font-awesome", "color": "#D575F5"}}');
+	PERFORM genscript_upsert_custom_node_kind('CertTemplate', '{"icon": {"name": "id-card", "type": "font-awesome", "color": "#B153F3"}}');
+	PERFORM genscript_upsert_custom_node_kind('IssuancePolicy', '{"icon": {"name": "clipboard-check", "type": "font-awesome", "color": "#99B2DD"}}');
+
 	PERFORM genscript_upsert_schema_relationship_kind(extension_id, 'Owns', '', true);
 	PERFORM genscript_upsert_schema_relationship_kind(extension_id, 'GenericAll', '', true);
 	PERFORM genscript_upsert_schema_relationship_kind(extension_id, 'GenericWrite', '', true);
@@ -354,6 +389,7 @@ END $$;
 DROP FUNCTION IF EXISTS genscript_upsert_kind;
 DROP FUNCTION IF EXISTS genscript_upsert_source_kind;
 DROP FUNCTION IF EXISTS genscript_upsert_schema_node_kind;
+DROP FUNCTION IF EXISTS genscript_upsert_custom_node_kind;
 DROP FUNCTION IF EXISTS genscript_upsert_schema_relationship_kind;
 DROP FUNCTION IF EXISTS genscript_upsert_schema_environments;
 DROP FUNCTION IF EXISTS genscript_upsert_schema_environments_principal_kinds;

--- a/cmd/api/src/database/migration/extensions/ad_graph_schema.sql
+++ b/cmd/api/src/database/migration/extensions/ad_graph_schema.sql
@@ -75,10 +75,10 @@ BEGIN
 
 	SELECT id INTO retrieved_schema_node_kind_id FROM schema_node_kinds WHERE kind_id = retrieved_kind_id;
 
-	IF NOT EXISTS (SELECT id FROM custom_node_kinds cnk WHERE cnk.kind_id = retrieved_kind_id) THEN
-		INSERT INTO custom_node_kinds (kind_id, config, schema_node_kind_id, created_at, updated_at) VALUES (retrieved_kind_id, v_config, retrieved_schema_node_kind_id, NOW(), NOW());
+	IF NOT EXISTS (SELECT id FROM custom_node_kinds cnk WHERE cnk.kind_name = v_kind_name) THEN
+		INSERT INTO custom_node_kinds (kind_name, config, schema_node_kind_id, created_at, updated_at) VALUES (v_kind_name, v_config, retrieved_schema_node_kind_id, NOW(), NOW());
 	ELSE
-		UPDATE custom_node_kinds SET config = v_config, schema_node_kind_id = retrieved_schema_node_kind_id, updated_at = NOW() WHERE kind_id = retrieved_kind_id;
+		UPDATE custom_node_kinds SET config = v_config, schema_node_kind_id = retrieved_schema_node_kind_id, updated_at = NOW() WHERE kind_name = v_kind_name;
 	END IF;
 END;
 $$ LANGUAGE plpgsql;

--- a/cmd/api/src/database/migration/extensions/az_graph_schema.sql
+++ b/cmd/api/src/database/migration/extensions/az_graph_schema.sql
@@ -75,10 +75,10 @@ BEGIN
 
 	SELECT id INTO retrieved_schema_node_kind_id FROM schema_node_kinds WHERE kind_id = retrieved_kind_id;
 
-	IF NOT EXISTS (SELECT id FROM custom_node_kinds cnk WHERE cnk.kind_id = retrieved_kind_id) THEN
-		INSERT INTO custom_node_kinds (kind_id, config, schema_node_kind_id, created_at, updated_at) VALUES (retrieved_kind_id, v_config, retrieved_schema_node_kind_id, NOW(), NOW());
+	IF NOT EXISTS (SELECT id FROM custom_node_kinds cnk WHERE cnk.kind_name = v_kind_name) THEN
+		INSERT INTO custom_node_kinds (kind_name, config, schema_node_kind_id, created_at, updated_at) VALUES (v_kind_name, v_config, retrieved_schema_node_kind_id, NOW(), NOW());
 	ELSE
-		UPDATE custom_node_kinds SET config = v_config, schema_node_kind_id = retrieved_schema_node_kind_id, updated_at = NOW() WHERE kind_id = retrieved_kind_id;
+		UPDATE custom_node_kinds SET config = v_config, schema_node_kind_id = retrieved_schema_node_kind_id, updated_at = NOW() WHERE kind_name = v_kind_name;
 	END IF;
 END;
 $$ LANGUAGE plpgsql;

--- a/cmd/api/src/database/migration/extensions/az_graph_schema.sql
+++ b/cmd/api/src/database/migration/extensions/az_graph_schema.sql
@@ -63,6 +63,26 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
+CREATE OR REPLACE FUNCTION genscript_upsert_custom_node_kind(v_kind_name VARCHAR(256), v_config JSONB) RETURNS void AS $$
+DECLARE
+	retrieved_kind_id SMALLINT;
+	retrieved_schema_node_kind_id INTEGER;
+BEGIN
+	SELECT id INTO retrieved_kind_id FROM kind WHERE name = v_kind_name;
+	IF retrieved_kind_id IS NULL THEN
+		SELECT genscript_upsert_kind(v_kind_name) INTO retrieved_kind_id;
+	END IF;
+
+	SELECT id INTO retrieved_schema_node_kind_id FROM schema_node_kinds WHERE kind_id = retrieved_kind_id;
+
+	IF NOT EXISTS (SELECT id FROM custom_node_kinds cnk WHERE cnk.kind_id = retrieved_kind_id) THEN
+		INSERT INTO custom_node_kinds (kind_id, config, schema_node_kind_id, created_at, updated_at) VALUES (retrieved_kind_id, v_config, retrieved_schema_node_kind_id, NOW(), NOW());
+	ELSE
+		UPDATE custom_node_kinds SET config = v_config, schema_node_kind_id = retrieved_schema_node_kind_id, updated_at = NOW() WHERE kind_id = retrieved_kind_id;
+	END IF;
+END;
+$$ LANGUAGE plpgsql;
+
 CREATE OR REPLACE FUNCTION genscript_upsert_schema_relationship_kind(v_extension_id INT, v_kind_name VARCHAR(256), v_description TEXT, v_is_traversable BOOLEAN) RETURNS void AS $$
 DECLARE
 	retrieved_kind_id SMALLINT;
@@ -231,6 +251,28 @@ BEGIN
 	PERFORM genscript_upsert_schema_node_kind(extension_id, 'AZAutomationAccount', 'AZAutomationAccount', '', true, 'cog', '#F4BA44');
 	PERFORM genscript_upsert_schema_node_kind(extension_id, 'AZFederatedIdentityCredential', 'AZFederatedIdentityCredential', '', true, 'key', '#FFEE8C');
 
+	-- Keep custom_node_kinds in sync with node kinds
+	PERFORM genscript_upsert_custom_node_kind('AZVMScaleSet', '{"icon": {"name": "server", "type": "font-awesome", "color": "#007CD0"}}');
+	PERFORM genscript_upsert_custom_node_kind('AZApp', '{"icon": {"name": "window-restore", "type": "font-awesome", "color": "#03FC84"}}');
+	PERFORM genscript_upsert_custom_node_kind('AZRole', '{"icon": {"name": "clipboard-list", "type": "font-awesome", "color": "#ED8537"}}');
+	PERFORM genscript_upsert_custom_node_kind('AZDevice', '{"icon": {"name": "desktop", "type": "font-awesome", "color": "#B18FCF"}}');
+	PERFORM genscript_upsert_custom_node_kind('AZFunctionApp', '{"icon": {"name": "bolt", "type": "font-awesome", "color": "#F4BA44"}}');
+	PERFORM genscript_upsert_custom_node_kind('AZGroup', '{"icon": {"name": "users", "type": "font-awesome", "color": "#F57C9B"}}');
+	PERFORM genscript_upsert_custom_node_kind('AZKeyVault', '{"icon": {"name": "lock", "type": "font-awesome", "color": "#ED658C"}}');
+	PERFORM genscript_upsert_custom_node_kind('AZManagementGroup', '{"icon": {"name": "sitemap", "type": "font-awesome", "color": "#BD93D8"}}');
+	PERFORM genscript_upsert_custom_node_kind('AZResourceGroup', '{"icon": {"name": "cube", "type": "font-awesome", "color": "#89BD9E"}}');
+	PERFORM genscript_upsert_custom_node_kind('AZServicePrincipal', '{"icon": {"name": "robot", "type": "font-awesome", "color": "#C1D6D6"}}');
+	PERFORM genscript_upsert_custom_node_kind('AZSubscription', '{"icon": {"name": "key", "type": "font-awesome", "color": "#D2CCA1"}}');
+	PERFORM genscript_upsert_custom_node_kind('AZTenant', '{"icon": {"name": "cloud", "type": "font-awesome", "color": "#54F2F2"}}');
+	PERFORM genscript_upsert_custom_node_kind('AZUser', '{"icon": {"name": "user", "type": "font-awesome", "color": "#34D2EB"}}');
+	PERFORM genscript_upsert_custom_node_kind('AZVM', '{"icon": {"name": "desktop", "type": "font-awesome", "color": "#F9ADA0"}}');
+	PERFORM genscript_upsert_custom_node_kind('AZManagedCluster', '{"icon": {"name": "cubes", "type": "font-awesome", "color": "#326CE5"}}');
+	PERFORM genscript_upsert_custom_node_kind('AZContainerRegistry', '{"icon": {"name": "box-open", "type": "font-awesome", "color": "#0885D7"}}');
+	PERFORM genscript_upsert_custom_node_kind('AZWebApp', '{"icon": {"name": "object-group", "type": "font-awesome", "color": "#4696E9"}}');
+	PERFORM genscript_upsert_custom_node_kind('AZLogicApp', '{"icon": {"name": "sitemap", "type": "font-awesome", "color": "#9EE047"}}');
+	PERFORM genscript_upsert_custom_node_kind('AZAutomationAccount', '{"icon": {"name": "cog", "type": "font-awesome", "color": "#F4BA44"}}');
+	PERFORM genscript_upsert_custom_node_kind('AZFederatedIdentityCredential', '{"icon": {"name": "key", "type": "font-awesome", "color": "#FFEE8C"}}');
+
 	PERFORM genscript_upsert_schema_relationship_kind(extension_id, 'AZAvereContributor', '', true);
 	PERFORM genscript_upsert_schema_relationship_kind(extension_id, 'AZContains', '', true);
 	PERFORM genscript_upsert_schema_relationship_kind(extension_id, 'AZContributor', '', true);
@@ -293,6 +335,7 @@ END $$;
 DROP FUNCTION IF EXISTS genscript_upsert_kind;
 DROP FUNCTION IF EXISTS genscript_upsert_source_kind;
 DROP FUNCTION IF EXISTS genscript_upsert_schema_node_kind;
+DROP FUNCTION IF EXISTS genscript_upsert_custom_node_kind;
 DROP FUNCTION IF EXISTS genscript_upsert_schema_relationship_kind;
 DROP FUNCTION IF EXISTS genscript_upsert_schema_environments;
 DROP FUNCTION IF EXISTS genscript_upsert_schema_environments_principal_kinds;

--- a/cmd/api/src/database/migration/extensions_integration_test.go
+++ b/cmd/api/src/database/migration/extensions_integration_test.go
@@ -163,6 +163,25 @@ func TestExtensions_GetOnStartExtensionData(t *testing.T) {
 		validateEnvironmentKind(t, extension.Name, environmentKind[0].Name)
 	}
 
+	// Validate all display schema node kinds are present in custom_node_kinds
+	displaySchemaNodeKinds, _, err := testSuite.BHDatabase.GetGraphSchemaNodeKinds(
+		testSuite.Context,
+		model.Filters{"is_display_kind": []model.Filter{{Operator: model.Equals, Value: "true", SetOperator: model.FilterAnd}}},
+		model.Sort{}, 0, 0,
+	)
+	require.NoError(t, err)
+
+	customNodeKinds, err := testSuite.BHDatabase.GetCustomNodeKinds(testSuite.Context, nil)
+	require.NoError(t, err)
+
+	customNodeKindNames := make(map[string]struct{}, len(customNodeKinds))
+	for _, cnk := range customNodeKinds {
+		customNodeKindNames[cnk.KindName] = struct{}{}
+	}
+
+	for _, snk := range displaySchemaNodeKinds {
+		require.Contains(t, customNodeKindNames, snk.Name, "display schema node kind %q should have a corresponding custom_node_kind entry", snk.Name)
+	}
 }
 
 func validateEnvironmentKind(t *testing.T, extensionName, environmentKindName string) {

--- a/packages/go/schemagen/generator/sql.go
+++ b/packages/go/schemagen/generator/sql.go
@@ -247,10 +247,10 @@ BEGIN
 
 	SELECT id INTO retrieved_schema_node_kind_id FROM schema_node_kinds WHERE kind_id = retrieved_kind_id;
 
-	IF NOT EXISTS (SELECT id FROM custom_node_kinds cnk WHERE cnk.kind_id = retrieved_kind_id) THEN
-		INSERT INTO custom_node_kinds (kind_id, config, schema_node_kind_id, created_at, updated_at) VALUES (retrieved_kind_id, v_config, retrieved_schema_node_kind_id, NOW(), NOW());
+	IF NOT EXISTS (SELECT id FROM custom_node_kinds cnk WHERE cnk.kind_name = v_kind_name) THEN
+		INSERT INTO custom_node_kinds (kind_name, config, schema_node_kind_id, created_at, updated_at) VALUES (v_kind_name, v_config, retrieved_schema_node_kind_id, NOW(), NOW());
 	ELSE
-		UPDATE custom_node_kinds SET config = v_config, schema_node_kind_id = retrieved_schema_node_kind_id, updated_at = NOW() WHERE kind_id = retrieved_kind_id;
+		UPDATE custom_node_kinds SET config = v_config, schema_node_kind_id = retrieved_schema_node_kind_id, updated_at = NOW() WHERE kind_name = v_kind_name;
 	END IF;
 END;
 $$ LANGUAGE plpgsql;

--- a/packages/go/schemagen/generator/sql.go
+++ b/packages/go/schemagen/generator/sql.go
@@ -235,6 +235,28 @@ $$ LANGUAGE plpgsql;
 `)
 
 	sb.WriteString(`
+CREATE OR REPLACE FUNCTION genscript_upsert_custom_node_kind(v_kind_name VARCHAR(256), v_config JSONB) RETURNS void AS $$
+DECLARE
+	retrieved_kind_id SMALLINT;
+	retrieved_schema_node_kind_id INTEGER;
+BEGIN
+	SELECT id INTO retrieved_kind_id FROM kind WHERE name = v_kind_name;
+	IF retrieved_kind_id IS NULL THEN
+		SELECT genscript_upsert_kind(v_kind_name) INTO retrieved_kind_id;
+	END IF;
+
+	SELECT id INTO retrieved_schema_node_kind_id FROM schema_node_kinds WHERE kind_id = retrieved_kind_id;
+
+	IF NOT EXISTS (SELECT id FROM custom_node_kinds cnk WHERE cnk.kind_id = retrieved_kind_id) THEN
+		INSERT INTO custom_node_kinds (kind_id, config, schema_node_kind_id, created_at, updated_at) VALUES (retrieved_kind_id, v_config, retrieved_schema_node_kind_id, NOW(), NOW());
+	ELSE
+		UPDATE custom_node_kinds SET config = v_config, schema_node_kind_id = retrieved_schema_node_kind_id, updated_at = NOW() WHERE kind_id = retrieved_kind_id;
+	END IF;
+END;
+$$ LANGUAGE plpgsql;
+`)
+
+	sb.WriteString(`
 CREATE OR REPLACE FUNCTION genscript_upsert_schema_relationship_kind(v_extension_id INT, v_kind_name VARCHAR(256), v_description TEXT, v_is_traversable BOOLEAN) RETURNS void AS $$
 DECLARE
 	retrieved_kind_id SMALLINT;
@@ -324,6 +346,16 @@ $$ LANGUAGE plpgsql;
 		fmt.Fprintf(&sb, "\tPERFORM genscript_upsert_schema_node_kind(extension_id, '%s', '%s', '', %t, '%s', '%s');\n", kind.GetRepresentation(), kind.GetRepresentation(), found, iconInfo.Icon, iconInfo.Color)
 	}
 
+	sb.WriteString("\n\t-- Keep custom_node_kinds in sync with node kinds\n")
+	for _, kind := range nodeKinds {
+		iconInfo, found := nodeIcons[kind.GetRepresentation()]
+
+		// if found, we have a builtin display node kind and it should be upserted into the custom_node_kinds table.
+		if found {
+			fmt.Fprintf(&sb, "\tPERFORM genscript_upsert_custom_node_kind('%s', '{\"icon\": {\"name\": \"%s\", \"type\": \"font-awesome\", \"color\": \"%s\"}}');\n", kind.GetRepresentation(), iconInfo.Icon, iconInfo.Color)
+		}
+	}
+
 	traversableMap := make(map[string]struct{})
 
 	for _, kind := range pathfindingRelationshipKinds {
@@ -352,6 +384,7 @@ $$ LANGUAGE plpgsql;
 DROP FUNCTION IF EXISTS genscript_upsert_kind;
 DROP FUNCTION IF EXISTS genscript_upsert_source_kind;
 DROP FUNCTION IF EXISTS genscript_upsert_schema_node_kind;
+DROP FUNCTION IF EXISTS genscript_upsert_custom_node_kind;
 DROP FUNCTION IF EXISTS genscript_upsert_schema_relationship_kind;
 DROP FUNCTION IF EXISTS genscript_upsert_schema_environments;
 DROP FUNCTION IF EXISTS genscript_upsert_schema_environments_principal_kinds;`)


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Our goal is to have `custom_node_kinds` be a source of truth for which kinds are node kinds. As such, the onstart migration which populates the various `schema_*` tables with builtin extensions should also upsert the builtin node kinds into `custom_node_kinds`. 

This depends on a db migration in BED-7922, which modifies `custom_node_kinds` to FK to the `kind` table. 

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves https://specterops.atlassian.net/browse/BED-8533

## How Has This Been Tested?

Tested locally 

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved synchronization of custom node-kind configurations and icon metadata across AD and Azure graph schemas, including a shared SQL helper for keeping records up to date and cleaning up on teardown.
  * Updated the default AzureHound artifact version used in Docker builds.
* **Bug Fixes**
  * Improved OpenGraph extension deletion UX with clearer permission handling, dialog state management, and keyboard-accessible header info.
* **Tests**
  * Added integration coverage ensuring displayed schema node kinds always have matching custom node-kind entries.
  * Updated tests to handle pre-existing custom node-kind data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->