### PR TITLE
feat: Add Synced Identities section to AD and Azure User entity panels

### DIFF
--- a/cmd/api/src/api/registration/v2.go
+++ b/cmd/api/src/api/registration/v2.go
@@ -329,6 +329,7 @@ func NewV2API(resources v2.Resources, routerInst *router.Router) {
 		routerInst.GET(fmt.Sprintf("/api/v2/users/{%s}/constrained-delegation-rights", api.URIPathVariableObjectID), resources.ListADEntityConstrainedDelegationRights).RequirePermissions(permissions.GraphDBRead),
 		routerInst.GET(fmt.Sprintf("/api/v2/users/{%s}/controllers", api.URIPathVariableObjectID), resources.ListADEntityControllers).RequirePermissions(permissions.GraphDBRead),
 		routerInst.GET(fmt.Sprintf("/api/v2/users/{%s}/controllables", api.URIPathVariableObjectID), resources.ListADEntityControllables).RequirePermissions(permissions.GraphDBRead),
+		routerInst.GET(fmt.Sprintf("/api/v2/users/{%s}/synced-identities", api.URIPathVariableObjectID), resources.ListADUserSyncedIdentities).RequirePermissions(permissions.GraphDBRead),
 
 		// Group Entity API
 		routerInst.GET(fmt.Sprintf("/api/v2/groups/{%s}", api.URIPathVariableObjectID), resources.GetGroupEntityInfo).RequirePermissions(permissions.GraphDBRead),

--- a/cmd/api/src/api/v2/ad_related_entity.go
+++ b/cmd/api/src/api/v2/ad_related_entity.go
@@ -84,6 +84,10 @@ func (s *Resources) ListADUserSQLAdminRights(response http.ResponseWriter, reque
 	s.handleAdRelatedEntityQuery(response, request, "ListADUserSQLAdminRights", adAnalysis.CreateSQLAdminPathDelegate(graph.DirectionOutbound), adAnalysis.CreateSQLAdminListDelegate(graph.DirectionOutbound))
 }
 
+func (s *Resources) ListADUserSyncedIdentities(response http.ResponseWriter, request *http.Request) {
+	s.handleAdRelatedEntityQuery(response, request, "ListADUserSyncedIdentities", adAnalysis.FetchSyncedIdentityPaths, adAnalysis.FetchSyncedIdentities)
+}
+
 func (s *Resources) ListADGroupSessions(response http.ResponseWriter, request *http.Request) {
 	s.handleAdRelatedEntityQuery(response, request, "ListADGroupSessions", adAnalysis.FetchGroupSessionPaths, adAnalysis.FetchGroupSessions)
 }

--- a/cmd/api/src/api/v2/azure.go
+++ b/cmd/api/src/api/v2/azure.go
@@ -204,6 +204,13 @@ func graphRelatedEntityType(request *http.Request, graphDb graph.Database, prima
 			return bloodhoundgraph.PathSetToBloodHoundGraph(primaryDisplayKinds, fics), fics.Len(), nil
 		}
 
+	case azure.RelatedEntityTypeSyncedIdentities:
+		if paths, err := azure.ListSyncedIdentityPaths(ctx, graphDb, objectID); err != nil {
+			return nil, 0, api.BuildErrorResponse(http.StatusInternalServerError, fmt.Sprintf("error fetching related entity type %s: %v", options.relatedEntityString, err), request)
+		} else {
+			return bloodhoundgraph.PathSetToBloodHoundGraph(primaryDisplayKinds, paths), paths.Len(), nil
+		}
+
 	default:
 		return nil, 0, api.BuildErrorResponse(http.StatusNotFound, fmt.Sprintf("no matching related entity list type for %s", options.relatedEntityString), request)
 	}
