### PR TITLE
feat: Optimize PG source_kind, relation deletion using indices - BED-8832

### DIFF
--- a/cmd/api/src/daemons/datapipe/delete.go
+++ b/cmd/api/src/daemons/datapipe/delete.go
@@ -204,17 +204,7 @@ func deleteNodesByOperation(ctx context.Context, graphDB graph.Database, deleteR
 	})
 
 	nodeOperation.SubmitWriter(func(ctx context.Context, batch graph.Batch, inC <-chan graph.ID) error {
-		for {
-			if nextID, hasNextID := channels.Receive(ctx, inC); hasNextID {
-				if err := batch.DeleteNode(nextID); err != nil {
-					return err
-				}
-			} else {
-				break
-			}
-		}
-
-		return nil
+		return drainAndDelete(ctx, inC, batch.DeleteNode)
 	})
 
 	return nodeOperation.Done()
@@ -246,18 +236,24 @@ func deleteRelationshipsByOperation(ctx context.Context, graphDB graph.Database,
 	})
 
 	edgeOperation.SubmitWriter(func(ctx context.Context, batch graph.Batch, inC <-chan graph.ID) error {
-		for {
-			if nextID, hasNextID := channels.Receive(ctx, inC); hasNextID {
-				if err := batch.DeleteRelationship(nextID); err != nil {
-					return err
-				}
-			} else {
-				break
-			}
-		}
-
-		return nil
+		return drainAndDelete(ctx, inC, batch.DeleteRelationship)
 	})
 
 	return edgeOperation.Done()
+}
+
+// drainAndDelete receives IDs from inC until the channel is drained, invoking deleteByID for each ID and returning the
+// first error encountered. It preserves the channels.Receive termination semantics used by the operation writers.
+func drainAndDelete(ctx context.Context, inC <-chan graph.ID, deleteByID func(graph.ID) error) error {
+	for {
+		if nextID, hasNextID := channels.Receive(ctx, inC); hasNextID {
+			if err := deleteByID(nextID); err != nil {
+				return err
+			}
+		} else {
+			break
+		}
+	}
+
+	return nil
 }

