### PR TITLE
feat(database, data quality): add `data_quality_stats` table and APIs BED-8616

### DIFF
--- a/cmd/api/src/database/dataquality.go
+++ b/cmd/api/src/database/dataquality.go
@@ -18,6 +18,7 @@ package database
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/specterops/bloodhound/cmd/api/src/model"
@@ -25,11 +26,27 @@ import (
 )
 
 type DataQualityData interface {
+	// Data Quality Stats
 	CreateADDataQualityStats(ctx context.Context, stats model.ADDataQualityStats) (model.ADDataQualityStats, error)
-	CreateADDataQualityAggregation(ctx context.Context, aggregation model.ADDataQualityAggregation) (model.ADDataQualityAggregation, error)
+	GetADDataQualityStats(ctx context.Context, domainSid string, start time.Time, end time.Time, sort_by string, limit int, skip int) (model.ADDataQualityStats, int, error)
+	GetAggregateADDataQualityStats(ctx context.Context, domainSIDs []string, start time.Time, end time.Time) (model.ADDataQualityStats, error)
 	CreateAzureDataQualityStats(ctx context.Context, stats model.AzureDataQualityStats) (model.AzureDataQualityStats, error)
+	GetAzureDataQualityStats(ctx context.Context, tenantId string, start time.Time, end time.Time, sort_by string, limit int, skip int) (model.AzureDataQualityStats, int, error)
+	CreateDataQualityStats(ctx context.Context, stats model.DataQualityStats) (model.DataQualityStats, error)
+	GetDataQualityStats(ctx context.Context, filters model.Filters, sort model.Sort, skip, limit int) (model.DataQualityStats, int, error)
+
+	// Data Quality Aggregations
+	CreateADDataQualityAggregation(ctx context.Context, aggregation model.ADDataQualityAggregation) (model.ADDataQualityAggregation, error)
+	GetADDataQualityAggregations(ctx context.Context, start time.Time, end time.Time, sort_by string, limit int, skip int) (model.ADDataQualityAggregations, int, error)
 	CreateAzureDataQualityAggregation(ctx context.Context, aggregation model.AzureDataQualityAggregation) (model.AzureDataQualityAggregation, error)
+	GetAzureDataQualityAggregations(ctx context.Context, start time.Time, end time.Time, sort_by string, limit int, skip int) (model.AzureDataQualityAggregations, int, error)
+
+	DeleteAllDataQuality(ctx context.Context) error
 }