@@ -319,6 +326,11 @@ func listRelatedEntityType(ctx context.Context, db graph.Database, primaryDispla
 		}
 	case azure.RelatedEntityTypeFederatedIdentityCredentials:
 		if nodeSet, err = azure.ListAppFederatedIdentityCredentials(ctx, db, objectID, 0, 0); err != nil {
+			return nil, 0, err
+		}
+
+	case azure.RelatedEntityTypeSyncedIdentities:
+		if nodeSet, err = azure.ListSyncedIdentities(ctx, db, objectID, 0, 0); err != nil {
 			return nil, 0, err
 		}
 

--- a/packages/go/analysis/ad/filters.go
+++ b/packages/go/analysis/ad/filters.go
@@ -19,6 +19,7 @@ package ad
 import (
 	"github.com/specterops/bloodhound/packages/go/analysis/tiering"
 	"github.com/specterops/bloodhound/packages/go/graphschema/ad"
+	"github.com/specterops/bloodhound/packages/go/graphschema/azure"
 	"github.com/specterops/dawgs/graph"
 	"github.com/specterops/dawgs/ops"
 	"github.com/specterops/dawgs/query"
@@ -176,6 +177,10 @@ func FilterEnrollers(node graph.Node) graph.Criteria {
 		query.Kind(query.Relationship(), ad.Enroll),
 		query.Kind(query.Start(), ad.Entity),
 	)
+}
+
+func FilterSyncedIdentities() graph.Criteria {
+	return query.KindIn(query.Relationship(), azure.SyncedToEntraUser)
 }
 
 func FilterPublishedCAs(certTemplate *graph.Node) graph.Criteria {

--- a/packages/go/analysis/ad/queries.go
+++ b/packages/go/analysis/ad/queries.go
@@ -1468,6 +1468,24 @@ func FetchLinkedGroup(ctx context.Context, db graph.Database, node *graph.Node) 
 	})
 }
 
