### PR TITLE
fix(UI): schema upload dialog should not open if file upload dialog is open BED-8656

### DIFF
--- a/packages/javascript/bh-shared-ui/src/components/SchemaUploadDialog/SchemaUploadDialog.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/SchemaUploadDialog/SchemaUploadDialog.test.tsx
@@ -132,12 +132,16 @@ describe('SchemaUploadDialog', () => {
         expect(screen.queryByRole('dialog', { name: 'Upload Schema Files' })).not.toBeInTheDocument();
     });
 
-    it('does not open the schema upload dialog via drag when the Quick Upload dialog is already open', async () => {
+    it('does not open the Schema Upload dialog via drag when the Quick Upload dialog is already open', async () => {
         showFileIngestDialogMock.value = true;
 
         const screen = render(<SchemaUploadDialog />);
 
-        const dragEvent = new Event('dragenter');
+        const dragEvent = new Event('dragenter', { bubbles: true }) as any;
+        dragEvent.dataTransfer = {
+            types: ['Files'],
+            items: [{ kind: 'file', type: 'application/json' }],
+        };
         document.dispatchEvent(dragEvent);
 
         expect(screen.queryByRole('dialog', { name: 'Upload Schema Files' })).not.toBeInTheDocument();

--- a/packages/javascript/bh-shared-ui/src/components/SchemaUploadDialog/SchemaUploadDialog.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/SchemaUploadDialog/SchemaUploadDialog.test.tsx
@@ -26,6 +26,7 @@ const testFile = new File([JSON.stringify({ value: 'test' })], 'test.json', { ty
 
 const addNotificationMock = vi.fn();
 const checkPermissionMock = vi.fn().mockReturnValue(true);
+const showFileIngestDialogMock = { value: false };
 
 vi.mock('../../providers', async () => {
     const actual = await vi.importActual('../../providers');
@@ -44,6 +45,16 @@ vi.mock('../../hooks/usePermissions', async () => {
         usePermissions: () => ({
             checkPermission: checkPermissionMock,
             isSuccess: true,
+        }),
+    };
+});
+
+vi.mock('../../hooks/useFileUploadDialogContext', async () => {
+    const actual = await vi.importActual('../../hooks');
+    return {
+        ...actual,
+        useFileUploadDialogContext: () => ({
+            showFileIngestDialog: showFileIngestDialogMock.value,
         }),
     };
 });
@@ -87,6 +98,7 @@ afterEach(() => {
     server.resetHandlers();
     addNotificationMock.mockClear();
     checkPermissionMock.mockReturnValue(true);
+    showFileIngestDialogMock.value = false;
 });
 afterAll(() => {
     server.close();
@@ -117,6 +129,17 @@ describe('SchemaUploadDialog', () => {
         expect(screen.getByRole('button', { name: 'Upload File' })).toBeDisabled();
 
         await user.click(screen.getByRole('button', { name: 'Upload File' }));
+        expect(screen.queryByRole('dialog', { name: 'Upload Schema Files' })).not.toBeInTheDocument();
+    });
+
+    it('does not open the schema upload dialog via drag when the Quick Upload dialog is already open', async () => {
+        showFileIngestDialogMock.value = true;
+
+        const screen = render(<SchemaUploadDialog />);
+
+        const dragEvent = new Event('dragenter');
+        document.dispatchEvent(dragEvent);
+
         expect(screen.queryByRole('dialog', { name: 'Upload Schema Files' })).not.toBeInTheDocument();
     });
 

--- a/packages/javascript/bh-shared-ui/src/components/SchemaUploadDialog/SchemaUploadDialog.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/SchemaUploadDialog/SchemaUploadDialog.tsx
@@ -46,6 +46,8 @@ export const SchemaUploadDialog = () => {
         [hasUploadPermission, showFileIngestDialog]
     );
 
+    // Dragging a file into the window displays the dialog. The normal global file upload drag and drop behavior is
+    // disabled for the OpenGraph Management page, unless the user explicitly clicks on the Quick Upload button to open the Quick Upload Dialog
     useExecuteOnFileDrag(
         () => {
             if (hasUploadPermission) setDialogOpen(true);

--- a/packages/javascript/bh-shared-ui/src/components/SchemaUploadDialog/SchemaUploadDialog.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/SchemaUploadDialog/SchemaUploadDialog.tsx
@@ -24,8 +24,8 @@ import {
     DialogTitle,
     DialogTrigger,
 } from 'doodle-ui';
-import { useState } from 'react';
-import { useExecuteOnFileDrag, usePermissions } from '../../hooks';
+import { useCallback, useState } from 'react';
+import { useExecuteOnFileDrag, useFileUploadDialogContext, usePermissions } from '../../hooks';
 import { Permission } from '../../utils';
 import { ConditionalTooltip } from '../ConditionalTooltip';
 import FileDrop from '../FileDrop';
@@ -39,15 +39,20 @@ export const SchemaUploadDialog = () => {
 
     const { checkPermission } = usePermissions();
     const hasUploadPermission = checkPermission(Permission.OPENGRAPH_WRITE);
+    const { showFileIngestDialog } = useFileUploadDialogContext();
 
-    // Dragging a file into the window displays the dialog. The normal global file upload drag and drop behavior is
-    // disabled for the OpenGraph Management page
+    const shouldRespondToDrag = useCallback(
+        () => hasUploadPermission && !showFileIngestDialog,
+        [hasUploadPermission, showFileIngestDialog]
+    );
+
     useExecuteOnFileDrag(
         () => {
             if (hasUploadPermission) setDialogOpen(true);
         },
         {
             acceptedTypes: ['application/json'],
+            condition: shouldRespondToDrag,
         }
     );
 


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

There was a bug on the OpenGraph Management page where if you were on the OpenGraph Management page and then clicked "Quick Upload", the Quick Upload dialog opens; but then if you attempt to drag a file into the dialog, the Schema Upload Dialog would also open behind it, and the UI sort of breaks. The file is attached to the Schema Upload dialog but is not visible which is a confusing experience. This change updates the Schema Upload dialog to not open if the Quick Upload dialog is already open.

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-8656

Solves the bug where both dialogs would open at the same time. 

## How Has This Been Tested?

Tested locally following the instructions in the ticket. Also added a new test for this case.

## Screenshots (optional):


https://github.com/user-attachments/assets/e4157f04-addc-4dd9-87f9-3afaf6b4720e



## Types of changes

<!-- Please remove any items that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage to verify the schema upload dialog does not open from drag-and-drop when another file ingest dialog is already active.

* **Bug Fixes**
  * Improved schema drag-and-drop handling so the “Upload Schema Files” dialog won’t appear if an ingest/upload dialog is currently displayed, while preserving existing behavior when uploads are permitted and no ingest dialog is showing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->