### PR TITLE
chore(GraphDB): update generated from prepare-for-codereview - BED-8585

### DIFF
--- a/server/graphdb/internal/appdb/node_integration_test.go
+++ b/server/graphdb/internal/appdb/node_integration_test.go
@@ -320,9 +320,10 @@ func TestStore_GetNodeKindsByNames_Integration(t *testing.T) {
 
 				var registeredKind, unregisteredKind services.Kind
 				for _, kind := range kinds {
-					if kind.Name == "TestRegisteredKindMixed" {
+					switch kind.Name {
+					case "TestRegisteredKindMixed":
 						registeredKind = kind
-					} else if kind.Name == "TestUnregisteredKind" {
+					case "TestUnregisteredKind":
 						unregisteredKind = kind
 					}
 				}


### PR DESCRIPTION
## Description

* Generated fix related to BHE PR that updates yarnrc to remove an age gate exemption

## Motivation and Context

Resolves BED-8585

## How Has This Been Tested?

Noop

- Chore (a change that does not modify the application functionality)

## Checklist:

- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated integration test assertions for node kind lookup to use clearer matching logic, keeping the same validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->