### PR TITLE
feat(Data Quality): Add `/data-quality-stats` endpoint BED-8610

### DIFF
--- a/cmd/api/src/api/registration/v2.go
+++ b/cmd/api/src/api/registration/v2.go
@@ -351,6 +351,7 @@ func NewV2API(resources v2.Resources, routerInst *router.Router) {
 		routerInst.GET(fmt.Sprintf("/api/v2/ad-domains/{%s}/data-quality-stats", api.URIPathVariableDomainID), resources.GetADDataQualityStats).RequirePermissions(permissions.GraphDBRead).SupportsETAC(resources.DB, resources.DogTags),
 		routerInst.GET(fmt.Sprintf("/api/v2/azure-tenants/{%s}/data-quality-stats", api.URIPathVariableTenantID), resources.GetAzureDataQualityStats).RequirePermissions(permissions.GraphDBRead).SupportsETAC(resources.DB, resources.DogTags),
 		routerInst.GET(fmt.Sprintf("/api/v2/platform/{%s}/data-quality-stats", api.URIPathVariablePlatformID), resources.GetPlatformAggregateStats).RequirePermissions(permissions.GraphDBRead),
+		routerInst.GET("/api/v2/data-quality-stats", resources.GetDataQualityStats).RequirePermissions(permissions.GraphDBRead).SupportsETAC(resources.DB, resources.DogTags),
 
 		// Datapipe API
 		routerInst.GET("/api/v2/datapipe/status", resources.GetDatapipeStatus).RequireAuth(),

--- a/cmd/api/src/api/registration/v2.go
+++ b/cmd/api/src/api/registration/v2.go
@@ -351,7 +351,7 @@ func NewV2API(resources v2.Resources, routerInst *router.Router) {
 		routerInst.GET(fmt.Sprintf("/api/v2/ad-domains/{%s}/data-quality-stats", api.URIPathVariableDomainID), resources.GetADDataQualityStats).RequirePermissions(permissions.GraphDBRead).SupportsETAC(resources.DB, resources.DogTags),
 		routerInst.GET(fmt.Sprintf("/api/v2/azure-tenants/{%s}/data-quality-stats", api.URIPathVariableTenantID), resources.GetAzureDataQualityStats).RequirePermissions(permissions.GraphDBRead).SupportsETAC(resources.DB, resources.DogTags),
 		routerInst.GET(fmt.Sprintf("/api/v2/platform/{%s}/data-quality-stats", api.URIPathVariablePlatformID), resources.GetPlatformAggregateStats).RequirePermissions(permissions.GraphDBRead),
-		routerInst.GET("/api/v2/data-quality-stats", resources.GetDataQualityStats).RequirePermissions(permissions.GraphDBRead).SupportsETAC(resources.DB, resources.DogTags),
+		routerInst.GET("/api/v2/data-quality-stats", resources.GetDataQualityStats).RequirePermissions(permissions.GraphDBRead),
 
 		// Datapipe API
 		routerInst.GET("/api/v2/datapipe/status", resources.GetDatapipeStatus).RequireAuth(),

--- a/cmd/api/src/api/registration/v2.go
+++ b/cmd/api/src/api/registration/v2.go
@@ -351,7 +351,7 @@ func NewV2API(resources v2.Resources, routerInst *router.Router) {
 		routerInst.GET(fmt.Sprintf("/api/v2/ad-domains/{%s}/data-quality-stats", api.URIPathVariableDomainID), resources.GetADDataQualityStats).RequirePermissions(permissions.GraphDBRead).SupportsETAC(resources.DB, resources.DogTags),
 		routerInst.GET(fmt.Sprintf("/api/v2/azure-tenants/{%s}/data-quality-stats", api.URIPathVariableTenantID), resources.GetAzureDataQualityStats).RequirePermissions(permissions.GraphDBRead).SupportsETAC(resources.DB, resources.DogTags),
 		routerInst.GET(fmt.Sprintf("/api/v2/platform/{%s}/data-quality-stats", api.URIPathVariablePlatformID), resources.GetPlatformAggregateStats).RequirePermissions(permissions.GraphDBRead),
-		routerInst.GET("/api/v2/data-quality-stats", resources.GetDataQualityStats).RequirePermissions(permissions.GraphDBRead),
+		routerInst.GET("/api/v2/data-quality-stats", resources.GetDataQualityStats).RequirePermissions(permissions.GraphDBRead).CheckFeatureFlag(resources.DB, appcfg.FeatureOpenGraphExtensionManagement),
 
 		// Datapipe API
 		routerInst.GET("/api/v2/datapipe/status", resources.GetDatapipeStatus).RequireAuth(),

--- a/cmd/api/src/api/v2/dataquality.go
+++ b/cmd/api/src/api/v2/dataquality.go
@@ -38,13 +38,12 @@ import (
 )
 
 const (
-	ErrNoTenantId                string = "no tenant id specified in url"
-	ErrNoPlatformId              string = "no platform id specified in url"
-	ErrInvalidPlatformId         string = "invalid platform id specified in url: %v"
-	ErrNoEnvironmentId           string = "environmentid is required"
-	ErrEnvironmentIdDoesNotExist string = "environmentid does not exist"
-	ErrUnknownUser               string = "unknown user"
-	ErrNoAccess                  string = "user does not have permission to access this environment"
+	ErrNoTenantId        string = "no tenant id specified in url"
+	ErrNoPlatformId      string = "no platform id specified in url"
+	ErrInvalidPlatformId string = "invalid platform id specified in url: %v"
+	ErrNoEnvironmentId   string = "environmentid is required"
+	ErrUnknownUser       string = "unknown user"
+	ErrNoAccess          string = "user does not have permission to access this environment"
 )
 
 func (s Resources) GetDatabaseCompleteness(response http.ResponseWriter, request *http.Request) {

--- a/cmd/api/src/api/v2/dataquality.go
+++ b/cmd/api/src/api/v2/dataquality.go
@@ -185,13 +185,6 @@ func (s *Resources) GetDataQualityStats(response http.ResponseWriter, request *h
 		api.WriteErrorResponse(ctx, api.BuildErrorResponse(http.StatusBadRequest, ErrNoEnvironmentId, request), response)
 	} else if user, found := auth.GetUserFromAuthCtx(bhctx.FromRequest(request).AuthCtx); !found {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusInternalServerError, ErrUnknownUser, request), response)
-	} else if ShouldFilterForETAC(s.DogTags, user) {
-		hasAccess, err := CheckUserAccessToEnvironments(ctx, s.DB, user, environmentId)
-		if err != nil {
-			api.WriteErrorResponse(ctx, api.BuildErrorResponse(http.StatusInternalServerError, err.Error(), request), response)
-		} else if !hasAccess {
-			api.WriteErrorResponse(ctx, api.BuildErrorResponse(http.StatusForbidden, ErrNoAccess, request), response)
-		}
 	} else if _, sort, err := parseOrder(queryParams, dataQualityStats); err != nil {
 		api.WriteErrorResponse(ctx, api.BuildErrorResponse(http.StatusBadRequest, err.Error(), request), response)
 	} else if start, err := ParseTimeQueryParameter(queryParams, "start", defaultStart); err != nil {
@@ -203,6 +196,16 @@ func (s *Resources) GetDataQualityStats(response http.ResponseWriter, request *h
 	} else if skip, err := ParseSkipQueryParameter(queryParams, 0); err != nil {
 		api.WriteErrorResponse(ctx, api.BuildErrorResponse(http.StatusBadRequest, fmt.Sprintf(utils.ErrorInvalidSkip, queryParams["skip"]), request), response)
 	} else {
+		if ShouldFilterForETAC(s.DogTags, user) {
+			hasAccess, err := CheckUserAccessToEnvironments(ctx, s.DB, user, environmentId)
+			if err != nil {
+				api.WriteErrorResponse(ctx, api.BuildErrorResponse(http.StatusInternalServerError, err.Error(), request), response)
+				return
+			} else if !hasAccess {
+				api.WriteErrorResponse(ctx, api.BuildErrorResponse(http.StatusForbidden, ErrNoAccess, request), response)
+				return
+			}
+		}
 		filters := model.Filters{
 			"environment_id": []model.Filter{{
 				Value:       environmentId,

--- a/cmd/api/src/api/v2/dataquality.go
+++ b/cmd/api/src/api/v2/dataquality.go
@@ -212,7 +212,7 @@ func (s *Resources) GetDataQualityStats(response http.ResponseWriter, request *h
 				Operator:    model.Equals,
 				SetOperator: model.FilterAnd,
 			}},
-			"created_at": []model.Filter{{Value: start.Format(time.RFC3339), Operator: model.GreaterThanOrEquals, SetOperator: model.FilterAnd}, {Value: end.Format(time.RFC3339), Operator: model.LessThanOrEquals, SetOperator: model.FilterAnd}},
+			"created_at": []model.Filter{{Value: start.Format(time.RFC3339), Operator: model.GreaterThanOrEquals, SetOperator: model.FilterAnd}, {Value: end.Format(time.RFC3339), Operator: model.LessThan, SetOperator: model.FilterAnd}},
 		}
 		if stats, count, err := s.DB.GetDataQualityStats(ctx, filters, sort, skip, limit); err != nil {
 			api.HandleDatabaseError(request, response, err)
@@ -226,11 +226,15 @@ type Sortable interface {
 	IsSortable(column string) bool
 }
 
-// parseOrder is a helper function which parses any sort_by query params into both the legacy sort string format and the model.Sort format. Returns an error if the columns is not sortable.
+// parseOrder is a helper function which parses any sort_by query params into both the legacy sort string format and the model.Sort format. Returns an error if the columns is not sortable, or if an empty sort param is provided.
 func parseOrder(queryParams url.Values, sortable Sortable) (string, model.Sort, error) {
 	order := []string{}
 	sort := model.Sort{}
 	for _, column := range queryParams[api.QueryParameterSortBy] {
+		if column == "" {
+			return "", sort, errors.New(api.ErrorResponseEmptySortParameter)
+		}
+
 		var descending bool
 		if string(column[0]) == "-" {
 			descending = true
@@ -238,7 +242,7 @@ func parseOrder(queryParams url.Values, sortable Sortable) (string, model.Sort, 
 		}
 
 		if !sortable.IsSortable(column) {
-			return strings.Join(order, ", "), sort, errors.New(api.ErrorResponseDetailsNotSortable)
+			return "", sort, errors.New(api.ErrorResponseDetailsNotSortable)
 		}
 
 		if descending {
@@ -249,6 +253,7 @@ func parseOrder(queryParams url.Values, sortable Sortable) (string, model.Sort, 
 			order = append(order, column)
 			sort = append(sort, model.SortItem{Column: column, Direction: model.AscendingSortDirection})
 		}
+
 	}
 	return strings.Join(order, ", "), sort, nil
 }

--- a/cmd/api/src/api/v2/dataquality.go
+++ b/cmd/api/src/api/v2/dataquality.go
@@ -33,7 +33,6 @@ import (
 	"github.com/specterops/bloodhound/cmd/api/src/utils"
 	"github.com/specterops/bloodhound/packages/go/analysis/ad"
 	"github.com/specterops/bloodhound/packages/go/bhlog/measure"
-	"github.com/specterops/bloodhound/packages/go/graphschema"
 	"github.com/specterops/dawgs/graph"
 )
 
@@ -41,7 +40,7 @@ const (
 	ErrNoTenantId        string = "no tenant id specified in url"
 	ErrNoPlatformId      string = "no platform id specified in url"
 	ErrInvalidPlatformId string = "invalid platform id specified in url: %v"
-	ErrNoEnvironmentId   string = "environmentid is required"
+	ErrNoEnvironmentId   string = "environment_id is required"
 	ErrUnknownUser       string = "unknown user"
 	ErrNoAccess          string = "user does not have permission to access this environment"
 )
@@ -181,7 +180,7 @@ func (s *Resources) GetDataQualityStats(response http.ResponseWriter, request *h
 		defaultEnd, defaultStart = DefaultTimeRange()
 	)
 
-	if environmentId := queryParams.Get(graphschema.EnvironmentIDKey); environmentId == "" {
+	if environmentId := queryParams.Get(api.QueryParameterEnvironmentId); environmentId == "" {
 		api.WriteErrorResponse(ctx, api.BuildErrorResponse(http.StatusBadRequest, ErrNoEnvironmentId, request), response)
 	} else if user, found := auth.GetUserFromAuthCtx(bhctx.FromRequest(request).AuthCtx); !found {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusInternalServerError, ErrUnknownUser, request), response)
@@ -222,12 +221,8 @@ func (s *Resources) GetDataQualityStats(response http.ResponseWriter, request *h
 	}
 }
 
-type Sortable interface {
-	IsSortable(column string) bool
-}
-
 // parseOrder is a helper function which parses any sort_by query params into both the legacy sort string format and the model.Sort format. Returns an error if the columns is not sortable, or if an empty sort param is provided.
-func parseOrder(queryParams url.Values, sortable Sortable) (string, model.Sort, error) {
+func parseOrder(queryParams url.Values, sortable api.Sortable) (string, model.Sort, error) {
 	order := []string{}
 	sort := model.Sort{}
 	for _, column := range queryParams[api.QueryParameterSortBy] {

--- a/cmd/api/src/api/v2/dataquality.go
+++ b/cmd/api/src/api/v2/dataquality.go
@@ -17,10 +17,14 @@
 package v2
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"strings"
+	"time"
 
 	"github.com/gorilla/mux"
 	"github.com/specterops/bloodhound/cmd/api/src/api"
@@ -28,13 +32,17 @@ import (
 	"github.com/specterops/bloodhound/cmd/api/src/utils"
 	"github.com/specterops/bloodhound/packages/go/analysis/ad"
 	"github.com/specterops/bloodhound/packages/go/bhlog/measure"
+	"github.com/specterops/bloodhound/packages/go/graphschema"
 	"github.com/specterops/dawgs/graph"
+	"github.com/specterops/dawgs/query"
 )
 
 const (
-	ErrNoTenantId        string = "no tenant id specified in url"
-	ErrNoPlatformId      string = "no platform id specified in url"
-	ErrInvalidPlatformId string = "invalid platform id specified in url: %v"
+	ErrNoTenantId                string = "no tenant id specified in url"
+	ErrNoPlatformId              string = "no platform id specified in url"
+	ErrInvalidPlatformId         string = "invalid platform id specified in url: %v"
+	ErrNoEnvironmentId           string = "environmentid is required"
+	ErrEnvironmentIdDoesNotExist string = "environmentid does not exist"
 )
 
 func (s Resources) GetDatabaseCompleteness(response http.ResponseWriter, request *http.Request) {
@@ -65,32 +73,14 @@ func (s Resources) GetDatabaseCompleteness(response http.ResponseWriter, request
 
 func (s *Resources) GetADDataQualityStats(response http.ResponseWriter, request *http.Request) {
 	var (
-		order                    []string
 		adDataQualityStats       model.ADDataQualityStats
 		queryParams              = request.URL.Query()
 		defaultEnd, defaultStart = DefaultTimeRange()
 	)
 
-	for _, column := range queryParams[api.QueryParameterSortBy] {
-		var descending bool
-		if string(column[0]) == "-" {
-			descending = true
-			column = column[1:]
-		}
-
-		if !adDataQualityStats.IsSortable(column) {
-			api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, api.ErrorResponseDetailsNotSortable, request), response)
-			return
-		}
-
-		if descending {
-			order = append(order, column+" desc")
-		} else {
-			order = append(order, column)
-		}
-	}
-
-	if id, hasDomainID := mux.Vars(request)[api.URIPathVariableDomainID]; !hasDomainID {
+	if order, _, err := parseOrder(queryParams, adDataQualityStats); err != nil {
+		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, err.Error(), request), response)
+	} else if id, hasDomainID := mux.Vars(request)[api.URIPathVariableDomainID]; !hasDomainID {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, api.ErrorNoDomainId, request), response)
 	} else if start, err := ParseTimeQueryParameter(queryParams, "start", defaultStart); err != nil {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, fmt.Sprintf(api.ErrorInvalidRFC3339, queryParams["start"]), request), response)
@@ -100,7 +90,7 @@ func (s *Resources) GetADDataQualityStats(response http.ResponseWriter, request 
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, fmt.Sprintf(utils.ErrorInvalidLimit, queryParams["limit"]), request), response)
 	} else if skip, err := ParseSkipQueryParameter(queryParams, 0); err != nil {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, fmt.Sprintf(utils.ErrorInvalidSkip, queryParams["skip"]), request), response)
-	} else if stats, count, err := s.DB.GetADDataQualityStats(request.Context(), id, start, end, strings.Join(order, ", "), limit, skip); err != nil {
+	} else if stats, count, err := s.DB.GetADDataQualityStats(request.Context(), id, start, end, order, limit, skip); err != nil {
 		api.HandleDatabaseError(request, response, err)
 	} else {
 		api.WriteResponseWrapperWithTimeWindowAndPagination(request.Context(), stats, start, end, limit, skip, count, http.StatusOK, response)
@@ -109,32 +99,14 @@ func (s *Resources) GetADDataQualityStats(response http.ResponseWriter, request 
 
 func (s *Resources) GetAzureDataQualityStats(response http.ResponseWriter, request *http.Request) {
 	var (
-		order                    []string
 		azureDataQualityStats    model.AzureDataQualityStats
 		queryParams              = request.URL.Query()
 		defaultEnd, defaultStart = DefaultTimeRange()
 	)
 
-	for _, column := range queryParams[api.QueryParameterSortBy] {
-		var descending bool
-		if string(column[0]) == "-" {
-			descending = true
-			column = column[1:]
-		}
-
-		if !azureDataQualityStats.IsSortable(column) {
-			api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, api.ErrorResponseDetailsNotSortable, request), response)
-			return
-		}
-
-		if descending {
-			order = append(order, column+" desc")
-		} else {
-			order = append(order, column)
-		}
-	}
-
-	if id, hasTenantID := mux.Vars(request)[api.URIPathVariableTenantID]; !hasTenantID {
+	if order, _, err := parseOrder(queryParams, azureDataQualityStats); err != nil {
+		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, err.Error(), request), response)
+	} else if id, hasTenantID := mux.Vars(request)[api.URIPathVariableTenantID]; !hasTenantID {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, ErrNoTenantId, request), response)
 	} else if start, err := ParseTimeQueryParameter(queryParams, "start", defaultStart); err != nil {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, fmt.Sprintf(api.ErrorInvalidRFC3339, queryParams["start"]), request), response)
