### PR TITLE
fix: fixed border radius BED-8754

### DIFF
--- a/packages/javascript/bh-shared-ui/src/components/DropdownSelector/DropdownTrigger.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/DropdownSelector/DropdownTrigger.tsx
@@ -14,24 +14,13 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { ButtonProps, PopoverTrigger } from 'doodle-ui';
-import { FC } from 'react';
-import DropdownTriggerContents from './DropdownTriggerContents';
+import { PopoverTrigger } from 'doodle-ui';
+import DropdownTriggerContents, { DropdownTriggerContentsProps } from './DropdownTriggerContents';
 
-const DropdownTrigger: FC<{
-    open: boolean;
-    selectedText: JSX.Element | string;
-    buttonProps?: ButtonProps;
-    StartAdornment?: React.FC;
-    EndAdornment?: React.FC;
-    testId?: string;
-    variant?: ButtonProps['variant'];
-}> = (props) => {
+const DropdownTrigger = (props: DropdownTriggerContentsProps) => {
     return (
         <PopoverTrigger asChild>
-            <div>
-                <DropdownTriggerContents {...props} />
-            </div>
+            <DropdownTriggerContents {...props} />
         </PopoverTrigger>
     );
 };

--- a/packages/javascript/bh-shared-ui/src/components/DropdownSelector/DropdownTriggerContents.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/DropdownSelector/DropdownTriggerContents.tsx
@@ -14,71 +14,83 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import { Button, ButtonProps } from 'doodle-ui';
+import { forwardRef, type FC } from 'react';
 import { cn } from '../../utils';
 import { AppIcon } from '../AppIcon';
 import { dropdownIconStateStyles, selectorIconStyles, triggerStyles } from './constants';
 
-type DropdownTriggerContentsProps = {
+export type DropdownTriggerContentsProps = ButtonProps & {
     open: boolean;
     selectedText: JSX.Element | string;
     buttonProps?: ButtonProps;
-    StartAdornment?: React.FC;
-    EndAdornment?: React.FC;
+    StartAdornment?: FC;
+    EndAdornment?: FC;
     testId?: string;
     variant?: ButtonProps['variant'];
     readOnly?: boolean;
 };
 
-const DropdownTriggerContents = ({
-    open,
-    selectedText,
-    buttonProps,
-    StartAdornment,
-    EndAdornment,
-    testId,
-    variant,
-    readOnly,
-}: DropdownTriggerContentsProps) => {
-    const buttonPrimary = variant === 'primary';
+const DropdownTriggerContents = forwardRef<HTMLButtonElement, DropdownTriggerContentsProps>(
+    (
+        {
+            open,
+            selectedText,
+            buttonProps,
+            StartAdornment,
+            EndAdornment,
+            testId,
+            variant,
+            readOnly,
+            className,
+            ...props
+        },
+        ref
+    ) => {
+        const buttonPrimary = variant === 'primary';
 
-    return (
-        <Button
-            variant={variant ?? 'transparent'}
-            className={cn(
-                'uppercase group',
-                buttonPrimary && `w-full text-sm ${dropdownIconStateStyles}`,
-                {
-                    [triggerStyles]: !buttonPrimary,
-                    'bg-primary text-white dark:text-neutral-dark-1 border-transparent [&_svg]:text-white dark:[&_svg]:text-neutral-dark-1 [&_svg]:fill-current [&_svg_*]:text-white dark:[&_svg_*]:text-neutral-dark-1 [&_svg_*]:fill-current':
-                        open,
-                },
-                buttonProps?.className
-            )}
-            size='small'
-            data-testid={testId ? testId : 'dropdown_context-selector'}>
-            <span
-                className={cn('flex justify-center items-center max-w-full', {
-                    'justify-between': StartAdornment,
-                })}>
-                <div className='flex items-center truncate'>
-                    {StartAdornment && <StartAdornment />}
-                    <p className='truncate font-bold mr-2'>{selectedText}</p>
-                </div>
-                {EndAdornment ? (
-                    <EndAdornment />
-                ) : (
-                    <span
-                        className={cn({
-                            'rotate-180 transition-transform': open,
-                            'justify-self-end': buttonPrimary,
-                            hidden: readOnly,
-                        })}>
-                        <AppIcon.CaretDown className={selectorIconStyles} size={12} />
-                    </span>
+        return (
+            <Button
+                ref={ref}
+                {...props}
+                variant={variant ?? 'transparent'}
+                className={cn(
+                    'uppercase group',
+                    buttonPrimary && `w-full text-sm ${dropdownIconStateStyles}`,
+                    {
+                        [triggerStyles]: !buttonPrimary,
+                        'bg-primary text-white dark:text-neutral-dark-1 border-transparent [&_svg]:text-white dark:[&_svg]:text-neutral-dark-1 [&_svg]:fill-current [&_svg_*]:text-white dark:[&_svg_*]:text-neutral-dark-1 [&_svg_*]:fill-current':
+                            open,
+                    },
+                    className,
+                    buttonProps?.className
                 )}
-            </span>
-        </Button>
-    );
-};
+                size='small'
+                data-testid={testId ? testId : 'dropdown_context-selector'}>
+                <span
+                    className={cn('flex justify-center items-center max-w-full', {
+                        'justify-between': StartAdornment,
+                    })}>
+                    <div className='flex items-center truncate'>
+                        {StartAdornment && <StartAdornment />}
+                        <p className='truncate font-bold mr-2'>{selectedText}</p>
+                    </div>
+                    {EndAdornment ? (
+                        <EndAdornment />
+                    ) : (
+                        <span
+                            className={cn({
+                                'rotate-180 transition-transform': open,
+                                'justify-self-end': buttonPrimary,
+                                hidden: readOnly,
+                            })}>
+                            <AppIcon.CaretDown className={selectorIconStyles} size={12} />
+                        </span>
+                    )}
+                </span>
+            </Button>
+        );
+    }
+);
+DropdownTriggerContents.displayName = 'DropdownTriggerContents';
 
 export default DropdownTriggerContents;


### PR DESCRIPTION
## Description

This makes sure the border radius on the zone selector is retained when in the active state.

## Motivation and Context

Resolves [BED-8754](https://specterops.atlassian.net/browse/BED-8754)

The popover trigger applied its `data-state=open` focus ring to a wrapper div instead of the actual button. By using forwardRef, we can use that ref to apply to the button instead.

## How Has This Been Tested?
Manually

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


[BED-8754]: https://specterops.atlassian.net/browse/BED-8754?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the dropdown trigger’s behavior so it integrates more reliably with interactive controls.
  * Kept the same visual appearance while making the trigger more robust and consistent.
* **Refactor**
  * Simplified the dropdown trigger structure for cleaner rendering and better support for button interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->