### PR TITLE
feat(data quality): count OpenGraph nodes by environment BED-8614

### DIFF
--- a/cmd/api/src/services/dataquality/dataquality.go
+++ b/cmd/api/src/services/dataquality/dataquality.go
@@ -18,7 +18,6 @@ package dataquality
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
 	"sync"
@@ -26,14 +25,12 @@ import (
 	"github.com/gofrs/uuid"
 	"github.com/specterops/bloodhound/cmd/api/src/database"
 	"github.com/specterops/bloodhound/cmd/api/src/database/types/nan"
-	"github.com/specterops/bloodhound/cmd/api/src/database/types/null"
 	"github.com/specterops/bloodhound/cmd/api/src/model"
 	"github.com/specterops/bloodhound/cmd/api/src/model/appcfg"
 	adAnalysis "github.com/specterops/bloodhound/packages/go/analysis/ad"
 	"github.com/specterops/bloodhound/packages/go/analysis/post"
 	"github.com/specterops/bloodhound/packages/go/bhlog/attr"
 	"github.com/specterops/bloodhound/packages/go/bhlog/measure"
-	"github.com/specterops/bloodhound/packages/go/graphschema"
 	"github.com/specterops/bloodhound/packages/go/graphschema/ad"
 	"github.com/specterops/bloodhound/packages/go/graphschema/azure"
 	"github.com/specterops/bloodhound/packages/go/graphschema/common"
@@ -497,7 +494,7 @@ func SaveDataQuality(ctx context.Context, db database.Database, graphDB graph.Da
 		}
 	}
 
-	// OpenGraph node counts
+	// OpenGraph node and relationship counts
 	if openGraphExtensionManagementFlag, err := db.GetFlagByKey(ctx, appcfg.FeatureOpenGraphExtensionManagement); err != nil {
 		return fmt.Errorf("could not get open graph extension management feature flag: %w", err)
 	} else if openGraphExtensionManagementFlag.Enabled {
@@ -517,215 +514,4 @@ func SaveDataQuality(ctx context.Context, db database.Database, graphDB graph.Da
 	}
 
 	return nil
-}
-
-func openGraphStats(ctx context.Context, db database.Database, graphDB graph.Database) (model.DataQualityStats, model.DataQualityAggregations, error) {
-	var (
-		aggregations = make(model.DataQualityAggregations, 0)
-		stats        = make(model.DataQualityStats, 0)
-
-		// We only are concerned with non-builtin types since AD and AZ have their own stat collection
-		// When we move AD and AZ stat collection to this common table, this will need to be changed
-		builtInFilter = model.Filters{"is_builtin": []model.Filter{{Operator: model.Equals, Value: "false"}}}
-	)
-
-	runID, err := uuid.NewV4()
-	if err != nil {
-		return stats, aggregations, fmt.Errorf("could not generate new UUID: %w", err)
-	}
-
-	extensions, _, err := db.GetGraphSchemaExtensions(ctx, builtInFilter, model.Sort{}, 0, 0)
-	if err != nil {
-		return stats, aggregations, fmt.Errorf("could not get graph schema extensions: %w", err)
-	}
-
-	for _, extension := range extensions {
-		environments, err := db.GetEnvironmentsByExtensionId(ctx, extension.ID)
-		if err != nil {
-			return stats, aggregations, fmt.Errorf("could not get environments for extension %d: %w", extension.ID, err)
-		}
-
-		// Each extension may define multiple environments with their own environment kind, principal kinds, and source kind.
-		for _, environment := range environments {
-			environmentSourceKind, err := getOpenGraphSourceKind(ctx, db, environment)
-			if err != nil {
-				return stats, aggregations, err
-			}
-
-			nodeKindCounts, err := countOpenGraphNodesByEnvironment(ctx, graphDB, graph.StringKind(environment.EnvironmentKindName), environmentSourceKind.ToKind())
-			if err != nil {
-				return stats, aggregations, fmt.Errorf("could not count open graph nodes for environment kind %s: %w", environment.EnvironmentKindName, err)
-			}
-
-			kindIDs, err := getOpenGraphCountKindIDs(ctx, db, nodeKindCounts)
-			if err != nil {
-				return stats, aggregations, err
-			}
-
-			environmentStats, environmentAggregations := buildOpenGraphNodeCountStats(runID.String(), extension, environment, nodeKindCounts, kindIDs)
-			stats = append(stats, environmentStats...)
-			aggregations = append(aggregations, environmentAggregations...)
-		}
-	}
-
-	return stats, aggregations, nil
-}
-
-func getOpenGraphSourceKind(ctx context.Context, db database.Database, environment model.SchemaEnvironment) (model.Kind, error) {
-	kinds, err := db.GetKindsByIDs(ctx, environment.SourceKindId)
-	if err != nil {
-		return model.Kind{}, fmt.Errorf("could not get source kind for schema environment %d: %w", environment.ID, err)
-	}
-
-	if len(kinds) == 0 {
-		return model.Kind{}, fmt.Errorf("could not get source kind for schema environment %d: %w", environment.ID, database.ErrNotFound)
-	}
-
-	return kinds[0], nil
-}
-
-func countOpenGraphNodesByEnvironment(ctx context.Context, graphDB graph.Database, environmentKind graph.Kind, sourceKind graph.Kind) (map[string]map[string]int, error) {
-	nodeKindCountsByEnvironmentID := map[string]map[string]int{}
-
-	err := graphDB.ReadTransaction(ctx, func(tx graph.Transaction) error {
-		environmentIDs, err := getOpenGraphEnvironmentIDs(ctx, tx, environmentKind)
-		if err != nil {
-			return err
-		}
-
-		for _, environmentID := range environmentIDs {
-			nodeKindCounts := map[string]int{}
-
-			if err := tx.Nodes().Filterf(func() graph.Criteria {
-				return query.And(
-					query.Kind(query.Node(), sourceKind),
-					query.Equals(query.NodeProperty(graphschema.EnvironmentIDKey), environmentID),
-				)
-			}).FetchKinds(func(cursor graph.Cursor[graph.KindsResult]) error {
-				for result := range cursor.Chan() {
-					countOpenGraphNodeKinds(result.Kinds, sourceKind, nodeKindCounts)
-				}
-
-				return cursor.Error()
-			}); err != nil {
-				return err
-			}
-
-			if len(nodeKindCounts) > 0 {
-				nodeKindCountsByEnvironmentID[environmentID] = nodeKindCounts
-			}
-		}
-
-		return nil
-	})
-
-	return nodeKindCountsByEnvironmentID, err
-}
-
-func countOpenGraphNodeKinds(kinds graph.Kinds, sourceKind graph.Kind, nodeKindCounts map[string]int) {
-	for _, kind := range kinds {
-		if kind.Is(sourceKind) || model.IsExtendedNodeKind(kind) {
-			continue
-		}
-
-		nodeKindCounts[kind.String()]++
-	}
-}
-
-func getOpenGraphEnvironmentIDs(ctx context.Context, tx graph.Transaction, environmentKind graph.Kind) ([]string, error) {
-	var environmentIDs []string
-
-	environments, err := ops.FetchNodes(tx.Nodes().Filterf(func() graph.Criteria {
-		return query.Kind(query.Node(), environmentKind)
-	}))
-	if err != nil {
-		return nil, err
-	}
-
-	for _, environment := range environments {
-		environmentID, err := environment.Properties.Get(graphschema.EnvironmentIDKey).String()
-		if err != nil {
-			slog.WarnContext(
-				ctx,
-				"OpenGraph environment node does not have a valid environment ID property",
-				slog.Uint64("node_id", uint64(environment.ID)),
-				slog.String("environment_kind", environmentKind.String()),
-				attr.Error(err),
-			)
-			continue
-		}
-
-		environmentIDs = append(environmentIDs, environmentID)
-	}
-
-	return environmentIDs, nil
-}
-
-func getOpenGraphCountKindIDs(ctx context.Context, db database.Database, countsByEnvironmentID map[string]map[string]int) (map[string]null.Int32, error) {
-	kindNames := make([]string, 0)
-	seenKindNames := map[string]struct{}{}
-
-	for _, nodeKindCounts := range countsByEnvironmentID {
-		for kindName := range nodeKindCounts {
-			if _, seen := seenKindNames[kindName]; !seen {
-				kindNames = append(kindNames, kindName)
-				seenKindNames[kindName] = struct{}{}
-			}
-		}
-	}
-
-	if len(kindNames) == 0 {
-		return map[string]null.Int32{}, nil
-	}
-
-	kinds, err := db.GetKindsByNames(ctx, kindNames...)
-	if err != nil && !errors.Is(err, database.ErrNotFound) {
-		return nil, fmt.Errorf("could not get data quality metric kinds: %w", err)
-	}
-
-	kindIDsByName := make(map[string]null.Int32, len(kinds))
-	for _, kind := range kinds {
-		kindIDsByName[kind.Name] = null.Int32From(kind.ID)
-	}
-
-	return kindIDsByName, nil
-}
-
-func buildOpenGraphNodeCountStats(runID string, extension model.GraphSchemaExtension, environment model.SchemaEnvironment, countsByEnvironmentID map[string]map[string]int, kindIDsByName map[string]null.Int32) (model.DataQualityStats, model.DataQualityAggregations) {
-	var (
-		aggregatedCounts = map[string]int{}
-		stats            = make(model.DataQualityStats, 0)
-		aggregations     = make(model.DataQualityAggregations, 0)
-	)
-
-	for environmentID, kindCounts := range countsByEnvironmentID {
-		for kindName, count := range kindCounts {
-			stats = append(stats, model.DataQualityStat{
-				RunID:                   runID,
-				SchemaExtensionID:       extension.ID,
-				SchemaEnvironmentKindID: environment.EnvironmentKindId,
-				EnvironmentID:           environmentID,
-				MetricType:              model.DataQualityMetricTypeNode,
-				MetricName:              kindName,
-				MetricValue:             float64(count),
-				KindID:                  kindIDsByName[kindName],
-			})
-
-			aggregatedCounts[kindName] += count
-		}
-	}
-
-	for kindName, count := range aggregatedCounts {
-		aggregations = append(aggregations, model.DataQualityAggregation{
-			RunID:                   runID,
-			SchemaExtensionID:       extension.ID,
-			SchemaEnvironmentKindID: environment.EnvironmentKindId,
-			MetricType:              model.DataQualityMetricTypeNode,
-			MetricName:              kindName,
-			MetricValue:             float64(count),
-			KindID:                  kindIDsByName[kindName],
-		})
-	}
-
-	return stats, aggregations
 }