--- a/cmd/api/src/daemons/datapipe/delete.go
+++ b/cmd/api/src/daemons/datapipe/delete.go
@@ -61,73 +61,18 @@ func DeleteCollectedGraphData(ctx context.Context, graphDB graph.Database, delet
 	}
 
 	if deleteRequest.DeleteAllGraph || deleteRequest.DeleteSourcelessGraph || len(deleteRequest.DeleteSourceKinds) > 0 {
-		nodeOperation := ops.StartNewOperation[graph.ID](ops.OperationContext{
-			Parent:     ctx,
-			DB:         graphDB,
-			NumReaders: 1,
-			NumWriters: 1,
-		})
-
 		deleteSourceKinds := make(graph.Kinds, len(deleteRequest.DeleteSourceKinds))
 		for i, sourceKind := range deleteRequest.DeleteSourceKinds {
 			deleteSourceKinds[i] = graph.StringKind(sourceKind)
 		}
 
-		nodeOperation.SubmitReader(func(ctx context.Context, tx graph.Transaction, outC chan<- graph.ID) error {
-			var (
-				nodeQuery graph.NodeQuery
-				filters   []graph.Criteria
-			)
-
-			// Always exclude MigrationData
-			migrationFilter := query.Not(query.Kind(query.Node(), common.MigrationData))
-
-			if !deleteRequest.DeleteAllGraph {
-				if deleteRequest.DeleteSourcelessGraph {
-					filters = append(filters,
-						query.Not(query.KindIn(query.Node(), sourceKinds...)),
-					)
-				}
-
-				if len(deleteSourceKinds) > 0 {
-					filters = append(filters,
-						query.KindIn(query.Node(), deleteSourceKinds...),
-					)
-				}
+		// On backends that support it, push the node deletes server-side as set-based deletes over the kind index
+		// instead of streaming every node ID through the application and deleting row-by-row.
+		if deleter, hasCapability := graph.AsDriver[nodesByKindDeleter](graphDB); hasCapability {
+			if err := deleteNodesByKindsSetBased(ctx, deleter, deleteRequest, sourceKinds, deleteSourceKinds); err != nil {
+				return fmt.Errorf("error deleting graph nodes: %w", err)
 			}
-
-			if len(filters) > 0 {
-				nodeQuery = tx.Nodes().Filter(
-					query.And(
-						migrationFilter,
-						query.Or(filters...),
-					),
-				)
-			} else {
-				nodeQuery = tx.Nodes().Filter(migrationFilter)
-			}
-
-			return nodeQuery.FetchIDs(func(cursor graph.Cursor[graph.ID]) error {
-				channels.PipeAll(ctx, cursor.Chan(), outC)
-				return cursor.Error()
-			})
-		})
-
-		nodeOperation.SubmitWriter(func(ctx context.Context, batch graph.Batch, inC <-chan graph.ID) error {
-			for {
-				if nextID, hasNextID := channels.Receive(ctx, inC); hasNextID {
-					if err := batch.DeleteNode(nextID); err != nil {
-						return err
-					}
-				} else {
-					break
-				}
-			}
-
-			return nil
-		})
-
-		if err := nodeOperation.Done(); err != nil {
+		} else if err := deleteNodesByOperation(ctx, graphDB, deleteRequest, sourceKinds, deleteSourceKinds); err != nil {
 			return fmt.Errorf("error deleting graph nodes: %w", err)
 		}
 	}
@@ -197,4 +142,104 @@ func wipeAllGraphData(ctx context.Context, graphDB graph.Database, wiper graphWi
 
 		return nil
 	})
+}
+
+// nodesByKindDeleter is implemented by graph drivers that can perform server-side, set-based node deletes filtered
+// by kind. A node is deleted when its kinds overlap includeAny (or, when includeAny is empty, for every node) and
+// do not overlap excludeAny.
+type nodesByKindDeleter interface {
+	DeleteNodesByKinds(ctx context.Context, includeAny graph.Kinds, excludeAny graph.Kinds) error
+}
+
+// deleteNodesByKindsSetBased translates the deletion request into one or more set-based node deletes. MigrationData
+// is always preserved. The DeleteSourcelessGraph and DeleteSourceKinds cases are unioned by issuing a delete for
+// each, mirroring the OR of filters used by the streaming path.
+func deleteNodesByKindsSetBased(ctx context.Context, deleter nodesByKindDeleter, deleteRequest model.AnalysisRequest, sourceKinds graph.Kinds, deleteSourceKinds graph.Kinds) error {
+	excludeMigration := graph.Kinds{common.MigrationData}
+
+	if deleteRequest.DeleteAllGraph {
+		return deleter.DeleteNodesByKinds(ctx, nil, excludeMigration)
+	}
+
+	if len(deleteSourceKinds) > 0 {
+		if err := deleter.DeleteNodesByKinds(ctx, deleteSourceKinds, excludeMigration); err != nil {
+			return err
+		}
+	}
+
+	if deleteRequest.DeleteSourcelessGraph {
+		excludeSourceless := append(graph.Kinds{common.MigrationData}, sourceKinds...)
+		if err := deleter.DeleteNodesByKinds(ctx, nil, excludeSourceless); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// deleteNodesByOperation is the backend-agnostic fallback that streams matching node IDs through the application and
+// deletes them row-by-row. It is used for drivers that do not implement nodesByKindDeleter.
+func deleteNodesByOperation(ctx context.Context, graphDB graph.Database, deleteRequest model.AnalysisRequest, sourceKinds graph.Kinds, deleteSourceKinds graph.Kinds) error {
+	nodeOperation := ops.StartNewOperation[graph.ID](ops.OperationContext{
+		Parent:     ctx,
+		DB:         graphDB,
+		NumReaders: 1,
+		NumWriters: 1,
+	})
+
+	nodeOperation.SubmitReader(func(ctx context.Context, tx graph.Transaction, outC chan<- graph.ID) error {
+		var (
+			nodeQuery graph.NodeQuery
+			filters   []graph.Criteria
+		)
+
+		// Always exclude MigrationData
+		migrationFilter := query.Not(query.Kind(query.Node(), common.MigrationData))
+
+		if !deleteRequest.DeleteAllGraph {
+			if deleteRequest.DeleteSourcelessGraph {
+				filters = append(filters,
+					query.Not(query.KindIn(query.Node(), sourceKinds...)),
+				)
+			}
+
+			if len(deleteSourceKinds) > 0 {
+				filters = append(filters,
+					query.KindIn(query.Node(), deleteSourceKinds...),
+				)
+			}
+		}
+
+		if len(filters) > 0 {
+			nodeQuery = tx.Nodes().Filter(
+				query.And(
+					migrationFilter,
+					query.Or(filters...),
+				),
+			)
+		} else {
+			nodeQuery = tx.Nodes().Filter(migrationFilter)
+		}
+
+		return nodeQuery.FetchIDs(func(cursor graph.Cursor[graph.ID]) error {
+			channels.PipeAll(ctx, cursor.Chan(), outC)
+			return cursor.Error()
+		})
+	})
+
+	nodeOperation.SubmitWriter(func(ctx context.Context, batch graph.Batch, inC <-chan graph.ID) error {
+		for {
+			if nextID, hasNextID := channels.Receive(ctx, inC); hasNextID {
+				if err := batch.DeleteNode(nextID); err != nil {
+					return err
+				}
+			} else {
+				break
+			}
+		}
+
+		return nil
+	})
+
+	return nodeOperation.Done()
 }

--- a/cmd/api/src/daemons/datapipe/delete.go
+++ b/cmd/api/src/daemons/datapipe/delete.go
@@ -78,42 +78,18 @@ func DeleteCollectedGraphData(ctx context.Context, graphDB graph.Database, delet
 	}
 
 	if len(deleteRequest.DeleteRelationships) > 0 {
-		edgeOperation := ops.StartNewOperation[graph.ID](ops.OperationContext{
-			Parent:     ctx,
-			DB:         graphDB,
-			NumReaders: 1,
-			NumWriters: 1,
-		})
-
 		deleteRelationshipKinds := make(graph.Kinds, len(deleteRequest.DeleteRelationships))
 		for i, relationshipKind := range deleteRequest.DeleteRelationships {
 			deleteRelationshipKinds[i] = graph.StringKind(relationshipKind)
 		}
 
-		edgeOperation.SubmitReader(func(ctx context.Context, tx graph.Transaction, outC chan<- graph.ID) error {
-			edgeQuery := tx.Relationships().Filter(query.KindIn(query.Relationship(), deleteRelationshipKinds...))
-
-			return edgeQuery.FetchIDs(func(cursor graph.Cursor[graph.ID]) error {
-				channels.PipeAll(ctx, cursor.Chan(), outC)
-				return cursor.Error()
-			})
-		})
-
-		edgeOperation.SubmitWriter(func(ctx context.Context, batch graph.Batch, inC <-chan graph.ID) error {
-			for {
-				if nextID, hasNextID := channels.Receive(ctx, inC); hasNextID {
-					if err := batch.DeleteRelationship(nextID); err != nil {
-						return err
-					}
-				} else {
-					break
-				}
+		// On backends that support it, push the relationship deletes server-side as a set-based delete over the
+		// edge kind index instead of streaming every relationship ID through the application and deleting row-by-row.
+		if deleter, hasCapability := graph.AsDriver[relationshipsByKindDeleter](graphDB); hasCapability {
+			if err := deleter.DeleteRelationshipsByKinds(ctx, deleteRelationshipKinds); err != nil {
+				return fmt.Errorf("error deleting graph edges: %w", err)
 			}
-
-			return nil
-		})
-
-		if err := edgeOperation.Done(); err != nil {
+		} else if err := deleteRelationshipsByOperation(ctx, graphDB, deleteRelationshipKinds); err != nil {
 			return fmt.Errorf("error deleting graph edges: %w", err)
 		}
 	}
@@ -242,4 +218,46 @@ func deleteNodesByOperation(ctx context.Context, graphDB graph.Database, deleteR
 	})
 
 	return nodeOperation.Done()
+}
+
+// relationshipsByKindDeleter is implemented by graph drivers that can perform server-side, set-based relationship
+// deletes filtered by kind.
+type relationshipsByKindDeleter interface {
+	DeleteRelationshipsByKinds(ctx context.Context, kinds graph.Kinds) error
+}
+
+// deleteRelationshipsByOperation is the backend-agnostic fallback that streams matching relationship IDs through the
+// application and deletes them row-by-row. It is used for drivers that do not implement relationshipsByKindDeleter.
+func deleteRelationshipsByOperation(ctx context.Context, graphDB graph.Database, deleteRelationshipKinds graph.Kinds) error {
+	edgeOperation := ops.StartNewOperation[graph.ID](ops.OperationContext{
+		Parent:     ctx,
+		DB:         graphDB,
+		NumReaders: 1,
+		NumWriters: 1,
+	})
+
+	edgeOperation.SubmitReader(func(ctx context.Context, tx graph.Transaction, outC chan<- graph.ID) error {
+		edgeQuery := tx.Relationships().Filter(query.KindIn(query.Relationship(), deleteRelationshipKinds...))
+
+		return edgeQuery.FetchIDs(func(cursor graph.Cursor[graph.ID]) error {
+			channels.PipeAll(ctx, cursor.Chan(), outC)
+			return cursor.Error()
+		})
+	})
+
+	edgeOperation.SubmitWriter(func(ctx context.Context, batch graph.Batch, inC <-chan graph.ID) error {
+		for {
+			if nextID, hasNextID := channels.Receive(ctx, inC); hasNextID {
+				if err := batch.DeleteRelationship(nextID); err != nil {
+					return err
+				}
+			} else {
+				break
+			}
+		}
+
+		return nil
+	})
+
+	return edgeOperation.Done()
 }

--- a/cmd/api/src/daemons/datapipe/delete_internal_test.go
+++ b/cmd/api/src/daemons/datapipe/delete_internal_test.go
@@ -1,0 +1,253 @@
+// Copyright 2025 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package datapipe
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/specterops/bloodhound/cmd/api/src/model"
+	"github.com/specterops/bloodhound/packages/go/graphschema/common"
+	"github.com/specterops/dawgs/graph"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// nodeDeleteCall records the arguments of a single DeleteNodesByKinds invocation as kind strings so tests can assert
+// on the translated set-based deletes without depending on graph.Kind identity.
+type nodeDeleteCall struct {
+	includeAny []string
+	excludeAny []string
+}
+
+// fakeGraphDeleter is a test double for graph.Database that additionally implements both nodesByKindDeleter and
+// relationshipsByKindDeleter. Because graph.AsDriver type-asserts the database against the requested interface, a value
+// of this type is dispatched down the set-based deletion path in DeleteCollectedGraphData. The embedded graph.Database
+// is left nil: only the set-based delete methods are expected to be called, and any accidental use of another method
+// will panic and surface the mistake.
+type fakeGraphDeleter struct {
+	graph.Database
+
+	nodeCalls         []nodeDeleteCall
+	relationshipCalls [][]string
+	nodeErr           error
+	relationshipErr   error
+}
+
+func (s *fakeGraphDeleter) DeleteNodesByKinds(_ context.Context, includeAny graph.Kinds, excludeAny graph.Kinds) error {
+	s.nodeCalls = append(s.nodeCalls, nodeDeleteCall{includeAny: includeAny.Strings(), excludeAny: excludeAny.Strings()})
+	return s.nodeErr
+}
+
+func (s *fakeGraphDeleter) DeleteRelationshipsByKinds(_ context.Context, kinds graph.Kinds) error {
+	s.relationshipCalls = append(s.relationshipCalls, kinds.Strings())
+	return s.relationshipErr
+}
+
+func TestDeleteCollectedGraphData_SetBasedNodeDeletion(t *testing.T) {
+	var (
+		ctx         = context.Background()
+		sourceKinds = graph.Kinds{graph.StringKind("Base"), graph.StringKind("AZBase"), graph.StringKind("GithubBase")}
+	)
+
+	type testCase struct {
+		name          string
+		deleteRequest model.AnalysisRequest
+		expectedCalls []nodeDeleteCall
+	}
+
+	testCases := []testCase{
+		{
+			name:          "DeleteAllGraph deletes every node except MigrationData",
+			deleteRequest: model.AnalysisRequest{DeleteAllGraph: true},
+			expectedCalls: []nodeDeleteCall{
+				{includeAny: nil, excludeAny: []string{common.MigrationData.String()}},
+			},
+		},
+		{
+			name:          "DeleteSourceKinds deletes only the requested kinds and preserves MigrationData",
+			deleteRequest: model.AnalysisRequest{DeleteSourceKinds: []string{"AZBase", "GithubBase"}},
+			expectedCalls: []nodeDeleteCall{
+				{includeAny: []string{"AZBase", "GithubBase"}, excludeAny: []string{common.MigrationData.String()}},
+			},
+		},
+		{
+			name:          "DeleteSourcelessGraph deletes nodes lacking any source kind and preserves MigrationData",
+			deleteRequest: model.AnalysisRequest{DeleteSourcelessGraph: true},
+			expectedCalls: []nodeDeleteCall{
+				{includeAny: nil, excludeAny: append([]string{common.MigrationData.String()}, sourceKinds.Strings()...)},
+			},
+		},
+		{
+			name:          "DeleteSourcelessGraph and DeleteSourceKinds issue a union of two deletes",
+			deleteRequest: model.AnalysisRequest{DeleteSourcelessGraph: true, DeleteSourceKinds: []string{"AZBase", "GithubBase"}},
+			expectedCalls: []nodeDeleteCall{
+				{includeAny: []string{"AZBase", "GithubBase"}, excludeAny: []string{common.MigrationData.String()}},
+				{includeAny: nil, excludeAny: append([]string{common.MigrationData.String()}, sourceKinds.Strings()...)},
+			},
+		},
+		{
+			name:          "DeleteAllGraph takes precedence over DeleteSourceKinds and DeleteSourcelessGraph",
+			deleteRequest: model.AnalysisRequest{DeleteAllGraph: true, DeleteSourcelessGraph: true, DeleteSourceKinds: []string{"AZBase"}},
+			expectedCalls: []nodeDeleteCall{
+				{includeAny: nil, excludeAny: []string{common.MigrationData.String()}},
+			},
+		},
+		{
+			name:          "empty request performs no node deletes",
+			deleteRequest: model.AnalysisRequest{},
+			expectedCalls: nil,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			deleter := &fakeGraphDeleter{}
+
+			err := DeleteCollectedGraphData(ctx, deleter, testCase.deleteRequest, sourceKinds)
+			require.NoError(t, err)
+
+			require.Len(t, deleter.nodeCalls, len(testCase.expectedCalls))
+			for i, expected := range testCase.expectedCalls {
+				assert.ElementsMatch(t, expected.includeAny, deleter.nodeCalls[i].includeAny, "includeAny for call %d", i)
+				assert.ElementsMatch(t, expected.excludeAny, deleter.nodeCalls[i].excludeAny, "excludeAny for call %d", i)
+			}
+			assert.Empty(t, deleter.relationshipCalls)
+		})
+	}
+}
+
+func TestDeleteCollectedGraphData_SetBasedRelationshipDeletion(t *testing.T) {
+	var (
+		ctx         = context.Background()
+		sourceKinds = graph.Kinds{graph.StringKind("Base")}
+	)
+
+	t.Run("DeleteRelationships issues a single set-based edge delete and no node deletes", func(t *testing.T) {
+		deleter := &fakeGraphDeleter{}
+
+		deleteRequest := model.AnalysisRequest{DeleteRelationships: []string{"MemberOf", "HasSession"}}
+
+		err := DeleteCollectedGraphData(ctx, deleter, deleteRequest, sourceKinds)
+		require.NoError(t, err)
+
+		assert.Empty(t, deleter.nodeCalls)
+		require.Len(t, deleter.relationshipCalls, 1)
+		assert.ElementsMatch(t, []string{"MemberOf", "HasSession"}, deleter.relationshipCalls[0])
+	})
+
+	t.Run("node and relationship deletes are both dispatched when requested together", func(t *testing.T) {
+		deleter := &fakeGraphDeleter{}
+
+		deleteRequest := model.AnalysisRequest{
+			DeleteSourceKinds:   []string{"AZBase"},
+			DeleteRelationships: []string{"MemberOf"},
+		}
+
+		err := DeleteCollectedGraphData(ctx, deleter, deleteRequest, sourceKinds)
+		require.NoError(t, err)
+
+		require.Len(t, deleter.nodeCalls, 1)
+		assert.ElementsMatch(t, []string{"AZBase"}, deleter.nodeCalls[0].includeAny)
+		assert.ElementsMatch(t, []string{common.MigrationData.String()}, deleter.nodeCalls[0].excludeAny)
+		require.Len(t, deleter.relationshipCalls, 1)
+		assert.ElementsMatch(t, []string{"MemberOf"}, deleter.relationshipCalls[0])
+	})
+}
+
+func TestDeleteCollectedGraphData_SetBasedErrors(t *testing.T) {
+	var (
+		ctx         = context.Background()
+		sourceKinds = graph.Kinds{graph.StringKind("Base")}
+		sentinelErr = errors.New("boom")
+	)
+
+	t.Run("node delete error is wrapped", func(t *testing.T) {
+		deleter := &fakeGraphDeleter{nodeErr: sentinelErr}
+
+		err := DeleteCollectedGraphData(ctx, deleter, model.AnalysisRequest{DeleteAllGraph: true}, sourceKinds)
+		require.ErrorIs(t, err, sentinelErr)
+		assert.Contains(t, err.Error(), "error deleting graph nodes")
+	})
+
+	t.Run("relationship delete error is wrapped", func(t *testing.T) {
+		deleter := &fakeGraphDeleter{relationshipErr: sentinelErr}
+
+		err := DeleteCollectedGraphData(ctx, deleter, model.AnalysisRequest{DeleteRelationships: []string{"MemberOf"}}, sourceKinds)
+		require.ErrorIs(t, err, sentinelErr)
+		assert.Contains(t, err.Error(), "error deleting graph edges")
+	})
+}
+
+func TestDrainAndDelete(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("deletes every id received from the channel", func(t *testing.T) {
+		var (
+			ids     = []graph.ID{graph.ID(1), graph.ID(2), graph.ID(3)}
+			deleted []graph.ID
+		)
+
+		inC := make(chan graph.ID, len(ids))
+		for _, id := range ids {
+			inC <- id
+		}
+		close(inC)
+
+		err := drainAndDelete(ctx, inC, func(id graph.ID) error {
+			deleted = append(deleted, id)
+			return nil
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, ids, deleted)
+	})
+
+	t.Run("returns the first delete error and stops draining", func(t *testing.T) {
+		var (
+			sentinelErr = errors.New("delete failed")
+			attempts    int
+		)
+
+		inC := make(chan graph.ID, 3)
+		inC <- graph.ID(1)
+		inC <- graph.ID(2)
+		inC <- graph.ID(3)
+		close(inC)
+
+		err := drainAndDelete(ctx, inC, func(id graph.ID) error {
+			attempts++
+			return sentinelErr
+		})
+
+		require.ErrorIs(t, err, sentinelErr)
+		assert.Equal(t, 1, attempts)
+	})
+
+	t.Run("returns nil for an already drained channel", func(t *testing.T) {
+		inC := make(chan graph.ID)
+		close(inC)
+
+		err := drainAndDelete(ctx, inC, func(id graph.ID) error {
+			t.Fatal("delete should not be called for an empty channel")
+			return nil
+		})
+
+		require.NoError(t, err)
+	})
+}


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Implements the new DeleteNodesByKinds/DeleteRelationshipsByKinds functions supported optionally on DAWGS drivers to execute rapid deletion of objects by kind. Initially, this is supported on PostgreSQL drivers.

Requires https://github.com/SpecterOps/DAWGS/pull/101

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-8832

*Why is this change required? What problem does it solve?*

## How Has This Been Tested?

Validated locally and confirmed existing tests continue to pass. 

## Screenshots (optional):

Tested using large OGGen payloads for validation:

Delete by source_kind:
Before:
```
time=2026-06-30T16:15:45.448Z level=INFO message=DeleteCollectedGraphData delete_all_data=false delete_sourceless_data=false delete_source_kinds=OggenBase delete_relationships="" measurement_id=129 elapsed=1m21.810004664s
```
After:
```
time=2026-06-30T16:21:37.337Z level=INFO message=DeleteCollectedGraphData delete_all_data=false delete_sourceless_data=false delete_source_kinds=OggenBase delete_relationships="" measurement_id=129 elapsed=1m14.96949745s
```

Delete by relationship:
Before:
```
time=2026-06-30T17:17:54.052Z level=INFO message=DeleteCollectedGraphData delete_all_data=false delete_sourceless_data=false delete_source_kinds="" delete_relationships=HasSession measurement_id=129 elapsed=10.140349088s
```
After:
```
time=2026-06-30T17:07:53.310Z level=INFO message=DeleteCollectedGraphData delete_all_data=false delete_sourceless_data=false delete_source_kinds="" delete_relationships=HasSession measurement_id=129 elapsed=453.611584ms
```

## Types of changes

<!-- Please remove any items that do not apply. -->

- New feature (non-breaking change which adds functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [X] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [X] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [X] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Graph data deletion now uses faster bulk operations when supported, improving cleanup speed for large datasets.
* **Bug Fixes**
  * Improved fallback deletion for environments without bulk-delete support.
  * More reliably removes nodes and relationships while preserving required migration data.
  * Expanded node filtering to cover source-based and sourceless data consistently.
  * Improved handling of combined node and relationship cleanup requests, including deletion errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->