@@ -144,7 +116,7 @@ func (s *Resources) GetAzureDataQualityStats(response http.ResponseWriter, reque
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, fmt.Sprintf(utils.ErrorInvalidLimit, queryParams["limit"]), request), response)
 	} else if skip, err := ParseSkipQueryParameter(queryParams, 0); err != nil {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, fmt.Sprintf(utils.ErrorInvalidSkip, queryParams["skip"]), request), response)
-	} else if stats, count, err := s.DB.GetAzureDataQualityStats(request.Context(), id, start, end, strings.Join(order, ", "), limit, skip); err != nil {
+	} else if stats, count, err := s.DB.GetAzureDataQualityStats(request.Context(), id, start, end, order, limit, skip); err != nil {
 		api.HandleDatabaseError(request, response, err)
 	} else {
 		api.WriteResponseWrapperWithTimeWindowAndPagination(request.Context(), stats, start, end, limit, skip, count, http.StatusOK, response)
@@ -153,7 +125,6 @@ func (s *Resources) GetAzureDataQualityStats(response http.ResponseWriter, reque
 
 func (s *Resources) GetPlatformAggregateStats(response http.ResponseWriter, request *http.Request) {
 	var (
-		order                    []string
 		azureDataQualityStats    model.AzureDataQualityStats
 		queryParams              = request.URL.Query()
 		defaultEnd, defaultStart = DefaultTimeRange()
@@ -161,26 +132,9 @@ func (s *Resources) GetPlatformAggregateStats(response http.ResponseWriter, requ
 
 	// TODO: This is currently using only the Azure stat type, but should check against the appropriate aggregate type for the chosen platform
 	// It's safe for now, but should be refactored
-	for _, column := range queryParams[api.QueryParameterSortBy] {
-		var descending bool
-		if string(column[0]) == "-" {
-			descending = true
-			column = column[1:]
-		}
-
-		if !azureDataQualityStats.IsSortable(column) {
-			api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, api.ErrorResponseDetailsNotSortable, request), response)
-			return
-		}
-
-		if descending {
-			order = append(order, column+" desc")
-		} else {
-			order = append(order, column)
-		}
-	}
-
-	if id, hasPlatformID := mux.Vars(request)[api.URIPathVariablePlatformID]; !hasPlatformID {
+	if order, _, err := parseOrder(queryParams, azureDataQualityStats); err != nil {
+		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, err.Error(), request), response)
+	} else if id, hasPlatformID := mux.Vars(request)[api.URIPathVariablePlatformID]; !hasPlatformID {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, ErrNoPlatformId, request), response)
 	} else if start, err := ParseTimeQueryParameter(queryParams, "start", defaultStart); err != nil {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, fmt.Sprintf(api.ErrorInvalidRFC3339, queryParams["start"]), request), response)
