### PR TITLE
feat(api): add GET data quality stats aggregations endpoint - BED-8611

### DIFF
--- a/cmd/api/src/api/registration/v2.go
+++ b/cmd/api/src/api/registration/v2.go
@@ -349,6 +349,7 @@ func NewV2API(resources v2.Resources, routerInst *router.Router) {
 		routerInst.GET(fmt.Sprintf("/api/v2/azure-tenants/{%s}/data-quality-stats", api.URIPathVariableTenantID), resources.GetAzureDataQualityStats).RequirePermissions(permissions.GraphDBRead).SupportsETAC(resources.DB, resources.DogTags),
 		routerInst.GET(fmt.Sprintf("/api/v2/platform/{%s}/data-quality-stats", api.URIPathVariablePlatformID), resources.GetPlatformAggregateStats).RequirePermissions(permissions.GraphDBRead),
 		routerInst.GET("/api/v2/data-quality-stats", resources.GetDataQualityStats).RequirePermissions(permissions.GraphDBRead).CheckFeatureFlag(resources.DB, appcfg.FeatureOpenGraphExtensionManagement),
+		routerInst.GET("/api/v2/data-quality-stats-aggregations", resources.GetDataQualityAggregations).RequirePermissions(permissions.GraphDBRead).CheckFeatureFlag(resources.DB, appcfg.FeatureOpenGraphExtensionManagement),
 
 		// Datapipe API
 		routerInst.GET("/api/v2/datapipe/status", resources.GetDatapipeStatus).RequireAuth(),

--- a/cmd/api/src/api/v2/dataquality.go
+++ b/cmd/api/src/api/v2/dataquality.go
@@ -232,6 +232,8 @@ func (s *Resources) GetDataQualityAggregations(response http.ResponseWriter, req
 		queryParams                   = request.URL.Query()
 		sortItems                     model.Sort
 		skip, limit                   int
+		start, end                    time.Time
+		defaultEnd, defaultStart      = DefaultTimeRange()
 	)
 
 	queryFilters, err := model.NewQueryParameterFilterParser().ParseQueryParameterFilters(request)
@@ -266,7 +268,7 @@ func (s *Resources) GetDataQualityAggregations(response http.ResponseWriter, req
 		}
 	}
 
-	// parse sort_by, skip, and limit
+	// parse sort_by, skip, limit, start, end
 	if sortItems, err = api.ParseSortParameters(model.DataQualityAggregations{}, queryParams); err != nil {
 		api.WriteErrorResponse(ctx, api.BuildErrorResponse(http.StatusBadRequest, err.Error(), request), response)
 		return
@@ -277,6 +279,14 @@ func (s *Resources) GetDataQualityAggregations(response http.ResponseWriter, req
 	}
 	if limit, err = ParseLimitQueryParameter(queryParams, 10); err != nil {
 		api.WriteErrorResponse(ctx, api.BuildErrorResponse(http.StatusBadRequest, err.Error(), request), response)
+		return
+	}
+	if start, err = ParseTimeQueryParameter(queryParams, "start", defaultStart); err != nil {
+		api.WriteErrorResponse(ctx, api.BuildErrorResponse(http.StatusBadRequest, fmt.Sprintf(api.ErrorInvalidRFC3339, queryParams["start"]), request), response)
+		return
+	}
+	if end, err = ParseTimeQueryParameter(queryParams, "end", defaultEnd); err != nil {
+		api.WriteErrorResponse(ctx, api.BuildErrorResponse(http.StatusBadRequest, fmt.Sprintf(api.ErrorInvalidRFC3339, queryParams["end"]), request), response)
 		return
 	}
 
@@ -302,12 +312,28 @@ func (s *Resources) GetDataQualityAggregations(response http.ResponseWriter, req
 	}
 
 	filters := queryFilters.ToFiltersModel()
+	// created_at is filtered by the start/end params, so set the time window here
+	filters["created_at"] = []model.Filter{
+		{
+			Value:        start.Format(time.RFC3339),
+			Operator:     model.GreaterThanOrEquals,
+			SetOperator:  model.FilterAnd,
+			IsStringData: false,
+		},
+		{
+			Value:        end.Format(time.RFC3339),
+			Operator:     model.LessThanOrEquals,
+			SetOperator:  model.FilterAnd,
+			IsStringData: false,
+		},
+	}
+
 	aggs, count, err := s.DB.GetDataQualityAggregations(ctx, filters, sortItems, skip, limit)
 	if err != nil {
 		api.HandleDatabaseError(request, response, err)
 		return
 	}
-	api.WriteResponseWrapperWithPagination(ctx, aggs, limit, skip, count, http.StatusOK, response)
+	api.WriteResponseWrapperWithTimeWindowAndPagination(ctx, aggs, start, end, limit, skip, count, http.StatusOK, response)
 }
 
 // parseOrder is a helper function which parses any sort_by query params into both the legacy sort string format and the model.Sort format. Returns an error if the columns is not sortable, or if an empty sort param is provided.

--- a/cmd/api/src/api/v2/dataquality.go
+++ b/cmd/api/src/api/v2/dataquality.go
@@ -236,7 +236,14 @@ func (s *Resources) GetDataQualityAggregations(response http.ResponseWriter, req
 		defaultEnd, defaultStart      = DefaultTimeRange()
 	)
 
-	queryFilters, err := model.NewQueryParameterFilterParser().ParseQueryParameterFilters(request)
+	// omit start and end from parser since they are processed as plain time parsers
+	filterQuery := request.URL.Query()
+	filterQuery.Del("start")
+	filterQuery.Del("end")
+	filterRequest := request.Clone(ctx)
+	filterRequest.URL.RawQuery = filterQuery.Encode()
+
+	queryFilters, err := model.NewQueryParameterFilterParser().ParseQueryParameterFilters(filterRequest)
 	if err != nil {
 		api.WriteErrorResponse(ctx, api.BuildErrorResponse(http.StatusBadRequest, api.ErrorResponseDetailsBadQueryParameterFilters, request), response)
 		return
@@ -277,7 +284,7 @@ func (s *Resources) GetDataQualityAggregations(response http.ResponseWriter, req
 		api.WriteErrorResponse(ctx, api.BuildErrorResponse(http.StatusBadRequest, err.Error(), request), response)
 		return
 	}
-	if limit, err = ParseLimitQueryParameter(queryParams, 10); err != nil {
+	if limit, err = ParseLimitQueryParameter(queryParams, 1000); err != nil {
 		api.WriteErrorResponse(ctx, api.BuildErrorResponse(http.StatusBadRequest, err.Error(), request), response)
 		return
 	}

--- a/cmd/api/src/api/v2/dataquality.go
+++ b/cmd/api/src/api/v2/dataquality.go
@@ -22,6 +22,8 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"slices"
+	"strconv"
 	"strings"
 	"time"
 
@@ -219,6 +221,93 @@ func (s *Resources) GetDataQualityStats(response http.ResponseWriter, request *h
 			api.WriteResponseWrapperWithTimeWindowAndPagination(ctx, stats, start, end, limit, skip, count, http.StatusOK, response)
 		}
 	}
+}
+
+// GetDataQualityAggregations returns data quality metric counts aggregated per environment kind for an OpenGraph extension,
+// with optional created_at filtering, sorting, and pagination.
+func (s *Resources) GetDataQualityAggregations(response http.ResponseWriter, request *http.Request) {
+	var (
+		ctx                           = request.Context()
+		requiredEnvironmentKindColumn = "schema_environment_kind_id"
+		queryParams                   = request.URL.Query()
+		sortItems                     model.Sort
+		skip, limit                   int
+	)
+
+	queryFilters, err := model.NewQueryParameterFilterParser().ParseQueryParameterFilters(request)
+	if err != nil {
+		api.WriteErrorResponse(ctx, api.BuildErrorResponse(http.StatusBadRequest, api.ErrorResponseDetailsBadQueryParameterFilters, request), response)
+		return
+	}
+
+	// schema_environment_kind_id is required
+	if !queryFilters.IsFiltered(requiredEnvironmentKindColumn) {
+		api.WriteErrorResponse(ctx, api.BuildErrorResponse(http.StatusBadRequest,
+			fmt.Sprintf(api.FmtErrorResponseDetailsMissingRequiredQueryParameter, requiredEnvironmentKindColumn), request),
+			response)
+		return
+	}
+
+	for column, columnFilters := range queryFilters {
+		validPredicates, err := api.GetValidFilterPredicatesAsStrings(model.DataQualityAggregations{}, column)
+		if err != nil {
+			api.WriteErrorResponse(ctx, api.BuildErrorResponse(http.StatusBadRequest, fmt.Sprintf("%s: %s", api.ErrorResponseDetailsColumnNotFilterable, column), request),
+				response)
+			return
+		}
+		for i, filter := range columnFilters {
+			if !slices.Contains(validPredicates, string(filter.Operator)) {
+				api.WriteErrorResponse(ctx,
+					api.BuildErrorResponse(http.StatusBadRequest, fmt.Sprintf("%s: %s %s", api.ErrorResponseDetailsFilterPredicateNotSupported, filter.Name, filter.Operator), request),
+					response)
+				return
+			}
+			queryFilters[column][i].IsStringData = model.DataQualityAggregations{}.IsStringColumn(filter.Name)
+		}
+	}
+
+	// parse sort_by, skip, and limit
+	if sortItems, err = api.ParseSortParameters(model.DataQualityAggregations{}, queryParams); err != nil {
+		api.WriteErrorResponse(ctx, api.BuildErrorResponse(http.StatusBadRequest, err.Error(), request), response)
+		return
+	}
+	if skip, err = ParseSkipQueryParameter(queryParams, 0); err != nil {
+		api.WriteErrorResponse(ctx, api.BuildErrorResponse(http.StatusBadRequest, err.Error(), request), response)
+		return
+	}
+	if limit, err = ParseLimitQueryParameter(queryParams, 10); err != nil {
+		api.WriteErrorResponse(ctx, api.BuildErrorResponse(http.StatusBadRequest, err.Error(), request), response)
+		return
+	}
+
+	// when filtering on schema_extension_id, verify the extension exists or return a 404
+	if extensionFilters, ok := queryFilters["schema_extension_id"]; ok {
+		for _, filter := range extensionFilters {
+			// only check existence for eq operator (exact ID)
+			if filter.Operator != model.Equals {
+				continue
+			}
+
+			id, err := strconv.ParseInt(filter.Value, 10, 32)
+			if err != nil {
+				convErrMessage := fmt.Sprintf("%s: schema_extension_id", api.ErrorResponseDetailsBadQueryParameterFilters)
+				api.WriteErrorResponse(ctx, api.BuildErrorResponse(http.StatusBadRequest, convErrMessage, request), response)
+				return
+			}
+			if _, err := s.DB.GetGraphSchemaExtensionById(ctx, int32(id)); err != nil {
+				api.HandleDatabaseError(request, response, err)
+				return
+			}
+		}
+	}
+
+	filters := queryFilters.ToFiltersModel()
+	aggs, count, err := s.DB.GetDataQualityAggregations(ctx, filters, sortItems, skip, limit)
+	if err != nil {
+		api.HandleDatabaseError(request, response, err)
+		return
+	}
+	api.WriteResponseWrapperWithPagination(ctx, aggs, limit, skip, count, http.StatusOK, response)
 }
 
 // parseOrder is a helper function which parses any sort_by query params into both the legacy sort string format and the model.Sort format. Returns an error if the columns is not sortable, or if an empty sort param is provided.

--- a/cmd/api/src/api/v2/dataquality.go
+++ b/cmd/api/src/api/v2/dataquality.go
@@ -22,7 +22,6 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
-	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -39,12 +38,13 @@ import (
 )
 
 const (
-	ErrNoTenantId        string = "no tenant id specified in url"
-	ErrNoPlatformId      string = "no platform id specified in url"
-	ErrInvalidPlatformId string = "invalid platform id specified in url: %v"
-	ErrNoEnvironmentId   string = "environment_id is required"
-	ErrUnknownUser       string = "unknown user"
-	ErrNoAccess          string = "user does not have permission to access this environment"
+	ErrNoAccess                        string = "user does not have permission to access this environment"
+	ErrNoEnvironmentId                 string = "environment_id is required"
+	ErrNoTenantId                      string = "no tenant id specified in url"
+	ErrNoPlatformId                    string = "no platform id specified in url"
+	ErrUnknownUser                     string = "unknown user"
+	FmtErrInvalidIntegerQueryParameter string = "query parameter must be an integer: %s"
+	FmtErrInvalidPlatformId            string = "invalid platform id specified in url: %v"
 )
 
 func (s Resources) GetDatabaseCompleteness(response http.ResponseWriter, request *http.Request) {
@@ -166,7 +166,7 @@ func (s *Resources) GetPlatformAggregateStats(response http.ResponseWriter, requ
 				return
 			}
 		default:
-			api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, fmt.Sprintf(ErrInvalidPlatformId, id), request), response)
+			api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, fmt.Sprintf(FmtErrInvalidPlatformId, id), request), response)
 			return
 		}
 
@@ -223,56 +223,37 @@ func (s *Resources) GetDataQualityStats(response http.ResponseWriter, request *h
 	}
 }
 