+
+//Data Quality Stats
+
+const createdAtColumn = "created_at"
 
 func (s *BloodhoundDB) CreateADDataQualityStats(ctx context.Context, stats model.ADDataQualityStats) (model.ADDataQualityStats, error) {
 	result := s.db.WithContext(ctx).Create(&stats)
@@ -132,39 +149,6 @@ ORDER BY created_at;`
 	return adDataQualityStats, CheckError(result)
 }
 
-func (s *BloodhoundDB) CreateADDataQualityAggregation(ctx context.Context, aggregation model.ADDataQualityAggregation) (model.ADDataQualityAggregation, error) {
-	result := s.db.WithContext(ctx).Create(&aggregation)
-	return aggregation, CheckError(result)
-}
-
-func (s *BloodhoundDB) GetADDataQualityAggregations(ctx context.Context, start time.Time, end time.Time, order string, limit int, skip int) (model.ADDataQualityAggregations, int, error) {
-	const (
-		defaultWhere = "created_at between ? and ?"
-	)
-
-	var (
-		adDataQualityAggregations model.ADDataQualityAggregations
-		count                     int64
-		result                    *gorm.DB
-	)
-
-	result = s.db.Model(model.ADDataQualityAggregations{}).WithContext(ctx).Where(defaultWhere, start, end).Count(&count)
-	if CheckError(result) != nil {
-		return adDataQualityAggregations, 0, result.Error
-	}
-
-	if order == "" {
-		order = "created_at desc"
-	}
-
-	result = s.Scope(Paginate(skip, limit)).WithContext(ctx).Where(defaultWhere, start, end).Order(order).Find(&adDataQualityAggregations)
-	if CheckError(result) != nil {
-		return adDataQualityAggregations, 0, result.Error
-	}
-
-	return adDataQualityAggregations, int(count), nil
-}
-
 func (s *BloodhoundDB) CreateAzureDataQualityStats(ctx context.Context, stats model.AzureDataQualityStats) (model.AzureDataQualityStats, error) {
 	result := s.db.WithContext(ctx).Create(&stats)
 	return stats, CheckError(result)
@@ -196,6 +180,101 @@ func (s *BloodhoundDB) GetAzureDataQualityStats(ctx context.Context, tenantId st
 	}
 
 	return azureDataQualityStats, int(count), nil
+}
+
+func (s *BloodhoundDB) CreateDataQualityStats(ctx context.Context, stats model.DataQualityStats) (model.DataQualityStats, error) {
+	result := s.db.WithContext(ctx).Create(&stats)
+	return stats, CheckError(result)
+}
+
+// GetDataQualityStats gets all rows from the Data Quality Stats table that match the given SQL Filter. If no sorting is provided, it will sort rows by the CreatedAt date in descending order.
+func (s *BloodhoundDB) GetDataQualityStats(ctx context.Context, filters model.Filters, sort model.Sort, skip, limit int) (model.DataQualityStats, int, error) {
+	var (
+		dataQualityStats = model.DataQualityStats{}
+		totalRowCount    int
+		skipLimit        string
+		whereClause      = "WHERE deleted_at IS NULL"
+	)
+
+	filter, err := buildSQLFilter(filters)
+	if err != nil {
+		return dataQualityStats, 0, err
+	}
+
+	// default sort by created_at descending
+	if len(sort) == 0 {
+		sort = append(sort, model.SortItem{Column: createdAtColumn, Direction: model.DescendingSortDirection})
+	}
+
+	orderSql, err := buildSQLSort(sort)
+	if err != nil {
+		return dataQualityStats, 0, err
+	}
+
+	if limit > 0 {
+		skipLimit = fmt.Sprintf(" LIMIT %d", limit)
+	}
+
+	if skip > 0 {
+		skipLimit += fmt.Sprintf(" OFFSET %d", skip)
+	}
+
+	if filter.sqlString != "" {
+		whereClause += fmt.Sprintf(" AND %s", filter.sqlString)
+	}
+
+	sqlStr := fmt.Sprintf(`SELECT * FROM %s %s %s %s`, model.DataQualityStat{}.TableName(), whereClause, orderSql, skipLimit)
+
+	if result := s.db.WithContext(ctx).Raw(sqlStr, filter.params...).Scan(&dataQualityStats); result.Error != nil {
+		return model.DataQualityStats{}, 0, CheckError(result)
+	} else {
+		if limit > 0 || skip > 0 {
+			countSql := fmt.Sprintf(`SELECT COUNT(*) FROM %s %s`, model.DataQualityStat{}.TableName(), whereClause)
+			if err := s.db.WithContext(ctx).Raw(countSql, filter.params...).Scan(&totalRowCount).Error; err != nil {
+				return model.DataQualityStats{}, 0, err
+			}
+		} else {
+			totalRowCount = len(dataQualityStats)
+		}
+
+		return dataQualityStats, totalRowCount, nil
+	}
+
+}
+
+// Data Quality Aggregations
+
+func (s *BloodhoundDB) CreateADDataQualityAggregation(ctx context.Context, aggregation model.ADDataQualityAggregation) (model.ADDataQualityAggregation, error) {
+	result := s.db.WithContext(ctx).Create(&aggregation)
+	return aggregation, CheckError(result)
+}
+
+func (s *BloodhoundDB) GetADDataQualityAggregations(ctx context.Context, start time.Time, end time.Time, order string, limit int, skip int) (model.ADDataQualityAggregations, int, error) {
+	const (
+		defaultWhere = "created_at between ? and ?"
+	)
+
+	var (
+		adDataQualityAggregations model.ADDataQualityAggregations
+		count                     int64
+		result                    *gorm.DB
+	)
+
+	result = s.db.Model(model.ADDataQualityAggregations{}).WithContext(ctx).Where(defaultWhere, start, end).Count(&count)
+	if CheckError(result) != nil {
+		return adDataQualityAggregations, 0, result.Error
+	}
+
+	if order == "" {
+		order = "created_at desc"
+	}
+
+	result = s.Scope(Paginate(skip, limit)).WithContext(ctx).Where(defaultWhere, start, end).Order(order).Find(&adDataQualityAggregations)
+	if CheckError(result) != nil {
+		return adDataQualityAggregations, 0, result.Error
+	}
+
+	return adDataQualityAggregations, int(count), nil
 }
 
 func (s *BloodhoundDB) CreateAzureDataQualityAggregation(ctx context.Context, aggregation model.AzureDataQualityAggregation) (model.AzureDataQualityAggregation, error) {
@@ -233,6 +312,6 @@ func (s *BloodhoundDB) GetAzureDataQualityAggregations(ctx context.Context, star
 
 func (s *BloodhoundDB) DeleteAllDataQuality(ctx context.Context) error {
 	return CheckError(
-		s.db.WithContext(ctx).Exec("DELETE FROM ad_data_quality_aggregations; DELETE FROM ad_data_quality_stats; DELETE FROM azure_data_quality_aggregations; DELETE FROM azure_data_quality_stats;"),
+		s.db.WithContext(ctx).Exec("DELETE FROM ad_data_quality_aggregations; DELETE FROM ad_data_quality_stats; DELETE FROM azure_data_quality_aggregations; DELETE FROM azure_data_quality_stats; DELETE FROM data_quality_stats;"),
 	)
 }

--- a/cmd/api/src/database/dataquality.go
+++ b/cmd/api/src/database/dataquality.go
@@ -46,8 +46,6 @@ type DataQualityData interface {
 
 //Data Quality Stats
 
-const createdAtColumn = "created_at"
-
 func (s *BloodhoundDB) CreateADDataQualityStats(ctx context.Context, stats model.ADDataQualityStats) (model.ADDataQualityStats, error) {
 	result := s.db.WithContext(ctx).Create(&stats)
 	return stats, CheckError(result)
@@ -199,11 +197,6 @@ func (s *BloodhoundDB) GetDataQualityStats(ctx context.Context, filters model.Fi
 	filter, err := buildSQLFilter(filters)
 	if err != nil {
 		return dataQualityStats, 0, err
-	}
-
-	// default sort by created_at descending
-	if len(sort) == 0 {
-		sort = append(sort, model.SortItem{Column: createdAtColumn, Direction: model.DescendingSortDirection})
 	}
 
 	orderSql, err := buildSQLSort(sort)

--- a/cmd/api/src/database/dataquality_integration_test.go
+++ b/cmd/api/src/database/dataquality_integration_test.go
@@ -1,0 +1,337 @@
+// Copyright 2026 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build integration
+
+package database_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/specterops/bloodhound/cmd/api/src/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDatabase_CreateDataQualityStats(t *testing.T) {
+	tests := []struct {
+		name   string
+		assert func(t *testing.T, testSuite IntegrationTestSuite)
+	}{
+		{
+			name: "Success: creates a single data quality stat",
+			assert: func(t *testing.T, testSuite IntegrationTestSuite) {
+				stat := model.DataQualityStat{
+					RunID:                   "run-1",
+					SchemaExtensionID:       1,
+					SchemaEnvironmentKindID: 1,
+					EnvironmentID:           "env-1",
+					MetricType:              model.DataQualityMetricTypeNode,
+					MetricName:              "users",
+					MetricValue:             42,
+				}
+
+				created, err := testSuite.BHDatabase.CreateDataQualityStats(testSuite.Context, model.DataQualityStats{stat})
+				require.NoError(t, err)
+				require.Len(t, created, 1)
+				assert.NotZero(t, created[0].ID)
+				assert.Equal(t, "run-1", created[0].RunID)
+				assert.Equal(t, float64(42), created[0].MetricValue)
+			},
+		},
+		{
+			name: "Success: creates multiple data quality stats",
+			assert: func(t *testing.T, testSuite IntegrationTestSuite) {
+				stats := model.DataQualityStats{
+					{RunID: "run-2", SchemaExtensionID: 1, SchemaEnvironmentKindID: 1, EnvironmentID: "env-1", MetricType: model.DataQualityMetricTypeNode, MetricName: "groups", MetricValue: 10},
+					{RunID: "run-2", SchemaExtensionID: 1, SchemaEnvironmentKindID: 1, EnvironmentID: "env-1", MetricType: model.DataQualityMetricTypeRelationship, MetricName: "edges", MetricValue: 20},
+				}
+
+				created, err := testSuite.BHDatabase.CreateDataQualityStats(testSuite.Context, stats)
+				require.NoError(t, err)
+				require.Len(t, created, 2)
+				assert.NotZero(t, created[0].ID)
+				assert.NotZero(t, created[1].ID)
+				assert.NotEqual(t, created[0].ID, created[1].ID)
+			},
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			testSuite := setupIntegrationTestSuite(t)
+			defer teardownIntegrationTestSuite(t, &testSuite)
+
+			testCase.assert(t, testSuite)
+		})
+	}
+}
+
+func TestDatabase_GetDataQualityStats(t *testing.T) {
+	type args struct {
+		filters     model.Filters
+		sort        model.Sort
+		skip, limit int
+	}
+
+	tests := []struct {
+		name   string
+		args   args
+		assert func(t *testing.T, testSuite IntegrationTestSuite, args args)
+	}{
+		{
+			name: "Success: returns stats with no filters or sorting",
+			args: args{},
+			assert: func(t *testing.T, testSuite IntegrationTestSuite, args args) {
+				stats := model.DataQualityStats{
+					{RunID: "run-3", SchemaExtensionID: 1, SchemaEnvironmentKindID: 1, EnvironmentID: "env-1", MetricType: model.DataQualityMetricTypeNode, MetricName: "users", MetricValue: 5},
+					{RunID: "run-3", SchemaExtensionID: 1, SchemaEnvironmentKindID: 1, EnvironmentID: "env-1", MetricType: model.DataQualityMetricTypeNode, MetricName: "groups", MetricValue: 15},
+				}
+				_, err := testSuite.BHDatabase.CreateDataQualityStats(testSuite.Context, stats)
+				require.NoError(t, err)
+
+				results, total, err := testSuite.BHDatabase.GetDataQualityStats(testSuite.Context, args.filters, args.sort, args.skip, args.limit)
+				require.NoError(t, err)
+				assert.Equal(t, 2, total)
+				assert.Len(t, results, 2)
+			},
+		},
+		{
+			name: "Success: returns stats with equals filter",
+			args: args{
+				filters: model.Filters{
+					"metric_name": []model.Filter{
+						{Operator: model.Equals, Value: "users", IsStringData: true},
+					},
+				},
+			},
+			assert: func(t *testing.T, testSuite IntegrationTestSuite, args args) {
+				stats := model.DataQualityStats{
+					{RunID: "run-4", SchemaExtensionID: 1, SchemaEnvironmentKindID: 1, EnvironmentID: "env-1", MetricType: model.DataQualityMetricTypeNode, MetricName: "users", MetricValue: 5},
+					{RunID: "run-4", SchemaExtensionID: 1, SchemaEnvironmentKindID: 1, EnvironmentID: "env-1", MetricType: model.DataQualityMetricTypeNode, MetricName: "groups", MetricValue: 15},
+				}
+				_, err := testSuite.BHDatabase.CreateDataQualityStats(testSuite.Context, stats)
+				require.NoError(t, err)
+
+				results, total, err := testSuite.BHDatabase.GetDataQualityStats(testSuite.Context, args.filters, args.sort, args.skip, args.limit)
+				require.NoError(t, err)
+				assert.Equal(t, 1, total)
+				require.Len(t, results, 1)
+				assert.Equal(t, "users", results[0].MetricName)
+			},
+		},
+		{
+			name: "Success: filters by created_at date range",
+			args: args{},
+			assert: func(t *testing.T, testSuite IntegrationTestSuite, args args) {
+				var (
+					yesterday = time.Now().UTC().Add(-24 * time.Hour)
+					now       = time.Now().UTC()
+				)
+
+				stats := model.DataQualityStats{
+					{RunID: "run-date", SchemaExtensionID: 1, SchemaEnvironmentKindID: 1, EnvironmentID: "env-1", MetricType: model.DataQualityMetricTypeNode, MetricName: "a", MetricValue: 1, Serial: model.Serial{Basic: model.Basic{CreatedAt: yesterday}}},
+					{RunID: "run-date", SchemaExtensionID: 1, SchemaEnvironmentKindID: 1, EnvironmentID: "env-1", MetricType: model.DataQualityMetricTypeNode, MetricName: "b", MetricValue: 2, Serial: model.Serial{Basic: model.Basic{CreatedAt: now}}},
+				}
+				_, err := testSuite.BHDatabase.CreateDataQualityStats(testSuite.Context, stats)
+				require.NoError(t, err)
+
+				rangeStart := now.Add(-1 * time.Hour).Format(time.RFC3339)
+				rangeEnd := now.Add(1 * time.Hour).Format(time.RFC3339)
+
+				dateFilters := model.Filters{
+					"created_at": []model.Filter{
+						{Operator: model.GreaterThanOrEquals, Value: rangeStart},
+						{Operator: model.LessThanOrEquals, Value: rangeEnd},
+					},
+				}
+
+				results, total, err := testSuite.BHDatabase.GetDataQualityStats(testSuite.Context, dateFilters, args.sort, args.skip, args.limit)
+				require.NoError(t, err)
+				assert.Equal(t, 1, total)
+				require.Len(t, results, 1)
+				assert.Equal(t, "b", results[0].MetricName)
+			},
+		},
+		{
+			name: "Success: filters by environment_id",
+			args: args{
+				filters: model.Filters{
+					"environment_id": []model.Filter{
+						{Operator: model.Equals, Value: "env-target", IsStringData: true},
+					},
+				},
+			},
+			assert: func(t *testing.T, testSuite IntegrationTestSuite, args args) {
+				stats := model.DataQualityStats{
+					{RunID: "run-env", SchemaExtensionID: 1, SchemaEnvironmentKindID: 1, EnvironmentID: "env-target", MetricType: model.DataQualityMetricTypeNode, MetricName: "users", MetricValue: 10},
+					{RunID: "run-env", SchemaExtensionID: 1, SchemaEnvironmentKindID: 1, EnvironmentID: "env-other", MetricType: model.DataQualityMetricTypeNode, MetricName: "groups", MetricValue: 20},
+					{RunID: "run-env", SchemaExtensionID: 1, SchemaEnvironmentKindID: 1, EnvironmentID: "env-target", MetricType: model.DataQualityMetricTypeRelationship, MetricName: "edges", MetricValue: 30},
+				}
+				_, err := testSuite.BHDatabase.CreateDataQualityStats(testSuite.Context, stats)
+				require.NoError(t, err)
+
+				results, total, err := testSuite.BHDatabase.GetDataQualityStats(testSuite.Context, args.filters, args.sort, args.skip, args.limit)
+				require.NoError(t, err)
+				assert.Equal(t, 2, total)
+				require.Len(t, results, 2)
+				for _, result := range results {
+					assert.Equal(t, "env-target", result.EnvironmentID)
+				}
+			},
+		},
+		{
+			name: "Success: returns stats with ascending sort",
+			args: args{
+				sort: model.Sort{
+					{Column: "metric_value", Direction: model.AscendingSortDirection},
+				},
+			},
+			assert: func(t *testing.T, testSuite IntegrationTestSuite, args args) {
+				stats := model.DataQualityStats{
+					{RunID: "run-5", SchemaExtensionID: 1, SchemaEnvironmentKindID: 1, EnvironmentID: "env-1", MetricType: model.DataQualityMetricTypeNode, MetricName: "a", MetricValue: 100},
+					{RunID: "run-5", SchemaExtensionID: 1, SchemaEnvironmentKindID: 1, EnvironmentID: "env-1", MetricType: model.DataQualityMetricTypeNode, MetricName: "b", MetricValue: 1},
+				}
+				_, err := testSuite.BHDatabase.CreateDataQualityStats(testSuite.Context, stats)
+				require.NoError(t, err)
+
+				results, _, err := testSuite.BHDatabase.GetDataQualityStats(testSuite.Context, args.filters, args.sort, args.skip, args.limit)
+				require.NoError(t, err)
+				require.Len(t, results, 2)
+				assert.Equal(t, float64(1), results[0].MetricValue)
+				assert.Equal(t, float64(100), results[1].MetricValue)
+			},
+		},
+		{
+			name: "Success: returns stats with pagination",
+			args: args{
+				sort:  model.Sort{{Column: "metric_value", Direction: model.AscendingSortDirection}},
+				skip:  1,
+				limit: 1,
+			},
+			assert: func(t *testing.T, testSuite IntegrationTestSuite, args args) {
+				stats := model.DataQualityStats{
+					{RunID: "run-6", SchemaExtensionID: 1, SchemaEnvironmentKindID: 1, EnvironmentID: "env-1", MetricType: model.DataQualityMetricTypeNode, MetricName: "a", MetricValue: 10},
+					{RunID: "run-6", SchemaExtensionID: 1, SchemaEnvironmentKindID: 1, EnvironmentID: "env-1", MetricType: model.DataQualityMetricTypeNode, MetricName: "b", MetricValue: 20},
+					{RunID: "run-6", SchemaExtensionID: 1, SchemaEnvironmentKindID: 1, EnvironmentID: "env-1", MetricType: model.DataQualityMetricTypeNode, MetricName: "c", MetricValue: 30},
+				}
+				_, err := testSuite.BHDatabase.CreateDataQualityStats(testSuite.Context, stats)
+				require.NoError(t, err)
+
+				results, total, err := testSuite.BHDatabase.GetDataQualityStats(testSuite.Context, args.filters, args.sort, args.skip, args.limit)
+				require.NoError(t, err)
+				assert.Equal(t, 3, total, "total count should reflect all matching rows")
+				require.Len(t, results, 1, "page should contain 1 row")
+				assert.Equal(t, float64(20), results[0].MetricValue, "skip=1 should return the second row")
+			},
+		},
+		{
+			name: "Success: soft-deleted rows are excluded",
+			args: args{},
+			assert: func(t *testing.T, testSuite IntegrationTestSuite, args args) {
+				stats := model.DataQualityStats{
+					{RunID: "run-7", SchemaExtensionID: 1, SchemaEnvironmentKindID: 1, EnvironmentID: "env-1", MetricType: model.DataQualityMetricTypeNode, MetricName: "visible", MetricValue: 1},
+					{RunID: "run-7", SchemaExtensionID: 1, SchemaEnvironmentKindID: 1, EnvironmentID: "env-1", MetricType: model.DataQualityMetricTypeNode, MetricName: "hidden", MetricValue: 2},
+				}
+				created, err := testSuite.BHDatabase.CreateDataQualityStats(testSuite.Context, stats)
+				require.NoError(t, err)
+				require.Len(t, created, 2)
+
+				// Soft-delete one row via raw SQL
+				testSuite.DB.Exec("UPDATE data_quality_stats SET deleted_at = NOW() WHERE id = ?", created[1].ID)
+
+				results, total, err := testSuite.BHDatabase.GetDataQualityStats(testSuite.Context, args.filters, args.sort, args.skip, args.limit)
+				require.NoError(t, err)
+				assert.Equal(t, 1, total)
+				require.Len(t, results, 1)
+				assert.Equal(t, "visible", results[0].MetricName)
+			},
+		},
+		{
+			name: "Success: returns empty results when no stats exist",
+			args: args{},
+			assert: func(t *testing.T, testSuite IntegrationTestSuite, args args) {
+				results, total, err := testSuite.BHDatabase.GetDataQualityStats(testSuite.Context, args.filters, args.sort, args.skip, args.limit)
+				require.NoError(t, err)
+				assert.Equal(t, 0, total)
+				assert.Empty(t, results)
+			},
+		},
+		{
+			name: "Error: invalid filter operator",
+			args: args{
+				filters: model.Filters{
+					"`": []model.Filter{{}},
+				},
+			},
+			assert: func(t *testing.T, testSuite IntegrationTestSuite, args args) {
+				_, _, err := testSuite.BHDatabase.GetDataQualityStats(testSuite.Context, args.filters, args.sort, args.skip, args.limit)
+				assert.Error(t, err)
+			},
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			testSuite := setupIntegrationTestSuite(t)
+			defer teardownIntegrationTestSuite(t, &testSuite)
+
+			testCase.assert(t, testSuite, testCase.args)
+		})
+	}
+}
+
+func TestDatabase_DeleteAllDataQuality(t *testing.T) {
+	tests := []struct {
+		name   string
+		assert func(t *testing.T, testSuite IntegrationTestSuite)
+	}{
+		{
+			name: "Success: deletes data quality stats",
+			assert: func(t *testing.T, testSuite IntegrationTestSuite) {
+				_, err := testSuite.BHDatabase.CreateDataQualityStats(testSuite.Context, model.DataQualityStats{
+					{RunID: "run-del", SchemaExtensionID: 1, SchemaEnvironmentKindID: 1, EnvironmentID: "env-1", MetricType: model.DataQualityMetricTypeNode, MetricName: "users", MetricValue: 10},
+				})
+				require.NoError(t, err)
+
+				err = testSuite.BHDatabase.DeleteAllDataQuality(testSuite.Context)
+				require.NoError(t, err)
+
+				results, total, err := testSuite.BHDatabase.GetDataQualityStats(testSuite.Context, nil, nil, 0, 0)
+				require.NoError(t, err)
+				assert.Equal(t, 0, total)
+				assert.Empty(t, results)
+			},
+		},
+		{
+			name: "Success: no error when tables are already empty",
+			assert: func(t *testing.T, testSuite IntegrationTestSuite) {
+				err := testSuite.BHDatabase.DeleteAllDataQuality(testSuite.Context)
+				require.NoError(t, err)
+			},
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			testSuite := setupIntegrationTestSuite(t)
+			defer teardownIntegrationTestSuite(t, &testSuite)
+
+			testCase.assert(t, testSuite)
+		})
+	}
+}

