### PR TITLE
fix(Docker): fix HMR when running dev in container - BED-8971

### DIFF
--- a/cmd/ui/vite.config.ts
+++ b/cmd/ui/vite.config.ts
@@ -87,7 +87,16 @@ export default defineConfig(({ mode }) => {
             hmr: env.VITE_HMR_CLIENT_PORT ? { clientPort: Number(env.VITE_HMR_CLIENT_PORT) } : true,
             // macOS Docker bind mounts don't reliably deliver fs events into the container, so enable
             // polling there (VITE_USE_POLLING=true) to detect source changes. Off locally to save CPU.
-            watch: env.VITE_USE_POLLING === 'true' ? { usePolling: true, interval: 100 } : undefined,
+            // A larger interval and ignored heavy paths keep polling from starving Vite on slower Docker setups.
+            watch:
+                env.VITE_USE_POLLING === 'true'
+                    ? {
+                          usePolling: true,
+                          interval: 300,
+                          binaryInterval: 1000,
+                          ignored: ['**/node_modules/**', '**/dist/**', '**/coverage/**', '**/.git/**'],
+                      }
+                    : undefined,
             fs: {
                 allow: [searchForWorkspaceRoot(process.cwd())],
             },

--- a/cmd/ui/vite.config.ts
+++ b/cmd/ui/vite.config.ts
@@ -81,7 +81,13 @@ export default defineConfig(({ mode }) => {
             },
             port: 3000,
             host: true,
-            hmr: true,
+            // When running behind the Traefik reverse proxy (docker compose dev), the browser reaches
+            // Vite on the proxy port, not the container's internal 3000. VITE_HMR_CLIENT_PORT points the
+            // HMR websocket back through the proxy. Left as `true` (default) for local `yarn dev`.
+            hmr: env.VITE_HMR_CLIENT_PORT ? { clientPort: Number(env.VITE_HMR_CLIENT_PORT) } : true,
+            // macOS Docker bind mounts don't reliably deliver fs events into the container, so enable
+            // polling there (VITE_USE_POLLING=true) to detect source changes. Off locally to save CPU.
+            watch: env.VITE_USE_POLLING === 'true' ? { usePolling: true, interval: 100 } : undefined,
             fs: {
                 allow: [searchForWorkspaceRoot(process.cwd())],
             },

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -161,6 +161,9 @@ services:
       context: .
       dockerfile: tools/docker-compose/ui.Dockerfile
     command: sh -c "yarn dev"
+    environment:
+      VITE_USE_POLLING: "true"
+      VITE_HMR_CLIENT_PORT: "${VITE_HMR_CLIENT_PORT:-80}"
     labels:
       - traefik.enable=true
       - traefik.http.routers.bhui.rule=Host(`${BH_HOSTNAME:-bloodhound.localhost}`)

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -162,7 +162,11 @@ services:
       dockerfile: tools/docker-compose/ui.Dockerfile
     command: sh -c "yarn dev"
     environment:
-      VITE_USE_POLLING: "true"
+      VITE_USE_POLLING: "${VITE_USE_POLLING:-true}"
+      # Must match the host-side port published by the proxy service (WEB_PORT, default 80). Compose
+      # interpolation can't extract the port from WEB_PORT's host:port binding, so if WEB_PORT uses a
+      # non-default port (e.g. 127.0.0.1:8080), set VITE_HMR_CLIENT_PORT to match; otherwise Vite
+      # advertises the stale default and the HMR websocket fails to connect through the proxy.
       VITE_HMR_CLIENT_PORT: "${VITE_HMR_CLIENT_PORT:-80}"
     labels:
       - traefik.enable=true


### PR DESCRIPTION
## Description

Updates Vite config to address issue with Hot Module Reloading in Docker dev container

## Motivation and Context

Resolves BED-8971


## How Has This Been Tested?

Manually tested. Run `just bh-dev` and make a code change to see it reflected in realtime.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved development-mode hot reload when running behind a reverse proxy or inside containers.
  * Added optional polling-based file watching to improve reliability with macOS bind mounts.
  * Updated the development server’s live-update (HMR) configuration to use the correct client port via environment settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->