### PR TITLE
feat: Add KindInfo to api/v2/nodes/node_id - BED-8762

### DIFF
--- a/packages/go/openapi/doc/openapi.json
+++ b/packages/go/openapi/doc/openapi.json
@@ -23218,15 +23218,7 @@
         }
       },
       "InfoMarkdown": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/InfoMarkdownContent"
-          },
-          {
-            "type": "object",
-            "additionalProperties": false
-          }
-        ]
+        "$ref": "#/components/schemas/InfoMarkdownContent"
       }
     },
     "examples": {

--- a/packages/go/openapi/doc/openapi.json
+++ b/packages/go/openapi/doc/openapi.json
@@ -7286,21 +7286,25 @@
           "name": "node_id",
           "in": "path",
           "required": true,
-          "description": "The node id assigned by the graph",
+          "description": "The Graph Node ID",
           "schema": {
-            "type": "integer",
-            "format": "int64"
+            "type": "integer"
+          }
+        },
+        {
+          "name": "include-info",
+          "in": "query",
+          "required": false,
+          "description": "When false or omitted, excludes entity panel information.\nWhen true, returns node details with entity panel information included.\n",
+          "schema": {
+            "type": "boolean"
           }
         }
       ],
       "get": {
-        "operationId": "GetNodeByID",
         "summary": "Get Node by Graph Node ID",
-        "description": "**Experimental** - Returns the details of a graph node identified by its graph-assigned integer ID",
         "tags": [
-          "OpenGraph (Experimental)",
-          "Community",
-          "Enterprise"
+          "OpenGraph (Experimental), Proposal"
         ],
         "responses": {
           "200": {
@@ -7309,32 +7313,50 @@
               "application/json": {
                 "schema": {
                   "type": "object",
+                  "required": [
+                    "data"
+                  ],
                   "properties": {
                     "data": {
-                      "$ref": "#/components/schemas/model.node-details"
+                      "anyOf": [
+                        {
+                          "$ref": "#/components/schemas/NodeDetails"
+                        },
+                        {
+                          "$ref": "#/components/schemas/NodeDetailsWithInfo"
+                        }
+                      ]
                     }
+                  }
+                },
+                "examples": {
+                  "NoInfo": {
+                    "$ref": "#/components/examples/NodeDetailsExample"
+                  },
+                  "WithInfo": {
+                    "$ref": "#/components/examples/NodeDetailsWithInfoExample"
                   }
                 }
               }
             }
           },
           "400": {
-            "$ref": "#/components/responses/bad-request"
+            "description": "Bad Request"
           },
           "401": {
-            "$ref": "#/components/responses/unauthorized"
+            "description": "Unauthorized"
           },
           "403": {
-            "$ref": "#/components/responses/forbidden"
+            "description": "Forbidden"
           },
           "404": {
-            "$ref": "#/components/responses/not-found"
+            "description": "Not found"
           },
           "429": {
-            "$ref": "#/components/responses/too-many-requests"
+            "description": "Too Many Requests"
           },
           "500": {
-            "$ref": "#/components/responses/internal-server-error"
+            "description": "Internal Server Error"
           }
         }
       }
@@ -23041,6 +23063,258 @@
           "attack-paths",
           "archived-findings"
         ]
+      },
+      "NodeDetails": {
+        "type": "object",
+        "required": [
+          "node_id",
+          "kinds",
+          "properties"
+        ],
+        "properties": {
+          "node_id": {
+            "type": "integer",
+            "readOnly": true
+          },
+          "kinds": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "node_kind_id",
+                "name"
+              ],
+              "properties": {
+                "node_kind_id": {
+                  "type": "integer"
+                },
+                "name": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "properties": {
+            "type": "object",
+            "required": [
+              "objectid",
+              "lastSeen"
+            ],
+            "properties": {
+              "objectid": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "displayName": {
+                "type": "string"
+              },
+              "lastSeen": {
+                "type": "string",
+                "format": "date-time"
+              }
+            }
+          }
+        }
+      },
+      "NodeDetailsWithInfo": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/NodeDetails"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "info": {
+                "type": "array",
+                "items": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/KindInfoResponse"
+                    },
+                    {
+                      "type": "object",
+                      "required": [
+                        "node_kind_id"
+                      ],
+                      "properties": {
+                        "node_kind_id": {
+                          "type": "integer"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        ]
+      },
+      "KindInfoResponse": {
+        "allOf": [
+          {
+            "type": "object",
+            "required": [
+              "name"
+            ],
+            "properties": {
+              "name": {
+                "type": "string",
+                "example": "panel_section_1"
+              }
+            }
+          },
+          {
+            "$ref": "#/components/schemas/KindInfoBase"
+          },
+          {
+            "$ref": "#/components/schemas/KindInfoContent"
+          }
+        ]
+      },
+      "KindInfoBase": {
+        "type": "object",
+        "required": [
+          "title",
+          "position"
+        ],
+        "properties": {
+          "title": {
+            "type": "string",
+            "example": "Entity Panel Section"
+          },
+          "position": {
+            "type": "integer",
+            "minimum": 1
+          }
+        }
+      },
+      "KindInfoContent": {
+        "type": "object",
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/InfoMarkdown"
+          }
+        ]
+      },
+      "InfoMarkdownContent": {
+        "type": "object",
+        "required": [
+          "markdown"
+        ],
+        "properties": {
+          "markdown": {
+            "type": "object",
+            "required": [
+              "content"
+            ],
+            "properties": {
+              "content": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "InfoMarkdown": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/InfoMarkdownContent"
+          },
+          {
+            "type": "object",
+            "additionalProperties": false
+          }
+        ]
+      }
+    },
+    "examples": {
+      "NodeDetailsExample": {
+        "summary": "Basic Node Details",
+        "value": {
+          "data": {
+            "node_id": 278346,
+            "kinds": [
+              {
+                "name": "Okta",
+                "node_kind_id": 263476
+              },
+              {
+                "name": "Okta_Organization",
+                "node_kind_id": 28937
+              },
+              {
+                "name": "Tag_Tier_Zero",
+                "node_kind_id": 987234
+              }
+            ],
+            "properties": {
+              "objectid": "00ow0o8if0CNwsKmk697",
+              "name": "contoso.okta.com",
+              "displayName": "Contoso",
+              "oktaDomain": "contoso.okta.com",
+              "subdomain": "contoso",
+              "status": "ACTIVE",
+              "created": "2025-10-02T09:21:31+00:00",
+              "lastSeen": "2025-12-09T23:04:15+00:00",
+              "lastUpdated": "2025-12-09T23:04:15+00:00"
+            }
+          }
+        }
+      },
+      "NodeDetailsWithInfoExample": {
+        "summary": "Node Details with Entity Panel Info",
+        "value": {
+          "data": {
+            "node_id": 278346,
+            "kinds": [
+              {
+                "name": "Okta",
+                "node_kind_id": 263476
+              },
+              {
+                "name": "Okta_Organization",
+                "node_kind_id": 28937
+              },
+              {
+                "name": "Tag_Tier_Zero",
+                "node_kind_id": 987234
+              }
+            ],
+            "properties": {
+              "objectid": "00ow0o8if0CNwsKmk697",
+              "name": "contoso.okta.com",
+              "displayName": "Contoso",
+              "oktaDomain": "contoso.okta.com",
+              "subdomain": "contoso",
+              "status": "ACTIVE",
+              "created": "2025-10-02T09:21:31+00:00",
+              "lastSeen": "2025-12-09T23:04:15+00:00",
+              "lastUpdated": "2025-12-09T23:04:15+00:00"
+            },
+            "info": [
+              {
+                "name": "panel1",
+                "title": "Info Panel Section 1",
+                "position": 1,
+                "node_kind_id": 827364,
+                "markdown": {
+                  "content": "This node represents a user account."
+                }
+              },
+              {
+                "name": "panel2",
+                "title": "Info Panel Section 2",
+                "position": 2,
+                "node_kind_id": 827364,
+                 "markdown": {
+                  "content": "This is some context for your selection."
+                }
+              }
+            ]
+          }
+        }
       }
     },
     "responses": {

--- a/packages/go/openapi/doc/openapi.json
+++ b/packages/go/openapi/doc/openapi.json
@@ -7286,25 +7286,21 @@
           "name": "node_id",
           "in": "path",
           "required": true,
-          "description": "The Graph Node ID",
+          "description": "The node id assigned by the graph",
           "schema": {
-            "type": "integer"
-          }
-        },
-        {
-          "name": "include-info",
-          "in": "query",
-          "required": false,
-          "description": "When false or omitted, excludes entity panel information.\nWhen true, returns node details with entity panel information included.\n",
-          "schema": {
-            "type": "boolean"
+            "type": "integer",
+            "format": "int64"
           }
         }
       ],
       "get": {
+        "operationId": "GetNodeByID",
         "summary": "Get Node by Graph Node ID",
+        "description": "**Experimental** - Returns the details of a graph node identified by its graph-assigned integer ID",
         "tags": [
-          "OpenGraph (Experimental), Proposal"
+          "OpenGraph (Experimental)",
+          "Community",
+          "Enterprise"
         ],
         "responses": {
           "200": {
@@ -7313,28 +7309,10 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": [
-                    "data"
-                  ],
                   "properties": {
                     "data": {
-                      "anyOf": [
-                        {
-                          "$ref": "#/components/schemas/NodeDetails"
-                        },
-                        {
-                          "$ref": "#/components/schemas/NodeDetailsWithInfo"
-                        }
-                      ]
+                      "$ref": "#/components/schemas/model.node-details"
                     }
-                  }
-                },
-                "examples": {
-                  "NoInfo": {
-                    "$ref": "#/components/examples/NodeDetailsExample"
-                  },
-                  "WithInfo": {
-                    "$ref": "#/components/examples/NodeDetailsWithInfoExample"
                   }
                 }
               }
@@ -23063,250 +23041,6 @@
           "attack-paths",
           "archived-findings"
         ]
