### PR TITLE
feat: add ?include-info to v2 relationships API BED-8763

### DIFF
--- a/packages/go/openapi/doc/openapi.json
+++ b/packages/go/openapi/doc/openapi.json
@@ -7232,6 +7232,15 @@
             "type": "integer",
             "format": "int64"
           }
+        },
+        {
+          "name": "include-info",
+          "in": "query",
+          "required": false,
+          "description": "When false or omitted, excludes entity panel information.\nWhen true, returns relationship details with entity panel information included.\n",
+          "schema": {
+            "type": "boolean"
+          }
         }
       ],
       "get": {
@@ -7252,7 +7261,14 @@
                   "type": "object",
                   "properties": {
                     "data": {
-                      "$ref": "#/components/schemas/model.relationship-details"
+                      "anyOf": [
+                        {
+                          "$ref": "#/components/schemas/model.relationship-details"
+                        },
+                        {
+                          "$ref": "#/components/schemas/model.relationship-details-with-info"
+                        }
+                      ]
                     }
                   }
                 }
@@ -22179,6 +22195,11 @@
       },
       "model.relationship-details": {
         "type": "object",
+        "required": [
+          "relationship_id",
+          "kind",
+          "properties"
+        ],
         "properties": {
           "relationship_id": {
             "type": "integer",
@@ -22200,6 +22221,10 @@
           },
           "kind": {
             "type": "object",
+            "required": [
+              "relationship_kind_id",
+              "name"
+            ],
             "properties": {
               "relationship_kind_id": {
                 "type": "integer",
@@ -22213,9 +22238,121 @@
           },
           "properties": {
             "type": "object",
-            "additionalProperties": true
+            "additionalProperties": true,
+            "required": [
+              "is_traversable",
+              "lastSeen"
+            ],
+            "properties": {
+              "is_traversable": {
+                "type": "boolean"
+              },
+              "lastSeen": {
+                "type": "string",
+                "format": "date-time"
+              }
+            }
           }
         }
+      },
+      "model.kind-info-base": {
+        "type": "object",
+        "required": [
+          "title",
+          "position"
+        ],
+        "properties": {
+          "title": {
+            "type": "string",
+            "example": "Entity Panel Section"
+          },
+          "position": {
+            "type": "integer",
+            "minimum": 1
+          }
+        }
+      },
+      "model.kind-info-type-markdown": {
+        "type": "object",
+        "required": [
+          "markdown"
+        ],
+        "properties": {
+          "markdown": {
+            "type": "object",
+            "required": [
+              "content"
+            ],
+            "properties": {
+              "content": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "model.kind-info-content": {
+        "type": "object",
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/model.kind-info-type-markdown"
+          }
+        ]
+      },
+      "model.kind-info-response": {
+        "allOf": [
+          {
+            "type": "object",
+            "required": [
+              "name"
+            ],
+            "properties": {
+              "name": {
+                "type": "string",
+                "example": "panel_section_1"
+              }
+            }
+          },
+          {
+            "$ref": "#/components/schemas/model.kind-info-base"
+          },
+          {
+            "$ref": "#/components/schemas/model.kind-info-content"
+          }
+        ]
+      },
+      "model.relationship-details-with-info": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/model.relationship-details"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "info": {
+                "type": "array",
+                "items": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/model.kind-info-response"
+                    },
+                    {
+                      "type": "object",
+                      "required": [
+                        "relationship_kind_id"
+                      ],
+                      "properties": {
+                        "relationship_kind_id": {
+                          "type": "integer"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        ]
       },
       "model.node-details": {
         "type": "object",

--- a/packages/go/openapi/doc/openapi.json
+++ b/packages/go/openapi/doc/openapi.json
@@ -22197,6 +22197,8 @@
         "type": "object",
         "required": [
           "relationship_id",
+          "source_node_id",
+          "target_node_id",
           "kind",
           "properties"
         ],

--- a/packages/go/openapi/src/paths/graph.relationships.id.yaml
+++ b/packages/go/openapi/src/paths/graph.relationships.id.yaml
@@ -22,6 +22,14 @@ parameters:
     schema:
       type: integer
       format: int64
+  - name: include-info
+    in: query
+    required: false
+    description: |
+      When false or omitted, excludes entity panel information.
+      When true, returns relationship details with entity panel information included.
+    schema:
+      type: boolean
 get:
   operationId: GetRelationshipByID
   summary: Get Relationship by Graph Relationship ID
@@ -39,16 +47,18 @@ get:
             type: object
             properties:
               data:
-                $ref: './../schemas/model.relationship-details.yaml'
+                anyOf:
+                  - $ref: "./../schemas/model.relationship-details.yaml"
+                  - $ref: "./../schemas/model.relationship-details-with-info.yaml"
     400:
-      $ref: './../responses/bad-request.yaml'
+      $ref: "./../responses/bad-request.yaml"
     401:
-      $ref: './../responses/unauthorized.yaml'
+      $ref: "./../responses/unauthorized.yaml"
     403:
-      $ref: './../responses/forbidden.yaml'
+      $ref: "./../responses/forbidden.yaml"
     404:
-      $ref: './../responses/not-found.yaml'
+      $ref: "./../responses/not-found.yaml"
     429:
-      $ref: './../responses/too-many-requests.yaml'
+      $ref: "./../responses/too-many-requests.yaml"
     500:
-      $ref: './../responses/internal-server-error.yaml'
+      $ref: "./../responses/internal-server-error.yaml"

--- a/packages/go/openapi/src/schemas/model.kind-info-base.yaml
+++ b/packages/go/openapi/src/schemas/model.kind-info-base.yaml
@@ -1,0 +1,25 @@
+# Copyright 2026 Specter Ops, Inc.
+#
+# Licensed under the Apache License, Version 2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+type: object
+required: [title, position]
+properties:
+  title:
+    type: string
+    example: "Entity Panel Section"
+  position:
+    type: integer
+    minimum: 1

--- a/packages/go/openapi/src/schemas/model.kind-info-content.yaml
+++ b/packages/go/openapi/src/schemas/model.kind-info-content.yaml
@@ -1,0 +1,19 @@
+# Copyright 2026 Specter Ops, Inc.
+#
+# Licensed under the Apache License, Version 2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+type: object
+oneOf:
+  - $ref: "./model.kind-info-type-markdown.yaml"

--- a/packages/go/openapi/src/schemas/model.kind-info-response.yaml
+++ b/packages/go/openapi/src/schemas/model.kind-info-response.yaml
@@ -1,0 +1,25 @@
+# Copyright 2026 Specter Ops, Inc.
+#
+# Licensed under the Apache License, Version 2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+allOf:
+  - type: object
+    required: [name]
+    properties:
+      name:
+        type: string
+        example: "panel_section_1"
+  - $ref: "./model.kind-info-base.yaml"
+  - $ref: "./model.kind-info-content.yaml"

--- a/packages/go/openapi/src/schemas/model.kind-info-type-markdown.yaml
+++ b/packages/go/openapi/src/schemas/model.kind-info-type-markdown.yaml
@@ -1,0 +1,25 @@
+# Copyright 2026 Specter Ops, Inc.
+#
+# Licensed under the Apache License, Version 2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+type: object
+required: [markdown]
+properties:
+  markdown:
+    type: object
+    required: [content]
+    properties:
+      content:
+        type: string

--- a/packages/go/openapi/src/schemas/model.relationship-details-with-info.yaml
+++ b/packages/go/openapi/src/schemas/model.relationship-details-with-info.yaml
@@ -1,0 +1,30 @@
+# Copyright 2026 Specter Ops, Inc.
+#
+# Licensed under the Apache License, Version 2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+allOf:
+  - $ref: "./model.relationship-details.yaml"
+  - type: object
+    properties:
+      info:
+        type: array
+        items:
+          allOf:
+            - $ref: "./model.kind-info-response.yaml"
+            - type: object
+              required: [relationship_kind_id]
+              properties:
+                relationship_kind_id:
+                  type: integer

--- a/packages/go/openapi/src/schemas/model.relationship-details.yaml
+++ b/packages/go/openapi/src/schemas/model.relationship-details.yaml
@@ -15,6 +15,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 type: object
+required:
+  - relationship_id
+  - kind
+  - properties
 properties:
   relationship_id:
     type: integer
@@ -33,6 +37,9 @@ properties:
     example: 1234567890
   kind:
     type: object
+    required:
+      - relationship_kind_id
+      - name
     properties:
       relationship_kind_id:
         type: integer
@@ -43,3 +50,12 @@ properties:
   properties:
     type: object
     additionalProperties: true
+    required:
+      - is_traversable
+      - lastSeen
+    properties:
+      is_traversable:
+        type: boolean
+      lastSeen:
+        type: string
+        format: date-time

--- a/packages/go/openapi/src/schemas/model.relationship-details.yaml
+++ b/packages/go/openapi/src/schemas/model.relationship-details.yaml
@@ -17,6 +17,8 @@
 type: object
 required:
   - relationship_id
+  - source_node_id
+  - target_node_id
   - kind
   - properties
 properties:

--- a/server/graphdb/graphdb_e2e_test.go
+++ b/server/graphdb/graphdb_e2e_test.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/gofrs/uuid"
 	"github.com/gorilla/mux"
+	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/peterldowns/pgtestdb"
 	"github.com/specterops/bloodhound/cmd/api/src/api/dbpool"
 	"github.com/specterops/bloodhound/cmd/api/src/auth"
@@ -59,11 +60,13 @@ import (
 // graphDBHarness bundles the wired HTTP handler and the test data IDs
 // so E2E test cases can assert the full response contract.
 type graphDBHarness struct {
-	handler        *mux.Router
-	nodeID         int64
-	relationshipID int64
-	sourceNodeID   int64
-	targetNodeID   int64
+	handler                  *mux.Router
+	nodeID                   int64
+	relationshipID           int64
+	relationshipKindID       int32
+	relationshipInfoMarkdown string
+	sourceNodeID             int64
+	targetNodeID             int64
 }
 
 // getPostgresConfig reads the integration test configuration from the environment
@@ -161,6 +164,7 @@ func newGraphDBHarness(t *testing.T) graphDBHarness {
 	harness := graphDBHarness{}
 	seedNode(t, ctx, graphDatabase, &harness)
 	seedRelationship(t, ctx, graphDatabase, &harness)
+	seedRelationshipKindInfo(t, ctx, bhDatabase, dbPool, &harness)
 
 	store := appdb.NewStore(graphDatabase, dbPool)
 	etacService := etac.Register(dbPool, dogtags.NewDefaultService())
@@ -241,6 +245,26 @@ func seedRelationship(t *testing.T, ctx context.Context, graphDB graph.Database,
 	require.NoError(t, err)
 }
 
+func seedRelationshipKindInfo(t *testing.T, ctx context.Context, bloodhoundDB *database.BloodhoundDB, dbPool *pgxpool.Pool, harness *graphDBHarness) {
+	t.Helper()
+
+	var backingKindID int32
+	require.NoError(t, dbPool.QueryRow(ctx, `
+		SELECT k.id, rk.id
+		FROM kind k
+		JOIN schema_relationship_kinds rk ON rk.kind_id = k.id
+		WHERE k.name = $1`, ad.MemberOf.String()).Scan(&backingKindID, &harness.relationshipKindID))
+
+	harness.relationshipInfoMarkdown = "relationship kind info markdown"
+	_, err := bloodhoundDB.CreateKindInfo(ctx, backingKindID, nil, &harness.relationshipKindID, model.KindInfoInput{
+		InfoKey:  "relationship_test_info",
+		Title:    "Relationship Test Info",
+		Position: 1,
+		Content:  json.RawMessage(`{"markdown":{"content":"relationship kind info markdown"}}`),
+	})
+	require.NoError(t, err)
+}
+
 func TestGetRelationshipByID(t *testing.T) {
 	var (
 		harness  = newGraphDBHarness(t)
@@ -268,6 +292,53 @@ func TestGetRelationshipByID(t *testing.T) {
 		assert.Equal(t, "MemberOf", envelope.Data.Kind.Name)
 		require.NotNil(t, envelope.Data.Kind.RelationshipKindID)
 		assert.Greater(t, *envelope.Data.Kind.RelationshipKindID, int32(0))
+		assert.NotContains(t, recorder.Body.String(), `"info"`)
+	})
+
+	t.Run("returns 200 without relationship info when include-info is false", func(t *testing.T) {
+		var (
+			recorder = httptest.NewRecorder()
+			request  = httptest.NewRequest("GET", basePath+strconv.FormatInt(harness.relationshipID, 10)+"?include-info=false", nil)
+		)
+
+		harness.handler.ServeHTTP(recorder, request)
+
+		require.Equal(t, http.StatusOK, recorder.Code)
+		assert.NotContains(t, recorder.Body.String(), `"info"`)
+	})
+
+	t.Run("returns 200 with relationship info when include-info is true", func(t *testing.T) {
+		var (
+			recorder = httptest.NewRecorder()
+			request  = httptest.NewRequest("GET", basePath+strconv.FormatInt(harness.relationshipID, 10)+"?include-info=true", nil)
+		)
+
+		harness.handler.ServeHTTP(recorder, request)
+
+		require.Equal(t, http.StatusOK, recorder.Code)
+
+		var envelope struct {
+			Data handlers.RelationshipView `json:"data"`
+		}
+		require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &envelope))
+
+		require.Len(t, envelope.Data.Info, 1)
+		assert.Equal(t, "relationship_test_info", envelope.Data.Info[0].Name)
+		assert.Equal(t, "Relationship Test Info", envelope.Data.Info[0].Title)
+		assert.Equal(t, int32(1), envelope.Data.Info[0].Position)
+		assert.Equal(t, int(harness.relationshipKindID), envelope.Data.Info[0].RelationshipKindID)
+		assert.Equal(t, harness.relationshipInfoMarkdown, envelope.Data.Info[0].Markdown.Content)
+	})
+
+	t.Run("returns 400 when include-info is malformed", func(t *testing.T) {
+		var (
+			recorder = httptest.NewRecorder()
+			request  = httptest.NewRequest("GET", basePath+strconv.FormatInt(harness.relationshipID, 10)+"?include-info=wat", nil)
+		)
+
+		harness.handler.ServeHTTP(recorder, request)
+
+		assert.Equal(t, http.StatusBadRequest, recorder.Code)
 	})
 
 	t.Run("returns 400 when the id is malformed", func(t *testing.T) {

--- a/server/graphdb/internal/handlers/handlers.go
+++ b/server/graphdb/internal/handlers/handlers.go
@@ -26,7 +26,7 @@ import (
 
 // GraphDB defines the graphdb service boundary for the graphdb handlers package.
 type GraphDB interface {
-	GetRelationship(ctx context.Context, id int64) (services.Relationship, error)
+	GetRelationship(ctx context.Context, id int64, includeKindInfo bool) (services.Relationship, error)
 	GetNode(ctx context.Context, id int64, includeKindInfo bool) (services.Node, error)
 }
 

--- a/server/graphdb/internal/handlers/mocks/graphdb.go
+++ b/server/graphdb/internal/handlers/mocks/graphdb.go
@@ -126,8 +126,8 @@ func (_c *MockGraphDB_GetNode_Call) RunAndReturn(run func(ctx context.Context, i
 }
 
 // GetRelationship provides a mock function for the type MockGraphDB
-func (_mock *MockGraphDB) GetRelationship(ctx context.Context, id int64) (services.Relationship, error) {
-	ret := _mock.Called(ctx, id)
+func (_mock *MockGraphDB) GetRelationship(ctx context.Context, id int64, includeKindInfo bool) (services.Relationship, error) {
+	ret := _mock.Called(ctx, id, includeKindInfo)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetRelationship")
@@ -135,16 +135,16 @@ func (_mock *MockGraphDB) GetRelationship(ctx context.Context, id int64) (servic
 
 	var r0 services.Relationship
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, int64) (services.Relationship, error)); ok {
-		return returnFunc(ctx, id)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, int64, bool) (services.Relationship, error)); ok {
+		return returnFunc(ctx, id, includeKindInfo)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, int64) services.Relationship); ok {
-		r0 = returnFunc(ctx, id)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, int64, bool) services.Relationship); ok {
+		r0 = returnFunc(ctx, id, includeKindInfo)
 	} else {
 		r0 = ret.Get(0).(services.Relationship)
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, int64) error); ok {
-		r1 = returnFunc(ctx, id)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, int64, bool) error); ok {
+		r1 = returnFunc(ctx, id, includeKindInfo)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -159,11 +159,12 @@ type MockGraphDB_GetRelationship_Call struct {
 // GetRelationship is a helper method to define mock.On call
 //   - ctx context.Context
 //   - id int64
-func (_e *MockGraphDB_Expecter) GetRelationship(ctx interface{}, id interface{}) *MockGraphDB_GetRelationship_Call {
-	return &MockGraphDB_GetRelationship_Call{Call: _e.mock.On("GetRelationship", ctx, id)}
+//   - includeKindInfo bool
+func (_e *MockGraphDB_Expecter) GetRelationship(ctx interface{}, id interface{}, includeKindInfo interface{}) *MockGraphDB_GetRelationship_Call {
+	return &MockGraphDB_GetRelationship_Call{Call: _e.mock.On("GetRelationship", ctx, id, includeKindInfo)}
 }
 
-func (_c *MockGraphDB_GetRelationship_Call) Run(run func(ctx context.Context, id int64)) *MockGraphDB_GetRelationship_Call {
+func (_c *MockGraphDB_GetRelationship_Call) Run(run func(ctx context.Context, id int64, includeKindInfo bool)) *MockGraphDB_GetRelationship_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -173,9 +174,14 @@ func (_c *MockGraphDB_GetRelationship_Call) Run(run func(ctx context.Context, id
 		if args[1] != nil {
 			arg1 = args[1].(int64)
 		}
+		var arg2 bool
+		if args[2] != nil {
+			arg2 = args[2].(bool)
+		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -186,7 +192,7 @@ func (_c *MockGraphDB_GetRelationship_Call) Return(relationship services.Relatio
 	return _c
 }
 
-func (_c *MockGraphDB_GetRelationship_Call) RunAndReturn(run func(ctx context.Context, id int64) (services.Relationship, error)) *MockGraphDB_GetRelationship_Call {
+func (_c *MockGraphDB_GetRelationship_Call) RunAndReturn(run func(ctx context.Context, id int64, includeKindInfo bool) (services.Relationship, error)) *MockGraphDB_GetRelationship_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/server/graphdb/internal/handlers/relationship.go
+++ b/server/graphdb/internal/handlers/relationship.go
@@ -31,10 +31,6 @@ import (
 // graph-assigned relationship id.
 const URIPathVariableRelationshipID = "relationship_id"
 
-// URIQueryParameterIncludeInfo is the name of the query parameter carrying the flag
-// for whether we should fetch the associated KindInfo for the relationship.
-const URIQueryParameterIncludeInfo = "include-info"
-
 // RelationshipKindView is the JSON shape of the kind embedded in a RelationshipView.
 // RelationshipKindID is null when the kind has no schema_relationship_kinds entry.
 type RelationshipKindView struct {

--- a/server/graphdb/internal/handlers/relationship.go
+++ b/server/graphdb/internal/handlers/relationship.go
@@ -104,11 +104,11 @@ func (s RelationshipView) JSONView() ([]byte, error) {
 // Kinds that are not registered in schema_relationship_kinds are returned with ID=nil.
 func (s Handlers) GetRelationshipByID(response http.ResponseWriter, request *http.Request) {
 	var (
-		err                error = nil
-		ctx                      = request.Context()
-		rawRelationshipID        = mux.Vars(request)[URIPathVariableRelationshipID]
-		includeKindInfoRaw       = request.URL.Query().Get("include-info")
-		includeKindInfo          = false
+		err                error
+		ctx                = request.Context()
+		rawRelationshipID  = mux.Vars(request)[URIPathVariableRelationshipID]
+		includeKindInfoRaw = request.URL.Query().Get("include-info")
+		includeKindInfo    = false
 	)
 
 	relationshipID, err := strconv.ParseInt(rawRelationshipID, 10, 64)

--- a/server/graphdb/internal/handlers/relationship.go
+++ b/server/graphdb/internal/handlers/relationship.go
@@ -31,6 +31,10 @@ import (
 // graph-assigned relationship id.
 const URIPathVariableRelationshipID = "relationship_id"
 
+// URIQueryParameterIncludeInfo is the name of the query parameter carrying the flag
+// for whether we should fetch the associated KindInfo for the relationship.
+const URIQueryParameterIncludeInfo = "include-info"
+
 // RelationshipKindView is the JSON shape of the kind embedded in a RelationshipView.
 // RelationshipKindID is null when the kind has no schema_relationship_kinds entry.
 type RelationshipKindView struct {
@@ -42,17 +46,27 @@ type RelationshipKindView struct {
 // decoupled from services.Relationship so the wire format can evolve independently of
 // the domain model.
 type RelationshipView struct {
-	RelationshipID int64                `json:"relationship_id"`
-	SourceNodeID   int64                `json:"source_node_id"`
-	TargetNodeID   int64                `json:"target_node_id"`
-	Kind           RelationshipKindView `json:"kind"`
-	Properties     map[string]any       `json:"properties"`
+	RelationshipID int64                      `json:"relationship_id"`
+	SourceNodeID   int64                      `json:"source_node_id"`
+	TargetNodeID   int64                      `json:"target_node_id"`
+	Kind           RelationshipKindView       `json:"kind"`
+	Properties     map[string]any             `json:"properties"`
+	Info           []RelationshipKindInfoView `json:"info,omitempty"`
+}
+
+// RelationshipKindInfoView is the JSON shape for each kind-info object associated with a relationship.
+type RelationshipKindInfoView struct {
+	Name               string       `json:"name"`
+	Title              string       `json:"title"`
+	Position           int32        `json:"position"`
+	RelationshipKindID int          `json:"relationship_kind_id"`
+	Markdown           MarkdownView `json:"markdown"`
 }
 
 // BuildRelationshipView projects a services.Relationship into the view type the handlers
 // return in their JSON envelope.
-func BuildRelationshipView(relationship services.Relationship) RelationshipView {
-	return RelationshipView{
+func BuildRelationshipView(relationship services.Relationship, includeKindInfo bool) RelationshipView {
+	relView := RelationshipView{
 		RelationshipID: relationship.ID,
 		SourceNodeID:   relationship.SourceNodeID,
 		TargetNodeID:   relationship.TargetNodeID,
@@ -62,6 +76,20 @@ func BuildRelationshipView(relationship services.Relationship) RelationshipView 
 		},
 		Properties: relationship.Properties,
 	}
+
+	if includeKindInfo {
+		for _, kindInfo := range relationship.KindInfos {
+			relView.Info = append(relView.Info, RelationshipKindInfoView{
+				Name:               kindInfo.InfoKey,
+				Title:              kindInfo.Title,
+				Position:           kindInfo.Position,
+				RelationshipKindID: int(*relationship.Kind.ID),
+				Markdown:           buildMarkdownView(kindInfo.Content),
+			})
+		}
+	}
+
+	return relView
 }
 
 // JSONView marshals the view to the byte slice expected by responses.WriteBasic,
@@ -76,8 +104,11 @@ func (s RelationshipView) JSONView() ([]byte, error) {
 // Kinds that are not registered in schema_relationship_kinds are returned with ID=nil.
 func (s Handlers) GetRelationshipByID(response http.ResponseWriter, request *http.Request) {
 	var (
-		ctx               = request.Context()
-		rawRelationshipID = mux.Vars(request)[URIPathVariableRelationshipID]
+		err                error = nil
+		ctx                      = request.Context()
+		rawRelationshipID        = mux.Vars(request)[URIPathVariableRelationshipID]
+		includeKindInfoRaw       = request.URL.Query().Get("include-info")
+		includeKindInfo          = false
 	)
 
 	relationshipID, err := strconv.ParseInt(rawRelationshipID, 10, 64)
@@ -86,7 +117,15 @@ func (s Handlers) GetRelationshipByID(response http.ResponseWriter, request *htt
 		return
 	}
 
-	relationship, err := s.graphDB.GetRelationship(ctx, relationshipID)
+	if includeKindInfoRaw != "" {
+		includeKindInfo, err = strconv.ParseBool(includeKindInfoRaw)
+		if err != nil {
+			responses.WriteError(ctx, http.StatusBadRequest, "include-info is malformed", response)
+			return
+		}
+	}
+
+	relationship, err := s.graphDB.GetRelationship(ctx, relationshipID, includeKindInfo)
 	if errors.Is(err, services.ErrRelationshipNotFound) {
 		responses.WriteError(ctx, http.StatusNotFound, "relationship not found", response)
 		return
@@ -96,5 +135,5 @@ func (s Handlers) GetRelationshipByID(response http.ResponseWriter, request *htt
 		return
 	}
 
-	responses.WriteBasic(ctx, BuildRelationshipView(relationship), http.StatusOK, response)
+	responses.WriteBasic(ctx, BuildRelationshipView(relationship, includeKindInfo), http.StatusOK, response)
 }

--- a/server/graphdb/internal/handlers/relationship_test.go
+++ b/server/graphdb/internal/handlers/relationship_test.go
@@ -71,7 +71,7 @@ func TestHandlers_GetRelationshipByID(t *testing.T) {
 			name:  "returns 200 with the relationship view on success",
 			rawID: "1234567890",
 			setupMock: func(graphDBMock *mocks.MockGraphDB) {
-				graphDBMock.EXPECT().GetRelationship(mock.Anything, relationshipID).Return(relationship, nil)
+				graphDBMock.EXPECT().GetRelationship(mock.Anything, relationshipID, false).Return(relationship, nil)
 			},
 			wantStatus: http.StatusOK,
 			assertBody: func(t *testing.T, body []byte) {
@@ -91,7 +91,7 @@ func TestHandlers_GetRelationshipByID(t *testing.T) {
 			name:  "returns 200 with a null relationship kind id when the kind has no schema entry",
 			rawID: "1234567890",
 			setupMock: func(graphDBMock *mocks.MockGraphDB) {
-				graphDBMock.EXPECT().GetRelationship(mock.Anything, relationshipID).Return(nilKindRelationship, nil)
+				graphDBMock.EXPECT().GetRelationship(mock.Anything, relationshipID, false).Return(nilKindRelationship, nil)
 			},
 			wantStatus: http.StatusOK,
 			assertBody: func(t *testing.T, body []byte) {
@@ -114,7 +114,7 @@ func TestHandlers_GetRelationshipByID(t *testing.T) {
 			name:  "returns 404 when the relationship is not found",
 			rawID: "1234567890",
 			setupMock: func(graphDBMock *mocks.MockGraphDB) {
-				graphDBMock.EXPECT().GetRelationship(mock.Anything, relationshipID).Return(services.Relationship{}, services.ErrRelationshipNotFound)
+				graphDBMock.EXPECT().GetRelationship(mock.Anything, relationshipID, false).Return(services.Relationship{}, services.ErrRelationshipNotFound)
 			},
 			wantStatus: http.StatusNotFound,
 		},

--- a/server/graphdb/internal/handlers/relationship_test.go
+++ b/server/graphdb/internal/handlers/relationship_test.go
@@ -33,10 +33,11 @@ import (
 
 // newRequestWithID builds a GET request whose mux path variables carry the
 // supplied raw relationship id, mirroring what the router does at runtime.
-func newRequestWithID(t *testing.T, rawID string) *http.Request {
+func newRequestWithID(t *testing.T, rawID string, rawQuery string) *http.Request {
 	t.Helper()
 	request, err := http.NewRequest(http.MethodGet, "/api/v2/relationships/"+rawID, nil)
 	require.NoError(t, err)
+	request.URL.RawQuery = rawQuery
 	return mux.SetURLVars(request, map[string]string{handlers.URIPathVariableRelationshipID: rawID})
 }
 
@@ -44,12 +45,29 @@ func TestHandlers_GetRelationshipByID(t *testing.T) {
 	var (
 		relationshipID = int64(1234567890)
 		kindID         = int32(42)
+		markdown       = "relationship markdown"
 		relationship   = services.Relationship{
 			ID:           relationshipID,
 			SourceNodeID: 100,
 			TargetNodeID: 200,
 			Kind:         services.Kind{ID: &kindID, Name: "MemberOf"},
 			Properties:   map[string]any{"foo": "bar"},
+		}
+		relationshipWithInfo = services.Relationship{
+			ID:           relationshipID,
+			SourceNodeID: 100,
+			TargetNodeID: 200,
+			Kind:         services.Kind{ID: &kindID, Name: "MemberOf"},
+			Properties:   map[string]any{"foo": "bar"},
+			KindInfos: []services.KindInfo{
+				{
+					InfoKey:            "abuse",
+					Title:              "Abuse",
+					Position:           1,
+					RelationshipKindID: &kindID,
+					Content:            json.RawMessage(`{"markdown":{"content":"relationship markdown"}}`),
+				},
+			},
 		}
 		nilKindRelationship = services.Relationship{
 			ID:           relationshipID,
@@ -63,6 +81,7 @@ func TestHandlers_GetRelationshipByID(t *testing.T) {
 	tests := []struct {
 		name       string
 		rawID      string
+		rawQuery   string
 		setupMock  func(graphDBMock *mocks.MockGraphDB)
 		wantStatus int
 		assertBody func(t *testing.T, body []byte)
@@ -85,6 +104,45 @@ func TestHandlers_GetRelationshipByID(t *testing.T) {
 				require.NotNil(t, envelope.Data.Kind.RelationshipKindID)
 				assert.Equal(t, int32(42), *envelope.Data.Kind.RelationshipKindID)
 				assert.Equal(t, "MemberOf", envelope.Data.Kind.Name)
+				assert.NotContains(t, string(body), `"info"`)
+			},
+		},
+		{
+			name:     "returns 200 with relationship info when include-info is true",
+			rawID:    "1234567890",
+			rawQuery: "include-info=true",
+			setupMock: func(graphDBMock *mocks.MockGraphDB) {
+				graphDBMock.EXPECT().GetRelationship(mock.Anything, relationshipID, true).Return(relationshipWithInfo, nil)
+			},
+			wantStatus: http.StatusOK,
+			assertBody: func(t *testing.T, body []byte) {
+				var envelope struct {
+					Data handlers.RelationshipView `json:"data"`
+				}
+				require.NoError(t, json.Unmarshal(body, &envelope))
+				require.Len(t, envelope.Data.Info, 1)
+				assert.Equal(t, "abuse", envelope.Data.Info[0].Name)
+				assert.Equal(t, "Abuse", envelope.Data.Info[0].Title)
+				assert.Equal(t, int32(1), envelope.Data.Info[0].Position)
+				assert.Equal(t, int(kindID), envelope.Data.Info[0].RelationshipKindID)
+				assert.Equal(t, markdown, envelope.Data.Info[0].Markdown.Content)
+			},
+		},
+		{
+			name:     "returns 200 without relationship info when include-info is false",
+			rawID:    "1234567890",
+			rawQuery: "include-info=false",
+			setupMock: func(graphDBMock *mocks.MockGraphDB) {
+				graphDBMock.EXPECT().GetRelationship(mock.Anything, relationshipID, false).Return(relationshipWithInfo, nil)
+			},
+			wantStatus: http.StatusOK,
+			assertBody: func(t *testing.T, body []byte) {
+				var envelope struct {
+					Data map[string]any `json:"data"`
+				}
+				require.NoError(t, json.Unmarshal(body, &envelope))
+				assert.NotContains(t, envelope.Data, "info")
+				assert.NotContains(t, string(body), `"info"`)
 			},
 		},
 		{
@@ -111,6 +169,12 @@ func TestHandlers_GetRelationshipByID(t *testing.T) {
 			wantStatus: http.StatusBadRequest,
 		},
 		{
+			name:       "returns 400 when include-info is malformed",
+			rawID:      "1234567890",
+			rawQuery:   "include-info=wat",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
 			name:  "returns 404 when the relationship is not found",
 			rawID: "1234567890",
 			setupMock: func(graphDBMock *mocks.MockGraphDB) {
@@ -127,7 +191,7 @@ func TestHandlers_GetRelationshipByID(t *testing.T) {
 				authorizerMock = mocks.NewMockNodeAuthorizer(t)
 				handlerSet     = handlers.NewHandlersContainer(graphDBMock, authorizerMock)
 				recorder       = httptest.NewRecorder()
-				request        = newRequestWithID(t, tt.rawID)
+				request        = newRequestWithID(t, tt.rawID, tt.rawQuery)
 			)
 
 			if tt.setupMock != nil {

--- a/server/graphdb/internal/services/relationship.go
+++ b/server/graphdb/internal/services/relationship.go
@@ -17,8 +17,10 @@
 package services
 
 import (
+	"cmp"
 	"context"
 	"errors"
+	"slices"
 )
 
 // Relationship is the domain representation of a graph relationship together with
@@ -29,6 +31,7 @@ type Relationship struct {
 	TargetNodeID int64
 	Kind         Kind
 	Properties   map[string]any
+	KindInfos    []KindInfo
 }
 
 // ErrRelationshipNotFound indicates that no graph relationship exists for the requested id.
@@ -43,7 +46,7 @@ var ErrKindNotFound = errors.New("relationship kind not found")
 // returned when the relationship does not exist. If the kind has no entry in the
 // schema_relationship_kinds table, the relationship is returned with Kind.Name populated
 // and Kind.ID set to nil (best-effort resolution).
-func (s *Service) GetRelationship(ctx context.Context, id int64) (Relationship, error) {
+func (s *Service) GetRelationship(ctx context.Context, id int64, includeKindInfo bool) (Relationship, error) {
 	var (
 		relationship Relationship
 		kind         Kind
@@ -59,6 +62,36 @@ func (s *Service) GetRelationship(ctx context.Context, id int64) (Relationship, 
 		return Relationship{}, err
 	} else {
 		relationship.Kind = kind
-		return relationship, nil
 	}
+
+	if includeKindInfo && relationship.Kind.ID != nil {
+		kindInfos, err := s.db.GetKindInfos(ctx, relationship.Kind.Name)
+		if err != nil {
+			return Relationship{}, err
+		}
+
+		var allKindInfos []KindInfo
+		for _, kindInfo := range kindInfos {
+			if kindInfo.RelationshipKindID == nil {
+				continue
+			}
+
+			allKindInfos = append(allKindInfos, kindInfo)
+		}
+
+		// Sort all kind infos by Position -> Title -> Kind ID
+		slices.SortFunc(allKindInfos, func(left, right KindInfo) int {
+			if result := cmp.Compare(left.Position, right.Position); result != 0 {
+				return result
+			} else if result := cmp.Compare(left.Title, right.Title); result != 0 {
+				return result
+			} else {
+				return cmp.Compare(*left.RelationshipKindID, *right.RelationshipKindID)
+			}
+		})
+
+		relationship.KindInfos = allKindInfos
+	}
+
+	return relationship, nil
 }

--- a/server/graphdb/internal/services/relationship_test.go
+++ b/server/graphdb/internal/services/relationship_test.go
@@ -118,7 +118,7 @@ func TestService_GetRelationship(t *testing.T) {
 
 			tt.setupMock(databaseMock)
 
-			result, err := svc.GetRelationship(ctx, relationshipID)
+			result, err := svc.GetRelationship(ctx, relationshipID, false)
 			if tt.wantErr != nil {
 				assert.ErrorIs(t, err, tt.wantErr)
 			} else {

--- a/server/graphdb/internal/services/relationship_test.go
+++ b/server/graphdb/internal/services/relationship_test.go
@@ -18,6 +18,7 @@ package services_test
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"testing"
 
@@ -46,10 +47,11 @@ func TestService_GetRelationship(t *testing.T) {
 	)
 
 	tests := []struct {
-		name       string
-		setupMock  func(databaseMock *mocks.MockDatabase)
-		wantResult services.Relationship
-		wantErr    error
+		name            string
+		includeKindInfo bool
+		setupMock       func(databaseMock *mocks.MockDatabase)
+		wantResult      services.Relationship
+		wantErr         error
 	}{
 		{
 			name: "resolves the kind id and preserves endpoint node ids on success",
@@ -66,7 +68,90 @@ func TestService_GetRelationship(t *testing.T) {
 			},
 		},
 		{
+			name:            "fetches filters and sorts relationship kind infos when requested",
+			includeKindInfo: true,
+			setupMock: func(databaseMock *mocks.MockDatabase) {
+				databaseMock.EXPECT().GetRelationship(ctx, relationshipID).Return(baseRelationship, nil)
+				databaseMock.EXPECT().GetKindByName(ctx, kindName).Return(resolvedKind, nil)
+				databaseMock.EXPECT().GetKindInfos(ctx, kindName).Return([]services.KindInfo{
+					{
+						InfoKey:            "later",
+						Title:              "Beta",
+						Position:           1,
+						RelationshipKindID: int32Ptr(42),
+						Content:            json.RawMessage(`{"markdown":{"content":"later"}}`),
+					},
+					{
+						InfoKey:    "node_info",
+						Title:      "Node Info",
+						Position:   0,
+						NodeKindID: int32Ptr(99),
+						Content:    json.RawMessage(`{"markdown":{"content":"node"}}`),
+					},
+					{
+						InfoKey:            "first",
+						Title:              "Gamma",
+						Position:           0,
+						RelationshipKindID: int32Ptr(42),
+						Content:            json.RawMessage(`{"markdown":{"content":"first"}}`),
+					},
+					{
+						InfoKey:            "middle",
+						Title:              "Alpha",
+						Position:           1,
+						RelationshipKindID: int32Ptr(42),
+						Content:            json.RawMessage(`{"markdown":{"content":"middle"}}`),
+					},
+				}, nil)
+			},
+			wantResult: services.Relationship{
+				ID:           relationshipID,
+				SourceNodeID: 100,
+				TargetNodeID: 200,
+				Kind:         resolvedKind,
+				Properties:   map[string]any{"foo": "bar"},
+				KindInfos: []services.KindInfo{
+					{
+						InfoKey:            "first",
+						Title:              "Gamma",
+						Position:           0,
+						RelationshipKindID: int32Ptr(42),
+						Content:            json.RawMessage(`{"markdown":{"content":"first"}}`),
+					},
+					{
+						InfoKey:            "middle",
+						Title:              "Alpha",
+						Position:           1,
+						RelationshipKindID: int32Ptr(42),
+						Content:            json.RawMessage(`{"markdown":{"content":"middle"}}`),
+					},
+					{
+						InfoKey:            "later",
+						Title:              "Beta",
+						Position:           1,
+						RelationshipKindID: int32Ptr(42),
+						Content:            json.RawMessage(`{"markdown":{"content":"later"}}`),
+					},
+				},
+			},
+		},
+		{
 			name: "preserves a nil kind id when the kind has no schema_relationship_kinds entry",
+			setupMock: func(databaseMock *mocks.MockDatabase) {
+				databaseMock.EXPECT().GetRelationship(ctx, relationshipID).Return(baseRelationship, nil)
+				databaseMock.EXPECT().GetKindByName(ctx, kindName).Return(nilIDKind, nil)
+			},
+			wantResult: services.Relationship{
+				ID:           relationshipID,
+				SourceNodeID: 100,
+				TargetNodeID: 200,
+				Kind:         nilIDKind,
+				Properties:   map[string]any{"foo": "bar"},
+			},
+		},
+		{
+			name:            "does not fetch relationship kind info when the resolved kind id is nil",
+			includeKindInfo: true,
 			setupMock: func(databaseMock *mocks.MockDatabase) {
 				databaseMock.EXPECT().GetRelationship(ctx, relationshipID).Return(baseRelationship, nil)
 				databaseMock.EXPECT().GetKindByName(ctx, kindName).Return(nilIDKind, nil)
@@ -107,6 +192,16 @@ func TestService_GetRelationship(t *testing.T) {
 			},
 			wantErr: unexpectedErr,
 		},
+		{
+			name:            "propagates relationship kind info errors",
+			includeKindInfo: true,
+			setupMock: func(databaseMock *mocks.MockDatabase) {
+				databaseMock.EXPECT().GetRelationship(ctx, relationshipID).Return(baseRelationship, nil)
+				databaseMock.EXPECT().GetKindByName(ctx, kindName).Return(resolvedKind, nil)
+				databaseMock.EXPECT().GetKindInfos(ctx, kindName).Return(nil, unexpectedErr)
+			},
+			wantErr: unexpectedErr,
+		},
 	}
 
 	for _, tt := range tests {
@@ -118,7 +213,7 @@ func TestService_GetRelationship(t *testing.T) {
 
 			tt.setupMock(databaseMock)
 
-			result, err := svc.GetRelationship(ctx, relationshipID, false)
+			result, err := svc.GetRelationship(ctx, relationshipID, tt.includeKindInfo)
 			if tt.wantErr != nil {
 				assert.ErrorIs(t, err, tt.wantErr)
 			} else {


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Adds `?include-info` query string parameter to `/api/v2/relationships/{id}` API route

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-8763

*Why is this change required? What problem does it solve?*

## How Has This Been Tested?

*Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc.*

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- New feature (non-breaking change which adds functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [X] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [X] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [X] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional `include-info` (boolean) to `GET /graph/relationships/{relationship_id}` to control whether relationship kind panel info is included.
  * When enabled, relationship responses now return `info` entries with name, title, position, and Markdown content.
* **Bug Fixes**
  * Malformed `include-info` values now correctly return HTTP 400.
* **API Improvements**
  * Strengthened relationship payload validation with more explicit required fields.
  * Updated the response schema to support both info and non-info payload shapes.
* **Tests**
  * Expanded E2E/handler/service coverage for `include-info` behavior and ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->