### PR TITLE
feat(Data Quality): add `environment_kind_id` and `environment_kind_display_name` to available-domains response BED-8685

### DIFF
--- a/cmd/api/src/api/v2/mocks/graphschemaextensions.go
+++ b/cmd/api/src/api/v2/mocks/graphschemaextensions.go
@@ -72,20 +72,20 @@ func (mr *MockOpenGraphSchemaServiceMockRecorder) DeleteExtension(ctx, extension
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteExtension", reflect.TypeOf((*MockOpenGraphSchemaService)(nil).DeleteExtension), ctx, extensionID)
 }
 
-// GetEnvironmentKindsAndEnvironmentExtensionDisplayNames mocks base method.
-func (m *MockOpenGraphSchemaService) GetEnvironmentKindsAndEnvironmentExtensionDisplayNames(ctx context.Context, onlyBuiltin bool) (graph.Kinds, map[string]string, error) {
+// GetEnvironmentKindsAndSchemaEnvironmentData mocks base method.
+func (m *MockOpenGraphSchemaService) GetEnvironmentKindsAndSchemaEnvironmentData(ctx context.Context, onlyBuiltin bool) (graph.Kinds, model.EnvironmentKindsToEnvironment, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetEnvironmentKindsAndEnvironmentExtensionDisplayNames", ctx, onlyBuiltin)
+	ret := m.ctrl.Call(m, "GetEnvironmentKindsAndSchemaEnvironmentData", ctx, onlyBuiltin)
 	ret0, _ := ret[0].(graph.Kinds)
-	ret1, _ := ret[1].(map[string]string)
+	ret1, _ := ret[1].(model.EnvironmentKindsToEnvironment)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
 }
 
-// GetEnvironmentKindsAndEnvironmentExtensionDisplayNames indicates an expected call of GetEnvironmentKindsAndEnvironmentExtensionDisplayNames.
-func (mr *MockOpenGraphSchemaServiceMockRecorder) GetEnvironmentKindsAndEnvironmentExtensionDisplayNames(ctx, onlyBuiltin any) *gomock.Call {
+// GetEnvironmentKindsAndSchemaEnvironmentData indicates an expected call of GetEnvironmentKindsAndSchemaEnvironmentData.
+func (mr *MockOpenGraphSchemaServiceMockRecorder) GetEnvironmentKindsAndSchemaEnvironmentData(ctx, onlyBuiltin any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEnvironmentKindsAndEnvironmentExtensionDisplayNames", reflect.TypeOf((*MockOpenGraphSchemaService)(nil).GetEnvironmentKindsAndEnvironmentExtensionDisplayNames), ctx, onlyBuiltin)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEnvironmentKindsAndSchemaEnvironmentData", reflect.TypeOf((*MockOpenGraphSchemaService)(nil).GetEnvironmentKindsAndSchemaEnvironmentData), ctx, onlyBuiltin)
 }
 
 // GetSchemaFindings mocks base method.

--- a/cmd/api/src/api/v2/opengraphschema.go
+++ b/cmd/api/src/api/v2/opengraphschema.go
@@ -44,7 +44,7 @@ type OpenGraphSchemaService interface {
 	UpsertOpenGraphExtension(ctx context.Context, openGraphExtension model.GraphExtensionInput) (bool, error)
 	ListExtensions(ctx context.Context) (model.GraphSchemaExtensions, error)
 	DeleteExtension(ctx context.Context, extensionID int32) error
-	GetEnvironmentKindsAndEnvironmentExtensionDisplayNames(ctx context.Context, onlyBuiltin bool) (graph.Kinds, map[string]string, error)
+	GetEnvironmentKindsAndSchemaEnvironmentData(ctx context.Context, onlyBuiltin bool) (graph.Kinds, model.EnvironmentKindsToEnvironment, error)
 	GetSchemaFindings(ctx context.Context, filters model.Filters, sort model.Sort, skip, limit int) ([]model.SchemaFinding, int, error)
 }
 

--- a/cmd/api/src/api/v2/search.go
+++ b/cmd/api/src/api/v2/search.go
@@ -232,6 +232,7 @@ func resolveEnvProperties(node *graph.Node, kindToSchemaEnvironment model.Enviro
 				envProperties.Type = schemaEnvironment.SchemaExtensionDisplayName
 				envProperties.KindDisplayName = &schemaEnvironment.EnvironmentKindName
 				envProperties.KindId = &schemaEnvironment.EnvironmentKindId
+				break
 			}
 		}
 	}

--- a/cmd/api/src/api/v2/search.go
+++ b/cmd/api/src/api/v2/search.go
@@ -182,15 +182,17 @@ func BuildEnvironmentSelectors(nodes []*graph.Node, kindToSchemaEnvironment mode
 		objectID, _ := node.Properties.GetOrDefault(common.ObjectID.String(), graphschema.DefaultMissingObjectId).String()
 
 		collected := resolveCollected(node)
-		envType := resolveEnvType(node, kindToSchemaEnvironment)
-		extensionID := resolveExtensionID(node, kindToSchemaEnvironment)
+		envProperties := resolveEnvProperties(node, kindToSchemaEnvironment)
 
 		envs = append(envs, model.EnvironmentSelector{
-			Type:        envType,
-			Name:        name,
-			ObjectID:    objectID,
-			Collected:   collected,
-			ExtensionID: extensionID,
+			Name:      name,
+			ObjectID:  objectID,
+			Collected: collected,
+			EnvironmentProperties: model.EnvironmentProperties{
+				Type:            envProperties.Type,
+				KindId:          envProperties.KindId,
+				KindDisplayName: envProperties.KindDisplayName,
+			},
 		})
 	}
 
@@ -215,24 +217,25 @@ func resolveCollected(node *graph.Node) bool {
 	return true
 }
 