-      },
-      "NodeDetails": {
-        "type": "object",
-        "required": [
-          "node_id",
-          "kinds",
-          "properties"
-        ],
-        "properties": {
-          "node_id": {
-            "type": "integer",
-            "readOnly": true
-          },
-          "kinds": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "required": [
-                "node_kind_id",
-                "name"
-              ],
-              "properties": {
-                "node_kind_id": {
-                  "type": "integer"
-                },
-                "name": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "properties": {
-            "type": "object",
-            "required": [
-              "objectid",
-              "lastSeen"
-            ],
-            "properties": {
-              "objectid": {
-                "type": "string"
-              },
-              "name": {
-                "type": "string"
-              },
-              "displayName": {
-                "type": "string"
-              },
-              "lastSeen": {
-                "type": "string",
-                "format": "date-time"
-              }
-            }
-          }
-        }
-      },
-      "NodeDetailsWithInfo": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/NodeDetails"
-          },
-          {
-            "type": "object",
-            "properties": {
-              "info": {
-                "type": "array",
-                "items": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/KindInfoResponse"
-                    },
-                    {
-                      "type": "object",
-                      "required": [
-                        "node_kind_id"
-                      ],
-                      "properties": {
-                        "node_kind_id": {
-                          "type": "integer"
-                        }
-                      }
-                    }
-                  ]
-                }
-              }
-            }
-          }
-        ]
-      },
-      "KindInfoResponse": {
-        "allOf": [
-          {
-            "type": "object",
-            "required": [
-              "name"
-            ],
-            "properties": {
-              "name": {
-                "type": "string",
-                "example": "panel_section_1"
-              }
-            }
-          },
-          {
-            "$ref": "#/components/schemas/KindInfoBase"
-          },
-          {
-            "$ref": "#/components/schemas/KindInfoContent"
-          }
-        ]
-      },
-      "KindInfoBase": {
-        "type": "object",
-        "required": [
-          "title",
-          "position"
-        ],
-        "properties": {
-          "title": {
-            "type": "string",
-            "example": "Entity Panel Section"
-          },
-          "position": {
-            "type": "integer",
-            "minimum": 1
-          }
-        }
-      },
-      "KindInfoContent": {
-        "type": "object",
-        "oneOf": [
-          {
-            "$ref": "#/components/schemas/InfoMarkdown"
-          }
-        ]
-      },
-      "InfoMarkdownContent": {
-        "type": "object",
-        "required": [
-          "markdown"
-        ],
-        "properties": {
-          "markdown": {
-            "type": "object",
-            "required": [
-              "content"
-            ],
-            "properties": {
-              "content": {
-                "type": "string"
-              }
-            }
-          }
-        }
-      },
-      "InfoMarkdown": {
-        "$ref": "#/components/schemas/InfoMarkdownContent"
-      }
-    },
-    "examples": {
-      "NodeDetailsExample": {
-        "summary": "Basic Node Details",
-        "value": {
-          "data": {
-            "node_id": 278346,
-            "kinds": [
-              {
-                "name": "Okta",
-                "node_kind_id": 263476
-              },
-              {
-                "name": "Okta_Organization",
-                "node_kind_id": 28937
-              },
-              {
-                "name": "Tag_Tier_Zero",
-                "node_kind_id": 987234
-              }
-            ],
-            "properties": {
-              "objectid": "00ow0o8if0CNwsKmk697",
-              "name": "contoso.okta.com",
-              "displayName": "Contoso",
-              "oktaDomain": "contoso.okta.com",
-              "subdomain": "contoso",
-              "status": "ACTIVE",
-              "created": "2025-10-02T09:21:31+00:00",
-              "lastSeen": "2025-12-09T23:04:15+00:00",
-              "lastUpdated": "2025-12-09T23:04:15+00:00"
-            }
-          }
-        }
-      },
-      "NodeDetailsWithInfoExample": {
-        "summary": "Node Details with Entity Panel Info",
-        "value": {
-          "data": {
-            "node_id": 278346,
-            "kinds": [
-              {
-                "name": "Okta",
-                "node_kind_id": 263476
-              },
-              {
-                "name": "Okta_Organization",
-                "node_kind_id": 28937
-              },
-              {
-                "name": "Tag_Tier_Zero",
-                "node_kind_id": 987234
-              }
-            ],
-            "properties": {
-              "objectid": "00ow0o8if0CNwsKmk697",
-              "name": "contoso.okta.com",
-              "displayName": "Contoso",
-              "oktaDomain": "contoso.okta.com",
-              "subdomain": "contoso",
-              "status": "ACTIVE",
-              "created": "2025-10-02T09:21:31+00:00",
-              "lastSeen": "2025-12-09T23:04:15+00:00",
-              "lastUpdated": "2025-12-09T23:04:15+00:00"
-            },
-            "info": [
-              {
-                "name": "panel1",
-                "title": "Info Panel Section 1",
-                "position": 1,
-                "node_kind_id": 827364,
-                "markdown": {
-                  "content": "This node represents a user account."
-                }
-              },
-              {
-                "name": "panel2",
-                "title": "Info Panel Section 2",
-                "position": 2,
-                "node_kind_id": 827364,
-                 "markdown": {
-                  "content": "This is some context for your selection."
-                }
-              }
-            ]
-          }
-        }
       }
     },
     "responses": {

--- a/packages/go/openapi/doc/openapi.json
+++ b/packages/go/openapi/doc/openapi.json
@@ -7341,22 +7341,22 @@
             }
           },
           "400": {
-            "description": "Bad Request"
+            "$ref": "#/components/responses/bad-request"
           },
           "401": {
-            "description": "Unauthorized"
+            "$ref": "#/components/responses/unauthorized"
           },
           "403": {
-            "description": "Forbidden"
+            "$ref": "#/components/responses/forbidden"
           },
           "404": {
-            "description": "Not found"
+            "$ref": "#/components/responses/not-found"
           },
           "429": {
-            "description": "Too Many Requests"
+            "$ref": "#/components/responses/too-many-requests"
           },
           "500": {
-            "description": "Internal Server Error"
+            "$ref": "#/components/responses/internal-server-error"
           }
         }
       }

--- a/packages/go/openapi/doc/openapi.json
+++ b/packages/go/openapi/doc/openapi.json
@@ -7302,16 +7302,144 @@
           "Community",
           "Enterprise"
         ],
