### PR TITLE
chore: UI test logging cleanup BED-8617

### DIFF
--- a/cmd/ui/src/setupTests.tsx
+++ b/cmd/ui/src/setupTests.tsx
@@ -40,6 +40,13 @@ beforeAll(() => {
         value: 800,
     });
 
+    // Keep MUI popovers from treating the global 800px offsetHeight mock as viewport overflow
+    Object.defineProperty(window, 'innerHeight', {
+        configurable: true,
+        writable: true,
+        value: 1024,
+    });
+
     // Radix Select relies on pointer events + scroll positioning under the hood
     // (Popper + focus management). In JSDOM, those methods (scrollIntoView,
     // hasPointerCapture, releasePointerCapture) don’t exist by default, so Radix
@@ -62,8 +69,14 @@ if (typeof window.URL.createObjectURL === 'undefined') {
 }
 
 vi.mock('@neo4j-cypher/react-codemirror', async () => {
+    const { forwardRef } = await import('react');
+
     return {
-        CypherEditor: () => 'cypher query',
+        CypherEditor: forwardRef<HTMLDivElement, { value?: string }>(({ value }, ref) => (
+            <div ref={ref} data-testid='cypher-editor'>
+                {value ?? 'cypher query'}
+            </div>
+        )),
     };
 });
 

