### PR TITLE
feat: Optimize PG graph database wipes - BED-8787

### DIFF
--- a/cmd/api/src/daemons/datapipe/delete.go
+++ b/cmd/api/src/daemons/datapipe/delete.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/specterops/bloodhound/cmd/api/src/migrations"
 	"github.com/specterops/bloodhound/cmd/api/src/model"
+	"github.com/specterops/bloodhound/packages/go/bhlog/measure"
 	"github.com/specterops/bloodhound/packages/go/graphschema/common"
 	"github.com/specterops/dawgs/graph"
 	"github.com/specterops/dawgs/ops"
@@ -39,14 +40,15 @@ type graphWiper interface {
 }
 
 func DeleteCollectedGraphData(ctx context.Context, graphDB graph.Database, deleteRequest model.AnalysisRequest, sourceKinds graph.Kinds) error {
-	slog.InfoContext(
+	defer measure.ContextLogAndMeasure(
 		ctx,
+		slog.LevelInfo,
 		"DeleteCollectedGraphData",
 		slog.Bool("delete_all_data", deleteRequest.DeleteAllGraph),
 		slog.Bool("delete_sourceless_data", deleteRequest.DeleteSourcelessGraph),
 		slog.String("delete_source_kinds", strings.Join(deleteRequest.DeleteSourceKinds, ",")),
 		slog.String("delete_relationships", strings.Join(deleteRequest.DeleteRelationships, ",")),
-	)
+	)()
 
 	// On backends that support a bulk wipe (PostgreSQL), a full graph deletion truncates every node and edge partition
 	// in a single transaction rather than streaming and deleting each node row-by-row. This also clears all edges, so

--- a/cmd/api/src/daemons/datapipe/delete.go
+++ b/cmd/api/src/daemons/datapipe/delete.go
@@ -18,7 +18,6 @@ package datapipe
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -181,16 +180,8 @@ func DeleteCollectedGraphData(ctx context.Context, graphDB graph.Database, delet
 // truncate, so the wipe and recreate are atomic.
 func wipeAllGraphData(ctx context.Context, graphDB graph.Database, wiper graphWiper) error {
 	migrationData, err := migrations.GetMigrationData(ctx, graphDB)
-	if err != nil && !errors.Is(err, migrations.ErrNoMigrationData) {
+	if err != nil {
 		return fmt.Errorf("reading migration data prior to graph wipe: %w", err)
-	} else if errors.Is(err, migrations.ErrNoMigrationData) {
-		// GetMigrationData returns the running binary version when no readable MigrationData node exists, which is the
-		// correct value to recreate after the wipe.
-		slog.WarnContext(
-			ctx,
-			"No readable MigrationData node found prior to graph wipe; recreating with current binary version",
-			slog.String("version", migrationData.String()),
-		)
 	}
 
 	return wiper.WipeGraph(ctx, func(tx graph.Transaction) error {

--- a/cmd/api/src/daemons/datapipe/delete.go
+++ b/cmd/api/src/daemons/datapipe/delete.go
@@ -18,10 +18,12 @@ package datapipe
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
 
+	"github.com/specterops/bloodhound/cmd/api/src/migrations"
 	"github.com/specterops/bloodhound/cmd/api/src/model"
 	"github.com/specterops/bloodhound/packages/go/graphschema/common"
 	"github.com/specterops/dawgs/graph"
@@ -29,6 +31,13 @@ import (
 	"github.com/specterops/dawgs/query"
 	"github.com/specterops/dawgs/util/channels"
 )
+
+// graphWiper is implemented by graph database drivers (currently PostgreSQL) that support a fast, bulk truncate-based
+// wipe of all graph data. The retain delegate runs within the same transaction as the wipe so survivor nodes can be
+// recreated atomically.
+type graphWiper interface {
+	WipeGraph(ctx context.Context, retain graph.TransactionDelegate) error
+}
 
 func DeleteCollectedGraphData(ctx context.Context, graphDB graph.Database, deleteRequest model.AnalysisRequest, sourceKinds graph.Kinds) error {
 	slog.InfoContext(
@@ -39,6 +48,16 @@ func DeleteCollectedGraphData(ctx context.Context, graphDB graph.Database, delet
 		slog.String("delete_source_kinds", strings.Join(deleteRequest.DeleteSourceKinds, ",")),
 		slog.String("delete_relationships", strings.Join(deleteRequest.DeleteRelationships, ",")),
 	)
+
+	// On backends that support a bulk wipe (PostgreSQL), a full graph deletion truncates every node and edge partition
+	// in a single transaction rather than streaming and deleting each node row-by-row. This also clears all edges, so
+	// any requested relationship deletions are subsumed by the wipe. Backends without this capability (Neo4j) fall
+	// through to the row-by-row path below.
+	if deleteRequest.DeleteAllGraph {
+		if wiper, isWiper := graph.AsDriver[graphWiper](graphDB); isWiper {
+			return wipeAllGraphData(ctx, graphDB, wiper)
+		}
+	}
 
 	if deleteRequest.DeleteAllGraph || deleteRequest.DeleteSourcelessGraph || len(deleteRequest.DeleteSourceKinds) > 0 {
 		nodeOperation := ops.StartNewOperation[graph.ID](ops.OperationContext{
@@ -154,4 +173,35 @@ func DeleteCollectedGraphData(ctx context.Context, graphDB graph.Database, delet
 	}
 
 	return nil
+}
+
+// wipeAllGraphData performs a full graph wipe via the backend's bulk truncate path. The MigrationData node records the
+// graph schema version and must survive the wipe, otherwise the migration system would re-initialize the database on the
+// next startup. Its version is read before the wipe and the node is recreated within the same transaction as the
+// truncate, so the wipe and recreate are atomic.
+func wipeAllGraphData(ctx context.Context, graphDB graph.Database, wiper graphWiper) error {
+	migrationData, err := migrations.GetMigrationData(ctx, graphDB)
+	if err != nil && !errors.Is(err, migrations.ErrNoMigrationData) {
+		return fmt.Errorf("reading migration data prior to graph wipe: %w", err)
+	} else if errors.Is(err, migrations.ErrNoMigrationData) {
+		// GetMigrationData returns the running binary version when no readable MigrationData node exists, which is the
+		// correct value to recreate after the wipe.
+		slog.WarnContext(
+			ctx,
+			"No readable MigrationData node found prior to graph wipe; recreating with current binary version",
+			slog.String("version", migrationData.String()),
+		)
+	}
+
+	return wiper.WipeGraph(ctx, func(tx graph.Transaction) error {
+		if _, err := tx.CreateNode(graph.AsProperties(map[string]any{
+			"Major": migrationData.Major,
+			"Minor": migrationData.Minor,
+			"Patch": migrationData.Patch,
+		}), common.MigrationData); err != nil {
+			return fmt.Errorf("recreating migration data after graph wipe: %w", err)
+		}
+
+		return nil
+	})
 }

--- a/cmd/api/src/daemons/datapipe/delete_integration_test.go
+++ b/cmd/api/src/daemons/datapipe/delete_integration_test.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/specterops/bloodhound/cmd/api/src/daemons/datapipe"
+	"github.com/specterops/bloodhound/cmd/api/src/migrations"
 	"github.com/specterops/bloodhound/cmd/api/src/model"
 	"github.com/specterops/bloodhound/cmd/api/src/services/graphify"
 	"github.com/specterops/bloodhound/cmd/api/src/services/graphify/endpoint"
@@ -68,6 +69,12 @@ func TestDeleteAllData(t *testing.T) {
 		require.Equal(t, 1, len(fileData))
 	}
 
+	// Capture the MigrationData version before the wipe. On the Postgres backend the full wipe takes the fast
+	// TRUNCATE path, which must recreate the MigrationData node so the migration system does not re-initialize the
+	// database on next startup.
+	preDeleteVersion, err := migrations.GetMigrationData(ctx, testSuite.GraphDB)
+	require.NoError(t, err)
+
 	// DELETE ALL
 	var (
 		deleteRequest = model.AnalysisRequest{DeleteAllGraph: true}
@@ -80,6 +87,12 @@ func TestDeleteAllData(t *testing.T) {
 	expected, err := generic.LoadGraphFromFile(os.DirFS(path.Join("fixtures", t.Name())), "deleteAllExpected.json")
 	require.NoError(t, err)
 	generic.AssertDatabaseGraph(t, ctx, testSuite.GraphDB, &expected)
+
+	// The MigrationData node must survive the wipe with its version intact. A non-nil error here means the node was
+	// not recreated (GetMigrationData returns ErrNoMigrationData when no readable node exists).
+	postDeleteVersion, err := migrations.GetMigrationData(ctx, testSuite.GraphDB)
+	require.NoError(t, err)
+	require.Equal(t, preDeleteVersion, postDeleteVersion)
 }
 
 // TestDeleteAllData_Alternative covers the case where a client intends to delete all data,


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Implements the new `WipeGraph` function supported optionally on DAWGS drivers to execute rapid graph wiping if supported. Initially, this is supported on PostgreSQL drivers utilizing TRUNCATE on node/edge tables.

This PR requires the merging/release of DAWGS from https://github.com/SpecterOps/DAWGS/pull/99 to realize the optimization gains, however merging may occur in any order as the implementation is optional on all graph drivers.

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-8787

*Why is this change required? What problem does it solve?*

## How Has This Been Tested?

Validated in local environments, and additional integration tests added to DAWGS.

## Screenshots (optional):

Utilizing a test dataset from OGGen with 1M nodes, 3 tiers, and 10 edges between each tier showed a 99% reduction in deletion time.

Pre-change:
```
time=2026-06-30T15:23:52.946Z level=INFO message=DeleteCollectedGraphData delete_all_data=true delete_sourceless_data=false delete_source_kinds="" delete_relationships="" measurement_id=75 elapsed=33.178734682s
```

Post-change:
```
time=2026-06-30T01:02:54.377Z level=INFO message=DeleteCollectedGraphData delete_all_data=true delete_sourceless_data=false delete_source_kinds="" delete_relationships="" measurement_id=156 elapsed=115.218083ms
```

## Types of changes

<!-- Please remove any items that do not apply. -->

- New feature (non-breaking change which adds functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [X] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [X] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [X] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved full-graph deletion to preserve the database’s migration version, keeping required system state consistent after a complete wipe.
  * Enabled supported graph backends to clear all graph data via an optimized wipe path while keeping migration metadata intact.
* **Tests**
  * Added/extended an integration test to verify the migration version is unchanged before and after a full graph wipe.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->