### PR TITLE
fix: fixed input issue BED-8998

### DIFF
--- a/cmd/ui/src/styles/swagger-overrides.scss
+++ b/cmd/ui/src/styles/swagger-overrides.scss
@@ -20,15 +20,6 @@
         }
     }
 
-    // swagger-ui renders each tag name as a bare text node sibling of the
-    // <span> wrapping its .opblock-tag-section, duplicating the h3 heading. CSS
-    // cannot target text nodes directly, so font-size:0 on the container collapses
-    // the stray text; the element children are restored below so only the duplicate
-    // text is hidden.
-    & > div:nth-child(2) > div:nth-child(2) {
-        font-size: 0;
-    }
-
     a.nostyle,
     div.renderedMarkdown > p,
     .response-col_status,

--- a/cmd/ui/src/styles/swagger-overrides.scss
+++ b/cmd/ui/src/styles/swagger-overrides.scss
@@ -20,6 +20,19 @@
         }
     }
 
+    // swagger-ui renders each tag name as a bare text node sibling of the
+    // <span> wrapping its .opblock-tag-section, duplicating the h3 heading. CSS
+    // cannot target text nodes directly, so font-size:0 on the container collapses
+    // the stray text; the element children are restored below so only the duplicate
+    // text is hidden.
+    & > div:nth-child(2) > div:nth-child(2) {
+        font-size: 0;
+
+        > span {
+            font-size: 1rem;
+        }
+    }
+
     a.nostyle,
     div.renderedMarkdown > p,
     .response-col_status,


### PR DESCRIPTION
## Description

This changeset fixes an issue where the input in the API Explorer was reduced in size and the user couldn't type in the input.

## Motivation and Context

Resolves [BED-8998](https://specterops.atlassian.net/browse/BED-8998)

## How Has This Been Tested?
Manually

## Screenshots (optional):
Before:
<img width="1036" height="585" alt="Screenshot 2026-07-16 at 1 55 20 PM" src="https://github.com/user-attachments/assets/0605af59-7a63-4faa-8849-d3d9189eab52" />
After:
<img width="1041" height="564" alt="Screenshot 2026-07-16 at 1 54 49 PM" src="https://github.com/user-attachments/assets/9252c338-50ee-46b2-ba24-44a40f5bd876" />


## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


[BED-8998]: https://specterops.atlassian.net/browse/BED-8998?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined Swagger UI styling so duplicate bare text nodes are hidden without impacting the visibility of actual Swagger tag/label content.
  * Swagger documentation labels now render more consistently across the UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->