--- a/cmd/api/src/services/dataquality/dataquality.go
+++ b/cmd/api/src/services/dataquality/dataquality.go
@@ -18,6 +18,7 @@ package dataquality
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"sync"
@@ -25,11 +26,14 @@ import (
 	"github.com/gofrs/uuid"
 	"github.com/specterops/bloodhound/cmd/api/src/database"
 	"github.com/specterops/bloodhound/cmd/api/src/database/types/nan"
+	"github.com/specterops/bloodhound/cmd/api/src/database/types/null"
 	"github.com/specterops/bloodhound/cmd/api/src/model"
+	"github.com/specterops/bloodhound/cmd/api/src/model/appcfg"
 	adAnalysis "github.com/specterops/bloodhound/packages/go/analysis/ad"
 	"github.com/specterops/bloodhound/packages/go/analysis/post"
 	"github.com/specterops/bloodhound/packages/go/bhlog/attr"
 	"github.com/specterops/bloodhound/packages/go/bhlog/measure"
+	"github.com/specterops/bloodhound/packages/go/graphschema"
 	"github.com/specterops/bloodhound/packages/go/graphschema/ad"
 	"github.com/specterops/bloodhound/packages/go/graphschema/azure"
 	"github.com/specterops/bloodhound/packages/go/graphschema/common"
@@ -454,7 +458,7 @@ func azureGraphStats(ctx context.Context, db graph.Database) (model.AzureDataQua
 	return stats, aggregation, err
 }
 
-func SaveDataQuality(ctx context.Context, db database.DataQualityData, graphDB graph.Database) error {
+func SaveDataQuality(ctx context.Context, db database.Database, graphDB graph.Database) error {
 	slog.InfoContext(
 		ctx,
 		"Started Data Quality Stats Collection",
@@ -493,5 +497,235 @@ func SaveDataQuality(ctx context.Context, db database.DataQualityData, graphDB g
 		}
 	}
 
+	// OpenGraph node counts
+	if openGraphExtensionManagementFlag, err := db.GetFlagByKey(ctx, appcfg.FeatureOpenGraphExtensionManagement); err != nil {
+		return fmt.Errorf("could not get open graph extension management feature flag: %w", err)
+	} else if openGraphExtensionManagementFlag.Enabled {
+		if stats, aggregations, err := openGraphStats(ctx, db, graphDB); err != nil {
+			return fmt.Errorf("could not get open graph stats: %w", err)
+		} else {
+			if len(stats) == 0 {
+				return nil
+			}
+
+			if _, err := db.CreateDataQualityStats(ctx, stats); err != nil {
+				return fmt.Errorf("could not save open graph stats: %w", err)
+			} else if _, err := db.CreateDataQualityAggregations(ctx, aggregations); err != nil {
+				return fmt.Errorf("could not save open graph aggregations: %w", err)
+			}
+		}
+	}
+
 	return nil
+}
+
+func openGraphStats(ctx context.Context, db database.Database, graphDB graph.Database) (model.DataQualityStats, model.DataQualityAggregations, error) {
+	var (
+		aggregations = make(model.DataQualityAggregations, 0)
+		stats        = make(model.DataQualityStats, 0)
+
+		// We only are concerned with non-builtin types since AD and AZ have their own stat collection
+		// When we move AD and AZ stat collection to this common table, this will need to be changed
+		builtInFilter = model.Filters{"is_builtin": []model.Filter{{Operator: model.Equals, Value: "false"}}}
+	)
+
+	runID, err := uuid.NewV4()
+	if err != nil {
+		return stats, aggregations, fmt.Errorf("could not generate new UUID: %w", err)
+	}
+
+	extensions, _, err := db.GetGraphSchemaExtensions(ctx, builtInFilter, model.Sort{}, 0, 0)
+	if err != nil {
+		return stats, aggregations, fmt.Errorf("could not get graph schema extensions: %w", err)
+	}
+
+	for _, extension := range extensions {
+		environments, err := db.GetEnvironmentsByExtensionId(ctx, extension.ID)
+		if err != nil {
+			return stats, aggregations, fmt.Errorf("could not get environments for extension %d: %w", extension.ID, err)
+		}
+
+		// Each extension may define multiple environments with their own environment kind, principal kinds, and source kind.
+		for _, environment := range environments {
+			environmentSourceKind, err := getOpenGraphSourceKind(ctx, db, environment)
+			if err != nil {
+				return stats, aggregations, err
+			}
+
+			nodeKindCounts, err := countOpenGraphNodesByEnvironment(ctx, graphDB, graph.StringKind(environment.EnvironmentKindName), environmentSourceKind.ToKind())
+			if err != nil {
+				return stats, aggregations, fmt.Errorf("could not count open graph nodes for environment kind %s: %w", environment.EnvironmentKindName, err)
+			}
+
+			kindIDs, err := getOpenGraphCountKindIDs(ctx, db, nodeKindCounts)
+			if err != nil {
+				return stats, aggregations, err
+			}
+
+			environmentStats, environmentAggregations := buildOpenGraphNodeCountStats(runID.String(), extension, environment, nodeKindCounts, kindIDs)
+			stats = append(stats, environmentStats...)
+			aggregations = append(aggregations, environmentAggregations...)
+		}
+	}
+
+	return stats, aggregations, nil
+}
+
+func getOpenGraphSourceKind(ctx context.Context, db database.Database, environment model.SchemaEnvironment) (model.Kind, error) {
+	kinds, err := db.GetKindsByIDs(ctx, environment.SourceKindId)
+	if err != nil {
+		return model.Kind{}, fmt.Errorf("could not get source kind for schema environment %d: %w", environment.ID, err)
+	}
+
+	if len(kinds) == 0 {
+		return model.Kind{}, fmt.Errorf("could not get source kind for schema environment %d: %w", environment.ID, database.ErrNotFound)
+	}
+
+	return kinds[0], nil
+}
+
+func countOpenGraphNodesByEnvironment(ctx context.Context, graphDB graph.Database, environmentKind graph.Kind, sourceKind graph.Kind) (map[string]map[string]int, error) {
+	nodeKindCountsByEnvironmentID := map[string]map[string]int{}
+
+	err := graphDB.ReadTransaction(ctx, func(tx graph.Transaction) error {
+		environmentIDs, err := getOpenGraphEnvironmentIDs(ctx, tx, environmentKind)
+		if err != nil {
+			return err
+		}
+
+		for _, environmentID := range environmentIDs {
+			nodeKindCounts := map[string]int{}
+
+			if err := tx.Nodes().Filterf(func() graph.Criteria {
+				return query.And(
+					query.Kind(query.Node(), sourceKind),
+					query.Equals(query.NodeProperty(graphschema.EnvironmentIDKey), environmentID),
+				)
+			}).FetchKinds(func(cursor graph.Cursor[graph.KindsResult]) error {
+				for result := range cursor.Chan() {
+					countOpenGraphNodeKinds(result.Kinds, sourceKind, nodeKindCounts)
+				}
+
+				return cursor.Error()
+			}); err != nil {
+				return err
+			}
+
+			if len(nodeKindCounts) > 0 {
+				nodeKindCountsByEnvironmentID[environmentID] = nodeKindCounts
+			}
+		}
+
+		return nil
+	})
+
+	return nodeKindCountsByEnvironmentID, err
+}
+
+func countOpenGraphNodeKinds(kinds graph.Kinds, sourceKind graph.Kind, nodeKindCounts map[string]int) {
+	for _, kind := range kinds {
+		if kind.Is(sourceKind) || model.IsExtendedNodeKind(kind) {
+			continue
+		}
+
+		nodeKindCounts[kind.String()]++
+	}
+}
+
+func getOpenGraphEnvironmentIDs(ctx context.Context, tx graph.Transaction, environmentKind graph.Kind) ([]string, error) {
+	var environmentIDs []string
+
+	environments, err := ops.FetchNodes(tx.Nodes().Filterf(func() graph.Criteria {
+		return query.Kind(query.Node(), environmentKind)
+	}))
+	if err != nil {
+		return nil, err
+	}
+
+	for _, environment := range environments {
+		environmentID, err := environment.Properties.Get(graphschema.EnvironmentIDKey).String()
+		if err != nil {
+			slog.WarnContext(
+				ctx,
+				"OpenGraph environment node does not have a valid environment ID property",
+				slog.Uint64("node_id", uint64(environment.ID)),
+				slog.String("environment_kind", environmentKind.String()),
+				attr.Error(err),
+			)
+			continue
+		}
+
+		environmentIDs = append(environmentIDs, environmentID)
+	}
+
+	return environmentIDs, nil
+}
+
+func getOpenGraphCountKindIDs(ctx context.Context, db database.Database, countsByEnvironmentID map[string]map[string]int) (map[string]null.Int32, error) {
+	kindNames := make([]string, 0)
+	seenKindNames := map[string]struct{}{}
+
+	for _, nodeKindCounts := range countsByEnvironmentID {
+		for kindName := range nodeKindCounts {
+			if _, seen := seenKindNames[kindName]; !seen {
+				kindNames = append(kindNames, kindName)
+				seenKindNames[kindName] = struct{}{}
+			}
+		}
+	}
+
+	if len(kindNames) == 0 {
+		return map[string]null.Int32{}, nil
+	}
+
+	kinds, err := db.GetKindsByNames(ctx, kindNames...)
+	if err != nil && !errors.Is(err, database.ErrNotFound) {
+		return nil, fmt.Errorf("could not get data quality metric kinds: %w", err)
+	}
+
+	kindIDsByName := make(map[string]null.Int32, len(kinds))
+	for _, kind := range kinds {
+		kindIDsByName[kind.Name] = null.Int32From(kind.ID)
+	}
+
+	return kindIDsByName, nil
+}
+
+func buildOpenGraphNodeCountStats(runID string, extension model.GraphSchemaExtension, environment model.SchemaEnvironment, countsByEnvironmentID map[string]map[string]int, kindIDsByName map[string]null.Int32) (model.DataQualityStats, model.DataQualityAggregations) {
+	var (
+		aggregatedCounts = map[string]int{}
+		stats            = make(model.DataQualityStats, 0)
+		aggregations     = make(model.DataQualityAggregations, 0)
+	)
+
+	for environmentID, kindCounts := range countsByEnvironmentID {
+		for kindName, count := range kindCounts {
+			stats = append(stats, model.DataQualityStat{
+				RunID:                   runID,
+				SchemaExtensionID:       extension.ID,
+				SchemaEnvironmentKindID: environment.EnvironmentKindId,
+				EnvironmentID:           environmentID,
+				MetricType:              model.DataQualityMetricTypeNode,
+				MetricName:              kindName,
+				MetricValue:             float64(count),
+				KindID:                  kindIDsByName[kindName],
+			})
+
+			aggregatedCounts[kindName] += count
+		}
+	}
+
+	for kindName, count := range aggregatedCounts {
+		aggregations = append(aggregations, model.DataQualityAggregation{
+			RunID:                   runID,
+			SchemaExtensionID:       extension.ID,
+			SchemaEnvironmentKindID: environment.EnvironmentKindId,
+			MetricType:              model.DataQualityMetricTypeNode,
+			MetricName:              kindName,
+			MetricValue:             float64(count),
+			KindID:                  kindIDsByName[kindName],
+		})
+	}
+
+	return stats, aggregations
 }

--- a/cmd/api/src/services/dataquality/dataquality_test.go
+++ b/cmd/api/src/services/dataquality/dataquality_test.go
@@ -1,0 +1,412 @@
+// Copyright 2026 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package dataquality_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/specterops/bloodhound/cmd/api/src/database/mocks"
+	"github.com/specterops/bloodhound/cmd/api/src/database/types/null"
+	"github.com/specterops/bloodhound/cmd/api/src/model"
+	"github.com/specterops/bloodhound/cmd/api/src/model/appcfg"
+	"github.com/specterops/bloodhound/cmd/api/src/services/dataquality"
+	graphmocks "github.com/specterops/bloodhound/cmd/api/src/vendormocks/dawgs/graph"
+	"github.com/specterops/bloodhound/packages/go/graphschema"
+	"github.com/specterops/dawgs/graph"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestSaveDataQuality(t *testing.T) {
+	var (
+		ctx                    = context.Background()
+		environmentKind        = graph.StringKind("dogpark_LargeDogArea")
+		sourceKind             = graph.StringKind("dogpark_Entity")
+		dogKind                = graph.StringKind("dogpark_Dog")
+		patronKind             = graph.StringKind("dogpark_Patron")
+		schemaExtension        = model.GraphSchemaExtension{Serial: model.Serial{ID: 44}}
+		schemaEnvironment      = model.SchemaEnvironment{Serial: model.Serial{ID: 88}, SchemaExtensionId: 44, EnvironmentKindId: 22, EnvironmentKindName: environmentKind.String(), SourceKindId: 11}
+		expectedKindIDs        = map[string]null.Int32{"dogpark_Dog": null.Int32From(101), "dogpark_Patron": null.Int32From(102)}
+		builtInExtensionFilter = model.Filters{"is_builtin": []model.Filter{{Operator: model.Equals, Value: "false"}}}
+		expectedError          = errors.New("expected error")
+	)
+
+	tests := []struct {
+		name          string
+		setupMocks    func(t *testing.T, mockDB *mocks.MockDatabase, mockGraph *graphmocks.MockDatabase)
+		expectedError string
+	}{
+		{
+			name: "saves opengraph node counts",
+			setupMocks: func(t *testing.T, mockDB *mocks.MockDatabase, mockGraph *graphmocks.MockDatabase) {
+				expectEmptyADAndAzureStatsReads(t, mockGraph)
+				expectOpenGraphExtensionManagementFlag(mockDB, true, nil)
+				expectOpenGraphStatsRead(t, mockGraph, environmentKind, sourceKind, dogKind, patronKind)
+
+				mockDB.EXPECT().
+					GetGraphSchemaExtensions(gomock.Any(), builtInExtensionFilter, model.Sort{}, 0, 0).
+					Return(model.GraphSchemaExtensions{schemaExtension}, 1, nil)
+				mockDB.EXPECT().
+					GetEnvironmentsByExtensionId(gomock.Any(), schemaExtension.ID).
+					Return([]model.SchemaEnvironment{schemaEnvironment}, nil)
+				mockDB.EXPECT().
+					GetKindsByIDs(gomock.Any(), schemaEnvironment.SourceKindId).
+					Return([]model.Kind{{ID: schemaEnvironment.SourceKindId, Name: sourceKind.String()}}, nil)
+				mockDB.EXPECT().
+					GetKindsByNames(gomock.Any(), gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ context.Context, names ...string) ([]model.Kind, error) {
+						if !gomock.InAnyOrder([]string{dogKind.String(), patronKind.String()}).Matches(names) {
+							t.Fatalf("expected kind names to match, got %#v", names)
+						}
+
+						return []model.Kind{
+							{ID: 101, Name: dogKind.String()},
+							{ID: 102, Name: patronKind.String()},
+						}, nil
+					})
+				mockDB.EXPECT().
+					CreateDataQualityStats(gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ context.Context, stats model.DataQualityStats) (model.DataQualityStats, error) {
+						require.Len(t, stats, 3)
+						require.NotEmpty(t, stats[0].RunID)
+
+						expectedStats := model.DataQualityStats{
+							{RunID: stats[0].RunID, SchemaExtensionID: 44, SchemaEnvironmentKindID: 22, EnvironmentID: "env-a", MetricType: model.DataQualityMetricTypeNode, MetricName: "dogpark_Dog", MetricValue: 1, KindID: expectedKindIDs["dogpark_Dog"]},
+							{RunID: stats[0].RunID, SchemaExtensionID: 44, SchemaEnvironmentKindID: 22, EnvironmentID: "env-a", MetricType: model.DataQualityMetricTypeNode, MetricName: "dogpark_Patron", MetricValue: 2, KindID: expectedKindIDs["dogpark_Patron"]},
+							{RunID: stats[0].RunID, SchemaExtensionID: 44, SchemaEnvironmentKindID: 22, EnvironmentID: "env-b", MetricType: model.DataQualityMetricTypeNode, MetricName: "dogpark_Patron", MetricValue: 3, KindID: expectedKindIDs["dogpark_Patron"]},
+						}
+
+						require.ElementsMatch(t, expectedStats, stats)
+						return stats, nil
+					})
+				mockDB.EXPECT().
+					CreateDataQualityAggregations(gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ context.Context, aggregations model.DataQualityAggregations) (model.DataQualityAggregations, error) {
+						require.Len(t, aggregations, 2)
+						require.NotEmpty(t, aggregations[0].RunID)
+
+						expectedAggregations := model.DataQualityAggregations{
+							{RunID: aggregations[0].RunID, SchemaExtensionID: 44, SchemaEnvironmentKindID: 22, MetricType: model.DataQualityMetricTypeNode, MetricName: "dogpark_Dog", MetricValue: 1, KindID: expectedKindIDs["dogpark_Dog"]},
+							{RunID: aggregations[0].RunID, SchemaExtensionID: 44, SchemaEnvironmentKindID: 22, MetricType: model.DataQualityMetricTypeNode, MetricName: "dogpark_Patron", MetricValue: 5, KindID: expectedKindIDs["dogpark_Patron"]},
+						}
+
+						require.ElementsMatch(t, expectedAggregations, aggregations)
+						return aggregations, nil
+					})
+			},
+		},
+		{
+			name: "skips opengraph inserts when there are no custom extensions",
+			setupMocks: func(t *testing.T, mockDB *mocks.MockDatabase, mockGraph *graphmocks.MockDatabase) {
+				expectEmptyADAndAzureStatsReads(t, mockGraph)
+				expectOpenGraphExtensionManagementFlag(mockDB, true, nil)
+				mockDB.EXPECT().
+					GetGraphSchemaExtensions(gomock.Any(), builtInExtensionFilter, model.Sort{}, 0, 0).
+					Return(model.GraphSchemaExtensions{}, 0, nil)
+			},
+		},
+		{
+			name: "skips opengraph collection when extension management feature flag is disabled",
+			setupMocks: func(t *testing.T, mockDB *mocks.MockDatabase, mockGraph *graphmocks.MockDatabase) {
+				expectEmptyADAndAzureStatsReads(t, mockGraph)
+				expectOpenGraphExtensionManagementFlag(mockDB, false, nil)
+			},
+		},
+		{
+			name: "returns error when active directory stats collection fails",
+			setupMocks: func(t *testing.T, mockDB *mocks.MockDatabase, mockGraph *graphmocks.MockDatabase) {
+				expectReadTransactionError(mockGraph, expectedError)
+			},
+			expectedError: "could not get active directory data quality stats",
+		},
+		{
+			name: "returns error when azure stats collection fails",
+			setupMocks: func(t *testing.T, mockDB *mocks.MockDatabase, mockGraph *graphmocks.MockDatabase) {
+				expectEmptyADStatsRead(t, mockGraph)
+				expectReadTransactionError(mockGraph, expectedError)
+			},
+			expectedError: "could not get azure data quality stats",
+		},
+		{
+			name: "returns error when opengraph extension lookup fails",
+			setupMocks: func(t *testing.T, mockDB *mocks.MockDatabase, mockGraph *graphmocks.MockDatabase) {
+				expectEmptyADAndAzureStatsReads(t, mockGraph)
+				expectOpenGraphExtensionManagementFlag(mockDB, true, nil)
+				mockDB.EXPECT().
+					GetGraphSchemaExtensions(gomock.Any(), builtInExtensionFilter, model.Sort{}, 0, 0).
+					Return(model.GraphSchemaExtensions{}, 0, expectedError)
+			},
+			expectedError: "could not get graph schema extensions",
+		},
+		{
+			name: "returns error when opengraph extension management feature flag lookup fails",
+			setupMocks: func(t *testing.T, mockDB *mocks.MockDatabase, mockGraph *graphmocks.MockDatabase) {
+				expectEmptyADAndAzureStatsReads(t, mockGraph)
+				expectOpenGraphExtensionManagementFlag(mockDB, false, expectedError)
+			},
+			expectedError: "could not get open graph extension management feature flag",
+		},
+		{
+			name: "returns error when opengraph environment lookup fails",
+			setupMocks: func(t *testing.T, mockDB *mocks.MockDatabase, mockGraph *graphmocks.MockDatabase) {
+				expectEmptyADAndAzureStatsReads(t, mockGraph)
+				expectOpenGraphExtensionManagementFlag(mockDB, true, nil)
+				mockDB.EXPECT().
+					GetGraphSchemaExtensions(gomock.Any(), builtInExtensionFilter, model.Sort{}, 0, 0).
+					Return(model.GraphSchemaExtensions{schemaExtension}, 1, nil)
+				mockDB.EXPECT().
+					GetEnvironmentsByExtensionId(gomock.Any(), schemaExtension.ID).
+					Return(nil, expectedError)
+			},
+			expectedError: "could not get environments for extension",
+		},
+		{
+			name: "returns error when opengraph source kind lookup fails",
+			setupMocks: func(t *testing.T, mockDB *mocks.MockDatabase, mockGraph *graphmocks.MockDatabase) {
+				expectEmptyADAndAzureStatsReads(t, mockGraph)
+				expectOpenGraphExtensionManagementFlag(mockDB, true, nil)
+				mockDB.EXPECT().
+					GetGraphSchemaExtensions(gomock.Any(), builtInExtensionFilter, model.Sort{}, 0, 0).
+					Return(model.GraphSchemaExtensions{schemaExtension}, 1, nil)
+				mockDB.EXPECT().
+					GetEnvironmentsByExtensionId(gomock.Any(), schemaExtension.ID).
+					Return([]model.SchemaEnvironment{schemaEnvironment}, nil)
+				mockDB.EXPECT().
+					GetKindsByIDs(gomock.Any(), schemaEnvironment.SourceKindId).
+					Return(nil, expectedError)
+			},
+			expectedError: "could not get source kind for schema environment",
+		},
+		{
+			name: "returns error when opengraph graph read fails",
+			setupMocks: func(t *testing.T, mockDB *mocks.MockDatabase, mockGraph *graphmocks.MockDatabase) {
+				expectEmptyADAndAzureStatsReads(t, mockGraph)
+				expectOpenGraphExtensionManagementFlag(mockDB, true, nil)
+				mockDB.EXPECT().
+					GetGraphSchemaExtensions(gomock.Any(), builtInExtensionFilter, model.Sort{}, 0, 0).
+					Return(model.GraphSchemaExtensions{schemaExtension}, 1, nil)
+				mockDB.EXPECT().
+					GetEnvironmentsByExtensionId(gomock.Any(), schemaExtension.ID).
+					Return([]model.SchemaEnvironment{schemaEnvironment}, nil)
+				mockDB.EXPECT().
+					GetKindsByIDs(gomock.Any(), schemaEnvironment.SourceKindId).
+					Return([]model.Kind{{ID: schemaEnvironment.SourceKindId, Name: sourceKind.String()}}, nil)
+				expectReadTransactionError(mockGraph, expectedError)
+			},
+			expectedError: "could not count open graph nodes",
+		},
+		{
+			name: "returns error when counted kind lookup fails",
+			setupMocks: func(t *testing.T, mockDB *mocks.MockDatabase, mockGraph *graphmocks.MockDatabase) {
+				expectEmptyADAndAzureStatsReads(t, mockGraph)
+				expectOpenGraphExtensionManagementFlag(mockDB, true, nil)
+				expectOpenGraphStatsRead(t, mockGraph, environmentKind, sourceKind, dogKind, patronKind)
+
+				mockDB.EXPECT().
+					GetGraphSchemaExtensions(gomock.Any(), builtInExtensionFilter, model.Sort{}, 0, 0).
+					Return(model.GraphSchemaExtensions{schemaExtension}, 1, nil)
+				mockDB.EXPECT().
+					GetEnvironmentsByExtensionId(gomock.Any(), schemaExtension.ID).
+					Return([]model.SchemaEnvironment{schemaEnvironment}, nil)
+				mockDB.EXPECT().
+					GetKindsByIDs(gomock.Any(), schemaEnvironment.SourceKindId).
+					Return([]model.Kind{{ID: schemaEnvironment.SourceKindId, Name: sourceKind.String()}}, nil)
+				mockDB.EXPECT().
+					GetKindsByNames(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil, expectedError)
+			},
+			expectedError: "could not get data quality metric kinds",
+		},
+		{
+			name: "returns error when opengraph stats insert fails",
+			setupMocks: func(t *testing.T, mockDB *mocks.MockDatabase, mockGraph *graphmocks.MockDatabase) {
+				expectEmptyADAndAzureStatsReads(t, mockGraph)
+				expectOpenGraphExtensionManagementFlag(mockDB, true, nil)
+				expectOpenGraphStatsRead(t, mockGraph, environmentKind, sourceKind, dogKind, patronKind)
+
+				mockDB.EXPECT().
+					GetGraphSchemaExtensions(gomock.Any(), builtInExtensionFilter, model.Sort{}, 0, 0).
+					Return(model.GraphSchemaExtensions{schemaExtension}, 1, nil)
+				mockDB.EXPECT().
+					GetEnvironmentsByExtensionId(gomock.Any(), schemaExtension.ID).
+					Return([]model.SchemaEnvironment{schemaEnvironment}, nil)
+				mockDB.EXPECT().
+					GetKindsByIDs(gomock.Any(), schemaEnvironment.SourceKindId).
+					Return([]model.Kind{{ID: schemaEnvironment.SourceKindId, Name: sourceKind.String()}}, nil)
+				mockDB.EXPECT().
+					GetKindsByNames(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return([]model.Kind{{ID: 101, Name: dogKind.String()}, {ID: 102, Name: patronKind.String()}}, nil)
+				mockDB.EXPECT().
+					CreateDataQualityStats(gomock.Any(), gomock.Any()).
+					Return(model.DataQualityStats{}, expectedError)
+			},
+			expectedError: "could not save open graph stats",
+		},
+		{
+			name: "returns error when opengraph aggregation insert fails",
+			setupMocks: func(t *testing.T, mockDB *mocks.MockDatabase, mockGraph *graphmocks.MockDatabase) {
+				expectEmptyADAndAzureStatsReads(t, mockGraph)
+				expectOpenGraphExtensionManagementFlag(mockDB, true, nil)
+				expectOpenGraphStatsRead(t, mockGraph, environmentKind, sourceKind, dogKind, patronKind)
+
+				mockDB.EXPECT().
+					GetGraphSchemaExtensions(gomock.Any(), builtInExtensionFilter, model.Sort{}, 0, 0).
+					Return(model.GraphSchemaExtensions{schemaExtension}, 1, nil)
+				mockDB.EXPECT().
+					GetEnvironmentsByExtensionId(gomock.Any(), schemaExtension.ID).
+					Return([]model.SchemaEnvironment{schemaEnvironment}, nil)
+				mockDB.EXPECT().
+					GetKindsByIDs(gomock.Any(), schemaEnvironment.SourceKindId).
+					Return([]model.Kind{{ID: schemaEnvironment.SourceKindId, Name: sourceKind.String()}}, nil)
+				mockDB.EXPECT().
+					GetKindsByNames(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return([]model.Kind{{ID: 101, Name: dogKind.String()}, {ID: 102, Name: patronKind.String()}}, nil)
+				mockDB.EXPECT().
+					CreateDataQualityStats(gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ context.Context, stats model.DataQualityStats) (model.DataQualityStats, error) {
+						return stats, nil
+					})
+				mockDB.EXPECT().
+					CreateDataQualityAggregations(gomock.Any(), gomock.Any()).
+					Return(model.DataQualityAggregations{}, expectedError)
+			},
+			expectedError: "could not save open graph aggregations",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			mockController := gomock.NewController(t)
+			mockDB := mocks.NewMockDatabase(mockController)
+			mockGraph := graphmocks.NewMockDatabase(mockController)
+
+			test.setupMocks(t, mockDB, mockGraph)
+
+			err := dataquality.SaveDataQuality(ctx, mockDB, mockGraph)
+			if test.expectedError != "" {
+				require.ErrorContains(t, err, test.expectedError)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func expectOpenGraphExtensionManagementFlag(mockDB *mocks.MockDatabase, enabled bool, err error) {
+	mockDB.EXPECT().
+		GetFlagByKey(gomock.Any(), appcfg.FeatureOpenGraphExtensionManagement).
+		Return(appcfg.FeatureFlag{Enabled: enabled}, err)
+}
+
+func expectEmptyADAndAzureStatsReads(t *testing.T, mockGraph *graphmocks.MockDatabase) {
+	t.Helper()
+
+	expectEmptyADStatsRead(t, mockGraph)
+
+	expectReadTransaction(t, mockGraph, func(mockController *gomock.Controller, mockTransaction *graphmocks.MockTransaction) {
+		expectFetchNodes(mockController, mockTransaction, nil)
+	})
+}
+
+func expectEmptyADStatsRead(t *testing.T, mockGraph *graphmocks.MockDatabase) {
+	t.Helper()
+
+	expectReadTransaction(t, mockGraph, func(mockController *gomock.Controller, mockTransaction *graphmocks.MockTransaction) {
+		expectFetchNodes(mockController, mockTransaction, nil)
+		expectFetchNodes(mockController, mockTransaction, nil)
+		expectFetchNodes(mockController, mockTransaction, nil)
+	})
+}
+
+func expectOpenGraphStatsRead(t *testing.T, mockGraph *graphmocks.MockDatabase, environmentKind graph.Kind, sourceKind graph.Kind, dogKind graph.Kind, patronKind graph.Kind) {
+	t.Helper()
+
+	expectReadTransaction(t, mockGraph, func(mockController *gomock.Controller, mockTransaction *graphmocks.MockTransaction) {
+		expectFetchNodes(mockController, mockTransaction, []*graph.Node{
+			graph.NewNode(1, graph.AsProperties(map[string]any{graphschema.EnvironmentIDKey: "env-a"}), environmentKind),
+			graph.NewNode(2, graph.AsProperties(map[string]any{graphschema.EnvironmentIDKey: "env-b"}), environmentKind),
+		})
+		expectFetchKinds(mockController, mockTransaction, []graph.KindsResult{
+			{ID: 3, Kinds: graph.Kinds{sourceKind, dogKind, patronKind, graphschema.Meta}},
+			{ID: 4, Kinds: graph.Kinds{sourceKind, patronKind}},
+		})
+		expectFetchKinds(mockController, mockTransaction, []graph.KindsResult{
+			{ID: 5, Kinds: graph.Kinds{sourceKind, patronKind}},
+			{ID: 6, Kinds: graph.Kinds{sourceKind, patronKind}},
+			{ID: 7, Kinds: graph.Kinds{sourceKind, patronKind}},
+		})
+	})
+}
+
+func expectReadTransactionError(mockGraph *graphmocks.MockDatabase, err error) {
+	mockGraph.EXPECT().
+		ReadTransaction(gomock.Any(), gomock.Any()).
+		Return(err)
+}
+
+func expectReadTransaction(t *testing.T, mockGraph *graphmocks.MockDatabase, setupTransaction func(mockController *gomock.Controller, mockTransaction *graphmocks.MockTransaction)) {
+	t.Helper()
+
+	mockController := gomock.NewController(t)
+	mockTransaction := graphmocks.NewMockTransaction(mockController)
+	setupTransaction(mockController, mockTransaction)
+
+	mockGraph.EXPECT().
+		ReadTransaction(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, delegate graph.TransactionDelegate, _ ...graph.TransactionOption) error {
+			return delegate(mockTransaction)
+		})
+}
+
+func expectFetchNodes(mockController *gomock.Controller, mockTransaction *graphmocks.MockTransaction, nodes []*graph.Node) {
+	mockNodeQuery := graphmocks.NewMockNodeQuery(mockController)
+	mockTransaction.EXPECT().Nodes().Return(mockNodeQuery)
+	mockNodeQuery.EXPECT().Filterf(gomock.Any()).Return(mockNodeQuery)
+	mockNodeQuery.EXPECT().
+		Fetch(gomock.Any()).
+		DoAndReturn(func(delegate func(graph.Cursor[*graph.Node]) error, _ ...graph.Criteria) error {
+			mockCursor := graphmocks.NewMockCursor[*graph.Node](mockController)
+			mockCursor.EXPECT().Chan().Return(cursorChan(nodes))
+			mockCursor.EXPECT().Error().Return(nil)
+			return delegate(mockCursor)
+		})
+}
+
+func expectFetchKinds(mockController *gomock.Controller, mockTransaction *graphmocks.MockTransaction, kindsResults []graph.KindsResult) {
+	mockNodeQuery := graphmocks.NewMockNodeQuery(mockController)
+	mockTransaction.EXPECT().Nodes().Return(mockNodeQuery)
+	mockNodeQuery.EXPECT().Filterf(gomock.Any()).Return(mockNodeQuery)
+	mockNodeQuery.EXPECT().
+		FetchKinds(gomock.Any()).
+		DoAndReturn(func(delegate func(graph.Cursor[graph.KindsResult]) error) error {
+			mockCursor := graphmocks.NewMockCursor[graph.KindsResult](mockController)
+			mockCursor.EXPECT().Chan().Return(cursorChan(kindsResults))
+			mockCursor.EXPECT().Error().Return(nil)
+			return delegate(mockCursor)
+		})
+}
+
+func cursorChan[T any](items []T) chan T {
+	ch := make(chan T, len(items))
+	for _, item := range items {
+		ch <- item
+	}
+	close(ch)
+	return ch
+}

--- a/cmd/api/src/services/dataquality/dataquality_test.go
+++ b/cmd/api/src/services/dataquality/dataquality_test.go
@@ -19,6 +19,7 @@ package dataquality_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/specterops/bloodhound/cmd/api/src/database/mocks"
@@ -40,9 +41,10 @@ func TestSaveDataQuality(t *testing.T) {
 		sourceKind             = graph.StringKind("dogpark_Entity")
 		dogKind                = graph.StringKind("dogpark_Dog")
 		patronKind             = graph.StringKind("dogpark_Patron")
+		relationshipKind       = graph.StringKind("dogpark_WalksWith")
 		schemaExtension        = model.GraphSchemaExtension{Serial: model.Serial{ID: 44}}
 		schemaEnvironment      = model.SchemaEnvironment{Serial: model.Serial{ID: 88}, SchemaExtensionId: 44, EnvironmentKindId: 22, EnvironmentKindName: environmentKind.String(), SourceKindId: 11}
-		expectedKindIDs        = map[string]null.Int32{"dogpark_Dog": null.Int32From(101), "dogpark_Patron": null.Int32From(102)}
+		expectedKindIDs        = map[string]null.Int32{"dogpark_Dog": null.Int32From(101), "dogpark_Patron": null.Int32From(102), "dogpark_WalksWith": null.Int32From(103)}
 		builtInExtensionFilter = model.Filters{"is_builtin": []model.Filter{{Operator: model.Equals, Value: "false"}}}
 		expectedError          = errors.New("expected error")
 	)
@@ -53,11 +55,11 @@ func TestSaveDataQuality(t *testing.T) {
 		expectedError string
 	}{
 		{
-			name: "saves opengraph node counts",
+			name: "saves opengraph node and relationship counts",
 			setupMocks: func(t *testing.T, mockDB *mocks.MockDatabase, mockGraph *graphmocks.MockDatabase) {
 				expectEmptyADAndAzureStatsReads(t, mockGraph)
 				expectOpenGraphExtensionManagementFlag(mockDB, true, nil)
-				expectOpenGraphStatsRead(t, mockGraph, environmentKind, sourceKind, dogKind, patronKind)
+				expectOpenGraphStatsRead(t, mockGraph, environmentKind, sourceKind, dogKind, patronKind, relationshipKind)
 
 				mockDB.EXPECT().
 					GetGraphSchemaExtensions(gomock.Any(), builtInExtensionFilter, model.Sort{}, 0, 0).
@@ -68,28 +70,32 @@ func TestSaveDataQuality(t *testing.T) {
 				mockDB.EXPECT().
 					GetKindsByIDs(gomock.Any(), schemaEnvironment.SourceKindId).
 					Return([]model.Kind{{ID: schemaEnvironment.SourceKindId, Name: sourceKind.String()}}, nil)
+				expectOpenGraphRelationshipKinds(mockDB, schemaExtension, relationshipKind)
 				mockDB.EXPECT().
-					GetKindsByNames(gomock.Any(), gomock.Any(), gomock.Any()).
+					GetKindsByNames(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					DoAndReturn(func(_ context.Context, names ...string) ([]model.Kind, error) {
-						if !gomock.InAnyOrder([]string{dogKind.String(), patronKind.String()}).Matches(names) {
+						if !gomock.InAnyOrder([]string{dogKind.String(), patronKind.String(), relationshipKind.String()}).Matches(names) {
 							t.Fatalf("expected kind names to match, got %#v", names)
 						}
 
 						return []model.Kind{
 							{ID: 101, Name: dogKind.String()},
 							{ID: 102, Name: patronKind.String()},
+							{ID: 103, Name: relationshipKind.String()},
 						}, nil
 					})
 				mockDB.EXPECT().
 					CreateDataQualityStats(gomock.Any(), gomock.Any()).
 					DoAndReturn(func(_ context.Context, stats model.DataQualityStats) (model.DataQualityStats, error) {
-						require.Len(t, stats, 3)
+						require.Len(t, stats, 5)
 						require.NotEmpty(t, stats[0].RunID)
 
 						expectedStats := model.DataQualityStats{
 							{RunID: stats[0].RunID, SchemaExtensionID: 44, SchemaEnvironmentKindID: 22, EnvironmentID: "env-a", MetricType: model.DataQualityMetricTypeNode, MetricName: "dogpark_Dog", MetricValue: 1, KindID: expectedKindIDs["dogpark_Dog"]},
 							{RunID: stats[0].RunID, SchemaExtensionID: 44, SchemaEnvironmentKindID: 22, EnvironmentID: "env-a", MetricType: model.DataQualityMetricTypeNode, MetricName: "dogpark_Patron", MetricValue: 2, KindID: expectedKindIDs["dogpark_Patron"]},
 							{RunID: stats[0].RunID, SchemaExtensionID: 44, SchemaEnvironmentKindID: 22, EnvironmentID: "env-b", MetricType: model.DataQualityMetricTypeNode, MetricName: "dogpark_Patron", MetricValue: 3, KindID: expectedKindIDs["dogpark_Patron"]},
+							{RunID: stats[0].RunID, SchemaExtensionID: 44, SchemaEnvironmentKindID: 22, EnvironmentID: "env-a", MetricType: model.DataQualityMetricTypeRelationship, MetricName: "dogpark_WalksWith", MetricValue: 2, KindID: expectedKindIDs["dogpark_WalksWith"]},
+							{RunID: stats[0].RunID, SchemaExtensionID: 44, SchemaEnvironmentKindID: 22, EnvironmentID: "env-b", MetricType: model.DataQualityMetricTypeRelationship, MetricName: "dogpark_WalksWith", MetricValue: 1, KindID: expectedKindIDs["dogpark_WalksWith"]},
 						}
 
 						require.ElementsMatch(t, expectedStats, stats)
@@ -98,12 +104,13 @@ func TestSaveDataQuality(t *testing.T) {
 				mockDB.EXPECT().
 					CreateDataQualityAggregations(gomock.Any(), gomock.Any()).
 					DoAndReturn(func(_ context.Context, aggregations model.DataQualityAggregations) (model.DataQualityAggregations, error) {
-						require.Len(t, aggregations, 2)
+						require.Len(t, aggregations, 3)
 						require.NotEmpty(t, aggregations[0].RunID)
 
 						expectedAggregations := model.DataQualityAggregations{
 							{RunID: aggregations[0].RunID, SchemaExtensionID: 44, SchemaEnvironmentKindID: 22, MetricType: model.DataQualityMetricTypeNode, MetricName: "dogpark_Dog", MetricValue: 1, KindID: expectedKindIDs["dogpark_Dog"]},
 							{RunID: aggregations[0].RunID, SchemaExtensionID: 44, SchemaEnvironmentKindID: 22, MetricType: model.DataQualityMetricTypeNode, MetricName: "dogpark_Patron", MetricValue: 5, KindID: expectedKindIDs["dogpark_Patron"]},
+							{RunID: aggregations[0].RunID, SchemaExtensionID: 44, SchemaEnvironmentKindID: 22, MetricType: model.DataQualityMetricTypeRelationship, MetricName: "dogpark_WalksWith", MetricValue: 3, KindID: expectedKindIDs["dogpark_WalksWith"]},
 						}
 
 						require.ElementsMatch(t, expectedAggregations, aggregations)
@@ -187,6 +194,7 @@ func TestSaveDataQuality(t *testing.T) {
 				mockDB.EXPECT().
 					GetEnvironmentsByExtensionId(gomock.Any(), schemaExtension.ID).
 					Return([]model.SchemaEnvironment{schemaEnvironment}, nil)
+				expectOpenGraphRelationshipKinds(mockDB, schemaExtension, relationshipKind)
 				mockDB.EXPECT().
 					GetKindsByIDs(gomock.Any(), schemaEnvironment.SourceKindId).
 					Return(nil, expectedError)
@@ -207,16 +215,39 @@ func TestSaveDataQuality(t *testing.T) {
 				mockDB.EXPECT().
 					GetKindsByIDs(gomock.Any(), schemaEnvironment.SourceKindId).
 					Return([]model.Kind{{ID: schemaEnvironment.SourceKindId, Name: sourceKind.String()}}, nil)
+				expectOpenGraphRelationshipKinds(mockDB, schemaExtension, relationshipKind)
 				expectReadTransactionError(mockGraph, expectedError)
 			},
 			expectedError: "could not count open graph nodes",
+		},
+		{
+			name: "returns error when opengraph relationship kind lookup fails",
+			setupMocks: func(t *testing.T, mockDB *mocks.MockDatabase, mockGraph *graphmocks.MockDatabase) {
+				expectEmptyADAndAzureStatsReads(t, mockGraph)
+				expectOpenGraphExtensionManagementFlag(mockDB, true, nil)
+
+				mockDB.EXPECT().
+					GetGraphSchemaExtensions(gomock.Any(), builtInExtensionFilter, model.Sort{}, 0, 0).
+					Return(model.GraphSchemaExtensions{schemaExtension}, 1, nil)
+				mockDB.EXPECT().
+					GetEnvironmentsByExtensionId(gomock.Any(), schemaExtension.ID).
+					Return([]model.SchemaEnvironment{schemaEnvironment}, nil)
+				mockDB.EXPECT().
+					GetGraphSchemaRelationshipKinds(gomock.Any(), model.Filters{"schema_extension_id": []model.Filter{{
+						Operator:    model.Equals,
+						Value:       fmt.Sprintf("%d", schemaExtension.ID),
+						SetOperator: model.FilterAnd,
+					}}}, model.Sort{}, 0, 0).
+					Return(nil, 0, expectedError)
+			},
+			expectedError: "could not get relationship kinds for extension",
 		},
 		{
 			name: "returns error when counted kind lookup fails",
 			setupMocks: func(t *testing.T, mockDB *mocks.MockDatabase, mockGraph *graphmocks.MockDatabase) {
 				expectEmptyADAndAzureStatsReads(t, mockGraph)
 				expectOpenGraphExtensionManagementFlag(mockDB, true, nil)
-				expectOpenGraphStatsRead(t, mockGraph, environmentKind, sourceKind, dogKind, patronKind)
+				expectOpenGraphStatsRead(t, mockGraph, environmentKind, sourceKind, dogKind, patronKind, relationshipKind)
 
 				mockDB.EXPECT().
 					GetGraphSchemaExtensions(gomock.Any(), builtInExtensionFilter, model.Sort{}, 0, 0).
@@ -227,8 +258,9 @@ func TestSaveDataQuality(t *testing.T) {
 				mockDB.EXPECT().
 					GetKindsByIDs(gomock.Any(), schemaEnvironment.SourceKindId).
 					Return([]model.Kind{{ID: schemaEnvironment.SourceKindId, Name: sourceKind.String()}}, nil)
+				expectOpenGraphRelationshipKinds(mockDB, schemaExtension, relationshipKind)
 				mockDB.EXPECT().
-					GetKindsByNames(gomock.Any(), gomock.Any(), gomock.Any()).
+					GetKindsByNames(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(nil, expectedError)
 			},
 			expectedError: "could not get data quality metric kinds",
@@ -238,7 +270,7 @@ func TestSaveDataQuality(t *testing.T) {
 			setupMocks: func(t *testing.T, mockDB *mocks.MockDatabase, mockGraph *graphmocks.MockDatabase) {
 				expectEmptyADAndAzureStatsReads(t, mockGraph)
 				expectOpenGraphExtensionManagementFlag(mockDB, true, nil)
-				expectOpenGraphStatsRead(t, mockGraph, environmentKind, sourceKind, dogKind, patronKind)
+				expectOpenGraphStatsRead(t, mockGraph, environmentKind, sourceKind, dogKind, patronKind, relationshipKind)
 
 				mockDB.EXPECT().
 					GetGraphSchemaExtensions(gomock.Any(), builtInExtensionFilter, model.Sort{}, 0, 0).
@@ -249,9 +281,10 @@ func TestSaveDataQuality(t *testing.T) {
 				mockDB.EXPECT().
 					GetKindsByIDs(gomock.Any(), schemaEnvironment.SourceKindId).
 					Return([]model.Kind{{ID: schemaEnvironment.SourceKindId, Name: sourceKind.String()}}, nil)
+				expectOpenGraphRelationshipKinds(mockDB, schemaExtension, relationshipKind)
 				mockDB.EXPECT().
-					GetKindsByNames(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return([]model.Kind{{ID: 101, Name: dogKind.String()}, {ID: 102, Name: patronKind.String()}}, nil)
+					GetKindsByNames(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return([]model.Kind{{ID: 101, Name: dogKind.String()}, {ID: 102, Name: patronKind.String()}, {ID: 103, Name: relationshipKind.String()}}, nil)
 				mockDB.EXPECT().
 					CreateDataQualityStats(gomock.Any(), gomock.Any()).
 					Return(model.DataQualityStats{}, expectedError)
@@ -263,7 +296,7 @@ func TestSaveDataQuality(t *testing.T) {
 			setupMocks: func(t *testing.T, mockDB *mocks.MockDatabase, mockGraph *graphmocks.MockDatabase) {
 				expectEmptyADAndAzureStatsReads(t, mockGraph)
 				expectOpenGraphExtensionManagementFlag(mockDB, true, nil)
-				expectOpenGraphStatsRead(t, mockGraph, environmentKind, sourceKind, dogKind, patronKind)
+				expectOpenGraphStatsRead(t, mockGraph, environmentKind, sourceKind, dogKind, patronKind, relationshipKind)
 
 				mockDB.EXPECT().
 					GetGraphSchemaExtensions(gomock.Any(), builtInExtensionFilter, model.Sort{}, 0, 0).
@@ -274,9 +307,10 @@ func TestSaveDataQuality(t *testing.T) {
 				mockDB.EXPECT().
 					GetKindsByIDs(gomock.Any(), schemaEnvironment.SourceKindId).
 					Return([]model.Kind{{ID: schemaEnvironment.SourceKindId, Name: sourceKind.String()}}, nil)
+				expectOpenGraphRelationshipKinds(mockDB, schemaExtension, relationshipKind)
 				mockDB.EXPECT().
-					GetKindsByNames(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return([]model.Kind{{ID: 101, Name: dogKind.String()}, {ID: 102, Name: patronKind.String()}}, nil)
+					GetKindsByNames(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return([]model.Kind{{ID: 101, Name: dogKind.String()}, {ID: 102, Name: patronKind.String()}, {ID: 103, Name: relationshipKind.String()}}, nil)
 				mockDB.EXPECT().
 					CreateDataQualityStats(gomock.Any(), gomock.Any()).
 					DoAndReturn(func(_ context.Context, stats model.DataQualityStats) (model.DataQualityStats, error) {
@@ -314,6 +348,21 @@ func expectOpenGraphExtensionManagementFlag(mockDB *mocks.MockDatabase, enabled 
 		Return(appcfg.FeatureFlag{Enabled: enabled}, err)
 }
 
+func expectOpenGraphRelationshipKinds(mockDB *mocks.MockDatabase, schemaExtension model.GraphSchemaExtension, relationshipKinds ...graph.Kind) {
+	schemaRelationshipKinds := make(model.GraphSchemaRelationshipKinds, 0, len(relationshipKinds))
+	for _, relationshipKind := range relationshipKinds {
+		schemaRelationshipKinds = append(schemaRelationshipKinds, model.GraphSchemaRelationshipKind{Name: relationshipKind.String()})
+	}
+
+	mockDB.EXPECT().
+		GetGraphSchemaRelationshipKinds(gomock.Any(), model.Filters{"schema_extension_id": []model.Filter{{
+			Operator:    model.Equals,
+			Value:       fmt.Sprintf("%d", schemaExtension.ID),
+			SetOperator: model.FilterAnd,
+		}}}, model.Sort{}, 0, 0).
+		Return(schemaRelationshipKinds, len(schemaRelationshipKinds), nil)
+}
+
 func expectEmptyADAndAzureStatsReads(t *testing.T, mockGraph *graphmocks.MockDatabase) {
 	t.Helper()
 
@@ -334,7 +383,7 @@ func expectEmptyADStatsRead(t *testing.T, mockGraph *graphmocks.MockDatabase) {
 	})
 }
 
-func expectOpenGraphStatsRead(t *testing.T, mockGraph *graphmocks.MockDatabase, environmentKind graph.Kind, sourceKind graph.Kind, dogKind graph.Kind, patronKind graph.Kind) {
+func expectOpenGraphStatsRead(t *testing.T, mockGraph *graphmocks.MockDatabase, environmentKind graph.Kind, sourceKind graph.Kind, dogKind graph.Kind, patronKind graph.Kind, relationshipKind graph.Kind) {
 	t.Helper()
 
 	expectReadTransaction(t, mockGraph, func(mockController *gomock.Controller, mockTransaction *graphmocks.MockTransaction) {
@@ -346,10 +395,17 @@ func expectOpenGraphStatsRead(t *testing.T, mockGraph *graphmocks.MockDatabase, 
 			{ID: 3, Kinds: graph.Kinds{sourceKind, dogKind, patronKind, graphschema.Meta}},
 			{ID: 4, Kinds: graph.Kinds{sourceKind, patronKind}},
 		})
+		expectFetchRelationshipKinds(mockController, mockTransaction, []graph.RelationshipKindsResult{
+			{RelationshipTripleResult: graph.RelationshipTripleResult{ID: 8, StartID: 3, EndID: 4}, Kind: relationshipKind},
+			{RelationshipTripleResult: graph.RelationshipTripleResult{ID: 9, StartID: 4, EndID: 3}, Kind: relationshipKind},
+		})
 		expectFetchKinds(mockController, mockTransaction, []graph.KindsResult{
 			{ID: 5, Kinds: graph.Kinds{sourceKind, patronKind}},
 			{ID: 6, Kinds: graph.Kinds{sourceKind, patronKind}},
 			{ID: 7, Kinds: graph.Kinds{sourceKind, patronKind}},
+		})
+		expectFetchRelationshipKinds(mockController, mockTransaction, []graph.RelationshipKindsResult{
+			{RelationshipTripleResult: graph.RelationshipTripleResult{ID: 10, StartID: 5, EndID: 6}, Kind: relationshipKind},
 		})
 	})
 }
@@ -396,6 +452,20 @@ func expectFetchKinds(mockController *gomock.Controller, mockTransaction *graphm
 		FetchKinds(gomock.Any()).
 		DoAndReturn(func(delegate func(graph.Cursor[graph.KindsResult]) error) error {
 			mockCursor := graphmocks.NewMockCursor[graph.KindsResult](mockController)
+			mockCursor.EXPECT().Chan().Return(cursorChan(kindsResults))
+			mockCursor.EXPECT().Error().Return(nil)
+			return delegate(mockCursor)
+		})
+}
+
+func expectFetchRelationshipKinds(mockController *gomock.Controller, mockTransaction *graphmocks.MockTransaction, kindsResults []graph.RelationshipKindsResult) {
+	mockRelationshipQuery := graphmocks.NewMockRelationshipQuery(mockController)
+	mockTransaction.EXPECT().Relationships().Return(mockRelationshipQuery)
+	mockRelationshipQuery.EXPECT().Filterf(gomock.Any()).Return(mockRelationshipQuery)
+	mockRelationshipQuery.EXPECT().
+		FetchKinds(gomock.Any()).
+		DoAndReturn(func(delegate func(graph.Cursor[graph.RelationshipKindsResult]) error) error {
+			mockCursor := graphmocks.NewMockCursor[graph.RelationshipKindsResult](mockController)
 			mockCursor.EXPECT().Chan().Return(cursorChan(kindsResults))
 			mockCursor.EXPECT().Error().Return(nil)
 			return delegate(mockCursor)

--- a/cmd/api/src/services/dataquality/opengraph.go
+++ b/cmd/api/src/services/dataquality/opengraph.go
@@ -1,0 +1,349 @@
+// Copyright 2026 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package dataquality
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/gofrs/uuid"
+	"github.com/specterops/bloodhound/cmd/api/src/database"
+	"github.com/specterops/bloodhound/cmd/api/src/database/types/null"
+	"github.com/specterops/bloodhound/cmd/api/src/model"
+	"github.com/specterops/bloodhound/packages/go/bhlog/attr"
+	"github.com/specterops/bloodhound/packages/go/graphschema"
+	"github.com/specterops/dawgs/graph"
+	"github.com/specterops/dawgs/ops"
+	"github.com/specterops/dawgs/query"
+)
+
+type kindCountsByEnvironment map[string]map[string]int
+
+type openGraphCountResults struct {
+	nodeKindCountsByEnvironmentID         kindCountsByEnvironment
+	relationshipKindCountsByEnvironmentID kindCountsByEnvironment
+	countedKindNames                      []string
+}
+
+func openGraphStats(ctx context.Context, db database.Database, graphDB graph.Database) (model.DataQualityStats, model.DataQualityAggregations, error) {
+	var (
+		aggregations = make(model.DataQualityAggregations, 0)
+		runID        string
+		stats        = make(model.DataQualityStats, 0)
+
+		// We only are concerned with non-builtin types since AD and AZ have their own stat collection
+		// When we move AD and AZ stat collection to this common table, this will need to be changed
+		builtInFilter = model.Filters{"is_builtin": []model.Filter{{Operator: model.Equals, Value: "false"}}}
+	)
+
+	if newUUID, err := uuid.NewV4(); err != nil {
+		return stats, aggregations, fmt.Errorf("could not generate new UUID: %w", err)
+	} else {
+		runID = newUUID.String()
+	}
+
+	extensions, _, err := db.GetGraphSchemaExtensions(ctx, builtInFilter, model.Sort{}, 0, 0)
+	if err != nil {
+		return stats, aggregations, fmt.Errorf("could not get graph schema extensions: %w", err)
+	}
+
+	for _, extension := range extensions {
+		environments, err := db.GetEnvironmentsByExtensionId(ctx, extension.ID)
+		if err != nil {
+			return stats, aggregations, fmt.Errorf("could not get environments for extension %d: %w", extension.ID, err)
+		}
+
+		if len(environments) == 0 {
+			continue
+		}
+
+		relationshipKinds, err := getOpenGraphRelationshipKinds(ctx, db, extension)
+		if err != nil {
+			return stats, aggregations, err
+		}
+
+		// Each extension may define multiple environments with their own environment kind, principal kinds, and source kind.
+		for _, environment := range environments {
+			environmentSourceKind, err := getOpenGraphEnvironmentSourceKind(ctx, db, environment)
+			if err != nil {
+				return stats, aggregations, err
+			}
+
+			countResults, err := countOpenGraphMetricsByEnvironment(ctx, graphDB, graph.StringKind(environment.EnvironmentKindName), environmentSourceKind.ToKind(), relationshipKinds)
+			if err != nil {
+				return stats, aggregations, fmt.Errorf("could not count open graph nodes and relationships for environment kind %s: %w", environment.EnvironmentKindName, err)
+			}
+
+			kindIDs, err := getOpenGraphCountKindIDs(ctx, db, countResults.countedKindNames)
+			if err != nil {
+				return stats, aggregations, err
+			}
+
+			for _, metricCountGroup := range []struct {
+				metricType            model.DataQualityMetricType
+				countsByEnvironmentID kindCountsByEnvironment
+			}{
+				{
+					metricType:            model.DataQualityMetricTypeNode,
+					countsByEnvironmentID: countResults.nodeKindCountsByEnvironmentID,
+				},
+				{
+					metricType:            model.DataQualityMetricTypeRelationship,
+					countsByEnvironmentID: countResults.relationshipKindCountsByEnvironmentID,
+				},
+			} {
+				metricStats, metricAggregations := buildOpenGraphCountStats(runID, extension, environment, metricCountGroup.metricType, metricCountGroup.countsByEnvironmentID, kindIDs)
+
+				stats = append(stats, metricStats...)
+				aggregations = append(aggregations, metricAggregations...)
+			}
+		}
+	}
+
+	return stats, aggregations, nil
+}
+
+func getOpenGraphRelationshipKinds(ctx context.Context, db database.Database, extension model.GraphSchemaExtension) (graph.Kinds, error) {
+	relationshipKindFilters := model.Filters{"schema_extension_id": []model.Filter{{
+		Operator:    model.Equals,
+		Value:       fmt.Sprintf("%d", extension.ID),
+		SetOperator: model.FilterAnd,
+	}}}
+
+	schemaRelationshipKinds, _, err := db.GetGraphSchemaRelationshipKinds(ctx, relationshipKindFilters, model.Sort{}, 0, 0)
+	if err != nil {
+		return nil, fmt.Errorf("could not get relationship kinds for extension %d: %w", extension.ID, err)
+	}
+
+	relationshipKinds := make(graph.Kinds, 0, len(schemaRelationshipKinds))
+	for _, schemaRelationshipKind := range schemaRelationshipKinds {
+		relationshipKinds = append(relationshipKinds, schemaRelationshipKind.ToKind())
+	}
+
+	return relationshipKinds, nil
+}
+
+func getOpenGraphEnvironmentSourceKind(ctx context.Context, db database.Database, environment model.SchemaEnvironment) (model.Kind, error) {
+	kinds, err := db.GetKindsByIDs(ctx, environment.SourceKindId)
+	if err != nil {
+		return model.Kind{}, fmt.Errorf("could not get source kind for schema environment %d: %w", environment.ID, err)
+	}
+
+	if len(kinds) == 0 {
+		return model.Kind{}, fmt.Errorf("could not get source kind for schema environment %d: %w", environment.ID, database.ErrNotFound)
+	}
+
+	return kinds[0], nil
+}
+
+func countOpenGraphMetricsByEnvironment(ctx context.Context, graphDB graph.Database, environmentKind graph.Kind, sourceKind graph.Kind, relationshipKinds graph.Kinds) (openGraphCountResults, error) {
+	var (
+		countResults = openGraphCountResults{
+			nodeKindCountsByEnvironmentID:         kindCountsByEnvironment{},
+			relationshipKindCountsByEnvironmentID: kindCountsByEnvironment{},
+			countedKindNames:                      make([]string, 0),
+		}
+		seenCountedKindNames = map[string]struct{}{}
+	)
+
+	err := graphDB.ReadTransaction(ctx, func(tx graph.Transaction) error {
+		environmentIDs, err := getOpenGraphEnvironmentIDs(ctx, tx, environmentKind)
+		if err != nil {
+			return err
+		}
+
+		for _, environmentID := range environmentIDs {
+			if err := countOpenGraphNodeMetricsForEnvironment(tx, &countResults, sourceKind, environmentID, seenCountedKindNames); err != nil {
+				return err
+			}
+
+			if err := countOpenGraphRelationshipMetricsForEnvironment(tx, &countResults, sourceKind, relationshipKinds, environmentID, seenCountedKindNames); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
+
+	return countResults, err
+}
+
+func countOpenGraphNodeMetricsForEnvironment(tx graph.Transaction, countResults *openGraphCountResults, sourceKind graph.Kind, environmentID string, seenCountedKindNames map[string]struct{}) error {
+	nodeKindCounts := map[string]int{}
+
+	if err := tx.Nodes().Filterf(func() graph.Criteria {
+		return query.And(
+			query.Kind(query.Node(), sourceKind),
+			query.Equals(query.NodeProperty(graphschema.EnvironmentIDKey), environmentID),
+		)
+	}).FetchKinds(func(cursor graph.Cursor[graph.KindsResult]) error {
+		for result := range cursor.Chan() {
+			countResults.countedKindNames = countOpenGraphNodeKinds(result.Kinds, sourceKind, nodeKindCounts, countResults.countedKindNames, seenCountedKindNames)
+		}
+
+		return cursor.Error()
+	}); err != nil {
+		return err
+	}
+
+	if len(nodeKindCounts) > 0 {
+		countResults.nodeKindCountsByEnvironmentID[environmentID] = nodeKindCounts
+	}
+
+	return nil
+}
+
+func countOpenGraphRelationshipMetricsForEnvironment(tx graph.Transaction, countResults *openGraphCountResults, sourceKind graph.Kind, relationshipKinds graph.Kinds, environmentID string, seenCountedKindNames map[string]struct{}) error {
+	if len(relationshipKinds) == 0 {
+		return nil
+	}
+
+	relationshipKindCounts := map[string]int{}
+
+	if err := tx.Relationships().Filterf(func() graph.Criteria {
+		return query.And(
+			query.Kind(query.Start(), sourceKind),
+			query.Equals(query.StartProperty(graphschema.EnvironmentIDKey), environmentID),
+			query.KindIn(query.Relationship(), relationshipKinds...),
+		)
+	}).FetchKinds(func(cursor graph.Cursor[graph.RelationshipKindsResult]) error {
+		for result := range cursor.Chan() {
+			countResults.countedKindNames = countOpenGraphKind(result.Kind.String(), relationshipKindCounts, countResults.countedKindNames, seenCountedKindNames)
+		}
+
+		return cursor.Error()
+	}); err != nil {
+		return err
+	}
+
+	if len(relationshipKindCounts) > 0 {
+		countResults.relationshipKindCountsByEnvironmentID[environmentID] = relationshipKindCounts
+	}
+
+	return nil
+}
+
+func countOpenGraphNodeKinds(kinds graph.Kinds, sourceKind graph.Kind, nodeKindCounts map[string]int, countedKindNames []string, seenCountedKindNames map[string]struct{}) []string {
+	for _, kind := range kinds {
+		if kind.Is(sourceKind) || model.IsExtendedNodeKind(kind) {
+			continue
+		}
+
+		countedKindNames = countOpenGraphKind(kind.String(), nodeKindCounts, countedKindNames, seenCountedKindNames)
+	}
+
+	return countedKindNames
+}
+
+func countOpenGraphKind(kindName string, kindCounts map[string]int, countedKindNames []string, seenCountedKindNames map[string]struct{}) []string {
+	kindCounts[kindName]++
+
+	if _, seen := seenCountedKindNames[kindName]; !seen {
+		countedKindNames = append(countedKindNames, kindName)
+		seenCountedKindNames[kindName] = struct{}{}
+	}
+
+	return countedKindNames
+}
+
+func getOpenGraphEnvironmentIDs(ctx context.Context, tx graph.Transaction, environmentKind graph.Kind) ([]string, error) {
+	var environmentIDs []string
+
+	environments, err := ops.FetchNodes(tx.Nodes().Filterf(func() graph.Criteria {
+		return query.Kind(query.Node(), environmentKind)
+	}))
+	if err != nil {
+		return nil, err
+	}
+
+	for _, environment := range environments {
+		environmentID, err := environment.Properties.Get(graphschema.EnvironmentIDKey).String()
+		if err != nil {
+			slog.WarnContext(
+				ctx,
+				"OpenGraph environment node does not have a valid environment ID property",
+				slog.Uint64("node_id", uint64(environment.ID)),
+				slog.String("environment_kind", environmentKind.String()),
+				attr.Error(err),
+			)
+			continue
+		}
+
+		environmentIDs = append(environmentIDs, environmentID)
+	}
+
+	return environmentIDs, nil
+}
+
+func getOpenGraphCountKindIDs(ctx context.Context, db database.Database, kindNames []string) (map[string]null.Int32, error) {
+	if len(kindNames) == 0 {
+		return map[string]null.Int32{}, nil
+	}
+
+	kinds, err := db.GetKindsByNames(ctx, kindNames...)
+	if err != nil && !errors.Is(err, database.ErrNotFound) {
+		return nil, fmt.Errorf("could not get data quality metric kinds: %w", err)
+	}
+
+	kindIDsByName := make(map[string]null.Int32, len(kinds))
+	for _, kind := range kinds {
+		kindIDsByName[kind.Name] = null.Int32From(kind.ID)
+	}
+
+	return kindIDsByName, nil
+}
+
+func buildOpenGraphCountStats(runID string, extension model.GraphSchemaExtension, environment model.SchemaEnvironment, metricType model.DataQualityMetricType, countsByEnvironmentID kindCountsByEnvironment, kindIDsByName map[string]null.Int32) (model.DataQualityStats, model.DataQualityAggregations) {
+	var (
+		aggregatedCounts = map[string]int{}
+		stats            = make(model.DataQualityStats, 0)
+		aggregations     = make(model.DataQualityAggregations, 0)
+	)
+
+	for environmentID, kindCounts := range countsByEnvironmentID {
+		for kindName, count := range kindCounts {
+			stats = append(stats, model.DataQualityStat{
+				RunID:                   runID,
+				SchemaExtensionID:       extension.ID,
+				SchemaEnvironmentKindID: environment.EnvironmentKindId,
+				EnvironmentID:           environmentID,
+				MetricType:              metricType,
+				MetricName:              kindName,
+				MetricValue:             float64(count),
+				KindID:                  kindIDsByName[kindName],
+			})
+
+			aggregatedCounts[kindName] += count
+		}
+	}
+
+	for kindName, count := range aggregatedCounts {
+		aggregations = append(aggregations, model.DataQualityAggregation{
+			RunID:                   runID,
+			SchemaExtensionID:       extension.ID,
+			SchemaEnvironmentKindID: environment.EnvironmentKindId,
+			MetricType:              metricType,
+			MetricName:              kindName,
+			MetricValue:             float64(count),
+			KindID:                  kindIDsByName[kindName],
+		})
+	}
+
+	return stats, aggregations
+}


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

This PR adds counting OpenGraph nodes for extensions. The counts are aggregated by each node's environment id

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves: BED-8614

*Why is this change required? What problem does it solve?*

## How Has This Been Tested?

I registered multiple extensions and ingested their data and then verified the counts in the data_quality_stats table against a simple Cypher query in Explore
<img width="2948" height="1162" alt="image" src="https://github.com/user-attachments/assets/7b2294e8-81a2-410e-a517-918e98d16714" />
<img width="2935" height="1122" alt="image" src="https://github.com/user-attachments/assets/99c74568-c96f-4e90-bc69-107dece1cc9d" />

<img width="2966" height="1145" alt="image" src="https://github.com/user-attachments/assets/4c1d77be-2b61-4481-9be9-5b2efa0241c0" />
<img width="2946" height="1310" alt="image" src="https://github.com/user-attachments/assets/7417c2b9-106b-4c05-ad6f-e9ca8bf179ee" />

I was able to test aggregations by adding the individual environment kinds collected for a specific run_id and verifying that that aggregation adds up to the individual counts of multiple environments for that same run_id
<img width="2712" height="738" alt="image" src="https://github.com/user-attachments/assets/7a81687a-71bc-411d-b176-3c1e4ec6078d" />

Testing relationship counts:
<img width="2844" height="1522" alt="image" src="https://github.com/user-attachments/assets/9d88099e-9d4f-4b44-9a4b-cf837bffd74f" />
<img width="2918" height="1325" alt="image" src="https://github.com/user-attachments/assets/59ec99b8-9e89-4d5f-8a96-330f1b6f69e6" />

Aggregations:
<img width="2846" height="1416" alt="image" src="https://github.com/user-attachments/assets/5904fa04-faa0-46f3-bb17-276d4209cacc" />



## Screenshots (optional):



## Types of changes

<!-- Please remove any items that do not apply. -->

- New feature (non-breaking change which adds functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added OpenGraph data-quality statistics collection, including per-environment and aggregated node and relationship counts.

* **Bug Fixes**
  * OpenGraph metrics are now conditional on the relevant feature being enabled.
  * If OpenGraph stats are enabled but no stats are returned, metrics are not persisted.

* **Tests**
  * Added end-to-end coverage for saving OpenGraph metrics, feature-flag behavior, skip conditions, and detailed failure propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->