--- a/cmd/api/src/database/db.go
+++ b/cmd/api/src/database/db.go
@@ -143,12 +143,6 @@ type Database interface {
 
 	// Data Quality
 	DataQualityData
-	GetADDataQualityStats(ctx context.Context, domainSid string, start time.Time, end time.Time, sort_by string, limit int, skip int) (model.ADDataQualityStats, int, error)
-	GetAggregateADDataQualityStats(ctx context.Context, domainSIDs []string, start time.Time, end time.Time) (model.ADDataQualityStats, error)
-	GetADDataQualityAggregations(ctx context.Context, start time.Time, end time.Time, sort_by string, limit int, skip int) (model.ADDataQualityAggregations, int, error)
-	GetAzureDataQualityStats(ctx context.Context, tenantId string, start time.Time, end time.Time, sort_by string, limit int, skip int) (model.AzureDataQualityStats, int, error)
-	GetAzureDataQualityAggregations(ctx context.Context, start time.Time, end time.Time, sort_by string, limit int, skip int) (model.AzureDataQualityAggregations, int, error)
-	DeleteAllDataQuality(ctx context.Context) error
 
 	// Saved Queries
 	SavedQueriesData

--- a/cmd/api/src/database/migration/migrations/20260622132700_v9_add_data_quality_stats_bed_8616.sql
+++ b/cmd/api/src/database/migration/migrations/20260622132700_v9_add_data_quality_stats_bed_8616.sql
@@ -25,7 +25,7 @@ CREATE TABLE IF NOT EXISTS data_quality_stats (
     metric_type TEXT NOT NULL,
     metric_name TEXT NOT NULL,
     metric_value NUMERIC NOT NULL DEFAULT 0,
-    kind_id INTEGER DEFAULT NULL REFERENCES kind(id),
+    kind_id INTEGER DEFAULT NULL REFERENCES kind(id) ON DELETE SET NULL,
     created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT current_timestamp,
     updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT current_timestamp,
     deleted_at TIMESTAMP WITH TIME ZONE DEFAULT NULL

--- a/cmd/api/src/database/migration/migrations/20260622132700_v9_add_data_quality_stats_bed_8616.sql
+++ b/cmd/api/src/database/migration/migrations/20260622132700_v9_add_data_quality_stats_bed_8616.sql
@@ -1,0 +1,37 @@
+-- Copyright 2026 Specter Ops, Inc.
+--
+-- Licensed under the Apache License, Version 2.0
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- SPDX-License-Identifier: Apache-2.0
+
+-- +goose Up
+
+CREATE TABLE IF NOT EXISTS data_quality_stats (
+    id SERIAL PRIMARY KEY,
+    run_id TEXT NOT NULL,
+    schema_extension_id INTEGER NOT NULL,
+    schema_environment_kind_id INTEGER NOT NULL REFERENCES kind(id),
+    environment_id TEXT NOT NULL,
+    metric_type TEXT NOT NULL,
+    metric_name TEXT NOT NULL,
+    metric_value NUMERIC NOT NULL DEFAULT 0,
+    kind_id INTEGER DEFAULT NULL REFERENCES kind(id),
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT current_timestamp,
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT current_timestamp,
+    deleted_at TIMESTAMP WITH TIME ZONE DEFAULT NULL
+); 
+
+CREATE INDEX IF NOT EXISTS idx_data_quality_stats_created_at ON data_quality_stats (created_at);
+
+-- +goose Down
+DROP TABLE IF EXISTS data_quality_stats;

--- a/cmd/api/src/database/mocks/db.go
+++ b/cmd/api/src/database/mocks/db.go
@@ -342,6 +342,21 @@ func (mr *MockDatabaseMockRecorder) CreateCustomNodeKinds(ctx, customNodeKind an
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateCustomNodeKinds", reflect.TypeOf((*MockDatabase)(nil).CreateCustomNodeKinds), ctx, customNodeKind)
 }
 
+// CreateDataQualityStats mocks base method.
+func (m *MockDatabase) CreateDataQualityStats(ctx context.Context, stats model.DataQualityStats) (model.DataQualityStats, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateDataQualityStats", ctx, stats)
+	ret0, _ := ret[0].(model.DataQualityStats)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateDataQualityStats indicates an expected call of CreateDataQualityStats.
+func (mr *MockDatabaseMockRecorder) CreateDataQualityStats(ctx, stats any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateDataQualityStats", reflect.TypeOf((*MockDatabase)(nil).CreateDataQualityStats), ctx, stats)
+}
+
 // CreateEnvironment mocks base method.
 func (m *MockDatabase) CreateEnvironment(ctx context.Context, extensionId, environmentKindId, sourceKindId int32) (model.SchemaEnvironment, error) {
 	m.ctrl.T.Helper()
@@ -1747,6 +1762,22 @@ func (m *MockDatabase) GetCustomNodeKinds(ctx context.Context, filters model.Fil
 func (mr *MockDatabaseMockRecorder) GetCustomNodeKinds(ctx, filters any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCustomNodeKinds", reflect.TypeOf((*MockDatabase)(nil).GetCustomNodeKinds), ctx, filters)
+}
+
+// GetDataQualityStats mocks base method.
+func (m *MockDatabase) GetDataQualityStats(ctx context.Context, filters model.Filters, sort model.Sort, skip, limit int) (model.DataQualityStats, int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDataQualityStats", ctx, filters, sort, skip, limit)
+	ret0, _ := ret[0].(model.DataQualityStats)
+	ret1, _ := ret[1].(int)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetDataQualityStats indicates an expected call of GetDataQualityStats.
+func (mr *MockDatabaseMockRecorder) GetDataQualityStats(ctx, filters, sort, skip, limit any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDataQualityStats", reflect.TypeOf((*MockDatabase)(nil).GetDataQualityStats), ctx, filters, sort, skip, limit)
 }
 
 // GetDatapipeStatus mocks base method.

--- a/cmd/api/src/model/dataqualitystats.go
+++ b/cmd/api/src/model/dataqualitystats.go
@@ -1,0 +1,63 @@
+// Copyright 2026 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package model
+
+import "github.com/specterops/bloodhound/cmd/api/src/database/types/null"
+
+type DataQualityMetricType string
+
+const (
+	DataQualityMetricTypeNode         DataQualityMetricType = "node"
+	DataQualityMetricTypeRelationship DataQualityMetricType = "relationship"
+)
+
+type DataQualityStat struct {
+	Serial
+	RunID                   string                `json:"run_id"`
+	SchemaExtensionID       int32                 `json:"schema_extension_id"`
+	SchemaEnvironmentKindID int32                 `json:"schema_environment_kind_id"`
+	EnvironmentID           string                `json:"environment_id"`
+	MetricType              DataQualityMetricType `json:"metric_type"`
+	MetricName              string                `json:"metric_name"`
+	MetricValue             float64               `json:"metric_value"`
+	KindID                  null.Int32            `json:"kind_id"`
+}
+
+func (DataQualityStat) TableName() string {
+	return "data_quality_stats"
+}
+
+type DataQualityStats []DataQualityStat
+
+func (s DataQualityStats) IsSortable(column string) bool {
+	switch column {
+	case "id",
+		"run_id",
+		"schema_extension_id",
+		"schema_environment_kind_id",
+		"environment_id",
+		"metric_type",
+		"metric_name",
+		"metric_value",
+		"kind_id",
+		"updated_at",
+		"created_at":
+		return true
+	default:
+		return false
+	}
+}


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

To enable OpenGraph data quality stat tracking, we are adding a new table for extension-agnostic `data_quality_stats`. 
Eventually, AD and Azure data will also be tracked in this table, but for MVP we are continuing to use the AD/AZ legacy tables. 

Also adding an index on the `created_at` column since the API endpoint will typically be sorting by when they were created. 

This PR also adds the DB model and basic CRUD for this table (Create, Get, and updated the `DeleteAllDataQuality` function to delete from this new table as well) 

I also moved some of the existing functions around to group them by Stats vs Aggregations per Domain (AD/AZ/Agnostic)

A few notes: 

- we are not foreign keying the environment and extension is because when an environment or extension is deleted, we still need to keep track of the historical data
- the `metric_type` will be what kind of metric the row tracks, like `node` or `relationship`, and will be a `const` on the Go side
- the `metric_name` will be something like the specific name of the kind (eg. `users`, `computers`) or completeness (eg. `session_completeness`)

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-8616

## How Has This Been Tested?

Ran locally, table is created. 

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->
- Database Migrations

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a new database table and data models for per-run data quality statistics (metric type/name/value and related identifiers).
  * Added capabilities to create and query data quality stats with time filtering, sorting, and pagination.
  * Added support for additional AD and Azure data-quality stats/aggregation operations.

* **Improvements**
  * Applied default “created at” ordering when no sort is specified.
  * Expanded “delete all” to fully clear stored data-quality data.
  * Added an index on creation time for faster retrieval.

* **Tests**
  * Added end-to-end integration coverage for create, query, and delete behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->