-// GetDataQualityAggregations returns data quality metric counts aggregated per environment kind for an OpenGraph extension,
-// with optional created_at filtering, sorting, and pagination.
+// GetDataQualityAggregations returns data quality metric counts aggregated per environment kind for an OpenGraph extension.
+// Requires a schema_environment_kind_id, with optional schema_extension_id, created_at range, sorting, and pagination.
 func (s *Resources) GetDataQualityAggregations(response http.ResponseWriter, request *http.Request) {
 	var (
-		ctx                           = request.Context()
-		requiredEnvironmentKindColumn = "schema_environment_kind_id"
-		queryParams                   = request.URL.Query()
-		sortItems                     model.Sort
-		skip, limit                   int
-		start, end                    time.Time
-		defaultEnd, defaultStart      = DefaultTimeRange()
+		ctx         = request.Context()
+		queryParams = request.URL.Query()
+
+		schemaEnvironmentKindIDParam = "schema_environment_kind_id"
+		schemaExtensionIDParam       = "schema_extension_id"
+
+		err         error
+		sortItems   model.Sort
+		skip, limit int
+		start, end  time.Time
+
+		defaultEnd, defaultStart = DefaultTimeRange()
 	)
 
-	// omit start and end from parser since they are processed as plain time parsers
-	filterQuery := request.URL.Query()
-	filterQuery.Del("start")
-	filterQuery.Del("end")
-	filterRequest := request.Clone(ctx)
-	filterRequest.URL.RawQuery = filterQuery.Encode()
-
-	queryFilters, err := model.NewQueryParameterFilterParser().ParseQueryParameterFilters(filterRequest)
-	if err != nil {
-		api.WriteErrorResponse(ctx, api.BuildErrorResponse(http.StatusBadRequest, api.ErrorResponseDetailsBadQueryParameterFilters, request), response)
-		return
-	}
-
 	// schema_environment_kind_id is required
-	if !queryFilters.IsFiltered(requiredEnvironmentKindColumn) {
+	kindID := queryParams.Get(schemaEnvironmentKindIDParam)
+	if kindID == "" {
 		api.WriteErrorResponse(ctx, api.BuildErrorResponse(http.StatusBadRequest,
-			fmt.Sprintf(api.FmtErrorResponseDetailsMissingRequiredQueryParameter, requiredEnvironmentKindColumn), request),
+			fmt.Sprintf(api.FmtErrorResponseDetailsMissingRequiredQueryParameter, schemaEnvironmentKindIDParam), request),
 			response)
 		return
 	}
-
-	for column, columnFilters := range queryFilters {
-		validPredicates, err := api.GetValidFilterPredicatesAsStrings(model.DataQualityAggregations{}, column)
-		if err != nil {
-			api.WriteErrorResponse(ctx, api.BuildErrorResponse(http.StatusBadRequest, fmt.Sprintf("%s: %s", api.ErrorResponseDetailsColumnNotFilterable, column), request),
-				response)
-			return
-		}
-		for i, filter := range columnFilters {
-			if !slices.Contains(validPredicates, string(filter.Operator)) {
-				api.WriteErrorResponse(ctx,
-					api.BuildErrorResponse(http.StatusBadRequest, fmt.Sprintf("%s: %s %s", api.ErrorResponseDetailsFilterPredicateNotSupported, filter.Name, filter.Operator), request),
-					response)
-				return
-			}
-			queryFilters[column][i].IsStringData = model.DataQualityAggregations{}.IsStringColumn(filter.Name)
-		}
+	if _, err := strconv.ParseInt(kindID, 10, 32); err != nil {
+		api.WriteErrorResponse(ctx, api.BuildErrorResponse(http.StatusBadRequest,
+			fmt.Sprintf(FmtErrInvalidIntegerQueryParameter, schemaEnvironmentKindIDParam), request),
+			response)
+		return
 	}
 
 	// parse sort_by, skip, limit, start, end
@@ -298,27 +279,32 @@ func (s *Resources) GetDataQualityAggregations(response http.ResponseWriter, req
 	}
 
 	// when filtering on schema_extension_id, verify the extension exists or return a 404
-	if extensionFilters, ok := queryFilters["schema_extension_id"]; ok {
-		for _, filter := range extensionFilters {
-			// only check existence for eq operator (exact ID)
-			if filter.Operator != model.Equals {
-				continue
-			}
-
-			id, err := strconv.ParseInt(filter.Value, 10, 32)
-			if err != nil {
-				convErrMessage := fmt.Sprintf("%s: schema_extension_id", api.ErrorResponseDetailsBadQueryParameterFilters)
-				api.WriteErrorResponse(ctx, api.BuildErrorResponse(http.StatusBadRequest, convErrMessage, request), response)
-				return
-			}
-			if _, err := s.DB.GetGraphSchemaExtensionById(ctx, int32(id)); err != nil {
-				api.HandleDatabaseError(request, response, err)
-				return
-			}
+	extensionID := queryParams.Get(schemaExtensionIDParam)
+	if extensionID != "" {
+		id, err := strconv.ParseInt(extensionID, 10, 32)
+		if err != nil {
+			api.WriteErrorResponse(ctx, api.BuildErrorResponse(http.StatusBadRequest,
+				fmt.Sprintf(FmtErrInvalidIntegerQueryParameter, schemaExtensionIDParam), request),
+				response)
+			return
+		}
+		if _, err := s.DB.GetGraphSchemaExtensionById(ctx, int32(id)); err != nil {
+			api.HandleDatabaseError(request, response, err)
+			return
 		}
 	}
 
-	filters := queryFilters.ToFiltersModel()
+	filters := model.Filters{
+		schemaEnvironmentKindIDParam: []model.Filter{
+			{Value: kindID, Operator: model.Equals, SetOperator: model.FilterAnd, IsStringData: false},
+		},
+	}
+	if extensionID != "" {
+		filters[schemaExtensionIDParam] = []model.Filter{
+			{Value: extensionID, Operator: model.Equals, SetOperator: model.FilterAnd, IsStringData: false},
+		}
+	}
+
 	// created_at is filtered by the start/end params, so set the time window here
 	filters["created_at"] = []model.Filter{
 		{

--- a/cmd/api/src/api/v2/dataquality.go
+++ b/cmd/api/src/api/v2/dataquality.go
@@ -308,13 +308,13 @@ func (s *Resources) GetDataQualityAggregations(response http.ResponseWriter, req
 	// created_at is filtered by the start/end params, so set the time window here
 	filters["created_at"] = []model.Filter{
 		{
-			Value:        start.Format(time.RFC3339),
+			Value:        start.Format(time.RFC3339Nano),
 			Operator:     model.GreaterThanOrEquals,
 			SetOperator:  model.FilterAnd,
 			IsStringData: false,
 		},
 		{
-			Value:        end.Format(time.RFC3339),
+			Value:        end.Format(time.RFC3339Nano),
 			Operator:     model.LessThanOrEquals,
 			SetOperator:  model.FilterAnd,
 			IsStringData: false,

--- a/cmd/api/src/api/v2/dataquality.go
+++ b/cmd/api/src/api/v2/dataquality.go
@@ -213,8 +213,8 @@ func (s *Resources) GetDataQualityStats(response http.ResponseWriter, request *h
 				Operator:    model.Equals,
 				SetOperator: model.FilterAnd,
 			}},
-			"created_at": []model.Filter{{Value: start.Format(time.RFC3339), Operator: model.GreaterThanOrEquals, SetOperator: model.FilterAnd}, {Value: end.Format(time.RFC3339), Operator: model.LessThan, SetOperator: model.FilterAnd}},
 		}
+		filters["created_at"] = dataQualityCreatedAtFilters(start, end)
 		if stats, count, err := s.DB.GetDataQualityStats(ctx, filters, sort, skip, limit); err != nil {
 			api.HandleDatabaseError(request, response, err)
 		} else {
@@ -306,20 +306,7 @@ func (s *Resources) GetDataQualityAggregations(response http.ResponseWriter, req
 	}
 
 	// created_at is filtered by the start/end params, so set the time window here
-	filters["created_at"] = []model.Filter{
-		{
-			Value:        start.Format(time.RFC3339Nano),
-			Operator:     model.GreaterThanOrEquals,
-			SetOperator:  model.FilterAnd,
-			IsStringData: false,
-		},
-		{
-			Value:        end.Format(time.RFC3339Nano),
-			Operator:     model.LessThanOrEquals,
-			SetOperator:  model.FilterAnd,
-			IsStringData: false,
-		},
-	}
+	filters["created_at"] = dataQualityCreatedAtFilters(start, end)
 
 	aggs, count, err := s.DB.GetDataQualityAggregations(ctx, filters, sortItems, skip, limit)
 	if err != nil {
@@ -359,4 +346,22 @@ func parseOrder(queryParams url.Values, sortable api.Sortable) (string, model.So
 
 	}
 	return strings.Join(order, ", "), sort, nil
+}
+
+// dataQualityCreatedAtFilters builds the created_at time window filter, inclusive on start and end bounds
+func dataQualityCreatedAtFilters(start, end time.Time) []model.Filter {
+	return []model.Filter{
+		{
+			Value:        start.Format(time.RFC3339Nano),
+			Operator:     model.GreaterThanOrEquals,
+			SetOperator:  model.FilterAnd,
+			IsStringData: false,
+		},
+		{
+			Value:        end.Format(time.RFC3339Nano),
+			Operator:     model.LessThanOrEquals,
+			SetOperator:  model.FilterAnd,
+			IsStringData: false,
+		},
+	}
 }

--- a/cmd/api/src/api/v2/dataquality_test.go
+++ b/cmd/api/src/api/v2/dataquality_test.go
@@ -1625,10 +1625,11 @@ func TestGetDataQualityAggregations_Success(t *testing.T) {
 	}
 
 	var cases = []struct {
-		Name     string
-		Input    Input
-		Setup    func(mockCtrl *gomock.Controller, mock mockResources) v2.Resources
-		Expected Expected
+		Name       string
+		Input      Input
+		Setup      func(mockCtrl *gomock.Controller, mock mockResources) v2.Resources
+		Expected   Expected
+		AssertBody func(t *testing.T, body map[string]any)
 	}{
 		{
 			Name:  "minimal required filter with eq",
@@ -1733,7 +1734,52 @@ func TestGetDataQualityAggregations_Success(t *testing.T) {
 			Expected: Expected{Code: http.StatusOK},
 		},
 		{
-			Name: "skip and limit are passed to the database in the correct positions",
+			Name: "descending sort direction is passed to the database",
+			Input: Input{Params: url.Values{
+				"schema_environment_kind_id": []string{"eq:100"},
+				"sort_by":                    []string{"-created_at"},
+			}},
+			Setup: func(mockCtrl *gomock.Controller, mock mockResources) v2.Resources {
+				mock.Database.EXPECT().GetDataQualityAggregations(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+					func(_ context.Context, _ model.Filters, sort model.Sort, _ int, _ int) (model.DataQualityAggregations, int, error) {
+						require.Len(t, sort, 1)
+						require.Equal(t, "created_at", sort[0].Column)
+						require.Equal(t, model.DescendingSortDirection, sort[0].Direction)
+						return model.DataQualityAggregations{}, 0, nil
+					})
+				return v2.Resources{DB: mock.Database}
+			},
+			Expected: Expected{Code: http.StatusOK},
+		},
+		{
+			Name: "schema_extension_id existence check only runs for eq, not neq",
+			Input: Input{Params: url.Values{
+				"schema_environment_kind_id": []string{"eq:100"},
+				"schema_extension_id":        []string{"neq:999"},
+			}},
+			Setup: func(mockCtrl *gomock.Controller, mock mockResources) v2.Resources {
+				mock.Database.EXPECT().GetGraphSchemaExtensionById(gomock.Any(), gomock.Any()).Times(0)
+				mock.Database.EXPECT().GetDataQualityAggregations(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(model.DataQualityAggregations{}, 0, nil)
+				return v2.Resources{DB: mock.Database}
+			},
+			Expected: Expected{Code: http.StatusOK},
+		},
+		{
+			Name:  "default skip and limit are passed to the database when omitted",
+			Input: Input{Params: url.Values{"schema_environment_kind_id": []string{"eq:100"}}},
+			Setup: func(mockCtrl *gomock.Controller, mock mockResources) v2.Resources {
+				mock.Database.EXPECT().GetDataQualityAggregations(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+					func(_ context.Context, _ model.Filters, _ model.Sort, skip int, limit int) (model.DataQualityAggregations, int, error) {
+						require.Equal(t, 0, skip)
+						require.Equal(t, 1000, limit)
+						return model.DataQualityAggregations{}, 0, nil
+					})
+				return v2.Resources{DB: mock.Database}
+			},
+			Expected: Expected{Code: http.StatusOK},
+		},
+		{
+			Name: "skip and limit keep correct order in both database call and response",
 			Input: Input{Params: url.Values{
 				"schema_environment_kind_id": []string{"eq:100"},
 				"skip":                       []string{"3"},
@@ -1744,11 +1790,16 @@ func TestGetDataQualityAggregations_Success(t *testing.T) {
 					func(_ context.Context, _ model.Filters, _ model.Sort, skip int, limit int) (model.DataQualityAggregations, int, error) {
 						require.Equal(t, 3, skip)
 						require.Equal(t, 7, limit)
-						return model.DataQualityAggregations{}, 0, nil
+						return model.DataQualityAggregations{}, 42, nil
 					})
 				return v2.Resources{DB: mock.Database}
 			},
 			Expected: Expected{Code: http.StatusOK},
+			AssertBody: func(t *testing.T, body map[string]any) {
+				require.Equal(t, float64(3), body["skip"])
+				require.Equal(t, float64(7), body["limit"])
+				require.Equal(t, float64(42), body["count"])
+			},
 		},
 	}
 	for _, tc := range cases {
@@ -1771,6 +1822,12 @@ func TestGetDataQualityAggregations_Success(t *testing.T) {
 			router.ServeHTTP(rr, req)
 
 			require.Equalf(t, tc.Expected.Code, rr.Code, "wrong status code; body=%s", rr.Body.String())
+
+			if tc.AssertBody != nil {
+				var body map[string]any
+				require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &body))
+				tc.AssertBody(t, body)
+			}
 		})
 	}
 }

--- a/cmd/api/src/api/v2/dataquality_test.go
+++ b/cmd/api/src/api/v2/dataquality_test.go
@@ -1425,255 +1425,354 @@ func TestGetPlatformAggregateStats_Success(t *testing.T) {
 	}
 }
 
-func TestGetDataQualityAggregations(t *testing.T) {
-	tests := []struct {
-		name string
-		test func(t *testing.T, mockDB *mocks.MockDatabase)
+func TestGetDataQualityAggregations_Failure(t *testing.T) {
+	endpoint := "/api/v2/data-quality-stats-aggregations%s"
+	type Input struct {
+		Params url.Values
+	}
+	type mockResources struct {
+		Database *mocks.MockDatabase
+	}
+	defaultResources := func(mockCtrl *gomock.Controller, mock mockResources) v2.Resources {
+		return v2.Resources{DB: mock.Database}
+	}
+
+	var cases = []struct {
+		Name     string
+		Input    Input
+		Setup    func(mockCtrl *gomock.Controller, mock mockResources) v2.Resources
+		Expected api.ErrorWrapper
 	}{
 		{
-			name: "Failure: missing required schema_environment_kind_id returns bad request",
-			test: func(t *testing.T, mockDB *mocks.MockDatabase) {
-				response := serveDataQualityAggregations(t, mockDB, url.Values{})
-
-				assertDataQualityAggregationsError(t, response, http.StatusBadRequest,
-					fmt.Sprintf(api.FmtErrorResponseDetailsMissingRequiredQueryParameter, "schema_environment_kind_id"))
+			Name:  "missing required schema_environment_kind_id returns bad request",
+			Input: Input{Params: url.Values{}},
+			Setup: defaultResources,
+			Expected: api.ErrorWrapper{
+				HTTPStatus: http.StatusBadRequest,
+				Errors:     []api.ErrorDetails{{Message: fmt.Sprintf(api.FmtErrorResponseDetailsMissingRequiredQueryParameter, "schema_environment_kind_id")}},
 			},
 		},
 		{
-			name: "Failure: column not filterable returns bad request",
-			test: func(t *testing.T, mockDB *mocks.MockDatabase) {
-				params := url.Values{
-					"schema_environment_kind_id": []string{"eq:100"},
-					"metric_value":               []string{"eq:5"},
-				}
-
-				response := serveDataQualityAggregations(t, mockDB, params)
-
-				assertDataQualityAggregationsError(t, response, http.StatusBadRequest,
-					fmt.Sprintf("%s: %s", api.ErrorResponseDetailsColumnNotFilterable, "metric_value"))
+			Name: "column not filterable returns bad request",
+			Input: Input{Params: url.Values{
+				"schema_environment_kind_id": []string{"eq:100"},
+				"metric_value":               []string{"eq:5"},
+			}},
+			Setup: defaultResources,
+			Expected: api.ErrorWrapper{
+				HTTPStatus: http.StatusBadRequest,
+				Errors:     []api.ErrorDetails{{Message: fmt.Sprintf("%s: %s", api.ErrorResponseDetailsColumnNotFilterable, "metric_value")}},
 			},
 		},
 		{
-			name: "Failure: unsupported filter predicate returns bad request",
-			test: func(t *testing.T, mockDB *mocks.MockDatabase) {
-				params := url.Values{
-					"schema_environment_kind_id": []string{"eq:100"},
-					"schema_extension_id":        []string{"gt:5"},
-				}
-
-				response := serveDataQualityAggregations(t, mockDB, params)
-
-				assertDataQualityAggregationsError(t, response, http.StatusBadRequest,
-					fmt.Sprintf("%s: %s %s", api.ErrorResponseDetailsFilterPredicateNotSupported, "schema_extension_id", "gt"))
+			Name: "unsupported filter predicate returns bad request",
+			Input: Input{Params: url.Values{
+				"schema_environment_kind_id": []string{"eq:100"},
+				"schema_extension_id":        []string{"gt:5"},
+			}},
+			Setup: defaultResources,
+			Expected: api.ErrorWrapper{
+				HTTPStatus: http.StatusBadRequest,
+				Errors:     []api.ErrorDetails{{Message: fmt.Sprintf("%s: %s %s", api.ErrorResponseDetailsFilterPredicateNotSupported, "schema_extension_id", "gt")}},
 			},
 		},
 		{
-			name: "Failure: invalid sort column returns bad request",
-			test: func(t *testing.T, mockDB *mocks.MockDatabase) {
-				params := url.Values{
-					"schema_environment_kind_id": []string{"eq:100"},
-					"sort_by":                    []string{"invalidColumn"},
-				}
-
-				response := serveDataQualityAggregations(t, mockDB, params)
-
-				assertDataQualityAggregationsError(t, response, http.StatusBadRequest,
-					fmt.Sprintf("%s: %s", api.ErrResponseDetailsColumnNotSortable, "invalidColumn"))
+			Name: "invalid sort column returns bad request",
+			Input: Input{Params: url.Values{
+				"schema_environment_kind_id": []string{"eq:100"},
+				"sort_by":                    []string{"invalidColumn"},
+			}},
+			Setup: defaultResources,
+			Expected: api.ErrorWrapper{
+				HTTPStatus: http.StatusBadRequest,
+				Errors:     []api.ErrorDetails{{Message: fmt.Sprintf("%s: %s", api.ErrResponseDetailsColumnNotSortable, "invalidColumn")}},
 			},
 		},
 		{
-			name: "Failure: invalid skip returns bad request",
-			test: func(t *testing.T, mockDB *mocks.MockDatabase) {
-				params := url.Values{
-					"schema_environment_kind_id": []string{"eq:100"},
-					"skip":                       []string{"-1"},
-				}
-
-				response := serveDataQualityAggregations(t, mockDB, params)
-
-				assertDataQualityAggregationsError(t, response, http.StatusBadRequest,
-					fmt.Sprintf(utils.ErrorInvalidSkip, -1))
+			Name: "invalid skip returns bad request",
+			Input: Input{Params: url.Values{
+				"schema_environment_kind_id": []string{"eq:100"},
+				"skip":                       []string{"-1"},
+			}},
+			Setup: defaultResources,
+			Expected: api.ErrorWrapper{
+				HTTPStatus: http.StatusBadRequest,
+				Errors:     []api.ErrorDetails{{Message: fmt.Sprintf(utils.ErrorInvalidSkip, -1)}},
 			},
 		},
 		{
-			name: "Failure: invalid limit returns bad request",
-			test: func(t *testing.T, mockDB *mocks.MockDatabase) {
-				params := url.Values{
-					"schema_environment_kind_id": []string{"eq:100"},
-					"limit":                      []string{"-1"},
-				}
-
-				response := serveDataQualityAggregations(t, mockDB, params)
-
-				assertDataQualityAggregationsError(t, response, http.StatusBadRequest,
-					fmt.Sprintf(utils.ErrorInvalidLimit, -1))
+			Name: "invalid limit returns bad request",
+			Input: Input{Params: url.Values{
+				"schema_environment_kind_id": []string{"eq:100"},
+				"limit":                      []string{"-1"},
+			}},
+			Setup: defaultResources,
+			Expected: api.ErrorWrapper{
+				HTTPStatus: http.StatusBadRequest,
+				Errors:     []api.ErrorDetails{{Message: fmt.Sprintf(utils.ErrorInvalidLimit, -1)}},
 			},
 		},
 		{
-			name: "Failure: non-integer schema_extension_id returns bad request",
-			test: func(t *testing.T, mockDB *mocks.MockDatabase) {
-				params := url.Values{
-					"schema_environment_kind_id": []string{"eq:100"},
-					"schema_extension_id":        []string{"eq:abc"},
-				}
-
-				response := serveDataQualityAggregations(t, mockDB, params)
-
-				assertDataQualityAggregationsError(t, response, http.StatusBadRequest,
-					fmt.Sprintf("%s: schema_extension_id", api.ErrorResponseDetailsBadQueryParameterFilters))
+			Name: "non-integer schema_extension_id returns bad request",
+			Input: Input{Params: url.Values{
+				"schema_environment_kind_id": []string{"eq:100"},
+				"schema_extension_id":        []string{"eq:abc"},
+			}},
+			Setup: defaultResources,
+			Expected: api.ErrorWrapper{
+				HTTPStatus: http.StatusBadRequest,
+				Errors:     []api.ErrorDetails{{Message: fmt.Sprintf("%s: schema_extension_id", api.ErrorResponseDetailsBadQueryParameterFilters)}},
 			},
 		},
 		{
-			name: "Failure: nonexistent schema_extension_id returns not found",
-			test: func(t *testing.T, mockDB *mocks.MockDatabase) {
-				mockDB.EXPECT().GetGraphSchemaExtensionById(gomock.Any(), gomock.Any()).Return(model.GraphSchemaExtension{}, database.ErrNotFound)
-
-				params := url.Values{
-					"schema_environment_kind_id": []string{"eq:100"},
-					"schema_extension_id":        []string{"eq:999"},
-				}
-
-				response := serveDataQualityAggregations(t, mockDB, params)
-
-				assertDataQualityAggregationsError(t, response, http.StatusNotFound,
-					api.ErrorResponseDetailsResourceNotFound)
+			Name: "nonexistent schema_extension_id returns not found",
+			Input: Input{Params: url.Values{
+				"schema_environment_kind_id": []string{"eq:100"},
+				"schema_extension_id":        []string{"eq:999"},
+			}},
+			Setup: func(mockCtrl *gomock.Controller, mock mockResources) v2.Resources {
+				mock.Database.EXPECT().GetGraphSchemaExtensionById(gomock.Any(), gomock.Any()).Return(model.GraphSchemaExtension{}, database.ErrNotFound)
+				return v2.Resources{DB: mock.Database}
+			},
+			Expected: api.ErrorWrapper{
+				HTTPStatus: http.StatusNotFound,
+				Errors:     []api.ErrorDetails{{Message: api.ErrorResponseDetailsResourceNotFound}},
 			},
 		},
 		{
-			name: "Failure: database error returns internal server error",
-			test: func(t *testing.T, mockDB *mocks.MockDatabase) {
-				mockDB.EXPECT().GetDataQualityAggregations(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, 0, fmt.Errorf("db error"))
-
-				params := url.Values{
-					"schema_environment_kind_id": []string{"eq:100"},
-				}
-
-				response := serveDataQualityAggregations(t, mockDB, params)
-
-				assertDataQualityAggregationsError(t, response, http.StatusInternalServerError,
-					api.ErrorResponseDetailsInternalServerError)
+			Name: "database error returns internal server error",
+			Input: Input{Params: url.Values{
+				"schema_environment_kind_id": []string{"eq:100"},
+			}},
+			Setup: func(mockCtrl *gomock.Controller, mock mockResources) v2.Resources {
+				mock.Database.EXPECT().GetDataQualityAggregations(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, 0, fmt.Errorf("db error"))
+				return v2.Resources{DB: mock.Database}
+			},
+			Expected: api.ErrorWrapper{
+				HTTPStatus: http.StatusInternalServerError,
+				Errors:     []api.ErrorDetails{{Message: api.ErrorResponseDetailsInternalServerError}},
 			},
 		},
 		{
-			name: "Success: minimal required filter with eq",
-			test: func(t *testing.T, mockDB *mocks.MockDatabase) {
-				mockDB.EXPECT().GetDataQualityAggregations(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(model.DataQualityAggregations{}, 0, nil)
-
-				params := url.Values{"schema_environment_kind_id": []string{"eq:100"}}
-
-				response := serveDataQualityAggregations(t, mockDB, params)
-
-				require.Equalf(t, http.StatusOK, response.Code, "wrong status code; body=%s", response.Body.String())
+			Name: "invalid start returns bad request",
+			Input: Input{Params: url.Values{
+				"schema_environment_kind_id": []string{"eq:100"},
+				"start":                      []string{"invalidRFC3339"},
+			}},
+			Setup: defaultResources,
+			Expected: api.ErrorWrapper{
+				HTTPStatus: http.StatusBadRequest,
+				Errors:     []api.ErrorDetails{{Message: fmt.Sprintf(api.ErrorInvalidRFC3339, []string{"invalidRFC3339"})}},
 			},
 		},
 		{
-			name: "Success: required filter with neq",
-			test: func(t *testing.T, mockDB *mocks.MockDatabase) {
-				mockDB.EXPECT().GetDataQualityAggregations(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(model.DataQualityAggregations{}, 0, nil)
-
-				params := url.Values{"schema_environment_kind_id": []string{"neq:100"}}
-
-				response := serveDataQualityAggregations(t, mockDB, params)
-
-				require.Equalf(t, http.StatusOK, response.Code, "wrong status code; body=%s", response.Body.String())
-			},
-		},
-		{
-			name: "Success: with sort, limit, and skip",
-			test: func(t *testing.T, mockDB *mocks.MockDatabase) {
-				mockDB.EXPECT().GetDataQualityAggregations(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(model.DataQualityAggregations{}, 0, nil)
-
-				params := url.Values{
-					"schema_environment_kind_id": []string{"eq:100"},
-					"sort_by":                    []string{"-created_at"},
-					"limit":                      []string{"1"},
-					"skip":                       []string{"0"},
-				}
-
-				response := serveDataQualityAggregations(t, mockDB, params)
-
-				require.Equalf(t, http.StatusOK, response.Code, "wrong status code; body=%s", response.Body.String())
-			},
-		},
-		{
-			name: "Success: with created_at range filter",
-			test: func(t *testing.T, mockDB *mocks.MockDatabase) {
-				mockDB.EXPECT().GetDataQualityAggregations(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(model.DataQualityAggregations{}, 0, nil)
-
-				params := url.Values{
-					"schema_environment_kind_id": []string{"eq:100"},
-					"created_at":                 []string{"gt:2022-03-23T07:20:50.52Z"},
-				}
-
-				response := serveDataQualityAggregations(t, mockDB, params)
-
-				require.Equalf(t, http.StatusOK, response.Code, "wrong status code; body=%s", response.Body.String())
-			},
-		},
-		{
-			name: "Success: with existing schema_extension_id",
-			test: func(t *testing.T, mockDB *mocks.MockDatabase) {
-				mockDB.EXPECT().GetGraphSchemaExtensionById(gomock.Any(), gomock.Any()).Return(model.GraphSchemaExtension{}, nil)
-				mockDB.EXPECT().GetDataQualityAggregations(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(model.DataQualityAggregations{}, 0, nil)
-
-				params := url.Values{
-					"schema_environment_kind_id": []string{"eq:100"},
-					"schema_extension_id":        []string{"eq:42"},
-				}
-
-				response := serveDataQualityAggregations(t, mockDB, params)
-
-				require.Equalf(t, http.StatusOK, response.Code, "wrong status code; body=%s", response.Body.String())
+			Name: "invalid end returns bad request",
+			Input: Input{Params: url.Values{
+				"schema_environment_kind_id": []string{"eq:100"},
+				"end":                        []string{"invalidRFC3339"},
+			}},
+			Setup: defaultResources,
+			Expected: api.ErrorWrapper{
+				HTTPStatus: http.StatusBadRequest,
+				Errors:     []api.ErrorDetails{{Message: fmt.Sprintf(api.ErrorInvalidRFC3339, []string{"invalidRFC3339"})}},
 			},
 		},
 	}
-
-	for _, testCase := range tests {
-		t.Run(testCase.name, func(t *testing.T) {
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
 			mockCtrl := gomock.NewController(t)
 			defer mockCtrl.Finish()
 
-			mockDB := mocks.NewMockDatabase(mockCtrl)
+			mock := mockResources{
+				Database: mocks.NewMockDatabase(mockCtrl),
+			}
+			resources := tc.Setup(mockCtrl, mock)
+			params := fmt.Sprintf("?%s", tc.Input.Params.Encode())
+			req, err := http.NewRequest("GET", fmt.Sprintf(endpoint, params), nil)
+			require.NoError(t, err)
 
-			testCase.test(t, mockDB)
+			router := mux.NewRouter()
+			router.HandleFunc("/api/v2/data-quality-stats-aggregations", resources.GetDataQualityAggregations).Methods("GET")
+
+			rr := httptest.NewRecorder()
+			router.ServeHTTP(rr, req)
+
+			if status := rr.Code; status != tc.Expected.HTTPStatus {
+				t.Errorf("handler returned wrong status code: got %v want %v", status, tc.Expected.HTTPStatus)
+			}
+
+			var body any
+			if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+				t.Fatal("failed to unmarshal response body")
+			}
+
+			require.Equal(t, 1, len(tc.Expected.Errors))
+			require.Equal(t, tc.Expected.Errors[0].Message, body.(map[string]any)["errors"].([]any)[0].(map[string]any)["message"])
 		})
 	}
 }
 
-// serveDataQualityAggregations builds a GET request for the data-quality-stats-aggregations endpoint
-// from the given query params, serves it against the handler, and returns the recorded response.
-func serveDataQualityAggregations(t *testing.T, mockDB *mocks.MockDatabase, params url.Values) *httptest.ResponseRecorder {
-	t.Helper()
+func TestGetDataQualityAggregations_Success(t *testing.T) {
+	endpoint := "/api/v2/data-quality-stats-aggregations%s"
+	type Input struct {
+		Params url.Values
+	}
+	type Expected struct {
+		Code int
+	}
+	type mockResources struct {
+		Database *mocks.MockDatabase
+	}
 
-	var (
-		endpoint  = "/api/v2/data-quality-stats-aggregations"
-		resources = v2.Resources{DB: mockDB}
-	)
+	var cases = []struct {
+		Name     string
+		Input    Input
+		Setup    func(mockCtrl *gomock.Controller, mock mockResources) v2.Resources
+		Expected Expected
+	}{
+		{
+			Name:  "minimal required filter with eq",
+			Input: Input{Params: url.Values{"schema_environment_kind_id": []string{"eq:100"}}},
+			Setup: func(mockCtrl *gomock.Controller, mock mockResources) v2.Resources {
+				mock.Database.EXPECT().GetDataQualityAggregations(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(model.DataQualityAggregations{}, 0, nil)
+				return v2.Resources{DB: mock.Database}
+			},
+			Expected: Expected{Code: http.StatusOK},
+		},
+		{
+			Name:  "required filter with neq",
+			Input: Input{Params: url.Values{"schema_environment_kind_id": []string{"neq:100"}}},
+			Setup: func(mockCtrl *gomock.Controller, mock mockResources) v2.Resources {
+				mock.Database.EXPECT().GetDataQualityAggregations(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(model.DataQualityAggregations{}, 0, nil)
+				return v2.Resources{DB: mock.Database}
+			},
+			Expected: Expected{Code: http.StatusOK},
+		},
+		{
+			Name: "with sort, limit, and skip",
+			Input: Input{Params: url.Values{
+				"schema_environment_kind_id": []string{"eq:100"},
+				"sort_by":                    []string{"-created_at"},
+				"limit":                      []string{"1"},
+				"skip":                       []string{"0"},
+			}},
+			Setup: func(mockCtrl *gomock.Controller, mock mockResources) v2.Resources {
+				mock.Database.EXPECT().GetDataQualityAggregations(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(model.DataQualityAggregations{}, 0, nil)
+				return v2.Resources{DB: mock.Database}
+			},
+			Expected: Expected{Code: http.StatusOK},
+		},
+		{
+			Name: "with existing schema_extension_id",
+			Input: Input{Params: url.Values{
+				"schema_environment_kind_id": []string{"eq:100"},
+				"schema_extension_id":        []string{"eq:42"},
+			}},
+			Setup: func(mockCtrl *gomock.Controller, mock mockResources) v2.Resources {
+				mock.Database.EXPECT().GetGraphSchemaExtensionById(gomock.Any(), gomock.Any()).Return(model.GraphSchemaExtension{}, nil)
+				mock.Database.EXPECT().GetDataQualityAggregations(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(model.DataQualityAggregations{}, 0, nil)
+				return v2.Resources{DB: mock.Database}
+			},
+			Expected: Expected{Code: http.StatusOK},
+		},
+		{
+			Name: "with start and end injects inclusive created_at window",
+			Input: Input{Params: url.Values{
+				"schema_environment_kind_id": []string{"eq:100"},
+				"start":                      []string{"2022-03-23T07:20:50.52Z"},
+				"end":                        []string{"2022-04-23T07:20:50.52Z"},
+			}},
+			Setup: func(mockCtrl *gomock.Controller, mock mockResources) v2.Resources {
+				mock.Database.EXPECT().GetDataQualityAggregations(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+					func(_ context.Context, filters model.Filters, _ model.Sort, _ int, _ int) (model.DataQualityAggregations, int, error) {
+						createdAt := filters["created_at"]
+						require.Len(t, createdAt, 2)
+						require.Equal(t, model.GreaterThanOrEquals, createdAt[0].Operator)
+						require.Equal(t, "2022-03-23T07:20:50Z", createdAt[0].Value)
+						require.False(t, createdAt[0].IsStringData)
+						require.Equal(t, model.LessThanOrEquals, createdAt[1].Operator)
+						require.Equal(t, "2022-04-23T07:20:50Z", createdAt[1].Value)
+						require.False(t, createdAt[1].IsStringData)
+						return model.DataQualityAggregations{}, 0, nil
+					})
+				return v2.Resources{DB: mock.Database}
+			},
+			Expected: Expected{Code: http.StatusOK},
+		},
+		{
+			Name: "with start only",
+			Input: Input{Params: url.Values{
+				"schema_environment_kind_id": []string{"eq:100"},
+				"start":                      []string{"2022-03-23T07:20:50.52Z"},
+			}},
+			Setup: func(mockCtrl *gomock.Controller, mock mockResources) v2.Resources {
+				mock.Database.EXPECT().GetDataQualityAggregations(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(model.DataQualityAggregations{}, 0, nil)
+				return v2.Resources{DB: mock.Database}
+			},
+			Expected: Expected{Code: http.StatusOK},
+		},
+		{
+			Name: "with end only",
+			Input: Input{Params: url.Values{
+				"schema_environment_kind_id": []string{"eq:100"},
+				"end":                        []string{"2022-04-23T07:20:50.52Z"},
+			}},
+			Setup: func(mockCtrl *gomock.Controller, mock mockResources) v2.Resources {
+				mock.Database.EXPECT().GetDataQualityAggregations(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(model.DataQualityAggregations{}, 0, nil)
+				return v2.Resources{DB: mock.Database}
+			},
+			Expected: Expected{Code: http.StatusOK},
+		},
+		{
+			Name:  "default window when start and end omitted",
+			Input: Input{Params: url.Values{"schema_environment_kind_id": []string{"eq:100"}}},
+			Setup: func(mockCtrl *gomock.Controller, mock mockResources) v2.Resources {
+				mock.Database.EXPECT().GetDataQualityAggregations(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(model.DataQualityAggregations{}, 0, nil)
+				return v2.Resources{DB: mock.Database}
+			},
+			Expected: Expected{Code: http.StatusOK},
+		},
+		{
+			Name: "skip and limit are passed to the database in the correct positions",
+			Input: Input{Params: url.Values{
+				"schema_environment_kind_id": []string{"eq:100"},
+				"skip":                       []string{"3"},
+				"limit":                      []string{"7"},
+			}},
+			Setup: func(mockCtrl *gomock.Controller, mock mockResources) v2.Resources {
+				mock.Database.EXPECT().GetDataQualityAggregations(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+					func(_ context.Context, _ model.Filters, _ model.Sort, skip int, limit int) (model.DataQualityAggregations, int, error) {
+						require.Equal(t, 3, skip)
+						require.Equal(t, 7, limit)
+						return model.DataQualityAggregations{}, 0, nil
+					})
+				return v2.Resources{DB: mock.Database}
+			},
+			Expected: Expected{Code: http.StatusOK},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
 
-	request, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s?%s", endpoint, params.Encode()), nil)
-	require.NoError(t, err)
+			mock := mockResources{
+				Database: mocks.NewMockDatabase(mockCtrl),
+			}
+			resources := tc.Setup(mockCtrl, mock)
+			params := fmt.Sprintf("?%s", tc.Input.Params.Encode())
+			req, err := http.NewRequest("GET", fmt.Sprintf(endpoint, params), nil)
+			require.NoError(t, err)
 
-	router := mux.NewRouter()
-	router.HandleFunc(endpoint, resources.GetDataQualityAggregations).Methods(http.MethodGet)
+			router := mux.NewRouter()
+			router.HandleFunc("/api/v2/data-quality-stats-aggregations", resources.GetDataQualityAggregations).Methods("GET")
 
-	recorder := httptest.NewRecorder()
-	router.ServeHTTP(recorder, request)
+			rr := httptest.NewRecorder()
+			router.ServeHTTP(rr, req)
 
-	return recorder
-}
-
-// assertDataQualityAggregationsError asserts that the response has the expected HTTP status code and
-// that the first error detail message matches the expected message.
-func assertDataQualityAggregationsError(t *testing.T, response *httptest.ResponseRecorder, expectedStatus int, expectedMessage string) {
-	t.Helper()
-
-	require.Equalf(t, expectedStatus, response.Code, "wrong status code; body=%s", response.Body.String())
-
-	var body map[string]any
-	require.NoError(t, json.Unmarshal(response.Body.Bytes(), &body))
-
-	message := body["errors"].([]any)[0].(map[string]any)["message"]
-	require.Equal(t, expectedMessage, message)
+			require.Equalf(t, tc.Expected.Code, rr.Code, "wrong status code; body=%s", rr.Body.String())
+		})
+	}
 }
 
 func TestResources_GetDatabaseCompleteness(t *testing.T) {

--- a/cmd/api/src/api/v2/dataquality_test.go
+++ b/cmd/api/src/api/v2/dataquality_test.go
@@ -1425,6 +1425,257 @@ func TestGetPlatformAggregateStats_Success(t *testing.T) {
 	}
 }
 
+func TestGetDataQualityAggregations(t *testing.T) {
+	tests := []struct {
+		name string
+		test func(t *testing.T, mockDB *mocks.MockDatabase)
+	}{
+		{
+			name: "Failure: missing required schema_environment_kind_id returns bad request",
+			test: func(t *testing.T, mockDB *mocks.MockDatabase) {
+				response := serveDataQualityAggregations(t, mockDB, url.Values{})
+
+				assertDataQualityAggregationsError(t, response, http.StatusBadRequest,
+					fmt.Sprintf(api.FmtErrorResponseDetailsMissingRequiredQueryParameter, "schema_environment_kind_id"))
+			},
+		},
+		{
+			name: "Failure: column not filterable returns bad request",
+			test: func(t *testing.T, mockDB *mocks.MockDatabase) {
+				params := url.Values{
+					"schema_environment_kind_id": []string{"eq:100"},
+					"metric_value":               []string{"eq:5"},
+				}
+
+				response := serveDataQualityAggregations(t, mockDB, params)
+
+				assertDataQualityAggregationsError(t, response, http.StatusBadRequest,
+					fmt.Sprintf("%s: %s", api.ErrorResponseDetailsColumnNotFilterable, "metric_value"))
+			},
+		},
+		{
+			name: "Failure: unsupported filter predicate returns bad request",
+			test: func(t *testing.T, mockDB *mocks.MockDatabase) {
+				params := url.Values{
+					"schema_environment_kind_id": []string{"eq:100"},
+					"schema_extension_id":        []string{"gt:5"},
+				}
+
+				response := serveDataQualityAggregations(t, mockDB, params)
+
+				assertDataQualityAggregationsError(t, response, http.StatusBadRequest,
+					fmt.Sprintf("%s: %s %s", api.ErrorResponseDetailsFilterPredicateNotSupported, "schema_extension_id", "gt"))
+			},
+		},
+		{
+			name: "Failure: invalid sort column returns bad request",
+			test: func(t *testing.T, mockDB *mocks.MockDatabase) {
+				params := url.Values{
+					"schema_environment_kind_id": []string{"eq:100"},
+					"sort_by":                    []string{"invalidColumn"},
+				}
+
+				response := serveDataQualityAggregations(t, mockDB, params)
+
+				assertDataQualityAggregationsError(t, response, http.StatusBadRequest,
+					fmt.Sprintf("%s: %s", api.ErrResponseDetailsColumnNotSortable, "invalidColumn"))
+			},
+		},
+		{
+			name: "Failure: invalid skip returns bad request",
+			test: func(t *testing.T, mockDB *mocks.MockDatabase) {
+				params := url.Values{
+					"schema_environment_kind_id": []string{"eq:100"},
+					"skip":                       []string{"-1"},
+				}
+
+				response := serveDataQualityAggregations(t, mockDB, params)
+
+				assertDataQualityAggregationsError(t, response, http.StatusBadRequest,
+					fmt.Sprintf(utils.ErrorInvalidSkip, -1))
+			},
+		},
+		{
+			name: "Failure: invalid limit returns bad request",
+			test: func(t *testing.T, mockDB *mocks.MockDatabase) {
+				params := url.Values{
+					"schema_environment_kind_id": []string{"eq:100"},
+					"limit":                      []string{"-1"},
+				}
+
+				response := serveDataQualityAggregations(t, mockDB, params)
+
+				assertDataQualityAggregationsError(t, response, http.StatusBadRequest,
+					fmt.Sprintf(utils.ErrorInvalidLimit, -1))
+			},
+		},
+		{
+			name: "Failure: non-integer schema_extension_id returns bad request",
+			test: func(t *testing.T, mockDB *mocks.MockDatabase) {
+				params := url.Values{
+					"schema_environment_kind_id": []string{"eq:100"},
+					"schema_extension_id":        []string{"eq:abc"},
+				}
+
+				response := serveDataQualityAggregations(t, mockDB, params)
+
+				assertDataQualityAggregationsError(t, response, http.StatusBadRequest,
+					fmt.Sprintf("%s: schema_extension_id", api.ErrorResponseDetailsBadQueryParameterFilters))
+			},
+		},
+		{
+			name: "Failure: nonexistent schema_extension_id returns not found",
+			test: func(t *testing.T, mockDB *mocks.MockDatabase) {
+				mockDB.EXPECT().GetGraphSchemaExtensionById(gomock.Any(), gomock.Any()).Return(model.GraphSchemaExtension{}, database.ErrNotFound)
+
+				params := url.Values{
+					"schema_environment_kind_id": []string{"eq:100"},
+					"schema_extension_id":        []string{"eq:999"},
+				}
+
+				response := serveDataQualityAggregations(t, mockDB, params)
+
+				assertDataQualityAggregationsError(t, response, http.StatusNotFound,
+					api.ErrorResponseDetailsResourceNotFound)
+			},
+		},
+		{
+			name: "Failure: database error returns internal server error",
+			test: func(t *testing.T, mockDB *mocks.MockDatabase) {
+				mockDB.EXPECT().GetDataQualityAggregations(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, 0, fmt.Errorf("db error"))
+
+				params := url.Values{
+					"schema_environment_kind_id": []string{"eq:100"},
+				}
+
+				response := serveDataQualityAggregations(t, mockDB, params)
+
+				assertDataQualityAggregationsError(t, response, http.StatusInternalServerError,
+					api.ErrorResponseDetailsInternalServerError)
+			},
+		},
+		{
+			name: "Success: minimal required filter with eq",
+			test: func(t *testing.T, mockDB *mocks.MockDatabase) {
+				mockDB.EXPECT().GetDataQualityAggregations(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(model.DataQualityAggregations{}, 0, nil)
+
+				params := url.Values{"schema_environment_kind_id": []string{"eq:100"}}
+
+				response := serveDataQualityAggregations(t, mockDB, params)
+
+				require.Equalf(t, http.StatusOK, response.Code, "wrong status code; body=%s", response.Body.String())
+			},
+		},
+		{
+			name: "Success: required filter with neq",
+			test: func(t *testing.T, mockDB *mocks.MockDatabase) {
+				mockDB.EXPECT().GetDataQualityAggregations(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(model.DataQualityAggregations{}, 0, nil)
+
+				params := url.Values{"schema_environment_kind_id": []string{"neq:100"}}
+
+				response := serveDataQualityAggregations(t, mockDB, params)
+
+				require.Equalf(t, http.StatusOK, response.Code, "wrong status code; body=%s", response.Body.String())
+			},
+		},
+		{
+			name: "Success: with sort, limit, and skip",
+			test: func(t *testing.T, mockDB *mocks.MockDatabase) {
+				mockDB.EXPECT().GetDataQualityAggregations(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(model.DataQualityAggregations{}, 0, nil)
+
+				params := url.Values{
+					"schema_environment_kind_id": []string{"eq:100"},
+					"sort_by":                    []string{"-created_at"},
+					"limit":                      []string{"1"},
+					"skip":                       []string{"0"},
+				}
+
+				response := serveDataQualityAggregations(t, mockDB, params)
+
+				require.Equalf(t, http.StatusOK, response.Code, "wrong status code; body=%s", response.Body.String())
+			},
+		},
+		{
+			name: "Success: with created_at range filter",
+			test: func(t *testing.T, mockDB *mocks.MockDatabase) {
+				mockDB.EXPECT().GetDataQualityAggregations(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(model.DataQualityAggregations{}, 0, nil)
+
+				params := url.Values{
+					"schema_environment_kind_id": []string{"eq:100"},
+					"created_at":                 []string{"gt:2022-03-23T07:20:50.52Z"},
+				}
+
+				response := serveDataQualityAggregations(t, mockDB, params)
+
+				require.Equalf(t, http.StatusOK, response.Code, "wrong status code; body=%s", response.Body.String())
+			},
+		},
+		{
+			name: "Success: with existing schema_extension_id",
+			test: func(t *testing.T, mockDB *mocks.MockDatabase) {
+				mockDB.EXPECT().GetGraphSchemaExtensionById(gomock.Any(), gomock.Any()).Return(model.GraphSchemaExtension{}, nil)
+				mockDB.EXPECT().GetDataQualityAggregations(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(model.DataQualityAggregations{}, 0, nil)
+
+				params := url.Values{
+					"schema_environment_kind_id": []string{"eq:100"},
+					"schema_extension_id":        []string{"eq:42"},
+				}
+
+				response := serveDataQualityAggregations(t, mockDB, params)
+
+				require.Equalf(t, http.StatusOK, response.Code, "wrong status code; body=%s", response.Body.String())
+			},
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+
+			mockDB := mocks.NewMockDatabase(mockCtrl)
+
+			testCase.test(t, mockDB)
+		})
+	}
+}
+
+// serveDataQualityAggregations builds a GET request for the data-quality-stats-aggregations endpoint
+// from the given query params, serves it against the handler, and returns the recorded response.
+func serveDataQualityAggregations(t *testing.T, mockDB *mocks.MockDatabase, params url.Values) *httptest.ResponseRecorder {
+	t.Helper()
+
+	var (
+		endpoint  = "/api/v2/data-quality-stats-aggregations"
+		resources = v2.Resources{DB: mockDB}
+	)
+
+	request, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s?%s", endpoint, params.Encode()), nil)
+	require.NoError(t, err)
+
+	router := mux.NewRouter()
+	router.HandleFunc(endpoint, resources.GetDataQualityAggregations).Methods(http.MethodGet)
+
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, request)
+
+	return recorder
+}
+
+// assertDataQualityAggregationsError asserts that the response has the expected HTTP status code and
+// that the first error detail message matches the expected message.
+func assertDataQualityAggregationsError(t *testing.T, response *httptest.ResponseRecorder, expectedStatus int, expectedMessage string) {
+	t.Helper()
+
+	require.Equalf(t, expectedStatus, response.Code, "wrong status code; body=%s", response.Body.String())
+
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(response.Body.Bytes(), &body))
+
+	message := body["errors"].([]any)[0].(map[string]any)["message"]
+	require.Equal(t, expectedMessage, message)
+}
+
 func TestResources_GetDatabaseCompleteness(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/api/src/api/v2/dataquality_test.go
+++ b/cmd/api/src/api/v2/dataquality_test.go
@@ -1675,10 +1675,10 @@ func TestGetDataQualityAggregations_Success(t *testing.T) {
 						createdAt := filters["created_at"]
 						require.Len(t, createdAt, 2)
 						require.Equal(t, model.GreaterThanOrEquals, createdAt[0].Operator)
-						require.Equal(t, "2022-03-23T07:20:50Z", createdAt[0].Value)
+						require.Equal(t, "2022-03-23T07:20:50.52Z", createdAt[0].Value)
 						require.False(t, createdAt[0].IsStringData)
 						require.Equal(t, model.LessThanOrEquals, createdAt[1].Operator)
-						require.Equal(t, "2022-04-23T07:20:50Z", createdAt[1].Value)
+						require.Equal(t, "2022-04-23T07:20:50.52Z", createdAt[1].Value)
 						require.False(t, createdAt[1].IsStringData)
 						return model.DataQualityAggregations{}, 0, nil
 					})

--- a/cmd/api/src/api/v2/dataquality_test.go
+++ b/cmd/api/src/api/v2/dataquality_test.go
@@ -1058,7 +1058,7 @@ func TestGetPlatformAggregateStats_Failure(t *testing.T) {
 			},
 			api.ErrorWrapper{
 				HTTPStatus: http.StatusBadRequest,
-				Errors:     []api.ErrorDetails{{Message: fmt.Sprintf(v2.ErrInvalidPlatformId, "invalidPlatform")}},
+				Errors:     []api.ErrorDetails{{Message: fmt.Sprintf(v2.FmtErrInvalidPlatformId, "invalidPlatform")}},
 			},
 		},
 		// AD
@@ -1426,7 +1426,12 @@ func TestGetPlatformAggregateStats_Success(t *testing.T) {
 }
 
 func TestGetDataQualityAggregations_Failure(t *testing.T) {
-	endpoint := "/api/v2/data-quality-stats-aggregations%s"
+	var (
+		endpoint                         = "/api/v2/data-quality-stats-aggregations%s"
+		testSchemaEnvironmentKindIDParam = "schema_environment_kind_id"
+		testSchemaExtensionIDParam       = "schema_extension_id"
+	)
+
 	type Input struct {
 		Params url.Values
 	}
@@ -1449,38 +1454,25 @@ func TestGetDataQualityAggregations_Failure(t *testing.T) {
 			Setup: defaultResources,
 			Expected: api.ErrorWrapper{
 				HTTPStatus: http.StatusBadRequest,
-				Errors:     []api.ErrorDetails{{Message: fmt.Sprintf(api.FmtErrorResponseDetailsMissingRequiredQueryParameter, "schema_environment_kind_id")}},
+				Errors:     []api.ErrorDetails{{Message: fmt.Sprintf(api.FmtErrorResponseDetailsMissingRequiredQueryParameter, testSchemaEnvironmentKindIDParam)}},
 			},
 		},
 		{
-			Name: "column not filterable returns bad request",
+			Name: "non-integer schema_environment_kind_id returns bad request",
 			Input: Input{Params: url.Values{
-				"schema_environment_kind_id": []string{"eq:100"},
-				"metric_value":               []string{"eq:5"},
+				testSchemaEnvironmentKindIDParam: []string{"abc"},
 			}},
 			Setup: defaultResources,
 			Expected: api.ErrorWrapper{
 				HTTPStatus: http.StatusBadRequest,
-				Errors:     []api.ErrorDetails{{Message: fmt.Sprintf("%s: %s", api.ErrorResponseDetailsColumnNotFilterable, "metric_value")}},
-			},
-		},
-		{
-			Name: "unsupported filter predicate returns bad request",
-			Input: Input{Params: url.Values{
-				"schema_environment_kind_id": []string{"eq:100"},
-				"schema_extension_id":        []string{"gt:5"},
-			}},
-			Setup: defaultResources,
-			Expected: api.ErrorWrapper{
-				HTTPStatus: http.StatusBadRequest,
-				Errors:     []api.ErrorDetails{{Message: fmt.Sprintf("%s: %s %s", api.ErrorResponseDetailsFilterPredicateNotSupported, "schema_extension_id", "gt")}},
+				Errors:     []api.ErrorDetails{{Message: fmt.Sprintf(v2.FmtErrInvalidIntegerQueryParameter, testSchemaEnvironmentKindIDParam)}},
 			},
 		},
 		{
 			Name: "invalid sort column returns bad request",
 			Input: Input{Params: url.Values{
-				"schema_environment_kind_id": []string{"eq:100"},
-				"sort_by":                    []string{"invalidColumn"},
+				testSchemaEnvironmentKindIDParam: []string{"100"},
+				"sort_by":                        []string{"invalidColumn"},
 			}},
 			Setup: defaultResources,
 			Expected: api.ErrorWrapper{
@@ -1491,8 +1483,8 @@ func TestGetDataQualityAggregations_Failure(t *testing.T) {
 		{
 			Name: "invalid skip returns bad request",
 			Input: Input{Params: url.Values{
-				"schema_environment_kind_id": []string{"eq:100"},
-				"skip":                       []string{"-1"},
+				testSchemaEnvironmentKindIDParam: []string{"100"},
+				"skip":                           []string{"-1"},
 			}},
 			Setup: defaultResources,
 			Expected: api.ErrorWrapper{
@@ -1503,8 +1495,8 @@ func TestGetDataQualityAggregations_Failure(t *testing.T) {
 		{
 			Name: "invalid limit returns bad request",
 			Input: Input{Params: url.Values{
-				"schema_environment_kind_id": []string{"eq:100"},
-				"limit":                      []string{"-1"},
+				testSchemaEnvironmentKindIDParam: []string{"100"},
+				"limit":                          []string{"-1"},
 			}},
 			Setup: defaultResources,
 			Expected: api.ErrorWrapper{
@@ -1515,20 +1507,20 @@ func TestGetDataQualityAggregations_Failure(t *testing.T) {
 		{
 			Name: "non-integer schema_extension_id returns bad request",
 			Input: Input{Params: url.Values{
-				"schema_environment_kind_id": []string{"eq:100"},
-				"schema_extension_id":        []string{"eq:abc"},
+				testSchemaEnvironmentKindIDParam: []string{"100"},
+				testSchemaExtensionIDParam:       []string{"abc"},
 			}},
 			Setup: defaultResources,
 			Expected: api.ErrorWrapper{
 				HTTPStatus: http.StatusBadRequest,
-				Errors:     []api.ErrorDetails{{Message: fmt.Sprintf("%s: schema_extension_id", api.ErrorResponseDetailsBadQueryParameterFilters)}},
+				Errors:     []api.ErrorDetails{{Message: fmt.Sprintf(v2.FmtErrInvalidIntegerQueryParameter, testSchemaExtensionIDParam)}},
 			},
 		},
 		{
 			Name: "nonexistent schema_extension_id returns not found",
 			Input: Input{Params: url.Values{
-				"schema_environment_kind_id": []string{"eq:100"},
-				"schema_extension_id":        []string{"eq:999"},
+				testSchemaEnvironmentKindIDParam: []string{"100"},
+				testSchemaExtensionIDParam:       []string{"999"},
 			}},
 			Setup: func(mockCtrl *gomock.Controller, mock mockResources) v2.Resources {
 				mock.Database.EXPECT().GetGraphSchemaExtensionById(gomock.Any(), gomock.Any()).Return(model.GraphSchemaExtension{}, database.ErrNotFound)
@@ -1542,7 +1534,7 @@ func TestGetDataQualityAggregations_Failure(t *testing.T) {
 		{
 			Name: "database error returns internal server error",
 			Input: Input{Params: url.Values{
-				"schema_environment_kind_id": []string{"eq:100"},
+				testSchemaEnvironmentKindIDParam: []string{"100"},
 			}},
 			Setup: func(mockCtrl *gomock.Controller, mock mockResources) v2.Resources {
 				mock.Database.EXPECT().GetDataQualityAggregations(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, 0, fmt.Errorf("db error"))
@@ -1556,8 +1548,8 @@ func TestGetDataQualityAggregations_Failure(t *testing.T) {
 		{
 			Name: "invalid start returns bad request",
 			Input: Input{Params: url.Values{
-				"schema_environment_kind_id": []string{"eq:100"},
-				"start":                      []string{"invalidRFC3339"},
+				testSchemaEnvironmentKindIDParam: []string{"100"},
+				"start":                          []string{"invalidRFC3339"},
 			}},
 			Setup: defaultResources,
 			Expected: api.ErrorWrapper{
@@ -1568,8 +1560,8 @@ func TestGetDataQualityAggregations_Failure(t *testing.T) {
 		{
 			Name: "invalid end returns bad request",
 			Input: Input{Params: url.Values{
-				"schema_environment_kind_id": []string{"eq:100"},
-				"end":                        []string{"invalidRFC3339"},
+				testSchemaEnvironmentKindIDParam: []string{"100"},
+				"end":                            []string{"invalidRFC3339"},
 			}},
 			Setup: defaultResources,
 			Expected: api.ErrorWrapper{
@@ -1597,9 +1589,7 @@ func TestGetDataQualityAggregations_Failure(t *testing.T) {
 			rr := httptest.NewRecorder()
 			router.ServeHTTP(rr, req)
 
-			if status := rr.Code; status != tc.Expected.HTTPStatus {
-				t.Errorf("handler returned wrong status code: got %v want %v", status, tc.Expected.HTTPStatus)
-			}
+			require.Equalf(t, tc.Expected.HTTPStatus, rr.Code, "wrong status code; body=%s", rr.Body.String())
 
 			var body any
 			if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
@@ -1613,7 +1603,12 @@ func TestGetDataQualityAggregations_Failure(t *testing.T) {
 }
 
 func TestGetDataQualityAggregations_Success(t *testing.T) {
-	endpoint := "/api/v2/data-quality-stats-aggregations%s"
+	var (
+		endpoint                         = "/api/v2/data-quality-stats-aggregations%s"
+		testSchemaEnvironmentKindIDParam = "schema_environment_kind_id"
+		testSchemaExtensionIDParam       = "schema_extension_id"
+	)
+
 	type Input struct {
 		Params url.Values
 	}
@@ -1632,17 +1627,8 @@ func TestGetDataQualityAggregations_Success(t *testing.T) {
 		AssertBody func(t *testing.T, body map[string]any)
 	}{
 		{
-			Name:  "minimal required filter with eq",
-			Input: Input{Params: url.Values{"schema_environment_kind_id": []string{"eq:100"}}},
-			Setup: func(mockCtrl *gomock.Controller, mock mockResources) v2.Resources {
-				mock.Database.EXPECT().GetDataQualityAggregations(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(model.DataQualityAggregations{}, 0, nil)
-				return v2.Resources{DB: mock.Database}
-			},
-			Expected: Expected{Code: http.StatusOK},
-		},
-		{
-			Name:  "required filter with neq",
-			Input: Input{Params: url.Values{"schema_environment_kind_id": []string{"neq:100"}}},
+			Name:  "minimal required filter",
+			Input: Input{Params: url.Values{testSchemaEnvironmentKindIDParam: []string{"100"}}},
 			Setup: func(mockCtrl *gomock.Controller, mock mockResources) v2.Resources {
 				mock.Database.EXPECT().GetDataQualityAggregations(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(model.DataQualityAggregations{}, 0, nil)
 				return v2.Resources{DB: mock.Database}
@@ -1652,10 +1638,10 @@ func TestGetDataQualityAggregations_Success(t *testing.T) {
 		{
 			Name: "with sort, limit, and skip",
 			Input: Input{Params: url.Values{
-				"schema_environment_kind_id": []string{"eq:100"},
-				"sort_by":                    []string{"-created_at"},
-				"limit":                      []string{"1"},
-				"skip":                       []string{"0"},
+				testSchemaEnvironmentKindIDParam: []string{"100"},
+				"sort_by":                        []string{"-created_at"},
+				"limit":                          []string{"1"},
+				"skip":                           []string{"0"},
 			}},
 			Setup: func(mockCtrl *gomock.Controller, mock mockResources) v2.Resources {
 				mock.Database.EXPECT().GetDataQualityAggregations(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(model.DataQualityAggregations{}, 0, nil)
@@ -1666,8 +1652,8 @@ func TestGetDataQualityAggregations_Success(t *testing.T) {
 		{
 			Name: "with existing schema_extension_id",
 			Input: Input{Params: url.Values{
-				"schema_environment_kind_id": []string{"eq:100"},
-				"schema_extension_id":        []string{"eq:42"},
+				testSchemaEnvironmentKindIDParam: []string{"100"},
+				testSchemaExtensionIDParam:       []string{"42"},
 			}},
 			Setup: func(mockCtrl *gomock.Controller, mock mockResources) v2.Resources {
 				mock.Database.EXPECT().GetGraphSchemaExtensionById(gomock.Any(), gomock.Any()).Return(model.GraphSchemaExtension{}, nil)
@@ -1679,9 +1665,9 @@ func TestGetDataQualityAggregations_Success(t *testing.T) {
 		{
 			Name: "with start and end injects inclusive created_at window",
 			Input: Input{Params: url.Values{
-				"schema_environment_kind_id": []string{"eq:100"},
-				"start":                      []string{"2022-03-23T07:20:50.52Z"},
-				"end":                        []string{"2022-04-23T07:20:50.52Z"},
+				testSchemaEnvironmentKindIDParam: []string{"100"},
+				"start":                          []string{"2022-03-23T07:20:50.52Z"},
+				"end":                            []string{"2022-04-23T07:20:50.52Z"},
 			}},
 			Setup: func(mockCtrl *gomock.Controller, mock mockResources) v2.Resources {
 				mock.Database.EXPECT().GetDataQualityAggregations(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
@@ -1703,8 +1689,8 @@ func TestGetDataQualityAggregations_Success(t *testing.T) {
 		{
 			Name: "with start only",
 			Input: Input{Params: url.Values{
-				"schema_environment_kind_id": []string{"eq:100"},
-				"start":                      []string{"2022-03-23T07:20:50.52Z"},
+				testSchemaEnvironmentKindIDParam: []string{"100"},
+				"start":                          []string{"2022-03-23T07:20:50.52Z"},
 			}},
 			Setup: func(mockCtrl *gomock.Controller, mock mockResources) v2.Resources {
 				mock.Database.EXPECT().GetDataQualityAggregations(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(model.DataQualityAggregations{}, 0, nil)
@@ -1715,8 +1701,8 @@ func TestGetDataQualityAggregations_Success(t *testing.T) {
 		{
 			Name: "with end only",
 			Input: Input{Params: url.Values{
-				"schema_environment_kind_id": []string{"eq:100"},
-				"end":                        []string{"2022-04-23T07:20:50.52Z"},
+				testSchemaEnvironmentKindIDParam: []string{"100"},
+				"end":                            []string{"2022-04-23T07:20:50.52Z"},
 			}},
 			Setup: func(mockCtrl *gomock.Controller, mock mockResources) v2.Resources {
 				mock.Database.EXPECT().GetDataQualityAggregations(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(model.DataQualityAggregations{}, 0, nil)
@@ -1726,7 +1712,7 @@ func TestGetDataQualityAggregations_Success(t *testing.T) {
 		},
 		{
 			Name:  "default window when start and end omitted",
-			Input: Input{Params: url.Values{"schema_environment_kind_id": []string{"eq:100"}}},
+			Input: Input{Params: url.Values{testSchemaEnvironmentKindIDParam: []string{"100"}}},
 			Setup: func(mockCtrl *gomock.Controller, mock mockResources) v2.Resources {
 				mock.Database.EXPECT().GetDataQualityAggregations(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(model.DataQualityAggregations{}, 0, nil)
 				return v2.Resources{DB: mock.Database}
@@ -1736,8 +1722,8 @@ func TestGetDataQualityAggregations_Success(t *testing.T) {
 		{
 			Name: "descending sort direction is passed to the database",
 			Input: Input{Params: url.Values{
-				"schema_environment_kind_id": []string{"eq:100"},
-				"sort_by":                    []string{"-created_at"},
+				testSchemaEnvironmentKindIDParam: []string{"100"},
+				"sort_by":                        []string{"-created_at"},
 			}},
 			Setup: func(mockCtrl *gomock.Controller, mock mockResources) v2.Resources {
 				mock.Database.EXPECT().GetDataQualityAggregations(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
@@ -1752,21 +1738,8 @@ func TestGetDataQualityAggregations_Success(t *testing.T) {
 			Expected: Expected{Code: http.StatusOK},
 		},
 		{
-			Name: "schema_extension_id existence check only runs for eq, not neq",
-			Input: Input{Params: url.Values{
-				"schema_environment_kind_id": []string{"eq:100"},
-				"schema_extension_id":        []string{"neq:999"},
-			}},
-			Setup: func(mockCtrl *gomock.Controller, mock mockResources) v2.Resources {
-				mock.Database.EXPECT().GetGraphSchemaExtensionById(gomock.Any(), gomock.Any()).Times(0)
-				mock.Database.EXPECT().GetDataQualityAggregations(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(model.DataQualityAggregations{}, 0, nil)
-				return v2.Resources{DB: mock.Database}
-			},
-			Expected: Expected{Code: http.StatusOK},
-		},
-		{
 			Name:  "default skip and limit are passed to the database when omitted",
-			Input: Input{Params: url.Values{"schema_environment_kind_id": []string{"eq:100"}}},
+			Input: Input{Params: url.Values{testSchemaEnvironmentKindIDParam: []string{"100"}}},
 			Setup: func(mockCtrl *gomock.Controller, mock mockResources) v2.Resources {
 				mock.Database.EXPECT().GetDataQualityAggregations(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
 					func(_ context.Context, _ model.Filters, _ model.Sort, skip int, limit int) (model.DataQualityAggregations, int, error) {
@@ -1781,9 +1754,9 @@ func TestGetDataQualityAggregations_Success(t *testing.T) {
 		{
 			Name: "skip and limit keep correct order in both database call and response",
 			Input: Input{Params: url.Values{
-				"schema_environment_kind_id": []string{"eq:100"},
-				"skip":                       []string{"3"},
-				"limit":                      []string{"7"},
+				testSchemaEnvironmentKindIDParam: []string{"100"},
+				"skip":                           []string{"3"},
+				"limit":                          []string{"7"},
 			}},
 			Setup: func(mockCtrl *gomock.Controller, mock mockResources) v2.Resources {
 				mock.Database.EXPECT().GetDataQualityAggregations(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(

--- a/cmd/api/src/database/dataquality.go
+++ b/cmd/api/src/database/dataquality.go
@@ -201,9 +201,7 @@ func (s *BloodhoundDB) GetDataQualityStats(ctx context.Context, filters model.Fi
 		return dataQualityStats, 0, err
 	}
 
-	if len(sort) == 0 {
-		sort = defaultDataQualitySort()
-	}
+	sort = deterministicDataQualitySort(sort)
 
 	orderSql, err := buildSQLSort(sort)
 	if err != nil {
@@ -337,10 +335,8 @@ func (s *BloodhoundDB) GetDataQualityAggregations(ctx context.Context, filters m
 		return aggregations, 0, err
 	}
 
-	// use a default sort when none is provided
-	if len(sort) == 0 {
-		sort = defaultDataQualitySort()
-	}
+	// use a default sort when none is provided and add an id tie-breaker for created_at and updated_at columns
+	sort = deterministicDataQualitySort(sort)
 	orderSql, err := buildSQLSort(sort)
 	if err != nil {
 		return aggregations, 0, err
@@ -386,19 +382,34 @@ func (s *BloodhoundDB) DeleteAllDataQuality(ctx context.Context) error {
 	)
 }
 
-// defaultDataQualitySort returns a default sort when none is provided: sort by created_at DESC,
-// with id ASC as a tiebreaker so pagination stays deterministic when created_at values are not unique
-func defaultDataQualitySort() model.Sort {
-	defaultSort := model.Sort{
-		{
-			Direction: model.DescendingSortDirection,
-			Column:    "created_at",
-		},
-		{
+// deterministicDataQualitySort defaults to created_at DESC when no sort is provided, and appends id ASC as a tiebreaker
+// so pagination stays deterministic when created_at or updated_at values are not unique
+func deterministicDataQualitySort(sort model.Sort) model.Sort {
+	if len(sort) == 0 {
+		sort = model.Sort{
+			{
+				Direction: model.DescendingSortDirection,
+				Column:    "created_at",
+			},
+		}
+	}
+	// only append the id tiebreaker if sort doesn't already have it
+	if !sortContainsColumn(sort, "id") {
+		sort = append(sort, model.SortItem{
 			Direction: model.AscendingSortDirection,
 			Column:    "id",
-		},
+		})
 	}
 
-	return defaultSort
+	return sort
+}
+
+// helper for deterministicDataQualitySort()
+func sortContainsColumn(sort model.Sort, column string) bool {
+	for _, item := range sort {
+		if item.Column == column {
+			return true
+		}
+	}
+	return false
 }

--- a/cmd/api/src/database/dataquality_integration_test.go
+++ b/cmd/api/src/database/dataquality_integration_test.go
@@ -583,8 +583,12 @@ func TestDatabase_GetDataQualityAggregations(t *testing.T) {
 				rowSecond := created[1]
 				rowThird := created[2]
 				require.True(t, rowFirst.ID < rowSecond.ID && rowSecond.ID < rowThird.ID, "serial ids should ascend in insert order")
-				// tie every created_at so only the appended id ascending tiebreaker can order the rows
-				require.NoError(t, testSuite.DB.WithContext(testSuite.Context).Exec("UPDATE data_quality_aggregations SET created_at = NOW()").Error)
+				// tie created_at, updating rows in reverse id order so the natural scan order (no tiebreaker)
+				// differs from id ascending; the test can only pass if the id tiebreaker is actually applied
+				tieTime := time.Now().UTC()
+				for _, row := range []model.DataQualityAggregation{rowThird, rowSecond, rowFirst} {
+					require.NoError(t, testSuite.DB.WithContext(testSuite.Context).Exec("UPDATE data_quality_aggregations SET created_at = ? WHERE id = ?", tieTime, row.ID).Error)
+				}
 
 				// explicit client sort on created_at; the id ascending tiebreaker must still be appended
 				sort := model.Sort{

--- a/cmd/api/src/database/dataquality_integration_test.go
+++ b/cmd/api/src/database/dataquality_integration_test.go
@@ -564,6 +564,41 @@ func TestDatabase_GetDataQualityAggregations(t *testing.T) {
 				assert.Equal(t, wantOrder, gotOrder)
 			},
 		},
+		{
+			name: "Success: appends id ascending tiebreaker to an explicit created_at sort when created_at values are equal",
+			test: func(t *testing.T, testSuite IntegrationTestSuite) {
+				envKind := registerAndGetKind(t, testSuite, "RandomEnvKind")
+
+				aggregations := model.DataQualityAggregations{
+					{RunID: "run-tie", SchemaExtensionID: 42, SchemaEnvironmentKindID: envKind.ID, MetricType: model.DataQualityMetricTypeNode, MetricName: "computers", MetricValue: 1},
+					{RunID: "run-tie", SchemaExtensionID: 42, SchemaEnvironmentKindID: envKind.ID, MetricType: model.DataQualityMetricTypeNode, MetricName: "users", MetricValue: 2},
+					{RunID: "run-tie", SchemaExtensionID: 42, SchemaEnvironmentKindID: envKind.ID, MetricType: model.DataQualityMetricTypeNode, MetricName: "groups", MetricValue: 3},
+				}
+				created, err := testSuite.BHDatabase.CreateDataQualityAggregations(testSuite.Context, aggregations)
+				require.NoError(t, err)
+				require.Len(t, created, 3)
+
+				// name each row by its insert position; serial ids ascend with insert order
+				rowFirst := created[0]
+				rowSecond := created[1]
+				rowThird := created[2]
+				require.True(t, rowFirst.ID < rowSecond.ID && rowSecond.ID < rowThird.ID, "serial ids should ascend in insert order")
+				// tie every created_at so only the appended id ascending tiebreaker can order the rows
+				require.NoError(t, testSuite.DB.WithContext(testSuite.Context).Exec("UPDATE data_quality_aggregations SET created_at = NOW()").Error)
+
+				// explicit client sort on created_at; the id ascending tiebreaker must still be appended
+				sort := model.Sort{
+					{Direction: model.AscendingSortDirection, Column: "created_at"},
+				}
+				results, _, err := testSuite.BHDatabase.GetDataQualityAggregations(testSuite.Context, nil, sort, 0, 0)
+				require.NoError(t, err)
+				require.Len(t, results, 3)
+
+				gotOrder := []int32{results[0].ID, results[1].ID, results[2].ID}
+				wantOrder := []int32{rowFirst.ID, rowSecond.ID, rowThird.ID}
+				assert.Equal(t, wantOrder, gotOrder)
+			},
+		},
 	}
 
 	for _, testCase := range tests {

--- a/cmd/api/src/model/dataqualitystats.go
+++ b/cmd/api/src/model/dataqualitystats.go
@@ -58,8 +58,8 @@ func (s DataQualityStats) IsSortable(column string) bool {
 // combined across environment instances for one collection run.
 type DataQualityAggregation struct {
 	RunID                   string                `json:"run_id"`
-	SchemaExtensionID       int32                 `json:"schema_extension_id"`
-	SchemaEnvironmentKindID int32                 `json:"schema_environment_kind_id"`
+	SchemaExtensionID       int32                 `json:"extension_id"`
+	SchemaEnvironmentKindID int32                 `json:"environment_kind_id"`
 	MetricType              DataQualityMetricType `json:"metric_type"`
 	MetricName              string                `json:"metric_name"`
 	MetricValue             float64               `json:"metric_value"`
@@ -76,19 +76,29 @@ type DataQualityAggregations []DataQualityAggregation
 
 func (s DataQualityAggregations) IsSortable(column string) bool {
 	switch column {
-	case "run_id",
-		"schema_extension_id",
-		"schema_environment_kind_id",
-		"metric_type",
-		"metric_name",
-		"metric_value",
-		"kind_id",
-		"id",
-		"created_at",
-		"updated_at",
-		"deleted_at":
+	case "created_at",
+		"updated_at":
 		return true
 	default:
 		return false
+	}
+}
+
+func (s DataQualityAggregations) IsStringColumn(column string) bool {
+	switch column {
+	case "run_id",
+		"metric_name",
+		"metric_type":
+		return true
+	default:
+		return false
+	}
+}
+
+func (s DataQualityAggregations) ValidFilters() map[string][]FilterOperator {
+	return map[string][]FilterOperator{
+		"schema_extension_id":        {Equals, NotEquals},
+		"schema_environment_kind_id": {Equals, NotEquals},
+		"created_at":                 {Equals, GreaterThan, GreaterThanOrEquals, LessThan, LessThanOrEquals, NotEquals},
 	}
 }

--- a/cmd/api/src/model/dataqualitystats.go
+++ b/cmd/api/src/model/dataqualitystats.go
@@ -99,6 +99,5 @@ func (s DataQualityAggregations) ValidFilters() map[string][]FilterOperator {
 	return map[string][]FilterOperator{
 		"schema_extension_id":        {Equals, NotEquals},
 		"schema_environment_kind_id": {Equals, NotEquals},
-		"created_at":                 {Equals, GreaterThan, GreaterThanOrEquals, LessThan, LessThanOrEquals, NotEquals},
 	}
 }

--- a/cmd/api/src/model/dataqualitystats.go
+++ b/cmd/api/src/model/dataqualitystats.go
@@ -83,21 +83,3 @@ func (s DataQualityAggregations) IsSortable(column string) bool {
 		return false
 	}
 }
-
-func (s DataQualityAggregations) IsStringColumn(column string) bool {
-	switch column {
-	case "run_id",
-		"metric_name",
-		"metric_type":
-		return true
-	default:
-		return false
-	}
-}
-
-func (s DataQualityAggregations) ValidFilters() map[string][]FilterOperator {
-	return map[string][]FilterOperator{
-		"schema_extension_id":        {Equals, NotEquals},
-		"schema_environment_kind_id": {Equals, NotEquals},
-	}
-}

--- a/packages/go/openapi/doc/openapi.json
+++ b/packages/go/openapi/doc/openapi.json
@@ -13924,7 +13924,7 @@
           },
           {
             "name": "end",
-            "description": "Ending datetime of range (exclusive) in RFC-3339 format; Defaults to current datetime",
+            "description": "Ending datetime of range (inclusive) in RFC-3339 format; Defaults to current datetime",
             "in": "query",
             "schema": {
               "type": "string",
@@ -14032,7 +14032,7 @@
           },
           {
             "name": "end",
-            "description": "Ending datetime of range (exclusive) in RFC-3339 format; Defaults to current datetime",
+            "description": "Ending datetime of range (inclusive) in RFC-3339 format; Defaults to current datetime",
             "in": "query",
             "schema": {
               "type": "string",
@@ -14144,7 +14144,7 @@
           },
           {
             "name": "end",
-            "description": "Ending datetime of range (exclusive) in RFC-3339 format; Defaults to current datetime",
+            "description": "Ending datetime of range (inclusive) in RFC-3339 format; Defaults to current datetime",
             "in": "query",
             "schema": {
               "type": "string",
@@ -14231,7 +14231,7 @@
           },
           {
             "name": "end",
-            "description": "Ending datetime of range (exclusive) in RFC-3339 format; Defaults to current datetime",
+            "description": "Ending datetime of range (inclusive) in RFC-3339 format; Defaults to current datetime",
             "in": "query",
             "schema": {
               "type": "string",

--- a/packages/go/openapi/doc/openapi.json
+++ b/packages/go/openapi/doc/openapi.json
@@ -14304,7 +14304,7 @@
       "get": {
         "operationId": "GetDataQualityAggregations",
         "summary": "Get data quality aggregations",
-        "description": "Returns data quality metric counts aggregated per environment kind for an OpenGraph schema extension, combined across environment instances for each collection run. Results can be filtered, sorted, and paginated.\n",
+        "description": "Returns data quality metric counts aggregated per environment kind, optionally scoped to an OpenGraph schema extension, combined across environment instances for each collection run. Results can be filtered, sorted, and paginated.\n",
         "tags": [
           "Data Quality",
           "Community",
@@ -14329,14 +14329,29 @@
             }
           },
           {
-            "$ref": "#/components/parameters/query.created-at"
-          },
-          {
             "name": "sort_by",
             "description": "Sortable columns are created_at, updated_at.\n",
             "in": "query",
             "schema": {
               "$ref": "#/components/schemas/api.params.query.sort-by"
+            }
+          },
+          {
+            "name": "start",
+            "description": "Beginning datetime of range (inclusive) in RFC-3339 format; Defaults to current datetime minus 30 days",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "name": "end",
+            "description": "Ending datetime of range (inclusive) in RFC-3339 format; Defaults to current datetime",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
             }
           },
           {
@@ -14355,6 +14370,9 @@
                   "allOf": [
                     {
                       "$ref": "#/components/schemas/api.response.pagination"
+                    },
+                    {
+                      "$ref": "#/components/schemas/api.response.time-window"
                     },
                     {
                       "type": "object",
@@ -23448,7 +23466,10 @@
                 "format": "double"
               },
               "kind_id": {
-                "$ref": "#/components/schemas/null.int32"
+                "description": "The kind ID for the counted node kind. Present when `metric_type` is `node`; otherwise null.",
+                "type": "integer",
+                "format": "int32",
+                "nullable": true
               }
             }
           }

--- a/packages/go/openapi/doc/openapi.json
+++ b/packages/go/openapi/doc/openapi.json
@@ -14303,7 +14303,7 @@
       ],
       "get": {
         "operationId": "GetDataQualityAggregations",
-        "summary": "Get data quality aggregations",
+        "summary": "Get data quality aggregations by environment kind",
         "description": "Returns data quality metric counts aggregated per environment kind, optionally scoped to an OpenGraph schema extension, combined across environment instances for each collection run. Results can be filtered, sorted, and paginated.\n",
         "tags": [
           "Data Quality",

--- a/packages/go/openapi/doc/openapi.json
+++ b/packages/go/openapi/doc/openapi.json
@@ -14313,19 +14313,21 @@
         "parameters": [
           {
             "name": "schema_environment_kind_id",
-            "description": "Required. Filter results by the environment kind id to scope the aggregation to a single kind. Valid filter predicates are `eq` and `neq`.\n",
+            "description": "Required. Scopes the aggregation to a single environment kind id.\n",
             "in": "query",
             "required": true,
             "schema": {
-              "$ref": "#/components/schemas/api.params.predicate.filter.integer"
+              "type": "integer",
+              "format": "int32"
             }
           },
           {
             "name": "schema_extension_id",
-            "description": "Filter results by the OpenGraph schema extension id. When an `eq` predicate is provided, the extension must exist or a 404 is returned. Valid filter predicates are `eq` and `neq`.\n",
+            "description": "Optional. Scopes the aggregation to a single OpenGraph schema extension id. The extension must exist or a 404 is returned.\n",
             "in": "query",
             "schema": {
-              "$ref": "#/components/schemas/api.params.predicate.filter.integer"
+              "type": "integer",
+              "format": "int32"
             }
           },
           {

--- a/packages/go/openapi/doc/openapi.json
+++ b/packages/go/openapi/doc/openapi.json
@@ -14295,6 +14295,104 @@
         }
       }
     },
+    "/api/v2/data-quality-stats-aggregations": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/header.prefer"
+        }
+      ],
+      "get": {
+        "operationId": "GetDataQualityAggregations",
+        "summary": "Get data quality aggregations",
+        "description": "Returns data quality metric counts aggregated per environment kind for an OpenGraph schema extension, combined across environment instances for each collection run. Results can be filtered, sorted, and paginated.\n",
+        "tags": [
+          "Data Quality",
+          "Community",
+          "Enterprise"
+        ],
+        "parameters": [
+          {
+            "name": "schema_environment_kind_id",
+            "description": "Required. Filter results by the environment kind id to scope the aggregation to a single kind. Valid filter predicates are `eq` and `neq`.\n",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/api.params.predicate.filter.integer"
+            }
+          },
+          {
+            "name": "schema_extension_id",
+            "description": "Filter results by the OpenGraph schema extension id. When an `eq` predicate is provided, the extension must exist or a 404 is returned. Valid filter predicates are `eq` and `neq`.\n",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/api.params.predicate.filter.integer"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/query.created-at"
+          },
+          {
+            "name": "sort_by",
+            "description": "Sortable columns are created_at, updated_at.\n",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/api.params.query.sort-by"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/query.skip"
+          },
+          {
+            "$ref": "#/components/parameters/query.limit"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/api.response.pagination"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/model.data-quality-aggregation"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/bad-request"
+          },
+          "401": {
+            "$ref": "#/components/responses/unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/not-found"
+          },
+          "429": {
+            "$ref": "#/components/responses/too-many-requests"
+          },
+          "500": {
+            "$ref": "#/components/responses/internal-server-error"
+          }
+        }
+      }
+    },
     "/api/v2/clear-database": {
       "parameters": [
         {
@@ -23308,6 +23406,49 @@
               "run_id": {
                 "type": "string",
                 "format": "uuid"
+              }
+            }
+          }
+        ]
+      },
+      "model.data-quality-aggregation": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/model.components.int32.id"
+          },
+          {
+            "$ref": "#/components/schemas/model.components.timestamps"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "run_id": {
+                "type": "string"
+              },
+              "extension_id": {
+                "type": "integer",
+                "format": "int32"
+              },
+              "environment_kind_id": {
+                "type": "integer",
+                "format": "int32"
+              },
+              "metric_type": {
+                "type": "string",
+                "enum": [
+                  "node",
+                  "relationship"
+                ]
+              },
+              "metric_name": {
+                "type": "string"
+              },
+              "metric_value": {
+                "type": "number",
+                "format": "double"
+              },
+              "kind_id": {
+                "$ref": "#/components/schemas/null.int32"
               }
             }
           }

--- a/packages/go/openapi/src/openapi.yaml
+++ b/packages/go/openapi/src/openapi.yaml
@@ -621,6 +621,8 @@ paths:
     $ref: './paths/data-quality.platform.id.data-quality-stats.yaml'
   /api/v2/data-quality-stats:
     $ref: './paths/data-quality.data-quality-stats.yaml'
+  /api/v2/data-quality-stats-aggregations:
+    $ref: './paths/data-quality.data-quality-stats-aggregations.yaml'
   /api/v2/clear-database:
     $ref: './paths/data-quality.clear-database.yaml'
 

--- a/packages/go/openapi/src/paths/data-quality.ad-domains.id.data-quality-stats.yaml
+++ b/packages/go/openapi/src/paths/data-quality.ad-domains.id.data-quality-stats.yaml
@@ -44,7 +44,7 @@ get:
         type: string
         format: date-time
     - name: end
-      description: Ending datetime of range (exclusive) in RFC-3339 format; Defaults
+      description: Ending datetime of range (inclusive) in RFC-3339 format; Defaults
         to current datetime
       in: query
       schema:

--- a/packages/go/openapi/src/paths/data-quality.azure-tenants.id.data-quality-stats.yaml
+++ b/packages/go/openapi/src/paths/data-quality.azure-tenants.id.data-quality-stats.yaml
@@ -44,7 +44,7 @@ get:
         type: string
         format: date-time
     - name: end
-      description: Ending datetime of range (exclusive) in RFC-3339 format; Defaults
+      description: Ending datetime of range (inclusive) in RFC-3339 format; Defaults
         to current datetime
       in: query
       schema:

--- a/packages/go/openapi/src/paths/data-quality.data-quality-stats-aggregations.yaml
+++ b/packages/go/openapi/src/paths/data-quality.data-quality-stats-aggregations.yaml
@@ -1,0 +1,81 @@
+# Copyright 2026 Specter Ops, Inc.
+#
+# Licensed under the Apache License, Version 2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+parameters:
+  - $ref: './../parameters/header.prefer.yaml'
+get:
+  operationId: GetDataQualityAggregations
+  summary: Get data quality aggregations
+  description: >
+    Returns data quality metric counts aggregated per environment kind for an
+    OpenGraph schema extension, combined across environment instances for each
+    collection run. Results can be filtered, sorted, and paginated.
+  tags:
+    - Data Quality
+    - Community
+    - Enterprise
+  parameters:
+    - name: schema_environment_kind_id
+      description: >
+        Required. Filter results by the environment kind id to scope the
+        aggregation to a single kind. Valid filter predicates are `eq` and `neq`.
+      in: query
+      required: true
+      schema:
+        $ref: './../schemas/api.params.predicate.filter.integer.yaml'
+    - name: schema_extension_id
+      description: >
+        Filter results by the OpenGraph schema extension id. When an `eq`
+        predicate is provided, the extension must exist or a 404 is returned.
+        Valid filter predicates are `eq` and `neq`.
+      in: query
+      schema:
+        $ref: './../schemas/api.params.predicate.filter.integer.yaml'
+    - $ref: './../parameters/query.created-at.yaml'
+    - name: sort_by
+      description: >
+        Sortable columns are created_at, updated_at.
+      in: query
+      schema:
+        $ref: './../schemas/api.params.query.sort-by.yaml'
+    - $ref: './../parameters/query.skip.yaml'
+    - $ref: './../parameters/query.limit.yaml'
+  responses:
+    200:
+      description: OK
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: './../schemas/api.response.pagination.yaml'
+              - type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: './../schemas/model.data-quality-aggregation.yaml'
+    400:
+      $ref: './../responses/bad-request.yaml'
+    401:
+      $ref: './../responses/unauthorized.yaml'
+    403:
+      $ref: './../responses/forbidden.yaml'
+    404:
+      $ref: './../responses/not-found.yaml'
+    429:
+      $ref: './../responses/too-many-requests.yaml'
+    500:
+      $ref: './../responses/internal-server-error.yaml'

--- a/packages/go/openapi/src/paths/data-quality.data-quality-stats-aggregations.yaml
+++ b/packages/go/openapi/src/paths/data-quality.data-quality-stats-aggregations.yaml
@@ -18,7 +18,7 @@ parameters:
   - $ref: './../parameters/header.prefer.yaml'
 get:
   operationId: GetDataQualityAggregations
-  summary: Get data quality aggregations
+  summary: Get data quality aggregations by environment kind
   description: >
     Returns data quality metric counts aggregated per environment kind, optionally scoped to an
     OpenGraph schema extension, combined across environment instances for each

--- a/packages/go/openapi/src/paths/data-quality.data-quality-stats-aggregations.yaml
+++ b/packages/go/openapi/src/paths/data-quality.data-quality-stats-aggregations.yaml
@@ -20,7 +20,7 @@ get:
   operationId: GetDataQualityAggregations
   summary: Get data quality aggregations
   description: >
-    Returns data quality metric counts aggregated per environment kind for an
+    Returns data quality metric counts aggregated per environment kind, optionally scoped to an
     OpenGraph schema extension, combined across environment instances for each
     collection run. Results can be filtered, sorted, and paginated.
   tags:
@@ -44,13 +44,26 @@ get:
       in: query
       schema:
         $ref: './../schemas/api.params.predicate.filter.integer.yaml'
-    - $ref: './../parameters/query.created-at.yaml'
     - name: sort_by
       description: >
         Sortable columns are created_at, updated_at.
       in: query
       schema:
         $ref: './../schemas/api.params.query.sort-by.yaml'
+    - name: start
+      description: Beginning datetime of range (inclusive) in RFC-3339 format; Defaults
+        to current datetime minus 30 days
+      in: query
+      schema:
+        type: string
+        format: date-time
+    - name: end
+      description: Ending datetime of range (inclusive) in RFC-3339 format; Defaults
+        to current datetime
+      in: query
+      schema:
+        type: string
+        format: date-time
     - $ref: './../parameters/query.skip.yaml'
     - $ref: './../parameters/query.limit.yaml'
   responses:
@@ -61,6 +74,7 @@ get:
           schema:
             allOf:
               - $ref: './../schemas/api.response.pagination.yaml'
+              - $ref: './../schemas/api.response.time-window.yaml'
               - type: object
                 properties:
                   data:

--- a/packages/go/openapi/src/paths/data-quality.data-quality-stats-aggregations.yaml
+++ b/packages/go/openapi/src/paths/data-quality.data-quality-stats-aggregations.yaml
@@ -30,20 +30,20 @@ get:
   parameters:
     - name: schema_environment_kind_id
       description: >
-        Required. Filter results by the environment kind id to scope the
-        aggregation to a single kind. Valid filter predicates are `eq` and `neq`.
+        Required. Scopes the aggregation to a single environment kind id.
       in: query
       required: true
       schema:
-        $ref: './../schemas/api.params.predicate.filter.integer.yaml'
+        type: integer
+        format: int32
     - name: schema_extension_id
       description: >
-        Filter results by the OpenGraph schema extension id. When an `eq`
-        predicate is provided, the extension must exist or a 404 is returned.
-        Valid filter predicates are `eq` and `neq`.
+        Optional. Scopes the aggregation to a single OpenGraph schema extension id.
+        The extension must exist or a 404 is returned.
       in: query
       schema:
-        $ref: './../schemas/api.params.predicate.filter.integer.yaml'
+        type: integer
+        format: int32
     - name: sort_by
       description: >
         Sortable columns are created_at, updated_at.

--- a/packages/go/openapi/src/paths/data-quality.data-quality-stats.yaml
+++ b/packages/go/openapi/src/paths/data-quality.data-quality-stats.yaml
@@ -44,7 +44,7 @@ get:
         type: string
         format: date-time
     - name: end
-      description: Ending datetime of range (exclusive) in RFC-3339 format; Defaults
+      description: Ending datetime of range (inclusive) in RFC-3339 format; Defaults
         to current datetime
       in: query
       schema:

--- a/packages/go/openapi/src/paths/data-quality.platform.id.data-quality-stats.yaml
+++ b/packages/go/openapi/src/paths/data-quality.platform.id.data-quality-stats.yaml
@@ -47,7 +47,7 @@ get:
         type: string
         format: date-time
     - name: end
-      description: Ending datetime of range (exclusive) in RFC-3339 format; Defaults
+      description: Ending datetime of range (inclusive) in RFC-3339 format; Defaults
         to current datetime
       in: query
       schema:

--- a/packages/go/openapi/src/schemas/model.data-quality-aggregation.yaml
+++ b/packages/go/openapi/src/schemas/model.data-quality-aggregation.yaml
@@ -38,4 +38,7 @@ allOf:
         type: number
         format: double
       kind_id:
-        $ref: './null.int32.yaml'
+        description: The kind ID for the counted node kind. Present when `metric_type` is `node`; otherwise null.
+        type: integer
+        format: int32
+        nullable: true

--- a/packages/go/openapi/src/schemas/model.data-quality-aggregation.yaml
+++ b/packages/go/openapi/src/schemas/model.data-quality-aggregation.yaml
@@ -1,0 +1,41 @@
+# Copyright 2026 Specter Ops, Inc.
+#
+# Licensed under the Apache License, Version 2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+allOf:
+  - $ref: './model.components.int32.id.yaml'
+  - $ref: './model.components.timestamps.yaml'
+  - type: object
+    properties:
+      run_id:
+        type: string
+      extension_id:
+        type: integer
+        format: int32
+      environment_kind_id:
+        type: integer
+        format: int32
+      metric_type:
+        type: string
+        enum:
+          - node
+          - relationship
+      metric_name:
+        type: string
+      metric_value:
+        type: number
+        format: double
+      kind_id:
+        $ref: './null.int32.yaml'


### PR DESCRIPTION
## Description

Adds a new `GET /api/v2/data-quality-stats-aggregations` endpoint (BED-8611) that returns  data quality metric counts aggregated per environment kind for an OpenGraph schema  extension, combined across environment instances for each collection run.  
  
The endpoint is behind the `opengraph_extension_management` feature flag.  
  
  **Detailed changes:**
- registers `GET /api/v2/data-quality-stats-aggregations` w/ the FeatureOpenGraphExtensionManagement flag.  
- adds handler supports filtering, sorting, and pagination (GetDataQualityAggregations)
- requires schema_environment_kind_id
- if the schema_extension_id query param is added, it verifies the extension exists and returns 404 if it does not 
- start / end are parsed as plain RFC-3339 timestamps and applied to `created_at`as an inclusive window, like the AZ/AD DQ handlers
- applies hardcoded filtering to match the existing endpoints 
- updates json tags of "schema-"-prefixed fields
- updates sortable columns, and adjusts JSON tags on `DataQualityAggregation`.  
- OpenAPI/Swagger changes  
- adds tests 

## Motivation and Context

Fixes: [BED-8611](https://specterops.atlassian.net/browse/BED-8611)
in support of the Data Quality project

Adds aggregations endpoint for OpenGraph support (we have an existing AD and AZ aggregate endpoint)

## How Has This Been Tested?
- added _Success/_Failure table tests for GetDataQualityAggregations covering basic and edge cases
- ran existing unit tests and integration tests, no regressions
- tested manually via Bruno (see screenshots below), enabling the feature flag locally and by creating mock data for the data_quality_aggregations across multiple environment kinds and extensions.
  
## Screenshots:

    **1. Basic:**
     ?schema_environment_kind_id=182

<img width="1012" height="572" alt="1_basic" src="https://github.com/user-attachments/assets/64c000ff-cdb5-47ba-b28d-a3fd45173fed" />


    **2. Pagination:**
     ?schema_environment_kind_id=182&limit=5&skip=0 
     → 5 rows; limit:5, skip:0 are shown, full count.

<img width="997" height="625" alt="2_pagination" src="https://github.com/user-attachments/assets/7629edb7-b6c1-411d-bd90-697ed00f0e2b" />



    **3. Time window:**
     ?schema_environment_kind_id=182&start=2026-07-04T00:00:00Z&end=2026-07-11T00:00:00Z
      → fewer rows.

  
<img width="1007" height="598" alt="3_time_window" src="https://github.com/user-attachments/assets/7240fbe7-9e3b-4b7d-a265-2d95af4f2205" />


    **4. Ascending sort (non-default):**
     ?schema_environment_kind_id=183&sort_by=-created_at
      → oldest first.

  
<img width="1003" height="596" alt="4_sorting_ascending(nondefault)" src="https://github.com/user-attachments/assets/7a68e0b9-82d1-47cf-8323-578ee35e4557" />



    **5. Extension filter passes (real id):**
     ?schema_environment_kind_id=182&schema_extension_id=3 
     → 200 with rows.

<img width="1010" height="603" alt="5_extensionfilter1" src="https://github.com/user-attachments/assets/97e6c0ac-8c14-448f-9cf9-2b35aefa9000" />


  **6. Extension filter exists but does not match schema_environment_kind_id:**
     ?schema_environment_kind_id=182&schema_extension_id=4
     → 200; count:0 

<img width="1004" height="540" alt="5B_mismatch" src="https://github.com/user-attachments/assets/64ae2c77-2a83-4458-813b-2391469b7d5e" />


    **7. Extension does not exist (404):**
     ?schema_environment_kind_id=182&schema_extension_id=999999 
     → 404.

<img width="1006" height="552" alt="6_extension_id does not exist --  404" src="https://github.com/user-attachments/assets/a6818307-601b-47db-b69b-728db7d15139" />



    **8. Missing required param (400):**
     ?limit=5 
     → 400 (missing required query parameter: schema_environment_kind_id).

<img width="988" height="556" alt="7_missing_required_paramId" src="https://github.com/user-attachments/assets/2690ce04-1980-43b2-8940-678972dac60b" />


  **9. Non-integer required param (400):**
     ?schema_environment_kind_id=abc
     → 400 (query parameter must be an integer: schema_environment_kind_id).

<img width="988" height="556" alt="8_noninteger" src="https://github.com/user-attachments/assets/50a21027-affa-4245-b13e-27ab920cc503" />



  **10. neq: rejected for required param (400):**
     ?schema_environment_kind_id=neq:183
     → 400 (query parameter must be an integer: schema_environment_kind_id).

<img width="988" height="556" alt="8b_neqnoninteger" src="https://github.com/user-attachments/assets/6fdb1350-563f-4bc6-8773-e1768dfe6268" />


## Types of changes

<!-- Please remove any items that do not apply. -->
- New feature (non-breaking change which adds functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


[BED-8611]: https://specterops.atlassian.net/browse/BED-8611?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added `GET /api/v2/data-quality-stats-aggregations` to return aggregated data-quality metric counts by environment kind, with optional extension filtering (feature-flagged).

* **Documentation**
  * Updated the OpenAPI spec with the new endpoint, query parameters (`schema_environment_kind_id`, `schema_extension_id`, `start`/`end`, `sort_by`, `skip`/`limit`), and response schema.

* **Bug Fixes**
  * Improved request validation and standardized sorting behavior.
  * Response fields now use `extension_id` and `environment_kind_id`.

* **Tests**
  * Added success and failure tests covering filtering, time windows, pagination, sorting, and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->