+func FetchSyncedIdentityPaths(tx graph.Transaction, node *graph.Node) (graph.PathSet, error) {
+	return ops.TraversePaths(tx, ops.TraversalPlan{
+		Root:        node,
+		Direction:   graph.DirectionOutbound,
+		BranchQuery: FilterSyncedIdentities,
+	})
+}
+
+func FetchSyncedIdentities(tx graph.Transaction, node *graph.Node, skip, limit int) (graph.NodeSet, error) {
+	return ops.AcyclicTraverseTerminals(tx, ops.TraversalPlan{
+		Root:        node,
+		Direction:   graph.DirectionOutbound,
+		BranchQuery: FilterSyncedIdentities,
+		Skip:        skip,
+		Limit:       limit,
+	})
+}
+
 func FetchGroupMemberPaths(tx graph.Transaction, node *graph.Node) (graph.PathSet, error) {
 	return ops.TraversePaths(tx, ops.TraversalPlan{
 		Root:        node,

--- a/packages/go/analysis/azure/db_ops.go
+++ b/packages/go/analysis/azure/db_ops.go
@@ -20,9 +20,11 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/specterops/bloodhound/packages/go/graphschema/ad"
 	"github.com/specterops/bloodhound/packages/go/graphschema/azure"
 	"github.com/specterops/dawgs/graph"
 	"github.com/specterops/dawgs/ops"
+	"github.com/specterops/dawgs/query"
 )
 
 func ListEntityDescendentPaths(ctx context.Context, db graph.Database, relatedEntityType RelatedEntityType, sourceKind graph.Kind, objectID string) (graph.PathSet, error) {
@@ -546,6 +548,46 @@ func ListAppFederatedIdentityCredentials(ctx context.Context, db graph.Database,
 			return err
 		} else {
 			nodes, err = FetchApplicationFederatedIdentityCredentialList(tx, node, skip, limit)
+			return err
+		}
+	})
+}
+
+func ListSyncedIdentityPaths(ctx context.Context, db graph.Database, objectID string) (graph.PathSet, error) {
+	var paths graph.PathSet
+
+	return paths, db.ReadTransaction(ctx, func(tx graph.Transaction) error {
+		if node, err := FetchEntityByObjectID(tx, objectID); err != nil {
+			return err
+		} else {
+			paths, err = ops.TraversePaths(tx, ops.TraversalPlan{
+				Root:      node,
+				Direction: graph.DirectionOutbound,
+				BranchQuery: func() graph.Criteria {
+					return query.KindIn(query.Relationship(), ad.SyncedToADUser)
+				},
+			})
+			return err
+		}
+	})
+}
+
+func ListSyncedIdentities(ctx context.Context, db graph.Database, objectID string, skip, limit int) (graph.NodeSet, error) {
+	var nodes graph.NodeSet
+
+	return nodes, db.ReadTransaction(ctx, func(tx graph.Transaction) error {
+		if node, err := FetchEntityByObjectID(tx, objectID); err != nil {
+			return err
+		} else {
+			nodes, err = ops.AcyclicTraverseTerminals(tx, ops.TraversalPlan{
+				Root:      node,
+				Direction: graph.DirectionOutbound,
+				BranchQuery: func() graph.Criteria {
+					return query.KindIn(query.Relationship(), ad.SyncedToADUser)
+				},
+				Skip:  skip,
+				Limit: limit,
+			})
 			return err
 		}
 	})

--- a/packages/go/analysis/azure/model.go
+++ b/packages/go/analysis/azure/model.go
@@ -64,6 +64,7 @@ const (
 	RelatedEntityTypeDescendentFunctionApps             RelatedEntityType = "descendent-function-apps"
 	RelatedEntityTypeRoleApprovers                      RelatedEntityType = "role-approvers"
 	RelatedEntityTypeFederatedIdentityCredentials       RelatedEntityType = "federated-identity-credentials"
+	RelatedEntityTypeSyncedIdentities                   RelatedEntityType = "synced-identities"
 )
 
 // FromGraphNodes takes a slice of *graph.Node and converts them to serializable node structs.

--- a/packages/javascript/bh-shared-ui/src/utils/content.ts
+++ b/packages/javascript/bh-shared-ui/src/utils/content.ts
@@ -1647,7 +1647,9 @@ export const entityRelationshipEndpoints = {
             .then((res) => res.data),
     'azuser-synced_identities': ({ id, counts, skip, limit, type }) =>
         apiClient
-            .getAZEntityInfoV2('users', id, 'synced-identities', counts, skip, limit, type, { signal: controller.signal })
+            .getAZEntityInfoV2('users', id, 'synced-identities', counts, skip, limit, type, {
+                signal: controller.signal,
+            })
             .then((res) => res.data),
     'azvm-local_admins': ({ id, counts, skip, limit, type }) =>
         apiClient
@@ -1872,5 +1874,7 @@ export const entityRelationshipEndpoints = {
     'user-inbound_object_control': ({ id, skip, limit, type }) =>
         apiClient.getUserControllersV2(id, skip, limit, type, { signal: controller.signal }).then((res) => res.data),
     'user-synced_identities': ({ id, skip, limit, type }) =>
-        apiClient.getUserSyncedIdentitiesV2(id, skip, limit, type, { signal: controller.signal }).then((res) => res.data),
+        apiClient
+            .getUserSyncedIdentitiesV2(id, skip, limit, type, { signal: controller.signal })
+            .then((res) => res.data),
 } as const satisfies EntityRelationshipEndpoint;

--- a/packages/javascript/bh-shared-ui/src/utils/content.ts
+++ b/packages/javascript/bh-shared-ui/src/utils/content.ts
@@ -634,6 +634,11 @@ export const allSections: Partial<Record<EntityKinds, (id: string) => EntityInfo
     [AzureNodeKind.User]: (id: string) => [
         {
             id,
+            label: 'Synced Identities',
+            queryType: 'azuser-synced_identities',
+        },
+        {
+            id,
             label: 'Member Of',
             queryType: 'azuser-member_of',
         },
@@ -1047,6 +1052,11 @@ export const allSections: Partial<Record<EntityKinds, (id: string) => EntityInfo
         },
     ],
     [ActiveDirectoryNodeKind.User]: (id: string) => [
+        {
+            id,
+            label: 'Synced Identities',
+            queryType: 'user-synced_identities',
+        },
         {
             id,
             label: 'Sessions',
@@ -1635,6 +1645,10 @@ export const entityRelationshipEndpoints = {
         apiClient
             .getAZEntityInfoV2('users', id, 'inbound-control', counts, skip, limit, type, { signal: controller.signal })
             .then((res) => res.data),
+    'azuser-synced_identities': ({ id, counts, skip, limit, type }) =>
+        apiClient
+            .getAZEntityInfoV2('users', id, 'synced-identities', counts, skip, limit, type, { signal: controller.signal })
+            .then((res) => res.data),
     'azvm-local_admins': ({ id, counts, skip, limit, type }) =>
         apiClient
             .getAZEntityInfoV2('vms', id, 'inbound-execution-privileges', counts, skip, limit, type, {
@@ -1857,4 +1871,6 @@ export const entityRelationshipEndpoints = {
         apiClient.getUserControllablesV2(id, skip, limit, type, { signal: controller.signal }).then((res) => res.data),
     'user-inbound_object_control': ({ id, skip, limit, type }) =>
         apiClient.getUserControllersV2(id, skip, limit, type, { signal: controller.signal }).then((res) => res.data),
+    'user-synced_identities': ({ id, skip, limit, type }) =>
+        apiClient.getUserSyncedIdentitiesV2(id, skip, limit, type, { signal: controller.signal }).then((res) => res.data),
 } as const satisfies EntityRelationshipEndpoint;

--- a/packages/javascript/js-client-library/src/client.ts
+++ b/packages/javascript/js-client-library/src/client.ts
@@ -2105,6 +2105,21 @@ class BHEAPIClient {
             )
         );
 
+    getUserSyncedIdentitiesV2 = (id: string, skip?: number, limit?: number, type?: string, options?: RequestOptions) =>
+        this.baseClient.get(
+            `/api/v2/users/${id}/synced-identities`,
+            Object.assign(
+                {
+                    params: {
+                        skip,
+                        limit,
+                        type,
+                    },
+                },
+                options
+            )
+        );
+
     getUserControllersV2 = (id: string, skip?: number, limit?: number, type?: string, options?: RequestOptions) =>
         this.baseClient.get(
             `/api/v2/users/${id}/controllers`,


### PR DESCRIPTION

## Description

Surfaces SyncedToEntraUser and SyncedToADUser edges in the entity info panel as a collapsible "Synced Identities" section. Uses generic naming to accommodate future OpenGraph identity sync extensions.

## Motivation and Context

Resolves #2682 

It is not always obvious that a user has a corresponding synced "identity" in another platform; the only place this is currently displayed is from the "On Prem Sync Enabled" property on Azure users. This lets users of BloodHound easily identify the synced user and view both at once on the graph without the use of pathfinding or cypher. Additionally, this should be expanded in the future to accommodate additional synced users in OpenGraph extensions.

## How Has This Been Tested?

Tested using a locally built CE with the example AD and Azure data available from SpecterOps. 

- Verified "Synced Identities" section appears on AD User entity panel
- Verified "Synced Identities" section appears on Azure User entity panel
- Expanding the section successfully returns the user nodes and connecting edge in the graph, when a synced user is present
- Non-synced users show a count of 0.

## Screenshots (optional):
<img width="1574" height="605" alt="synced-users-entity-panel" src="https://github.com/user-attachments/assets/f5de521c-a395-44c2-934c-9bc810ce5318" />

## Types of changes

<!-- Please remove any items that do not apply. -->

- New feature (non-breaking change which adds functionality)


## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [ ] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [ ] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [ ] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new **“Synced Identities”** section for **Azure** and **Active Directory** users in the UI.
  * Introduced an API endpoint to list a user’s synced identities (with support for graph and list modes), surfaced in the client with pagination.

* **Bug Fixes**
  * Updated related-entity handling so synced identities resolve consistently across both **graph** and **list** views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->