### PR TITLE
feat(logging): add query parameter logging for /api/v2 requests - BED-8563

### DIFF
--- a/cmd/api/src/api/middleware/logging.go
+++ b/cmd/api/src/api/middleware/logging.go
@@ -118,6 +118,19 @@ func setSignedRequestFields(request *http.Request, logAttrs *[]slog.Attr) {
 	}
 }
 
+func isSSOCallbackPath(requestPath string) bool {
+	pathSegments := strings.Split(strings.Trim(requestPath, "/"), "/")
+
+	if len(pathSegments) < 5 {
+		return false
+	}
+
+	return pathSegments[0] == "api" &&
+		pathSegments[1] == "v2" &&
+		pathSegments[2] == "sso" &&
+		pathSegments[4] == "callback"
+}
+
 // LoggingMiddleware is a middleware func that outputs a log for each request-response lifecycle. It includes timestamped
 // information organized into fields suitable for searching or parsing.
 func LoggingMiddleware(_ auth.IdentityResolver, bypassLimitsParam bool) func(http.Handler) http.Handler {
@@ -193,7 +206,8 @@ func LoggingMiddleware(_ auth.IdentityResolver, bypassLimitsParam bool) func(htt
 			)
 
 			// Add logging of query parameters for /api/v2 endpoints
-			if strings.HasPrefix(request.URL.Path, "/api/v2") && request.URL.RawQuery != "" {
+			// Ignore SSO callback path logging
+			if strings.HasPrefix(request.URL.Path, "/api/v2/") && request.URL.RawQuery != "" && !isSSOCallbackPath(request.URL.Path) {
 				logAttrs = append(logAttrs, slog.String("query_parameters", request.URL.RawQuery))
 			}
 		})

--- a/cmd/api/src/api/middleware/logging.go
+++ b/cmd/api/src/api/middleware/logging.go
@@ -21,6 +21,7 @@ import (
 	"log/slog"
 	"net/http"
 	"runtime/debug"
+	"strings"
 	"time"
 
 	"github.com/gofrs/uuid"
@@ -119,7 +120,7 @@ func setSignedRequestFields(request *http.Request, logAttrs *[]slog.Attr) {
 
 // LoggingMiddleware is a middleware func that outputs a log for each request-response lifecycle. It includes timestamped
 // information organized into fields suitable for searching or parsing.
-func LoggingMiddleware(idResolver auth.IdentityResolver, bypassLimitsParam bool) func(http.Handler) http.Handler {
+func LoggingMiddleware(_ auth.IdentityResolver, bypassLimitsParam bool) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
 			var (
@@ -190,6 +191,18 @@ func LoggingMiddleware(idResolver auth.IdentityResolver, bypassLimitsParam bool)
 				slog.Int("status", loggedResponse.statusCode),
 				slog.Duration("elapsed", time.Since(requestContext.StartTime.UTC())),
 			)
+
+			// Add structured logging of query parameters for /api/v2 endpoints
+			if strings.HasPrefix(request.URL.Path, "/api/v2") {
+				var params []any
+				for k, v := range request.URL.Query() {
+					params = append(params, slog.String(k, strings.Join(v, ",")))
+				}
+
+				if len(params) > 0 {
+					logAttrs = append(logAttrs, slog.Group("query_parameters", params...))
+				}
+			}
 		})
 	}
 }

--- a/cmd/api/src/api/middleware/logging.go
+++ b/cmd/api/src/api/middleware/logging.go
@@ -192,16 +192,9 @@ func LoggingMiddleware(_ auth.IdentityResolver, bypassLimitsParam bool) func(htt
 				slog.Duration("elapsed", time.Since(requestContext.StartTime.UTC())),
 			)
 
-			// Add structured logging of query parameters for /api/v2 endpoints
-			if strings.HasPrefix(request.URL.Path, "/api/v2") {
-				var params []any
-				for k, v := range request.URL.Query() {
-					params = append(params, slog.String(k, strings.Join(v, ",")))
-				}
-
-				if len(params) > 0 {
-					logAttrs = append(logAttrs, slog.Group("query_parameters", params...))
-				}
+			// Add logging of query parameters for /api/v2 endpoints
+			if strings.HasPrefix(request.URL.Path, "/api/v2") && request.URL.RawQuery != "" {
+				logAttrs = append(logAttrs, slog.String("query_parameters", request.URL.RawQuery))
 			}
 		})
 	}

