### PR TITLE
refactor: retrieve edge entity info via get relationship by id BED-8743

### DIFF
--- a/cmd/api/src/api/bloodhoundgraph/bloodhoundgraph.go
+++ b/cmd/api/src/api/bloodhoundgraph/bloodhoundgraph.go
@@ -135,6 +135,7 @@ type BloodHoundGraphLinkFlow struct {
 
 type BloodHoundGraphLink struct {
 	*BloodHoundGraphItem
+	ID        graph.ID                  `json:"id"`
 	End1      *BloodHoundGraphLinkEnd   `json:"end1,omitempty"`
 	End2      *BloodHoundGraphLinkEnd   `json:"end2,omitempty"`
 	Flow      *BloodHoundGraphLinkFlow  `json:"flow,omitempty"`

--- a/cmd/api/src/api/bloodhoundgraph/conversions.go
+++ b/cmd/api/src/api/bloodhoundgraph/conversions.go
@@ -63,6 +63,7 @@ func RelationshipToBloodHoundGraph(rel *graph.Relationship) BloodHoundGraphLink 
 	}
 
 	return BloodHoundGraphLink{
+		ID: rel.ID,
 		BloodHoundGraphItem: &BloodHoundGraphItem{
 			Color: defaultRelationshipColor,
 			Data:  relProperties,

--- a/cmd/api/src/api/v2/cypherquery_test.go
+++ b/cmd/api/src/api/v2/cypherquery_test.go
@@ -144,7 +144,7 @@ func TestResources_CypherQuery(t *testing.T) {
 			},
 			expected: expected{
 				responseCode:   http.StatusOK,
-				responseBody:   `{"data":{"node_keys": ["apple", "ball", "key", "zebra"], "edge_keys": ["apple", "ball", "key", "zebra"], "nodes":{"1":{"label":"label","properties": {"apple": "snake", "zebra": "elmo", "key": "value", "ball": "value"},"kind":"","kinds":null, "objectId":"","isTierZero":false,"isOwnedObject":false,"lastSeen":"0001-01-01T00:00:00Z"}},"edges":[{"source":"source","target":"","label":"","properties": {"apple": "snake", "zebra": "elmo", "key": "value", "ball": "value"},"kind":"","lastSeen":"0001-01-01T00:00:00Z"}],"literals":[]}}`,
+				responseBody:   `{"data":{"node_keys": ["apple", "ball", "key", "zebra"], "edge_keys": ["apple", "ball", "key", "zebra"], "nodes":{"1":{"label":"label","properties": {"apple": "snake", "zebra": "elmo", "key": "value", "ball": "value"},"kind":"","kinds":null, "objectId":"","isTierZero":false,"isOwnedObject":false,"lastSeen":"0001-01-01T00:00:00Z"}},"edges":[{"id":"","source":"source","target":"","label":"","properties": {"apple": "snake", "zebra": "elmo", "key": "value", "ball": "value"},"kind":"","lastSeen":"0001-01-01T00:00:00Z"}],"literals":[]}}`,
 				responseHeader: http.Header{"Content-Type": []string{"application/json"}},
 			},
 		},
@@ -470,7 +470,7 @@ func TestResources_CypherQuery(t *testing.T) {
 			},
 			expected: expected{
 				responseCode:   http.StatusOK,
-				responseBody:   `{"data":{"edges":[{"kind":"","label":"","lastSeen":"0001-01-01T00:00:00Z","source":"source","target":""}],"literals": [],"node_keys":["key"],"nodes":{"1":{"isOwnedObject":false,"isTierZero":false,"kind":"","kinds":null,"label":"label","lastSeen":"0001-01-01T00:00:00Z","objectId":"","properties":{"key":"value"}}}}}`,
+				responseBody:   `{"data":{"edges":[{"id":"","kind":"","label":"","lastSeen":"0001-01-01T00:00:00Z","source":"source","target":""}],"literals": [],"node_keys":["key"],"nodes":{"1":{"isOwnedObject":false,"isTierZero":false,"kind":"","kinds":null,"label":"label","lastSeen":"0001-01-01T00:00:00Z","objectId":"","properties":{"key":"value"}}}}}`,
 				responseHeader: http.Header{"Content-Type": []string{"application/json"}},
 			},
 		},
@@ -537,7 +537,7 @@ func TestResources_CypherQuery(t *testing.T) {
 			},
 			expected: expected{
 				responseCode:   http.StatusOK,
-				responseBody:   `{"data":{"edges":[{"kind":"","label":"","lastSeen":"0001-01-01T00:00:00Z","source":"source","target":""}],"literals":[], "node_keys":["key"],"nodes":{"1":{"isOwnedObject":false,"isTierZero":false,"kind":"","kinds":null,"label":"label","lastSeen":"0001-01-01T00:00:00Z","objectId":"","properties":{"key":"value"}}}}}`,
+				responseBody:   `{"data":{"edges":[{"id":"","kind":"","label":"","lastSeen":"0001-01-01T00:00:00Z","source":"source","target":""}],"literals":[], "node_keys":["key"],"nodes":{"1":{"isOwnedObject":false,"isTierZero":false,"kind":"","kinds":null,"label":"label","lastSeen":"0001-01-01T00:00:00Z","objectId":"","properties":{"key":"value"}}}}}`,
 				responseHeader: http.Header{"Content-Type": []string{"application/json"}},
 			},
 		},
@@ -620,7 +620,7 @@ func TestResources_CypherQuery(t *testing.T) {
 			},
 			expected: expected{
 				responseCode:   http.StatusOK,
-				responseBody:   `{"data":{"edges":[{"kind":"","label":"","lastSeen":"0001-01-01T00:00:00Z","source":"source","target":"1"},{"kind":"HIDDEN","label":"** Hidden Edge **","lastSeen":"0001-01-01T00:00:00Z","source":"source","target":"2"},{"kind":"HIDDEN","label":"** Hidden Edge **","lastSeen":"0001-01-01T00:00:00Z","source":"2","target":"1"}],"literals":[],"node_keys":["domainsid"],"nodes":{"1":{"isOwnedObject":false,"isTierZero":false,"kind":"","kinds":["kinds"],"label":"label","lastSeen":"0001-01-01T00:00:00Z","objectId":"","properties":{"domainsid":"testenv"}},"2":{"hidden":true,"isOwnedObject":false,"isTierZero":false,"kind":"HIDDEN","kinds":[],"label":"** Hidden kinds Object **","lastSeen":"0001-01-01T00:00:00Z","objectId":"HIDDEN"},"source":{"isOwnedObject":false,"isTierZero":false,"kind":"","kinds":["kinds"],"label":"labelSource","lastSeen":"0001-01-01T00:00:00Z","objectId":"","properties":{"domainsid":"testenv"}}}}}`,
+				responseBody:   `{"data":{"edges":[{"id":"","kind":"","label":"","lastSeen":"0001-01-01T00:00:00Z","source":"source","target":"1"},{"id":"","kind":"HIDDEN","label":"** Hidden Edge **","lastSeen":"0001-01-01T00:00:00Z","source":"source","target":"2"},{"id":"","kind":"HIDDEN","label":"** Hidden Edge **","lastSeen":"0001-01-01T00:00:00Z","source":"2","target":"1"}],"literals":[],"node_keys":["domainsid"],"nodes":{"1":{"isOwnedObject":false,"isTierZero":false,"kind":"","kinds":["kinds"],"label":"label","lastSeen":"0001-01-01T00:00:00Z","objectId":"","properties":{"domainsid":"testenv"}},"2":{"hidden":true,"isOwnedObject":false,"isTierZero":false,"kind":"HIDDEN","kinds":[],"label":"** Hidden kinds Object **","lastSeen":"0001-01-01T00:00:00Z","objectId":"HIDDEN"},"source":{"isOwnedObject":false,"isTierZero":false,"kind":"","kinds":["kinds"],"label":"labelSource","lastSeen":"0001-01-01T00:00:00Z","objectId":"","properties":{"domainsid":"testenv"}}}}}`,
 				responseHeader: http.Header{"Content-Type": []string{"application/json"}},
 			},
 		},
@@ -693,7 +693,7 @@ func TestResources_CypherQuery(t *testing.T) {
 			},
 			expected: expected{
 				responseCode:   http.StatusOK,
-				responseBody:   `{"data":{"nodes":{"1":{"hidden":true,"isOwnedObject":false,"isTierZero":false,"kind":"HIDDEN","kinds":[],"label":"** Hidden kinds Object **","lastSeen":"0001-01-01T00:00:00Z","objectId":"HIDDEN"},"2":{"hidden":true,"isOwnedObject":false,"isTierZero":false,"kind":"HIDDEN","kinds":[],"label":"** Hidden kinds Object **","lastSeen":"0001-01-01T00:00:00Z","objectId":"HIDDEN"}},"edges":[{"source":"source","target":"1","label":"** Hidden Edge **","kind":"HIDDEN","lastSeen":"0001-01-01T00:00:00Z"}],"literals":[]}}`,
+				responseBody:   `{"data":{"nodes":{"1":{"hidden":true,"isOwnedObject":false,"isTierZero":false,"kind":"HIDDEN","kinds":[],"label":"** Hidden kinds Object **","lastSeen":"0001-01-01T00:00:00Z","objectId":"HIDDEN"},"2":{"hidden":true,"isOwnedObject":false,"isTierZero":false,"kind":"HIDDEN","kinds":[],"label":"** Hidden kinds Object **","lastSeen":"0001-01-01T00:00:00Z","objectId":"HIDDEN"}},"edges":[{"id":"","source":"source","target":"1","label":"** Hidden Edge **","kind":"HIDDEN","lastSeen":"0001-01-01T00:00:00Z"}],"literals":[]}}`,
 				responseHeader: http.Header{"Content-Type": []string{"application/json"}},
 			},
 		},

