### PR TITLE
fix: Expand number of entries included in ConvertAzureRoleEligibilityScheduleInstanceToRel relationships (BED-6391)

### DIFF
--- a/packages/go/ein/azure.go
+++ b/packages/go/ein/azure.go
@@ -1957,7 +1957,7 @@ func ConvertAzureRoleEligibilityScheduleInstanceToRel(instance models.RoleEligib
 	id := strings.ToUpper(fmt.Sprintf("%s@%s", instance.RoleDefinitionId, instance.TenantId))
 
 	relationships := make([]IngestibleRelationship, 0)
-	
+
 	relationships = append(relationships, NewIngestibleRelationship(
 		IngestibleEndpoint{
 			Value: strings.ToUpper(instance.PrincipalId),

--- a/packages/go/ein/azure.go
+++ b/packages/go/ein/azure.go
@@ -1957,11 +1957,7 @@ func ConvertAzureRoleEligibilityScheduleInstanceToRel(instance models.RoleEligib
 	id := strings.ToUpper(fmt.Sprintf("%s@%s", instance.RoleDefinitionId, instance.TenantId))
 
 	relationships := make([]IngestibleRelationship, 0)
-	//If the scope is not the directory, we are going to skip creating the edges for now until later work is done
-	//This isn't necessarily the best spot for this, but it works and it makes testing simple, since none of our azure convertors are exported
-	if instance.DirectoryScopeId != "/" {
-		return relationships
-	}
+	
 	relationships = append(relationships, NewIngestibleRelationship(
 		IngestibleEndpoint{
 			Value: strings.ToUpper(instance.PrincipalId),

--- a/packages/go/ein/azure_test.go
+++ b/packages/go/ein/azure_test.go
@@ -51,6 +51,36 @@ func TestConvertAzureRoleEligibilityScheduleInstanceToRel(t *testing.T) {
 		Id:               "lAPpYvVpN0KRkAEhdxReELKn6QMIlSROgkgWZy9fE3c-1-e",
 		RoleDefinitionId: "62e90394-69f5-4237-9190-012177145e10",
 		PrincipalId:      "03e9a7b2-9508-4e24-8248-16672f5f1377",
+		DirectoryScopeId: "/",
+		StartDateTime:    "2024-01-04T01:22:36.867Z",
+		TenantId:         "6c12b0b0-b2cc-4a73-8252-0b94bfca2145",
+	}
+
+	expectedRels = ein.ConvertAzureRoleEligibilityScheduleInstanceToRel(testData)
+	require.Len(t, expectedRels, 1)
+}
+
+func TestNonRootDirectoryScopeIdConvertAzureRoleEligibilityScheduleInstanceToRel(t *testing.T) {
+	testData := models.RoleEligibilityScheduleInstance{
+		Id:               "lAPpYvVpN0KRkAEhdxReELKn6QMIlSROgkgWZy9fE3c-1-e",
+		RoleDefinitionId: "62e90394-69f5-4237-9190-012177145e10",
+		PrincipalId:      "03e9a7b2-9508-4e24-8248-16672f5f1377",
+		DirectoryScopeId: "abc123",
+		StartDateTime:    "2024-01-04T01:22:36.867Z",
+		TenantId:         "6c12b0b0-b2cc-4a73-8252-0b94bfca2145",
+	}
+
+	expectedRels := ein.ConvertAzureRoleEligibilityScheduleInstanceToRel(testData)
+	require.Len(t, expectedRels, 1)
+	expectedRel := expectedRels[0]
+	require.Equal(t, expectedRel.Target.Value, strings.ToUpper(fmt.Sprintf("%s@%s", testData.RoleDefinitionId, testData.TenantId)))
+	require.Equal(t, expectedRel.RelType, azure.AZRoleEligible)
+	require.Equal(t, expectedRel.Source.Value, strings.ToUpper(testData.PrincipalId))
+
+	testData = models.RoleEligibilityScheduleInstance{
+		Id:               "lAPpYvVpN0KRkAEhdxReELKn6QMIlSROgkgWZy9fE3c-1-e",
+		RoleDefinitionId: "62e90394-69f5-4237-9190-012177145e10",
+		PrincipalId:      "03e9a7b2-9508-4e24-8248-16672f5f1377",
 		DirectoryScopeId: "abc123",
 		StartDateTime:    "2024-01-04T01:22:36.867Z",
 		TenantId:         "6c12b0b0-b2cc-4a73-8252-0b94bfca2145",

--- a/packages/go/ein/azure_test.go
+++ b/packages/go/ein/azure_test.go
@@ -51,43 +51,14 @@ func TestConvertAzureRoleEligibilityScheduleInstanceToRel(t *testing.T) {
 		Id:               "lAPpYvVpN0KRkAEhdxReELKn6QMIlSROgkgWZy9fE3c-1-e",
 		RoleDefinitionId: "62e90394-69f5-4237-9190-012177145e10",
 		PrincipalId:      "03e9a7b2-9508-4e24-8248-16672f5f1377",
-		DirectoryScopeId: "/",
-		StartDateTime:    "2024-01-04T01:22:36.867Z",
-		TenantId:         "6c12b0b0-b2cc-4a73-8252-0b94bfca2145",
-	}
-
-	expectedRels = ein.ConvertAzureRoleEligibilityScheduleInstanceToRel(testData)
-	require.Len(t, expectedRels, 1)
-}
-
-func TestNonRootDirectoryScopeIdConvertAzureRoleEligibilityScheduleInstanceToRel(t *testing.T) {
-	testData := models.RoleEligibilityScheduleInstance{
-		Id:               "lAPpYvVpN0KRkAEhdxReELKn6QMIlSROgkgWZy9fE3c-1-e",
-		RoleDefinitionId: "62e90394-69f5-4237-9190-012177145e10",
-		PrincipalId:      "03e9a7b2-9508-4e24-8248-16672f5f1377",
-		DirectoryScopeId: "abc123",
-		StartDateTime:    "2024-01-04T01:22:36.867Z",
-		TenantId:         "6c12b0b0-b2cc-4a73-8252-0b94bfca2145",
-	}
-
-	expectedRels := ein.ConvertAzureRoleEligibilityScheduleInstanceToRel(testData)
-	require.Len(t, expectedRels, 1)
-	expectedRel := expectedRels[0]
-	require.Equal(t, expectedRel.Target.Value, strings.ToUpper(fmt.Sprintf("%s@%s", testData.RoleDefinitionId, testData.TenantId)))
-	require.Equal(t, expectedRel.RelType, azure.AZRoleEligible)
-	require.Equal(t, expectedRel.Source.Value, strings.ToUpper(testData.PrincipalId))
-
-	testData = models.RoleEligibilityScheduleInstance{
-		Id:               "lAPpYvVpN0KRkAEhdxReELKn6QMIlSROgkgWZy9fE3c-1-e",
-		RoleDefinitionId: "62e90394-69f5-4237-9190-012177145e10",
-		PrincipalId:      "03e9a7b2-9508-4e24-8248-16672f5f1377",
+		// Note that we no longer exclude items with directory scope other than "/""
 		DirectoryScopeId: "abc123",
 		StartDateTime:    "2024-01-04T01:22:36.867Z",
 		TenantId:         "6c12b0b0-b2cc-4a73-8252-0b94bfca2145",
 	}
 
 	expectedRels = ein.ConvertAzureRoleEligibilityScheduleInstanceToRel(testData)
-	require.Len(t, expectedRels, 0)
+	require.Len(t, expectedRels, 1)
 }
 
 func Test_ConvertAppFederatedIdentityCredential(t *testing.T) {


### PR DESCRIPTION

## Motivation and Context

A customer noticed that not all eligible user roles are being surfaced in their environment. Seems to be that is because in `ConvertAzureRoleEligibilityScheduleInstanceToRel` we skip the assignment of relationships if the `DirectoryScoped` is not `"/"`

This PR removes that gate, assigning relationships for all instances, not just those whose `DirectoryScoped` is `/`.

Resolves BED-6391


*Why is this change required? What problem does it solve?*

## How Has This Been Tested?

*Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc.*

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)
- Database Migrations

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [ ] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [ ] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [ ] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Azure role eligibility schedule conversion to always create the Azure role eligibility relationship, including when the directory scope is non-root (previously it could be skipped for non-root scope).

* **Tests**
  * Updated Azure role eligibility schedule conversion tests to expect exactly one relationship for non-root directory scopes, and to verify the relationship type and source/target values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->