--- a/cmd/api/src/api/middleware/logging.go
+++ b/cmd/api/src/api/middleware/logging.go
@@ -118,17 +118,19 @@ func setSignedRequestFields(request *http.Request, logAttrs *[]slog.Attr) {
 	}
 }
 
-func isSSOCallbackPath(requestPath string) bool {
-	pathSegments := strings.Split(strings.Trim(requestPath, "/"), "/")
-
-	if len(pathSegments) < 5 {
-		return false
+// isQueryLoggingExcludedPath matches paths whose query_parameters field should be omitted (v2 only)
+func isQueryLoggingExcludedPath(requestPath string) bool {
+	if requestPath == "/api/v2/login/support" {
+		return true
+	}
+	if strings.HasPrefix(requestPath, "/api/v2/sso/") && strings.HasSuffix(requestPath, "/callback") {
+		return true
+	}
+	if strings.HasPrefix(requestPath, "/api/v2/login/saml/") && strings.HasSuffix(requestPath, "/acs") {
+		return true
 	}
 
-	return pathSegments[0] == "api" &&
-		pathSegments[1] == "v2" &&
-		pathSegments[2] == "sso" &&
-		pathSegments[4] == "callback"
+	return false
 }
 
 // LoggingMiddleware is a middleware func that outputs a log for each request-response lifecycle. It includes timestamped
@@ -205,9 +207,8 @@ func LoggingMiddleware(_ auth.IdentityResolver, bypassLimitsParam bool) func(htt
 				slog.Duration("elapsed", time.Since(requestContext.StartTime.UTC())),
 			)
 
-			// Add logging of query parameters for /api/v2 endpoints
-			// Ignore SSO callback path logging
-			if strings.HasPrefix(request.URL.Path, "/api/v2/") && request.URL.RawQuery != "" && !isSSOCallbackPath(request.URL.Path) {
+			// Add logging of query parameters for /api/v2 endpoints, excluding potentially sensitive paths
+			if strings.HasPrefix(request.URL.Path, "/api/v2/") && request.URL.RawQuery != "" && !isQueryLoggingExcludedPath(request.URL.Path) {
 				logAttrs = append(logAttrs, slog.String("query_parameters", request.URL.RawQuery))
 			}
 		})

--- a/cmd/api/src/api/middleware/logging_test.go
+++ b/cmd/api/src/api/middleware/logging_test.go
@@ -1,0 +1,86 @@
+package middleware_test
+
+import (
+	"bytes"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/specterops/bloodhound/cmd/api/src/api/middleware"
+	"github.com/specterops/bloodhound/cmd/api/src/auth"
+	"github.com/specterops/bloodhound/cmd/api/src/ctx"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLoggingMiddleware_QueryParameters(t *testing.T) {
+	var (
+		testURL1  = "/api/v2/bloodhound-users"
+		testURL2  = "/api/v2/search"
+		healthURL = "/health"
+	)
+	testCases := []struct {
+		name              string
+		url               string
+		logContains       []string
+		logDoesNotContain []string
+	}{
+		{
+			name:              "non /api/v2 path does not log query parameters",
+			url:               healthURL + "?randomparam=123",
+			logContains:       []string{"HTTP request"},
+			logDoesNotContain: []string{"query_parameters"},
+		},
+		{
+			name:              "/api/v2 path with no query params does not log query parameters",
+			url:               testURL1,
+			logContains:       []string{"HTTP request"},
+			logDoesNotContain: []string{"query_parameters"},
+		},
+		{
+			name:        "single query parameter is logged as structured field",
+			url:         testURL1 + "?first_name=eq:Hubert",
+			logContains: []string{"HTTP request", "query_parameters", "first_name", "eq:Hubert"},
+		},
+		{
+			name:        "multiple query parameters are logged as structured fields",
+			url:         testURL1 + "?first_name=eq:Hubert&limit=10",
+			logContains: []string{"HTTP request", "query_parameters", "first_name", "eq:Hubert", "limit", "10"},
+		},
+		{
+			name:        "multi-value query parameter values are comma-joined",
+			url:         testURL2 + "?type=Computer&type=User&type=Group",
+			logContains: []string{"HTTP request", "query_parameters", "type", "Computer", "User", "Group"},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			var logBuffer bytes.Buffer
+			slog.SetDefault(slog.New(slog.NewJSONHandler(&logBuffer, &slog.HandlerOptions{})))
+
+			nextHandler := http.HandlerFunc(func(responseWriter http.ResponseWriter, request *http.Request) {
+				responseWriter.WriteHeader(http.StatusOK)
+			})
+			handler := middleware.LoggingMiddleware(auth.NewIdentityResolver(), false)(nextHandler)
+
+			request := httptest.NewRequest(http.MethodGet, testCase.url, nil)
+			bhCtx := &ctx.Context{
+				StartTime: time.Now(),
+				RequestID: "123456",
+			}
+			request = ctx.SetRequestContext(request, bhCtx)
+			response := httptest.NewRecorder()
+			handler.ServeHTTP(response, request)
+
+			logOutput := logBuffer.String()
+			for _, expected := range testCase.logContains {
+				assert.Contains(t, logOutput, expected)
+			}
+			for _, unexpected := range testCase.logDoesNotContain {
+				assert.NotContains(t, logOutput, unexpected)
+			}
+		})
+	}
+}

--- a/cmd/api/src/api/middleware/logging_test.go
+++ b/cmd/api/src/api/middleware/logging_test.go
@@ -61,7 +61,7 @@ func TestLoggingMiddleware_QueryParameters(t *testing.T) {
 			logDoesNotContain: []string{"query_parameters"},
 		},
 		{
-			name:              "SSO callback path with query params does not log query parameters",
+			name:              "SSO callback path with query params does not add query_parameters field and logs",
 			url:               ssoCallbackURL + "?code=abc123&state=xyz789",
 			logContains:       []string{"HTTP request"},
 			logDoesNotContain: []string{`"query_parameters":"`, `"code":`, `"state":`},

--- a/cmd/api/src/api/middleware/logging_test.go
+++ b/cmd/api/src/api/middleware/logging_test.go
@@ -1,3 +1,18 @@
+// Copyright 2026 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 package middleware_test
 
 import (

--- a/cmd/api/src/api/middleware/logging_test.go
+++ b/cmd/api/src/api/middleware/logging_test.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/specterops/bloodhound/cmd/api/src/api/middleware"
 	"github.com/specterops/bloodhound/cmd/api/src/auth"
-	"github.com/specterops/bloodhound/cmd/api/src/ctx"
+	"github.com/specterops/bloodhound/cmd/api/src/bhctx"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -102,11 +102,11 @@ func TestLoggingMiddleware_QueryParameters(t *testing.T) {
 			handler := middleware.LoggingMiddleware(auth.NewIdentityResolver(), false)(nextHandler)
 
 			request := httptest.NewRequest(http.MethodGet, testCase.url, nil)
-			bhCtx := &ctx.Context{
+			bhCtx := &bhctx.Context{
 				StartTime: time.Now(),
 				RequestID: "123456",
 			}
-			request = ctx.SetRequestContext(request, bhCtx)
+			request = bhctx.SetRequestContext(request, bhCtx)
 			response := httptest.NewRecorder()
 			handler.ServeHTTP(response, request)
 

--- a/cmd/api/src/api/middleware/logging_test.go
+++ b/cmd/api/src/api/middleware/logging_test.go
@@ -31,9 +31,10 @@ import (
 
 func TestLoggingMiddleware_QueryParameters(t *testing.T) {
 	var (
-		testURL1  = "/api/v2/bloodhound-users"
-		testURL2  = "/api/v2/search"
-		healthURL = "/health"
+		testURL1       = "/api/v2/bloodhound-users"
+		testURL2       = "/api/v2/search"
+		healthURL      = "/health"
+		ssoCallbackURL = "/api/v2/sso/73d94be8-a18c-4de2-b63c-75c28d3d4bff/callback"
 	)
 	testCases := []struct {
 		name              string
@@ -48,10 +49,22 @@ func TestLoggingMiddleware_QueryParameters(t *testing.T) {
 			logDoesNotContain: []string{"query_parameters"},
 		},
 		{
+			name:              "similar /api/v20 does not log query parameters",
+			url:               "/api/v20/search?foo=bar",
+			logContains:       []string{"HTTP request"},
+			logDoesNotContain: []string{"query_parameters"},
+		},
+		{
 			name:              "/api/v2 path with no query params does not log query parameters",
 			url:               testURL1,
 			logContains:       []string{"HTTP request"},
 			logDoesNotContain: []string{"query_parameters"},
+		},
+		{
+			name:              "SSO callback path with query params does not log query parameters",
+			url:               ssoCallbackURL + "?code=abc123&state=xyz789",
+			logContains:       []string{"HTTP request"},
+			logDoesNotContain: []string{`"query_parameters":"`, `"code":`, `"state":`},
 		},
 		{
 			name:        "/api/v2 path with query params adds a query_parameters field",
@@ -66,7 +79,7 @@ func TestLoggingMiddleware_QueryParameters(t *testing.T) {
 		{
 			name:        "multiple query parameters are logged",
 			url:         testURL2 + "?q=abcd&limit=1000&type=Computer&type=User&type=Group",
-			logContains: []string{"HTTP request", "query_parameters", "q", "abcd", "limit", "1000", "type", "Computer", "User", "Group"},
+			logContains: []string{"HTTP request", "query_parameters", "abcd", "limit", "1000", "type", "Computer", "User", "Group"},
 		},
 		{
 			name:        "query_parameters field contains the full raw query string",
@@ -77,6 +90,9 @@ func TestLoggingMiddleware_QueryParameters(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
+			previousLogger := slog.Default()
+			t.Cleanup(func() { slog.SetDefault(previousLogger) })
+
 			var logBuffer bytes.Buffer
 			slog.SetDefault(slog.New(slog.NewJSONHandler(&logBuffer, &slog.HandlerOptions{})))
 

--- a/cmd/api/src/api/middleware/logging_test.go
+++ b/cmd/api/src/api/middleware/logging_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -54,19 +54,24 @@ func TestLoggingMiddleware_QueryParameters(t *testing.T) {
 			logDoesNotContain: []string{"query_parameters"},
 		},
 		{
-			name:        "single query parameter is logged as structured field",
+			name:        "/api/v2 path with query params adds a query_parameters field",
+			url:         testURL1 + "?first_name=eq:Hubert",
+			logContains: []string{`"query_parameters":"`},
+		},
+		{
+			name:        "single query parameter is logged",
 			url:         testURL1 + "?first_name=eq:Hubert",
 			logContains: []string{"HTTP request", "query_parameters", "first_name", "eq:Hubert"},
 		},
 		{
-			name:        "multiple query parameters are logged as structured fields",
-			url:         testURL1 + "?first_name=eq:Hubert&limit=10",
-			logContains: []string{"HTTP request", "query_parameters", "first_name", "eq:Hubert", "limit", "10"},
+			name:        "multiple query parameters are logged",
+			url:         testURL2 + "?q=abcd&limit=1000&type=Computer&type=User&type=Group",
+			logContains: []string{"HTTP request", "query_parameters", "q", "abcd", "limit", "1000", "type", "Computer", "User", "Group"},
 		},
 		{
-			name:        "multi-value query parameter values are comma-joined",
-			url:         testURL2 + "?type=Computer&type=User&type=Group",
-			logContains: []string{"HTTP request", "query_parameters", "type", "Computer", "User", "Group"},
+			name:        "query_parameters field contains the full raw query string",
+			url:         testURL2 + "?q=abcd&limit=1000&type=Computer&type=User&type=Group",
+			logContains: []string{"HTTP request", `"query_parameters":"q=abcd&limit=1000&type=Computer&type=User&type=Group"`},
 		},
 	}
 

--- a/cmd/api/src/api/middleware/logging_test.go
+++ b/cmd/api/src/api/middleware/logging_test.go
@@ -31,10 +31,19 @@ import (
 
 func TestLoggingMiddleware_QueryParameters(t *testing.T) {
 	var (
-		testURL1       = "/api/v2/bloodhound-users"
-		testURL2       = "/api/v2/search"
-		healthURL      = "/health"
-		ssoCallbackURL = "/api/v2/sso/73d94be8-a18c-4de2-b63c-75c28d3d4bff/callback"
+		testURL1  = "/api/v2/bloodhound-users"
+		testURL2  = "/api/v2/search"
+		healthURL = "/health"
+
+		// Excluded paths (should NOT emit query_parameters)
+		loginSupportURL = "/api/v2/login/support"
+		ssoCallbackURL  = "/api/v2/sso/abcd/callback"
+		samlACSURL      = "/api/v2/login/saml/abcd/acs"
+
+		// Non-excluded paths (SHOULD still emit query_parameters)
+		samlMetadataURL = "/api/v2/login/saml/abcd/metadata"
+		ssoLoginURL     = "/api/v2/sso/abcd/login"
+		ssoProvidersURL = "/api/v2/sso-providers"
 	)
 	testCases := []struct {
 		name              string
@@ -61,10 +70,43 @@ func TestLoggingMiddleware_QueryParameters(t *testing.T) {
 			logDoesNotContain: []string{"query_parameters"},
 		},
 		{
-			name:              "SSO callback path with query params does not add query_parameters field and logs",
+			name:              "SSO callback path with query params does not add query_parameters field",
 			url:               ssoCallbackURL + "?code=abc123&state=xyz789",
 			logContains:       []string{"HTTP request"},
 			logDoesNotContain: []string{`"query_parameters":"`, `"code":`, `"state":`},
+		},
+		{
+			name:        "other SSO path with query params still adds query_parameters field",
+			url:         ssoProvidersURL + "?sort_by=name",
+			logContains: []string{`"query_parameters":"`, "sort_by"},
+		},
+		{
+			name:              "login/support path with query params does not add query_parameters field",
+			url:               loginSupportURL + "?auth_code=abcd1111-25a9-4a08-9e11-9965acb126f7",
+			logContains:       []string{"HTTP request"},
+			logDoesNotContain: []string{`"query_parameters":"`, `"auth_code":`},
+		},
+		{
+			name:        "SSO login path with query params still adds query_parameters field",
+			url:         ssoLoginURL + "?redirect=/ui",
+			logContains: []string{`"query_parameters":"`, "redirect"},
+		},
+		{
+			name:              "SAML ACS path with query params does not add query_parameters field",
+			url:               samlACSURL + "?SAMLart=AAQAAMx8test123",
+			logContains:       []string{"HTTP request"},
+			logDoesNotContain: []string{`"query_parameters":"`, `"SAMLart":`},
+		},
+		{
+			name:        "SAML metadata path with query params still adds query_parameters field",
+			url:         samlMetadataURL + "?entityID=urn:test",
+			logContains: []string{`"query_parameters":"`, "entityID"},
+		},
+		{
+			name:              "non /api/v2 path (v1 SAML ACS) does not add query_parameters field",
+			url:               "/api/v1/login/saml/abcd/acs?SAMLart=AAQAAMx8test123",
+			logContains:       []string{"HTTP request"},
+			logDoesNotContain: []string{`"query_parameters":"`},
 		},
 		{
 			name:        "/api/v2 path with query params adds a query_parameters field",


### PR DESCRIPTION
## Description
Add query parameter logging for /api/v2 requests for easier Elastic/Kibana lookups. This logs the raw string and makes it easier to filter and search in Elastic without parsing the full request_uri field. 

- adds query_parameters slog attribute in LoggingMiddleware
- only logs for /api/v2 endpoints with non-empty query strings
- ignores SSO callback endpoint and a few others (see link for [full audit](https://specterops.atlassian.net/browse/BED-8722 )). Even if params are already being logged via `request_uri`, it is probably better not to add them to the new `query_parameters` field. 
- adds table-driven tests

Note:
After some deliberation, decided not to add nested logging due to potential Elastic index mapping problems. (If we were to add a large list of parameters (in the hundreds) to our Elastic daily indexes mapping, that could cause issues – indexes are already > 1000). 


## Motivation and Context

Resolves BED-8563. 

There's a general benefit to having query_parameters as a dedicated field since it makes it easier to filter and aggregate on query param usage across most endpoints. 

Specifically, we were looking at non-default limit and skip parameters queries for the api/v2/search endpoint

## How Has This Been Tested?

- Added unit tests (table-driven) covering non-/api/v2 paths, empty query strings, ignoring a specific endpoint, etc.
- Manually tested output with EnableAPILogging enabled, hit various /api/v2 endpoints, verified logs

## Screenshots (optional):

log output showing query_parameters field (/api/v2 request with a single parameter)

<img width="1349" height="84" alt="1" src="https://github.com/user-attachments/assets/65367c7e-c6e9-4b56-9bf7-17eb7ef51bcc" />

pretty print of the above log output (disabling text logging)

<img width="586" height="378" alt="2" src="https://github.com/user-attachments/assets/d3d817d7-8be0-43cd-a514-0ba2e6a5c703" />

log output showing query_parameters field (/api/v2 request with multiple parameters)

<img width="1327" height="83" alt="3" src="https://github.com/user-attachments/assets/a164bdfa-31a7-4840-ab15-ea11aa0721d4" />


## Types of changes

<!-- Please remove any items that do not apply. -->
- New feature (non-breaking change which adds functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Improvements

* Request logs now omit query-parameter details for login-support, SSO callback, and SAML authentication endpoints.
* Query parameters continue to be logged for other API v2 requests, including repeated parameters and complete query strings.

## Tests

* Added coverage for query-parameter logging and exclusion behavior across API, SSO, login-support, and SAML URL patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->