### PR TITLE
fix: Copy Server Pkg to Prod Image in BCHE Dockerfile - BED-8683

### DIFF
--- a/dockerfiles/bloodhound.Dockerfile
+++ b/dockerfiles/bloodhound.Dockerfile
@@ -106,7 +106,7 @@ RUN apk add --update --no-cache git
 RUN mkdir -p /opt/bloodhound /etc/bloodhound /var/log
 
 WORKDIR /build
-COPY --parents go* cmd/api packages/go ./
+COPY --parents go* cmd/api packages/go server ./
 COPY --from=ldflag-builder /build/LDFLAGS ./
 COPY --from=ui-builder /build/cmd/ui/dist ./cmd/api/src/api/static/assets
 RUN --mount=type=cache,target=/go/pkg/mod go build -C cmd/api/src -o /bloodhound -ldflags "$(cat LDFLAGS)" github.com/specterops/bloodhound/cmd/api/src/cmd/bhapi


### PR DESCRIPTION
## Description

Copies the /server pkg to the production dockerfile during image build so its available when the binary is built

## Motivation and Context
Resolves: BED-8683

The build docker image CI action is failing because this directory is not being copied over. 

## How Has This Been Tested?

Built the image locally using the prod dockerfile to ensure the binary compiles and the docker build successfully finishes. 

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to optimize the API build process by including additional project directories in the build context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->