--- a/cmd/ui/src/store.test.ts
+++ b/cmd/ui/src/store.test.ts
@@ -13,14 +13,6 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
-
-vi.mock('js-cookie', () => ({
-    default: {
-        get: () => 'valid_session_token',
-        remove: vi.fn(),
-    },
-}));
-
 describe('redux store', () => {
     beforeEach(() => {
         vi.resetModules();
@@ -66,9 +58,13 @@ describe('redux store', () => {
     });
 
     test('app does not crash if "token" cookie exists and "persistedState" localstorage key does not exist', async () => {
-        // See https://specterops.atlassian.net/browse/BED-2224 for details
-        Storage.prototype.getItem = vi.fn().mockImplementationOnce(() => null);
-        await import('src/store');
+        localStorage.removeItem('persistedState');
+        document.cookie = 'token=valid_session_token';
+
+        const { store } = await import('src/store');
+
+        expect(store.getState().auth.sessionToken).toBe('valid_session_token');
+        expect(document.cookie).not.toContain('token=');
     });
 });
 

--- a/cmd/ui/src/store.test.ts
+++ b/cmd/ui/src/store.test.ts
@@ -14,6 +14,13 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+vi.mock('js-cookie', () => ({
+    default: {
+        get: () => 'valid_session_token',
+        remove: vi.fn(),
+    },
+}));
+
 describe('redux store', () => {
     beforeEach(() => {
         vi.resetModules();
@@ -60,12 +67,6 @@ describe('redux store', () => {
 
     test('app does not crash if "token" cookie exists and "persistedState" localstorage key does not exist', async () => {
         // See https://specterops.atlassian.net/browse/BED-2224 for details
-        vi.mock('js-cookie', () => ({
-            default: {
-                get: () => 'valid_session_token',
-                remove: vi.fn(),
-            },
-        }));
         Storage.prototype.getItem = vi.fn().mockImplementationOnce(() => null);
         await import('src/store');
     });

--- a/cmd/ui/src/views/DownloadCollectors/DownloadCollectors.test.tsx
+++ b/cmd/ui/src/views/DownloadCollectors/DownloadCollectors.test.tsx
@@ -24,7 +24,15 @@ import DownloadCollectors from './DownloadCollectors';
 
 vi.mock('js-file-download');
 
-const server = setupServer();
+const server = setupServer(
+    rest.get('/api/v2/features', (req, res, ctx) => {
+        return res(
+            ctx.json({
+                data: [],
+            })
+        );
+    })
+);
 beforeAll(() => server.listen());
 afterEach(() => server.resetHandlers());
 afterAll(() => server.close());

--- a/cmd/ui/src/views/EarlyAccessFeatures/EarlyAccessFeatures.test.tsx
+++ b/cmd/ui/src/views/EarlyAccessFeatures/EarlyAccessFeatures.test.tsx
@@ -15,10 +15,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import userEvent from '@testing-library/user-event';
-import { createAuthStateWithPermissions, Flag, Permission } from 'bh-shared-ui';
+import { createAuthStateWithPermissions, Flag, mockGetConfigurationHandler, Permission } from 'bh-shared-ui';
 import { rest } from 'msw';
 import { setupServer } from 'msw/node';
-import { act, render, screen } from 'src/test-utils';
+import { act, render, screen, waitForElementToBeRemoved } from 'src/test-utils';
 import EarlyAccessFeatures from '.';
 
 const testFeatureFlags: Flag[] = [
@@ -50,11 +50,7 @@ const testFeatureFlags: Flag[] = [
 
 const server = setupServer(
     rest.get('/api/v2/self', (req, res, ctx) => {
-        return res(
-            ctx.json({
-                data: createAuthStateWithPermissions([Permission.AUTH_MANAGE_APPLICATION_CONFIGURATIONS]).user,
-            })
-        );
+        return res(ctx.json(createAuthStateWithPermissions([Permission.APP_WRITE_APPLICATION_CONFIGURATION])));
     }),
     rest.get(`/api/v2/features`, (req, res, ctx) => {
         return res(
@@ -62,7 +58,8 @@ const server = setupServer(
                 data: testFeatureFlags,
             })
         );
-    })
+    }),
+    mockGetConfigurationHandler()
 );
 
 const mockNavigate = vi.fn();
@@ -111,9 +108,7 @@ describe('EarlyAccessFeatures', () => {
         // Close (accept) warning dialog
         await user.click(screen.getByRole('button', { name: 'I understand, show me the new stuff!' }));
 
-        expect(screen.getByRole('dialog')).not.toBeVisible();
-
-        expect(screen.getByText('Early Access Features')).toBeInTheDocument();
+        await waitForElementToBeRemoved(() => screen.queryByRole('dialog'));
 
         for (const featureFlag of testFeatureFlags) {
             expect(await screen.findByText(featureFlag.name)).toBeInTheDocument();
@@ -138,9 +133,7 @@ describe('EarlyAccessFeatures', () => {
         // Close (accept) warning dialog
         await user.click(screen.getByRole('button', { name: 'I understand, show me the new stuff!' }));
 
-        expect(screen.getByRole('dialog')).not.toBeVisible();
-
-        expect(screen.getByText('Early Access Features')).toBeInTheDocument();
+        await waitForElementToBeRemoved(() => screen.queryByRole('dialog'));
 
         expect(await screen.findByText('No Early Access Features Available')).toBeInTheDocument();
 
@@ -164,24 +157,29 @@ describe('EarlyAccessFeatures', () => {
         // Close (accept) warning dialog
         await user.click(screen.getByRole('button', { name: 'I understand, show me the new stuff!' }));
 
-        expect(screen.getByRole('dialog')).not.toBeVisible();
-
-        expect(screen.getByText('Early Access Features')).toBeInTheDocument();
+        await waitForElementToBeRemoved(() => screen.queryByRole('dialog'));
 
         expect(await screen.findByText('Could Not Display Early Access Features')).toBeInTheDocument();
     });
 
     it('disables any available button toggles if the user lacks the permission', async () => {
+        server.use(
+            rest.get('/api/v2/self', (req, res, ctx) => {
+                return res(ctx.json(createAuthStateWithPermissions([])));
+            })
+        );
         render(<EarlyAccessFeatures />);
         const user = userEvent.setup();
 
         // Close (accept) warning dialog
         await user.click(screen.getByRole('button', { name: 'I understand, show me the new stuff!' }));
 
+        await waitForElementToBeRemoved(() => screen.queryByRole('dialog'));
+
         const buttons = screen.getAllByRole('button');
 
         buttons.forEach((button) => {
-            expect(button).toBeDisabled;
+            expect(button).toBeDisabled();
         });
     });
 });

--- a/cmd/ui/src/views/EarlyAccessFeatures/EarlyAccessFeatures.test.tsx
+++ b/cmd/ui/src/views/EarlyAccessFeatures/EarlyAccessFeatures.test.tsx
@@ -50,7 +50,11 @@ const testFeatureFlags: Flag[] = [
 
 const server = setupServer(
     rest.get('/api/v2/self', (req, res, ctx) => {
-        return res(ctx.json(createAuthStateWithPermissions([Permission.APP_WRITE_APPLICATION_CONFIGURATION])));
+        return res(
+            ctx.json({
+                data: createAuthStateWithPermissions([Permission.APP_WRITE_APPLICATION_CONFIGURATION]).user,
+            })
+        );
     }),
     rest.get(`/api/v2/features`, (req, res, ctx) => {
         return res(
@@ -165,7 +169,7 @@ describe('EarlyAccessFeatures', () => {
     it('disables any available button toggles if the user lacks the permission', async () => {
         server.use(
             rest.get('/api/v2/self', (req, res, ctx) => {
-                return res(ctx.json(createAuthStateWithPermissions([])));
+                return res(ctx.json({ data: createAuthStateWithPermissions([]).user }));
             })
         );
         render(<EarlyAccessFeatures />);

--- a/cmd/ui/src/views/Explore/ContextMenu/AssetGroupMenuItem.test.tsx
+++ b/cmd/ui/src/views/Explore/ContextMenu/AssetGroupMenuItem.test.tsx
@@ -15,7 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import userEvent from '@testing-library/user-event';
-import { apiClient } from 'bh-shared-ui';
+import { apiClient, mockGetConfigurationHandler } from 'bh-shared-ui';
 import { rest } from 'msw';
 import { setupServer } from 'msw/node';
 import { act } from 'react-dom/test-utils';
@@ -84,7 +84,8 @@ describe('AssetGroupMenuItem', async () => {
             }),
             rest.get('/api/v2/graph-search', (req, res, ctx) => {
                 return res(ctx.json({}));
-            })
+            }),
+            mockGetConfigurationHandler()
         );
 
         beforeAll(() => server.listen());
@@ -207,7 +208,8 @@ describe('AssetGroupMenuItem', async () => {
             }),
             rest.get('/api/v2/graph-search', (req, res, ctx) => {
                 return res(ctx.json({}));
-            })
+            }),
+            mockGetConfigurationHandler()
         );
 
         beforeAll(() => server.listen());

--- a/cmd/ui/src/views/Explore/ContextMenu/ContextMenu.test.tsx
+++ b/cmd/ui/src/views/Explore/ContextMenu/ContextMenu.test.tsx
@@ -16,7 +16,7 @@
 
 import userEvent from '@testing-library/user-event';
 import * as bhSharedUi from 'bh-shared-ui';
-import { DeepPartial, Permission, createAuthStateWithPermissions } from 'bh-shared-ui';
+import { DeepPartial, Permission, createAuthStateWithPermissions, mockGetConfigurationHandler } from 'bh-shared-ui';
 import { rest } from 'msw';
 import { setupServer } from 'msw/node';
 import { act } from 'react-dom/test-utils';
@@ -59,7 +59,8 @@ const server = setupServer(
                 data: [],
             })
         );
-    })
+    }),
+    mockGetConfigurationHandler()
 );
 
 beforeAll(() => server.listen());

--- a/cmd/ui/src/views/Explore/ExploreSearch/ExploreSearch.test.tsx
+++ b/cmd/ui/src/views/Explore/ExploreSearch/ExploreSearch.test.tsx
@@ -156,7 +156,7 @@ describe('ExploreSearch rendering per tab', async () => {
     it('should render the cypher search controls when user clicks on cypher tab ', async () => {
         await setup('cypher');
 
-        expect(screen.getByText(/cypher/i)).toBeInTheDocument();
+        expect(screen.getByTestId('cypher-search-section')).toBeInTheDocument();
 
         expect(screen.getByRole('link', { name: /Learn more about cypher/i })).toBeInTheDocument();
         expect(screen.getByLabelText('Run cypher query')).toBeInTheDocument();

--- a/cmd/ui/src/views/Explore/ExploreSearch/ExploreSearch.test.tsx
+++ b/cmd/ui/src/views/Explore/ExploreSearch/ExploreSearch.test.tsx
@@ -156,7 +156,7 @@ describe('ExploreSearch rendering per tab', async () => {
     it('should render the cypher search controls when user clicks on cypher tab ', async () => {
         await setup('cypher');
 
-        expect(screen.getByText(/cypher query/i)).toBeInTheDocument();
+        expect(screen.getByText(/cypher/i)).toBeInTheDocument();
 
         expect(screen.getByRole('link', { name: /Learn more about cypher/i })).toBeInTheDocument();
         expect(screen.getByLabelText('Run cypher query')).toBeInTheDocument();

--- a/cmd/ui/src/views/Explore/GraphView.test.tsx
+++ b/cmd/ui/src/views/Explore/GraphView.test.tsx
@@ -15,12 +15,36 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import userEvent from '@testing-library/user-event';
-import { cypherTestResponse, mockKindsHandler, singleNodeResponse } from 'bh-shared-ui';
+import {
+    createAuthStateWithPermissions,
+    cypherTestResponse,
+    mockGetConfigurationHandler,
+    mockKindsHandler,
+    singleNodeResponse,
+} from 'bh-shared-ui';
 import { GraphEdge } from 'js-client-library';
 import { rest } from 'msw';
 import { setupServer } from 'msw/node';
 import { render, screen, waitFor, within } from 'src/test-utils';
 import GraphView from './GraphView';
+
+// Mock sigma here to avoid rendering conflicts in jsdom
+vi.mock('src/components/SigmaChart', async () => {
+    const { forwardRef, useImperativeHandle } = await import('react');
+
+    return {
+        default: forwardRef((_props, ref) => {
+            useImperativeHandle(ref, () => ({
+                runStandardLayout: vi.fn(),
+                runSequentialLayout: vi.fn(),
+                resetCamera: vi.fn(),
+                zoomTo: vi.fn(),
+            }));
+
+            return <div data-testid='sigma-container-wrapper' />;
+        }),
+    };
+});
 
 const baseGlobalView = {
     notifications: [],
@@ -52,10 +76,10 @@ const server = setupServer(
         return res(ctx.json(cypherTestResponse));
     }),
     rest.get('/api/v2/features', (req, res, ctx) => {
-        return res(ctx.status(200));
+        return res(ctx.json({ data: [] }));
     }),
     rest.get('/api/v2/self', (req, res, ctx) => {
-        return res(ctx.status(200));
+        return res(ctx.json({ data: createAuthStateWithPermissions([]).user }));
     }),
     rest.get(`/api/v2/custom-nodes`, async (_req, res, ctx) => {
         return res(ctx.json({ data: [] }));
@@ -64,21 +88,53 @@ const server = setupServer(
         return res(ctx.json({ data: { tags: [] } }));
     }),
     rest.get('/api/v2/file-upload/accepted-types', async (_, res, ctx) => {
-        return res(ctx.status(200));
+        return res(ctx.json({ data: [] }));
     }),
     rest.get('/api/v2/saved-queries', async (_, res, ctx) => {
-        return res(ctx.status(200));
+        return res(ctx.json({ queries: [] }));
     }),
     rest.get('/api/v2/graph-search', (_req, res, ctx) => {
         return res(ctx.json(graphSearchResponse));
     }),
     mockKindsHandler(),
+    mockGetConfigurationHandler(),
     rest.get(`/api/v2/roles`, (req, res, ctx) => {
         return res(
             ctx.json({
                 data: {
                     roles: [],
                 },
+            })
+        );
+    }),
+    rest.get('/api/v2/search', (_req, res, ctx) => {
+        return res(ctx.json({ data: [] }));
+    }),
+    rest.get('/api/v2/graphs/shortest-path', (_req, res, ctx) => {
+        return res(ctx.json({ data: { nodes: {}, edges: [] } }));
+    }),
+    rest.get('/api/v2/users/:id', (_req, res, ctx) => {
+        return res(
+            ctx.json({
+                data: {
+                    data: {
+                        kinds: ['Base', 'User'],
+                        props: {
+                            objectid: searchedNode.objectId,
+                            name: searchedNode.label,
+                        },
+                    },
+                },
+            })
+        );
+    }),
+    rest.get('/api/v2/users/:id/:relationship', (_req, res, ctx) => {
+        return res(
+            ctx.json({
+                count: 0,
+                skip: 0,
+                limit: 128,
+                data: [],
             })
         );
     })

--- a/packages/javascript/bh-shared-ui/src/components/AssetGroupEdit/AssetGroupEdit.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/AssetGroupEdit/AssetGroupEdit.test.tsx
@@ -18,7 +18,7 @@ import userEvent from '@testing-library/user-event';
 import { rest } from 'msw';
 import { setupServer } from 'msw/node';
 import { createMockAssetGroup, createMockMemberCounts, createMockSearchResults } from '../../mocks/factories';
-import { mockKindsHandler } from '../../mocks/handlers/graphKinds';
+import { mockGetConfigurationHandler, mockKindsHandler } from '../../mocks/handlers';
 import { act, render, waitFor } from '../../test-utils';
 import { AUTOCOMPLETE_PLACEHOLDER } from './AssetGroupAutocomplete';
 import AssetGroupEdit from './AssetGroupEdit';
@@ -29,6 +29,7 @@ const memberCounts = createMockMemberCounts();
 
 const server = setupServer(
     mockKindsHandler(),
+    mockGetConfigurationHandler(),
     rest.get('/api/v2/search', (req, res, ctx) => {
         return res(
             ctx.json({

--- a/packages/javascript/bh-shared-ui/src/components/ExploreSearchCombobox/ExploreSearchCombobox.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/ExploreSearchCombobox/ExploreSearchCombobox.test.tsx
@@ -20,6 +20,7 @@ import { setupServer } from 'msw/node';
 import ExploreSearchCombobox from '.';
 import { ActiveDirectoryNodeKind } from '../../graphSchema';
 import { mockKindsHandler } from '../../mocks';
+import { mockGetConfigurationHandler } from '../../mocks/handlers';
 import { act, render, screen, within } from '../../test-utils';
 
 const testSearchResults = {
@@ -53,7 +54,8 @@ const server = setupServer(
             })
         );
     }),
-    mockKindsHandler()
+    mockKindsHandler(),
+    mockGetConfigurationHandler()
 );
 
 beforeAll(() => server.listen());

--- a/packages/javascript/bh-shared-ui/src/components/FileIngestTable/FileIngestTable.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/FileIngestTable/FileIngestTable.test.tsx
@@ -121,6 +121,9 @@ const server = setupServer(
                 ],
             })
         );
+    }),
+    rest.get('/api/v2/bloodhound-users-minimal', (_req, res, ctx) => {
+        return res(ctx.json({ data: { users: [] } }));
     })
 );
 

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/AdcsEsc14ScenarioA/AdcsEsc14ScenarioA.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/AdcsEsc14ScenarioA/AdcsEsc14ScenarioA.tsx
@@ -32,14 +32,14 @@ export const AdcsEsc14ScenarioALinux: FC = () => (
             An attacker can add an explicit certificate mapping in the AltSecurityIdentities of the target referring to
             a certificate in the attacker's possession, and then use this certificate to authenticate as the target.
         </Typography>
-        <Typography variant='body2'>
+        <Typography variant='body2' component='div'>
             The certificate must meet the following requirements:
             <ol style={{ listStyleType: 'decimal', paddingLeft: '1.5em' }}>
                 <li>Chain up to trusted root CA on the DC</li>
                 <li>Enhanced Key Usage extension contains an EKU that enables domain authentication</li>
                 <li>Subject Alternative Name (SAN) does NOT contain a "Other Name/Principal Name" entry (UPN)</li>
             </ol>
-            <p className='my-4'>
+            <div className='my-4'>
                 The EKUs that enable domain authentication over Kerberos:
                 <ul style={{ paddingLeft: '1.5em' }}>
                     <li>Client Authentication (1.3.6.1.5.5.7.3.2)</li>
@@ -48,7 +48,7 @@ export const AdcsEsc14ScenarioALinux: FC = () => (
                     <li>Any Purpose (2.5.29.37.0)</li>
                     <li>SubCA (no EKUs)</li>
                 </ul>
-            </p>
+            </div>
             <p className='my-4'>
                 The last certificate requirement means that user certificates will not work, so the certificate
                 typically must be of a computer. By default, the ADCS certificate template <i>Computer (Machine)</i>{' '}
@@ -129,14 +129,14 @@ export const AdcsEsc14ScenarioAWindows: FC = () => {
                 to a certificate in the attacker's possession, and then use this certificate to authenticate as the
                 target.
             </Typography>
-            <Typography variant='body2'>
+            <Typography variant='body2' component='div'>
                 The certificate must meet the following requirements:
                 <ol style={{ listStyleType: 'decimal', paddingLeft: '1.5em' }}>
                     <li>Chain up to trusted root CA on the DC</li>
                     <li>Enhanced Key Usage extension contains an EKU that enables domain authentication</li>
                     <li>Subject Alternative Name (SAN) does NOT contain a "Other Name/Principal Name" entry (UPN)</li>
                 </ol>
-                <p className='my-4'>
+                <div className='my-4'>
                     The EKUs that enable domain authentication over Kerberos:
                     <ul style={{ paddingLeft: '1.5em' }}>
                         <li>Client Authentication (1.3.6.1.5.5.7.3.2)</li>
@@ -145,7 +145,7 @@ export const AdcsEsc14ScenarioAWindows: FC = () => {
                         <li>Any Purpose (2.5.29.37.0)</li>
                         <li>SubCA (no EKUs)</li>
                     </ul>
-                </p>
+                </div>
                 <p className='my-4'>
                     The last certificate requirement means that user certificates will not work, so the certificate
                     typically must be of a computer. By default, the ADCS certificate template <i>Computer (Machine)</i>{' '}

--- a/packages/javascript/bh-shared-ui/src/components/SchemaUploadDialog/SchemaUploadDialog.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/SchemaUploadDialog/SchemaUploadDialog.test.tsx
@@ -185,10 +185,13 @@ describe('SchemaUploadDialog', () => {
         await user.click(screen.getByRole('button', { name: 'Upload File' }));
         const fileInput = screen.getByTestId('ingest-file-upload');
         await user.upload(fileInput, testFile);
-        await user.click(screen.getByRole('button', { name: 'Upload' }));
 
-        expect(await screen.findByText('Failed to Upload')).toBeInTheDocument();
-        expect(await screen.findByRole('button', { name: 'Close' })).toBeInTheDocument();
+        await withoutErrorLogging(async () => {
+            await user.click(screen.getByRole('button', { name: 'Upload' }));
+
+            expect(await screen.findByText('Failed to Upload')).toBeInTheDocument();
+            expect(await screen.findByRole('button', { name: 'Close' })).toBeInTheDocument();
+        });
     });
 
     it('invalidates the extensions query after a successful upload', async () => {

--- a/packages/javascript/bh-shared-ui/src/hooks/useAssetGroupTags/useAssetGroupTags.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/hooks/useAssetGroupTags/useAssetGroupTags.test.tsx
@@ -26,6 +26,11 @@ import { SortOrder } from '../../types';
 import { apiClient } from '../../utils';
 import * as agtHook from './useAssetGroupTags';
 
+const emptyMembersResponse = {
+    data: { members: [] },
+    count: 0,
+};
+
 const handlers = [
     rest.get('/api/v2/features', async (_req, res, ctx) => {
         return res(
@@ -55,11 +60,11 @@ const handlers = [
         );
     }),
     rest.get('/api/v2/asset-group-tags/:tagId/members', async (_, res, ctx) => {
-        return res(ctx.status(200));
+        return res(ctx.json(emptyMembersResponse));
     }),
 
     rest.get('/api/v2/asset-group-tags/:tagId/selectors/:selectorId/members', async (_, res, ctx) => {
-        return res(ctx.status(200));
+        return res(ctx.json(emptyMembersResponse));
     }),
     rest.get('/api/v2/features', async (_req, res, ctx) => {
         return res(

--- a/packages/javascript/bh-shared-ui/src/hooks/useExploreGraph/useNodeSearch.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/hooks/useExploreGraph/useNodeSearch.test.tsx
@@ -16,7 +16,7 @@
 
 import { rest } from 'msw';
 import { setupServer } from 'msw/node';
-import { mockKindsHandler } from '../../mocks/handlers/graphKinds';
+import { mockGetConfigurationHandler, mockKindsHandler } from '../../mocks/handlers';
 import { act, renderHook, waitFor } from '../../test-utils';
 import { useNodeSearch } from './useNodeSearch';
 
@@ -30,7 +30,8 @@ const server = setupServer(
 
         return res(ctx.json({ data: [{ name: searchTerm, objectid: searchTerm }] }));
     }),
-    mockKindsHandler()
+    mockKindsHandler(),
+    mockGetConfigurationHandler()
 );
 
 beforeAll(() => server.listen());

--- a/packages/javascript/bh-shared-ui/src/hooks/useExploreGraph/usePathfindingSearch.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/hooks/useExploreGraph/usePathfindingSearch.test.tsx
@@ -16,7 +16,7 @@
 
 import { rest } from 'msw';
 import { setupServer } from 'msw/node';
-import { mockKindsHandler } from '../../mocks/handlers/graphKinds';
+import { mockGetConfigurationHandler, mockKindsHandler } from '../../mocks/handlers';
 import { act, renderHook, waitFor } from '../../test-utils';
 import { usePathfindingSearch } from './usePathfindingSearch';
 
@@ -30,7 +30,8 @@ const server = setupServer(
 
         return res(ctx.json({ data: [{ name: searchTerm, objectid: searchTerm }] }));
     }),
-    mockKindsHandler()
+    mockKindsHandler(),
+    mockGetConfigurationHandler()
 );
 
 beforeAll(() => server.listen());

--- a/packages/javascript/bh-shared-ui/src/hooks/useExploreTableAutoDisplay/useExploreTableAutoDisplay.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/hooks/useExploreTableAutoDisplay/useExploreTableAutoDisplay.test.tsx
@@ -15,6 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { rest } from 'msw';
 import { setupServer } from 'msw/node';
+import { mockGetConfigurationHandler, withoutErrorLogging } from '../../mocks';
 import { renderHook, waitFor } from '../../test-utils';
 import { useExploreTableAutoDisplay } from './useExploreTableAutoDisplay';
 const emptyResponse = { edges: [], nodes: {} };
@@ -33,7 +34,7 @@ const getCypherAPIMock = (results: Record<string, any>) => {
         );
     });
 };
-const server = setupServer(getCypherAPIMock(tableShapedResponse));
+const server = setupServer(getCypherAPIMock(tableShapedResponse), mockGetConfigurationHandler());
 
 beforeAll(() => server.listen());
 afterEach(() => server.resetHandlers());
@@ -61,12 +62,14 @@ describe('useExploreTableAutoDisplay', () => {
     });
 
     it('sets autoDisplayTable to false if query returns no results', async () => {
-        server.use(getCypherAPIMock(emptyResponse));
+        await withoutErrorLogging(async () => {
+            server.use(getCypherAPIMock(emptyResponse));
 
-        const initialRoute = '?searchType=cypher&cypherSearch=YQ%3D%3D';
-        const { result } = setup({ initialRoute });
+            const initialRoute = '?searchType=cypher&cypherSearch=YQ%3D%3D';
+            const { result } = setup({ initialRoute });
 
-        await waitFor(() => expect(result.current[0]).toBe(false));
+            await waitFor(() => expect(result.current[0]).toBe(false));
+        });
     });
 
     it('sets autoDisplayTable to false if query returns nodes only but the enabled prop is false', async () => {

--- a/packages/javascript/bh-shared-ui/src/mocks/handlers/configuration.ts
+++ b/packages/javascript/bh-shared-ui/src/mocks/handlers/configuration.ts
@@ -1,3 +1,18 @@
+// Copyright 2026 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 import { rest } from 'msw';
 
 export const defaultConfigurationResponse = { data: [] };

--- a/packages/javascript/bh-shared-ui/src/mocks/handlers/configuration.ts
+++ b/packages/javascript/bh-shared-ui/src/mocks/handlers/configuration.ts
@@ -1,0 +1,7 @@
+import { rest } from 'msw';
+
+export const defaultConfigurationResponse = { data: [] };
+
+export const mockGetConfigurationHandler = (response = defaultConfigurationResponse) => {
+    return rest.get('/api/v2/config', (_req, res, ctx) => res(ctx.json(response)));
+};

--- a/packages/javascript/bh-shared-ui/src/mocks/handlers/index.ts
+++ b/packages/javascript/bh-shared-ui/src/mocks/handlers/index.ts
@@ -15,6 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 export * from './bloodHoundUsers';
+export * from './configuration';
 export * from './environments';
 export * from './graphKinds';
 export { default as zoneHandlers } from './zoneHandlers';

--- a/packages/javascript/bh-shared-ui/src/providers/AnnouncementProvider/AnnouncementProvider.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/providers/AnnouncementProvider/AnnouncementProvider.test.tsx
@@ -102,9 +102,21 @@ describe('AnnouncementProvider', () => {
 describe('useAnnounce', () => {
     it('throws when used outside of AnnouncementProvider', () => {
         const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
-        expect(() => renderHook(() => useAnnounce())).toThrow(
-            'useAnnounce must be used within an AnnouncementProvider'
-        );
-        consoleError.mockRestore();
+        const expectedMessage = 'useAnnounce must be used within an AnnouncementProvider';
+
+        const suppressExpectedError = (event: ErrorEvent) => {
+            if (event.message.includes(expectedMessage)) {
+                event.preventDefault();
+            }
+        };
+
+        window.addEventListener('error', suppressExpectedError);
+
+        try {
+            expect(() => renderHook(() => useAnnounce())).toThrow(expectedMessage);
+        } finally {
+            window.removeEventListener('error', suppressExpectedError);
+            consoleError.mockRestore();
+        }
     });
 });

--- a/packages/javascript/bh-shared-ui/src/setupTests.tsx
+++ b/packages/javascript/bh-shared-ui/src/setupTests.tsx
@@ -36,6 +36,13 @@ beforeAll(() => {
         value: 800,
     });
 
+    // Keep MUI popovers from treating the global 800px offsetHeight mock as viewport overflow
+    Object.defineProperty(window, 'innerHeight', {
+        configurable: true,
+        writable: true,
+        value: 1024,
+    });
+
     // Radix Select relies on pointer events + scroll positioning under the hood
     // (Popper + focus management). In JSDOM, those methods (scrollIntoView,
     // hasPointerCapture, releasePointerCapture) don’t exist by default, so Radix

--- a/packages/javascript/bh-shared-ui/src/views/Explore/ExploreSearch/CypherSearch.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/Explore/ExploreSearch/CypherSearch.test.tsx
@@ -194,7 +194,7 @@ describe('CypherSearch', () => {
     });
 
     it('should call performSearch on keyboard press alt+R', async () => {
-        const { user } = await setup({ ...testState, cypherQuery: 'Anything' });
+        const { user } = await setup({ ...testState, cypherQuery: 'Anything' }, '/', false);
 
         expect(testPerformSearch).not.toHaveBeenCalled();
 

--- a/packages/javascript/bh-shared-ui/src/views/Explore/ExploreSearch/PathfindingSearch.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/Explore/ExploreSearch/PathfindingSearch.test.tsx
@@ -18,7 +18,7 @@ import userEvent from '@testing-library/user-event';
 import { rest } from 'msw';
 import { setupServer } from 'msw/node';
 import { usePathfindingFilters, usePathfindingSearch } from '../../../hooks';
-import { mockKindsHandler } from '../../../mocks/handlers/graphKinds';
+import { mockGetConfigurationHandler, mockKindsHandler } from '../../../mocks/handlers';
 import { act, render } from '../../../test-utils';
 import PathfindingSearch from './PathfindingSearch';
 
@@ -61,7 +61,8 @@ describe('Pathfinding: interaction', () => {
                 })
             );
         }),
-        mockKindsHandler()
+        mockKindsHandler(),
+        mockGetConfigurationHandler()
     );
 
     const WrappedPathfindingSearch = () => {

--- a/packages/javascript/bh-shared-ui/src/views/OpenGraphManagement/ActiveExtensionsCard.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/OpenGraphManagement/ActiveExtensionsCard.test.tsx
@@ -19,6 +19,7 @@ import { AxiosResponse } from 'axios';
 import { Extension } from 'js-client-library';
 import { rest } from 'msw';
 import { setupServer } from 'msw/node';
+import { withoutErrorLogging } from '../../mocks';
 import { fireEvent, render, screen, waitFor } from '../../test-utils';
 import { apiClient } from '../../utils';
 import {
@@ -112,10 +113,10 @@ describe('ActiveExtensionsCard', () => {
                 return res(ctx.status(500));
             })
         );
-
-        render(<ActiveExtensionsCard />);
-
-        expect(await screen.findByText(ERROR_MESSAGE)).toBeInTheDocument();
+        await withoutErrorLogging(async () => {
+            render(<ActiveExtensionsCard />);
+            expect(await screen.findByText(ERROR_MESSAGE)).toBeInTheDocument();
+        });
     });
 
     it('displays no data message when there are no extensions', async () => {
@@ -392,17 +393,20 @@ describe('ActiveExtensionsCard', () => {
 
         const confirmButton = screen.getByRole('button', { name: /confirm/i });
         await waitFor(() => expect(confirmButton).not.toBeDisabled());
-        await user.click(confirmButton);
 
-        await waitFor(() => {
-            expect(addNotificationSpy).toHaveBeenCalledWith(
-                'Failed to delete extension "Custom Extension". Please try again.',
-                'deleteExtensionError',
-                expect.objectContaining({
-                    variant: 'error',
-                    anchorOrigin: { horizontal: 'right', vertical: 'top' },
-                })
-            );
+        await withoutErrorLogging(async () => {
+            await user.click(confirmButton);
+
+            await waitFor(() => {
+                expect(addNotificationSpy).toHaveBeenCalledWith(
+                    'Failed to delete extension "Custom Extension". Please try again.',
+                    'deleteExtensionError',
+                    expect.objectContaining({
+                        variant: 'error',
+                        anchorOrigin: { horizontal: 'right', vertical: 'top' },
+                    })
+                );
+            });
         });
     });
 });

--- a/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/Save/RuleForm/ObjectSelect.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/Save/RuleForm/ObjectSelect.test.tsx
@@ -17,7 +17,7 @@
 import userEvent from '@testing-library/user-event';
 import { rest } from 'msw';
 import { setupServer } from 'msw/node';
-import { mockKindsHandler } from '../../../../mocks/handlers/graphKinds';
+import { mockGetConfigurationHandler, mockKindsHandler } from '../../../../mocks/handlers';
 import { act, render, screen, waitFor } from '../../../../test-utils';
 import ObjectSelect from './ObjectSelect';
 import RuleFormContext, { initialValue } from './RuleFormContext';
@@ -46,7 +46,8 @@ const server = setupServer(
     rest.get(`/api/v2/custom-nodes`, async (_req, res, ctx) => {
         return res(ctx.json({ data: [] }));
     }),
-    mockKindsHandler()
+    mockKindsHandler(),
+    mockGetConfigurationHandler()
 );
 
 beforeAll(() => server.listen());

--- a/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/Save/TagForm/TagForm.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/Save/TagForm/TagForm.test.tsx
@@ -397,17 +397,13 @@ describe('Tag Form', () => {
     });
 
     test('clicking cancel on the form takes the user back to the page the user was on previously', async () => {
-        vi.mocked(useParams).mockReturnValue({ zoneId: '', labelId: '2' });
+        vi.mocked(useParams).mockReturnValue({ zoneId: '', labelId: undefined });
         vi.mocked(useLocation).mockReturnValue({ pathname: createNewLabelPath } as Location);
         render(<TagForm />, { route: createNewLabelPath });
 
-        await act(async () => {
-            fireEvent.click(await screen.findByTestId('privilege-zones_save_tag-form_cancel-button'));
-        });
+        await user.click(await screen.findByTestId('privilege-zones_save_tag-form_cancel-button'));
 
-        await waitFor(() => {
-            expect(mockNavigate).toHaveBeenCalledWith(-1);
-        });
+        expect(mockNavigate).toHaveBeenCalledWith(-1);
     });
 
     test('a name value is required to submit the form', async () => {

--- a/packages/javascript/bh-shared-ui/src/views/Users/Users.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/Users/Users.test.tsx
@@ -19,9 +19,10 @@ import { rest } from 'msw';
 import { setupServer } from 'msw/node';
 import Users from '.';
 import { bloodHoundUsersHandlers, testAuthenticatedUser, testBloodHoundUsers, testSSOProviders } from '../../mocks';
+import { mockGetConfigurationHandler } from '../../mocks/handlers';
 import { render, screen, waitFor, within } from '../../test-utils';
 
-const server = setupServer(...bloodHoundUsersHandlers);
+const server = setupServer(...bloodHoundUsersHandlers, mockGetConfigurationHandler());
 
 const selfHandler = (roles: { name: string; permissions: { authority: string; name: string }[] }[]) =>
     rest.get('/api/v2/self', async (_req, res, ctx) => {

--- a/packages/javascript/doodle-ui/src/components/Typography/Typography.test.tsx
+++ b/packages/javascript/doodle-ui/src/components/Typography/Typography.test.tsx
@@ -13,7 +13,7 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
-import { screen } from '@storybook/test';
+import { screen } from '@testing-library/react';
 import { render } from '../../utils';
 import { Typography } from './Typography';
 import { DEFAULT_VARIANT, variantMapping } from './utils';

--- a/packages/javascript/doodle-ui/src/components/Typography/Typography.tsx
+++ b/packages/javascript/doodle-ui/src/components/Typography/Typography.tsx
@@ -14,7 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import { cva } from 'class-variance-authority';
-import { ElementType } from 'react';
+import { ElementType, forwardRef } from 'react';
 import { cn } from '../utils';
 import { DEFAULT_VARIANT, Variant, variantMapping } from './utils';
 
@@ -47,15 +47,20 @@ interface TypographyProps extends React.HTMLAttributes<HTMLElement> {
     component?: ElementType;
 }
 
-const Typography = ({ variant, component, children, className, ...rest }: TypographyProps) => {
-    const Tag = (component || variantMapping[variant ?? DEFAULT_VARIANT]) as ElementType;
+const Typography = forwardRef<HTMLElement, TypographyProps>(
+    ({ variant, component, children, className, ...rest }, ref) => {
+        const Tag = (component || variantMapping[variant ?? DEFAULT_VARIANT]) as ElementType;
 
-    return (
-        <Tag className={cn(TypographyVariants({ variant }), `typography-${variant}`, className)} {...rest}>
-            {children}
-        </Tag>
-    );
-};
+        return (
+            <Tag
+                ref={ref}
+                className={cn(TypographyVariants({ variant }), `typography-${variant}`, className)}
+                {...rest}>
+                {children}
+            </Tag>
+        );
+    }
+);
 
 Typography.displayName = 'Typography';
 


### PR DESCRIPTION
## Description
Our UI test logging has gotten noisy again, mostly due to unmocked MSW endpoints. This PR updates our tests with mocks and fixes as necessary to prevent unwanted errors from surfacing.

## Motivation and Context

Resolves BED-8617

A higher signal-to-noise ratio in our test logs makes issues easier to troubleshoot, and often these errors reveal real issues with our testing strategies.

## How Has This Been Tested?

## Screenshots (optional):

## Types of changes
- Chore (a change that does not modify the application functionality)

## Checklist:
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# Release Notes

* **Refactor**
  * Updated the `Typography` component to forward refs to the underlying rendered element for better parent-level element access.

* **Tests**
  * Improved test stability by simulating viewport sizing and refining mocks to better match real UI components/behavior.
  * Expanded mocked API responses (notably configuration data) and adjusted UI assertions to align with current dialog and permission flows.
  * Reduced flaky output by suppressing expected errors/logging noise in error-path tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->