-func resolveEnvType(node *graph.Node, kindToSchemaEnvironment model.EnvironmentKindsToEnvironment) string {
+func resolveEnvProperties(node *graph.Node, kindToSchemaEnvironment model.EnvironmentKindsToEnvironment) model.EnvironmentProperties {
+	envProperties := model.EnvironmentProperties{}
 	// TODO: Remove hardcoded built-in types once they are saved in DB and not CUE
 	if node.Kinds.ContainsOneOf(azure.Tenant) {
-		return "azure"
-	}
-	if node.Kinds.ContainsOneOf(ad.Domain) {
-		return "active-directory"
-	}
-
-	// For custom extensions, use the display name from the schema extension
-	// Note: Nodes should only have one environment kind. In the edge case where there are multiple, we take the first.
-	for _, kind := range node.Kinds {
-		if schemaEnvironment, ok := kindToSchemaEnvironment[kind.String()]; ok {
-			return schemaEnvironment.SchemaExtensionDisplayName
+		envProperties.Type = "azure"
+	} else if node.Kinds.ContainsOneOf(ad.Domain) {
+		envProperties.Type = "active-directory"
+	} else {
+		// For custom extensions, use the display name from the schema extension
+		// Note: Nodes should only have one environment kind. In the edge case where there are multiple, we take the first.
+		for _, kind := range node.Kinds {
+			if schemaEnvironment, ok := kindToSchemaEnvironment[kind.String()]; ok {
+				envProperties.Type = schemaEnvironment.SchemaExtensionDisplayName
+				envProperties.KindDisplayName = &schemaEnvironment.EnvironmentKindName
+				envProperties.KindId = &schemaEnvironment.EnvironmentKindId
+			}
 		}
 	}
-
-	return ""
+	return envProperties
 }
 
 func resolveExtensionID(node *graph.Node, kindToSchemaEnvironment model.EnvironmentKindsToEnvironment) *int32 {

--- a/cmd/api/src/api/v2/search.go
+++ b/cmd/api/src/api/v2/search.go
@@ -238,23 +238,6 @@ func resolveEnvProperties(node *graph.Node, kindToSchemaEnvironment model.Enviro
 	return envProperties
 }
 
-func resolveExtensionID(node *graph.Node, kindToSchemaEnvironment model.EnvironmentKindsToEnvironment) *int32 {
-	// TODO: Remove hardcoded built-in types once they are saved in DB and not CUE
-	isBuiltinEnvironment := node.Kinds.ContainsOneOf(azure.Tenant, ad.Domain)
-	if isBuiltinEnvironment {
-		return nil
-	}
-
-	// Note: Nodes should only have one environment kind. In the edge case where there are multiple, we take the first.
-	for _, kind := range node.Kinds {
-		if schemaEnvironment, ok := kindToSchemaEnvironment[kind.String()]; ok {
-			return &schemaEnvironment.SchemaExtensionId
-		}
-	}
-
-	return nil
-}
-
 // EnvironmentFilterResult contains the filter criteria environment data for mapping environments
 type EnvironmentFilterResult struct {
 	FilterCriteria          graph.Criteria

--- a/cmd/api/src/api/v2/search.go
+++ b/cmd/api/src/api/v2/search.go
@@ -183,14 +183,14 @@ func BuildEnvironmentSelectors(nodes []*graph.Node, kindToSchemaEnvironment mode
 
 		collected := resolveCollected(node)
 		envType := resolveEnvType(node, kindToSchemaEnvironment)
-		schemaExtensionID := resolveSchemaExtensionID(node, kindToSchemaEnvironment)
+		extensionID := resolveExtensionID(node, kindToSchemaEnvironment)
 
 		envs = append(envs, model.EnvironmentSelector{
-			Type:              envType,
-			Name:              name,
-			ObjectID:          objectID,
-			Collected:         collected,
-			SchemaExtensionID: schemaExtensionID,
+			Type:        envType,
+			Name:        name,
+			ObjectID:    objectID,
+			Collected:   collected,
+			ExtensionID: extensionID,
 		})
 	}
 
@@ -235,7 +235,7 @@ func resolveEnvType(node *graph.Node, kindToSchemaEnvironment model.EnvironmentK
 	return ""
 }
 
-func resolveSchemaExtensionID(node *graph.Node, kindToSchemaEnvironment model.EnvironmentKindsToEnvironment) *int32 {
+func resolveExtensionID(node *graph.Node, kindToSchemaEnvironment model.EnvironmentKindsToEnvironment) *int32 {
 	// TODO: Remove hardcoded built-in types once they are saved in DB and not CUE
 	isBuiltinEnvironment := node.Kinds.ContainsOneOf(azure.Tenant, ad.Domain)
 	if isBuiltinEnvironment {

--- a/cmd/api/src/api/v2/search.go
+++ b/cmd/api/src/api/v2/search.go
@@ -26,6 +26,7 @@ import (
 	"github.com/specterops/bloodhound/cmd/api/src/auth"
 	"github.com/specterops/bloodhound/cmd/api/src/bhctx"
 	"github.com/specterops/bloodhound/cmd/api/src/database"
+	"github.com/specterops/bloodhound/cmd/api/src/database/types/null"
 	"github.com/specterops/bloodhound/cmd/api/src/model"
 	"github.com/specterops/bloodhound/cmd/api/src/model/appcfg"
 	"github.com/specterops/bloodhound/cmd/api/src/utils"
@@ -230,8 +231,8 @@ func resolveEnvProperties(node *graph.Node, kindToSchemaEnvironment model.Enviro
 		for _, kind := range node.Kinds {
 			if schemaEnvironment, ok := kindToSchemaEnvironment[kind.String()]; ok {
 				envProperties.Type = schemaEnvironment.SchemaExtensionDisplayName
-				envProperties.KindDisplayName = &schemaEnvironment.EnvironmentKindName
-				envProperties.KindId = &schemaEnvironment.EnvironmentKindId
+				envProperties.KindDisplayName = null.StringFrom(schemaEnvironment.EnvironmentKindName)
+				envProperties.KindId = null.Int32From(schemaEnvironment.EnvironmentKindId)
 				break
 			}
 		}

--- a/cmd/api/src/api/v2/search.go
+++ b/cmd/api/src/api/v2/search.go
@@ -169,26 +169,28 @@ func (s *Resources) ListAvailableEnvironments(response http.ResponseWriter, requ
 	}
 
 	// Build response with domain type display names
-	responseData := BuildEnvironmentSelectors(nodes, filterResult.KindToDisplayName)
+	responseData := BuildEnvironmentSelectors(nodes, filterResult.KindToSchemaEnvironment)
 
 	api.WriteBasicResponse(ctx, responseData, http.StatusOK, response)
 }
 
-func BuildEnvironmentSelectors(nodes []*graph.Node, kindToDisplayName map[string]string) model.EnvironmentSelectors {
+func BuildEnvironmentSelectors(nodes []*graph.Node, kindToSchemaEnvironment model.EnvironmentKindsToEnvironment) model.EnvironmentSelectors {
 	envs := make(model.EnvironmentSelectors, 0, len(nodes))
 
 	for _, node := range nodes {
 		name, _ := node.Properties.GetOrDefault(common.Name.String(), graphschema.DefaultMissingName).String()
 		objectID, _ := node.Properties.GetOrDefault(common.ObjectID.String(), graphschema.DefaultMissingObjectId).String()
 
-		envType := resolveEnvType(node, kindToDisplayName)
 		collected := resolveCollected(node)
+		envType := resolveEnvType(node, kindToSchemaEnvironment)
+		schemaExtensionID := resolveSchemaExtensionID(node, kindToSchemaEnvironment)
 
 		envs = append(envs, model.EnvironmentSelector{
-			Type:      envType,
-			Name:      name,
-			ObjectID:  objectID,
-			Collected: collected,
+			Type:              envType,
+			Name:              name,
+			ObjectID:          objectID,
+			Collected:         collected,
+			SchemaExtensionID: schemaExtensionID,
 		})
 	}
 
@@ -213,7 +215,7 @@ func resolveCollected(node *graph.Node) bool {
 	return true
 }
 
-func resolveEnvType(node *graph.Node, kindToDisplayName map[string]string) string {
+func resolveEnvType(node *graph.Node, kindToSchemaEnvironment model.EnvironmentKindsToEnvironment) string {
 	// TODO: Remove hardcoded built-in types once they are saved in DB and not CUE
 	if node.Kinds.ContainsOneOf(azure.Tenant) {
 		return "azure"
@@ -225,18 +227,35 @@ func resolveEnvType(node *graph.Node, kindToDisplayName map[string]string) strin
 	// For custom extensions, use the display name from the schema extension
 	// Note: Nodes should only have one environment kind. In the edge case where there are multiple, we take the first.
 	for _, kind := range node.Kinds {
-		if displayName, ok := kindToDisplayName[kind.String()]; ok {
-			return displayName
+		if schemaEnvironment, ok := kindToSchemaEnvironment[kind.String()]; ok {
+			return schemaEnvironment.SchemaExtensionDisplayName
 		}
 	}
 
 	return ""
 }
 
-// EnvironmentFilterResult contains the filter criteria and display name mapping for environments
+func resolveSchemaExtensionID(node *graph.Node, kindToSchemaEnvironment model.EnvironmentKindsToEnvironment) *int32 {
+	// TODO: Remove hardcoded built-in types once they are saved in DB and not CUE
+	isBuiltinEnvironment := node.Kinds.ContainsOneOf(azure.Tenant, ad.Domain)
+	if isBuiltinEnvironment {
+		return nil
+	}
+
+	// Note: Nodes should only have one environment kind. In the edge case where there are multiple, we take the first.
+	for _, kind := range node.Kinds {
+		if schemaEnvironment, ok := kindToSchemaEnvironment[kind.String()]; ok {
+			return &schemaEnvironment.SchemaExtensionId
+		}
+	}
+
+	return nil
+}
+
+// EnvironmentFilterResult contains the filter criteria environment data for mapping environments
 type EnvironmentFilterResult struct {
-	FilterCriteria    graph.Criteria
-	KindToDisplayName map[string]string
+	FilterCriteria          graph.Criteria
+	KindToSchemaEnvironment model.EnvironmentKindsToEnvironment
 }
 
 // ErrInvalidQueryParameters is an error that is used to wrap other errors when the query parameters are invalid
@@ -251,7 +270,7 @@ func BuildEnvironmentFilter(ctx context.Context, db database.Database, openGraph
 	if err != nil {
 		return result, err
 		// Fetch schema environments and extension display names
-	} else if environmentKinds, envKindToExtensionDisplayName, err := openGraphSchemaService.GetEnvironmentKindsAndEnvironmentExtensionDisplayNames(ctx, !openGraphFlag.Enabled); err != nil {
+	} else if environmentKinds, envKindToExtension, err := openGraphSchemaService.GetEnvironmentKindsAndSchemaEnvironmentData(ctx, !openGraphFlag.Enabled); err != nil {
 		return result, err
 	} else {
 		// Build base filter criteria
@@ -261,7 +280,7 @@ func BuildEnvironmentFilter(ctx context.Context, db database.Database, openGraph
 		}
 
 		result.FilterCriteria = filterCriteria
-		result.KindToDisplayName = envKindToExtensionDisplayName
+		result.KindToSchemaEnvironment = envKindToExtension
 		return result, nil
 	}
 }

--- a/cmd/api/src/api/v2/search_internal_test.go
+++ b/cmd/api/src/api/v2/search_internal_test.go
@@ -52,10 +52,10 @@ func Test_SetNodeProperties(t *testing.T) {
 			},
 			expected: model.EnvironmentSelectors{
 				{
-					Type:      "active-directory",
-					Name:      "Node1",
-					ObjectID:  "1",
-					Collected: false,
+					EnvironmentProperties: model.EnvironmentProperties{Type: "active-directory"},
+					Name:                  "Node1",
+					ObjectID:              "1",
+					Collected:             false,
 				},
 			},
 		},
@@ -75,10 +75,10 @@ func Test_SetNodeProperties(t *testing.T) {
 			},
 			expected: model.EnvironmentSelectors{
 				{
-					Type:      "azure",
-					Name:      "Node2",
-					ObjectID:  "2",
-					Collected: true,
+					EnvironmentProperties: model.EnvironmentProperties{Type: "azure"},
+					Name:                  "Node2",
+					ObjectID:              "2",
+					Collected:             true,
 				},
 			},
 		},
@@ -93,10 +93,10 @@ func Test_SetNodeProperties(t *testing.T) {
 			},
 			expected: model.EnvironmentSelectors{
 				{
-					Type:      "",
-					Name:      graphschema.DefaultMissingName,
-					ObjectID:  graphschema.DefaultMissingObjectId,
-					Collected: false,
+					EnvironmentProperties: model.EnvironmentProperties{},
+					Name:                  graphschema.DefaultMissingName,
+					ObjectID:              graphschema.DefaultMissingObjectId,
+					Collected:             false,
 				},
 			},
 		},

--- a/cmd/api/src/api/v2/search_internal_test.go
+++ b/cmd/api/src/api/v2/search_internal_test.go
@@ -104,7 +104,7 @@ func Test_SetNodeProperties(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := BuildEnvironmentSelectors(tt.nodes, map[string]string{})
+			got := BuildEnvironmentSelectors(tt.nodes, model.EnvironmentKindsToEnvironment{})
 			assert.Equal(t, tt.expected, got, tt.name)
 		})
 	}

--- a/cmd/api/src/api/v2/search_test.go
+++ b/cmd/api/src/api/v2/search_test.go
@@ -532,7 +532,7 @@ func TestResources_ListAvailableEnvironments(t *testing.T) {
 			expected: expected{
 				responseCode:   http.StatusOK,
 				responseHeader: http.Header{"Content-Type": []string{"application/json"}},
-				responseBody:   `{"data":[{"type":"HeeHaw","name":"HeeHaw Name","id":"1","collected":true,"schema_extension_id": 10}]}`,
+				responseBody:   `{"data":[{"type":"HeeHaw","name":"HeeHaw Name","id":"1","collected":true,"extension_id": 10}]}`,
 			},
 		},
 		{

--- a/cmd/api/src/api/v2/search_test.go
+++ b/cmd/api/src/api/v2/search_test.go
@@ -515,7 +515,7 @@ func TestResources_ListAvailableEnvironments(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mock *mock) {
 				mock.mockDatabase.EXPECT().GetFlagByKey(gomock.Any(), appcfg.FeatureOpenGraphFindings).Return(appcfg.FeatureFlag{Enabled: true}, nil)
-				mock.mockOpenGraphSchemaService.EXPECT().GetEnvironmentKindsAndSchemaEnvironmentData(gomock.Any(), false).Return(graph.Kinds{graph.StringKind("HeeHaw Kind")}, model.EnvironmentKindsToEnvironment{graph.StringKind("HeeHaw Kind").String(): model.SchemaEnvironment{SchemaExtensionDisplayName: "HeeHaw", SchemaExtensionId: 10}}, nil)
+				mock.mockOpenGraphSchemaService.EXPECT().GetEnvironmentKindsAndSchemaEnvironmentData(gomock.Any(), false).Return(graph.Kinds{graph.StringKind("HeeHaw Kind")}, model.EnvironmentKindsToEnvironment{graph.StringKind("HeeHaw Kind").String(): model.SchemaEnvironment{SchemaExtensionDisplayName: "HeeHaw", SchemaExtensionId: 10, EnvironmentKindId: 101, EnvironmentKindName: "heehaw_Kind"}}, nil)
 				mock.mockGraphQuery.EXPECT().
 					GetFilteredAndSortedNodes(gomock.Any(), gomock.Any()).
 					Return([]*graph.Node{
@@ -532,7 +532,7 @@ func TestResources_ListAvailableEnvironments(t *testing.T) {
 			expected: expected{
 				responseCode:   http.StatusOK,
 				responseHeader: http.Header{"Content-Type": []string{"application/json"}},
-				responseBody:   `{"data":[{"type":"HeeHaw","name":"HeeHaw Name","id":"1","collected":true,"extension_id": 10}]}`,
+				responseBody:   `{"data":[{"type":"HeeHaw","environment_kind_id":101,"environment_kind_display_name":"heehaw_Kind","name":"HeeHaw Name","id":"1","collected":true}]}`,
 			},
 		},
 		{

--- a/cmd/api/src/api/v2/search_test.go
+++ b/cmd/api/src/api/v2/search_test.go
@@ -397,7 +397,7 @@ func TestResources_ListAvailableEnvironments(t *testing.T) {
 			},
 		},
 		{
-			name: "fail - GetEnvironmentKindsAndEnvironmentExtensionDisplayNames error",
+			name: "fail - GetEnvironmentKindsAndSchemaEnvironmentData error",
 			buildRequest: func() *http.Request {
 				return &http.Request{
 					URL: &url.URL{
@@ -408,7 +408,7 @@ func TestResources_ListAvailableEnvironments(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mock *mock) {
 				mock.mockDatabase.EXPECT().GetFlagByKey(gomock.Any(), appcfg.FeatureOpenGraphFindings).Return(appcfg.FeatureFlag{Enabled: false}, nil)
-				mock.mockOpenGraphSchemaService.EXPECT().GetEnvironmentKindsAndEnvironmentExtensionDisplayNames(gomock.Any(), true).Return(graph.Kinds{}, map[string]string{}, fmt.Errorf("Some error"))
+				mock.mockOpenGraphSchemaService.EXPECT().GetEnvironmentKindsAndSchemaEnvironmentData(gomock.Any(), true).Return(graph.Kinds{}, model.EnvironmentKindsToEnvironment{}, fmt.Errorf("Some error"))
 			},
 			expected: expected{
 				responseCode:   http.StatusInternalServerError,
@@ -428,11 +428,17 @@ func TestResources_ListAvailableEnvironments(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mock *mock) {
 				mock.mockDatabase.EXPECT().GetFlagByKey(gomock.Any(), appcfg.FeatureOpenGraphFindings).Return(appcfg.FeatureFlag{Enabled: false}, nil)
-				mock.mockOpenGraphSchemaService.EXPECT().GetEnvironmentKindsAndEnvironmentExtensionDisplayNames(gomock.Any(), true).Return(graph.Kinds{
+				mock.mockOpenGraphSchemaService.EXPECT().GetEnvironmentKindsAndSchemaEnvironmentData(gomock.Any(), true).Return(graph.Kinds{
 					ad.Domain, azure.Tenant,
-				}, map[string]string{
-					ad.Domain.String():    "Active Directory",
-					azure.Tenant.String(): "Azure",
+				}, model.EnvironmentKindsToEnvironment{
+					ad.Domain.String(): model.SchemaEnvironment{
+						SchemaExtensionId:          1,
+						SchemaExtensionDisplayName: "Active Directory",
+					},
+					azure.Tenant.String(): model.SchemaEnvironment{
+						SchemaExtensionId:          2,
+						SchemaExtensionDisplayName: "Azure",
+					},
 				}, nil)
 				mock.mockGraphQuery.EXPECT().GetFilteredAndSortedNodes(gomock.Any(), gomock.Any()).Return([]*graph.Node{}, fmt.Errorf("Some error"))
 			},
@@ -454,7 +460,7 @@ func TestResources_ListAvailableEnvironments(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mock *mock) {
 				mock.mockDatabase.EXPECT().GetFlagByKey(gomock.Any(), appcfg.FeatureOpenGraphFindings).Return(appcfg.FeatureFlag{Enabled: false}, nil)
-				mock.mockOpenGraphSchemaService.EXPECT().GetEnvironmentKindsAndEnvironmentExtensionDisplayNames(gomock.Any(), true).Return(graph.Kinds{}, map[string]string{}, nil)
+				mock.mockOpenGraphSchemaService.EXPECT().GetEnvironmentKindsAndSchemaEnvironmentData(gomock.Any(), true).Return(graph.Kinds{}, model.EnvironmentKindsToEnvironment{}, nil)
 				mock.mockGraphQuery.EXPECT().GetFilteredAndSortedNodes(gomock.Any(), gomock.Any()).Return([]*graph.Node{}, nil)
 			},
 			expected: expected{
@@ -475,7 +481,11 @@ func TestResources_ListAvailableEnvironments(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mock *mock) {
 				mock.mockDatabase.EXPECT().GetFlagByKey(gomock.Any(), appcfg.FeatureOpenGraphFindings).Return(appcfg.FeatureFlag{Enabled: false}, nil)
-				mock.mockOpenGraphSchemaService.EXPECT().GetEnvironmentKindsAndEnvironmentExtensionDisplayNames(gomock.Any(), true).Return(graph.Kinds{ad.Domain}, map[string]string{ad.Domain.String(): "Active Directory"}, nil)
+				mock.mockOpenGraphSchemaService.EXPECT().GetEnvironmentKindsAndSchemaEnvironmentData(gomock.Any(), true).Return(graph.Kinds{ad.Domain}, model.EnvironmentKindsToEnvironment{
+					ad.Domain.String(): model.SchemaEnvironment{
+						SchemaExtensionId:          1,
+						SchemaExtensionDisplayName: "Active Directory",
+					}}, nil)
 				mock.mockGraphQuery.EXPECT().GetFilteredAndSortedNodes(gomock.Any(), gomock.Any()).Return([]*graph.Node{
 					{
 						Properties: graph.AsProperties(map[string]any{
@@ -505,7 +515,7 @@ func TestResources_ListAvailableEnvironments(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mock *mock) {
 				mock.mockDatabase.EXPECT().GetFlagByKey(gomock.Any(), appcfg.FeatureOpenGraphFindings).Return(appcfg.FeatureFlag{Enabled: true}, nil)
-				mock.mockOpenGraphSchemaService.EXPECT().GetEnvironmentKindsAndEnvironmentExtensionDisplayNames(gomock.Any(), false).Return(graph.Kinds{graph.StringKind("HeeHaw Kind")}, map[string]string{graph.StringKind("HeeHaw Kind").String(): "HeeHaw"}, nil)
+				mock.mockOpenGraphSchemaService.EXPECT().GetEnvironmentKindsAndSchemaEnvironmentData(gomock.Any(), false).Return(graph.Kinds{graph.StringKind("HeeHaw Kind")}, model.EnvironmentKindsToEnvironment{graph.StringKind("HeeHaw Kind").String(): model.SchemaEnvironment{SchemaExtensionDisplayName: "HeeHaw", SchemaExtensionId: 10}}, nil)
 				mock.mockGraphQuery.EXPECT().
 					GetFilteredAndSortedNodes(gomock.Any(), gomock.Any()).
 					Return([]*graph.Node{
@@ -522,7 +532,7 @@ func TestResources_ListAvailableEnvironments(t *testing.T) {
 			expected: expected{
 				responseCode:   http.StatusOK,
 				responseHeader: http.Header{"Content-Type": []string{"application/json"}},
-				responseBody:   `{"data":[{"type":"HeeHaw","name":"HeeHaw Name","id":"1","collected":true}]}`,
+				responseBody:   `{"data":[{"type":"HeeHaw","name":"HeeHaw Name","id":"1","collected":true,"schema_extension_id": 10}]}`,
 			},
 		},
 		{
@@ -538,8 +548,12 @@ func TestResources_ListAvailableEnvironments(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mock *mock) {
 				mock.mockDatabase.EXPECT().GetFlagByKey(gomock.Any(), appcfg.FeatureOpenGraphFindings).Return(appcfg.FeatureFlag{Enabled: false}, nil)
-				mock.mockOpenGraphSchemaService.EXPECT().GetEnvironmentKindsAndEnvironmentExtensionDisplayNames(gomock.Any(), true).
-					Return(graph.Kinds{ad.Domain}, map[string]string{ad.Domain.String(): "Active Directory"}, nil)
+				mock.mockOpenGraphSchemaService.EXPECT().GetEnvironmentKindsAndSchemaEnvironmentData(gomock.Any(), true).
+					Return(graph.Kinds{ad.Domain}, model.EnvironmentKindsToEnvironment{
+						ad.Domain.String(): model.SchemaEnvironment{
+							SchemaExtensionId:          1,
+							SchemaExtensionDisplayName: "Active Directory",
+						}}, nil)
 				mock.mockGraphQuery.EXPECT().GetFilteredAndSortedNodes(gomock.Any(), gomock.Any()).
 					Return([]*graph.Node{{
 						Properties: graph.AsProperties(map[string]any{
@@ -569,8 +583,12 @@ func TestResources_ListAvailableEnvironments(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mock *mock) {
 				mock.mockDatabase.EXPECT().GetFlagByKey(gomock.Any(), appcfg.FeatureOpenGraphFindings).Return(appcfg.FeatureFlag{Enabled: false}, nil)
-				mock.mockOpenGraphSchemaService.EXPECT().GetEnvironmentKindsAndEnvironmentExtensionDisplayNames(gomock.Any(), true).
-					Return(graph.Kinds{ad.Domain}, map[string]string{ad.Domain.String(): "Active Directory"}, nil)
+				mock.mockOpenGraphSchemaService.EXPECT().GetEnvironmentKindsAndSchemaEnvironmentData(gomock.Any(), true).
+					Return(graph.Kinds{ad.Domain}, model.EnvironmentKindsToEnvironment{
+						ad.Domain.String(): model.SchemaEnvironment{
+							SchemaExtensionId:          1,
+							SchemaExtensionDisplayName: "Active Directory",
+						}}, nil)
 				mock.mockGraphQuery.EXPECT().GetFilteredAndSortedNodes(gomock.Any(), gomock.Any()).
 					Return([]*graph.Node{{
 						Properties: graph.AsProperties(map[string]any{
@@ -600,8 +618,12 @@ func TestResources_ListAvailableEnvironments(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mock *mock) {
 				mock.mockDatabase.EXPECT().GetFlagByKey(gomock.Any(), appcfg.FeatureOpenGraphFindings).Return(appcfg.FeatureFlag{Enabled: false}, nil)
-				mock.mockOpenGraphSchemaService.EXPECT().GetEnvironmentKindsAndEnvironmentExtensionDisplayNames(gomock.Any(), true).
-					Return(graph.Kinds{ad.Domain}, map[string]string{ad.Domain.String(): "Active Directory"}, nil)
+				mock.mockOpenGraphSchemaService.EXPECT().GetEnvironmentKindsAndSchemaEnvironmentData(gomock.Any(), true).
+					Return(graph.Kinds{ad.Domain}, model.EnvironmentKindsToEnvironment{
+						ad.Domain.String(): model.SchemaEnvironment{
+							SchemaExtensionId:          1,
+							SchemaExtensionDisplayName: "Active Directory",
+						}}, nil)
 				mock.mockGraphQuery.EXPECT().GetFilteredAndSortedNodes(gomock.Any(), gomock.Any()).
 					Return([]*graph.Node{{
 						Properties: graph.AsProperties(map[string]any{
@@ -631,8 +653,12 @@ func TestResources_ListAvailableEnvironments(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mock *mock) {
 				mock.mockDatabase.EXPECT().GetFlagByKey(gomock.Any(), appcfg.FeatureOpenGraphFindings).Return(appcfg.FeatureFlag{Enabled: false}, nil)
-				mock.mockOpenGraphSchemaService.EXPECT().GetEnvironmentKindsAndEnvironmentExtensionDisplayNames(gomock.Any(), true).
-					Return(graph.Kinds{ad.Domain}, map[string]string{ad.Domain.String(): "Active Directory"}, nil)
+				mock.mockOpenGraphSchemaService.EXPECT().GetEnvironmentKindsAndSchemaEnvironmentData(gomock.Any(), true).
+					Return(graph.Kinds{ad.Domain}, model.EnvironmentKindsToEnvironment{
+						ad.Domain.String(): model.SchemaEnvironment{
+							SchemaExtensionId:          1,
+							SchemaExtensionDisplayName: "Active Directory",
+						}}, nil)
 				mock.mockGraphQuery.EXPECT().GetFilteredAndSortedNodes(gomock.Any(), gomock.Any()).
 					Return([]*graph.Node{{
 						Properties: graph.AsProperties(map[string]any{

--- a/cmd/api/src/model/graphschema.go
+++ b/cmd/api/src/model/graphschema.go
@@ -204,6 +204,8 @@ type SchemaEnvironment struct {
 	SourceKindId               int32
 }
 
+type EnvironmentKindsToEnvironment map[string]SchemaEnvironment
+
 func (SchemaEnvironment) TableName() string {
 	return "schema_environments"
 }

--- a/cmd/api/src/model/search.go
+++ b/cmd/api/src/model/search.go
@@ -36,6 +36,7 @@ type EnvironmentSelector struct {
 	Type               string    `json:"type"`
 	Name               string    `json:"name"`
 	ObjectID           string    `json:"id"`
+	SchemaExtensionID  *int32    `json:"schema_extension_id,omitempty"`
 	Collected          bool      `json:"collected"`
 	ImpactValue        *int      `json:"impactValue,omitempty"`
 	HygieneAttackPaths *int64    `json:"hygiene_attack_paths,omitempty"` // caution: if value is bigger than maxsafeint, the UI will truncate the value

--- a/cmd/api/src/model/search.go
+++ b/cmd/api/src/model/search.go
@@ -36,7 +36,7 @@ type EnvironmentSelector struct {
 	Type               string    `json:"type"`
 	Name               string    `json:"name"`
 	ObjectID           string    `json:"id"`
-	SchemaExtensionID  *int32    `json:"schema_extension_id,omitempty"`
+	ExtensionID        *int32    `json:"extension_id,omitempty"`
 	Collected          bool      `json:"collected"`
 	ImpactValue        *int      `json:"impactValue,omitempty"`
 	HygieneAttackPaths *int64    `json:"hygiene_attack_paths,omitempty"` // caution: if value is bigger than maxsafeint, the UI will truncate the value

--- a/cmd/api/src/model/search.go
+++ b/cmd/api/src/model/search.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"slices"
 
+	"github.com/specterops/bloodhound/cmd/api/src/database/types/null"
 	"github.com/specterops/dawgs/graph"
 	"github.com/specterops/dawgs/query"
 )
@@ -43,9 +44,9 @@ type EnvironmentSelector struct {
 }
 
 type EnvironmentProperties struct {
-	Type            string  `json:"type"`
-	KindId          *int32  `json:"environment_kind_id,omitempty"`
-	KindDisplayName *string `json:"environment_kind_display_name,omitempty"`
+	Type            string      `json:"type"`
+	KindId          null.Int32  `json:"environment_kind_id,omitzero"`
+	KindDisplayName null.String `json:"environment_kind_display_name,omitzero"`
 }
 
 type EnvironmentSelectors []EnvironmentSelector

--- a/cmd/api/src/model/search.go
+++ b/cmd/api/src/model/search.go
@@ -33,14 +33,19 @@ const (
 )
 
 type EnvironmentSelector struct {
-	Type               string    `json:"type"`
+	EnvironmentProperties
 	Name               string    `json:"name"`
 	ObjectID           string    `json:"id"`
-	ExtensionID        *int32    `json:"extension_id,omitempty"`
 	Collected          bool      `json:"collected"`
 	ImpactValue        *int      `json:"impactValue,omitempty"`
 	HygieneAttackPaths *int64    `json:"hygiene_attack_paths,omitempty"` // caution: if value is bigger than maxsafeint, the UI will truncate the value
 	Exposures          Exposures `json:"exposures,omitempty"`
+}
+
+type EnvironmentProperties struct {
+	Type            string  `json:"type"`
+	KindId          *int32  `json:"environment_kind_id,omitempty"`
+	KindDisplayName *string `json:"environment_kind_display_name,omitempty"`
 }
 
 type EnvironmentSelectors []EnvironmentSelector

--- a/cmd/api/src/services/opengraphschema/extension.go
+++ b/cmd/api/src/services/opengraphschema/extension.go
@@ -73,10 +73,10 @@ func (s *OpenGraphSchemaService) DeleteExtension(ctx context.Context, extensionI
 	return nil
 }
 
-// GetEnvironmentKindsAndEnvironmentExtensionDisplayNames - returns all environment kinds as graph.Kinds and a map of
-// their extension display names. If the findings feature flag is not enabled, it will only return builtin environment kinds.
+// GetEnvironmentKindsAndSchemaEnvironmentData - returns all environment kinds as graph.Kinds and a map of
+// their schema environments. If the findings feature flag is not enabled, it will only return builtin environment kinds.
 // TODO: Remove the onlyBuiltin parameter once the appcfg.FeatureOpenGraphFindings feature flag is removed.
-func (s *OpenGraphSchemaService) GetEnvironmentKindsAndEnvironmentExtensionDisplayNames(ctx context.Context, onlyBuiltin bool) (graph.Kinds, map[string]string, error) {
+func (s *OpenGraphSchemaService) GetEnvironmentKindsAndSchemaEnvironmentData(ctx context.Context, onlyBuiltin bool) (graph.Kinds, model.EnvironmentKindsToEnvironment, error) {
 	var filters = make(model.Filters)
 	if onlyBuiltin {
 		filters = model.Filters{"is_builtin": []model.Filter{{Operator: model.Equals, Value: "true", SetOperator: model.FilterAnd}}}
@@ -86,12 +86,12 @@ func (s *OpenGraphSchemaService) GetEnvironmentKindsAndEnvironmentExtensionDispl
 	} else {
 		// Build environment kind mappings
 		environmentKinds := make([]graph.Kind, 0)
-		envKindToExtensionDisplayName := make(map[string]string, len(environments))
+		envKindToEnvironment := make(model.EnvironmentKindsToEnvironment, len(environments))
 		for _, env := range environments {
 			environmentKinds = append(environmentKinds, graph.StringKind(env.EnvironmentKindName))
-			envKindToExtensionDisplayName[env.EnvironmentKindName] = env.SchemaExtensionDisplayName
+			envKindToEnvironment[env.EnvironmentKindName] = env
 		}
-		return environmentKinds, envKindToExtensionDisplayName, nil
+		return environmentKinds, envKindToEnvironment, nil
 	}
 }
 

--- a/cmd/api/src/services/opengraphschema/extension_test.go
+++ b/cmd/api/src/services/opengraphschema/extension_test.go
@@ -785,7 +785,7 @@ func TestOpenGraphSchemaService_DeleteExtension(t *testing.T) {
 	}
 }
 
-func TestOpenGraphSchemaService_GetEnvironmentKindsAndEnvironmentExtensionDisplayNames(t *testing.T) {
+func TestOpenGraphSchemaService_GetEnvironmentKindsAndSchemaEnvironmentData(t *testing.T) {
 	t.Parallel()
 
 	type mocks struct {
@@ -797,9 +797,9 @@ func TestOpenGraphSchemaService_GetEnvironmentKindsAndEnvironmentExtensionDispla
 		onlyBuiltin bool
 	}
 	type expected struct {
-		graphKinds     graph.Kinds
-		displayNameMap map[string]string
-		err            error
+		graphKinds                    graph.Kinds
+		environmentKindsToEnvironment model.EnvironmentKindsToEnvironment
+		err                           error
 	}
 	tests := []struct {
 		name       string
@@ -826,10 +826,12 @@ func TestOpenGraphSchemaService_GetEnvironmentKindsAndEnvironmentExtensionDispla
 					{
 						EnvironmentKindName:        "Domain",
 						SchemaExtensionDisplayName: "AD",
+						SchemaExtensionId:          1,
 					},
 					{
 						EnvironmentKindName:        "Tenant",
 						SchemaExtensionDisplayName: "Azure",
+						SchemaExtensionId:          2,
 					},
 				}, nil)
 			},
@@ -838,9 +840,17 @@ func TestOpenGraphSchemaService_GetEnvironmentKindsAndEnvironmentExtensionDispla
 					graph.StringKind("Domain"),
 					graph.StringKind("Tenant"),
 				},
-				displayNameMap: map[string]string{
-					"Domain": "AD",
-					"Tenant": "Azure",
+				environmentKindsToEnvironment: model.EnvironmentKindsToEnvironment{
+					"Domain": model.SchemaEnvironment{
+						SchemaExtensionDisplayName: "AD",
+						EnvironmentKindName:        "Domain",
+						SchemaExtensionId:          1,
+					},
+					"Tenant": model.SchemaEnvironment{
+						SchemaExtensionDisplayName: "Azure",
+						EnvironmentKindName:        "Tenant",
+						SchemaExtensionId:          2,
+					},
 				},
 			},
 			args: args{
@@ -855,10 +865,12 @@ func TestOpenGraphSchemaService_GetEnvironmentKindsAndEnvironmentExtensionDispla
 					{
 						EnvironmentKindName:        "Domain",
 						SchemaExtensionDisplayName: "AD",
+						SchemaExtensionId:          1,
 					},
 					{
 						EnvironmentKindName:        "Tenant",
 						SchemaExtensionDisplayName: "Azure",
+						SchemaExtensionId:          2,
 					},
 				}, nil)
 			},
@@ -867,9 +879,17 @@ func TestOpenGraphSchemaService_GetEnvironmentKindsAndEnvironmentExtensionDispla
 					graph.StringKind("Domain"),
 					graph.StringKind("Tenant"),
 				},
-				displayNameMap: map[string]string{
-					"Domain": "AD",
-					"Tenant": "Azure",
+				environmentKindsToEnvironment: model.EnvironmentKindsToEnvironment{
+					"Domain": model.SchemaEnvironment{
+						SchemaExtensionDisplayName: "AD",
+						EnvironmentKindName:        "Domain",
+						SchemaExtensionId:          1,
+					},
+					"Tenant": model.SchemaEnvironment{
+						SchemaExtensionDisplayName: "Azure",
+						EnvironmentKindName:        "Tenant",
+						SchemaExtensionId:          2,
+					},
 				},
 			},
 			args: args{
@@ -891,11 +911,11 @@ func TestOpenGraphSchemaService_GetEnvironmentKindsAndEnvironmentExtensionDispla
 
 			service := opengraphschema.NewOpenGraphSchemaService(m.mockOpenGraphSchema, m.mockGraphDB)
 
-			if envKinds, envKindToExtensionDisplayName, err := service.GetEnvironmentKindsAndEnvironmentExtensionDisplayNames(tt.args.ctx, tt.args.onlyBuiltin); tt.expected.err != nil {
+			if envKinds, envKindToSchemaEnvironmentData, err := service.GetEnvironmentKindsAndSchemaEnvironmentData(tt.args.ctx, tt.args.onlyBuiltin); tt.expected.err != nil {
 				assert.EqualError(t, err, tt.expected.err.Error())
 			} else {
-				assert.Equalf(t, tt.expected.graphKinds, envKinds, "GetEnvironmentKindsAndEnvironmentExtensionDisplayNames(%v, %v)", tt.args.ctx, tt.args.onlyBuiltin)
-				assert.Equalf(t, tt.expected.displayNameMap, envKindToExtensionDisplayName, "GetEnvironmentKindsAndEnvironmentExtensionDisplayNames(%v, %v)", tt.args.ctx, tt.args.onlyBuiltin)
+				assert.Equalf(t, tt.expected.graphKinds, envKinds, "GetEnvironmentKindsAndSchemaEnvironmentData(%v, %v)", tt.args.ctx, tt.args.onlyBuiltin)
+				assert.Equalf(t, tt.expected.environmentKindsToEnvironment, envKindToSchemaEnvironmentData, "GetEnvironmentKindsAndSchemaEnvironmentData(%v, %v)", tt.args.ctx, tt.args.onlyBuiltin)
 			}
 		})
 	}

--- a/packages/go/openapi/doc/openapi.json
+++ b/packages/go/openapi/doc/openapi.json
@@ -20457,6 +20457,11 @@
             "type": "boolean",
             "readOnly": true
           },
+          "schema_extension_id": {
+            "type": "integer",
+            "readOnly": true,
+            "description": "OpenGraph schema extension ID for custom environments"
+          },
           "impactValue": {
             "type": "integer",
             "readOnly": true,

--- a/packages/go/openapi/doc/openapi.json
+++ b/packages/go/openapi/doc/openapi.json
@@ -20457,10 +20457,15 @@
             "type": "boolean",
             "readOnly": true
           },
-          "extension_id": {
+          "environment_kind_id": {
             "type": "integer",
             "readOnly": true,
-            "description": "OpenGraph schema extension ID for custom environments"
+            "description": "OpenGraph environment kind ID for custom environments"
+          },
+          "environment_kind_display_name": {
+            "type": "string",
+            "readOnly": true,
+            "description": "Human-readable display name for the node's environment kind"
           },
           "impactValue": {
             "type": "integer",

--- a/packages/go/openapi/doc/openapi.json
+++ b/packages/go/openapi/doc/openapi.json
@@ -20457,7 +20457,7 @@
             "type": "boolean",
             "readOnly": true
           },
-          "schema_extension_id": {
+          "extension_id": {
             "type": "integer",
             "readOnly": true,
             "description": "OpenGraph schema extension ID for custom environments"

--- a/packages/go/openapi/src/schemas/model.domain-selector.yaml
+++ b/packages/go/openapi/src/schemas/model.domain-selector.yaml
@@ -28,7 +28,7 @@ properties:
   collected:
     type: boolean
     readOnly: true
-  schema_extension_id: 
+  extension_id: 
     type: integer
     readOnly: true
     description: "OpenGraph schema extension ID for custom environments"

--- a/packages/go/openapi/src/schemas/model.domain-selector.yaml
+++ b/packages/go/openapi/src/schemas/model.domain-selector.yaml
@@ -28,6 +28,10 @@ properties:
   collected:
     type: boolean
     readOnly: true
+  schema_extension_id: 
+    type: integer
+    readOnly: true
+    description: "OpenGraph schema extension ID for custom environments"
   impactValue:
     type: integer
     readOnly: true

--- a/packages/go/openapi/src/schemas/model.domain-selector.yaml
+++ b/packages/go/openapi/src/schemas/model.domain-selector.yaml
@@ -28,10 +28,14 @@ properties:
   collected:
     type: boolean
     readOnly: true
-  extension_id: 
+  environment_kind_id: 
     type: integer
     readOnly: true
-    description: "OpenGraph schema extension ID for custom environments"
+    description: "OpenGraph environment kind ID for custom environments"
+  environment_kind_display_name: 
+    type: string
+    readOnly: true
+    description: "Human-readable display name for the node's environment kind"
   impactValue:
     type: integer
     readOnly: true


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

We want to enrich the /available-domains response with the`environment_kind_id` and `environment_kind_display_name` to be able to populate Data Quality stats per environment on the Data Quality page.

To do this, I expanded the GetEnvironmentKindsAndEnvironmentExtensionDisplayNames function from the OpenGraph Service to return complete environment data rather than just the extension display name. The DB was already returning all of the data, but the service function was stripping it down to just the display name. The display name is still accessible to the existing functionality, but now we also have access to the other fields we need.

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-8685

## How Has This Been Tested?

Tests updated, and tested locally. 

## Screenshots (optional):

<img width="591" height="543" alt="Screenshot 2026-06-29 at 15 54 17" src="https://github.com/user-attachments/assets/f4f5a71f-6875-4d0f-af0c-fa2612eb5e9f" />


## Types of changes

<!-- Please remove any items that do not apply. -->
- New feature (non-breaking change which adds functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Environment results now include additional environment kind details: `environment_kind_id` and `environment_kind_display_name` (read-only).
  * OpenGraph environment listings expose these fields alongside existing environment information.
* **Bug Fixes**
  * Environment listing and filtering now consistently derive environment properties from schema environment metadata.
* **Tests**
  * Updated API/service tests to match the revised environment selector payload.
* **Documentation**
  * Updated the OpenAPI schema to include `environment_kind_id` and `environment_kind_display_name`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->