--- a/cmd/api/src/model/unified_graph.go
+++ b/cmd/api/src/model/unified_graph.go
@@ -65,6 +65,7 @@ type UnifiedNode struct {
 
 // UnifiedEdge represents a single path segment in a graph containing a minimal set of attributes for graph rendering
 type UnifiedEdge struct {
+	ID         string         `json:"id"`
 	Source     string         `json:"source"`
 	Target     string         `json:"target"`
 	Label      string         `json:"label"`
@@ -115,6 +116,7 @@ func FromDAWGSRelationship(includeProperties bool) func(*graph.Relationship) Uni
 		}
 
 		return UnifiedEdge{
+			ID:         rel.ID.String(),
 			Source:     rel.StartID.String(),
 			Target:     rel.EndID.String(),
 			Kind:       rel.Kind.String(),

--- a/cmd/ui/src/components/SigmaChart/GraphEdgeEvents.tsx
+++ b/cmd/ui/src/components/SigmaChart/GraphEdgeEvents.tsx
@@ -56,7 +56,7 @@ export const GraphEdgeEvents: FC<GraphEdgeEventProps> = ({ onClickEdge }) => {
                     const edge: string = edges[i];
                     const attributes = graph.getEdgeAttributes(edge);
 
-                    const edgeData = getEdgeDataFromKey(edge);
+                    const edgeData = getEdgeDataFromKey(attributes.exploreGraphId);
                     if (edgeData === null) continue;
                     const nodeDisplayData = getEdgeSourceAndTargetDisplayData(edgeData.source, edgeData.target, sigma);
                     if (nodeDisplayData === null) continue;

--- a/cmd/ui/src/views/Explore/ContextMenu/AssetGroupMenuItem.test.tsx
+++ b/cmd/ui/src/views/Explore/ContextMenu/AssetGroupMenuItem.test.tsx
@@ -48,6 +48,21 @@ const getAssetGroupTestProps = ({ isTierZero }: { isTierZero: boolean }) => ({
 describe('AssetGroupMenuItem', async () => {
     describe('adding to an asset group', () => {
         const server = setupServer(
+            rest.get('/api/v2/nodes/:nodeId', (req, res, ctx) => {
+                return res(
+                    ctx.json({
+                        data: {
+                            node_id: parseInt(req.params.nodeId as string),
+                            kinds: [{ node_kind_id: 1, name: 'User' }],
+                            properties: {
+                                objectid: req.params.nodeId,
+                                name: 'foo',
+                                lastSeen: '',
+                            },
+                        },
+                    })
+                );
+            }),
             rest.get('/api/v2/asset-groups/:assetGroupId/members', (req, res, ctx) => {
                 // handle `tier zero` requests
                 if (req.params.assetGroupId === tierZeroAssetGroup.id.toString()) {
@@ -173,6 +188,21 @@ describe('AssetGroupMenuItem', async () => {
 
     describe('removing from an asset group', () => {
         const server = setupServer(
+            rest.get('/api/v2/nodes/:nodeId', (req, res, ctx) => {
+                return res(
+                    ctx.json({
+                        data: {
+                            node_id: parseInt(req.params.nodeId as string),
+                            kinds: [{ node_kind_id: 1, name: 'User' }],
+                            properties: {
+                                objectid: req.params.nodeId,
+                                name: 'foo',
+                                lastSeen: '',
+                            },
+                        },
+                    })
+                );
+            }),
             rest.get('/api/v2/asset-groups/:assetGroupId/members', (req, res, ctx) => {
                 // handle `tier zero` requests
                 if (req.params.assetGroupId === tierZeroAssetGroup.id.toString()) {

--- a/cmd/ui/src/views/Explore/ContextMenu/AssetGroupMenuItem.tsx
+++ b/cmd/ui/src/views/Explore/ContextMenu/AssetGroupMenuItem.tsx
@@ -15,7 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Dialog, DialogActions, DialogContent, DialogTitle, MenuItem } from '@mui/material';
-import { NodeResponse, apiClient, useExploreGraph, useExploreSelectedItem, useNotifications } from 'bh-shared-ui';
+import { apiClient, isNodeResponse, useExploreGraph, useExploreSelectedItem, useNotifications } from 'bh-shared-ui';
 import { Button } from 'doodle-ui';
 import { FC, useState } from 'react';
 import { useMutation, useQuery } from 'react-query';
@@ -29,6 +29,11 @@ const AssetGroupMenuItem: FC<{ assetGroupId: number; assetGroupName: string }> =
     const [open, setOpen] = useState(false);
 
     const { selectedItemQuery } = useExploreSelectedItem();
+
+    const nodeObjectId = isNodeResponse(selectedItemQuery.data)
+        ? selectedItemQuery.data.properties.objectid
+        : undefined;
+
     const tierZeroAssetGroupId = useAppSelector(selectTierZeroAssetGroupId);
 
     const isMenuItemForTierZero = assetGroupId === tierZeroAssetGroupId;
@@ -53,25 +58,25 @@ const AssetGroupMenuItem: FC<{ assetGroupId: number; assetGroupName: string }> =
         },
     });
 
-    const { data: assetGroupMembers } = useQuery(['listAssetGroupMembers', assetGroupId], () =>
+    const { data: assetGroupMembers } = useQuery(['listAssetGroupMembers', assetGroupId, nodeObjectId], () =>
         apiClient
             .listAssetGroupMembers(assetGroupId, undefined, {
                 params: {
-                    object_id: `object_id=eq:${(selectedItemQuery.data as NodeResponse)?.objectId}`,
+                    object_id: `object_id=eq:${nodeObjectId}`,
                 },
             })
             .then((res) => res.data.data?.members)
     );
 
     const handleAddToAssetGroup = () => {
-        if (selectedItemQuery.data && 'objectId' in selectedItemQuery.data) {
-            mutation.mutate({ nodeId: selectedItemQuery.data.objectId, action: 'add' });
+        if (nodeObjectId) {
+            mutation.mutate({ nodeId: nodeObjectId, action: 'add' });
         }
     };
 
     const handleRemoveFromAssetGroup = () => {
-        if (selectedItemQuery.data && 'objectId' in selectedItemQuery.data) {
-            mutation.mutate({ nodeId: selectedItemQuery.data.objectId, action: 'remove' });
+        if (nodeObjectId) {
+            mutation.mutate({ nodeId: nodeObjectId, action: 'remove' });
         }
     };
 

--- a/cmd/ui/src/views/Explore/ContextMenu/ContextMenu.test.tsx
+++ b/cmd/ui/src/views/Explore/ContextMenu/ContextMenu.test.tsx
@@ -17,6 +17,7 @@
 import userEvent from '@testing-library/user-event';
 import * as bhSharedUi from 'bh-shared-ui';
 import { DeepPartial, Permission, createAuthStateWithPermissions, mockGetConfigurationHandler } from 'bh-shared-ui';
+import { NodeDetails } from 'js-client-library';
 import { rest } from 'msw';
 import { setupServer } from 'msw/node';
 import { act } from 'react-dom/test-utils';
@@ -28,11 +29,18 @@ const mockUseExploreParams = vi.spyOn(bhSharedUi, 'useExploreParams');
 const mockSelectedItemQuery = vi.spyOn(bhSharedUi, 'useExploreSelectedItem');
 
 const fakeSelectedItemId = 'abc';
+
+const mockNode: NodeDetails = {
+    node_id: 1,
+    kinds: [],
+    properties: {
+        objectid: fakeSelectedItemId,
+    },
+};
+
 mockSelectedItemQuery.mockReturnValue({
     selectedItemQuery: {
-        data: {
-            objectId: fakeSelectedItemId,
-        },
+        data: mockNode,
     },
 } as any);
 

--- a/cmd/ui/src/views/Explore/ContextMenu/ContextMenu.tsx
+++ b/cmd/ui/src/views/Explore/ContextMenu/ContextMenu.tsx
@@ -19,7 +19,7 @@ import { Menu, MenuItem } from '@mui/material';
 import {
     CopyMenuItem,
     Permission,
-    isNode,
+    isNodeResponse,
     useExploreParams,
     useExploreSelectedItem,
     useFeatureFlag,
@@ -45,12 +45,12 @@ const ContextMenu: FC<{
 
     const handleSetStartingNode = () => {
         const selectedItemData = selectedItemQuery.data;
-        if (selectedItemData && isNode(selectedItemData)) {
+        if (selectedItemData && isNodeResponse(selectedItemData)) {
             const searchType = secondarySearch ? 'pathfinding' : 'node';
             setExploreParams({
                 exploreSearchTab: 'pathfinding',
                 searchType,
-                primarySearch: selectedItemData?.objectId as string,
+                primarySearch: selectedItemData?.properties.objectid ?? '',
             });
         }
     };
@@ -58,11 +58,11 @@ const ContextMenu: FC<{
     const handleSetEndingNode = () => {
         const searchType = primarySearch ? 'pathfinding' : 'node';
         const selectedItemData = selectedItemQuery.data;
-        if (selectedItemData && isNode(selectedItemData)) {
+        if (selectedItemData && isNodeResponse(selectedItemData)) {
             setExploreParams({
                 exploreSearchTab: 'pathfinding',
                 searchType,
-                secondarySearch: selectedItemData?.objectId as string,
+                secondarySearch: selectedItemData?.properties.objectid ?? '',
             });
         }
     };

--- a/cmd/ui/src/views/Explore/GraphView.test.tsx
+++ b/cmd/ui/src/views/Explore/GraphView.test.tsx
@@ -137,6 +137,21 @@ const server = setupServer(
                 data: [],
             })
         );
+    }),
+    rest.get('/api/v2/nodes/:id', (_req, res, ctx) => {
+        return res(
+            ctx.json({
+                data: {
+                    node_id: 42,
+                    kinds: [{ node_kind_id: 1, name: searchedNode.kind }],
+                    properties: {
+                        objectid: searchedNode.objectId,
+                        name: searchedNode.label,
+                        lastSeen: searchedNode.lastSeen,
+                    },
+                },
+            })
+        );
     })
 );
 
@@ -221,13 +236,14 @@ describe('GraphView', () => {
         };
 
         clonedCypherResponse.data.edges.push({
+            id: 1,
             source: '108',
             target: '108',
             label: 'some label',
-            kind: 'some kind',
+            kind: 'kind',
             lastSeen: 'some lastSeen',
             impactPercent: 10,
-            exploreGraphId: 'some exploreGraphId',
+            exploreGraphId: '108_kind_108',
             data: {},
         });
 

--- a/cmd/ui/src/views/Explore/GraphView.tsx
+++ b/cmd/ui/src/views/Explore/GraphView.tsx
@@ -21,6 +21,7 @@ import {
     ExploreTable,
     FeatureFlag,
     GraphControls,
+    GraphItemInformationPanel,
     GraphProgress,
     GraphViewErrorAlert,
     ManageColumnsComboBoxOption,
@@ -29,7 +30,7 @@ import {
     baseGraphLayouts,
     defaultGraphLayout,
     glyphUtils,
-    isNode,
+    isNodeResponse,
     isWebGLEnabled,
     makeStoreMapFromColumnOptions,
     useAppName,
@@ -64,7 +65,6 @@ import { useAppDispatch, useAppSelector } from 'src/store';
 import { initGraph } from 'src/views/Explore/utils';
 import ContextMenu from './ContextMenu/ContextMenu';
 import ExploreSearch from './ExploreSearch/ExploreSearch';
-import GraphItemInformationPanel from './GraphItemInformationPanel';
 import { transformIconDictionary } from './svgIcons';
 
 const GraphView: FC = () => {
@@ -310,13 +310,13 @@ const GraphView: FC = () => {
                 flagKey='tier_management_engine'
                 enabled={
                     <ContextMenuPrivilegeZonesEnabled
-                        contextMenu={isNode(selectedItemQuery.data) ? contextMenu : null}
+                        contextMenu={isNodeResponse(selectedItemQuery.data) ? contextMenu : null}
                         onClose={handleCloseContextMenu}
                     />
                 }
                 disabled={
                     <ContextMenu
-                        contextMenu={isNode(selectedItemQuery.data) ? contextMenu : null}
+                        contextMenu={isNodeResponse(selectedItemQuery.data) ? contextMenu : null}
                         handleClose={handleCloseContextMenu}
                     />
                 }

--- a/cmd/ui/src/views/Explore/utils.test.ts
+++ b/cmd/ui/src/views/Explore/utils.test.ts
@@ -110,9 +110,9 @@ describe('Explore utils', () => {
             );
 
             expect(graph.edges().length).toEqual(3);
-            expect(graph.hasEdge('1')).toBeTruthy();
-            expect(graph.hasEdge('2')).toBeTruthy();
-            expect(graph.hasEdge('3')).toBeTruthy();
+            expect(graph.hasEdge('rel_1')).toBeTruthy();
+            expect(graph.hasEdge('rel_2')).toBeTruthy();
+            expect(graph.hasEdge('rel_3')).toBeTruthy();
         });
     });
 });

--- a/cmd/ui/src/views/Explore/utils.test.ts
+++ b/cmd/ui/src/views/Explore/utils.test.ts
@@ -44,6 +44,7 @@ const testNodes = {
 
 const testEdgesWithDuplicate = [
     {
+        id: 1,
         source: '1',
         target: '2',
         label: 'MemberOf',
@@ -51,6 +52,7 @@ const testEdgesWithDuplicate = [
         lastSeen: '',
     },
     {
+        id: 1,
         source: '1',
         target: '2',
         label: 'MemberOf',
@@ -58,6 +60,7 @@ const testEdgesWithDuplicate = [
         lastSeen: '',
     },
     {
+        id: 2,
         source: '2',
         target: '1',
         label: 'MemberOf',
@@ -65,6 +68,7 @@ const testEdgesWithDuplicate = [
         lastSeen: '',
     },
     {
+        id: 3,
         source: '1',
         target: '2',
         label: 'GetChangesAll',
@@ -106,9 +110,9 @@ describe('Explore utils', () => {
             );
 
             expect(graph.edges().length).toEqual(3);
-            expect(graph.hasEdge('1_MemberOf_2')).toBeTruthy();
-            expect(graph.hasEdge('2_MemberOf_1')).toBeTruthy();
-            expect(graph.hasEdge('1_GetChangesAll_2')).toBeTruthy();
+            expect(graph.hasEdge('1')).toBeTruthy();
+            expect(graph.hasEdge('2')).toBeTruthy();
+            expect(graph.hasEdge('3')).toBeTruthy();
         });
     });
 });

--- a/cmd/ui/src/views/Explore/utils.ts
+++ b/cmd/ui/src/views/Explore/utils.ts
@@ -239,7 +239,7 @@ const initGraphEdges = (
                 label: edge.label,
                 groupPosition: 0,
                 groupSize: 1,
-                exploreGraphId: edge.exploreGraphId || key,
+                exploreGraphId: key,
                 forceLabel: true,
                 ...themedOptions.labels,
             };
@@ -265,7 +265,7 @@ const initGraphEdges = (
                 edgeParams.groupSize = groupSize;
             }
 
-            graph.addEdgeWithKey(key, edge.source, edge.target, edgeParams);
+            graph.addEdgeWithKey(edge.id, edge.source, edge.target, edgeParams);
         }
     }
 };

--- a/cmd/ui/src/views/Explore/utils.ts
+++ b/cmd/ui/src/views/Explore/utils.ts
@@ -19,6 +19,7 @@ import {
     GLYPH_SCALE,
     GetIconInfo,
     IconDictionary,
+    REL_ID_PREFIX,
     TagGlyphs,
     Theme,
     getGlyphFromKinds,
@@ -265,7 +266,7 @@ const initGraphEdges = (
                 edgeParams.groupSize = groupSize;
             }
 
-            graph.addEdgeWithKey(edge.id, edge.source, edge.target, edgeParams);
+            graph.addEdgeWithKey(`${REL_ID_PREFIX}${edge.id}`, edge.source, edge.target, edgeParams);
         }
     }
 };

--- a/packages/javascript/bh-shared-ui/src/components/ExploreTable/ExploreTable.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/ExploreTable/ExploreTable.test.tsx
@@ -41,8 +41,7 @@ const server = setupServer(
     rest.get('/api/v2/features', (req, res, ctx) => {
         return res(ctx.status(200), ctx.json({ data: [{ key: 'explore_table_view', enabled: true }] }));
     }),
-
-    rest.get('/api/v2/features', (req, res, ctx) => {
+    rest.get('/api/v2/nodes/:id', (req, res, ctx) => {
         return res(ctx.status(200));
     }),
     rest.get('/api/v2/config', (_req, res, ctx) => {

--- a/packages/javascript/bh-shared-ui/src/components/GraphDataCheckboxes/GraphDataCheckboxes.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/GraphDataCheckboxes/GraphDataCheckboxes.tsx
@@ -16,16 +16,9 @@
 
 import { Checkbox, FormControlLabel } from '@mui/material';
 import { Skeleton } from 'doodle-ui';
-import { type OptionsObject } from 'notistack';
+import { type SourceKind } from 'js-client-library';
 import { type FC } from 'react';
-import { useQuery } from 'react-query';
-import { useNotifications } from '../../providers/NotificationProvider/hooks';
-import { apiClient } from '../../utils/api';
-
-type SourceKind = {
-    id: number;
-    name: string;
-};
+import { useSourceKindsQuery } from '../../hooks/useSourceKinds';
 
 type GraphDataOption = {
     key: string;
@@ -44,25 +37,6 @@ type GraphDataChecked = Record<number, GraphDataSelection>;
 export type GraphDataSelections = {
     sourceKinds: number[];
     relationships: string[];
-};
-
-const ERROR = {
-    key: 'database-management-source-kind',
-    message: 'An error occurred while loading source kinds. Deleting graph data is disabled. Try refreshing the page.',
-    options: {
-        persist: true,
-        anchorOrigin: { vertical: 'top', horizontal: 'right' },
-    } as OptionsObject,
-};
-
-const useSourceKindsQuery = () => {
-    const { addNotification } = useNotifications();
-
-    return useQuery({
-        queryKey: ['source-kinds'],
-        queryFn: ({ signal }) => apiClient.getSourceKinds({ signal }).then((res) => res.data.data.kinds),
-        onError: () => addNotification(ERROR.message, ERROR.key, ERROR.options),
-    });
 };
 
 // Displayed while source kinds are loading

--- a/packages/javascript/bh-shared-ui/src/components/HelpTexts/shared/ACLInheritance.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/HelpTexts/shared/ACLInheritance.tsx
@@ -22,8 +22,8 @@ import { EdgeInfoItems, useEdgeInfoItems } from '../../../hooks/useExploreGraph/
 import VirtualizedNodeList, { NormalizedNodeItem } from '../../VirtualizedNodeList';
 
 type ACLInheritanceListProps = {
-    sourceDBId: number;
-    targetDBId: number;
+    sourceDBId: number | undefined;
+    targetDBId: number | undefined;
     edgeName: string;
     inheritanceHash: string;
 };

--- a/packages/javascript/bh-shared-ui/src/components/PageWithTitle.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/PageWithTitle.test.tsx
@@ -15,8 +15,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { screen, waitFor } from '@testing-library/react';
+import { AppNameProvider } from '../providers/AppNameProvider';
 import { render } from '../test-utils';
-import PageWithTitle, { AppNameProvider } from './PageWithTitle';
+import PageWithTitle from './PageWithTitle';
 
 describe('PageWithTitle', () => {
     it('sets the document title using the default app name', async () => {

--- a/packages/javascript/bh-shared-ui/src/components/PageWithTitle.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/PageWithTitle.tsx
@@ -16,16 +16,9 @@
 
 import { Box, Container, ContainerProps } from '@mui/material';
 import { Typography } from 'doodle-ui';
-import React, { createContext, useContext } from 'react';
+import React from 'react';
 import { Helmet } from 'react-helmet-async';
-
-const AppNameContext = createContext('BloodHound Enterprise');
-
-export const AppNameProvider: React.FC<{ name: string; children: React.ReactNode }> = ({ name, children }) => (
-    <AppNameContext.Provider value={name}>{children}</AppNameContext.Provider>
-);
-
-export const useAppName = () => useContext(AppNameContext);
+import { useAppName } from '../providers/AppNameProvider';
 
 type PageWithTitleProps = ContainerProps<
     'div',

--- a/packages/javascript/bh-shared-ui/src/components/index.ts
+++ b/packages/javascript/bh-shared-ui/src/components/index.ts
@@ -113,7 +113,6 @@ export * from './NodeIcon';
 export { default as NodeIcon } from './NodeIcon';
 export * from './OneTimePasscodeForm';
 export { default as OneTimePasscodeForm } from './OneTimePasscodeForm';
-export * from './PageWithTitle';
 export { default as PageWithTitle } from './PageWithTitle';
 export * from './PasswordDialog';
 export { default as PasswordDialog } from './PasswordDialog';

--- a/packages/javascript/bh-shared-ui/src/constants.ts
+++ b/packages/javascript/bh-shared-ui/src/constants.ts
@@ -406,6 +406,11 @@ export const defaultPortalContainer = {
     container: () => document.getElementById('app-root'), // Callback so this is re-run on useLayoutEffect within MUI
 };
 
+// The word "Label" here is used in the sense of a cypher Label,
+// e.g., in the cypher query: `match(u:User) return u`, 'User' is a cypher Label.
+// That is to say the "Label" usage here does not reflect a type of AssetGroupTag
+export const TagLabelPrefix = 'Tag_' as const;
+
 /**
  * Returns a schema object describing node kinds (`labels`), relationship kinds (`relationshipTypes`),
  * and known property keys. This is primarily used for type completion in the cypher editor.

--- a/packages/javascript/bh-shared-ui/src/hooks/index.ts
+++ b/packages/javascript/bh-shared-ui/src/hooks/index.ts
@@ -56,6 +56,7 @@ export { default as useOnClickOutside } from './useOnClickOutside';
 export * from './usePermissions';
 export * from './usePrebuiltQueries';
 export * from './usePreviousValue';
+export * from './usePrimaryKind';
 export * from './usePZParams';
 export { default as useRoleBasedFiltering } from './useRoleBasedFiltering';
 export * from './useSavedQueries';

--- a/packages/javascript/bh-shared-ui/src/hooks/useAssetGroupTags/useAssetGroupTags.tsx
+++ b/packages/javascript/bh-shared-ui/src/hooks/useAssetGroupTags/useAssetGroupTags.tsx
@@ -76,28 +76,17 @@ export const privilegeZonesKeys = {
         [...privilegeZonesKeys.all, 'certifications', filters, search, ...environments] as const,
 };
 
-export const getIsOwnedTag = (tags: AssetGroupTag[]) => tags.find((tag) => tag.type === AssetGroupTagTypeOwned);
+export const getOwnedTag = (tags: AssetGroupTag[]) => tags.find((tag) => tag.type === AssetGroupTagTypeOwned);
 
-export const getIsTierZeroTag = (tags: AssetGroupTag[]) =>
-    tags.find((tag) => tag.position === HighestPrivilegePosition);
+export const getTierZeroTag = (tags: AssetGroupTag[]) => tags.find((tag) => tag.position === HighestPrivilegePosition);
 
-export const isOwnedObject = (
+export const isTaggedObject = (
     node: NodeDetails | RelationshipDetails | RelationshipDetailsWithInfo | NodeDetailsWithInfo | undefined,
-    ownedTag: AssetGroupTag | undefined
+    tag: AssetGroupTag | undefined
 ): boolean => {
-    if (!node || !ownedTag || !isNodeResponse(node)) return false;
+    if (!node || !tag || !isNodeResponse(node)) return false;
 
-    const underscoredTagName = ownedTag.name.split(' ').join('_');
-    return node.kinds.some((kind) => kind.name === `${TagLabelPrefix}${underscoredTagName}`);
-};
-
-export const isTierZero = (
-    node: NodeDetails | RelationshipDetails | RelationshipDetailsWithInfo | NodeDetailsWithInfo | undefined,
-    tierZeroTag: AssetGroupTag | undefined
-): boolean => {
-    if (!node || !tierZeroTag || !isNodeResponse(node)) return false;
-
-    const underscoredTagName = tierZeroTag.name.split(' ').join('_');
+    const underscoredTagName = tag.name.split(' ').join('_');
     return node.kinds.some((kind) => kind.name === `${TagLabelPrefix}${underscoredTagName}`);
 };
 
@@ -366,14 +355,14 @@ export const useOrderedTags = () => {
 
 export const useHighestPrivilegeTag = () => {
     const { data: orderedTags, isLoading, isError } = useOrderedTags();
-    const tag = orderedTags?.find((tag) => tag.position === HighestPrivilegePosition);
+    const tag = getTierZeroTag(orderedTags ?? []);
 
     return { isLoading, isError, tag };
 };
 
 export const useHighestPrivilegeTagId = () => {
     const { data: orderedTags, isLoading, isError } = useOrderedTags();
-    const tagId = orderedTags?.find((tag) => tag.position === HighestPrivilegePosition)?.id;
+    const tagId = getTierZeroTag(orderedTags ?? [])?.id;
 
     return { isLoading, isError, tagId };
 };
@@ -387,5 +376,5 @@ export const useLabels = () => {
 
 export const useOwnedTagId = () => {
     const tagsQuery = useTagsQuery();
-    return tagsQuery.data?.find((tag) => tag.type === AssetGroupTagTypeOwned)?.id;
+    return getOwnedTag(tagsQuery.data ?? [])?.id;
 };

--- a/packages/javascript/bh-shared-ui/src/hooks/useAssetGroupTags/useAssetGroupTags.tsx
+++ b/packages/javascript/bh-shared-ui/src/hooks/useAssetGroupTags/useAssetGroupTags.tsx
@@ -19,8 +19,12 @@ import {
     AssetGroupTagTypeOwned,
     AssetGroupTagTypeZone,
     HighestPrivilegePosition,
+    NodeDetails,
+    NodeDetailsWithInfo,
     ObjectKey,
     ObjectsKey,
+    RelationshipDetails,
+    RelationshipDetailsWithInfo,
     RuleKey,
     RulesKey,
     type AssetGroupTag,
@@ -30,11 +34,12 @@ import {
     type RequestOptions,
 } from 'js-client-library';
 import { useInfiniteQuery, useQuery } from 'react-query';
+import { TagLabelPrefix } from '../../constants';
 import { SortOrderAscending, type SortOrder } from '../../types';
 import { apiClient, type GenericQueryOptions } from '../../utils';
 import { createPaginatedFetcher, type PageParam } from '../../utils/paginatedFetcher';
 import { useFeatureFlag } from '../useFeatureFlags';
-import { isNode, type ItemResponse } from '../useGraphItem';
+import { isNodeResponse } from '../useGraphItem';
 
 export const privilegeZonesKeys = {
     all: ['privilege-zones'] as const,
@@ -76,16 +81,24 @@ export const getIsOwnedTag = (tags: AssetGroupTag[]) => tags.find((tag) => tag.t
 export const getIsTierZeroTag = (tags: AssetGroupTag[]) =>
     tags.find((tag) => tag.position === HighestPrivilegePosition);
 
-export const isOwnedObject = (item: ItemResponse): boolean => {
-    if (!isNode(item)) return false;
+export const isOwnedObject = (
+    node: NodeDetails | RelationshipDetails | RelationshipDetailsWithInfo | NodeDetailsWithInfo | undefined,
+    ownedTag: AssetGroupTag | undefined
+): boolean => {
+    if (!node || !ownedTag || !isNodeResponse(node)) return false;
 
-    return item.isOwnedObject;
+    const underscoredTagName = ownedTag.name.split(' ').join('_');
+    return node.kinds.some((kind) => kind.name === `${TagLabelPrefix}${underscoredTagName}`);
 };
 
-export const isTierZero = (item: ItemResponse): boolean => {
-    if (!isNode(item)) return false;
+export const isTierZero = (
+    node: NodeDetails | RelationshipDetails | RelationshipDetailsWithInfo | NodeDetailsWithInfo | undefined,
+    tierZeroTag: AssetGroupTag | undefined
+): boolean => {
+    if (!node || !tierZeroTag || !isNodeResponse(node)) return false;
 
-    return item.isTierZero;
+    const underscoredTagName = tierZeroTag.name.split(' ').join('_');
+    return node.kinds.some((kind) => kind.name === `${TagLabelPrefix}${underscoredTagName}`);
 };
 
 const getAssetGroupTags = (options: RequestOptions) =>

--- a/packages/javascript/bh-shared-ui/src/hooks/useAssetGroupTags/useTagGlyphs.ts
+++ b/packages/javascript/bh-shared-ui/src/hooks/useAssetGroupTags/useTagGlyphs.ts
@@ -17,6 +17,7 @@ import { findIconDefinition } from '@fortawesome/fontawesome-svg-core';
 import { IconName } from '@fortawesome/free-solid-svg-icons';
 import { AssetGroupTag, AssetGroupTagTypeOwned } from 'js-client-library';
 import { useEffect, useState } from 'react';
+import { TagLabelPrefix } from '../../constants';
 import {
     DEFAULT_GLYPH_BACKGROUND_COLOR,
     DEFAULT_GLYPH_COLOR,
@@ -53,11 +54,6 @@ export const glyphUtils: GlyphUtils = {
     qualifier: glyphQualifier,
     transformer: glyphTransformer,
 };
-
-// The word "Label" here is used in the sense of a cypher Label,
-// e.g., in the cypher query: `match(u:User) return u`, 'User' is a cypher Label.
-// That is to say the "Label" usage here does not reflect a type of AssetGroupTag
-export const TagLabelPrefix = 'Tag_' as const;
 
 export const createGlyphMapFromTags = (
     tags: AssetGroupTag[] | undefined,

--- a/packages/javascript/bh-shared-ui/src/hooks/useExploreGraph/queries/utils.ts
+++ b/packages/javascript/bh-shared-ui/src/hooks/useExploreGraph/queries/utils.ts
@@ -81,6 +81,7 @@ export const transformFlatGraphResponse = (graph: FlatGraphResponse): GraphData 
             const edge = item as StyledGraphEdge;
             const lastSeen = getLastSeenValue(edge);
             result.edges.push({
+                id: edge.id,
                 impactPercent: edge.data ? edge.data.composite_risk_impact_percent : undefined,
                 source: edge.id1,
                 target: edge.id2,

--- a/packages/javascript/bh-shared-ui/src/hooks/useExploreSelectedItem.tsx
+++ b/packages/javascript/bh-shared-ui/src/hooks/useExploreSelectedItem.tsx
@@ -19,11 +19,13 @@ import { parseItemId } from '../utils';
 import { useExploreParams } from './useExploreParams';
 import { useGraphItem } from './useGraphItem';
 
+const HIDDEN_STRING = 'HIDDEN';
+
 export const useExploreSelectedItem = () => {
     const [previousSelectedItem, setPreviousSelectedItem] = useState<string | null>();
     const { selectedItem, setExploreParams } = useExploreParams();
 
-    const selectedItemQuery = useGraphItem(selectedItem!);
+    const selectedItemQuery = useGraphItem(selectedItem);
 
     /** Set the selected node or edge. The most recently selected item will stay highlighted */
     const setSelectedItem = useCallback(
@@ -53,23 +55,7 @@ export const useExploreSelectedItem = () => {
         [selectedItem]
     );
 
-    const selectedHiddenEdge = {
-        id: selectedItem ? selectedItem : 'Hidden',
-        name: '** Hidden Edge **',
-        data: {},
-        sourceNode: {
-            id: 'HIDDEN',
-            objectId: 'HIDDEN',
-            name: 'HIDDEN',
-            type: 'HIDDEN',
-        },
-        targetNode: {
-            id: 'HIDDEN',
-            objectId: 'HIDDEN',
-            name: 'HIDDEN',
-            type: 'HIDDEN',
-        },
-    };
+    const isHidden = selectedItem?.includes(HIDDEN_STRING);
 
     return {
         selectedItem,
@@ -77,8 +63,8 @@ export const useExploreSelectedItem = () => {
         setSelectedItem,
         selectedItemType,
         clearSelectedItem,
-        selectedHiddenEdge,
         previousSelectedItem,
         setPreviousSelectedItem,
+        isHidden,
     };
 };

--- a/packages/javascript/bh-shared-ui/src/hooks/useFetchEntityInfo/utils.ts
+++ b/packages/javascript/bh-shared-ui/src/hooks/useFetchEntityInfo/utils.ts
@@ -14,9 +14,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import { AssetGroupTag, AssetGroupTagTypeZone } from 'js-client-library';
+import { TagLabelPrefix } from '../../constants';
 import { ActiveDirectoryNodeKind, AzureNodeKind } from '../../graphSchema';
 import { EntityKinds } from '../../utils/content';
-import { TagLabelPrefix } from '../useAssetGroupTags';
 
 export const getZoneNameFromKinds = (
     tags: AssetGroupTag[] | undefined,

--- a/packages/javascript/bh-shared-ui/src/hooks/useGraphItem.tsx
+++ b/packages/javascript/bh-shared-ui/src/hooks/useGraphItem.tsx
@@ -14,8 +14,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+import { NodeDetails, NodeDetailsWithInfo, RelationshipDetails, RelationshipDetailsWithInfo } from 'js-client-library';
 import { useQuery } from 'react-query';
-import { apiClient, parseItemId } from '../utils';
+import { apiClient, REL_ID_PREFIX } from '../utils';
 
 export interface BaseItemResponse {
     id: string;
@@ -50,42 +51,56 @@ export const isEdge = (response: ItemResponse): response is EdgeResponse => {
     return 'source' in response;
 };
 
-export const useGraphItem = (itemId?: string) => {
-    return useQuery<ItemResponse>(
-        ['getGraphItem', itemId],
-        () => {
-            const parsedItem = parseItemId(itemId!);
-            return apiClient.cypherSearch(parsedItem.cypherQuery, undefined, true).then((res) => {
-                if (!itemId) {
-                    return undefined;
-                }
-                if (parsedItem.itemType === 'edge') {
-                    const edgeResponse = res.data?.data?.edges?.[0];
-                    const sourceNode = { id: edgeResponse.source, ...res.data?.data?.nodes?.[edgeResponse.source] };
-                    const targetNode = { id: edgeResponse.target, ...res.data?.data?.nodes?.[edgeResponse.target] };
-                    return {
-                        id: itemId,
-                        ...edgeResponse,
-                        sourceNode,
-                        targetNode,
-                    };
-                }
+export const isRelationshipResponse = (
+    response: RelationshipDetails | RelationshipDetailsWithInfo | NodeDetails | NodeDetailsWithInfo
+): response is RelationshipDetails | RelationshipDetailsWithInfo => {
+    return 'relationship_id' in response;
+};
 
-                const [id, nodeData] = Object.entries(res.data?.data?.nodes)[0];
-                return {
-                    id,
-                    ...nodeData,
-                };
-            });
+export const isNodeResponse = (
+    response?: RelationshipDetails | RelationshipDetailsWithInfo | NodeDetails | NodeDetailsWithInfo
+): response is NodeDetails | NodeDetailsWithInfo => {
+    return response ? 'node_id' in response : false;
+};
+
+export const useGetRelationshipById = (id?: number) => {
+    return useQuery({
+        queryKey: ['getRelationshipById', id],
+        queryFn: async () => {
+            return apiClient.getRelationshipByID(id!).then((res) => res.data.data);
         },
-        {
-            enabled: !!itemId,
-            retryOnMount: false,
-            retry: false,
-            refetchOnWindowFocus: false,
-            keepPreviousData: true,
-        }
-    );
+        enabled: !!id,
+        retryOnMount: false,
+        retry: false,
+        refetchOnWindowFocus: false,
+        keepPreviousData: true,
+    });
+};
+
+export const useGetNodeById = (id?: number) => {
+    return useQuery({
+        queryKey: ['getNodeById', id],
+        queryFn: async () => {
+            return apiClient.getNodeByID(id!).then((res) => res.data.data);
+        },
+        enabled: !!id,
+        retryOnMount: false,
+        retry: false,
+        refetchOnWindowFocus: false,
+        keepPreviousData: true,
+    });
+};
+
+export const useGraphItem = (itemId?: string | null) => {
+    const isRelationship = !!itemId?.includes(REL_ID_PREFIX);
+
+    const relationshipId = itemId ? parseInt(itemId.slice(REL_ID_PREFIX.length)) : undefined;
+    const relQuery = useGetRelationshipById(relationshipId);
+
+    const nodeId = itemId ? parseInt(itemId) : undefined;
+    const nodeQuery = useGetNodeById(nodeId);
+
+    return isRelationship ? relQuery : nodeQuery;
 };
 
 export const useNodeByObjectId = (itemId?: string) => {

--- a/packages/javascript/bh-shared-ui/src/hooks/usePrimaryKind.ts
+++ b/packages/javascript/bh-shared-ui/src/hooks/usePrimaryKind.ts
@@ -1,0 +1,59 @@
+// Copyright 2026 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { NodeKindRef, RelationshipKindRef, SourceKind } from 'js-client-library';
+import { TagLabelPrefix } from '../constants';
+import { useSourceKindsQuery } from './useSourceKinds';
+
+type KindNames = string[];
+
+type KindObject = { name: string };
+type KindObjects = KindObject[];
+
+type EntityKinds = NodeKindRef[] | RelationshipKindRef[];
+
+type KindList = KindNames | EntityKinds;
+
+const isKindNames = (kinds: KindList): kinds is KindNames => {
+    return !kinds[0] || typeof kinds[0] === 'string';
+};
+
+const kindObjectsToKindNames = (kinds: KindObjects): KindNames => {
+    return kinds.map((kind) => kind.name);
+};
+
+const getSourceKindNames = (sourceKinds: SourceKind[] | undefined): KindNames => {
+    if (!sourceKinds) return [];
+
+    return kindObjectsToKindNames(sourceKinds);
+};
+
+const filterTagsAndSourceKinds = (kinds: KindNames, sourceKindNames: KindNames) => {
+    return kinds.filter((kind) => !kind.startsWith(TagLabelPrefix) && !sourceKindNames.includes(kind));
+};
+
+export const usePrimaryKind = (kinds: KindList) => {
+    const { data: sourceKinds } = useSourceKindsQuery();
+    const sourceKindNames = getSourceKindNames(sourceKinds);
+
+    const kindNames = isKindNames(kinds) ? kinds : kindObjectsToKindNames(kinds);
+
+    const sourceAndTagFilteredKinds = filterTagsAndSourceKinds(kindNames, sourceKindNames);
+
+    const primaryKind = sourceAndTagFilteredKinds[0];
+
+    return primaryKind ? primaryKind : kindNames[0];
+};

--- a/packages/javascript/bh-shared-ui/src/hooks/useSourceKinds.ts
+++ b/packages/javascript/bh-shared-ui/src/hooks/useSourceKinds.ts
@@ -1,0 +1,39 @@
+// Copyright 2026 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { type OptionsObject } from 'notistack';
+import { useQuery } from 'react-query';
+import { useNotifications } from '../providers/NotificationProvider/hooks';
+import { apiClient } from '../utils/api';
+
+const ERROR = {
+    key: 'source-kinds',
+    message: 'An error occurred while loading source kinds. Try refreshing the page.',
+    options: {
+        persist: true,
+        anchorOrigin: { vertical: 'top', horizontal: 'right' },
+    } as OptionsObject,
+};
+
+export const useSourceKindsQuery = () => {
+    const { addNotification } = useNotifications();
+
+    return useQuery({
+        queryKey: ['source-kinds'],
+        queryFn: ({ signal }) => apiClient.getSourceKinds({ signal }).then((res) => res.data.data.kinds),
+        onError: () => addNotification(ERROR.message, ERROR.key, ERROR.options),
+    });
+};

--- a/packages/javascript/bh-shared-ui/src/mocks/handlers/zoneHandlers.ts
+++ b/packages/javascript/bh-shared-ui/src/mocks/handlers/zoneHandlers.ts
@@ -69,6 +69,14 @@ const zoneHandlers = [
         );
     }),
 
+    rest.get('/api/v2/nodes/:id', async (_, res, ctx) => {
+        return res(
+            ctx.json({
+                data: {},
+            })
+        );
+    }),
+
     rest.get('/api/v2/config', async (_, res, ctx) => {
         return res(
             ctx.json({

--- a/packages/javascript/bh-shared-ui/src/providers/AppNameProvider.tsx
+++ b/packages/javascript/bh-shared-ui/src/providers/AppNameProvider.tsx
@@ -1,4 +1,4 @@
-// Copyright 2023 Specter Ops, Inc.
+// Copyright 2026 Specter Ops, Inc.
 //
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
@@ -14,6 +14,14 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-export * from './AnnouncementProvider';
-export * from './AppNameProvider';
-export * from './NotificationProvider';
+import React, { createContext, useContext } from 'react';
+
+const EnterpriseString = 'BloodHound Enterprise';
+const AppNameContext = createContext(EnterpriseString);
+
+export const AppNameProvider: React.FC<{ name: string; children: React.ReactNode }> = ({ name, children }) => (
+    <AppNameContext.Provider value={name}>{children}</AppNameContext.Provider>
+);
+
+export const useAppName = () => useContext(AppNameContext);
+export const useIsEnterprise = () => useContext(AppNameContext) === EnterpriseString;

--- a/packages/javascript/bh-shared-ui/src/types.ts
+++ b/packages/javascript/bh-shared-ui/src/types.ts
@@ -14,7 +14,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { EntityKinds } from './utils/content';
 import { Permission } from './utils/permissions';
 
 // recursively applies Partial<T> to nested object types
@@ -104,7 +103,7 @@ export type SaveQueryAction = 'edit' | 'save-as' | undefined;
 
 export type SelectedNode = {
     id: string;
-    type: EntityKinds;
+    type: string;
     name: string;
     graphId?: string;
 };

--- a/packages/javascript/bh-shared-ui/src/views/Explore/ContextMenu/AssetGroupMenuItemPrivilegeZonesEnabled.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/Explore/ContextMenu/AssetGroupMenuItemPrivilegeZonesEnabled.test.tsx
@@ -18,7 +18,7 @@ import userEvent from '@testing-library/user-event';
 import { NodeDetails } from 'js-client-library';
 import { rest } from 'msw';
 import { setupServer } from 'msw/node';
-import { getIsOwnedTag, getIsTierZeroTag, isOwnedObject, isTierZero } from '../../../hooks';
+import { getOwnedTag, getTierZeroTag } from '../../../hooks';
 import { createAuthStateWithPermissions } from '../../../mocks';
 import { withoutErrorLogging } from '../../../mocks/stderr';
 import { render, screen } from '../../../test-utils';
@@ -116,9 +116,8 @@ describe('AssetGroupMenuItem', () => {
         render(
             <AssetGroupMenuItem
                 addNodePayload={{} as any}
-                isCurrentMemberFn={isOwnedObject}
                 removeNodePathFn={() => '/privilege-zones/labels/1/details'}
-                tagIdentifierFn={getIsOwnedTag}
+                tagIdentifierFn={getOwnedTag}
             />,
             {
                 route: ROUTE_WITH_SELECTED_ITEM_PARAM,
@@ -140,9 +139,8 @@ describe('AssetGroupMenuItem', () => {
             render(
                 <AssetGroupMenuItem
                     addNodePayload={{} as any}
-                    isCurrentMemberFn={isOwnedObject}
                     removeNodePathFn={() => '/privilege-zones/labels/1/details'}
-                    tagIdentifierFn={getIsOwnedTag}
+                    tagIdentifierFn={getOwnedTag}
                 />,
                 {
                     route: ROUTE_WITH_SELECTED_ITEM_PARAM,
@@ -160,9 +158,8 @@ describe('AssetGroupMenuItem', () => {
         render(
             <AssetGroupMenuItem
                 addNodePayload={{} as any}
-                isCurrentMemberFn={isTierZero}
                 removeNodePathFn={() => '/privilege-zones/zones/1/details'}
-                tagIdentifierFn={getIsTierZeroTag}
+                tagIdentifierFn={getTierZeroTag}
                 showConfirmationOnAdd={true}
             />,
             {
@@ -193,9 +190,8 @@ describe('AssetGroupMenuItem', () => {
         render(
             <AssetGroupMenuItem
                 addNodePayload={{} as any}
-                isCurrentMemberFn={isOwnedObject}
                 removeNodePathFn={() => '/privilege-zones/labels/1/details'}
-                tagIdentifierFn={getIsOwnedTag}
+                tagIdentifierFn={getOwnedTag}
             />,
             {
                 route: ROUTE_WITH_SELECTED_ITEM_PARAM,
@@ -222,9 +218,8 @@ describe('AssetGroupMenuItem', () => {
         render(
             <AssetGroupMenuItem
                 addNodePayload={{} as any}
-                isCurrentMemberFn={isOwnedObject}
                 removeNodePathFn={() => '/privilege-zones/labels/1/details'}
-                tagIdentifierFn={getIsOwnedTag}
+                tagIdentifierFn={getOwnedTag}
             />,
             { route: ROUTE_WITH_SELECTED_ITEM_PARAM }
         );

--- a/packages/javascript/bh-shared-ui/src/views/Explore/ContextMenu/AssetGroupMenuItemPrivilegeZonesEnabled.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/Explore/ContextMenu/AssetGroupMenuItemPrivilegeZonesEnabled.test.tsx
@@ -15,6 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import userEvent from '@testing-library/user-event';
+import { NodeDetails } from 'js-client-library';
 import { rest } from 'msw';
 import { setupServer } from 'msw/node';
 import { getIsOwnedTag, getIsTierZeroTag, isOwnedObject, isTierZero } from '../../../hooks';
@@ -46,42 +47,30 @@ const assetGroupTags = {
     },
 };
 
-const cypherSearchResponse = {
-    data: {
-        nodes: {
-            '1234': {
-                label: 'TEST@DOMAIN.CORP',
-                kind: 'GPO',
-                kinds: ['Base', 'GPO'],
-                objectId: 'A1B2C3D4-1111-2222-3333-0123456789AB',
-                isTierZero: false,
-                isOwnedObject: false,
-                lastSeen: '2025-12-04T20:16:49.209Z',
-            },
-        },
-        edges: [],
+const selectedNode: NodeDetails = {
+    node_id: 1234,
+    kinds: [{ node_kind_id: 3, name: 'GPO' }],
+    properties: {
+        objectid: 'A1B2C3D4-1111-2222-3333-0123456789AB',
+        name: 'TEST@DOMAIN.CORP',
+        lastSeen: '2025-12-04T20:16:49.209Z',
     },
 };
 
-const cypherSearchOwnedResponse = {
+const nodeDetailsResponse = {
+    data: selectedNode,
+};
+
+const nodeDetailsOwnedResponse = {
     data: {
-        nodes: {
-            '1234': {
-                ...cypherSearchResponse.data.nodes['1234'],
-                isOwnedObject: true,
-            },
-        },
-        edges: [],
+        ...nodeDetailsResponse.data,
+        kinds: [...nodeDetailsResponse.data.kinds, { node_kind_id: 2, name: 'Tag_Owned' }],
     },
 };
 
 const getEntityInfoTestProps = () => ({
     entityinfo: {
-        selectedNode: {
-            name: 'foo',
-            id: '1234',
-            type: 'User',
-        },
+        selectedNode: selectedNode,
     },
 });
 
@@ -96,8 +85,8 @@ const server = setupServer(
     rest.get('/api/v2/asset-group-tags', (req, res, ctx) => {
         return res(ctx.json(assetGroupTags));
     }),
-    rest.post('/api/v2/graphs/cypher', (req, res, ctx) => {
-        return res(ctx.json(cypherSearchResponse));
+    rest.get('/api/v2/nodes/1234', (req, res, ctx) => {
+        return res(ctx.json(nodeDetailsResponse));
     }),
     rest.get('/api/v2/self', (req, res, ctx) => {
         return res(
@@ -111,7 +100,7 @@ const server = setupServer(
     })
 );
 
-const ROUTE_WITH_SELECTED_ITEM_PARAM = `?selectedItem=${getEntityInfoTestProps().entityinfo.selectedNode.id}&searchType=node&primarySearch=${getEntityInfoTestProps().entityinfo.selectedNode.id}`;
+const ROUTE_WITH_SELECTED_ITEM_PARAM = `?selectedItem=${getEntityInfoTestProps().entityinfo.selectedNode.node_id}&searchType=node&primarySearch=${getEntityInfoTestProps().entityinfo.selectedNode.node_id}`;
 
 describe('AssetGroupMenuItem', () => {
     beforeAll(() => server.listen());
@@ -225,8 +214,8 @@ describe('AssetGroupMenuItem', () => {
 
     it('removes a node from an asset group tag', async () => {
         server.use(
-            rest.post('/api/v2/graphs/cypher', (req, res, ctx) => {
-                return res(ctx.json(cypherSearchOwnedResponse));
+            rest.get('/api/v2/nodes/1234', (req, res, ctx) => {
+                return res(ctx.json(nodeDetailsOwnedResponse));
             })
         );
 

--- a/packages/javascript/bh-shared-ui/src/views/Explore/ContextMenu/AssetGroupMenuItemPrivilegeZonesEnabled.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/Explore/ContextMenu/AssetGroupMenuItemPrivilegeZonesEnabled.tsx
@@ -20,8 +20,15 @@ import { FC, useState } from 'react';
 import { useMutation } from 'react-query';
 import { Link } from 'react-router-dom';
 
-import type { AssetGroupTag, CreateSelectorRequest } from 'js-client-library';
-import { useExploreSelectedItem, usePermissions, useTagsQuery, type ItemResponse } from '../../../hooks';
+import type {
+    AssetGroupTag,
+    CreateSelectorRequest,
+    NodeDetails,
+    NodeDetailsWithInfo,
+    RelationshipDetails,
+    RelationshipDetailsWithInfo,
+} from 'js-client-library';
+import { useExploreSelectedItem, usePermissions, useTagsQuery } from '../../../hooks';
 import { useNotifications } from '../../../providers';
 import { Permission, apiClient } from '../../../utils';
 
@@ -54,7 +61,10 @@ const ConfirmNodeChangesDialog: FC<{
 
 export const AssetGroupMenuItem: FC<{
     addNodePayload: CreateSelectorRequest;
-    isCurrentMemberFn: (node: ItemResponse) => boolean;
+    isCurrentMemberFn: (
+        node: NodeDetails | RelationshipDetails | RelationshipDetailsWithInfo | NodeDetailsWithInfo | undefined,
+        tag: AssetGroupTag | undefined
+    ) => boolean;
     removeNodePathFn: (tag: AssetGroupTag) => string;
     showConfirmationOnAdd?: boolean;
     tagIdentifierFn: (tags: AssetGroupTag[]) => AssetGroupTag | undefined;
@@ -89,7 +99,7 @@ export const AssetGroupMenuItem: FC<{
     const hasPermission = checkPermission(Permission.GRAPH_DB_WRITE);
 
     // Is the selected node already a member of tier zero or owned?
-    const isCurrentMember = isCurrentMemberFn(selectedItemQuery.data);
+    const isCurrentMember = isCurrentMemberFn(selectedItemQuery.data, assetGroupTag);
 
     // Don't render anything if the user doesn't have permission or the asset group doesn't exist
     if (!hasPermission) {

--- a/packages/javascript/bh-shared-ui/src/views/Explore/ContextMenu/AssetGroupMenuItemPrivilegeZonesEnabled.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/Explore/ContextMenu/AssetGroupMenuItemPrivilegeZonesEnabled.tsx
@@ -20,15 +20,8 @@ import { FC, useState } from 'react';
 import { useMutation } from 'react-query';
 import { Link } from 'react-router-dom';
 
-import type {
-    AssetGroupTag,
-    CreateSelectorRequest,
-    NodeDetails,
-    NodeDetailsWithInfo,
-    RelationshipDetails,
-    RelationshipDetailsWithInfo,
-} from 'js-client-library';
-import { useExploreSelectedItem, usePermissions, useTagsQuery } from '../../../hooks';
+import type { AssetGroupTag, CreateSelectorRequest } from 'js-client-library';
+import { isTaggedObject, useExploreSelectedItem, usePermissions, useTagsQuery } from '../../../hooks';
 import { useNotifications } from '../../../providers';
 import { Permission, apiClient } from '../../../utils';
 
@@ -61,14 +54,10 @@ const ConfirmNodeChangesDialog: FC<{
 
 export const AssetGroupMenuItem: FC<{
     addNodePayload: CreateSelectorRequest;
-    isCurrentMemberFn: (
-        node: NodeDetails | RelationshipDetails | RelationshipDetailsWithInfo | NodeDetailsWithInfo | undefined,
-        tag: AssetGroupTag | undefined
-    ) => boolean;
     removeNodePathFn: (tag: AssetGroupTag) => string;
     showConfirmationOnAdd?: boolean;
     tagIdentifierFn: (tags: AssetGroupTag[]) => AssetGroupTag | undefined;
-}> = ({ addNodePayload, isCurrentMemberFn, removeNodePathFn, showConfirmationOnAdd = false, tagIdentifierFn }) => {
+}> = ({ addNodePayload, removeNodePathFn, showConfirmationOnAdd = false, tagIdentifierFn }) => {
     const [dialogOpen, setDialogOpen] = useState(false);
     const { addNotification } = useNotifications();
     const { selectedItemQuery } = useExploreSelectedItem();
@@ -99,7 +88,7 @@ export const AssetGroupMenuItem: FC<{
     const hasPermission = checkPermission(Permission.GRAPH_DB_WRITE);
 
     // Is the selected node already a member of tier zero or owned?
-    const isCurrentMember = isCurrentMemberFn(selectedItemQuery.data, assetGroupTag);
+    const isCurrentMember = isTaggedObject(selectedItemQuery.data, assetGroupTag);
 
     // Don't render anything if the user doesn't have permission or the asset group doesn't exist
     if (!hasPermission) {

--- a/packages/javascript/bh-shared-ui/src/views/Explore/ContextMenu/ContextMenuPrivilegeZonesEnabled.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/Explore/ContextMenu/ContextMenuPrivilegeZonesEnabled.test.tsx
@@ -37,8 +37,20 @@ const server = setupServer(
             })
         );
     }),
-    rest.post('/api/v2/graphs/cypher', (req, res, ctx) => {
-        return res(ctx.json({ data: { nodes: { abc: { objectId: 'abc' }, def: { objectId: 'def' } }, edges: [] } }));
+    rest.get('/api/v2/nodes/1234', (req, res, ctx) => {
+        return res(
+            ctx.json({
+                data: {
+                    node_id: 1234,
+                    kinds: [{ node_kind_id: 3, name: 'User' }],
+                    properties: {
+                        objectid: 'abc',
+                        name: 'Test Node',
+                        lastSeen: '2025-01-01T00:00:00Z',
+                    },
+                },
+            })
+        );
     }),
     rest.get('/api/v2/asset-group-tags', (req, res, ctx) => {
         return res(
@@ -120,7 +132,7 @@ describe('ContextMenu', () => {
 
     it('sets a primarySearch=id and searchType=node when secondarySearch is falsey', async () => {
         render(<ContextMenu contextMenu={{ mouseX: 0, mouseY: 0 }} onClose={vi.fn()} />, {
-            route: '/test?selectedItem=abc',
+            route: '/test?selectedItem=1234',
         });
 
         const startNodeOption = await screen.findByRole('menuitem', { name: /set as starting node/i });
@@ -135,7 +147,7 @@ describe('ContextMenu', () => {
 
     it('sets a primarySearch=id and searchType=pathfinding when secondarySearch is truethy', async () => {
         render(<ContextMenu contextMenu={{ mouseX: 0, mouseY: 0 }} onClose={vi.fn()} />, {
-            route: '/test?selectedItem=abc&secondarySearch=def',
+            route: '/test?selectedItem=1234&secondarySearch=def',
         });
 
         const startNodeOption = await screen.findByRole('menuitem', { name: /set as starting node/i });
@@ -149,7 +161,7 @@ describe('ContextMenu', () => {
 
     it('sets secondarySearch=id and searchType=node when primarySearch is falsey', async () => {
         render(<ContextMenu contextMenu={{ mouseX: 0, mouseY: 0 }} onClose={vi.fn()} />, {
-            route: '/test?selectedItem=abc',
+            route: '/test?selectedItem=1234',
         });
 
         const endNodeOption = await screen.findByRole('menuitem', { name: /set as ending node/i });
@@ -163,7 +175,7 @@ describe('ContextMenu', () => {
 
     it('sets a secondary=id and searchType=pathfinding when primary is truethy', async () => {
         render(<ContextMenu contextMenu={{ mouseX: 0, mouseY: 0 }} onClose={vi.fn()} />, {
-            route: '/test?selectedItem=abc&primarySearch=def',
+            route: '/test?selectedItem=1234&primarySearch=def',
         });
 
         const endNodeOption = await screen.findByRole('menuitem', { name: /set as ending node/i });

--- a/packages/javascript/bh-shared-ui/src/views/Explore/ContextMenu/ContextMenuPrivilegeZonesEnabled.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/Explore/ContextMenu/ContextMenuPrivilegeZonesEnabled.tsx
@@ -24,11 +24,9 @@ import {
 } from 'js-client-library';
 import { FC } from 'react';
 import {
-    getIsOwnedTag,
-    getIsTierZeroTag,
+    getOwnedTag,
+    getTierZeroTag,
     isNodeResponse,
-    isOwnedObject,
-    isTierZero,
     useExploreParams,
     useExploreSelectedItem,
     usePZPathParams,
@@ -97,17 +95,15 @@ const ContextMenu: FC<{
 
             <AssetGroupMenuItem
                 addNodePayload={tierZeroPayload}
-                isCurrentMemberFn={isTierZero}
                 removeNodePathFn={(tag: AssetGroupTag) => tagDetailsLink(tag.id, 'zones')}
                 showConfirmationOnAdd
-                tagIdentifierFn={getIsTierZeroTag}
+                tagIdentifierFn={getTierZeroTag}
             />
 
             <AssetGroupMenuItem
                 addNodePayload={ownedPayload}
-                isCurrentMemberFn={isOwnedObject}
                 removeNodePathFn={(tag: AssetGroupTag) => tagDetailsLink(tag.id, 'labels')}
-                tagIdentifierFn={getIsOwnedTag}
+                tagIdentifierFn={getOwnedTag}
             />
 
             <CopyMenuItem />

--- a/packages/javascript/bh-shared-ui/src/views/Explore/ContextMenu/ContextMenuPrivilegeZonesEnabled.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/Explore/ContextMenu/ContextMenuPrivilegeZonesEnabled.tsx
@@ -19,19 +19,19 @@ import {
     AssetGroupTag,
     AssetGroupTagSelectorAutoCertifySeedsOnly,
     CreateSelectorRequest,
+    NodeDetails,
     SeedTypeObjectId,
 } from 'js-client-library';
 import { FC } from 'react';
 import {
     getIsOwnedTag,
     getIsTierZeroTag,
-    isNode,
+    isNodeResponse,
     isOwnedObject,
     isTierZero,
     useExploreParams,
     useExploreSelectedItem,
     usePZPathParams,
-    type NodeResponse,
 } from '../../../hooks';
 import { AssetGroupMenuItem } from './AssetGroupMenuItemPrivilegeZonesEnabled';
 import CopyMenuItem from './CopyMenuItem';
@@ -44,14 +44,14 @@ const ContextMenu: FC<{
     const { setExploreParams, primarySearch, secondarySearch } = useExploreParams();
     const { tagDetailsLink } = usePZPathParams();
 
-    const node = selectedItemQuery.data ? (selectedItemQuery.data as NodeResponse) : undefined;
+    const node = selectedItemQuery.data ? (selectedItemQuery.data as NodeDetails) : undefined;
 
     const ownedPayload: CreateSelectorRequest = {
-        name: node?.label ?? node?.objectId ?? '',
+        name: node?.properties.name ?? node?.properties.objectid ?? '',
         seeds: [
             {
                 type: SeedTypeObjectId,
-                value: node?.objectId ?? '',
+                value: node?.properties.objectid ?? '',
             },
         ],
     };
@@ -63,24 +63,24 @@ const ContextMenu: FC<{
 
     const handleSetStartingNode = () => {
         const selectedItemData = selectedItemQuery.data;
-        if (selectedItemData && isNode(selectedItemData)) {
+        if (selectedItemData && isNodeResponse(selectedItemData)) {
             const searchType = secondarySearch ? 'pathfinding' : 'node';
             setExploreParams({
                 exploreSearchTab: 'pathfinding',
                 searchType,
-                primarySearch: selectedItemData?.objectId,
+                primarySearch: selectedItemData?.properties.objectid,
             });
         }
     };
 
     const handleSetEndingNode = () => {
         const selectedItemData = selectedItemQuery.data;
-        if (selectedItemData && isNode(selectedItemData)) {
+        if (selectedItemData && isNodeResponse(selectedItemData)) {
             const searchType = primarySearch ? 'pathfinding' : 'node';
             setExploreParams({
                 exploreSearchTab: 'pathfinding',
                 searchType,
-                secondarySearch: selectedItemData?.objectId,
+                secondarySearch: selectedItemData?.properties.objectid,
             });
         }
     };

--- a/packages/javascript/bh-shared-ui/src/views/Explore/ContextMenu/CopyMenuItem.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/Explore/ContextMenu/CopyMenuItem.test.tsx
@@ -15,6 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import userEvent from '@testing-library/user-event';
+import { NodeDetails } from 'js-client-library';
 import * as hooks from '../../../hooks';
 import { render } from '../../../test-utils';
 import CopyMenuItem from './CopyMenuItem';
@@ -22,8 +23,10 @@ import CopyMenuItem from './CopyMenuItem';
 const useExploreSelectedItemSpy = vi.spyOn(hooks, 'useExploreSelectedItem');
 
 describe('CopyMenuItem', () => {
-    const selectedNode = {
-        label: 'foo',
+    const selectedNode: NodeDetails = {
+        node_id: 1,
+        kinds: [],
+        properties: { name: 'foo', objectid: 'bar', lastSeen: '' },
     };
 
     const setup = () => {
@@ -48,6 +51,6 @@ describe('CopyMenuItem', () => {
         await user.click(nameOption);
 
         const clipboardText = await navigator.clipboard.readText();
-        expect(clipboardText).toBe(selectedNode.label);
+        expect(clipboardText).toBe(selectedNode.properties.name);
     });
 });

--- a/packages/javascript/bh-shared-ui/src/views/Explore/ContextMenu/CopyMenuItem.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/Explore/ContextMenu/CopyMenuItem.tsx
@@ -61,7 +61,7 @@ const CopyMenuItem = () => {
 
     const handleCopyCypher = () => {
         if (nodeInfo) {
-            const cypher = `MATCH (n:${primaryKind}}) WHERE n.objectid = ${escapeCypherString(nodeInfo.properties.objectid || '')} RETURN n`;
+            const cypher = `MATCH (n:${primaryKind}) WHERE n.objectid = ${escapeCypherString(nodeInfo.properties.objectid || '')} RETURN n`;
             navigator.clipboard.writeText(cypher);
             addNotification(`Cypher copied to clipboard`, 'copyToClipboard');
         }

--- a/packages/javascript/bh-shared-ui/src/views/Explore/ContextMenu/CopyMenuItem.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/Explore/ContextMenu/CopyMenuItem.tsx
@@ -17,11 +17,13 @@
 import { faCaretRight } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { MenuItem, Tooltip, TooltipProps, styled, tooltipClasses } from '@mui/material';
-import { NodeResponse, useExploreSelectedItem } from '../../../hooks';
+import { NodeDetails } from 'js-client-library';
+import { useExploreSelectedItem } from '../../../hooks';
+import { usePrimaryKind } from '../../../hooks/usePrimaryKind';
 import { useNotifications } from '../../../providers';
 import { escapeCypherString } from '../../../utils/cypher';
 
-const StyledTooltip = styled(({ className, ...props }: TooltipProps) => (
+export const StyledTooltip = styled(({ className, ...props }: TooltipProps) => (
     <Tooltip {...props} classes={{ popper: className }} />
 ))(({ theme }) => ({
     [`& .${tooltipClasses.tooltip}`]: {
@@ -39,24 +41,27 @@ const CopyMenuItem = () => {
     const { addNotification } = useNotifications();
 
     const { selectedItemQuery } = useExploreSelectedItem();
+    const nodeInfo = selectedItemQuery.data as NodeDetails | undefined;
+
+    const primaryKind = usePrimaryKind(nodeInfo?.kinds || []);
 
     const handleCopyName = () => {
-        if (selectedItemQuery.data) {
-            navigator.clipboard.writeText(selectedItemQuery.data.label);
+        if (nodeInfo) {
+            navigator.clipboard.writeText(nodeInfo.properties.name || nodeInfo.properties.objectid || '');
             addNotification(`Name copied to clipboard`, 'copyToClipboard');
         }
     };
 
     const handleCopyObjectId = () => {
-        if (selectedItemQuery.data) {
-            navigator.clipboard.writeText((selectedItemQuery.data as NodeResponse).objectId);
+        if (nodeInfo) {
+            navigator.clipboard.writeText(nodeInfo.properties.objectid || '');
             addNotification(`Object ID copied to clipboard`, 'copyToClipboard');
         }
     };
 
     const handleCopyCypher = () => {
-        if (selectedItemQuery.data) {
-            const cypher = `MATCH (n:${selectedItemQuery.data.kind}) WHERE n.objectid = ${escapeCypherString((selectedItemQuery.data as NodeResponse).objectId)} RETURN n`;
+        if (nodeInfo) {
+            const cypher = `MATCH (n:${primaryKind}}) WHERE n.objectid = ${escapeCypherString(nodeInfo.properties.objectid || '')} RETURN n`;
             navigator.clipboard.writeText(cypher);
             addNotification(`Cypher copied to clipboard`, 'copyToClipboard');
         }

--- a/packages/javascript/bh-shared-ui/src/views/Explore/EdgeInfo/EdgeInfoContent.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/Explore/EdgeInfo/EdgeInfoContent.test.tsx
@@ -14,83 +14,93 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import userEvent from '@testing-library/user-event';
+import { RelationshipDetails } from 'js-client-library';
 import { rest } from 'msw';
 import { setupServer } from 'msw/node';
 import { INHERITANCE_DROPDOWN_DESCRIPTION } from '../../../components/HelpTexts/shared/ACLInheritance';
 import {
     ActiveDirectoryKindProperties,
-    ActiveDirectoryNodeKind,
     ActiveDirectoryRelationshipKind,
     CommonKindProperties,
 } from '../../../graphSchema';
 import { render, screen, waitFor } from '../../../test-utils';
-import { SelectedEdge } from '../ExploreSearch/EdgeFilter/edgeCategories';
 import { ObjectInfoPanelContextProvider } from '../providers';
 import EdgeInfoContent from './EdgeInfoContent';
 
 const server = setupServer(
-    rest.post(`/api/v2/graphs/cypher`, (req, res, ctx) => {
+    rest.get(`/api/v2/relationships/1`, (req, res, ctx) => {
         return res(
             ctx.json({
                 data: {
-                    nodes: {},
-                    edges: [
-                        {
-                            source: '1',
-                            target: '2',
-                            label: 'CustomEdge',
-                            kind: 'CustomEdge',
-                            lastSeen: '2023-09-07T11:10:33.664596893Z',
-                            properties: {
-                                lastseen: '2023-09-07T11:10:33.664596893Z',
-                                isacl: false,
-                            },
-                        },
-                    ],
-                },
-            })
-        );
-    }),
-    rest.get(`/api/v2/users/:id`, async (req, res, ctx) => {
-        return res(
-            ctx.json({
-                data: {
-                    props: {
-                        objectid: '2',
+                    relationship_id: 1,
+                    kind: { relationship_kind_id: 1, name: 'CustomEdge' },
+                    source_node_id: 1,
+                    target_node_id: 2,
+                    properties: {
+                        isacl: false,
+                        is_traversable: true,
+                        lastSeen: '2023-09-07T11:10:33.664596893Z',
                     },
                 },
             })
         );
     }),
-    rest.get(`/api/v2/computers/testing-node-123`, async (req, res, ctx) => {
+    rest.get(`/api/v2/nodes/1`, async (req, res, ctx) => {
         return res(
             ctx.json({
                 data: {
-                    props: {
+                    node_id: 1,
+                    kinds: [{ node_kind_id: 1, name: 'User' }],
+                    properties: {
+                        objectid: 'source-node-1',
+                        name: 'Source User',
+                        lastSeen: '2023-09-07T11:10:33.664596893Z',
+                    },
+                },
+            })
+        );
+    }),
+    rest.get(`/api/v2/nodes/2`, async (req, res, ctx) => {
+        return res(
+            ctx.json({
+                data: {
+                    node_id: 2,
+                    kinds: [{ node_kind_id: 2, name: 'User' }],
+                    properties: {
+                        objectid: 'target-node-2',
+                        name: 'Target User',
+                        lastSeen: '2023-09-07T11:10:33.664596893Z',
+                    },
+                },
+            })
+        );
+    }),
+    rest.get(`/api/v2/nodes/3`, async (req, res, ctx) => {
+        return res(
+            ctx.json({
+                data: {
+                    node_id: 3,
+                    kinds: [{ node_kind_id: 3, name: 'Computer' }],
+                    properties: {
+                        objectid: 'target-node-3',
+                        name: 'Target Computer With LAPS',
                         haslaps: true,
-                        objectid: 'testing-node-123',
+                        lastSeen: '2023-09-07T11:10:33.664596893Z',
                     },
                 },
             })
         );
     }),
-    rest.get(`/api/v2/computers/testing-node-456`, async (req, res, ctx) => {
+    rest.get(`/api/v2/nodes/4`, async (req, res, ctx) => {
         return res(
             ctx.json({
                 data: {
-                    props: {
-                        objectid: 'testing-node-456',
-                    },
-                },
-            })
-        );
-    }),
-    rest.get(`/api/v2/groups/testing-node-456`, async (req, res, ctx) => {
-        return res(
-            ctx.json({
-                data: {
-                    props: {
-                        objectid: 'testing-node-456',
+                    node_id: 4,
+                    kinds: [{ node_kind_id: 4, name: 'Computer' }],
+                    properties: {
+                        objectid: 'target-node-4',
+                        name: 'Target Computer Without LAPS',
+                        lastSeen: '2023-09-07T11:10:33.664596893Z',
                     },
                 },
             })
@@ -114,129 +124,74 @@ const server = setupServer(
         );
     })
 );
-
-const selectedEdge: SelectedEdge = {
-    id: 'rel_1',
-    name: 'CustomEdge',
-    data: {
+const selectedEdge: RelationshipDetails = {
+    relationship_id: 1,
+    kind: { name: 'CustomEdge', relationship_kind_id: 1 },
+    properties: {
+        lastSeen: '',
+        is_traversable: false,
         [ActiveDirectoryKindProperties.IsACL]: false,
         [CommonKindProperties.LastSeen]: '2023-09-07T11:10:33.664596893Z',
     },
-    sourceNode: {
-        name: 'source node',
-        id: '1',
-        objectId: '1',
-        type: ActiveDirectoryNodeKind.User,
-    },
-    targetNode: {
-        name: 'target node',
-        id: '2',
-        objectId: '2',
-        type: ActiveDirectoryNodeKind.User,
-    },
+    source_node_id: 1,
+    target_node_id: 2,
 };
 
-const selectedEdgeHasLapsEnabled: SelectedEdge = {
-    id: '2',
-    name: ActiveDirectoryRelationshipKind.GenericAll,
-    data: {
+const selectedEdgeHasLapsEnabled: RelationshipDetails = {
+    relationship_id: 2,
+    kind: { name: ActiveDirectoryRelationshipKind.GenericAll, relationship_kind_id: 2 },
+    properties: {
+        lastSeen: '',
+        is_traversable: false,
         [ActiveDirectoryKindProperties.IsACL]: false,
         [CommonKindProperties.LastSeen]: '2023-09-07T11:10:33.664596893Z',
     },
-    sourceNode: {
-        name: 'source node',
-        id: '1',
-        objectId: '1',
-        type: ActiveDirectoryNodeKind.User,
-    },
-    targetNode: {
-        name: 'target node',
-        id: '3',
-        objectId: 'testing-node-123',
-        type: ActiveDirectoryNodeKind.Computer,
-    },
+    source_node_id: 1,
+    target_node_id: 3,
 };
 
-const selectedEdgeHasLapsDisabled: SelectedEdge = {
-    id: '3',
-    name: ActiveDirectoryRelationshipKind.GenericAll,
-    data: {
+const selectedEdgeHasLapsDisabled: RelationshipDetails = {
+    relationship_id: 3,
+    kind: { name: ActiveDirectoryRelationshipKind.GenericAll, relationship_kind_id: 2 },
+    properties: {
+        lastSeen: '',
+        is_traversable: false,
         [ActiveDirectoryKindProperties.IsACL]: false,
         [CommonKindProperties.LastSeen]: '2023-09-07T11:10:33.664596893Z',
     },
-    sourceNode: {
-        name: 'source node',
-        id: '1',
-        objectId: '1',
-        type: ActiveDirectoryNodeKind.User,
-    },
-    targetNode: {
-        name: 'target node',
-        id: '4',
-        objectId: 'testing-node-456',
-        type: ActiveDirectoryNodeKind.Computer,
-    },
+    source_node_id: 1,
+    target_node_id: 4,
 };
 
-const selectedEdgeADCSESC4: SelectedEdge = {
+const selectedEdgeADCSESC4: RelationshipDetails = {
     ...selectedEdge,
-    name: ActiveDirectoryRelationshipKind.ADCSESC4,
+    kind: { name: ActiveDirectoryRelationshipKind.ADCSESC4, relationship_kind_id: 4 },
 };
 
-const selectedEdgeHidden: SelectedEdge = {
-    id: 'HIDDEN',
-    name: '*** Hidden Edge ***',
-    data: {},
-    sourceNode: {
-        name: 'hidden',
-        id: 'hidden',
-        objectId: 'hidden',
-        type: 'hidden',
-    },
-    targetNode: {
-        name: 'hidden',
-        id: 'hidden',
-        objectId: 'hidden',
-        type: 'hidden',
-    },
-};
-
-const selectedEdgeACLInheritance: SelectedEdge = {
-    id: '3',
-    name: ActiveDirectoryRelationshipKind.WriteOwner,
-    data: {
+const selectedEdgeACLInheritance: RelationshipDetails = {
+    relationship_id: 2,
+    kind: { name: ActiveDirectoryRelationshipKind.GenericAll, relationship_kind_id: 2 },
+    properties: {
+        lastSeen: '',
+        is_traversable: false,
         [ActiveDirectoryKindProperties.IsACL]: true,
+        [CommonKindProperties.LastSeen]: '2023-09-07T11:10:33.664596893Z',
         [CommonKindProperties.IsInherited]: true,
         [ActiveDirectoryKindProperties.InheritanceHash]: 'test_hash',
     },
-    sourceNode: {
-        name: 'source node',
-        id: '1',
-        objectId: '1',
-        type: ActiveDirectoryNodeKind.Group,
-    },
-    targetNode: {
-        name: 'target node',
-        id: '4',
-        objectId: 'testing-node-456',
-        type: ActiveDirectoryNodeKind.Group,
-    },
+    source_node_id: 1,
+    target_node_id: 4,
 };
 
 const windowsAbuseHasLapsText = (sourceName: string, targetName: string) => {
     return `The GenericAll permission grants ${sourceName} the ability to obtain the LAPS (RID 500 administrator) password of ${targetName}.`;
 };
 
-const hasLapsEnabledTestText = windowsAbuseHasLapsText(
-    selectedEdgeHasLapsEnabled.sourceNode.name,
-    selectedEdgeHasLapsEnabled.targetNode.name
-);
-const hasLapsDisabledTestText = windowsAbuseHasLapsText(
-    selectedEdgeHasLapsDisabled.sourceNode.name,
-    selectedEdgeHasLapsDisabled.targetNode.name
-);
+// Node names are sourced from the MSW mock handlers for /api/v2/nodes/:id
+const hasLapsEnabledTestText = windowsAbuseHasLapsText('Source User', 'Target Computer With LAPS');
+const hasLapsDisabledTestText = windowsAbuseHasLapsText('Source User', 'Target Computer Without LAPS');
 
-const EdgeInfoContentWithProvider = ({ selectedEdge }: { selectedEdge: SelectedEdge }) => (
+const EdgeInfoContentWithProvider = ({ selectedEdge }: { selectedEdge: RelationshipDetails }) => (
     <ObjectInfoPanelContextProvider>
         <EdgeInfoContent selectedEdge={selectedEdge!} />
     </ObjectInfoPanelContextProvider>
@@ -250,12 +205,12 @@ describe('EdgeInfoContent', () => {
     test('Trying to view the edge info does not crash the app when selecting an unrecognized edge', async () => {
         render(<EdgeInfoContentWithProvider selectedEdge={selectedEdge} />);
 
-        expect(await screen.findByText(/source node/)).toBeInTheDocument();
+        expect(await screen.findByText(/Source Node:/)).toBeInTheDocument();
 
         //The text is broken up into different elements because of the span that bolds the custom edge so these assertions are broken up to match that
         //The assertions use regex to avoid having to match on the white space
         expect(screen.getByText(/The edge/)).toBeInTheDocument();
-        expect(screen.getByText(selectedEdge.name)).toBeInTheDocument();
+        expect(screen.getByText(selectedEdge.kind.name)).toBeInTheDocument();
         expect(
             screen.getByText(/does not have any additional contextual information at this time./)
         ).toBeInTheDocument();
@@ -275,7 +230,7 @@ describe('EdgeInfoContent', () => {
         render(<EdgeInfoContentWithProvider selectedEdge={selectedEdgeHasLapsEnabled} />);
 
         const user = userEvent.setup();
-        const windowAbuseAccordion = screen.getByText('Windows Abuse');
+        const windowAbuseAccordion = await screen.findByText('Windows Abuse');
         await user.click(windowAbuseAccordion);
 
         expect(screen.getByText(hasLapsEnabledTestText, { exact: false })).toBeInTheDocument();
@@ -284,7 +239,7 @@ describe('EdgeInfoContent', () => {
         render(<EdgeInfoContentWithProvider selectedEdge={selectedEdgeHasLapsDisabled} />);
 
         const user = userEvent.setup();
-        const windowAbuseAccordion = screen.getByText('Windows Abuse');
+        const windowAbuseAccordion = await screen.findByText('Windows Abuse');
         await user.click(windowAbuseAccordion);
 
         expect(screen.queryByText(hasLapsDisabledTestText, { exact: false })).not.toBeInTheDocument();
@@ -293,13 +248,13 @@ describe('EdgeInfoContent', () => {
         render(<EdgeInfoContentWithProvider selectedEdge={selectedEdgeACLInheritance} />);
 
         const user = userEvent.setup();
-        const inheritanceAccordion = screen.getByText('ACE Inherited From');
+        const inheritanceAccordion = await screen.findByText('ACE Inherited From');
         await user.click(inheritanceAccordion);
 
         expect(screen.queryByText(INHERITANCE_DROPDOWN_DESCRIPTION)).toBeInTheDocument();
     });
     describe('EdgeInfoContent support for Deep Linking', () => {
-        const test_id = selectedEdgeADCSESC4.id;
+        const test_id = selectedEdgeADCSESC4.relationship_id;
         const setup = () => {
             const screen = render(<EdgeInfoContentWithProvider selectedEdge={selectedEdgeADCSESC4} />, {
                 route: `?selectedItem=${test_id}`,
@@ -322,18 +277,18 @@ describe('EdgeInfoContent', () => {
         it('calls setExploreParams with searchType and relationshipQueryItemId when selecting a composition accordion', async () => {
             const { user, screen } = setup();
 
-            const compositionAccordion = screen.getByText('Composition');
+            const compositionAccordion = await screen.findByText('Composition');
             await user.click(compositionAccordion);
 
             await waitFor(() => {
                 expect(window.location.search).toContain('searchType=composition');
             });
-            expect(window.location.search).toContain(`relationshipQueryItemId=${test_id}`);
+            expect(window.location.search).toContain(`relationshipQueryItemId=rel_${test_id}`);
         });
         it('calls setExploreParams with only the expandedSection label when selecting any accordion that is not composition', async () => {
             const { user, screen } = setup();
 
-            const generalAccordion = screen.getByText('General');
+            const generalAccordion = await screen.findByText('General');
             await user.click(generalAccordion);
 
             await waitFor(() => expect(window.location.search).toContain('expandedPanelSections=general'));
@@ -344,29 +299,11 @@ describe('EdgeInfoContent', () => {
 
     describe('EdgeInfoContent support for hidden edges', () => {
         const setup = () => {
-            const screen = render(<EdgeInfoContentWithProvider selectedEdge={selectedEdgeHidden} />);
+            // isHidden is derived from selectedItem URL param containing 'HIDDEN'
+            const screen = render(<EdgeInfoContentWithProvider selectedEdge={selectedEdge} />, {
+                route: '?selectedItem=HIDDEN',
+            });
             const user = userEvent.setup();
-
-            server.use(
-                rest.post(`/api/v2/graphs/cypher`, (req, res, ctx) => {
-                    return res(
-                        ctx.json({
-                            data: {
-                                nodes: {},
-                                edges: [
-                                    {
-                                        id: 'HIDDEN',
-                                        source: 'HIDDEN',
-                                        target: 'HIDDEN',
-                                        label: 'HIDDEN',
-                                        kind: 'HIDDEN',
-                                    },
-                                ],
-                            },
-                        })
-                    );
-                })
-            );
 
             return { screen, user };
         };

--- a/packages/javascript/bh-shared-ui/src/views/Explore/EdgeInfo/EdgeInfoContent.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/Explore/EdgeInfo/EdgeInfoContent.tsx
@@ -15,27 +15,31 @@
 // SPDX-License-Identifier: Apache-2.0
 import { Box, Divider } from '@mui/material';
 import { Typography } from 'doodle-ui';
+import { RelationshipDetails } from 'js-client-library';
 import { ElementType, FC, Fragment } from 'react';
 import EdgeInfoComponents from '../../../components/HelpTexts';
 import ACLInheritance from '../../../components/HelpTexts/shared/ACLInheritance';
 import { ActiveDirectoryKindProperties, CommonKindProperties } from '../../../graphSchema';
-import { useExploreParams, useFetchEntityInfo } from '../../../hooks';
-import { EdgeSections, SelectedEdge } from '../ExploreSearch/EdgeFilter/edgeCategories';
+import { useExploreParams, useExploreSelectedItem, useGetNodeById } from '../../../hooks';
+import { usePrimaryKind } from '../../../hooks/usePrimaryKind';
+import { EdgeSections } from '../ExploreSearch/EdgeFilter/edgeCategories';
 import { FieldsContainer } from '../fragments';
 import EdgeInfoCollapsibleSection from './EdgeInfoCollapsibleSection';
 import EdgeObjectInformation from './EdgeObjectInformation';
 
-const EdgeInfoContent: FC<{ selectedEdge: NonNullable<SelectedEdge> }> = ({ selectedEdge }) => {
+const EdgeInfoContent: FC<{ selectedEdge: NonNullable<RelationshipDetails> }> = ({ selectedEdge }) => {
     const { setExploreParams, expandedPanelSections } = useExploreParams();
-    const sections = EdgeInfoComponents[selectedEdge.name as keyof typeof EdgeInfoComponents];
-    const { sourceNode, targetNode } = selectedEdge;
-    const { objectId, type } = targetNode;
-    const { data: targetNodeProperties } = useFetchEntityInfo({
-        objectId,
-        nodeType: type,
-    });
+    const { isHidden } = useExploreSelectedItem();
+    const sections = EdgeInfoComponents[selectedEdge.kind.name as keyof typeof EdgeInfoComponents];
+    const { source_node_id, target_node_id } = selectedEdge;
 
-    const hiddenEdge = selectedEdge.data && selectedEdge.id.includes('HIDDEN') && selectedEdge.name.includes('Hidden');
+    const { data: sourceNode, ...sourceNodeQuery } = useGetNodeById(source_node_id);
+    const { data: targetNode, ...targetNodeQuery } = useGetNodeById(target_node_id);
+
+    const sourcePrimaryKind = usePrimaryKind(sourceNode?.kinds ?? []);
+    const targetPrimaryKind = usePrimaryKind(targetNode?.kinds ?? []);
+
+    if (sourceNodeQuery.isLoading || targetNodeQuery.isLoading) return null;
 
     const removeExpandedPanelSectionParams = () => {
         setExploreParams({
@@ -44,10 +48,10 @@ const EdgeInfoContent: FC<{ selectedEdge: NonNullable<SelectedEdge> }> = ({ sele
     };
 
     const shouldRenderACLInheritance = !!(
-        selectedEdge.data[ActiveDirectoryKindProperties.IsACL] &&
-        selectedEdge.data[CommonKindProperties.IsInherited] &&
-        typeof selectedEdge.data[ActiveDirectoryKindProperties.InheritanceHash] === 'string' &&
-        selectedEdge.data[ActiveDirectoryKindProperties.InheritanceHash].length > 0
+        selectedEdge.properties[ActiveDirectoryKindProperties.IsACL] &&
+        selectedEdge.properties[CommonKindProperties.IsInherited] &&
+        typeof selectedEdge.properties[ActiveDirectoryKindProperties.InheritanceHash] === 'string' &&
+        selectedEdge.properties[ActiveDirectoryKindProperties.InheritanceHash].length > 0
     );
 
     const renderDropdownFromSection = (section: [string, any], index: number) => {
@@ -61,7 +65,7 @@ const EdgeInfoContent: FC<{ selectedEdge: NonNullable<SelectedEdge> }> = ({ sele
                 expandedPanelSections: [sectionKeyLabel],
                 ...(sectionKeyLabel === 'composition' && {
                     searchType: 'composition',
-                    relationshipQueryItemId: selectedEdge.id,
+                    relationshipQueryItemId: `rel_${selectedEdge.relationship_id}`,
                 }),
             });
         };
@@ -81,15 +85,15 @@ const EdgeInfoContent: FC<{ selectedEdge: NonNullable<SelectedEdge> }> = ({ sele
                     isExpanded={isExpandedPanelSection}
                     onChange={handleOnChange}>
                     <Section
-                        edgeName={selectedEdge.name}
-                        sourceDBId={sourceNode.id}
-                        sourceName={sourceNode.name}
-                        sourceType={sourceNode.type}
-                        targetDBId={targetNode.id}
-                        targetName={targetNode.name}
-                        targetType={targetNode.type}
-                        targetId={targetNode.objectId}
-                        haslaps={!!targetNodeProperties?.properties.haslaps}
+                        edgeName={selectedEdge.kind.name}
+                        sourceDBId={source_node_id}
+                        sourceName={sourceNode?.properties.name}
+                        sourceType={sourcePrimaryKind}
+                        targetDBId={target_node_id}
+                        targetName={targetNode?.properties.name}
+                        targetType={targetPrimaryKind}
+                        targetId={targetNode?.properties.objectid}
+                        haslaps={!!targetNode?.properties.haslaps}
                     />
                 </EdgeInfoCollapsibleSection>
             </Fragment>
@@ -103,7 +107,7 @@ const EdgeInfoContent: FC<{ selectedEdge: NonNullable<SelectedEdge> }> = ({ sele
             setExploreParams({
                 expandedPanelSections: ['aclinheritance'],
                 searchType: 'aclinheritance',
-                relationshipQueryItemId: selectedEdge.id,
+                relationshipQueryItemId: `rel_${selectedEdge.relationship_id}`,
             });
         };
 
@@ -111,8 +115,6 @@ const EdgeInfoContent: FC<{ selectedEdge: NonNullable<SelectedEdge> }> = ({ sele
             if (isOpen) setExpandedPanelSectionsParam();
             else removeExpandedPanelSectionParams();
         };
-
-        const castIdToInt = (id: string | number) => (typeof id === 'string' ? parseInt(id) : id);
 
         return (
             <Fragment key={Object.keys(sections).length}>
@@ -124,10 +126,12 @@ const EdgeInfoContent: FC<{ selectedEdge: NonNullable<SelectedEdge> }> = ({ sele
                     isExpanded={isExpandedPanelSection}
                     onChange={handleOnChange}>
                     <ACLInheritance
-                        edgeName={selectedEdge.name}
-                        sourceDBId={castIdToInt(sourceNode.id)}
-                        targetDBId={castIdToInt(targetNode.id)}
-                        inheritanceHash={selectedEdge.data[ActiveDirectoryKindProperties.InheritanceHash]}
+                        edgeName={selectedEdge.kind.name}
+                        sourceDBId={source_node_id}
+                        targetDBId={target_node_id}
+                        inheritanceHash={
+                            selectedEdge.properties[ActiveDirectoryKindProperties.InheritanceHash] as string
+                        }
                     />
                 </EdgeInfoCollapsibleSection>
             </Fragment>
@@ -136,9 +140,7 @@ const EdgeInfoContent: FC<{ selectedEdge: NonNullable<SelectedEdge> }> = ({ sele
 
     return (
         <Box>
-            {!hiddenEdge ? (
-                <EdgeObjectInformation selectedEdge={selectedEdge} />
-            ) : (
+            {isHidden ? (
                 <FieldsContainer>
                     <div>
                         <p className='text-sm'>
@@ -146,6 +148,8 @@ const EdgeInfoContent: FC<{ selectedEdge: NonNullable<SelectedEdge> }> = ({ sele
                         </p>
                     </div>
                 </FieldsContainer>
+            ) : (
+                <EdgeObjectInformation selectedEdge={selectedEdge} sourceNode={sourceNode} targetNode={targetNode} />
             )}
             {sections || shouldRenderACLInheritance ? (
                 <>
@@ -154,7 +158,7 @@ const EdgeInfoContent: FC<{ selectedEdge: NonNullable<SelectedEdge> }> = ({ sele
                 </>
             ) : (
                 <>
-                    {!hiddenEdge && (
+                    {!isHidden && (
                         <>
                             <Box padding={1}>
                                 <Divider />
@@ -162,7 +166,7 @@ const EdgeInfoContent: FC<{ selectedEdge: NonNullable<SelectedEdge> }> = ({ sele
 
                             <Box paddingLeft={'0.5rem'}>
                                 <Typography variant='body1' className='text-xs'>
-                                    The edge <strong className='text-xs'>{selectedEdge.name}</strong>
+                                    The edge <strong className='text-xs'>{selectedEdge.kind.name}</strong>
                                     does not have any additional contextual information at this time.
                                 </Typography>
                             </Box>

--- a/packages/javascript/bh-shared-ui/src/views/Explore/EdgeInfo/EdgeInfoHeader.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/Explore/EdgeInfo/EdgeInfoHeader.tsx
@@ -28,7 +28,7 @@ export interface HeaderProps {
 const Header: React.FC<HeaderProps> = ({ name = 'None Selected' }) => {
     const { setIsObjectInfoPanelOpen } = useObjectInfoPanelContext();
     const { setExploreParams } = useExploreParams();
-    const { clearSelectedItem, selectedItem, selectedItemType } = useExploreSelectedItem();
+    const { clearSelectedItem, isHidden } = useExploreSelectedItem();
 
     const handleCollapseAll = () => {
         setIsObjectInfoPanelOpen(false);
@@ -36,8 +36,6 @@ const Header: React.FC<HeaderProps> = ({ name = 'None Selected' }) => {
             expandedPanelSections: [],
         });
     };
-
-    const hiddenEdge = selectedItem?.includes('HIDDEN') && selectedItemType === 'edge';
 
     return (
         <div className='flex justify-between items-center text-sm font-bold'>
@@ -49,7 +47,7 @@ const Header: React.FC<HeaderProps> = ({ name = 'None Selected' }) => {
                 <FontAwesomeIcon icon={faAngleDoubleUp} />
             </Icon>
 
-            {hiddenEdge && <HiddenEntityIcon />}
+            {isHidden && <HiddenEntityIcon />}
 
             <h2 data-testid='explore_edge-information-pane_header-text' className='text-nowrap leading-10 grow'>
                 {name}

--- a/packages/javascript/bh-shared-ui/src/views/Explore/EdgeInfo/EdgeInfoPane.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/Explore/EdgeInfo/EdgeInfoPane.tsx
@@ -16,16 +16,16 @@
 import { faEyeSlash } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Badge } from 'doodle-ui';
+import { RelationshipDetails } from 'js-client-library';
 import React, { HTMLProps } from 'react';
 import useRoleBasedFiltering from '../../../hooks/useRoleBasedFiltering';
 import { cn } from '../../../utils';
-import { SelectedEdge } from '../ExploreSearch/EdgeFilter/edgeCategories';
 import { ObjectInfoPanelContextProvider } from '../providers';
 import EdgeInfoContent from './EdgeInfoContent';
 import Header from './EdgeInfoHeader';
 
 interface EdgeInfoPaneProps {
-    selectedEdge: SelectedEdge | null;
+    selectedEdge: RelationshipDetails | null;
     className?: HTMLProps<HTMLDivElement>['className'];
 }
 
@@ -52,7 +52,7 @@ const EdgeInfoPane: React.FC<EdgeInfoPaneProps> = ({ className, selectedEdge }) 
             {selectedEdge && (
                 <>
                     <div className='bg-neutral-2 pointer-events-auto rounded-lg shadow-outer-1'>
-                        <Header name={selectedEdge?.name || 'None'} />
+                        <Header name={selectedEdge?.kind.name || 'None'} />
                     </div>
                     <div className='bg-neutral-2 mt-2 overflow-x-hidden overflow-y-auto py-1 px-4 pointer-events-auto rounded-lg shadow-outer-1'>
                         <EdgeInfoContent selectedEdge={selectedEdge} />

--- a/packages/javascript/bh-shared-ui/src/views/Explore/EdgeInfo/EdgeObjectInformation.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/Explore/EdgeInfo/EdgeObjectInformation.test.tsx
@@ -13,70 +13,44 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
-import { rest } from 'msw';
-import { setupServer } from 'msw/node';
+import { NodeDetails, RelationshipDetails } from 'js-client-library';
 import { render, screen } from '../../../test-utils';
-import { SelectedEdge } from '../ExploreSearch/EdgeFilter/edgeCategories';
 import { ObjectInfoPanelContextProvider } from '../providers';
 import EdgeObjectInformation from './EdgeObjectInformation';
 
-const server = setupServer();
+const selectedEdge: RelationshipDetails = {
+    relationship_id: 1,
+    kind: { name: 'DCSync', relationship_kind_id: 1 },
+    properties: { lastSeen: '2023-09-07T11:10:33.664596893Z', is_traversable: true, isacl: false },
+    source_node_id: 1,
+    target_node_id: 2,
+};
 
-const selectedEdge: SelectedEdge = {
-    id: '1',
-    name: 'DCSync',
-    data: { lastseen: '2023-09-07T11:10:33.664596893Z' },
-    sourceNode: {
-        name: 'source_node',
-        id: '1',
-        objectId: '1',
-        type: 'User',
-    },
-    targetNode: { name: 'target_node', id: '2', objectId: '2', type: 'User' },
+const mockSourceNode: NodeDetails = {
+    node_id: 1,
+    kinds: [],
+    properties: { objectid: 'source-objectid', name: 'source_node', lastSeen: '2023-09-07T11:10:33.664596893Z' },
+};
+
+const mockTargetNode: NodeDetails = {
+    node_id: 2,
+    kinds: [],
+    properties: { objectid: 'target-objectid', name: 'target_node', lastSeen: '2023-09-07T11:10:33.664596893Z' },
 };
 
 const EdgeObjectInformationWithProvider = () => (
     <ObjectInfoPanelContextProvider>
-        <EdgeObjectInformation selectedEdge={selectedEdge} />
+        <EdgeObjectInformation selectedEdge={selectedEdge} sourceNode={mockSourceNode} targetNode={mockTargetNode} />
     </ObjectInfoPanelContextProvider>
 );
 
-beforeAll(() => server.listen());
-afterEach(() => server.resetHandlers());
-afterAll(() => server.close());
-
 describe('EdgeObjectInformation', () => {
-    test('The edge properties are fetched through a cypher search which includes lastseen', async () => {
-        server.use(
-            rest.post(`/api/v2/graphs/cypher`, (req, res, ctx) => {
-                return res(
-                    ctx.json({
-                        data: {
-                            nodes: {},
-                            edges: [
-                                {
-                                    source: '48297',
-                                    target: '1238',
-                                    label: 'DCSync',
-                                    kind: 'DCSync',
-                                    lastSeen: '2023-09-07T11:10:33.664596893Z',
-                                    properties: {
-                                        lastseen: '2023-09-07T11:10:33.664596893Z',
-                                        isacl: false,
-                                    },
-                                },
-                            ],
-                        },
-                    })
-                );
-            })
-        );
-
+    test('The edge properties are fetched through the relationship endpoint which includes lastseen', async () => {
         render(<EdgeObjectInformationWithProvider />);
 
         expect(await screen.findByText(/source_node/)).toBeInTheDocument();
 
-        //Display the information obtained from the cypher query for all edge properties
+        //Display the information obtained from the relationship endpoint for all edge properties
         expect(screen.getByText(/Source Node:/)).toBeInTheDocument();
         expect(screen.getByText(/source_node/)).toBeInTheDocument();
         expect(screen.getByText(/Target Node:/)).toBeInTheDocument();
@@ -84,35 +58,5 @@ describe('EdgeObjectInformation', () => {
         expect(screen.getByText(/Is ACL:/)).toBeInTheDocument();
         expect(screen.getByText(/FALSE/)).toBeInTheDocument();
         expect(screen.getByText(/Last Seen by BloodHound:/)).toBeInTheDocument();
-    });
-
-    test('Error handling for fetching edge information', async () => {
-        console.error = vi.fn();
-        server.use(
-            rest.post(`/api/v2/graphs/cypher`, (req, res, ctx) => {
-                return res(
-                    ctx.status(500),
-                    ctx.json({
-                        errorMessage: `Internal Server Error`,
-                    })
-                );
-            })
-        );
-
-        render(<EdgeObjectInformationWithProvider />);
-
-        expect(await screen.findByText(/source_node/)).toBeInTheDocument();
-
-        //These fields are all obtainable from the original graph response information
-        //so if there is an error we can still display at least this information
-        expect(screen.getByText(/Source Node:/)).toBeInTheDocument();
-        expect(screen.getByText(/source_node/)).toBeInTheDocument();
-        expect(screen.getByText(/Target Node:/)).toBeInTheDocument();
-        expect(screen.getByText(/target_node/)).toBeInTheDocument();
-
-        //These are extra fields that don't come with the graph response
-        //so if there is an error with the edge query they will not be displayed
-        expect(screen.queryByText(/Is ACL:/)).toBeNull();
-        expect(screen.queryByText(/FALSE/)).toBeNull();
     });
 });

--- a/packages/javascript/bh-shared-ui/src/views/Explore/EdgeInfo/EdgeObjectInformation.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/Explore/EdgeInfo/EdgeObjectInformation.tsx
@@ -13,71 +13,48 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
-import { Skeleton } from '@mui/material';
+import { NodeDetails, RelationshipDetails } from 'js-client-library';
 import { FC, useEffect } from 'react';
-import { useQuery } from 'react-query';
 import { usePreviousValue } from '../../../hooks';
-import { EntityField, apiClient, formatObjectInfoFields } from '../../../utils';
-import { SelectedEdge } from '../ExploreSearch/EdgeFilter/edgeCategories';
+import { EntityField, formatObjectInfoFields } from '../../../utils';
 import { FieldsContainer, ObjectInfoFields } from '../fragments';
 import { useObjectInfoPanelContext } from '../providers';
 import EdgeInfoCollapsibleSection from './EdgeInfoCollapsibleSection';
 
-const selectedEdgeCypherQuery = (sourceId: string | number, targetId: string | number, edgeKind: string): string =>
-    `MATCH (s)-[r:${edgeKind}]->(t) WHERE ID(s) = ${sourceId} AND ID(t) = ${targetId} RETURN r LIMIT 1`;
+type EdgeObjectInformationProps = {
+    selectedEdge: NonNullable<RelationshipDetails>;
+    sourceNode: NodeDetails | undefined;
+    targetNode: NodeDetails | undefined;
+};
 
-const EdgeObjectInformation: FC<{ selectedEdge: NonNullable<SelectedEdge> }> = ({ selectedEdge }) => {
+const EdgeObjectInformation: FC<EdgeObjectInformationProps> = ({ selectedEdge, sourceNode, targetNode }) => {
     const { isObjectInfoPanelOpen, setIsObjectInfoPanelOpen } = useObjectInfoPanelContext();
 
-    const previousId = usePreviousValue(selectedEdge.id);
+    const previousId = usePreviousValue(selectedEdge.relationship_id);
 
     useEffect(() => {
-        if (previousId !== selectedEdge.id) {
+        if (previousId !== selectedEdge.relationship_id) {
             setIsObjectInfoPanelOpen(true);
         }
-    }, [previousId, selectedEdge.id, setIsObjectInfoPanelOpen]);
-
-    const {
-        data: cypherResponse,
-        isLoading,
-        isError,
-    } = useQuery([selectedEdge.id], async ({ signal }) => {
-        return apiClient
-            .cypherSearch(
-                selectedEdgeCypherQuery(selectedEdge.sourceNode.id, selectedEdge.targetNode.id, selectedEdge.name),
-                { signal },
-                true
-            )
-            .then((result: any) => {
-                if (!result.data.data) return { nodes: {}, edges: [] };
-                return result.data.data;
-            });
-    });
-
-    if (isLoading) {
-        return <Skeleton variant='rectangular' />;
-    }
+    }, [previousId, selectedEdge.relationship_id, setIsObjectInfoPanelOpen]);
 
     const sourceNodeField: EntityField = {
         label: 'Source Node:',
-        value: selectedEdge.sourceNode.name,
+        value: sourceNode?.properties.name || sourceNode?.properties.objectid || '',
     };
 
     const targetNodeField: EntityField = {
         label: 'Target Node:',
-        value: selectedEdge.targetNode.name,
+        value: targetNode?.properties.name || targetNode?.properties.objectid || '',
     };
 
-    let formattedObjectFields: EntityField[] = [sourceNodeField, targetNodeField];
-
-    if (!isError) {
-        formattedObjectFields = [
-            ...formattedObjectFields,
-            ...formatObjectInfoFields({
-                ...(cypherResponse.edges[0]?.properties || {}),
-            }),
-        ];
-    }
+    const formattedObjectFields: EntityField[] = [
+        sourceNodeField,
+        targetNodeField,
+        ...formatObjectInfoFields({
+            ...selectedEdge.properties,
+        }),
+    ];
 
     const sectionLabel = 'Relationship Information';
 

--- a/packages/javascript/bh-shared-ui/src/views/Explore/ExploreSearch/CypherSearch.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/Explore/ExploreSearch/CypherSearch.test.tsx
@@ -54,7 +54,7 @@ const singleNodeGraphResponse = {
 const zeroNodeGraphResponse = {
     data: {
         nodes: {},
-        edges: [{ source: '1', target: '2', label: 'HasSession', kind: 'HasSession', lastSeen: '2023-01-01' }],
+        edges: [{ id: 1, source: '1', target: '2', label: 'HasSession', kind: 'HasSession', lastSeen: '2023-01-01' }],
     },
 };
 

--- a/packages/javascript/bh-shared-ui/src/views/Explore/GraphItemInformationPanel.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/Explore/GraphItemInformationPanel.tsx
@@ -14,21 +14,28 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import {
-    EdgeInfoPane,
-    EntityInfoDataTableGraphed,
-    EntityInfoPanel,
-    EntityKinds,
-    isEdge,
-    isNode,
-    useExploreSelectedItem,
-} from 'bh-shared-ui';
+import { NodeDetails, RelationshipDetails } from 'js-client-library';
 import { HTMLProps } from 'react';
+import { EntityInfoDataTableGraphed, EntityInfoPanel } from '../../components';
+import { isNodeResponse, isRelationshipResponse, useExploreSelectedItem, usePrimaryKind } from '../../hooks';
+import { useIsEnterprise } from '../../providers/AppNameProvider';
+import { EdgeInfoPane } from './EdgeInfo';
 
 const defaultClasses: HTMLProps<HTMLElement>['className'] = 'bottom-0 top-0 py-4 absolute right-4';
 
+const getItemKinds = (item: NodeDetails | RelationshipDetails | undefined) => {
+    if (!item) return [];
+
+    return isNodeResponse(item) ? item.kinds : [item.kind];
+};
+
 const GraphItemInformationPanel = () => {
     const { selectedItem, selectedItemQuery } = useExploreSelectedItem();
+
+    const showFilteringBanner = useIsEnterprise();
+
+    const kinds = getItemKinds(selectedItemQuery.data);
+    const primaryKind = usePrimaryKind(kinds);
 
     if (!selectedItem || selectedItemQuery.isLoading) {
         return null;
@@ -37,43 +44,30 @@ const GraphItemInformationPanel = () => {
     if (selectedItemQuery.isError) {
         return (
             <EntityInfoPanel
+                showFilteringBanner={showFilteringBanner}
                 DataTable={EntityInfoDataTableGraphed}
                 className={defaultClasses}
-                selectedNode={{ graphId: selectedItem, id: '', name: 'Unknown', type: 'Unknown' as EntityKinds }}
+                selectedNode={{ graphId: selectedItem, id: '', name: 'Unknown', type: 'Unknown' }}
             />
         );
     }
 
-    if (selectedItemQuery.data && isEdge(selectedItemQuery.data)) {
-        const selectedEdge = {
-            id: selectedItem as string,
-            name: selectedItemQuery.data.label || '',
-            data: selectedItemQuery.data.properties || {},
-            sourceNode: {
-                id: selectedItemQuery.data.source,
-                objectId: selectedItemQuery.data.sourceNode.objectId,
-                name: selectedItemQuery.data.sourceNode.label,
-                type: selectedItemQuery.data.sourceNode.kind,
-            },
-            targetNode: {
-                id: selectedItemQuery.data.target,
-                objectId: selectedItemQuery.data.targetNode.objectId,
-                name: selectedItemQuery.data.targetNode.label,
-                type: selectedItemQuery.data.targetNode.kind,
-            },
-        };
-        return <EdgeInfoPane className={defaultClasses} selectedEdge={selectedEdge} />;
+    if (!selectedItemQuery.data) return null;
+
+    if (isRelationshipResponse(selectedItemQuery.data)) {
+        return <EdgeInfoPane className={defaultClasses} selectedEdge={selectedItemQuery.data} />;
     }
 
-    if (selectedItemQuery.data && isNode(selectedItemQuery.data)) {
+    if (isNodeResponse(selectedItemQuery.data)) {
         const selectedNode = {
-            graphId: selectedItem,
-            id: selectedItemQuery.data.objectId,
-            name: selectedItemQuery.data.label,
-            type: selectedItemQuery.data.kind as EntityKinds,
+            graphId: selectedItemQuery.data.node_id.toString(),
+            id: selectedItemQuery.data.properties.objectid ?? '',
+            name: selectedItemQuery.data.properties.name || selectedItemQuery.data.properties.objectid || '',
+            type: primaryKind,
         };
         return (
             <EntityInfoPanel
+                showFilteringBanner={showFilteringBanner}
                 className={defaultClasses}
                 selectedNode={selectedNode}
                 DataTable={EntityInfoDataTableGraphed}

--- a/packages/javascript/bh-shared-ui/src/views/Explore/index.ts
+++ b/packages/javascript/bh-shared-ui/src/views/Explore/index.ts
@@ -17,9 +17,9 @@
 export * from './BasicObjectInfoFields';
 export * from './ContextMenu/AssetGroupMenuItemPrivilegeZonesEnabled';
 export { default as ContextMenuPrivilegeZonesEnabled } from './ContextMenu/ContextMenuPrivilegeZonesEnabled';
-export { default as CopyMenuItem } from './ContextMenu/CopyMenuItem';
-export * from './EdgeInfo';
+export { default as CopyMenuItem, StyledTooltip } from './ContextMenu/CopyMenuItem';
 export * from './ExploreSearch';
 export * from './fragments';
+export { default as GraphItemInformationPanel } from './GraphItemInformationPanel';
 export * from './InfoStyles';
 export * from './providers';

--- a/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/PrivilegeZones.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/PrivilegeZones.tsx
@@ -21,8 +21,8 @@ import { Badge, Tabs, TabsList, TabsTrigger } from 'doodle-ui';
 import React, { FC, Suspense } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { Route, Routes, useLocation } from 'react-router-dom';
-import { useAppName } from '../../components/PageWithTitle';
 import { useHighestPrivilegeTagId, useOwnedTagId, usePZPathParams, useRoleBasedFiltering } from '../../hooks';
+import { useAppName } from '../../providers/AppNameProvider';
 import {
     ROUTE_PZ_CERTIFICATIONS,
     ROUTE_PZ_HISTORY,

--- a/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/PrivilegeZonesCypherEditor/PrivilegeZonesCypherEditor.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/PrivilegeZonesCypherEditor/PrivilegeZonesCypherEditor.tsx
@@ -19,7 +19,7 @@ import { Button, Card, CardContent, CardHeader, CardTitle } from 'doodle-ui';
 import { SeedTypeCypher } from 'js-client-library';
 import { FC, useCallback, useEffect, useRef, useState } from 'react';
 import { useLocation } from 'react-router-dom';
-import { TagLabelPrefix } from '../../../hooks/useAssetGroupTags';
+import { TagLabelPrefix } from '../../../constants';
 import { useCypherSchema } from '../../../hooks/useGraphKinds';
 import { usePZPathParams } from '../../../hooks/usePZParams';
 import { cn } from '../../../utils';

--- a/packages/javascript/js-client-library/src/client.ts
+++ b/packages/javascript/js-client-library/src/client.ts
@@ -107,6 +107,7 @@ import {
     RotateWebhookSecretResponse,
     SavedQuery,
     SavedQueryPermissionsResponse,
+    SourceKindsResponse,
     StartFileIngestResponse,
     UnifiedFindingResponse,
     UpdateConfigurationResponse,
@@ -256,10 +257,7 @@ class BHEAPIClient {
     getKinds = (options?: RequestOptions) => this.baseClient.get<GraphKindsResponse>('/api/v2/graphs/kinds', options);
 
     getSourceKinds = (options?: RequestOptions) =>
-        this.baseClient.get<BasicResponse<{ kinds: { id: number; name: string }[] }>>(
-            '/api/v2/graphs/source-kinds',
-            options
-        );
+        this.baseClient.get<SourceKindsResponse>('/api/v2/graphs/source-kinds', options);
 
     clearDatabase = (payload: ClearDatabaseRequest, options?: RequestOptions) => {
         return this.baseClient.post('/api/v2/clear-database', payload, options);

--- a/packages/javascript/js-client-library/src/responses.ts
+++ b/packages/javascript/js-client-library/src/responses.ts
@@ -39,6 +39,7 @@ import {
     RelationshipKindResponse,
     Role,
     ScheduledJobDisplay,
+    SourceKind,
     TimestampFields,
     Webhook,
     WebhookSecret,
@@ -413,6 +414,8 @@ export type UnifiedFinding = {
 };
 
 export type UnifiedFindingResponse = PaginatedResponse<UnifiedFinding[]>;
+
+export type SourceKindsResponse = BasicResponse<{ kinds: SourceKind[] }>;
 
 export type CreateWebhookResponse = {
     webhook: Webhook;

--- a/packages/javascript/js-client-library/src/types.ts
+++ b/packages/javascript/js-client-library/src/types.ts
@@ -831,7 +831,7 @@ export type RelationshipKindResponse = RelationshipKindBase & {
 };
 
 export interface NodeKindRef {
-    node_kind_id: number;
+    node_kind_id: number | null;
     name: string;
 }
 
@@ -856,7 +856,7 @@ export type NodeDetailsWithInfo = NodeDetails & {
 };
 
 export interface RelationshipKindRef {
-    relationship_kind_id: number;
+    relationship_kind_id: number | null;
     name: string;
 }
 

--- a/packages/javascript/js-client-library/src/types.ts
+++ b/packages/javascript/js-client-library/src/types.ts
@@ -410,6 +410,7 @@ export type GraphNodeSpreadWithProperties = Partial<Omit<GraphNode, 'properties'
 export type GraphNodes = Record<string, GraphNode>;
 
 export type GraphEdge = {
+    id: number;
     source: string;
     target: string;
     label: string;
@@ -443,6 +444,7 @@ export type StyledGraphNode = {
 };
 
 export type StyledGraphEdge = {
+    id: number;
     color: string;
     data: Record<string, any>;
     end1?: {

--- a/packages/javascript/js-client-library/src/types.ts
+++ b/packages/javascript/js-client-library/src/types.ts
@@ -680,6 +680,11 @@ export interface WebhookTest {
     version: string;
 }
 
+export type SourceKind = {
+    id: number;
+    name: string;
+};
+
 // ---------------------------------------------------------------------------
 // Base schemas
 // ---------------------------------------------------------------------------
@@ -831,11 +836,11 @@ export interface NodeKindRef {
 }
 
 export interface NodeProperties {
-    objectid: string;
+    objectid?: string;
     name?: string;
-    displayName?: string;
+    displayname?: string;
     /** date-time */
-    lastSeen: string;
+    lastseen?: string;
     [key: string]: unknown;
 }
 


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

The main changes involved in this pull request are:

- API now exposes relationship id in graph responses
- UI now calls for realtionship entity information using the new GET /api/v2/relationships/{relationship_id} endpoint

Aside from that there are various refactors in the UI to adapt to the new response shapes for passing, using, and displaying data in various components. 

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-8743

In order to support opengraph entity panels for relationships we need to start using the new get relationship by id endpoint to pull kind info data for a given edge since it will contain content to populate the collapsible sections.

## How Has This Been Tested?

Unit tests have been updated to expect the new response shape as well as to call the new endpoint in the test server. 

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added stable `id` fields for graph edges/relationships in API responses and the Explore experience, improving consistent labeling and interactions.
  * Updated Explore edge details to render from relationship data, with improved hidden/undisclosed behavior and primary kind selection for Cypher.

* **Bug Fixes**
  * Fixed Explore context-menu and asset-group add/remove actions to use the correct node identifiers from node properties.
  * Corrected edge-label hover/click detection so it targets the correct edge information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->