@@ -198,13 +152,13 @@ func (s *Resources) GetPlatformAggregateStats(response http.ResponseWriter, requ
 
 		switch id {
 		case "ad":
-			stats, count, err = s.DB.GetADDataQualityAggregations(request.Context(), start, end, strings.Join(order, ", "), limit, skip)
+			stats, count, err = s.DB.GetADDataQualityAggregations(request.Context(), start, end, order, limit, skip)
 			if err != nil {
 				api.HandleDatabaseError(request, response, err)
 				return
 			}
 		case "azure":
-			stats, count, err = s.DB.GetAzureDataQualityAggregations(request.Context(), start, end, strings.Join(order, ", "), limit, skip)
+			stats, count, err = s.DB.GetAzureDataQualityAggregations(request.Context(), start, end, order, limit, skip)
 			if err != nil {
 				api.HandleDatabaseError(request, response, err)
 				return
@@ -216,4 +170,95 @@ func (s *Resources) GetPlatformAggregateStats(response http.ResponseWriter, requ
 
 		api.WriteResponseWrapperWithTimeWindowAndPagination(request.Context(), stats, start, end, limit, skip, count, http.StatusOK, response)
 	}
+}
+
+func (s *Resources) GetDataQualityStats(response http.ResponseWriter, request *http.Request) {
+	var (
+		ctx                      = request.Context()
+		dataQualityStats         model.DataQualityStats
+		queryParams              = request.URL.Query()
+		defaultEnd, defaultStart = DefaultTimeRange()
+	)
+
+	// TODO -- ETAC
+
+	if _, sort, err := parseOrder(queryParams, dataQualityStats); err != nil {
+		api.WriteErrorResponse(ctx, api.BuildErrorResponse(http.StatusBadRequest, err.Error(), request), response)
+	} else if environmentId := queryParams.Get(graphschema.EnvironmentIDKey); environmentId == "" {
+		api.WriteErrorResponse(ctx, api.BuildErrorResponse(http.StatusBadRequest, ErrNoEnvironmentId, request), response)
+	} else if environmentExists, err := s.environmentIdExists(ctx, environmentId); err != nil {
+		api.WriteErrorResponse(ctx, api.BuildErrorResponse(http.StatusInternalServerError, err.Error(), request), response)
+	} else if !environmentExists {
+		api.WriteErrorResponse(ctx, api.BuildErrorResponse(http.StatusNotFound, ErrEnvironmentIdDoesNotExist, request), response)
+	} else if start, err := ParseTimeQueryParameter(queryParams, "start", defaultStart); err != nil {
+		api.WriteErrorResponse(ctx, api.BuildErrorResponse(http.StatusBadRequest, fmt.Sprintf(api.ErrorInvalidRFC3339, queryParams["start"]), request), response)
+	} else if end, err := ParseTimeQueryParameter(queryParams, "end", defaultEnd); err != nil {
+		api.WriteErrorResponse(ctx, api.BuildErrorResponse(http.StatusBadRequest, fmt.Sprintf(api.ErrorInvalidRFC3339, queryParams["end"]), request), response)
+	} else if limit, err := ParseLimitQueryParameter(queryParams, 1000); err != nil {
+		api.WriteErrorResponse(ctx, api.BuildErrorResponse(http.StatusBadRequest, fmt.Sprintf(utils.ErrorInvalidLimit, queryParams["limit"]), request), response)
+	} else if skip, err := ParseSkipQueryParameter(queryParams, 0); err != nil {
+		api.WriteErrorResponse(ctx, api.BuildErrorResponse(http.StatusBadRequest, fmt.Sprintf(utils.ErrorInvalidSkip, queryParams["skip"]), request), response)
+	} else if stats, count, err := s.DB.GetDataQualityStats(ctx, toCreatedAtFilter(start, end), sort, skip, limit); err != nil {
+		api.HandleDatabaseError(request, response, err)
+	} else {
+		api.WriteResponseWrapperWithTimeWindowAndPagination(ctx, stats, start, end, limit, skip, count, http.StatusOK, response)
+	}
+}
+
+func (s *Resources) environmentIdExists(ctx context.Context, environmentID string) (bool, error) {
+	var exists bool
+
+	err := s.Graph.ReadTransaction(ctx, func(tx graph.Transaction) error {
+		count, err := tx.Nodes().Filterf(func() graph.Criteria {
+			return query.Equals(
+				query.NodeProperty(graphschema.EnvironmentIDKey),
+				environmentID,
+			)
+		}).Count()
+		if err != nil {
+			return err
+		}
+
+		exists = count > 0
+		return nil
+	})
+
+	return exists, err
+}
+
+type Sortable interface {
+	IsSortable(column string) bool
+}
+
+// parseOrder is a helper function which parses any sort_by query params into both the legacy sort string format and the model.Sort format. Returns an error if the columns is not sortable.
+func parseOrder(queryParams url.Values, sortable Sortable) (string, model.Sort, error) {
+	order := []string{}
+	sort := model.Sort{}
+	for _, column := range queryParams[api.QueryParameterSortBy] {
+		var descending bool
+		if string(column[0]) == "-" {
+			descending = true
+			column = column[1:]
+		}
+
+		if !sortable.IsSortable(column) {
+			return strings.Join(order, ", "), sort, errors.New(api.ErrorResponseDetailsNotSortable)
+		}
+
+		if descending {
+			order = append(order, column+" desc")
+			sort = append(sort, model.SortItem{Column: column, Direction: model.DescendingSortDirection})
+
+		} else {
+			order = append(order, column)
+			sort = append(sort, model.SortItem{Column: column, Direction: model.AscendingSortDirection})
+		}
+	}
+	return strings.Join(order, ", "), sort, nil
+}
+
+// toCreatedAtFilter transforms the given start and end time into database-compatible Filters.
+func toCreatedAtFilter(start, end time.Time) model.Filters {
+	return model.Filters{"created_at": []model.Filter{{Value: start.String(), Operator: model.GreaterThanOrEquals, SetOperator: model.FilterAnd}, {Value: end.String(), Operator: model.LessThanOrEquals, SetOperator: model.FilterAnd}}}
+
 }

--- a/cmd/api/src/api/v2/dataquality.go
+++ b/cmd/api/src/api/v2/dataquality.go
@@ -28,6 +28,8 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/specterops/bloodhound/cmd/api/src/api"
+	"github.com/specterops/bloodhound/cmd/api/src/auth"
+	"github.com/specterops/bloodhound/cmd/api/src/bhctx"
 	"github.com/specterops/bloodhound/cmd/api/src/model"
 	"github.com/specterops/bloodhound/cmd/api/src/utils"
 	"github.com/specterops/bloodhound/packages/go/analysis/ad"
@@ -43,6 +45,8 @@ const (
 	ErrInvalidPlatformId         string = "invalid platform id specified in url: %v"
 	ErrNoEnvironmentId           string = "environmentid is required"
 	ErrEnvironmentIdDoesNotExist string = "environmentid does not exist"
+	ErrUnknownUser               string = "unknown user"
+	ErrNoAccess                  string = "user does not have permission to access this environment"
 )
 
 func (s Resources) GetDatabaseCompleteness(response http.ResponseWriter, request *http.Request) {
@@ -180,16 +184,23 @@ func (s *Resources) GetDataQualityStats(response http.ResponseWriter, request *h
 		defaultEnd, defaultStart = DefaultTimeRange()
 	)
 
-	// TODO -- ETAC
-
-	if _, sort, err := parseOrder(queryParams, dataQualityStats); err != nil {
-		api.WriteErrorResponse(ctx, api.BuildErrorResponse(http.StatusBadRequest, err.Error(), request), response)
-	} else if environmentId := queryParams.Get(graphschema.EnvironmentIDKey); environmentId == "" {
+	if environmentId := queryParams.Get(graphschema.EnvironmentIDKey); environmentId == "" {
 		api.WriteErrorResponse(ctx, api.BuildErrorResponse(http.StatusBadRequest, ErrNoEnvironmentId, request), response)
+	} else if user, found := auth.GetUserFromAuthCtx(bhctx.FromRequest(request).AuthCtx); !found {
+		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusInternalServerError, ErrUnknownUser, request), response)
+	} else if ShouldFilterForETAC(s.DogTags, user) {
+		hasAccess, err := CheckUserAccessToEnvironments(ctx, s.DB, user, environmentId)
+		if err != nil {
+			api.WriteErrorResponse(ctx, api.BuildErrorResponse(http.StatusInternalServerError, err.Error(), request), response)
+		} else if !hasAccess {
+			api.WriteErrorResponse(ctx, api.BuildErrorResponse(http.StatusForbidden, ErrNoAccess, request), response)
+		}
 	} else if environmentExists, err := s.environmentIdExists(ctx, environmentId); err != nil {
 		api.WriteErrorResponse(ctx, api.BuildErrorResponse(http.StatusInternalServerError, err.Error(), request), response)
 	} else if !environmentExists {
 		api.WriteErrorResponse(ctx, api.BuildErrorResponse(http.StatusNotFound, ErrEnvironmentIdDoesNotExist, request), response)
+	} else if _, sort, err := parseOrder(queryParams, dataQualityStats); err != nil {
+		api.WriteErrorResponse(ctx, api.BuildErrorResponse(http.StatusBadRequest, err.Error(), request), response)
 	} else if start, err := ParseTimeQueryParameter(queryParams, "start", defaultStart); err != nil {
 		api.WriteErrorResponse(ctx, api.BuildErrorResponse(http.StatusBadRequest, fmt.Sprintf(api.ErrorInvalidRFC3339, queryParams["start"]), request), response)
 	} else if end, err := ParseTimeQueryParameter(queryParams, "end", defaultEnd); err != nil {
@@ -198,10 +209,21 @@ func (s *Resources) GetDataQualityStats(response http.ResponseWriter, request *h
 		api.WriteErrorResponse(ctx, api.BuildErrorResponse(http.StatusBadRequest, fmt.Sprintf(utils.ErrorInvalidLimit, queryParams["limit"]), request), response)
 	} else if skip, err := ParseSkipQueryParameter(queryParams, 0); err != nil {
 		api.WriteErrorResponse(ctx, api.BuildErrorResponse(http.StatusBadRequest, fmt.Sprintf(utils.ErrorInvalidSkip, queryParams["skip"]), request), response)
-	} else if stats, count, err := s.DB.GetDataQualityStats(ctx, toCreatedAtFilter(start, end), sort, skip, limit); err != nil {
-		api.HandleDatabaseError(request, response, err)
 	} else {
-		api.WriteResponseWrapperWithTimeWindowAndPagination(ctx, stats, start, end, limit, skip, count, http.StatusOK, response)
+		filters := model.Filters{
+			"environment_id": []model.Filter{{
+				Value:       environmentId,
+				Operator:    model.Equals,
+				SetOperator: model.FilterAnd,
+			}},
+			"created_at": []model.Filter{{Value: start.Format(time.RFC3339), Operator: model.GreaterThanOrEquals, SetOperator: model.FilterAnd}, {Value: end.Format(time.RFC3339), Operator: model.LessThanOrEquals, SetOperator: model.FilterAnd}},
+		}
+		if stats, count, err := s.DB.GetDataQualityStats(ctx, filters, sort, skip, limit); err != nil {
+			api.HandleDatabaseError(request, response, err)
+		} else {
+			api.WriteResponseWrapperWithTimeWindowAndPagination(ctx, stats, start, end, limit, skip, count, http.StatusOK, response)
+		}
+
 	}
 }
 
@@ -255,10 +277,4 @@ func parseOrder(queryParams url.Values, sortable Sortable) (string, model.Sort, 
 		}
 	}
 	return strings.Join(order, ", "), sort, nil
-}
-
-// toCreatedAtFilter transforms the given start and end time into database-compatible Filters.
-func toCreatedAtFilter(start, end time.Time) model.Filters {
-	return model.Filters{"created_at": []model.Filter{{Value: start.String(), Operator: model.GreaterThanOrEquals, SetOperator: model.FilterAnd}, {Value: end.String(), Operator: model.LessThanOrEquals, SetOperator: model.FilterAnd}}}
-
 }

--- a/cmd/api/src/api/v2/dataquality.go
+++ b/cmd/api/src/api/v2/dataquality.go
@@ -17,7 +17,6 @@
 package v2
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -36,7 +35,6 @@ import (
 	"github.com/specterops/bloodhound/packages/go/bhlog/measure"
 	"github.com/specterops/bloodhound/packages/go/graphschema"
 	"github.com/specterops/dawgs/graph"
-	"github.com/specterops/dawgs/query"
 )
 
 const (
@@ -195,10 +193,6 @@ func (s *Resources) GetDataQualityStats(response http.ResponseWriter, request *h
 		} else if !hasAccess {
 			api.WriteErrorResponse(ctx, api.BuildErrorResponse(http.StatusForbidden, ErrNoAccess, request), response)
 		}
-	} else if environmentExists, err := s.environmentIdExists(ctx, environmentId); err != nil {
-		api.WriteErrorResponse(ctx, api.BuildErrorResponse(http.StatusInternalServerError, err.Error(), request), response)
-	} else if !environmentExists {
-		api.WriteErrorResponse(ctx, api.BuildErrorResponse(http.StatusNotFound, ErrEnvironmentIdDoesNotExist, request), response)
 	} else if _, sort, err := parseOrder(queryParams, dataQualityStats); err != nil {
 		api.WriteErrorResponse(ctx, api.BuildErrorResponse(http.StatusBadRequest, err.Error(), request), response)
 	} else if start, err := ParseTimeQueryParameter(queryParams, "start", defaultStart); err != nil {
@@ -223,29 +217,7 @@ func (s *Resources) GetDataQualityStats(response http.ResponseWriter, request *h
 		} else {
 			api.WriteResponseWrapperWithTimeWindowAndPagination(ctx, stats, start, end, limit, skip, count, http.StatusOK, response)
 		}
-
 	}