+        "parameters": [
+          {
+            "name": "include-info",
+            "in": "query",
+            "required": false,
+            "description": "When true, populates `data.info` with kindinfo objects for the node's registered kinds.",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
         "responses": {
           "200": {
-            "description": "OK",
+            "description": "OK\n\nWhen `include-info=true`, the `info` field is populated with kindinfo objects.\n",
             "content": {
               "application/json": {
                 "schema": {
                   "type": "object",
                   "properties": {
                     "data": {
-                      "$ref": "#/components/schemas/model.node-details"
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/model.node-details"
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "info": {
+                              "type": "array",
+                              "description": "Kindinfo objects populated when `include-info=true`.",
+                              "items": {
+                                "type": "object",
+                                "required": [
+                                  "name",
+                                  "title",
+                                  "position",
+                                  "node_kind_id",
+                                  "markdown"
+                                ],
+                                "properties": {
+                                  "name": {
+                                    "type": "string",
+                                    "description": "Kindinfo key."
+                                  },
+                                  "title": {
+                                    "type": "string",
+                                    "description": "Human-readable kindinfo title."
+                                  },
+                                  "position": {
+                                    "type": "integer",
+                                    "format": "int32",
+                                    "description": "Display position for the kindinfo object."
+                                  },
+                                  "node_kind_id": {
+                                    "type": "integer",
+                                    "format": "int32",
+                                    "description": "Schema node kind ID associated with the kindinfo object."
+                                  },
+                                  "markdown": {
+                                    "type": "object",
+                                    "required": [
+                                      "content"
+                                    ],
+                                    "properties": {
+                                      "content": {
+                                        "type": "string",
+                                        "description": "Markdown content for the kindinfo object."
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                },
+                "examples": {
+                  "Info omitted": {
+                    "summary": "Node details when include-info is not present",
+                    "value": {
+                      "data": {
+                        "node_id": 1234567890,
+                        "kinds": [
+                          {
+                            "node_kind_id": 1,
+                            "name": "User"
+                          },
+                          {
+                            "node_kind_id": 2,
+                            "name": "Entity"
+                          }
+                        ],
+                        "properties": {
+                          "objectid": "S-1-5-21-3130019616-2776909439-2417379446-1108",
+                          "name": "ADMIN@CORP.EXAMPLE.COM",
+                          "displayName": "Admin",
+                          "lastSeen": "2026-07-14T18:24:32Z"
+                        }
+                      }
+                    }
+                  },
+                  "Info included": {
+                    "summary": "Node details when include-info is true",
+                    "value": {
+                      "data": {
+                        "node_id": 1234567890,
+                        "kinds": [
+                          {
+                            "node_kind_id": 1,
+                            "name": "User"
+                          },
+                          {
+                            "node_kind_id": 2,
+                            "name": "Entity"
+                          }
+                        ],
+                        "properties": {
+                          "objectid": "S-1-5-21-3130019616-2776909439-2417379446-1108",
+                          "name": "ADMIN@CORP.EXAMPLE.COM",
+                          "displayName": "Admin",
+                          "lastSeen": "2026-07-14T18:24:32Z"
+                        },
+                        "info": [
+                          {
+                            "name": "overview",
+                            "title": "Overview",
+                            "position": 0,
+                            "node_kind_id": 1,
+                            "markdown": {
+                              "content": "This user has privileged access in the environment."
+                            }
+                          }
+                        ]
+                      }
                     }
                   }
                 }

--- a/packages/go/openapi/src/paths/graph.nodes.id.yaml
+++ b/packages/go/openapi/src/paths/graph.nodes.id.yaml
@@ -30,16 +30,102 @@ get:
     - OpenGraph (Experimental)
     - Community
     - Enterprise
+  parameters:
+    - name: include-info
+      in: query
+      required: false
+      description: When true, populates `data.info` with kindinfo objects for the node's registered kinds.
+      schema:
+        type: boolean
+        default: false
   responses:
     200:
-      description: OK
+      description: |
+        OK
+
+        When `include-info=true`, the `info` field is populated with kindinfo objects.
       content:
         application/json:
           schema:
             type: object
             properties:
               data:
-                $ref: './../schemas/model.node-details.yaml'
+                allOf:
+                  - $ref: './../schemas/model.node-details.yaml'
+                  - type: object
+                    properties:
+                      info:
+                        type: array
+                        description: Kindinfo objects populated when `include-info=true`.
+                        items:
+                          type: object
+                          required:
+                            - name
+                            - title
+                            - position
+                            - node_kind_id
+                            - markdown
+                          properties:
+                            name:
+                              type: string
+                              description: Kindinfo key.
+                            title:
+                              type: string
+                              description: Human-readable kindinfo title.
+                            position:
+                              type: integer
+                              format: int32
+                              description: Display position for the kindinfo object.
+                            node_kind_id:
+                              type: integer
+                              format: int32
+                              description: Schema node kind ID associated with the kindinfo object.
+                            markdown:
+                              type: object
+                              required:
+                                - content
+                              properties:
+                                content:
+                                  type: string
+                                  description: Markdown content for the kindinfo object.
+          examples:
+            Info omitted:
+              summary: Node details when include-info is not present
+              value:
+                data:
+                  node_id: 1234567890
+                  kinds:
+                    - node_kind_id: 1
+                      name: User
+                    - node_kind_id: 2
+                      name: Entity
+                  properties:
+                    objectid: S-1-5-21-3130019616-2776909439-2417379446-1108
+                    name: ADMIN@CORP.EXAMPLE.COM
+                    displayName: Admin
+                    lastSeen: "2026-07-14T18:24:32Z"
+            Info included:
+              summary: Node details when include-info is true
+              value:
+                data:
+                  node_id: 1234567890
+                  kinds:
+                    - node_kind_id: 1
+                      name: User
+                    - node_kind_id: 2
+                      name: Entity
+                  properties:
+                    objectid: S-1-5-21-3130019616-2776909439-2417379446-1108
+                    name: ADMIN@CORP.EXAMPLE.COM
+                    displayName: Admin
+                    lastSeen: "2026-07-14T18:24:32Z"
+                  info:
+                    - name: overview
+                      title: Overview
+                      position: 0
+                      node_kind_id: 1
+                      markdown:
+                        content: This user has privileged access in the environment.
     400:
       $ref: './../responses/bad-request.yaml'
     401:

--- a/server/graphdb/internal/appdb/kindinfo.go
+++ b/server/graphdb/internal/appdb/kindinfo.go
@@ -59,9 +59,9 @@ func toKindInfo(row kindInfoRow) services.KindInfo {
 	}
 }
 
-// GetKindInfos returns all KindInfo's associated with the given kind_id,
+// GetKindInfos returns all KindInfo's associated with the given node or relationship kind,
 // ordered by position then title. An empty slice is returned when no rows match.
-func (s *Store) GetKindInfos(ctx context.Context, kindID int32) ([]services.KindInfo, error) {
+func (s *Store) GetKindInfos(ctx context.Context, nodeKindID *int32, relationshipKindID *int32) ([]services.KindInfo, error) {
 	var (
 		selectBuilder = sqlbuilder.PostgreSQL.NewSelectBuilder()
 		sqlQuery      string
@@ -84,7 +84,18 @@ func (s *Store) GetKindInfos(ctx context.Context, kindID int32) ([]services.Kind
 		"updated_at",
 	)
 	selectBuilder.From(tableSchemaKindInfo)
-	selectBuilder.Where(selectBuilder.Equal("kind_id", kindID))
+
+	switch {
+	case nodeKindID == nil && relationshipKindID == nil:
+		return nil, fmt.Errorf("exactly one of nodeKindID or relationshipKindID must be provided")
+	case nodeKindID != nil && relationshipKindID != nil:
+		return nil, fmt.Errorf("exactly one of nodeKindID or relationshipKindID must be provided")
+	case nodeKindID != nil:
+		selectBuilder.Where(selectBuilder.Equal("node_kind_id", *nodeKindID))
+	default:
+		selectBuilder.Where(selectBuilder.Equal("relationship_kind_id", *relationshipKindID))
+	}
+
 	selectBuilder.OrderBy("position", "title")
 
 	sqlQuery, args = selectBuilder.Build()

--- a/server/graphdb/internal/appdb/kindinfo.go
+++ b/server/graphdb/internal/appdb/kindinfo.go
@@ -86,7 +86,7 @@ func (s *Store) GetKindInfos(ctx context.Context, kindName string) ([]services.K
 	selectBuilder.From(selectBuilder.As(tableSchemaKindInfo, "ki"))
 	selectBuilder.Join(selectBuilder.As(tableKind, "k"), "ki.kind_id = k.id")
 	selectBuilder.Where(selectBuilder.Equal("k.name", kindName))
-	selectBuilder.OrderBy("position", "title")
+	selectBuilder.OrderBy("ki.position", "ki.title")
 
 	sqlQuery, args = selectBuilder.Build()
 

--- a/server/graphdb/internal/appdb/kindinfo.go
+++ b/server/graphdb/internal/appdb/kindinfo.go
@@ -59,9 +59,9 @@ func toKindInfo(row kindInfoRow) services.KindInfo {
 	}
 }
 
-// GetKindInfos returns all KindInfo's associated with the given node or relationship kind,
+// GetKindInfos returns all KindInfo's associated with the given kind name,
 // ordered by position then title. An empty slice is returned when no rows match.
-func (s *Store) GetKindInfos(ctx context.Context, nodeKindID *int32, relationshipKindID *int32) ([]services.KindInfo, error) {
+func (s *Store) GetKindInfos(ctx context.Context, kindName string) ([]services.KindInfo, error) {
 	var (
 		selectBuilder = sqlbuilder.PostgreSQL.NewSelectBuilder()
 		sqlQuery      string
@@ -72,30 +72,20 @@ func (s *Store) GetKindInfos(ctx context.Context, nodeKindID *int32, relationshi
 	)
 
 	selectBuilder.Select(
-		"id",
-		"kind_id",
-		"node_kind_id",
-		"relationship_kind_id",
-		"info_key",
-		"title",
-		"position",
-		"content",
-		"created_at",
-		"updated_at",
+		"ki.id",
+		"ki.kind_id",
+		"ki.node_kind_id",
+		"ki.relationship_kind_id",
+		"ki.info_key",
+		"ki.title",
+		"ki.position",
+		"ki.content",
+		"ki.created_at",
+		"ki.updated_at",
 	)
-	selectBuilder.From(tableSchemaKindInfo)
-
-	switch {
-	case nodeKindID == nil && relationshipKindID == nil:
-		return nil, fmt.Errorf("exactly one of nodeKindID or relationshipKindID must be provided")
-	case nodeKindID != nil && relationshipKindID != nil:
-		return nil, fmt.Errorf("exactly one of nodeKindID or relationshipKindID must be provided")
-	case nodeKindID != nil:
-		selectBuilder.Where(selectBuilder.Equal("node_kind_id", *nodeKindID))
-	default:
-		selectBuilder.Where(selectBuilder.Equal("relationship_kind_id", *relationshipKindID))
-	}
-
+	selectBuilder.From(selectBuilder.As(tableSchemaKindInfo, "ki"))
+	selectBuilder.Join(selectBuilder.As(tableKind, "k"), "ki.kind_id = k.id")
+	selectBuilder.Where(selectBuilder.Equal("k.name", kindName))
 	selectBuilder.OrderBy("position", "title")
 
 	sqlQuery, args = selectBuilder.Build()

--- a/server/graphdb/internal/handlers/handlers.go
+++ b/server/graphdb/internal/handlers/handlers.go
@@ -27,7 +27,7 @@ import (
 // GraphDB defines the graphdb service boundary for the graphdb handlers package.
 type GraphDB interface {
 	GetRelationship(ctx context.Context, id int64) (services.Relationship, error)
-	GetNode(ctx context.Context, id int64) (services.Node, error)
+	GetNode(ctx context.Context, id int64, includeKindInfo bool) (services.Node, error)
 }
 
 // Handlers is a dependency injection container for graphdb handlers.

--- a/server/graphdb/internal/handlers/mocks/graphdb.go
+++ b/server/graphdb/internal/handlers/mocks/graphdb.go
@@ -54,8 +54,8 @@ func (_m *MockGraphDB) EXPECT() *MockGraphDB_Expecter {
 }
 
 // GetNode provides a mock function for the type MockGraphDB
-func (_mock *MockGraphDB) GetNode(ctx context.Context, id int64) (services.Node, error) {
-	ret := _mock.Called(ctx, id)
+func (_mock *MockGraphDB) GetNode(ctx context.Context, id int64, includeKindInfo bool) (services.Node, error) {
+	ret := _mock.Called(ctx, id, includeKindInfo)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetNode")
@@ -63,16 +63,16 @@ func (_mock *MockGraphDB) GetNode(ctx context.Context, id int64) (services.Node,
 
 	var r0 services.Node
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, int64) (services.Node, error)); ok {
-		return returnFunc(ctx, id)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, int64, bool) (services.Node, error)); ok {
+		return returnFunc(ctx, id, includeKindInfo)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, int64) services.Node); ok {
-		r0 = returnFunc(ctx, id)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, int64, bool) services.Node); ok {
+		r0 = returnFunc(ctx, id, includeKindInfo)
 	} else {
 		r0 = ret.Get(0).(services.Node)
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, int64) error); ok {
-		r1 = returnFunc(ctx, id)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, int64, bool) error); ok {
+		r1 = returnFunc(ctx, id, includeKindInfo)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -87,11 +87,12 @@ type MockGraphDB_GetNode_Call struct {
 // GetNode is a helper method to define mock.On call
 //   - ctx context.Context
 //   - id int64
-func (_e *MockGraphDB_Expecter) GetNode(ctx interface{}, id interface{}) *MockGraphDB_GetNode_Call {
-	return &MockGraphDB_GetNode_Call{Call: _e.mock.On("GetNode", ctx, id)}
+//   - includeKindInfo bool
+func (_e *MockGraphDB_Expecter) GetNode(ctx interface{}, id interface{}, includeKindInfo interface{}) *MockGraphDB_GetNode_Call {
+	return &MockGraphDB_GetNode_Call{Call: _e.mock.On("GetNode", ctx, id, includeKindInfo)}
 }
 
-func (_c *MockGraphDB_GetNode_Call) Run(run func(ctx context.Context, id int64)) *MockGraphDB_GetNode_Call {
+func (_c *MockGraphDB_GetNode_Call) Run(run func(ctx context.Context, id int64, includeKindInfo bool)) *MockGraphDB_GetNode_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -101,9 +102,14 @@ func (_c *MockGraphDB_GetNode_Call) Run(run func(ctx context.Context, id int64))
 		if args[1] != nil {
 			arg1 = args[1].(int64)
 		}
+		var arg2 bool
+		if args[2] != nil {
+			arg2 = args[2].(bool)
+		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -114,7 +120,7 @@ func (_c *MockGraphDB_GetNode_Call) Return(node services.Node, err error) *MockG
 	return _c
 }
 
-func (_c *MockGraphDB_GetNode_Call) RunAndReturn(run func(ctx context.Context, id int64) (services.Node, error)) *MockGraphDB_GetNode_Call {
+func (_c *MockGraphDB_GetNode_Call) RunAndReturn(run func(ctx context.Context, id int64, includeKindInfo bool) (services.Node, error)) *MockGraphDB_GetNode_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/server/graphdb/internal/handlers/node.go
+++ b/server/graphdb/internal/handlers/node.go
@@ -61,12 +61,10 @@ type NodeView struct {
 	NodeID     int64          `json:"node_id"`
 	Kinds      []NodeKindView `json:"kinds"`
 	Properties map[string]any `json:"properties"`
-	KindInfos  []KindInfoView `json:"info"`
+	KindInfos  []KindInfoView `json:"info,omitempty"`
 }
 
-// BuildNodeView projects a services.Node into the view type the handlers
-// return in their JSON envelope.
-func BuildNodeView(node services.Node) NodeView {
+func BuildNodeView(node services.Node, includeInfo bool) NodeView {
 	kinds := []NodeKindView{}
 
 	for _, kind := range node.Kinds {
@@ -76,23 +74,25 @@ func BuildNodeView(node services.Node) NodeView {
 		})
 	}
 
-	kindInfos := []KindInfoView{}
-	for _, kindInfo := range node.KindInfos {
-		kindInfos = append(kindInfos, KindInfoView{
-			Name:       kindInfo.InfoKey,
-			Title:      kindInfo.Title,
-			Position:   kindInfo.Position,
-			NodeKindID: int(*kindInfo.NodeKindID),
-			Markdown:   buildMarkdownView(kindInfo.Content),
-		})
-	}
-
-	return NodeView{
+	nodeView := NodeView{
 		NodeID:     node.ID,
 		Kinds:      kinds,
 		Properties: node.Properties,
-		KindInfos:  kindInfos,
 	}
+
+	if includeInfo {
+		for _, kindInfo := range node.KindInfos {
+			nodeView.KindInfos = append(nodeView.KindInfos, KindInfoView{
+				Name:       kindInfo.InfoKey,
+				Title:      kindInfo.Title,
+				Position:   kindInfo.Position,
+				NodeKindID: int(*kindInfo.NodeKindID),
+				Markdown:   buildMarkdownView(kindInfo.Content),
+			})
+		}
+	}
+
+	return nodeView
 }
 
 func buildMarkdownView(content json.RawMessage) MarkdownView {
@@ -116,17 +116,27 @@ func (s NodeView) JSONView() ([]byte, error) {
 // node or its kinds cannot be found, and 200 with the node details otherwise.
 func (s Handlers) GetNodeByID(response http.ResponseWriter, request *http.Request) {
 	var (
-		ctx       = request.Context()
-		rawNodeID = mux.Vars(request)[URIPathVariableNodeID]
+		ctx            = request.Context()
+		nodeIDRaw      = mux.Vars(request)[URIPathVariableNodeID]
+		includeInfoRaw = request.URL.Query().Get("includeInfo")
+		includeInfo    bool
+		err            error
 	)
 
-	if nodeID, err := strconv.ParseInt(rawNodeID, 10, 64); err != nil {
+	if includeInfoRaw != "" {
+		if includeInfo, err = strconv.ParseBool(includeInfoRaw); err != nil {
+			responses.WriteError(ctx, http.StatusBadRequest, "includeInfo is malformed", response)
+			return
+		}
+	}
+
+	if nodeID, err := strconv.ParseInt(nodeIDRaw, 10, 64); err != nil {
 		responses.WriteError(ctx, http.StatusBadRequest, "node id is malformed", response)
-	} else if node, err := s.graphDB.GetNode(ctx, nodeID, true); errors.Is(err, services.ErrNodeNotFound) || errors.Is(err, services.ErrKindNotFound) {
+	} else if node, err := s.graphDB.GetNode(ctx, nodeID, includeInfo); errors.Is(err, services.ErrNodeNotFound) || errors.Is(err, services.ErrKindNotFound) {
 		responses.WriteError(ctx, http.StatusNotFound, "node not found", response)
 	} else if err != nil {
 		responses.WriteInternalServerError(ctx, err, response)
 	} else {
-		responses.WriteBasic(ctx, BuildNodeView(node), http.StatusOK, response)
+		responses.WriteBasic(ctx, BuildNodeView(node, includeInfo), http.StatusOK, response)
 	}
 }

--- a/server/graphdb/internal/handlers/node.go
+++ b/server/graphdb/internal/handlers/node.go
@@ -38,6 +38,22 @@ type NodeKindView struct {
 	Name       string `json:"name"`
 }
 
+type KindInfoView struct {
+	Name       string       `json:"name"`
+	Title      string       `json:"title"`
+	Position   int32        `json:"position"`
+	NodeKindID int          `json:"node_kind_id"`
+	Markdown   MarkdownView `json:"markdown"`
+}
+
+type MarkdownView struct {
+	Content string `json:"content"`
+}
+
+type kindInfoContentView struct {
+	Markdown MarkdownView `json:"markdown"`
+}
+
 // NodeView is the JSON shape returned by the node handlers. It is
 // decoupled from services.Node so the wire format can evolve independently of
 // the domain model.
@@ -45,12 +61,13 @@ type NodeView struct {
 	NodeID     int64          `json:"node_id"`
 	Kinds      []NodeKindView `json:"kinds"`
 	Properties map[string]any `json:"properties"`
+	KindInfos  []KindInfoView `json:"info"`
 }
 
 // BuildNodeView projects a services.Node into the view type the handlers
 // return in their JSON envelope.
 func BuildNodeView(node services.Node) NodeView {
-	var kinds []NodeKindView
+	kinds := []NodeKindView{}
 
 	for _, kind := range node.Kinds {
 		kinds = append(kinds, NodeKindView{
@@ -59,11 +76,33 @@ func BuildNodeView(node services.Node) NodeView {
 		})
 	}
 
+	kindInfos := []KindInfoView{}
+	for _, kindInfo := range node.KindInfos {
+		kindInfos = append(kindInfos, KindInfoView{
+			Name:       kindInfo.InfoKey,
+			Title:      kindInfo.Title,
+			Position:   kindInfo.Position,
+			NodeKindID: int(*kindInfo.NodeKindID),
+			Markdown:   buildMarkdownView(kindInfo.Content),
+		})
+	}
+
 	return NodeView{
 		NodeID:     node.ID,
 		Kinds:      kinds,
 		Properties: node.Properties,
+		KindInfos:  kindInfos,
 	}
+}
+
+func buildMarkdownView(content json.RawMessage) MarkdownView {
+	var contentView kindInfoContentView
+
+	if err := json.Unmarshal(content, &contentView); err != nil {
+		return MarkdownView{}
+	}
+
+	return contentView.Markdown
 }
 
 // JSONView marshals the view to the byte slice expected by responses.WriteBasic,
@@ -83,7 +122,7 @@ func (s Handlers) GetNodeByID(response http.ResponseWriter, request *http.Reques
 
 	if nodeID, err := strconv.ParseInt(rawNodeID, 10, 64); err != nil {
 		responses.WriteError(ctx, http.StatusBadRequest, "node id is malformed", response)
-	} else if node, err := s.graphDB.GetNode(ctx, nodeID); errors.Is(err, services.ErrNodeNotFound) || errors.Is(err, services.ErrKindNotFound) {
+	} else if node, err := s.graphDB.GetNode(ctx, nodeID, true); errors.Is(err, services.ErrNodeNotFound) || errors.Is(err, services.ErrKindNotFound) {
 		responses.WriteError(ctx, http.StatusNotFound, "node not found", response)
 	} else if err != nil {
 		responses.WriteInternalServerError(ctx, err, response)

--- a/server/graphdb/internal/handlers/node.go
+++ b/server/graphdb/internal/handlers/node.go
@@ -82,6 +82,10 @@ func BuildNodeView(node services.Node, includeInfo bool) NodeView {
 
 	if includeInfo {
 		for _, kindInfo := range node.KindInfos {
+			if kindInfo.NodeKindID == nil {
+				continue
+			}
+
 			nodeView.KindInfos = append(nodeView.KindInfos, KindInfoView{
 				Name:       kindInfo.InfoKey,
 				Title:      kindInfo.Title,

--- a/server/graphdb/internal/handlers/node.go
+++ b/server/graphdb/internal/handlers/node.go
@@ -118,14 +118,14 @@ func (s Handlers) GetNodeByID(response http.ResponseWriter, request *http.Reques
 	var (
 		ctx            = request.Context()
 		nodeIDRaw      = mux.Vars(request)[URIPathVariableNodeID]
-		includeInfoRaw = request.URL.Query().Get("includeInfo")
+		includeInfoRaw = request.URL.Query().Get("include-info")
 		includeInfo    bool
 		err            error
 	)
 
 	if includeInfoRaw != "" {
 		if includeInfo, err = strconv.ParseBool(includeInfoRaw); err != nil {
-			responses.WriteError(ctx, http.StatusBadRequest, "includeInfo is malformed", response)
+			responses.WriteError(ctx, http.StatusBadRequest, "include-info is malformed", response)
 			return
 		}
 	}

--- a/server/graphdb/internal/handlers/node_test.go
+++ b/server/graphdb/internal/handlers/node_test.go
@@ -79,9 +79,9 @@ func TestHandlers_GetNodeByID(t *testing.T) {
 		assertBody func(t *testing.T, body []byte)
 	}{
 		{
-			name:     "returns 200 with the node view and info when includeInfo is true",
+			name:     "returns 200 with the node view and info when include-info is true",
 			rawID:    "9876543210",
-			rawQuery: "includeInfo=true",
+			rawQuery: "include-info=true",
 			setupMock: func(graphDBMock *mocks.MockGraphDB) {
 				graphDBMock.EXPECT().GetNode(mock.Anything, nodeID, true).Return(node, nil)
 			},
@@ -106,7 +106,7 @@ func TestHandlers_GetNodeByID(t *testing.T) {
 			},
 		},
 		{
-			name:  "returns 200 without info when includeInfo is omitted",
+			name:  "returns 200 without info when include-info is omitted",
 			rawID: "9876543210",
 			setupMock: func(graphDBMock *mocks.MockGraphDB) {
 				graphDBMock.EXPECT().GetNode(mock.Anything, nodeID, false).Return(node, nil)
@@ -127,9 +127,9 @@ func TestHandlers_GetNodeByID(t *testing.T) {
 			wantStatus: http.StatusBadRequest,
 		},
 		{
-			name:       "returns 400 when includeInfo is malformed",
+			name:       "returns 400 when include-info is malformed",
 			rawID:      "9876543210",
-			rawQuery:   "includeInfo=wat",
+			rawQuery:   "include-info=wat",
 			wantStatus: http.StatusBadRequest,
 		},
 		{

--- a/server/graphdb/internal/handlers/node_test.go
+++ b/server/graphdb/internal/handlers/node_test.go
@@ -33,10 +33,13 @@ import (
 
 // newNodeRequestWithID builds a GET request whose mux path variables carry the
 // supplied raw node id, mirroring what the router does at runtime.
-func newNodeRequestWithID(t *testing.T, rawID string) *http.Request {
+func newNodeRequestWithID(t *testing.T, rawID string, rawQuery ...string) *http.Request {
 	t.Helper()
 	request, err := http.NewRequest(http.MethodGet, "/api/v2/nodes/"+rawID, nil)
 	require.NoError(t, err)
+	if len(rawQuery) > 0 {
+		request.URL.RawQuery = rawQuery[0]
+	}
 	return mux.SetURLVars(request, map[string]string{handlers.URIPathVariableNodeID: rawID})
 }
 
@@ -70,13 +73,15 @@ func TestHandlers_GetNodeByID(t *testing.T) {
 	tests := []struct {
 		name       string
 		rawID      string
+		rawQuery   string
 		setupMock  func(graphDBMock *mocks.MockGraphDB)
 		wantStatus int
 		assertBody func(t *testing.T, body []byte)
 	}{
 		{
-			name:  "returns 200 with the node view on success",
-			rawID: "9876543210",
+			name:     "returns 200 with the node view and info when includeInfo is true",
+			rawID:    "9876543210",
+			rawQuery: "includeInfo=true",
 			setupMock: func(graphDBMock *mocks.MockGraphDB) {
 				graphDBMock.EXPECT().GetNode(mock.Anything, nodeID, true).Return(node, nil)
 			},
@@ -101,15 +106,37 @@ func TestHandlers_GetNodeByID(t *testing.T) {
 			},
 		},
 		{
+			name:  "returns 200 without info when includeInfo is omitted",
+			rawID: "9876543210",
+			setupMock: func(graphDBMock *mocks.MockGraphDB) {
+				graphDBMock.EXPECT().GetNode(mock.Anything, nodeID, false).Return(node, nil)
+			},
+			wantStatus: http.StatusOK,
+			assertBody: func(t *testing.T, body []byte) {
+				var envelope struct {
+					Data map[string]any `json:"data"`
+				}
+				require.NoError(t, json.Unmarshal(body, &envelope))
+				assert.NotContains(t, envelope.Data, "info")
+				assert.NotContains(t, string(body), `"info"`)
+			},
+		},
+		{
 			name:       "returns 400 when the id is malformed",
 			rawID:      "not-a-number",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "returns 400 when includeInfo is malformed",
+			rawID:      "9876543210",
+			rawQuery:   "includeInfo=wat",
 			wantStatus: http.StatusBadRequest,
 		},
 		{
 			name:  "returns 404 when the node is not found",
 			rawID: "9876543210",
 			setupMock: func(graphDBMock *mocks.MockGraphDB) {
-				graphDBMock.EXPECT().GetNode(mock.Anything, nodeID, true).Return(services.Node{}, services.ErrNodeNotFound)
+				graphDBMock.EXPECT().GetNode(mock.Anything, nodeID, false).Return(services.Node{}, services.ErrNodeNotFound)
 			},
 			wantStatus: http.StatusNotFound,
 		},
@@ -117,7 +144,7 @@ func TestHandlers_GetNodeByID(t *testing.T) {
 			name:  "returns 404 when the kind is not found",
 			rawID: "9876543210",
 			setupMock: func(graphDBMock *mocks.MockGraphDB) {
-				graphDBMock.EXPECT().GetNode(mock.Anything, nodeID, true).Return(services.Node{}, services.ErrKindNotFound)
+				graphDBMock.EXPECT().GetNode(mock.Anything, nodeID, false).Return(services.Node{}, services.ErrKindNotFound)
 			},
 			wantStatus: http.StatusNotFound,
 		},
@@ -129,7 +156,7 @@ func TestHandlers_GetNodeByID(t *testing.T) {
 				graphDBMock = mocks.NewMockGraphDB(t)
 				handlerSet  = handlers.NewHandlersContainer(graphDBMock)
 				recorder    = httptest.NewRecorder()
-				request     = newNodeRequestWithID(t, tt.rawID)
+				request     = newNodeRequestWithID(t, tt.rawID, tt.rawQuery)
 			)
 
 			if tt.setupMock != nil {

--- a/server/graphdb/internal/handlers/node_test.go
+++ b/server/graphdb/internal/handlers/node_test.go
@@ -55,6 +55,15 @@ func TestHandlers_GetNodeByID(t *testing.T) {
 				{ID: int32Ptr(2), Name: "Group"},
 			},
 			Properties: map[string]any{"name": "admin"},
+			KindInfos: []services.KindInfo{
+				{
+					InfoKey:    "overview",
+					Title:      "Overview",
+					Position:   0,
+					NodeKindID: int32Ptr(1),
+					Content:    json.RawMessage(`{"markdown":{"content":"one"}}`),
+				},
+			},
 		}
 	)
 
@@ -69,7 +78,7 @@ func TestHandlers_GetNodeByID(t *testing.T) {
 			name:  "returns 200 with the node view on success",
 			rawID: "9876543210",
 			setupMock: func(graphDBMock *mocks.MockGraphDB) {
-				graphDBMock.EXPECT().GetNode(mock.Anything, nodeID).Return(node, nil)
+				graphDBMock.EXPECT().GetNode(mock.Anything, nodeID, true).Return(node, nil)
 			},
 			wantStatus: http.StatusOK,
 			assertBody: func(t *testing.T, body []byte) {
@@ -86,6 +95,9 @@ func TestHandlers_GetNodeByID(t *testing.T) {
 				assert.Equal(t, int32(2), *envelope.Data.Kinds[1].NodeKindID)
 				assert.Equal(t, "Group", envelope.Data.Kinds[1].Name)
 				assert.Equal(t, "admin", envelope.Data.Properties["name"])
+				require.Len(t, envelope.Data.KindInfos, 1)
+				assert.Equal(t, "one", envelope.Data.KindInfos[0].Markdown.Content)
+				assert.NotContains(t, string(body), `\"markdown\"`)
 			},
 		},
 		{
@@ -97,7 +109,7 @@ func TestHandlers_GetNodeByID(t *testing.T) {
 			name:  "returns 404 when the node is not found",
 			rawID: "9876543210",
 			setupMock: func(graphDBMock *mocks.MockGraphDB) {
-				graphDBMock.EXPECT().GetNode(mock.Anything, nodeID).Return(services.Node{}, services.ErrNodeNotFound)
+				graphDBMock.EXPECT().GetNode(mock.Anything, nodeID, true).Return(services.Node{}, services.ErrNodeNotFound)
 			},
 			wantStatus: http.StatusNotFound,
 		},
@@ -105,7 +117,7 @@ func TestHandlers_GetNodeByID(t *testing.T) {
 			name:  "returns 404 when the kind is not found",
 			rawID: "9876543210",
 			setupMock: func(graphDBMock *mocks.MockGraphDB) {
-				graphDBMock.EXPECT().GetNode(mock.Anything, nodeID).Return(services.Node{}, services.ErrKindNotFound)
+				graphDBMock.EXPECT().GetNode(mock.Anything, nodeID, true).Return(services.Node{}, services.ErrKindNotFound)
 			},
 			wantStatus: http.StatusNotFound,
 		},

--- a/server/graphdb/internal/services/mocks/database.go
+++ b/server/graphdb/internal/services/mocks/database.go
@@ -119,6 +119,80 @@ func (_c *MockDatabase_GetKindByName_Call) RunAndReturn(run func(ctx context.Con
 	return _c
 }
 
+// GetKindInfos provides a mock function for the type MockDatabase
+func (_mock *MockDatabase) GetKindInfos(ctx context.Context, nodeKindID *int32, relationshipKindID *int32) ([]services.KindInfo, error) {
+	ret := _mock.Called(ctx, nodeKindID, relationshipKindID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetKindInfos")
+	}
+
+	var r0 []services.KindInfo
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *int32, *int32) ([]services.KindInfo, error)); ok {
+		return returnFunc(ctx, nodeKindID, relationshipKindID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *int32, *int32) []services.KindInfo); ok {
+		r0 = returnFunc(ctx, nodeKindID, relationshipKindID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]services.KindInfo)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, *int32, *int32) error); ok {
+		r1 = returnFunc(ctx, nodeKindID, relationshipKindID)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockDatabase_GetKindInfos_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetKindInfos'
+type MockDatabase_GetKindInfos_Call struct {
+	*mock.Call
+}
+
+// GetKindInfos is a helper method to define mock.On call
+//   - ctx context.Context
+//   - nodeKindID *int32
+//   - relationshipKindID *int32
+func (_e *MockDatabase_Expecter) GetKindInfos(ctx interface{}, nodeKindID interface{}, relationshipKindID interface{}) *MockDatabase_GetKindInfos_Call {
+	return &MockDatabase_GetKindInfos_Call{Call: _e.mock.On("GetKindInfos", ctx, nodeKindID, relationshipKindID)}
+}
+
+func (_c *MockDatabase_GetKindInfos_Call) Run(run func(ctx context.Context, nodeKindID *int32, relationshipKindID *int32)) *MockDatabase_GetKindInfos_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *int32
+		if args[1] != nil {
+			arg1 = args[1].(*int32)
+		}
+		var arg2 *int32
+		if args[2] != nil {
+			arg2 = args[2].(*int32)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockDatabase_GetKindInfos_Call) Return(kindInfos []services.KindInfo, err error) *MockDatabase_GetKindInfos_Call {
+	_c.Call.Return(kindInfos, err)
+	return _c
+}
+
+func (_c *MockDatabase_GetKindInfos_Call) RunAndReturn(run func(ctx context.Context, nodeKindID *int32, relationshipKindID *int32) ([]services.KindInfo, error)) *MockDatabase_GetKindInfos_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetNode provides a mock function for the type MockDatabase
 func (_mock *MockDatabase) GetNode(ctx context.Context, id int64) (services.Node, error) {
 	ret := _mock.Called(ctx, id)

--- a/server/graphdb/internal/services/mocks/database.go
+++ b/server/graphdb/internal/services/mocks/database.go
@@ -120,8 +120,8 @@ func (_c *MockDatabase_GetKindByName_Call) RunAndReturn(run func(ctx context.Con
 }
 
 // GetKindInfos provides a mock function for the type MockDatabase
-func (_mock *MockDatabase) GetKindInfos(ctx context.Context, nodeKindID *int32, relationshipKindID *int32) ([]services.KindInfo, error) {
-	ret := _mock.Called(ctx, nodeKindID, relationshipKindID)
+func (_mock *MockDatabase) GetKindInfos(ctx context.Context, kindName string) ([]services.KindInfo, error) {
+	ret := _mock.Called(ctx, kindName)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetKindInfos")
@@ -129,18 +129,18 @@ func (_mock *MockDatabase) GetKindInfos(ctx context.Context, nodeKindID *int32, 
 
 	var r0 []services.KindInfo
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, *int32, *int32) ([]services.KindInfo, error)); ok {
-		return returnFunc(ctx, nodeKindID, relationshipKindID)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) ([]services.KindInfo, error)); ok {
+		return returnFunc(ctx, kindName)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, *int32, *int32) []services.KindInfo); ok {
-		r0 = returnFunc(ctx, nodeKindID, relationshipKindID)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) []services.KindInfo); ok {
+		r0 = returnFunc(ctx, kindName)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]services.KindInfo)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, *int32, *int32) error); ok {
-		r1 = returnFunc(ctx, nodeKindID, relationshipKindID)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, kindName)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -154,30 +154,24 @@ type MockDatabase_GetKindInfos_Call struct {
 
 // GetKindInfos is a helper method to define mock.On call
 //   - ctx context.Context
-//   - nodeKindID *int32
-//   - relationshipKindID *int32
-func (_e *MockDatabase_Expecter) GetKindInfos(ctx interface{}, nodeKindID interface{}, relationshipKindID interface{}) *MockDatabase_GetKindInfos_Call {
-	return &MockDatabase_GetKindInfos_Call{Call: _e.mock.On("GetKindInfos", ctx, nodeKindID, relationshipKindID)}
+//   - kindName string
+func (_e *MockDatabase_Expecter) GetKindInfos(ctx interface{}, kindName interface{}) *MockDatabase_GetKindInfos_Call {
+	return &MockDatabase_GetKindInfos_Call{Call: _e.mock.On("GetKindInfos", ctx, kindName)}
 }
 
-func (_c *MockDatabase_GetKindInfos_Call) Run(run func(ctx context.Context, nodeKindID *int32, relationshipKindID *int32)) *MockDatabase_GetKindInfos_Call {
+func (_c *MockDatabase_GetKindInfos_Call) Run(run func(ctx context.Context, kindName string)) *MockDatabase_GetKindInfos_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
 			arg0 = args[0].(context.Context)
 		}
-		var arg1 *int32
+		var arg1 string
 		if args[1] != nil {
-			arg1 = args[1].(*int32)
-		}
-		var arg2 *int32
-		if args[2] != nil {
-			arg2 = args[2].(*int32)
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
 			arg1,
-			arg2,
 		)
 	})
 	return _c
@@ -188,7 +182,7 @@ func (_c *MockDatabase_GetKindInfos_Call) Return(kindInfos []services.KindInfo, 
 	return _c
 }
 
-func (_c *MockDatabase_GetKindInfos_Call) RunAndReturn(run func(ctx context.Context, nodeKindID *int32, relationshipKindID *int32) ([]services.KindInfo, error)) *MockDatabase_GetKindInfos_Call {
+func (_c *MockDatabase_GetKindInfos_Call) RunAndReturn(run func(ctx context.Context, kindName string) ([]services.KindInfo, error)) *MockDatabase_GetKindInfos_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/server/graphdb/internal/services/node.go
+++ b/server/graphdb/internal/services/node.go
@@ -76,7 +76,13 @@ func (s *Service) GetNode(ctx context.Context, id int64, includeKindInfo bool) (
 				return Node{}, fmt.Errorf("failed to get kind info for %s", nodeKind.Name)
 			}
 
-			allKindInfos = append(allKindInfos, kindInfos...)
+			for _, kindInfo := range kindInfos {
+				if kindInfo.NodeKindID == nil { // defensive guard to make the dereference in the sort below safe from a nil-panic.
+					continue
+				}
+
+				allKindInfos = append(allKindInfos, kindInfo)
+			}
 		}
 
 		slices.SortFunc(allKindInfos, func(left, right KindInfo) int {

--- a/server/graphdb/internal/services/node.go
+++ b/server/graphdb/internal/services/node.go
@@ -71,7 +71,7 @@ func (s *Service) GetNode(ctx context.Context, id int64, includeKindInfo bool) (
 				continue
 			}
 
-			kindInfos, err := s.db.GetKindInfos(ctx, nodeKind.ID, nil)
+			kindInfos, err := s.db.GetKindInfos(ctx, nodeKind.Name)
 			if err != nil {
 				return Node{}, fmt.Errorf("failed to get kind info for %s", nodeKind.Name)
 			}

--- a/server/graphdb/internal/services/node.go
+++ b/server/graphdb/internal/services/node.go
@@ -17,9 +17,11 @@
 package services
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 )
 
 // Node is the domain representation of a graph node together with
@@ -60,12 +62,12 @@ func (s *Service) GetNode(ctx context.Context, id int64, includeKindInfo bool) (
 		node.Kinds = kinds
 	}
 
-	// grab all the associate kind info objects for all the node's kinds that are registered in schema_node_kinds
+	// grab all the associated kind info objects for every kind.
 	if includeKindInfo {
 		var allKindInfos []KindInfo
 
 		for _, nodeKind := range node.Kinds {
-			if nodeKind.ID == nil {
+			if nodeKind.ID == nil { // only nodes registered in the schema_node_kind table will have IDs
 				continue
 			}
 
@@ -76,6 +78,16 @@ func (s *Service) GetNode(ctx context.Context, id int64, includeKindInfo bool) (
 
 			allKindInfos = append(allKindInfos, kindInfos...)
 		}
+
+		slices.SortFunc(allKindInfos, func(left, right KindInfo) int {
+			if result := cmp.Compare(left.Position, right.Position); result != 0 {
+				return result
+			} else if result := cmp.Compare(left.Title, right.Title); result != 0 {
+				return result
+			} else {
+				return cmp.Compare(*left.NodeKindID, *right.NodeKindID)
+			}
+		})
 
 		node.KindInfos = allKindInfos
 	}

--- a/server/graphdb/internal/services/node.go
+++ b/server/graphdb/internal/services/node.go
@@ -19,6 +19,7 @@ package services
 import (
 	"context"
 	"errors"
+	"fmt"
 )
 
 // Node is the domain representation of a graph node together with
@@ -27,6 +28,7 @@ type Node struct {
 	ID         int64
 	Kinds      []Kind
 	Properties map[string]any
+	KindInfos  []KindInfo
 }
 
 // ErrNodeNotFound indicates that no graph node exists for the requested id.
@@ -36,7 +38,7 @@ var ErrNodeNotFound = errors.New("node not found")
 // kinds resolved to the integer identifiers from the schema_node_kinds table.
 // ErrNodeNotFound is returned when the node does not exist. Kinds that are not
 // registered in schema_node_kinds are returned with ID=nil (best-effort resolution).
-func (s *Service) GetNode(ctx context.Context, id int64) (Node, error) {
+func (s *Service) GetNode(ctx context.Context, id int64, includeKindInfo bool) (Node, error) {
 	var (
 		node      Node
 		kindNames []string
@@ -56,6 +58,27 @@ func (s *Service) GetNode(ctx context.Context, id int64) (Node, error) {
 		return Node{}, err
 	} else {
 		node.Kinds = kinds
-		return node, nil
 	}
+
+	// grab all the associate kind info objects for all the node's kinds that are registered in schema_node_kinds
+	if includeKindInfo {
+		var allKindInfos []KindInfo
+
+		for _, nodeKind := range node.Kinds {
+			if nodeKind.ID == nil {
+				continue
+			}
+
+			kindInfos, err := s.db.GetKindInfos(ctx, nodeKind.ID, nil)
+			if err != nil {
+				return Node{}, fmt.Errorf("failed to get kind info for %s", nodeKind.Name)
+			}
+
+			allKindInfos = append(allKindInfos, kindInfos...)
+		}
+
+		node.KindInfos = allKindInfos
+	}
+
+	return node, nil
 }

--- a/server/graphdb/internal/services/node_test.go
+++ b/server/graphdb/internal/services/node_test.go
@@ -129,12 +129,11 @@ func TestService_GetNode(t *testing.T) {
 			setupMock: func(databaseMock *mocks.MockDatabase) {
 				databaseMock.EXPECT().GetNode(ctx, nodeID).Return(baseNode, nil)
 				databaseMock.EXPECT().GetNodeKindsByNames(ctx, []string{"User", "Group"}).Return(resolvedKinds, nil)
-				var nilPtr *int32 // this slots into the relationshipKindID param, which should be nil
-				databaseMock.EXPECT().GetKindInfos(ctx, resolvedKinds[0].ID, nilPtr).Return([]services.KindInfo{
+				databaseMock.EXPECT().GetKindInfos(ctx, "User").Return([]services.KindInfo{
 					{InfoKey: "user_later", Title: "Beta", Position: 1, NodeKindID: int32Ptr(1)},
 					{InfoKey: "user_tie", Title: "Alpha", Position: 1, NodeKindID: int32Ptr(1)},
 				}, nil)
-				databaseMock.EXPECT().GetKindInfos(ctx, resolvedKinds[1].ID, nilPtr).Return([]services.KindInfo{
+				databaseMock.EXPECT().GetKindInfos(ctx, "Group").Return([]services.KindInfo{
 					{InfoKey: "group_first", Title: "Gamma", Position: 0, NodeKindID: int32Ptr(2)},
 					{InfoKey: "group_tie", Title: "Alpha", Position: 1, NodeKindID: int32Ptr(2)},
 				}, nil)

--- a/server/graphdb/internal/services/node_test.go
+++ b/server/graphdb/internal/services/node_test.go
@@ -18,6 +18,7 @@ package services_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/specterops/bloodhound/server/graphdb/internal/services"
@@ -33,11 +34,10 @@ func int32Ptr(v int32) *int32 {
 
 func TestService_GetNode(t *testing.T) {
 	var (
-		ctx    = context.Background()
-		nodeID = int64(9876543210)
-		// nilInt32      *int32
-		// unexpectedErr = errors.New("connection refused")
-		baseNode = services.Node{
+		ctx           = context.Background()
+		nodeID        = int64(9876543210)
+		unexpectedErr = errors.New("connection refused")
+		baseNode      = services.Node{
 			ID: nodeID,
 			Kinds: []services.Kind{
 				{Name: "User"},
@@ -57,73 +57,73 @@ func TestService_GetNode(t *testing.T) {
 		wantResult services.Node
 		wantErr    error
 	}{
-		// {
-		// 	name: "success_-_resolves_all_kind_ids",
-		// 	setupMock: func(databaseMock *mocks.MockDatabase) {
-		// 		databaseMock.EXPECT().GetNode(ctx, nodeID).Return(baseNode, nil)
-		// 		databaseMock.EXPECT().GetNodeKindsByNames(ctx, []string{"User", "Group"}).Return(resolvedKinds, nil)
-		// 	},
-		// 	wantResult: services.Node{
-		// 		ID:         nodeID,
-		// 		Kinds:      resolvedKinds,
-		// 		Properties: map[string]any{"name": "admin"},
-		// 	},
-		// },
-		// {
-		// 	name: "error_-_propagates_node_not_found",
-		// 	setupMock: func(databaseMock *mocks.MockDatabase) {
-		// 		databaseMock.EXPECT().GetNode(ctx, nodeID).Return(services.Node{}, services.ErrNodeNotFound)
-		// 	},
-		// 	wantErr: services.ErrNodeNotFound,
-		// },
-		// {
-		// 	name: "error_-_propagates_unexpected_database_errors",
-		// 	setupMock: func(databaseMock *mocks.MockDatabase) {
-		// 		databaseMock.EXPECT().GetNode(ctx, nodeID).Return(services.Node{}, unexpectedErr)
-		// 	},
-		// 	wantErr: unexpectedErr,
-		// },
-		// {
-		// 	name: "success_-_handles_node_with_single_kind",
-		// 	setupMock: func(databaseMock *mocks.MockDatabase) {
-		// 		singleKindNode := services.Node{
-		// 			ID:         nodeID,
-		// 			Kinds:      []services.Kind{{Name: "User"}},
-		// 			Properties: map[string]any{"name": "admin"},
-		// 		}
-		// 		databaseMock.EXPECT().GetNode(ctx, nodeID).Return(singleKindNode, nil)
-		// 		databaseMock.EXPECT().GetNodeKindsByNames(ctx, []string{"User"}).Return([]services.Kind{{ID: int32Ptr(1), Name: "User"}}, nil)
-		// 	},
-		// 	wantResult: services.Node{
-		// 		ID:         nodeID,
-		// 		Kinds:      []services.Kind{{ID: int32Ptr(1), Name: "User"}},
-		// 		Properties: map[string]any{"name": "admin"},
-		// 	},
-		// },
-		// {
-		// 	name: "success_-_handles_mixed_resolved_and_unresolved_kinds",
-		// 	setupMock: func(databaseMock *mocks.MockDatabase) {
-		// 		mixedKindNode := services.Node{
-		// 			ID:         nodeID,
-		// 			Kinds:      []services.Kind{{Name: "User"}, {Name: "CustomKind"}},
-		// 			Properties: map[string]any{"name": "admin"},
-		// 		}
-		// 		mixedResolvedKinds := []services.Kind{
-		// 			{ID: int32Ptr(1), Name: "User"},
-		// 			{ID: nil, Name: "CustomKind"},
-		// 		}
-		// 		databaseMock.EXPECT().GetNode(ctx, nodeID).Return(mixedKindNode, nil)
-		// 		databaseMock.EXPECT().GetNodeKindsByNames(ctx, []string{"User", "CustomKind"}).Return(mixedResolvedKinds, nil)
-		// 	},
-		// 	wantResult: services.Node{
-		// 		ID: nodeID,
-		// 		Kinds: []services.Kind{
-		// 			{ID: int32Ptr(1), Name: "User"},
-		// 			{ID: nil, Name: "CustomKind"},
-		// 		},
-		// 		Properties: map[string]any{"name": "admin"},
-		// 	},
-		// },
+		{
+			name: "success_-_resolves_all_kind_ids",
+			setupMock: func(databaseMock *mocks.MockDatabase) {
+				databaseMock.EXPECT().GetNode(ctx, nodeID).Return(baseNode, nil)
+				databaseMock.EXPECT().GetNodeKindsByNames(ctx, []string{"User", "Group"}).Return(resolvedKinds, nil)
+			},
+			wantResult: services.Node{
+				ID:         nodeID,
+				Kinds:      resolvedKinds,
+				Properties: map[string]any{"name": "admin"},
+			},
+		},
+		{
+			name: "error_-_propagates_node_not_found",
+			setupMock: func(databaseMock *mocks.MockDatabase) {
+				databaseMock.EXPECT().GetNode(ctx, nodeID).Return(services.Node{}, services.ErrNodeNotFound)
+			},
+			wantErr: services.ErrNodeNotFound,
+		},
+		{
+			name: "error_-_propagates_unexpected_database_errors",
+			setupMock: func(databaseMock *mocks.MockDatabase) {
+				databaseMock.EXPECT().GetNode(ctx, nodeID).Return(services.Node{}, unexpectedErr)
+			},
+			wantErr: unexpectedErr,
+		},
+		{
+			name: "success_-_handles_node_with_single_kind",
+			setupMock: func(databaseMock *mocks.MockDatabase) {
+				singleKindNode := services.Node{
+					ID:         nodeID,
+					Kinds:      []services.Kind{{Name: "User"}},
+					Properties: map[string]any{"name": "admin"},
+				}
+				databaseMock.EXPECT().GetNode(ctx, nodeID).Return(singleKindNode, nil)
+				databaseMock.EXPECT().GetNodeKindsByNames(ctx, []string{"User"}).Return([]services.Kind{{ID: int32Ptr(1), Name: "User"}}, nil)
+			},
+			wantResult: services.Node{
+				ID:         nodeID,
+				Kinds:      []services.Kind{{ID: int32Ptr(1), Name: "User"}},
+				Properties: map[string]any{"name": "admin"},
+			},
+		},
+		{
+			name: "success_-_handles_mixed_resolved_and_unresolved_kinds",
+			setupMock: func(databaseMock *mocks.MockDatabase) {
+				mixedKindNode := services.Node{
+					ID:         nodeID,
+					Kinds:      []services.Kind{{Name: "User"}, {Name: "CustomKind"}},
+					Properties: map[string]any{"name": "admin"},
+				}
+				mixedResolvedKinds := []services.Kind{
+					{ID: int32Ptr(1), Name: "User"},
+					{ID: nil, Name: "CustomKind"},
+				}
+				databaseMock.EXPECT().GetNode(ctx, nodeID).Return(mixedKindNode, nil)
+				databaseMock.EXPECT().GetNodeKindsByNames(ctx, []string{"User", "CustomKind"}).Return(mixedResolvedKinds, nil)
+			},
+			wantResult: services.Node{
+				ID: nodeID,
+				Kinds: []services.Kind{
+					{ID: int32Ptr(1), Name: "User"},
+					{ID: nil, Name: "CustomKind"},
+				},
+				Properties: map[string]any{"name": "admin"},
+			},
+		},
 		{
 			name: "success_-_sorts_kind_infos_by_position_title_then_node_kind_id",
 			setupMock: func(databaseMock *mocks.MockDatabase) {

--- a/server/graphdb/internal/services/node_test.go
+++ b/server/graphdb/internal/services/node_test.go
@@ -135,7 +135,7 @@ func TestService_GetNode(t *testing.T) {
 
 			tt.setupMock(databaseMock)
 
-			result, err := svc.GetNode(ctx, nodeID)
+			result, err := svc.GetNode(ctx, nodeID, false)
 			if tt.wantErr != nil {
 				assert.ErrorIs(t, err, tt.wantErr)
 			} else {

--- a/server/graphdb/internal/services/node_test.go
+++ b/server/graphdb/internal/services/node_test.go
@@ -18,7 +18,6 @@ package services_test
 
 import (
 	"context"
-	"errors"
 	"testing"
 
 	"github.com/specterops/bloodhound/server/graphdb/internal/services"
@@ -34,10 +33,11 @@ func int32Ptr(v int32) *int32 {
 
 func TestService_GetNode(t *testing.T) {
 	var (
-		ctx           = context.Background()
-		nodeID        = int64(9876543210)
-		unexpectedErr = errors.New("connection refused")
-		baseNode      = services.Node{
+		ctx    = context.Background()
+		nodeID = int64(9876543210)
+		// nilInt32      *int32
+		// unexpectedErr = errors.New("connection refused")
+		baseNode = services.Node{
 			ID: nodeID,
 			Kinds: []services.Kind{
 				{Name: "User"},
@@ -57,71 +57,98 @@ func TestService_GetNode(t *testing.T) {
 		wantResult services.Node
 		wantErr    error
 	}{
+		// {
+		// 	name: "success_-_resolves_all_kind_ids",
+		// 	setupMock: func(databaseMock *mocks.MockDatabase) {
+		// 		databaseMock.EXPECT().GetNode(ctx, nodeID).Return(baseNode, nil)
+		// 		databaseMock.EXPECT().GetNodeKindsByNames(ctx, []string{"User", "Group"}).Return(resolvedKinds, nil)
+		// 	},
+		// 	wantResult: services.Node{
+		// 		ID:         nodeID,
+		// 		Kinds:      resolvedKinds,
+		// 		Properties: map[string]any{"name": "admin"},
+		// 	},
+		// },
+		// {
+		// 	name: "error_-_propagates_node_not_found",
+		// 	setupMock: func(databaseMock *mocks.MockDatabase) {
+		// 		databaseMock.EXPECT().GetNode(ctx, nodeID).Return(services.Node{}, services.ErrNodeNotFound)
+		// 	},
+		// 	wantErr: services.ErrNodeNotFound,
+		// },
+		// {
+		// 	name: "error_-_propagates_unexpected_database_errors",
+		// 	setupMock: func(databaseMock *mocks.MockDatabase) {
+		// 		databaseMock.EXPECT().GetNode(ctx, nodeID).Return(services.Node{}, unexpectedErr)
+		// 	},
+		// 	wantErr: unexpectedErr,
+		// },
+		// {
+		// 	name: "success_-_handles_node_with_single_kind",
+		// 	setupMock: func(databaseMock *mocks.MockDatabase) {
+		// 		singleKindNode := services.Node{
+		// 			ID:         nodeID,
+		// 			Kinds:      []services.Kind{{Name: "User"}},
+		// 			Properties: map[string]any{"name": "admin"},
+		// 		}
+		// 		databaseMock.EXPECT().GetNode(ctx, nodeID).Return(singleKindNode, nil)
+		// 		databaseMock.EXPECT().GetNodeKindsByNames(ctx, []string{"User"}).Return([]services.Kind{{ID: int32Ptr(1), Name: "User"}}, nil)
+		// 	},
+		// 	wantResult: services.Node{
+		// 		ID:         nodeID,
+		// 		Kinds:      []services.Kind{{ID: int32Ptr(1), Name: "User"}},
+		// 		Properties: map[string]any{"name": "admin"},
+		// 	},
+		// },
+		// {
+		// 	name: "success_-_handles_mixed_resolved_and_unresolved_kinds",
+		// 	setupMock: func(databaseMock *mocks.MockDatabase) {
+		// 		mixedKindNode := services.Node{
+		// 			ID:         nodeID,
+		// 			Kinds:      []services.Kind{{Name: "User"}, {Name: "CustomKind"}},
+		// 			Properties: map[string]any{"name": "admin"},
+		// 		}
+		// 		mixedResolvedKinds := []services.Kind{
+		// 			{ID: int32Ptr(1), Name: "User"},
+		// 			{ID: nil, Name: "CustomKind"},
+		// 		}
+		// 		databaseMock.EXPECT().GetNode(ctx, nodeID).Return(mixedKindNode, nil)
+		// 		databaseMock.EXPECT().GetNodeKindsByNames(ctx, []string{"User", "CustomKind"}).Return(mixedResolvedKinds, nil)
+		// 	},
+		// 	wantResult: services.Node{
+		// 		ID: nodeID,
+		// 		Kinds: []services.Kind{
+		// 			{ID: int32Ptr(1), Name: "User"},
+		// 			{ID: nil, Name: "CustomKind"},
+		// 		},
+		// 		Properties: map[string]any{"name": "admin"},
+		// 	},
+		// },
 		{
-			name: "success_-_resolves_all_kind_ids",
+			name: "success_-_sorts_kind_infos_by_position_title_then_node_kind_id",
 			setupMock: func(databaseMock *mocks.MockDatabase) {
 				databaseMock.EXPECT().GetNode(ctx, nodeID).Return(baseNode, nil)
 				databaseMock.EXPECT().GetNodeKindsByNames(ctx, []string{"User", "Group"}).Return(resolvedKinds, nil)
+				var nilPtr *int32 // this slots into the relationshipKindID param, which should be nil
+				databaseMock.EXPECT().GetKindInfos(ctx, resolvedKinds[0].ID, nilPtr).Return([]services.KindInfo{
+					{InfoKey: "user_later", Title: "Beta", Position: 1, NodeKindID: int32Ptr(1)},
+					{InfoKey: "user_tie", Title: "Alpha", Position: 1, NodeKindID: int32Ptr(1)},
+				}, nil)
+				databaseMock.EXPECT().GetKindInfos(ctx, resolvedKinds[1].ID, nilPtr).Return([]services.KindInfo{
+					{InfoKey: "group_first", Title: "Gamma", Position: 0, NodeKindID: int32Ptr(2)},
+					{InfoKey: "group_tie", Title: "Alpha", Position: 1, NodeKindID: int32Ptr(2)},
+				}, nil)
 			},
 			wantResult: services.Node{
 				ID:         nodeID,
 				Kinds:      resolvedKinds,
 				Properties: map[string]any{"name": "admin"},
-			},
-		},
-		{
-			name: "error_-_propagates_node_not_found",
-			setupMock: func(databaseMock *mocks.MockDatabase) {
-				databaseMock.EXPECT().GetNode(ctx, nodeID).Return(services.Node{}, services.ErrNodeNotFound)
-			},
-			wantErr: services.ErrNodeNotFound,
-		},
-		{
-			name: "error_-_propagates_unexpected_database_errors",
-			setupMock: func(databaseMock *mocks.MockDatabase) {
-				databaseMock.EXPECT().GetNode(ctx, nodeID).Return(services.Node{}, unexpectedErr)
-			},
-			wantErr: unexpectedErr,
-		},
-		{
-			name: "success_-_handles_node_with_single_kind",
-			setupMock: func(databaseMock *mocks.MockDatabase) {
-				singleKindNode := services.Node{
-					ID:         nodeID,
-					Kinds:      []services.Kind{{Name: "User"}},
-					Properties: map[string]any{"name": "admin"},
-				}
-				databaseMock.EXPECT().GetNode(ctx, nodeID).Return(singleKindNode, nil)
-				databaseMock.EXPECT().GetNodeKindsByNames(ctx, []string{"User"}).Return([]services.Kind{{ID: int32Ptr(1), Name: "User"}}, nil)
-			},
-			wantResult: services.Node{
-				ID:         nodeID,
-				Kinds:      []services.Kind{{ID: int32Ptr(1), Name: "User"}},
-				Properties: map[string]any{"name": "admin"},
-			},
-		},
-		{
-			name: "success_-_handles_mixed_resolved_and_unresolved_kinds",
-			setupMock: func(databaseMock *mocks.MockDatabase) {
-				mixedKindNode := services.Node{
-					ID:         nodeID,
-					Kinds:      []services.Kind{{Name: "User"}, {Name: "CustomKind"}},
-					Properties: map[string]any{"name": "admin"},
-				}
-				mixedResolvedKinds := []services.Kind{
-					{ID: int32Ptr(1), Name: "User"},
-					{ID: nil, Name: "CustomKind"},
-				}
-				databaseMock.EXPECT().GetNode(ctx, nodeID).Return(mixedKindNode, nil)
-				databaseMock.EXPECT().GetNodeKindsByNames(ctx, []string{"User", "CustomKind"}).Return(mixedResolvedKinds, nil)
-			},
-			wantResult: services.Node{
-				ID: nodeID,
-				Kinds: []services.Kind{
-					{ID: int32Ptr(1), Name: "User"},
-					{ID: nil, Name: "CustomKind"},
+				KindInfos: []services.KindInfo{
+					{InfoKey: "group_first", Title: "Gamma", Position: 0, NodeKindID: int32Ptr(2)},
+					{InfoKey: "user_tie", Title: "Alpha", Position: 1, NodeKindID: int32Ptr(1)},
+					{InfoKey: "group_tie", Title: "Alpha", Position: 1, NodeKindID: int32Ptr(2)},
+					{InfoKey: "user_later", Title: "Beta", Position: 1, NodeKindID: int32Ptr(1)},
 				},
-				Properties: map[string]any{"name": "admin"},
 			},
 		},
 	}
@@ -135,7 +162,7 @@ func TestService_GetNode(t *testing.T) {
 
 			tt.setupMock(databaseMock)
 
-			result, err := svc.GetNode(ctx, nodeID, false)
+			result, err := svc.GetNode(ctx, nodeID, tt.wantResult.KindInfos != nil)
 			if tt.wantErr != nil {
 				assert.ErrorIs(t, err, tt.wantErr)
 			} else {

--- a/server/graphdb/internal/services/services.go
+++ b/server/graphdb/internal/services/services.go
@@ -33,6 +33,7 @@ type Database interface {
 	GetNode(ctx context.Context, id int64) (Node, error)
 	GetKindByName(ctx context.Context, name string) (Kind, error)
 	GetNodeKindsByNames(ctx context.Context, names []string) ([]Kind, error)
+	GetKindInfos(ctx context.Context, nodeKindID *int32, relationshipKindID *int32) ([]KindInfo, error)
 }
 
 // Kind is the domain representation of a relationship or node kind, pairing the kind name

--- a/server/graphdb/internal/services/services.go
+++ b/server/graphdb/internal/services/services.go
@@ -33,7 +33,7 @@ type Database interface {
 	GetNode(ctx context.Context, id int64) (Node, error)
 	GetKindByName(ctx context.Context, name string) (Kind, error)
 	GetNodeKindsByNames(ctx context.Context, names []string) ([]Kind, error)
-	GetKindInfos(ctx context.Context, nodeKindID *int32, relationshipKindID *int32) ([]KindInfo, error)
+	GetKindInfos(ctx context.Context, kindName string) ([]KindInfo, error)
 }
 
 // Kind is the domain representation of a relationship or node kind, pairing the kind name


### PR DESCRIPTION
## Description
- Parse out query param and add `KindInfoView` to handlers/node.go
- Wire up GetNode() service to pull `KindInfos`
- Swagger documentation updated with examples

## Motivation and Context
Resolves BED-8762
We want to extend the existing `api/v2/nodes/{node_id}` endpoint with a query param named `include-info`. When set to true, it pulls the associated entity panels for the node's kinds.

## How Has This Been Tested?
You can see the API shape in the Swagger UI.

1. Load some graph data into the app. 
2. Pick a node. 
3. Populate the `schema_node_kind` table with a few records that correspond to a kind on the node you picked in step 2.
4. Ping the endpoint! Either through the API explorer or any other API tool.

## Screenshots (optional):
Example API response:
<img width="546" height="959" alt="Screenshot 2026-07-10 at 3 05 34 PM" src="https://github.com/user-attachments/assets/21e18f7d-911d-4cf8-ae09-adb063c71ef4" />


## Types of changes
- New feature (non-breaking change which adds functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [ ] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [ ] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [ ] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `GET /api/v2/nodes/{node_id}` can now optionally include per-kind “info” metadata (with markdown content) when `include-info=true`.
* **Bug Fixes**
  * Malformed `include-info` values now return HTTP 400.
  * Returned kind info is sorted deterministically (position/title) for consistent responses.
* **Documentation**
  * Updated the OpenAPI spec for `GET /api/v2/nodes/{node_id}` to document the new optional response shape and examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->