### PR TITLE
chore: PZ History UI height fix BED-8828 

### DIFF
--- a/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/History/HistoryContent.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/History/HistoryContent.tsx
@@ -93,7 +93,7 @@ const HistoryContent = () => {
                         ref={scrollRef}
                         // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
                         tabIndex={0}
-                        className='overflow-y-auto mb-1 min-h-32'>
+                        className='overflow-y-auto mb-1 min-h-32 h-full'>
                         <DataTable
                             aria-label='History Log Table'
                             data={records}


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Updated the History table to better utilize available space when the dataset contains a small number of rows.

## Motivation and Context


Resolves BED-8828



## How Has This Been Tested?

Tested locally

## Screenshots (optional):

https://github.com/user-attachments/assets/a76fc3ee-d439-4b4a-a472-507b2995ef32


## Types of changes

<!-- Please remove any items that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [ ] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the History view layout so the scrollable table area now fills the available height, resulting in a more consistent full-page display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->