### PR TITLE
fix: Colon breaking search in explore graph - BED-8642  

### DIFF
--- a/packages/javascript/bh-shared-ui/src/components/AssetGroupEdit/AssetGroupAutocomplete.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/AssetGroupEdit/AssetGroupAutocomplete.tsx
@@ -17,7 +17,7 @@
 import { Autocomplete, AutocompleteRenderInputParams, TextField } from '@mui/material';
 import { AssetGroup } from 'js-client-library';
 import { FC, HTMLAttributes, ReactNode, SyntheticEvent, useState } from 'react';
-import { getEmptyResultsText, getKeywordAndTypeValues, useDebouncedValue, useSearch } from '../../hooks';
+import { getEmptyResultsText, useDebouncedValue, useKeywordAndTypeValues, useSearch } from '../../hooks';
 import AutocompleteOption from './AutocompleteOption';
 import { AssetGroupChangelog, AssetGroupChangelogEntry, ChangelogAction } from './types';
 
@@ -30,7 +30,7 @@ const AssetGroupAutocomplete: FC<{
 }> = ({ assetGroup, changelog, onChange }) => {
     const [searchInput, setSearchInput] = useState('');
     const debouncedInputValue = useDebouncedValue(searchInput, 250);
-    const { keyword, type } = getKeywordAndTypeValues(debouncedInputValue);
+    const { keyword, type } = useKeywordAndTypeValues(debouncedInputValue);
     const { data, isLoading, isFetching, isError, error } = useSearch(keyword, type);
 
     const noOptionsText = getEmptyResultsText(

--- a/packages/javascript/bh-shared-ui/src/components/ExploreSearchCombobox/ExploreSearchCombobox.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/ExploreSearchCombobox/ExploreSearchCombobox.tsx
@@ -17,7 +17,7 @@
 import { List, ListItem, ListItemText, Paper, TextField, TextFieldVariants } from '@mui/material';
 import { useCombobox } from 'downshift';
 import { useRef } from 'react';
-import { SearchResult, getEmptyResultsText, getKeywordAndTypeValues, useSearch, useTheme } from '../../hooks';
+import { SearchResult, getEmptyResultsText, useKeywordAndTypeValues, useSearch, useTheme } from '../../hooks';
 import { SearchValue } from '../../views/Explore/ExploreSearch/types';
 import NodeIcon from '../NodeIcon';
 import SearchResultItem from '../SearchResultItem';
@@ -44,7 +44,7 @@ const ExploreSearchCombobox: React.FC<{
     const theme = useTheme();
     const searchNodesRef = useRef<HTMLInputElement>();
 
-    const { keyword, type } = getKeywordAndTypeValues(inputValue);
+    const { keyword, type } = useKeywordAndTypeValues(inputValue);
     const { data, error, isError, isLoading, isFetching } = useSearch(keyword, type);
 
     const { isOpen, getMenuProps, getInputProps, highlightedIndex, getItemProps, openMenu } = useCombobox({

--- a/packages/javascript/bh-shared-ui/src/components/HighlightedText/HighlightedText.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HighlightedText/HighlightedText.tsx
@@ -20,7 +20,7 @@ import React from 'react';
 const escapeSpecialCharacters = (text: string) => text.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&');
 
 const HighlightedText: React.FC<{ text: string; search: string | undefined }> = ({ text, search }) => {
-    if (!search) return;
+    if (!search) return <>{text}</>;
     const escapedSearch = escapeSpecialCharacters(search);
     const regex = new RegExp(`(.*?)(${escapedSearch})(.*)`, 'mi');
     const groups = text.match(regex);

--- a/packages/javascript/bh-shared-ui/src/components/HighlightedText/HighlightedText.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HighlightedText/HighlightedText.tsx
@@ -19,7 +19,8 @@ import React from 'react';
 
 const escapeSpecialCharacters = (text: string) => text.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&');
 
-const HighlightedText: React.FC<{ text: string; search: string }> = ({ text, search }) => {
+const HighlightedText: React.FC<{ text: string; search: string | undefined }> = ({ text, search }) => {
+    if (!search) return;
     const escapedSearch = escapeSpecialCharacters(search);
     const regex = new RegExp(`(.*?)(${escapedSearch})(.*)`, 'mi');
     const groups = text.match(regex);

--- a/packages/javascript/bh-shared-ui/src/components/SearchResultItem/SearchResultItem.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/SearchResultItem/SearchResultItem.tsx
@@ -72,7 +72,7 @@ const SearchResultItem: FC<{
                                 flexGrow: 1,
                                 marginRight: '1em',
                             }}>
-                            <HighlightedText text={item.label || item.objectId} search={keyword as string} />
+                            <HighlightedText text={item.label || item.objectId} search={keyword} />
                         </Box>
                     </Box>
                 }

--- a/packages/javascript/bh-shared-ui/src/components/SearchResultItem/SearchResultItem.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/SearchResultItem/SearchResultItem.tsx
@@ -72,7 +72,7 @@ const SearchResultItem: FC<{
                                 flexGrow: 1,
                                 marginRight: '1em',
                             }}>
-                            <HighlightedText text={item.label || item.objectId} search={keyword} />
+                            <HighlightedText text={item.label || item.objectId} search={keyword as string} />
                         </Box>
                     </Box>
                 }

--- a/packages/javascript/bh-shared-ui/src/components/SearchResultItem/SearchResultItem.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/SearchResultItem/SearchResultItem.tsx
@@ -30,10 +30,10 @@ export type NodeSearchResult = {
 const SearchResultItem: FC<{
     item: NodeSearchResult;
     index: number;
-    keyword: string;
     getItemProps: (options: any) => any;
     highlightedIndex?: number;
     style?: React.CSSProperties;
+    keyword?: string;
 }> = ({ style, item, index, highlightedIndex, keyword, getItemProps }) => {
     return (
         <ListItem

--- a/packages/javascript/bh-shared-ui/src/hooks/useExploreGraph/useNodeSearch.ts
+++ b/packages/javascript/bh-shared-ui/src/hooks/useExploreGraph/useNodeSearch.ts
@@ -14,10 +14,10 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { SearchValue } from '../../views/Explore/ExploreSearch/types';
 import { useExploreParams } from '../useExploreParams';
-import { getKeywordAndTypeValues, useSearch } from '../useSearch';
+import { useKeywordAndTypeValues, useSearch } from '../useSearch';
 
 /* Reusable logic for syncing up a single node search field with browser query params on the Explore page. The value of the search field is tracked
 internally, and is only pushed to query params once the event handler is called by the consumer component. Direct changes to the associated query
@@ -29,7 +29,7 @@ export const useNodeSearch = () => {
     const { primarySearch, searchType, setExploreParams } = useExploreParams();
 
     // Wire up search query. we should only recompute the keyword/type when the param value changes
-    const { keyword, type } = useMemo(() => getKeywordAndTypeValues(primarySearch ?? undefined), [primarySearch]);
+    const { keyword, type } = useKeywordAndTypeValues(primarySearch ?? undefined);
     const { data: searchData } = useSearch(keyword, type);
 
     // Watch query params for a new incoming node search and sync to internal state

--- a/packages/javascript/bh-shared-ui/src/hooks/useExploreGraph/useNodeSearch.ts
+++ b/packages/javascript/bh-shared-ui/src/hooks/useExploreGraph/useNodeSearch.ts
@@ -29,7 +29,7 @@ export const useNodeSearch = () => {
     const { primarySearch, searchType, setExploreParams } = useExploreParams();
 
     // Wire up search query. we should only recompute the keyword/type when the param value changes
-    const { keyword, type } = useKeywordAndTypeValues(primarySearch ?? undefined);
+    const { keyword, type } = useKeywordAndTypeValues(primarySearch);
     const { data: searchData } = useSearch(keyword, type);
 
     // Watch query params for a new incoming node search and sync to internal state

--- a/packages/javascript/bh-shared-ui/src/hooks/useExploreGraph/usePathfindingSearch.ts
+++ b/packages/javascript/bh-shared-ui/src/hooks/useExploreGraph/usePathfindingSearch.ts
@@ -28,10 +28,8 @@ export const usePathfindingSearch = () => {
     const { primarySearch, secondarySearch, setExploreParams } = useExploreParams();
 
     // Wire up search queries. we should only recompute keywords when the param values change
-    const { keyword: sourceKeyword, type: sourceType } = useKeywordAndTypeValues(primarySearch ?? undefined);
-    const { keyword: destinationKeyword, type: destinationType } = useKeywordAndTypeValues(
-        secondarySearch ?? undefined
-    );
+    const { keyword: sourceKeyword, type: sourceType } = useKeywordAndTypeValues(primarySearch);
+    const { keyword: destinationKeyword, type: destinationType } = useKeywordAndTypeValues(secondarySearch);
 
     const { data: sourceSearchData } = useSearch(sourceKeyword, sourceType);
     const { data: destinationSearchData } = useSearch(destinationKeyword, destinationType);

--- a/packages/javascript/bh-shared-ui/src/hooks/useExploreGraph/usePathfindingSearch.ts
+++ b/packages/javascript/bh-shared-ui/src/hooks/useExploreGraph/usePathfindingSearch.ts
@@ -14,10 +14,10 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { SearchValue } from '../../views/Explore/ExploreSearch/types';
 import { useExploreParams } from '../useExploreParams';
-import { getKeywordAndTypeValues, useSearch } from '../useSearch';
+import { useKeywordAndTypeValues, useSearch } from '../useSearch';
 
 export const usePathfindingSearch = () => {
     const [sourceSearchTerm, setSourceSearchTerm] = useState<string>('');
@@ -28,14 +28,11 @@ export const usePathfindingSearch = () => {
     const { primarySearch, secondarySearch, setExploreParams } = useExploreParams();
 
     // Wire up search queries. we should only recompute keywords when the param values change
-    const { keyword: sourceKeyword, type: sourceType } = useMemo(
-        () => getKeywordAndTypeValues(primarySearch ?? undefined),
-        [primarySearch]
+    const { keyword: sourceKeyword, type: sourceType } = useKeywordAndTypeValues(primarySearch ?? undefined);
+    const { keyword: destinationKeyword, type: destinationType } = useKeywordAndTypeValues(
+        secondarySearch ?? undefined
     );
-    const { keyword: destinationKeyword, type: destinationType } = useMemo(
-        () => getKeywordAndTypeValues(secondarySearch ?? undefined),
-        [secondarySearch]
-    );
+
     const { data: sourceSearchData } = useSearch(sourceKeyword, sourceType);
     const { data: destinationSearchData } = useSearch(destinationKeyword, destinationType);
 

--- a/packages/javascript/bh-shared-ui/src/hooks/useSearch/useSearch.test.ts
+++ b/packages/javascript/bh-shared-ui/src/hooks/useSearch/useSearch.test.ts
@@ -14,8 +14,17 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+import { setupServer } from 'msw/node';
 import { ActiveDirectoryNodeKind } from '../../graphSchema';
-import { getEmptyResultsText, getKeywordAndTypeValues } from './useSearch';
+import { mockKindsHandler } from '../../mocks/handlers';
+import { renderHook, waitFor } from '../../test-utils';
+import { getEmptyResultsText, useKeywordAndTypeValues } from './useSearch';
+
+const server = setupServer(mockKindsHandler(['computer', 'azapp']));
+
+beforeAll(() => server.listen());
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
 
 describe('Getting the text for the disabled item display for a search when there are no results', () => {
     describe('Loading states', () => {
@@ -86,21 +95,29 @@ describe('Getting the text for the disabled item display for a search when there
 
 describe('Parsing the debounced input for type and keyword values', () => {
     test('`undefined` input is provided', () => {
-        expect(getKeywordAndTypeValues(undefined)).toEqual({ keyword: '', type: undefined });
+        const { result } = renderHook(() => useKeywordAndTypeValues(undefined));
+        expect(result.current).toEqual({ keyword: undefined, type: undefined });
     });
 
     test('Empty input is provided', () => {
-        expect(getKeywordAndTypeValues('')).toEqual({ keyword: '', type: undefined });
+        const { result } = renderHook(() => useKeywordAndTypeValues(''));
+        expect(result.current).toEqual({ keyword: '', type: undefined });
     });
 
     test('Input does not contain a type', () => {
-        expect(getKeywordAndTypeValues('test')).toEqual({ keyword: 'test', type: undefined });
+        const { result } = renderHook(() => useKeywordAndTypeValues('test'));
+        expect(result.current).toEqual({ keyword: 'test', type: undefined });
     });
 
-    it('Will ignore colons after the first and use them as part of the keyword search', () => {
-        expect(getKeywordAndTypeValues('computer:user:domain:ou:gpo:test')).toEqual({
-            keyword: 'user:domain:ou:gpo:test',
-            type: 'computer',
-        });
+    it('Will treat what is to the left of the first colon as a search filter if it matches an existing kind', async () => {
+        const { result } = renderHook(() => useKeywordAndTypeValues('computer:user:domain:ou:gpo:test'));
+        await waitFor(() => expect(result.current.type).toBe('computer'));
+        expect(result.current).toEqual({ keyword: 'user:domain:ou:gpo:test', type: 'computer' });
+    });
+
+    it('Will ignore what is to the left of the first colon if it doesnt match an existing kind and will treat all as keyword', async () => {
+        const { result } = renderHook(() => useKeywordAndTypeValues('testing:user:domain:ou:gpo:test'));
+        await waitFor(() => expect(result.current.keyword).toBe('testing:user:domain:ou:gpo:test'));
+        expect(result.current).toEqual({ keyword: 'testing:user:domain:ou:gpo:test', type: undefined });
     });
 });

--- a/packages/javascript/bh-shared-ui/src/hooks/useSearch/useSearch.test.ts
+++ b/packages/javascript/bh-shared-ui/src/hooks/useSearch/useSearch.test.ts
@@ -17,8 +17,7 @@
 import { setupServer } from 'msw/node';
 import { ActiveDirectoryNodeKind } from '../../graphSchema';
 import { mockKindsHandler } from '../../mocks/handlers';
-import { renderHook, waitFor } from '../../test-utils';
-import { getEmptyResultsText, useKeywordAndTypeValues } from './useSearch';
+import { getEmptyResultsText } from './useSearch';
 
 const server = setupServer(mockKindsHandler(['computer', 'azapp']));
 
@@ -90,34 +89,5 @@ describe('Getting the text for the disabled item display for a search when there
                 'No results found for "test"'
             );
         });
-    });
-});
-
-describe('Parsing the debounced input for type and keyword values', () => {
-    test('`undefined` input is provided', () => {
-        const { result } = renderHook(() => useKeywordAndTypeValues(undefined));
-        expect(result.current).toEqual({ keyword: undefined, type: undefined });
-    });
-
-    test('Empty input is provided', () => {
-        const { result } = renderHook(() => useKeywordAndTypeValues(''));
-        expect(result.current).toEqual({ keyword: '', type: undefined });
-    });
-
-    test('Input does not contain a type', () => {
-        const { result } = renderHook(() => useKeywordAndTypeValues('test'));
-        expect(result.current).toEqual({ keyword: 'test', type: undefined });
-    });
-
-    it('Will treat what is to the left of the first colon as a search filter if it matches an existing kind', async () => {
-        const { result } = renderHook(() => useKeywordAndTypeValues('computer:user:domain:ou:gpo:test'));
-        await waitFor(() => expect(result.current.type).toBe('computer'));
-        expect(result.current).toEqual({ keyword: 'user:domain:ou:gpo:test', type: 'computer' });
-    });
-
-    it('Will ignore what is to the left of the first colon if it doesnt match an existing kind and will treat all as keyword', async () => {
-        const { result } = renderHook(() => useKeywordAndTypeValues('testing:user:domain:ou:gpo:test'));
-        await waitFor(() => expect(result.current.keyword).toBe('testing:user:domain:ou:gpo:test'));
-        expect(result.current).toEqual({ keyword: 'testing:user:domain:ou:gpo:test', type: undefined });
     });
 });

--- a/packages/javascript/bh-shared-ui/src/hooks/useSearch/useSearch.test.ts
+++ b/packages/javascript/bh-shared-ui/src/hooks/useSearch/useSearch.test.ts
@@ -1,4 +1,4 @@
-// Copyright 2023 Specter Ops, Inc.
+// Copyright 2026 Specter Ops, Inc.
 //
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
@@ -14,16 +14,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { setupServer } from 'msw/node';
 import { ActiveDirectoryNodeKind } from '../../graphSchema';
-import { mockKindsHandler } from '../../mocks/handlers';
 import { getEmptyResultsText } from './useSearch';
-
-const server = setupServer(mockKindsHandler(['computer', 'azapp']));
-
-beforeAll(() => server.listen());
-afterEach(() => server.resetHandlers());
-afterAll(() => server.close());
 
 describe('Getting the text for the disabled item display for a search when there are no results', () => {
     describe('Loading states', () => {

--- a/packages/javascript/bh-shared-ui/src/hooks/useSearch/useSearch.tsx
+++ b/packages/javascript/bh-shared-ui/src/hooks/useSearch/useSearch.tsx
@@ -16,7 +16,7 @@
 
 import { isAxiosError } from 'js-client-library';
 import { useQuery } from 'react-query';
-import { apiClient } from '../../utils';
+import { apiClient, type KeywordAndTypeValues, Maybe, parseKeywordAndTypeValue } from '../../utils';
 import { useTimeoutLimitConfiguration } from '../useConfiguration';
 import { useGraphNodeKinds } from '../useGraphKinds';
 
@@ -53,36 +53,9 @@ export const useSearch = (keyword = '', type: string | undefined) => {
     });
 };
 
-export const useKeywordAndTypeValues = (
-    inputValue: string | undefined
-): { keyword: string | undefined; type: string | undefined } => {
-    const { data, isLoading } = useGraphNodeKinds();
-
-    let keyword: string | undefined = inputValue;
-    let type: string | undefined = undefined;
-
-    const hasQualifier = !!inputValue?.includes(':');
-
-    if (hasQualifier && isLoading) {
-        return { keyword: undefined, type: undefined };
-    }
-
-    if (inputValue && inputValue.length > 1) {
-        // We use the : as q search/qualifier operator for searches so we need to perform the below to parse it if necessary
-        // Only do it if more than one char and that way if a user wants to use the : as a search string it works
-        const splitValue = inputValue.split(':');
-        if (splitValue.length > 1) {
-            const nodeKind = data?.kinds.find(
-                (kind) => kind.toLocaleLowerCase() === splitValue[0].toLocaleLowerCase() //abstract
-            );
-            if (nodeKind) {
-                type = nodeKind;
-                keyword = splitValue.slice(1).join(':');
-            }
-        }
-    }
-
-    return { keyword, type };
+export const useKeywordAndTypeValues = (inputValue: Maybe<string>): KeywordAndTypeValues => {
+    const { data } = useGraphNodeKinds();
+    return parseKeywordAndTypeValue(inputValue, data?.kinds);
 };
 
 const getErrorText = (error: any, type: string | undefined): string => {

--- a/packages/javascript/bh-shared-ui/src/hooks/useSearch/useSearch.tsx
+++ b/packages/javascript/bh-shared-ui/src/hooks/useSearch/useSearch.tsx
@@ -35,7 +35,8 @@ export const searchKeys = {
     detail: (keyword: string, type: string | undefined) => [...searchKeys.all, keyword, type] as const,
 };
 
-export const useSearch = (keyword: string, type: string | undefined) => {
+export const useSearch = (keyword = '', type: string | undefined) => {
+    console.log('use search keyword', keyword);
     const timeoutLimitEnabled = useTimeoutLimitConfiguration();
     const timeout = timeoutLimitEnabled ? 60000 : 0;
 
@@ -59,6 +60,32 @@ export const useSearch = (keyword: string, type: string | undefined) => {
         keepPreviousData: true,
         retry: false,
     });
+};
+
+export const useKeywordAndTypeValues = (
+    inputValue: string | undefined
+): { keyword: string | undefined; type: string | undefined } => {
+    const { data } = useGraphNodeKinds();
+
+    let keyword: string | undefined = inputValue;
+    let type: string | undefined = undefined;
+
+    if (inputValue && inputValue.length > 1) {
+        // We use the : as q search/qualifier operator for searches so we need to perform the below to parse it if necessary
+        // Only do it if more than one char and that way if a user wants to use the : as a search string it works
+        const splitValue = inputValue.split(':');
+        if (splitValue.length > 1) {
+            const hasNodeKind = !!data?.kinds.find(
+                (kind) => kind.toLocaleLowerCase() === splitValue[0].toLocaleLowerCase() //abstract
+            );
+            if (hasNodeKind) {
+                type = splitValue[0];
+                keyword = splitValue.slice(1).join(':');
+            }
+        }
+    }
+
+    return { keyword, type };
 };
 
 export const getKeywordAndTypeValues = (inputValue = ''): { keyword: string; type: string | undefined } => {
@@ -90,7 +117,7 @@ const getErrorText = (error: any, type: string | undefined): string => {
     return errorMessage;
 };
 
-const getNoDataText = (debouncedInputValue: string, type: string | undefined, keyword: string): string => {
+const getNoDataText = (debouncedInputValue: string, type: string | undefined, keyword: string | undefined): string => {
     if (debouncedInputValue === '' && type === undefined)
         return 'Begin typing to search. Prepend a type followed by a colon to search by type, e.g., user:bob';
     else if (debouncedInputValue === '' && type !== undefined)
@@ -107,7 +134,7 @@ export const getEmptyResultsText = (
     error: any,
     debouncedInputValue: string,
     type: string | undefined,
-    keyword: string,
+    keyword: string | undefined,
     data: SearchResults | undefined
 ): string => {
     if (isLoading || isFetching) {

--- a/packages/javascript/bh-shared-ui/src/hooks/useSearch/useSearch.tsx
+++ b/packages/javascript/bh-shared-ui/src/hooks/useSearch/useSearch.tsx
@@ -16,7 +16,7 @@
 
 import { isAxiosError } from 'js-client-library';
 import { useQuery } from 'react-query';
-import { apiClient, type KeywordAndTypeValues, Maybe, parseKeywordAndTypeValue } from '../../utils';
+import { apiClient, type KeywordAndTypeValues, type Nullable, parseKeywordAndTypeValue } from '../../utils';
 import { useTimeoutLimitConfiguration } from '../useConfiguration';
 import { useGraphNodeKinds } from '../useGraphKinds';
 
@@ -53,7 +53,7 @@ export const useSearch = (keyword = '', type: string | undefined) => {
     });
 };
 
-export const useKeywordAndTypeValues = (inputValue: Maybe<string>): KeywordAndTypeValues => {
+export const useKeywordAndTypeValues = (inputValue: Nullable<string>): KeywordAndTypeValues => {
     const { data } = useGraphNodeKinds();
     return parseKeywordAndTypeValue(inputValue, data?.kinds);
 };

--- a/packages/javascript/bh-shared-ui/src/hooks/useSearch/useSearch.tsx
+++ b/packages/javascript/bh-shared-ui/src/hooks/useSearch/useSearch.tsx
@@ -36,27 +36,18 @@ export const searchKeys = {
 };
 
 export const useSearch = (keyword = '', type: string | undefined) => {
-    console.log('use search keyword', keyword);
     const timeoutLimitEnabled = useTimeoutLimitConfiguration();
     const timeout = timeoutLimitEnabled ? 60000 : 0;
-
-    const kindsQuery = useGraphNodeKinds();
-    const kinds = kindsQuery.data?.kinds ?? [];
-
-    // the current behavior is to case insensitive match the kind name from the input
-    // find and use the case sensitive kind name because the API requires the correct case
-    const kind = kinds.find((kind) => kind.toLocaleLowerCase() === type?.toLocaleLowerCase()) ?? type;
 
     return useQuery<SearchResults, any>({
         queryKey: searchKeys.detail(keyword, type),
         queryFn: ({ signal }) => {
             if (keyword === '') return [];
-            return apiClient.searchHandler(keyword, kind, { signal, timeout }).then((result) => {
+            return apiClient.searchHandler(keyword, type, { signal, timeout }).then((result) => {
                 if (!result.data.data) return [];
                 return result.data.data;
             });
         },
-        enabled: kindsQuery.isSuccess,
         keepPreviousData: true,
         retry: false,
     });
@@ -75,31 +66,17 @@ export const useKeywordAndTypeValues = (
         // Only do it if more than one char and that way if a user wants to use the : as a search string it works
         const splitValue = inputValue.split(':');
         if (splitValue.length > 1) {
-            const hasNodeKind = !!data?.kinds.find(
+            const nodeKind = data?.kinds.find(
                 (kind) => kind.toLocaleLowerCase() === splitValue[0].toLocaleLowerCase() //abstract
             );
-            if (hasNodeKind) {
-                type = splitValue[0];
+            if (nodeKind) {
+                type = nodeKind;
                 keyword = splitValue.slice(1).join(':');
             }
         }
     }
 
     return { keyword, type };
-};
-
-export const getKeywordAndTypeValues = (inputValue = ''): { keyword: string; type: string | undefined } => {
-    const splitValue = inputValue.split(':');
-
-    let keyword: string;
-    let type: string | undefined = undefined;
-
-    if (splitValue.length > 1) {
-        type = splitValue[0];
-        keyword = splitValue.slice(1).join(':');
-    } else keyword = splitValue[0];
-
-    return { keyword: keyword, type: type };
 };
 
 const getErrorText = (error: any, type: string | undefined): string => {

--- a/packages/javascript/bh-shared-ui/src/hooks/useSearch/useSearch.tsx
+++ b/packages/javascript/bh-shared-ui/src/hooks/useSearch/useSearch.tsx
@@ -56,10 +56,16 @@ export const useSearch = (keyword = '', type: string | undefined) => {
 export const useKeywordAndTypeValues = (
     inputValue: string | undefined
 ): { keyword: string | undefined; type: string | undefined } => {
-    const { data } = useGraphNodeKinds();
+    const { data, isLoading } = useGraphNodeKinds();
 
     let keyword: string | undefined = inputValue;
     let type: string | undefined = undefined;
+
+    const hasQualifier = !!inputValue?.includes(':');
+
+    if (hasQualifier && isLoading) {
+        return { keyword: undefined, type: undefined };
+    }
 
     if (inputValue && inputValue.length > 1) {
         // We use the : as q search/qualifier operator for searches so we need to perform the below to parse it if necessary

--- a/packages/javascript/bh-shared-ui/src/utils/strings.test.ts
+++ b/packages/javascript/bh-shared-ui/src/utils/strings.test.ts
@@ -1,0 +1,33 @@
+import { parseKeywordAndTypeValue } from './strings';
+
+describe('parseKeywordAndTypeValue', () => {
+    test('`undefined` input is provided', () => {
+        const result = parseKeywordAndTypeValue(undefined, []);
+        expect(result).toEqual({ keyword: undefined, type: undefined });
+    });
+
+    test('Empty input is provided', () => {
+        const result = parseKeywordAndTypeValue('', []);
+        expect(result).toEqual({ keyword: undefined, type: undefined });
+    });
+
+    test('Null input is provided', () => {
+        const result = parseKeywordAndTypeValue(null, []);
+        expect(result).toEqual({ keyword: undefined, type: undefined });
+    });
+
+    test('Input does not contain a type', () => {
+        const result = parseKeywordAndTypeValue('test', ['computer']);
+        expect(result).toEqual({ keyword: 'test', type: undefined });
+    });
+
+    it('Will treat what is to the left of the first colon as a search filter if it matches an existing kind', async () => {
+        const result = parseKeywordAndTypeValue('computer:user:domain:ou:gpo:test', ['computer']);
+        expect(result).toEqual({ keyword: 'user:domain:ou:gpo:test', type: 'computer' });
+    });
+
+    it('Will ignore what is to the left of the first colon if it doesnt match an existing kind and will treat all as keyword', async () => {
+        const result = parseKeywordAndTypeValue('testing:user:domain:ou:gpo:test', ['computer']);
+        expect(result).toEqual({ keyword: 'testing:user:domain:ou:gpo:test', type: undefined });
+    });
+});

--- a/packages/javascript/bh-shared-ui/src/utils/strings.test.ts
+++ b/packages/javascript/bh-shared-ui/src/utils/strings.test.ts
@@ -1,3 +1,19 @@
+// Copyright 2026 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { parseKeywordAndTypeValue } from './strings';
 
 describe('parseKeywordAndTypeValue', () => {

--- a/packages/javascript/bh-shared-ui/src/utils/strings.ts
+++ b/packages/javascript/bh-shared-ui/src/utils/strings.ts
@@ -14,7 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { Maybe } from './type';
+import { type Nullable } from './type';
 
 /** Represents a string literal type that can be widened to string, keeping intellisense for literal values */
 // eslint-disable-next-line @typescript-eslint/ban-types
@@ -36,7 +36,10 @@ export type KeywordAndTypeValues = {
     type: string | undefined;
 };
 
-export function parseKeywordAndTypeValue(inputValue: Maybe<string>, kinds: string[] | undefined): KeywordAndTypeValues {
+export function parseKeywordAndTypeValue(
+    inputValue: Nullable<string>,
+    kinds: string[] | undefined
+): KeywordAndTypeValues {
     const value = inputValue ?? undefined;
 
     if (!value) {

--- a/packages/javascript/bh-shared-ui/src/utils/strings.ts
+++ b/packages/javascript/bh-shared-ui/src/utils/strings.ts
@@ -14,9 +14,12 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+import { Maybe } from './type';
+
 /** Represents a string literal type that can be widened to string, keeping intellisense for literal values */
 // eslint-disable-next-line @typescript-eslint/ban-types
 export type LiteralUnion<T extends string> = T | (string & {});
+
 // Allows to truncate text and add an ellipsis
 export const truncateText = (
     text: string | undefined,
@@ -27,3 +30,43 @@ export const truncateText = (
     if (text.length <= maxChars) return text;
     return text.slice(0, maxChars) + trailingChars;
 };
+
+export type KeywordAndTypeValues = {
+    keyword: string | undefined;
+    type: string | undefined;
+};
+
+export function parseKeywordAndTypeValue(inputValue: Maybe<string>, kinds: string[] | undefined): KeywordAndTypeValues {
+    const value = inputValue ?? undefined;
+
+    if (!value) {
+        return {
+            keyword: undefined,
+            type: undefined,
+        };
+    }
+
+    const hasParsableQualifier = value.length > 1 && value.includes(':');
+
+    if (!hasParsableQualifier) {
+        return {
+            keyword: value,
+            type: undefined,
+        };
+    }
+
+    const [qualifier, ...keywordParts] = value.split(':');
+    const nodeKind = kinds?.find((kind) => kind.toLocaleLowerCase() === qualifier.toLocaleLowerCase());
+
+    if (!nodeKind) {
+        return {
+            keyword: value,
+            type: undefined,
+        };
+    }
+
+    return {
+        keyword: keywordParts.join(':'),
+        type: nodeKind,
+    };
+}

--- a/packages/javascript/bh-shared-ui/src/utils/type.ts
+++ b/packages/javascript/bh-shared-ui/src/utils/type.ts
@@ -14,6 +14,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+/** For use when value is expected but not yet available */
+export type Maybe<T> = T | null | undefined;
+
 /** Exclusive OR (XOR) type utility. */
 export type XOR<T, U> =
     | (T & { [K in Exclude<keyof U, keyof T>]?: never })

--- a/packages/javascript/bh-shared-ui/src/utils/type.ts
+++ b/packages/javascript/bh-shared-ui/src/utils/type.ts
@@ -14,8 +14,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-/** For use when value is expected but not yet available */
-export type Maybe<T> = T | null | undefined;
+/** Value maybe be null or undefined; Typically used when value is expected but not yet available */
+export type Nullable<T> = T | null | undefined;
 
 /** Exclusive OR (XOR) type utility. */
 export type XOR<T, U> =


### PR DESCRIPTION
## Description

Adds handling colons in search inputs to see if it is being used as a search filter or as a keyword. It checks to see if to the left of the first colon the value is a valid kind, if so then its treats what is on the right of the colon as a keyword. If not that it treats the whole thing as a keyword

## Motivation and Context

Resolves [BED-8642](https://specterops.atlassian.net/browse/BED-8642)

## How Has This Been Tested?

Manually, existing tests pass and new tests added

## Screenshots (optional):


https://github.com/user-attachments/assets/1182cc8b-8961-4d27-bc55-49cf95aa45a0


## Types of changes

- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


[BED-8642]: https://specterops.atlassian.net/browse/BED-8642?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified keyword/type parsing across search, autocomplete, and graph search flows using a shared hook for consistent behavior.
* **Bug Fixes**
  * Improved highlighted text and search results to gracefully handle empty or missing search/keyword values without regex-related issues.
* **Tests**
  * Expanded coverage for keyword/type colon-delimited parsing via the new parsing hook, including updated MSW setup and assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->