### PR TITLE
fix: explore table id collision confusion BED-8026

### DIFF
--- a/packages/javascript/bh-shared-ui/src/components/ExploreTable/ExploreTable.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/ExploreTable/ExploreTable.tsx
@@ -24,14 +24,14 @@ import TableControls from './TableControls';
 import {
     DEFAULT_EXPLORE_TABLE_COLUMN_KEYS,
     ExploreTableProps,
-    MungedTableRowWithId,
+    MungedTableRowWithGraphId,
     createColumnStateFromKeys,
     defaultColumns,
     getExploreTableData,
 } from './explore-table-utils';
 import useExploreTableRowsAndColumns from './useExploreTableRowsAndColumns';
 
-const MemoDataTable = memo(DataTable<MungedTableRowWithId, any>);
+const MemoDataTable = memo(DataTable<MungedTableRowWithGraphId, any>);
 
 type DataTableProps = React.ComponentProps<typeof MemoDataTable>;
 
@@ -53,7 +53,7 @@ const tableCellProps: DataTableProps['TableCellProps'] = {
 };
 
 const tableOptions: DataTableProps['tableOptions'] = {
-    getRowId: (row) => row.id,
+    getRowId: (row) => row.bhGraphId,
 };
 
 const virtualizationOptions: DataTableProps['virtualizationOptions'] = {
@@ -117,9 +117,9 @@ const ExploreTable = ({
     );
 
     const handleRowClick = useCallback(
-        (row: MungedTableRowWithId) => {
-            if (row.id !== selectedItem) {
-                setSelectedItem(row.id);
+        (row: MungedTableRowWithGraphId) => {
+            if (row.bhGraphId !== selectedItem) {
+                setSelectedItem(row.bhGraphId);
             } else {
                 clearSelectedItem();
             }

--- a/packages/javascript/bh-shared-ui/src/components/ExploreTable/ExploreTableHeaderCell.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/ExploreTable/ExploreTableHeaderCell.tsx
@@ -17,7 +17,7 @@ import { Tooltip } from '@mui/material';
 import { cn, formatPotentiallyUnknownLabel } from '../../utils';
 import { adaptClickHandlerToKeyDown } from '../../utils/adaptClickHandlerToKeyDown';
 import { AppIcon } from '../AppIcon';
-import { MungedTableRowWithId } from './explore-table-utils';
+import { MungedTableRowWithGraphId } from './explore-table-utils';
 
 const ExploreTableHeaderCell = ({
     headerKey,
@@ -25,8 +25,8 @@ const ExploreTableHeaderCell = ({
     sortOrder,
     onClick,
 }: {
-    headerKey: keyof MungedTableRowWithId;
-    sortBy?: keyof MungedTableRowWithId;
+    headerKey: keyof MungedTableRowWithGraphId;
+    sortBy?: keyof MungedTableRowWithGraphId;
     dataType: string;
     sortOrder?: string;
     onClick: () => void;

--- a/packages/javascript/bh-shared-ui/src/components/ExploreTable/explore-table-utils.ts
+++ b/packages/javascript/bh-shared-ui/src/components/ExploreTable/explore-table-utils.ts
@@ -30,7 +30,7 @@ export const makeStoreMapFromColumnOptions = (columnOptions: ManageColumnsComboB
     );
 
 export type NodeClickInfo = { id: string; x: number; y: number };
-export type MungedTableRowWithId = GraphNodeSpreadWithProperties & { id: string };
+export type MungedTableRowWithGraphId = GraphNodeSpreadWithProperties & { bhGraphId: string };
 export type ExportColumns = 'all' | 'selected';
 
 export const DEFAULT_EXPLORE_TABLE_COLUMN_KEYS = [

--- a/packages/javascript/bh-shared-ui/src/components/ExploreTable/useExploreTableRowsAndColumns.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/ExploreTable/useExploreTableRowsAndColumns.test.tsx
@@ -1,0 +1,56 @@
+// Copyright 2026 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { renderHook } from '../../test-utils';
+import useExploreTableRowsAndColumns from './useExploreTableRowsAndColumns';
+
+describe('useExploreTableRowsAndColumns', () => {
+    describe('bhGraphId', () => {
+        it('is not overwritten when node properties contain an id field', () => {
+            const graphNodeKey = '100';
+            const nodeIdProperty = 'property-level-id-value';
+
+            const exploreTableData = {
+                nodes: {
+                    [graphNodeKey]: {
+                        label: 'TestNode',
+                        kind: 'User',
+                        kinds: ['User'],
+                        objectId: 'obj-123',
+                        lastSeen: '2026-01-01',
+                        isTierZero: false,
+                        isOwnedObject: false,
+                        properties: { id: nodeIdProperty },
+                    },
+                },
+                node_keys: ['label', 'kind', 'objectId', 'isTierZero', 'isOwnedObject', 'lastSeen'],
+            };
+
+            const { result } = renderHook(() =>
+                useExploreTableRowsAndColumns({
+                    onKebabMenuClick: vi.fn(),
+                    searchInput: '',
+                    selectedColumns: {},
+                    exploreTableData,
+                })
+            );
+
+            const row = result.current.rows[0];
+
+            expect(row.bhGraphId).toBe(graphNodeKey);
+            expect(row.bhGraphId).not.toBe(nodeIdProperty);
+        });
+    });
+});

--- a/packages/javascript/bh-shared-ui/src/components/ExploreTable/useExploreTableRowsAndColumns.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/ExploreTable/useExploreTableRowsAndColumns.tsx
@@ -33,16 +33,16 @@ import {
     getExploreTableData,
     isSmallColumn,
     type ExploreTableProps,
-    type MungedTableRowWithId,
+    type MungedTableRowWithGraphId,
 } from './explore-table-utils';
 import ExploreTableDataCell from './ExploreTableDataCell';
 import ExploreTableHeaderCell from './ExploreTableHeaderCell';
 
-const columnHelper = createColumnHelper<MungedTableRowWithId>();
+const columnHelper = createColumnHelper<MungedTableRowWithGraphId>();
 
 type DataTableProps = React.ComponentProps<typeof DataTable>;
 
-const filterKeys: (keyof MungedTableRowWithId)[] = ['label', 'objectid'];
+const filterKeys: (keyof MungedTableRowWithGraphId)[] = ['label', 'objectid'];
 
 type UseExploreTableRowsAndColumnsProps = Pick<ExploreTableProps, 'onKebabMenuClick' | 'selectedColumns'> & {
     searchInput: string;
@@ -55,17 +55,17 @@ const useExploreTableRowsAndColumns = ({
     selectedColumns,
     exploreTableData,
 }: UseExploreTableRowsAndColumnsProps) => {
-    const [sortBy, setSortBy] = useState<keyof MungedTableRowWithId>();
+    const [sortBy, setSortBy] = useState<keyof MungedTableRowWithGraphId>();
     const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>();
     const announce = useAnnounce();
 
-    const rows: MungedTableRowWithId[] = useMemo(
+    const rows: MungedTableRowWithGraphId[] = useMemo(
         () =>
             exploreTableData?.nodes
                 ? Object.entries(exploreTableData?.nodes).map(([key, node]) => {
                       // To avoid extra enumerations for spread operators, the known properties are manually set
                       const flattenedNode = {
-                          id: key,
+                          bhGraphId: key,
                           label: node.label,
                           kind: node.kind,
                           objectId: node.objectId,
@@ -73,7 +73,7 @@ const useExploreTableRowsAndColumns = ({
                           isTierZero: node.isTierZero,
                           isOwnedObject: node.isOwnedObject,
                           ...node.properties,
-                      } satisfies MungedTableRowWithId;
+                      } satisfies MungedTableRowWithGraphId;
 
                       return flattenedNode;
                   })
@@ -82,7 +82,7 @@ const useExploreTableRowsAndColumns = ({
     );
 
     const handleSort = useCallback(
-        (sortByColumn: keyof MungedTableRowWithId) => {
+        (sortByColumn: keyof MungedTableRowWithGraphId) => {
             if (!sortByColumn || sortByColumn !== sortBy) {
                 // first sort of a new column
                 setSortBy(sortByColumn);
@@ -118,7 +118,7 @@ const useExploreTableRowsAndColumns = ({
 
     const firstTenRows = useMemo(() => rows?.slice(0, 10), [rows]);
     const makeColumnDef = useCallback(
-        (rawKey: keyof MungedTableRowWithId) => {
+        (rawKey: keyof MungedTableRowWithGraphId) => {
             const key = rawKey?.toString();
             const firstTruthyValueInFirst10Rows = firstTenRows.find((row) => !!row?.[key])?.[key];
             const bestGuessAtDataType = typeof firstTruthyValueInFirst10Rows;
@@ -173,8 +173,8 @@ const useExploreTableRowsAndColumns = ({
                         role='button'
                         data-testid='kebab-menu'
                         aria-label='Row details'
-                        onClick={(e) => handleKebabMenuClick(e, row?.original?.id)}
-                        onKeyDown={adaptClickHandlerToKeyDown((e) => handleKebabMenuClick(e, row?.original?.id))}
+                        onClick={(e) => handleKebabMenuClick(e, row?.original?.bhGraphId)}
+                        onKeyDown={adaptClickHandlerToKeyDown((e) => handleKebabMenuClick(e, row?.original?.bhGraphId))}
                         className='explore-table-cell-icon h-full flex justify-center items-center -outline-offset-4'>
                         <FontAwesomeIcon
                             icon={faEllipsis}
@@ -190,7 +190,7 @@ const useExploreTableRowsAndColumns = ({
         [handleKebabMenuClick]
     );
 
-    const filteredRows: MungedTableRowWithId[] = useMemo(() => {
+    const filteredRows: MungedTableRowWithGraphId[] = useMemo(() => {
         const lowercaseSearchInput = searchInput?.toLowerCase();
 
         return rows.filter((item) => {


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Fixes an issue with selecting a node from the explore table that has a bespoke `id` property.

## Motivation and Context

Resolves BED-8026

BloodHound uses a number of entity properties for bespoke functionality. With the introduction of generic ingest and OpenGraph, users are able to create their own nodes with whatever properties they wish to use. When users create entities with the same property names as the aforementioned bespoke BH properties, expected functionality can potentially fall apart. 

This is the case with adding an `id` property to a node since that breaks the association that the application expects for loading that node in the entity panel. 

The fix here is a bandaid. There are more properties that BH treats specifically in certain contexts that needs to be addressed. 

## How Has This Been Tested?

Unit tests updated. Verified locally.

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Table rows now keep selection, sorting, and action-menu behavior aligned with the graph node’s true identifier.
  * Improved row handling so nested data no longer conflicts with item selection when an `id` appears in properties.
* **Tests**
  * Added coverage to verify table rows preserve the graph-level identifier in the expected field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->