### PR TITLE
refactor: useFetchEntityInfo uses new getNodeByID endpoint BED-8742

### DIFF
--- a/packages/javascript/bh-shared-ui/src/components/EntityInfo/EntityInfoContent.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/EntityInfo/EntityInfoContent.test.tsx
@@ -45,16 +45,13 @@ const server = setupServer(
             })
         );
     }),
-    rest.post('/api/v2/graphs/cypher', (req, res, ctx) => {
+    rest.get('/api/v2/nodes/:id', (req, res, ctx) => {
         return res(
             ctx.json({
                 data: {
-                    nodes: {
-                        '42': {
-                            kind: 'Unknown',
-                            properties: { objectid: 'unknown kind' },
-                        },
-                    },
+                    node_id: 42,
+                    kinds: [{ node_kind_id: 1, name: 'Unknown' }],
+                    properties: { objectid: 'unknown kind' },
                 },
             })
         );
@@ -135,7 +132,7 @@ describe('EntityObjectInformation', () => {
         expect(await screen.findByText('test')).toBeInTheDocument();
     });
 
-    it('Calls the cypher search endpoint for a node with a type that is not in our schema', async () => {
+    it('Calls the get node by id endpoint for a node with a type that is not in our schema', async () => {
         const testId = '1';
         const nodeType = 'Unknown';
         const databaseId = '42';

--- a/packages/javascript/bh-shared-ui/src/hooks/useFetchEntityInfo/useFetchEntityInfo.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/hooks/useFetchEntityInfo/useFetchEntityInfo.test.tsx
@@ -37,16 +37,13 @@ vi.mock('../../utils/content', () => ({
 
 vi.mock('../../utils/api', () => ({
     apiClient: {
-        cypherSearch: vi.fn(() =>
+        getNodeByID: vi.fn(() =>
             Promise.resolve({
                 data: {
                     data: {
-                        nodes: {
-                            '1': {
-                                kinds: ['Admin_Tier_0'],
-                                properties: mockEntityProperties,
-                            },
-                        },
+                        node_id: 1,
+                        kinds: [{ node_kind_id: 1, name: 'Admin_Tier_0' }],
+                        properties: mockEntityProperties,
                     },
                 },
             })
@@ -62,24 +59,6 @@ const entityObjectIdRequest = () =>
                     data: {
                         props: mockEntityProperties,
                         kinds: ['Admin_Tier_0'],
-                    },
-                },
-            })
-        )
-    );
-
-const entityGraphIdRequest = () =>
-    rest.post(`/api/v2/graphs/cypher`, async (_req, res, ctx) =>
-        res(
-            ctx.json({
-                data: {
-                    data: {
-                        nodes: {
-                            '1': {
-                                kinds: ['Admin_Tier_0'],
-                                properties: mockEntityProperties,
-                            },
-                        },
                     },
                 },
             })
@@ -106,7 +85,7 @@ const mockEntityProperties = {
 };
 
 describe('useFetchEntityInfo', () => {
-    const server = setupServer(entityObjectIdRequest(), entityGraphIdRequest());
+    const server = setupServer(entityObjectIdRequest());
 
     beforeAll(() => server.listen());
     afterEach(() => server.resetHandlers());
@@ -150,7 +129,7 @@ describe('useFetchEntityInfo', () => {
     });
 
     it('fetches new information when a different databaseId is passed', async () => {
-        const cypherSearchSpy = vi.spyOn(apiClient, 'cypherSearch');
+        const getNodeByIDSpy = vi.spyOn(apiClient, 'getNodeByID');
 
         const { result, rerender } = renderHook<FetchEntityInfoResult, FetchEntityInfoParams>(
             (params) => useFetchEntityInfo(params),
@@ -163,12 +142,12 @@ describe('useFetchEntityInfo', () => {
             expect(result.current.isSuccess).toBe(true);
         });
 
-        expect(cypherSearchSpy).toHaveBeenCalledTimes(1);
+        expect(getNodeByIDSpy).toHaveBeenCalledTimes(1);
 
         rerender({ ...initialPropsCustom, databaseId: '7' });
 
         await waitFor(() => {
-            expect(cypherSearchSpy).toHaveBeenCalledTimes(2);
+            expect(getNodeByIDSpy).toHaveBeenCalledTimes(2);
         });
     });
 });

--- a/packages/javascript/bh-shared-ui/src/hooks/useFetchEntityInfo/useFetchEntityInfo.tsx
+++ b/packages/javascript/bh-shared-ui/src/hooks/useFetchEntityInfo/useFetchEntityInfo.tsx
@@ -18,12 +18,11 @@ import { RequestOptions } from 'js-client-library';
 import { useQuery, UseQueryResult } from 'react-query';
 import { apiClient } from '../../utils/api';
 import { entityInformationEndpoints } from '../../utils/content';
-import { getNodeByDatabaseIdCypher } from '../../utils/entityInfoDisplay';
 import { validateNodeType } from './utils';
 
 export type FetchEntityInfoParams = {
-    objectId: string;
-    nodeType: string;
+    objectId?: string;
+    nodeType?: string;
     databaseId?: string;
 };
 
@@ -46,48 +45,34 @@ export const useFetchEntityInfo: (param: FetchEntityInfoParams) => FetchEntityIn
     nodeType,
     databaseId,
 }) => {
-    const requestDetails: {
-        endpoint: (
-            params: string,
-            options?: RequestOptions,
-            includeProperties?: boolean
-        ) => Promise<Record<string, any>>;
-        param: string;
-    } = {
-        endpoint: async function () {
-            return {};
-        },
-        param: '',
-    };
+    const validatedKind = nodeType ? validateNodeType(nodeType) : undefined;
 
-    const validatedKind = validateNodeType(nodeType);
-
-    if (validatedKind) {
-        requestDetails.endpoint = entityInformationEndpoints[validatedKind];
-        requestDetails.param = objectId;
-    } else if (databaseId) {
-        requestDetails.endpoint = apiClient.cypherSearch;
-        requestDetails.param = getNodeByDatabaseIdCypher(databaseId);
-    }
-
-    const informationAvailable = !!validatedKind || !!databaseId;
+    const informationAvailable = !!databaseId || !!validatedKind;
 
     return {
         ...useQuery(
             [FetchEntityCacheId, nodeType, objectId, databaseId],
-            ({ signal }) =>
-                requestDetails.endpoint(requestDetails.param, { signal }, true).then((res) => {
-                    if (validatedKind) {
+            ({ signal }) => {
+                if (validatedKind && objectId) {
+                    const endpoint = entityInformationEndpoints[validatedKind] as (
+                        params: string,
+                        options?: RequestOptions,
+                        includeProperties?: boolean
+                    ) => Promise<Record<string, any>>;
+                    return endpoint(objectId, { signal }, true).then((res) => {
                         const kinds = res.data.data.kinds;
                         const properties = res.data.data.props;
                         return { kinds, properties };
-                    } else if (databaseId) {
-                        const data = Object.values(res.data.data.nodes as Record<string, any>)[0];
-                        const kinds = data.kinds;
-                        const properties = data.properties;
+                    });
+                } else if (databaseId) {
+                    return apiClient.getNodeByID(Number(databaseId), { signal }).then((res) => {
+                        const kinds = res.data.data.kinds.map((kind) => kind.name);
+                        const properties = res.data.data.properties;
                         return { kinds, properties };
-                    } else return { kinds: [], properties: {} };
-                }),
+                    });
+                }
+                return Promise.resolve({ kinds: [], properties: {} });
+            },
             {
                 refetchOnWindowFocus: false,
                 retry: false,

--- a/packages/javascript/bh-shared-ui/src/utils/entityInfoDisplay.ts
+++ b/packages/javascript/bh-shared-ui/src/utils/entityInfoDisplay.ts
@@ -200,8 +200,6 @@ export const getEntityName = (selectedEntity: SelectedNode | null | undefined) =
     return name;
 };
 
-export const getNodeByDatabaseIdCypher = (id: string): string => `MATCH (n) WHERE ID(n) = ${id} RETURN n LIMIT 1`;
-
 // Map containing all properties that should display as bitwise integers in the entity panel.
 // The key is the property string, the value is the amount of significant digits the hex value should display with.
 const BitwiseInts = new Map([['certificatemappingmethodsraw', 2]]);

--- a/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/Details/SelectedDetailsTabs/SelectedDetailsTabContent.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/Details/SelectedDetailsTabs/SelectedDetailsTabContent.test.tsx
@@ -87,16 +87,13 @@ describe('Selected Details Tab Content', () => {
                     })
                 );
             }),
-            rest.post('/api/v2/graphs/cypher', async (_req, res, ctx) => {
+            rest.get('/api/v2/nodes/:id', async (_req, res, ctx) => {
                 return res(
                     ctx.json({
                         data: {
-                            nodes: {
-                                '123': {
-                                    properties: {
-                                        customprop: 'OpenGraph Value',
-                                    },
-                                },
+                            kinds: [{ name: 'Custom' }],
+                            properties: {
+                                customprop: 'OpenGraph Value',
                             },
                         },
                     })


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

The useFetchEntityInfo hook is updated to use the getNodByID endpoint to retrieve entity information instead of the cypher search endpoint.

## Motivation and Context
 
Resolves BED-8742

This refactor will enable OG entity info support by routing through an endpoint that will return info section information derived from extension managed schemas.

## How Has This Been Tested?
Unit tests have been updated and the change was verified locally.

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved entity info loading for nodes whose type isn’t in the schema, ensuring the UI correctly displays the “unknown kind” information.
  * Switched entity details fetching to direct node-by-ID retrieval when a database ID is available, improving data accuracy on refresh (including OpenGraph values).
* **Tests**
  * Updated entity info and details tab tests to mock the node-by-ID API flow instead of graph/Cypher-based responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->