-}
-
-func (s *Resources) environmentIdExists(ctx context.Context, environmentID string) (bool, error) {
-	var exists bool
-
-	err := s.Graph.ReadTransaction(ctx, func(tx graph.Transaction) error {
-		count, err := tx.Nodes().Filterf(func() graph.Criteria {
-			return query.Equals(
-				query.NodeProperty(graphschema.EnvironmentIDKey),
-				environmentID,
-			)
-		}).Count()
-		if err != nil {
-			return err
-		}
-
-		exists = count > 0
-		return nil
-	})
-
-	return exists, err
 }
 
 type Sortable interface {

--- a/cmd/api/src/api/v2/dataquality_test.go
+++ b/cmd/api/src/api/v2/dataquality_test.go
@@ -38,7 +38,6 @@ import (
 	"github.com/specterops/bloodhound/cmd/api/src/database/mocks"
 	"github.com/specterops/bloodhound/cmd/api/src/model"
 	"github.com/specterops/bloodhound/cmd/api/src/services/dogtags"
-	"github.com/specterops/bloodhound/packages/go/graphschema"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -565,7 +564,7 @@ func TestGetDataQualityStats_Failure(t *testing.T) {
 			Name: "UnknownUser",
 			Input: Input{
 				Params: url.Values{
-					graphschema.EnvironmentIDKey: []string{environmentID},
+					api.QueryParameterEnvironmentId: []string{environmentID},
 				},
 				Context: context.Background(),
 			},
@@ -579,7 +578,7 @@ func TestGetDataQualityStats_Failure(t *testing.T) {
 			Name: "CheckUserETACAccessError",
 			Input: Input{
 				Params: url.Values{
-					graphschema.EnvironmentIDKey: []string{environmentID},
+					api.QueryParameterEnvironmentId: []string{environmentID},
 				},
 				Context: userCtx,
 			},
@@ -604,7 +603,7 @@ func TestGetDataQualityStats_Failure(t *testing.T) {
 			Name: "NoEnvironmentAccess",
 			Input: Input{
 				Params: url.Values{
-					graphschema.EnvironmentIDKey: []string{environmentID},
+					api.QueryParameterEnvironmentId: []string{environmentID},
 				},
 				Context: userCtx,
 			},
@@ -631,7 +630,7 @@ func TestGetDataQualityStats_Failure(t *testing.T) {
 			Name: "EnvironmentIDNotFound",
 			Input: Input{
 				Params: url.Values{
-					graphschema.EnvironmentIDKey: []string{environmentID},
+					api.QueryParameterEnvironmentId: []string{environmentID},
 				},
 				Context: userCtx,
 			},
@@ -649,8 +648,8 @@ func TestGetDataQualityStats_Failure(t *testing.T) {
 			Name: "NonSortableColumn",
 			Input: Input{
 				Params: url.Values{
-					graphschema.EnvironmentIDKey: []string{environmentID},
-					"sort_by":                    []string{"metric_name"},
+					api.QueryParameterEnvironmentId: []string{environmentID},
+					"sort_by":                       []string{"metric_name"},
 				},
 				Context: userCtx,
 			},
@@ -666,8 +665,8 @@ func TestGetDataQualityStats_Failure(t *testing.T) {
 			Name: "EmptySortByParameter",
 			Input: Input{
 				Params: url.Values{
-					graphschema.EnvironmentIDKey: []string{environmentID},
-					"sort_by":                    []string{""},
+					api.QueryParameterEnvironmentId: []string{environmentID},
+					"sort_by":                       []string{""},
 				},
 				Context: userCtx,
 			},
@@ -683,8 +682,8 @@ func TestGetDataQualityStats_Failure(t *testing.T) {
 			Name: "InvalidStartTime",
 			Input: Input{
 				Params: url.Values{
-					graphschema.EnvironmentIDKey: []string{environmentID},
-					"start":                      []string{"invalidRFC3339"},
+					api.QueryParameterEnvironmentId: []string{environmentID},
+					"start":                         []string{"invalidRFC3339"},
 				},
 				Context: userCtx,
 			},
@@ -700,8 +699,8 @@ func TestGetDataQualityStats_Failure(t *testing.T) {
 			Name: "InvalidEndTime",
 			Input: Input{
 				Params: url.Values{
-					graphschema.EnvironmentIDKey: []string{environmentID},
-					"end":                        []string{"invalidRFC3339"},
+					api.QueryParameterEnvironmentId: []string{environmentID},
+					"end":                           []string{"invalidRFC3339"},
 				},
 				Context: userCtx,
 			},
@@ -717,8 +716,8 @@ func TestGetDataQualityStats_Failure(t *testing.T) {
 			Name: "InvalidLimit",
 			Input: Input{
 				Params: url.Values{
-					graphschema.EnvironmentIDKey: []string{environmentID},
-					"limit":                      []string{"invalidLimit"},
+					api.QueryParameterEnvironmentId: []string{environmentID},
+					"limit":                         []string{"invalidLimit"},
 				},
 				Context: userCtx,
 			},
@@ -734,8 +733,8 @@ func TestGetDataQualityStats_Failure(t *testing.T) {
 			Name: "InvalidSkip",
 			Input: Input{
 				Params: url.Values{
-					graphschema.EnvironmentIDKey: []string{environmentID},
-					"skip":                       []string{"invalidSkip"},
+					api.QueryParameterEnvironmentId: []string{environmentID},
+					"skip":                          []string{"invalidSkip"},
 				},
 				Context: userCtx,
 			},
@@ -751,7 +750,7 @@ func TestGetDataQualityStats_Failure(t *testing.T) {
 			Name: "DatabaseError",
 			Input: Input{
 				Params: url.Values{
-					graphschema.EnvironmentIDKey: []string{environmentID},
+					api.QueryParameterEnvironmentId: []string{environmentID},
 				},
 				Context: userCtx,
 			},
@@ -834,12 +833,12 @@ func TestGetDataQualityStats_Success(t *testing.T) {
 			Name: "AllQueryParams",
 			Input: Input{
 				Params: url.Values{
-					graphschema.EnvironmentIDKey: []string{environmentID},
-					"sort_by":                    []string{"-updated_at"},
-					"limit":                      []string{"1"},
-					"start":                      []string{"2022-03-23T07:20:50.52Z"},
-					"end":                        []string{"2022-04-23T07:20:50.52Z"},
-					"skip":                       []string{"0"},
+					api.QueryParameterEnvironmentId: []string{environmentID},
+					"sort_by":                       []string{"-updated_at"},
+					"limit":                         []string{"1"},
+					"start":                         []string{"2022-03-23T07:20:50.52Z"},
+					"end":                           []string{"2022-04-23T07:20:50.52Z"},
+					"skip":                          []string{"0"},
 				},
 			},
 			Expected: Expected{
@@ -850,8 +849,8 @@ func TestGetDataQualityStats_Success(t *testing.T) {
 			Name: "SortByUpdatedAtAscending",
 			Input: Input{
 				Params: url.Values{
-					graphschema.EnvironmentIDKey: []string{environmentID},
-					"sort_by":                    []string{"updated_at"},
+					api.QueryParameterEnvironmentId: []string{environmentID},
+					"sort_by":                       []string{"updated_at"},
 				},
 			},
 			Expected: Expected{
@@ -862,8 +861,8 @@ func TestGetDataQualityStats_Success(t *testing.T) {
 			Name: "SortByCreatedAtAscending",
 			Input: Input{
 				Params: url.Values{
-					graphschema.EnvironmentIDKey: []string{environmentID},
-					"sort_by":                    []string{"created_at"},
+					api.QueryParameterEnvironmentId: []string{environmentID},
+					"sort_by":                       []string{"created_at"},
 				},
 			},
 			Expected: Expected{
@@ -874,8 +873,8 @@ func TestGetDataQualityStats_Success(t *testing.T) {
 			Name: "SortByCreatedAtDescending",
 			Input: Input{
 				Params: url.Values{
-					graphschema.EnvironmentIDKey: []string{environmentID},
-					"sort_by":                    []string{"-created_at"},
+					api.QueryParameterEnvironmentId: []string{environmentID},
+					"sort_by":                       []string{"-created_at"},
 				},
 			},
 			Expected: Expected{
@@ -886,8 +885,8 @@ func TestGetDataQualityStats_Success(t *testing.T) {
 			Name: "StartTime",
 			Input: Input{
 				Params: url.Values{
-					graphschema.EnvironmentIDKey: []string{environmentID},
-					"start":                      []string{"2022-03-23T07:20:50.52Z"},
+					api.QueryParameterEnvironmentId: []string{environmentID},
+					"start":                         []string{"2022-03-23T07:20:50.52Z"},
 				},
 			},
 			Expected: Expected{
@@ -898,8 +897,8 @@ func TestGetDataQualityStats_Success(t *testing.T) {
 			Name: "EndTime",
 			Input: Input{
 				Params: url.Values{
-					graphschema.EnvironmentIDKey: []string{environmentID},
-					"end":                        []string{"2022-04-23T07:20:50.52Z"},
+					api.QueryParameterEnvironmentId: []string{environmentID},
+					"end":                           []string{"2022-04-23T07:20:50.52Z"},
 				},
 			},
 			Expected: Expected{
@@ -910,8 +909,8 @@ func TestGetDataQualityStats_Success(t *testing.T) {
 			Name: "Limit",
 			Input: Input{
 				Params: url.Values{
-					graphschema.EnvironmentIDKey: []string{environmentID},
-					"limit":                      []string{"2"},
+					api.QueryParameterEnvironmentId: []string{environmentID},
+					"limit":                         []string{"2"},
 				},
 			},
 			Expected: Expected{
@@ -922,8 +921,8 @@ func TestGetDataQualityStats_Success(t *testing.T) {
 			Name: "Skip",
 			Input: Input{
 				Params: url.Values{
-					graphschema.EnvironmentIDKey: []string{environmentID},
-					"skip":                       []string{"1"},
+					api.QueryParameterEnvironmentId: []string{environmentID},
+					"skip":                          []string{"1"},
 				},
 			},
 			Expected: Expected{
@@ -934,7 +933,7 @@ func TestGetDataQualityStats_Success(t *testing.T) {
 			Name: "DefaultOptionalParams",
 			Input: Input{
 				Params: url.Values{
-					graphschema.EnvironmentIDKey: []string{environmentID},
+					api.QueryParameterEnvironmentId: []string{environmentID},
 				},
 			},
 			Expected: Expected{
@@ -945,7 +944,7 @@ func TestGetDataQualityStats_Success(t *testing.T) {
 			Name: "ETACDisabledSkipsAccessCheck",
 			Input: Input{
 				Params: url.Values{
-					graphschema.EnvironmentIDKey: []string{environmentID},
+					api.QueryParameterEnvironmentId: []string{environmentID},
 				},
 			},
 			Expected: Expected{
@@ -956,7 +955,7 @@ func TestGetDataQualityStats_Success(t *testing.T) {
 			Name: "ETACEnabledWithAllEnvironmentsSkipsAccessCheck",
 			Input: Input{
 				Params: url.Values{
-					graphschema.EnvironmentIDKey: []string{environmentID},
+					api.QueryParameterEnvironmentId: []string{environmentID},
 				},
 				User: func() model.User {
 					user := setupUser()
@@ -973,7 +972,7 @@ func TestGetDataQualityStats_Success(t *testing.T) {
 			Name: "ETACEnabledWithEnvironmentAccessChecksAccessThenFetchesStats",
 			Input: Input{
 				Params: url.Values{
-					graphschema.EnvironmentIDKey: []string{environmentID},
+					api.QueryParameterEnvironmentId: []string{environmentID},
 				},
 				DogTagsOverrides: etacEnabled,
 			},

--- a/cmd/api/src/api/v2/dataquality_test.go
+++ b/cmd/api/src/api/v2/dataquality_test.go
@@ -791,10 +791,16 @@ func TestGetDataQualityStats_Failure(t *testing.T) {
 func TestGetDataQualityStats_Success(t *testing.T) {
 	environmentID := "environment-1"
 	endpoint := "/api/v2/data-quality-stats%s"
-	userCtx := setupUserCtx(setupUser())
+	etacEnabled := dogtags.TestOverrides{
+		Bools: map[dogtags.BoolDogTag]bool{
+			dogtags.ETAC_ENABLED: true,
+		},
+	}
 
 	type Input struct {
-		Params url.Values
+		Params           url.Values
+		User             model.User
+		DogTagsOverrides dogtags.TestOverrides
 	}
 
 	type Expected struct {
@@ -804,6 +810,7 @@ func TestGetDataQualityStats_Success(t *testing.T) {
 	var cases = []struct {
 		Name     string
 		Input    Input
+		Setup    func(mockDB *mocks.MockDatabase, user model.User)
 		Expected Expected
 	}{
 		{
@@ -917,6 +924,53 @@ func TestGetDataQualityStats_Success(t *testing.T) {
 				Code: http.StatusOK,
 			},
 		},
+		{
+			Name: "ETACDisabledSkipsAccessCheck",
+			Input: Input{
+				Params: url.Values{
+					graphschema.EnvironmentIDKey: []string{environmentID},
+				},
+			},
+			Expected: Expected{
+				Code: http.StatusOK,
+			},
+		},
+		{
+			Name: "ETACEnabledWithAllEnvironmentsSkipsAccessCheck",
+			Input: Input{
+				Params: url.Values{
+					graphschema.EnvironmentIDKey: []string{environmentID},
+				},
+				User: func() model.User {
+					user := setupUser()
+					user.AllEnvironments = true
+					return user
+				}(),
+				DogTagsOverrides: etacEnabled,
+			},
+			Expected: Expected{
+				Code: http.StatusOK,
+			},
+		},
+		{
+			Name: "ETACEnabledWithEnvironmentAccessChecksAccessThenFetchesStats",
+			Input: Input{
+				Params: url.Values{
+					graphschema.EnvironmentIDKey: []string{environmentID},
+				},
+				DogTagsOverrides: etacEnabled,
+			},
+			Setup: func(mockDB *mocks.MockDatabase, user model.User) {
+				successfulAccessCheck := mockDB.EXPECT().GetEnvironmentTargetedAccessControlForUser(gomock.Any(), user).Return([]model.EnvironmentTargetedAccessControl{
+					{EnvironmentID: environmentID},
+				}, nil).Times(1)
+				successfulStatsFetch := mockDB.EXPECT().GetDataQualityStats(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(model.DataQualityStats{}, 0, nil).Times(1)
+				gomock.InOrder(successfulAccessCheck, successfulStatsFetch)
+			},
+			Expected: Expected{
+				Code: http.StatusOK,
+			},
+		},
 	}
 
 	for _, tc := range cases {
@@ -924,17 +978,26 @@ func TestGetDataQualityStats_Success(t *testing.T) {
 			mockCtrl := gomock.NewController(t)
 			defer mockCtrl.Finish()
 
+			user := tc.Input.User
+			if user.PrincipalName == "" {
+				user = setupUser()
+			}
+
 			mockDB := mocks.NewMockDatabase(mockCtrl)
-			mockDB.EXPECT().GetDataQualityStats(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(model.DataQualityStats{}, 0, nil)
+			if tc.Setup == nil {
+				mockDB.EXPECT().GetDataQualityStats(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(model.DataQualityStats{}, 0, nil).Times(1)
+			} else {
+				tc.Setup(mockDB, user)
+			}
 
 			resources := v2.Resources{
 				DB:      mockDB,
-				DogTags: dogtags.NewTestService(dogtags.TestOverrides{}),
+				DogTags: dogtags.NewTestService(tc.Input.DogTagsOverrides),
 			}
 			params := fmt.Sprintf("?%s", tc.Input.Params.Encode())
 			req, err := http.NewRequest("GET", fmt.Sprintf(endpoint, params), nil)
 			require.NoError(t, err)
-			req = req.WithContext(userCtx)
+			req = req.WithContext(setupUserCtx(user))
 
 			router := mux.NewRouter()
 			router.HandleFunc("/api/v2/data-quality-stats", resources.GetDataQualityStats).Methods("GET")

--- a/cmd/api/src/api/v2/dataquality_test.go
+++ b/cmd/api/src/api/v2/dataquality_test.go
@@ -17,6 +17,7 @@
 package v2_test
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -35,6 +36,9 @@ import (
 	v2 "github.com/specterops/bloodhound/cmd/api/src/api/v2"
 	"github.com/specterops/bloodhound/cmd/api/src/database/mocks"
 	"github.com/specterops/bloodhound/cmd/api/src/model"
+	"github.com/specterops/bloodhound/cmd/api/src/services/dogtags"
+	"github.com/specterops/bloodhound/packages/go/graphschema"
+	"github.com/specterops/dawgs/graph"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -514,6 +518,509 @@ func TestGetAzureDataQualityStats_Success(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestGetDataQualityStats_Failure(t *testing.T) {
+	environmentID := "environment-1"
+	endpoint := "/api/v2/data-quality-stats%s"
+	user := setupUser()
+	userCtx := setupUserCtx(user)
+	etacError := errors.New("etac error")
+	graphError := errors.New("graph error")
+
+	type Input struct {
+		Params  url.Values
+		Context context.Context
+	}
+
+	type mockResources struct {
+		Database *mocks.MockDatabase
+		Graph    *graphmocks.MockDatabase
+	}
+
+	expectEnvironmentIDExists := func(mockCtrl *gomock.Controller, mockGraph *graphmocks.MockDatabase, exists bool) {
+		var count int64
+		if exists {
+			count = 1
+		}
+
+		mockTransaction := graphmocks.NewMockTransaction(mockCtrl)
+		mockNodeQuery := graphmocks.NewMockNodeQuery(mockCtrl)
+		mockFilteredNodeQuery := graphmocks.NewMockNodeQuery(mockCtrl)
+
+		mockGraph.EXPECT().ReadTransaction(gomock.Any(), gomock.Any()).DoAndReturn(
+			func(ctx context.Context, txDelegate graph.TransactionDelegate, options ...graph.TransactionOption) error {
+				return txDelegate(mockTransaction)
+			},
+		)
+		mockTransaction.EXPECT().Nodes().Return(mockNodeQuery)
+		mockNodeQuery.EXPECT().Filterf(gomock.Any()).Return(mockFilteredNodeQuery)
+		mockFilteredNodeQuery.EXPECT().Count().Return(count, nil)
+	}
+
+	defaultResources := func(mockCtrl *gomock.Controller, mock mockResources) v2.Resources {
+		return v2.Resources{
+			DB:      mock.Database,
+			Graph:   mock.Graph,
+			DogTags: dogtags.NewTestService(dogtags.TestOverrides{}),
+		}
+	}
+
+	var cases = []struct {
+		Name     string
+		Input    Input
+		Setup    func(mockCtrl *gomock.Controller, mock mockResources) v2.Resources
+		Expected api.ErrorWrapper
+	}{
+		{
+			Name: "NoEnvironmentID",
+			Input: Input{
+				Params:  url.Values{},
+				Context: userCtx,
+			},
+			Setup: defaultResources,
+			Expected: api.ErrorWrapper{
+				HTTPStatus: http.StatusBadRequest,
+				Errors:     []api.ErrorDetails{{Message: v2.ErrNoEnvironmentId}},
+			},
+		},
+		{
+			Name: "UnknownUser",
+			Input: Input{
+				Params: url.Values{
+					graphschema.EnvironmentIDKey: []string{environmentID},
+				},
+				Context: context.Background(),
+			},
+			Setup: defaultResources,
+			Expected: api.ErrorWrapper{
+				HTTPStatus: http.StatusInternalServerError,
+				Errors:     []api.ErrorDetails{{Message: v2.ErrUnknownUser}},
+			},
+		},
+		{
+			Name: "CheckUserETACAccessError",
+			Input: Input{
+				Params: url.Values{
+					graphschema.EnvironmentIDKey: []string{environmentID},
+				},
+				Context: userCtx,
+			},
+			Setup: func(mockCtrl *gomock.Controller, mock mockResources) v2.Resources {
+				mock.Database.EXPECT().GetEnvironmentTargetedAccessControlForUser(gomock.Any(), user).Return(nil, etacError)
+
+				return v2.Resources{
+					DB:    mock.Database,
+					Graph: mock.Graph,
+					DogTags: dogtags.NewTestService(dogtags.TestOverrides{
+						Bools: map[dogtags.BoolDogTag]bool{
+							dogtags.ETAC_ENABLED: true,
+						},
+					}),
+				}
+			},
+			Expected: api.ErrorWrapper{
+				HTTPStatus: http.StatusInternalServerError,
+				Errors:     []api.ErrorDetails{{Message: etacError.Error()}},
+			},
+		},
+		{
+			Name: "NoEnvironmentAccess",
+			Input: Input{
+				Params: url.Values{
+					graphschema.EnvironmentIDKey: []string{environmentID},
+				},
+				Context: userCtx,
+			},
+			Setup: func(mockCtrl *gomock.Controller, mock mockResources) v2.Resources {
+				mock.Database.EXPECT().GetEnvironmentTargetedAccessControlForUser(gomock.Any(), user).Return([]model.EnvironmentTargetedAccessControl{
+					{EnvironmentID: "other-environment"},
+				}, nil)
+
+				return v2.Resources{
+					DB:    mock.Database,
+					Graph: mock.Graph,
+					DogTags: dogtags.NewTestService(dogtags.TestOverrides{
+						Bools: map[dogtags.BoolDogTag]bool{
+							dogtags.ETAC_ENABLED: true,
+						},
+					}),
+				}
+			},
+			Expected: api.ErrorWrapper{
+				HTTPStatus: http.StatusForbidden,
+				Errors:     []api.ErrorDetails{{Message: v2.ErrNoAccess}},
+			},
+		},
+		{
+			Name: "EnvironmentIDGraphError",
+			Input: Input{
+				Params: url.Values{
+					graphschema.EnvironmentIDKey: []string{environmentID},
+				},
+				Context: userCtx,
+			},
+			Setup: func(mockCtrl *gomock.Controller, mock mockResources) v2.Resources {
+				mock.Graph.EXPECT().ReadTransaction(gomock.Any(), gomock.Any()).Return(graphError)
+
+				return defaultResources(mockCtrl, mock)
+			},
+			Expected: api.ErrorWrapper{
+				HTTPStatus: http.StatusInternalServerError,
+				Errors:     []api.ErrorDetails{{Message: graphError.Error()}},
+			},
+		},
+		{
+			Name: "EnvironmentIDNotFound",
+			Input: Input{
+				Params: url.Values{
+					graphschema.EnvironmentIDKey: []string{environmentID},
+				},
+				Context: userCtx,
+			},
+			Setup: func(mockCtrl *gomock.Controller, mock mockResources) v2.Resources {
+				expectEnvironmentIDExists(mockCtrl, mock.Graph, false)
+
+				return defaultResources(mockCtrl, mock)
+			},
+			Expected: api.ErrorWrapper{
+				HTTPStatus: http.StatusNotFound,
+				Errors:     []api.ErrorDetails{{Message: v2.ErrEnvironmentIdDoesNotExist}},
+			},
+		},
+		{
+			Name: "NonSortableColumn",
+			Input: Input{
+				Params: url.Values{
+					graphschema.EnvironmentIDKey: []string{environmentID},
+					"sort_by":                    []string{"metric_name"},
+				},
+				Context: userCtx,
+			},
+			Setup: func(mockCtrl *gomock.Controller, mock mockResources) v2.Resources {
+				expectEnvironmentIDExists(mockCtrl, mock.Graph, true)
+
+				return defaultResources(mockCtrl, mock)
+			},
+			Expected: api.ErrorWrapper{
+				HTTPStatus: http.StatusBadRequest,
+				Errors:     []api.ErrorDetails{{Message: api.ErrorResponseDetailsNotSortable}},
+			},
+		},
+		{
+			Name: "InvalidStartTime",
+			Input: Input{
+				Params: url.Values{
+					graphschema.EnvironmentIDKey: []string{environmentID},
+					"start":                      []string{"invalidRFC3339"},
+				},
+				Context: userCtx,
+			},
+			Setup: func(mockCtrl *gomock.Controller, mock mockResources) v2.Resources {
+				expectEnvironmentIDExists(mockCtrl, mock.Graph, true)
+
+				return defaultResources(mockCtrl, mock)
+			},
+			Expected: api.ErrorWrapper{
+				HTTPStatus: http.StatusBadRequest,
+				Errors:     []api.ErrorDetails{{Message: fmt.Sprintf(api.ErrorInvalidRFC3339, []string{"invalidRFC3339"})}},
+			},
+		},
+		{
+			Name: "InvalidEndTime",
+			Input: Input{
+				Params: url.Values{
+					graphschema.EnvironmentIDKey: []string{environmentID},
+					"end":                        []string{"invalidRFC3339"},
+				},
+				Context: userCtx,
+			},
+			Setup: func(mockCtrl *gomock.Controller, mock mockResources) v2.Resources {
+				expectEnvironmentIDExists(mockCtrl, mock.Graph, true)
+
+				return defaultResources(mockCtrl, mock)
+			},
+			Expected: api.ErrorWrapper{
+				HTTPStatus: http.StatusBadRequest,
+				Errors:     []api.ErrorDetails{{Message: fmt.Sprintf(api.ErrorInvalidRFC3339, []string{"invalidRFC3339"})}},
+			},
+		},
+		{
+			Name: "InvalidLimit",
+			Input: Input{
+				Params: url.Values{
+					graphschema.EnvironmentIDKey: []string{environmentID},
+					"limit":                      []string{"invalidLimit"},
+				},
+				Context: userCtx,
+			},
+			Setup: func(mockCtrl *gomock.Controller, mock mockResources) v2.Resources {
+				expectEnvironmentIDExists(mockCtrl, mock.Graph, true)
+
+				return defaultResources(mockCtrl, mock)
+			},
+			Expected: api.ErrorWrapper{
+				HTTPStatus: http.StatusBadRequest,
+				Errors:     []api.ErrorDetails{{Message: fmt.Sprintf(utils.ErrorInvalidLimit, []string{"invalidLimit"})}},
+			},
+		},
+		{
+			Name: "InvalidSkip",
+			Input: Input{
+				Params: url.Values{
+					graphschema.EnvironmentIDKey: []string{environmentID},
+					"skip":                       []string{"invalidSkip"},
+				},
+				Context: userCtx,
+			},
+			Setup: func(mockCtrl *gomock.Controller, mock mockResources) v2.Resources {
+				expectEnvironmentIDExists(mockCtrl, mock.Graph, true)
+
+				return defaultResources(mockCtrl, mock)
+			},
+			Expected: api.ErrorWrapper{
+				HTTPStatus: http.StatusBadRequest,
+				Errors:     []api.ErrorDetails{{Message: fmt.Sprintf(utils.ErrorInvalidSkip, []string{"invalidSkip"})}},
+			},
+		},
+		{
+			Name: "DatabaseError",
+			Input: Input{
+				Params: url.Values{
+					graphschema.EnvironmentIDKey: []string{environmentID},
+				},
+				Context: userCtx,
+			},
+			Setup: func(mockCtrl *gomock.Controller, mock mockResources) v2.Resources {
+				expectEnvironmentIDExists(mockCtrl, mock.Graph, true)
+				mock.Database.EXPECT().GetDataQualityStats(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(model.DataQualityStats{}, 0, fmt.Errorf("db error"))
+
+				return defaultResources(mockCtrl, mock)
+			},
+			Expected: api.ErrorWrapper{
+				HTTPStatus: http.StatusInternalServerError,
+				Errors:     []api.ErrorDetails{{Message: api.ErrorResponseDetailsInternalServerError}},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+
+			mock := mockResources{
+				Database: mocks.NewMockDatabase(mockCtrl),
+				Graph:    graphmocks.NewMockDatabase(mockCtrl),
+			}
+			resources := tc.Setup(mockCtrl, mock)
+			params := fmt.Sprintf("?%s", tc.Input.Params.Encode())
+			req, err := http.NewRequest("GET", fmt.Sprintf(endpoint, params), nil)
+			require.NoError(t, err)
+			req = req.WithContext(tc.Input.Context)
+
+			router := mux.NewRouter()
+			router.HandleFunc("/api/v2/data-quality-stats", resources.GetDataQualityStats).Methods("GET")
+
+			rr := httptest.NewRecorder()
+			router.ServeHTTP(rr, req)
+
+			if status := rr.Code; status != tc.Expected.HTTPStatus {
+				t.Errorf("handler returned wrong status code: got %v want %v", status, tc.Expected.HTTPStatus)
+			}
+
+			var body any
+			if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+				t.Fatal("failed to unmarshal response body")
+			}
+
+			require.Equal(t, len(tc.Expected.Errors), 1)
+			if !reflect.DeepEqual(body.(map[string]any)["errors"].([]any)[0].(map[string]any)["message"], tc.Expected.Errors[0].Message) {
+				t.Errorf("For input: %v, got %v, want %v", tc.Input, body, tc.Expected.Errors[0].Message)
+			}
+		})
+	}
+
+}
+
+func TestGetDataQualityStats_Success(t *testing.T) {
+	environmentID := "environment-1"
+	endpoint := "/api/v2/data-quality-stats%s"
+	userCtx := setupUserCtx(setupUser())
+
+	type Input struct {
+		Params url.Values
+	}
+
+	type Expected struct {
+		Code int
+	}
+
+	expectEnvironmentIDExists := func(mockCtrl *gomock.Controller, mockGraph *graphmocks.MockDatabase) {
+		mockTransaction := graphmocks.NewMockTransaction(mockCtrl)
+		mockNodeQuery := graphmocks.NewMockNodeQuery(mockCtrl)
+		mockFilteredNodeQuery := graphmocks.NewMockNodeQuery(mockCtrl)
+
+		mockGraph.EXPECT().ReadTransaction(gomock.Any(), gomock.Any()).DoAndReturn(
+			func(ctx context.Context, txDelegate graph.TransactionDelegate, options ...graph.TransactionOption) error {
+				return txDelegate(mockTransaction)
+			},
+		)
+		mockTransaction.EXPECT().Nodes().Return(mockNodeQuery)
+		mockNodeQuery.EXPECT().Filterf(gomock.Any()).Return(mockFilteredNodeQuery)
+		mockFilteredNodeQuery.EXPECT().Count().Return(int64(1), nil)
+	}
+
+	var cases = []struct {
+		Name     string
+		Input    Input
+		Expected Expected
+	}{
+		{
+			Name: "AllQueryParams",
+			Input: Input{
+				Params: url.Values{
+					graphschema.EnvironmentIDKey: []string{environmentID},
+					"sort_by":                    []string{"-updated_at"},
+					"limit":                      []string{"1"},
+					"start":                      []string{"2022-03-23T07:20:50.52Z"},
+					"end":                        []string{"2022-04-23T07:20:50.52Z"},
+					"skip":                       []string{"0"},
+				},
+			},
+			Expected: Expected{
+				Code: http.StatusOK,
+			},
+		},
+		{
+			Name: "SortByUpdatedAtAscending",
+			Input: Input{
+				Params: url.Values{
+					graphschema.EnvironmentIDKey: []string{environmentID},
+					"sort_by":                    []string{"updated_at"},
+				},
+			},
+			Expected: Expected{
+				Code: http.StatusOK,
+			},
+		},
+		{
+			Name: "SortByCreatedAtAscending",
+			Input: Input{
+				Params: url.Values{
+					graphschema.EnvironmentIDKey: []string{environmentID},
+					"sort_by":                    []string{"created_at"},
+				},
+			},
+			Expected: Expected{
+				Code: http.StatusOK,
+			},
+		},
+		{
+			Name: "SortByCreatedAtDescending",
+			Input: Input{
+				Params: url.Values{
+					graphschema.EnvironmentIDKey: []string{environmentID},
+					"sort_by":                    []string{"-created_at"},
+				},
+			},
+			Expected: Expected{
+				Code: http.StatusOK,
+			},
+		},
+		{
+			Name: "StartTime",
+			Input: Input{
+				Params: url.Values{
+					graphschema.EnvironmentIDKey: []string{environmentID},
+					"start":                      []string{"2022-03-23T07:20:50.52Z"},
+				},
+			},
+			Expected: Expected{
+				Code: http.StatusOK,
+			},
+		},
+		{
+			Name: "EndTime",
+			Input: Input{
+				Params: url.Values{
+					graphschema.EnvironmentIDKey: []string{environmentID},
+					"end":                        []string{"2022-04-23T07:20:50.52Z"},
+				},
+			},
+			Expected: Expected{
+				Code: http.StatusOK,
+			},
+		},
+		{
+			Name: "Limit",
+			Input: Input{
+				Params: url.Values{
+					graphschema.EnvironmentIDKey: []string{environmentID},
+					"limit":                      []string{"2"},
+				},
+			},
+			Expected: Expected{
+				Code: http.StatusOK,
+			},
+		},
+		{
+			Name: "Skip",
+			Input: Input{
+				Params: url.Values{
+					graphschema.EnvironmentIDKey: []string{environmentID},
+					"skip":                       []string{"1"},
+				},
+			},
+			Expected: Expected{
+				Code: http.StatusOK,
+			},
+		},
+		{
+			Name: "DefaultOptionalParams",
+			Input: Input{
+				Params: url.Values{
+					graphschema.EnvironmentIDKey: []string{environmentID},
+				},
+			},
+			Expected: Expected{
+				Code: http.StatusOK,
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+
+			mockDB := mocks.NewMockDatabase(mockCtrl)
+			mockGraph := graphmocks.NewMockDatabase(mockCtrl)
+			expectEnvironmentIDExists(mockCtrl, mockGraph)
+			mockDB.EXPECT().GetDataQualityStats(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(model.DataQualityStats{}, 0, nil)
+
+			resources := v2.Resources{
+				DB:      mockDB,
+				Graph:   mockGraph,
+				DogTags: dogtags.NewTestService(dogtags.TestOverrides{}),
+			}
+			params := fmt.Sprintf("?%s", tc.Input.Params.Encode())
+			req, err := http.NewRequest("GET", fmt.Sprintf(endpoint, params), nil)
+			require.NoError(t, err)
+			req = req.WithContext(userCtx)
+
+			router := mux.NewRouter()
+			router.HandleFunc("/api/v2/data-quality-stats", resources.GetDataQualityStats).Methods("GET")
+
+			rr := httptest.NewRecorder()
+			router.ServeHTTP(rr, req)
+
+			if status := rr.Code; status != tc.Expected.Code {
+				t.Errorf("handler returned wrong status code: got %v want %v", status, tc.Expected.Code)
+			}
+		})
+	}
+
 }
 
 func TestGetPlatformAggregateStats_Failure(t *testing.T) {

--- a/cmd/api/src/api/v2/dataquality_test.go
+++ b/cmd/api/src/api/v2/dataquality_test.go
@@ -663,6 +663,23 @@ func TestGetDataQualityStats_Failure(t *testing.T) {
 			},
 		},
 		{
+			Name: "EmptySortByParameter",
+			Input: Input{
+				Params: url.Values{
+					graphschema.EnvironmentIDKey: []string{environmentID},
+					"sort_by":                    []string{""},
+				},
+				Context: userCtx,
+			},
+			Setup: func(mockCtrl *gomock.Controller, mock mockResources) v2.Resources {
+				return defaultResources(mockCtrl, mock)
+			},
+			Expected: api.ErrorWrapper{
+				HTTPStatus: http.StatusBadRequest,
+				Errors:     []api.ErrorDetails{{Message: api.ErrorResponseEmptySortParameter}},
+			},
+		},
+		{
 			Name: "InvalidStartTime",
 			Input: Input{
 				Params: url.Values{

--- a/cmd/api/src/api/v2/dataquality_test.go
+++ b/cmd/api/src/api/v2/dataquality_test.go
@@ -34,11 +34,11 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/specterops/bloodhound/cmd/api/src/api"
 	v2 "github.com/specterops/bloodhound/cmd/api/src/api/v2"
+	"github.com/specterops/bloodhound/cmd/api/src/database"
 	"github.com/specterops/bloodhound/cmd/api/src/database/mocks"
 	"github.com/specterops/bloodhound/cmd/api/src/model"
 	"github.com/specterops/bloodhound/cmd/api/src/services/dogtags"
 	"github.com/specterops/bloodhound/packages/go/graphschema"
-	"github.com/specterops/dawgs/graph"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -526,7 +526,6 @@ func TestGetDataQualityStats_Failure(t *testing.T) {
 	user := setupUser()
 	userCtx := setupUserCtx(user)
 	etacError := errors.New("etac error")
-	graphError := errors.New("graph error")
 
 	type Input struct {
 		Params  url.Values
@@ -535,33 +534,11 @@ func TestGetDataQualityStats_Failure(t *testing.T) {
 
 	type mockResources struct {
 		Database *mocks.MockDatabase
-		Graph    *graphmocks.MockDatabase
-	}
-
-	expectEnvironmentIDExists := func(mockCtrl *gomock.Controller, mockGraph *graphmocks.MockDatabase, exists bool) {
-		var count int64
-		if exists {
-			count = 1
-		}
-
-		mockTransaction := graphmocks.NewMockTransaction(mockCtrl)
-		mockNodeQuery := graphmocks.NewMockNodeQuery(mockCtrl)
-		mockFilteredNodeQuery := graphmocks.NewMockNodeQuery(mockCtrl)
-
-		mockGraph.EXPECT().ReadTransaction(gomock.Any(), gomock.Any()).DoAndReturn(
-			func(ctx context.Context, txDelegate graph.TransactionDelegate, options ...graph.TransactionOption) error {
-				return txDelegate(mockTransaction)
-			},
-		)
-		mockTransaction.EXPECT().Nodes().Return(mockNodeQuery)
-		mockNodeQuery.EXPECT().Filterf(gomock.Any()).Return(mockFilteredNodeQuery)
-		mockFilteredNodeQuery.EXPECT().Count().Return(count, nil)
 	}
 
 	defaultResources := func(mockCtrl *gomock.Controller, mock mockResources) v2.Resources {
 		return v2.Resources{
 			DB:      mock.Database,
-			Graph:   mock.Graph,
 			DogTags: dogtags.NewTestService(dogtags.TestOverrides{}),
 		}
 	}
@@ -610,8 +587,7 @@ func TestGetDataQualityStats_Failure(t *testing.T) {
 				mock.Database.EXPECT().GetEnvironmentTargetedAccessControlForUser(gomock.Any(), user).Return(nil, etacError)
 
 				return v2.Resources{
-					DB:    mock.Database,
-					Graph: mock.Graph,
+					DB: mock.Database,
 					DogTags: dogtags.NewTestService(dogtags.TestOverrides{
 						Bools: map[dogtags.BoolDogTag]bool{
 							dogtags.ETAC_ENABLED: true,
@@ -638,8 +614,7 @@ func TestGetDataQualityStats_Failure(t *testing.T) {
 				}, nil)
 
 				return v2.Resources{
-					DB:    mock.Database,
-					Graph: mock.Graph,
+					DB: mock.Database,
 					DogTags: dogtags.NewTestService(dogtags.TestOverrides{
 						Bools: map[dogtags.BoolDogTag]bool{
 							dogtags.ETAC_ENABLED: true,
@@ -653,24 +628,6 @@ func TestGetDataQualityStats_Failure(t *testing.T) {
 			},
 		},
 		{
-			Name: "EnvironmentIDGraphError",
-			Input: Input{
-				Params: url.Values{
-					graphschema.EnvironmentIDKey: []string{environmentID},
-				},
-				Context: userCtx,
-			},
-			Setup: func(mockCtrl *gomock.Controller, mock mockResources) v2.Resources {
-				mock.Graph.EXPECT().ReadTransaction(gomock.Any(), gomock.Any()).Return(graphError)
-
-				return defaultResources(mockCtrl, mock)
-			},
-			Expected: api.ErrorWrapper{
-				HTTPStatus: http.StatusInternalServerError,
-				Errors:     []api.ErrorDetails{{Message: graphError.Error()}},
-			},
-		},
-		{
 			Name: "EnvironmentIDNotFound",
 			Input: Input{
 				Params: url.Values{
@@ -679,13 +636,13 @@ func TestGetDataQualityStats_Failure(t *testing.T) {
 				Context: userCtx,
 			},
 			Setup: func(mockCtrl *gomock.Controller, mock mockResources) v2.Resources {
-				expectEnvironmentIDExists(mockCtrl, mock.Graph, false)
+				mock.Database.EXPECT().GetDataQualityStats(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(model.DataQualityStats{}, 0, database.ErrNotFound)
 
 				return defaultResources(mockCtrl, mock)
 			},
 			Expected: api.ErrorWrapper{
 				HTTPStatus: http.StatusNotFound,
-				Errors:     []api.ErrorDetails{{Message: v2.ErrEnvironmentIdDoesNotExist}},
+				Errors:     []api.ErrorDetails{{Message: api.ErrorResponseDetailsResourceNotFound}},
 			},
 		},
 		{
@@ -698,8 +655,6 @@ func TestGetDataQualityStats_Failure(t *testing.T) {
 				Context: userCtx,
 			},
 			Setup: func(mockCtrl *gomock.Controller, mock mockResources) v2.Resources {
-				expectEnvironmentIDExists(mockCtrl, mock.Graph, true)
-
 				return defaultResources(mockCtrl, mock)
 			},
 			Expected: api.ErrorWrapper{
@@ -717,8 +672,6 @@ func TestGetDataQualityStats_Failure(t *testing.T) {
 				Context: userCtx,
 			},
 			Setup: func(mockCtrl *gomock.Controller, mock mockResources) v2.Resources {
-				expectEnvironmentIDExists(mockCtrl, mock.Graph, true)
-
 				return defaultResources(mockCtrl, mock)
 			},
 			Expected: api.ErrorWrapper{
@@ -736,8 +689,6 @@ func TestGetDataQualityStats_Failure(t *testing.T) {
 				Context: userCtx,
 			},
 			Setup: func(mockCtrl *gomock.Controller, mock mockResources) v2.Resources {
-				expectEnvironmentIDExists(mockCtrl, mock.Graph, true)
-
 				return defaultResources(mockCtrl, mock)
 			},
 			Expected: api.ErrorWrapper{
@@ -755,8 +706,6 @@ func TestGetDataQualityStats_Failure(t *testing.T) {
 				Context: userCtx,
 			},
 			Setup: func(mockCtrl *gomock.Controller, mock mockResources) v2.Resources {
-				expectEnvironmentIDExists(mockCtrl, mock.Graph, true)
-
 				return defaultResources(mockCtrl, mock)
 			},
 			Expected: api.ErrorWrapper{
@@ -774,8 +723,6 @@ func TestGetDataQualityStats_Failure(t *testing.T) {
 				Context: userCtx,
 			},
 			Setup: func(mockCtrl *gomock.Controller, mock mockResources) v2.Resources {
-				expectEnvironmentIDExists(mockCtrl, mock.Graph, true)
-
 				return defaultResources(mockCtrl, mock)
 			},
 			Expected: api.ErrorWrapper{
@@ -792,7 +739,6 @@ func TestGetDataQualityStats_Failure(t *testing.T) {
 				Context: userCtx,
 			},
 			Setup: func(mockCtrl *gomock.Controller, mock mockResources) v2.Resources {
-				expectEnvironmentIDExists(mockCtrl, mock.Graph, true)
 				mock.Database.EXPECT().GetDataQualityStats(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(model.DataQualityStats{}, 0, fmt.Errorf("db error"))
 
 				return defaultResources(mockCtrl, mock)
@@ -811,7 +757,6 @@ func TestGetDataQualityStats_Failure(t *testing.T) {
 
 			mock := mockResources{
 				Database: mocks.NewMockDatabase(mockCtrl),
-				Graph:    graphmocks.NewMockDatabase(mockCtrl),
 			}
 			resources := tc.Setup(mockCtrl, mock)
 			params := fmt.Sprintf("?%s", tc.Input.Params.Encode())
@@ -854,21 +799,6 @@ func TestGetDataQualityStats_Success(t *testing.T) {
 
 	type Expected struct {
 		Code int
-	}
-
-	expectEnvironmentIDExists := func(mockCtrl *gomock.Controller, mockGraph *graphmocks.MockDatabase) {
-		mockTransaction := graphmocks.NewMockTransaction(mockCtrl)
-		mockNodeQuery := graphmocks.NewMockNodeQuery(mockCtrl)
-		mockFilteredNodeQuery := graphmocks.NewMockNodeQuery(mockCtrl)
-
-		mockGraph.EXPECT().ReadTransaction(gomock.Any(), gomock.Any()).DoAndReturn(
-			func(ctx context.Context, txDelegate graph.TransactionDelegate, options ...graph.TransactionOption) error {
-				return txDelegate(mockTransaction)
-			},
-		)
-		mockTransaction.EXPECT().Nodes().Return(mockNodeQuery)
-		mockNodeQuery.EXPECT().Filterf(gomock.Any()).Return(mockFilteredNodeQuery)
-		mockFilteredNodeQuery.EXPECT().Count().Return(int64(1), nil)
 	}
 
 	var cases = []struct {
@@ -995,13 +925,10 @@ func TestGetDataQualityStats_Success(t *testing.T) {
 			defer mockCtrl.Finish()
 
 			mockDB := mocks.NewMockDatabase(mockCtrl)
-			mockGraph := graphmocks.NewMockDatabase(mockCtrl)
-			expectEnvironmentIDExists(mockCtrl, mockGraph)
 			mockDB.EXPECT().GetDataQualityStats(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(model.DataQualityStats{}, 0, nil)
 
 			resources := v2.Resources{
 				DB:      mockDB,
-				Graph:   mockGraph,
 				DogTags: dogtags.NewTestService(dogtags.TestOverrides{}),
 			}
 			params := fmt.Sprintf("?%s", tc.Input.Params.Encode())

--- a/cmd/api/src/database/dataquality.go
+++ b/cmd/api/src/database/dataquality.go
@@ -236,6 +236,9 @@ func (s *BloodhoundDB) GetDataQualityStats(ctx context.Context, filters model.Fi
 			totalRowCount = len(dataQualityStats)
 		}
 
+		if totalRowCount == 0 {
+			return dataQualityStats, totalRowCount, ErrNotFound
+		}
 		return dataQualityStats, totalRowCount, nil
 	}
 

--- a/cmd/api/src/database/dataquality_integration_test.go
+++ b/cmd/api/src/database/dataquality_integration_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/specterops/bloodhound/cmd/api/src/database"
 	"github.com/specterops/bloodhound/cmd/api/src/database/types/null"
 	"github.com/specterops/bloodhound/cmd/api/src/model"
 	"github.com/stretchr/testify/assert"
@@ -263,11 +264,11 @@ func TestDatabase_GetDataQualityStats(t *testing.T) {
 			},
 		},
 		{
-			name: "Success: returns empty results when no stats exist",
+			name: "Error: returns not found when no stats exist",
 			args: args{},
 			assert: func(t *testing.T, testSuite IntegrationTestSuite, args args) {
 				results, total, err := testSuite.BHDatabase.GetDataQualityStats(testSuite.Context, args.filters, args.sort, args.skip, args.limit)
-				require.NoError(t, err)
+				require.ErrorIs(t, err, database.ErrNotFound)
 				assert.Equal(t, 0, total)
 				assert.Empty(t, results)
 			},
@@ -592,7 +593,7 @@ func TestDatabase_DeleteAllDataQuality(t *testing.T) {
 				require.NoError(t, err)
 
 				results, total, err := testSuite.BHDatabase.GetDataQualityStats(testSuite.Context, nil, nil, 0, 0)
-				require.NoError(t, err)
+				require.ErrorIs(t, err, database.ErrNotFound)
 				assert.Equal(t, 0, total)
 				assert.Empty(t, results)
 			},

--- a/cmd/api/src/model/dataqualitystats.go
+++ b/cmd/api/src/model/dataqualitystats.go
@@ -30,7 +30,7 @@ type DataQualityStat struct {
 	RunID                   string                `json:"run_id"`
 	SchemaExtensionID       int32                 `json:"extension_id"`
 	SchemaEnvironmentKindID int32                 `json:"environment_kind_id"`
-	EnvironmentID           string                `json:"environment_id"`
+	EnvironmentID           string                `json:"environmentid"`
 	MetricType              DataQualityMetricType `json:"metric_type"`
 	MetricName              string                `json:"metric_name"`
 	MetricValue             float64               `json:"metric_value"`

--- a/cmd/api/src/model/dataqualitystats.go
+++ b/cmd/api/src/model/dataqualitystats.go
@@ -30,11 +30,11 @@ type DataQualityStat struct {
 	RunID                   string                `json:"run_id"`
 	SchemaExtensionID       int32                 `json:"extension_id"`
 	SchemaEnvironmentKindID int32                 `json:"environment_kind_id"`
-	EnvironmentID           string                `json:"environmentid"`
+	EnvironmentID           string                `json:"environment_id"`
 	MetricType              DataQualityMetricType `json:"metric_type"`
 	MetricName              string                `json:"metric_name"`
 	MetricValue             float64               `json:"metric_value"`
-	KindID                  null.Int32            `json:"metric_kind_id"`
+	KindID                  null.Int32            `json:"kind_id"`
 }
 
 func (DataQualityStat) TableName() string {

--- a/cmd/api/src/model/dataqualitystats.go
+++ b/cmd/api/src/model/dataqualitystats.go
@@ -28,13 +28,13 @@ const (
 type DataQualityStat struct {
 	Serial
 	RunID                   string                `json:"run_id"`
-	SchemaExtensionID       int32                 `json:"schema_extension_id"`
-	SchemaEnvironmentKindID int32                 `json:"schema_environment_kind_id"`
+	SchemaExtensionID       int32                 `json:"extension_id"`
+	SchemaEnvironmentKindID int32                 `json:"environment_kind_id"`
 	EnvironmentID           string                `json:"environment_id"`
 	MetricType              DataQualityMetricType `json:"metric_type"`
 	MetricName              string                `json:"metric_name"`
 	MetricValue             float64               `json:"metric_value"`
-	KindID                  null.Int32            `json:"kind_id"`
+	KindID                  null.Int32            `json:"metric_kind_id"`
 }
 
 func (DataQualityStat) TableName() string {
@@ -45,15 +45,7 @@ type DataQualityStats []DataQualityStat
 
 func (s DataQualityStats) IsSortable(column string) bool {
 	switch column {
-	case "id",
-		"run_id",
-		"schema_extension_id",
-		"schema_environment_kind_id",
-		"environment_id",
-		"metric_type",
-		"metric_name",
-		"metric_value",
-		"kind_id",
+	case
 		"updated_at",
 		"created_at":
 		return true

--- a/packages/go/openapi/doc/openapi.json
+++ b/packages/go/openapi/doc/openapi.json
@@ -13994,7 +13994,7 @@
         ],
         "parameters": [
           {
-            "name": "environmentid",
+            "name": "environment_id",
             "description": "Required. Filters results to the given environment.",
             "required": true,
             "in": "query",
@@ -22348,7 +22348,7 @@
               "environment_kind_id": {
                 "type": "integer"
               },
-              "environmentid": {
+              "environment_id": {
                 "type": "string"
               },
               "metric_type": {
@@ -22365,7 +22365,7 @@
                 "type": "number",
                 "format": "double"
               },
-              "metric_node_kind_id": {
+              "kind_id": {
                 "description": "The kind ID for the counted node kind. Present when `metric_type` is `node`; otherwise null.",
                 "type": "integer",
                 "format": "int32",

--- a/packages/go/openapi/doc/openapi.json
+++ b/packages/go/openapi/doc/openapi.json
@@ -13977,6 +13977,114 @@
         }
       }
     },
+    "/api/v2/data-quality-stats": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/header.prefer"
+        }
+      ],
+      "get": {
+        "operationId": "GetDataQualityStats",
+        "summary": "Get environment-specific data quality stats",
+        "description": "Time series list of data quality stats for a given environment",
+        "tags": [
+          "Data Quality",
+          "Community",
+          "Enterprise"
+        ],
+        "parameters": [
+          {
+            "name": "environmentid",
+            "description": "Required. Filters results to the given environment.",
+            "required": true,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sort_by",
+            "description": "Sortable columns are created_at, updated_at.",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/api.params.query.sort-by"
+            }
+          },
+          {
+            "name": "start",
+            "description": "Beginning datetime of range (inclusive) in RFC-3339 format; Defaults to current datetime minus 30 days",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "name": "end",
+            "description": "Ending datetime of range (exclusive) in RFC-3339 format; Defaults to current datetime",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/query.skip"
+          },
+          {
+            "$ref": "#/components/parameters/query.limit"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/api.response.pagination"
+                    },
+                    {
+                      "$ref": "#/components/schemas/api.response.time-window"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/model.data-quality-stat"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/bad-request"
+          },
+          "401": {
+            "$ref": "#/components/responses/unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/not-found"
+          },
+          "429": {
+            "$ref": "#/components/responses/too-many-requests"
+          },
+          "500": {
+            "$ref": "#/components/responses/internal-server-error"
+          }
+        }
+      }
+    },
     "/api/v2/clear-database": {
       "parameters": [
         {
@@ -22218,6 +22326,54 @@
                     }
                   ]
                 }
+              }
+            }
+          }
+        ]
+      },
+      "model.data-quality-stat": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/model.components.int32.id"
+          },
+          {
+            "$ref": "#/components/schemas/model.components.timestamps"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "extension_id": {
+                "type": "integer"
+              },
+              "environment_kind_id": {
+                "type": "integer"
+              },
+              "environmentid": {
+                "type": "string"
+              },
+              "metric_type": {
+                "type": "string",
+                "enum": [
+                  "node",
+                  "relationship"
+                ]
+              },
+              "metric_name": {
+                "type": "string"
+              },
+              "metric_value": {
+                "type": "number",
+                "format": "double"
+              },
+              "metric_node_kind_id": {
+                "description": "The kind ID for the counted node kind. Present when `metric_type` is `node`; otherwise null.",
+                "type": "integer",
+                "format": "int32",
+                "nullable": true
+              },
+              "run_id": {
+                "type": "string",
+                "format": "uuid"
               }
             }
           }

--- a/packages/go/openapi/src/openapi.yaml
+++ b/packages/go/openapi/src/openapi.yaml
@@ -619,6 +619,8 @@ paths:
     $ref: './paths/data-quality.azure-tenants.id.data-quality-stats.yaml'
   /api/v2/platform/{platform_id}/data-quality-stats:
     $ref: './paths/data-quality.platform.id.data-quality-stats.yaml'
+  /api/v2/data-quality-stats:
+    $ref: './paths/data-quality.data-quality-stats.yaml'
   /api/v2/clear-database:
     $ref: './paths/data-quality.clear-database.yaml'
 

--- a/packages/go/openapi/src/paths/data-quality.data-quality-stats.yaml
+++ b/packages/go/openapi/src/paths/data-quality.data-quality-stats.yaml
@@ -25,7 +25,7 @@ get:
     - Community
     - Enterprise
   parameters:
-    - name: environmentid
+    - name: environment_id
       description: Required. Filters results to the given environment.
       required: true
       in: query

--- a/packages/go/openapi/src/paths/data-quality.data-quality-stats.yaml
+++ b/packages/go/openapi/src/paths/data-quality.data-quality-stats.yaml
@@ -25,8 +25,9 @@ get:
     - Community
     - Enterprise
   parameters:
-    - name: environment_id
-      description: Filters results to the given environment.
+    - name: environmentid
+      description: Required. Filters results to the given environment.
+      required: true
       in: query
       schema: 
         type: string

--- a/packages/go/openapi/src/paths/data-quality.data-quality-stats.yaml
+++ b/packages/go/openapi/src/paths/data-quality.data-quality-stats.yaml
@@ -1,0 +1,80 @@
+# Copyright 2026 Specter Ops, Inc.
+#
+# Licensed under the Apache License, Version 2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+parameters:
+  - $ref: './../parameters/header.prefer.yaml'
+get:
+  operationId: GetDataQualityStats
+  summary: Get environment-specific data quality stats
+  description: Time series list of data quality stats for a given environment
+  tags:
+    - Data Quality
+    - Community
+    - Enterprise
+  parameters:
+    - name: environment_id
+      description: Filters results to the given environment.
+      in: query
+      schema: 
+        type: string
+    - name: sort_by
+      description: Sortable columns are created_at, updated_at.
+      in: query
+      schema:
+        $ref: './../schemas/api.params.query.sort-by.yaml'
+    - name: start
+      description: Beginning datetime of range (inclusive) in RFC-3339 format; Defaults
+        to current datetime minus 30 days
+      in: query
+      schema:
+        type: string
+        format: date-time
+    - name: end
+      description: Ending datetime of range (exclusive) in RFC-3339 format; Defaults
+        to current datetime
+      in: query
+      schema:
+        type: string
+        format: date-time
+    - $ref: './../parameters/query.skip.yaml'
+    - $ref: './../parameters/query.limit.yaml'
+  responses:
+    200:
+      description: OK
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: './../schemas/api.response.pagination.yaml'
+              - $ref: './../schemas/api.response.time-window.yaml'
+              - type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: './../schemas/model.data-quality-stat.yaml'
+    400: 
+      $ref: './../responses/bad-request.yaml'
+    404:
+      $ref: './../responses/not-found.yaml'
+    401:
+      $ref: './../responses/unauthorized.yaml'
+    403:
+      $ref: './../responses/forbidden.yaml'
+    429:
+      $ref: './../responses/too-many-requests.yaml'
+    500:
+      $ref: './../responses/internal-server-error.yaml'

--- a/packages/go/openapi/src/schemas/model.data-quality-stat.yaml
+++ b/packages/go/openapi/src/schemas/model.data-quality-stat.yaml
@@ -35,7 +35,8 @@ allOf:
       metric_value:
         type: number
         format: double
-      metric_kind_id:
+      metric_node_kind_id:
+        description: The kind ID for the counted node kind. Present when `metric_type` is `node`; otherwise null.
         type: integer
         format: int32
         nullable: true

--- a/packages/go/openapi/src/schemas/model.data-quality-stat.yaml
+++ b/packages/go/openapi/src/schemas/model.data-quality-stat.yaml
@@ -1,0 +1,44 @@
+# Copyright 2026 Specter Ops, Inc.
+#
+# Licensed under the Apache License, Version 2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+allOf:
+  - $ref: './model.components.int32.id.yaml'
+  - $ref: './model.components.timestamps.yaml'
+  - type: object
+    properties:
+      extension_id:
+        type: integer
+      environment_kind_id:
+        type: integer
+      environmentid:
+        type: string
+      metric_type:
+        type: string
+        enum: 
+          - node
+          - relationship
+      metric_name:
+        type: string
+      metric_value:
+        type: number
+        format: double
+      metric_kind_id:
+        type: integer
+        format: int32
+        nullable: true
+      run_id:
+        type: string
+        format: uuid

--- a/packages/go/openapi/src/schemas/model.data-quality-stat.yaml
+++ b/packages/go/openapi/src/schemas/model.data-quality-stat.yaml
@@ -23,7 +23,7 @@ allOf:
         type: integer
       environment_kind_id:
         type: integer
-      environmentid:
+      environment_id:
         type: string
       metric_type:
         type: string
@@ -35,7 +35,7 @@ allOf:
       metric_value:
         type: number
         format: double
-      metric_node_kind_id:
+      kind_id:
         description: The kind ID for the counted node kind. Present when `metric_type` is `node`; otherwise null.
         type: integer
         format: int32


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Adds a new endpoint to fetch data quality stats from the new platform-agnostic `Data Quality Stats` table. 
`environmentid` is required. Can also provide a `start`, `end`, `sort_by`, `skip`, and `limit` params.
If no`start` and `end` query params provided, the endpoint will return data from the last 30 days, sorted by `created_at` descending. 

Also updated some of the json field names to match opengraph conventions, and to be more descriptive. 

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-8610

Will eventually power the new data quality stats page, which shows data quality stats for OpenGraph data.

## How Has This Been Tested?

Tests added, and testing locally by hitting the new endpoint (must populate the `data_quality_stats` table in the database with data manually to get results): 

```
curl --request GET \
  --url 'http://bhe.localhost/api/v2/data-quality-stats?environmentid=LARGEDOGAREA-001' \
  --header 'authorization: Bearer {{auth_token}}'
```

## Screenshots (optional):

<img width="1237" height="732" alt="Screenshot 2026-07-06 at 11 44 08" src="https://github.com/user-attachments/assets/b03e69d6-0e6d-436a-9438-d2b515be84bc" />


## Types of changes

<!-- Please remove any items that do not apply. -->
- New feature (non-breaking change which adds functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `GET /api/v2/data-quality-stats` to retrieve paginated, time-windowed, environment-scoped stats (required `environment_id`; supports `sort_by`, `start`/`end`, `skip`, `limit`).
* **Bug Fixes**
  * Returns `404` when no matching stats exist (instead of an empty result).
  * Improved validation for query parameters and `sort_by`, with clearer `400` responses for invalid inputs.
* **Documentation**
  * Updated OpenAPI spec and response schema, including renamed fields (`extension_id`, `environment_kind_id`) and supported sortable columns (`created_at`, `updated_at`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->