### PR TITLE
fix: fixed hover states for the zone selector and env selector BED-8997

### DIFF
--- a/packages/javascript/bh-shared-ui/src/components/DropdownSelector/DropdownTriggerContents.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/DropdownSelector/DropdownTriggerContents.tsx
@@ -58,7 +58,7 @@ const DropdownTriggerContents = forwardRef<HTMLButtonElement, DropdownTriggerCon
                     buttonPrimary && `w-full text-sm ${dropdownIconStateStyles}`,
                     {
                         [triggerStyles]: !buttonPrimary,
-                        'bg-primary text-common-white border-transparent': open,
+                        'bg-primary text-common-white dark:text-common-dark border-transparent': open,
                     },
                     className,
                     buttonProps?.className

--- a/packages/javascript/bh-shared-ui/src/components/DropdownSelector/constants.ts
+++ b/packages/javascript/bh-shared-ui/src/components/DropdownSelector/constants.ts
@@ -13,22 +13,30 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
-export const focusedControlStateStyles =
-    'focus:bg-primary focus:text-common-white focus-visible:bg-secondary focus-visible:text-common-white dark:focus-visible:text-common-dark';
+const focusVisibleControlStateStyles =
+    'focus-visible:bg-secondary focus-visible:text-common-white dark:focus-visible:text-common-dark';
 
-export const dropdownIconStateStyles =
-    'hover:[&_svg]:text-common-white dark:hover:[&_svg]:text-common-dark hover:[&_svg]:fill-current hover:[&_svg_*]:text-common-white dark:hover:[&_svg_*]:text-common-dark hover:[&_svg_*]:fill-current focus:[&_svg]:text-common-white focus:[&_svg]:fill-current focus:[&_svg_*]:text-common-white focus:[&_svg_*]:fill-current focus-visible:[&_svg]:text-common-white dark:focus-visible:[&_svg]:text-common-dark focus-visible:[&_svg]:fill-current focus-visible:[&_svg_*]:text-common-white dark:focus-visible:[&_svg_*]:text-common-dark focus-visible:[&_svg_*]:fill-current';
+export const focusedControlStateStyles = `focus:bg-primary focus:text-common-white dark:focus:text-common-dark ${focusVisibleControlStateStyles}`;
+
+const focusVisibleDropdownIconStateStyles =
+    'focus-visible:[&_svg]:text-common-white dark:focus-visible:[&_svg]:text-common-dark focus-visible:[&_svg]:fill-current focus-visible:[&_svg_*]:text-common-white dark:focus-visible:[&_svg_*]:text-common-dark focus-visible:[&_svg_*]:fill-current';
+
+const focusedDropdownIconStateStyles = `focus:[&_svg]:text-common-white dark:focus:[&_svg]:text-common-dark focus:[&_svg]:fill-current focus:[&_svg_*]:text-common-white dark:focus:[&_svg_*]:text-common-dark focus:[&_svg_*]:fill-current ${focusVisibleDropdownIconStateStyles}`;
+
+export const dropdownIconStateStyles = `hover:[&_svg]:text-common-white dark:hover:[&_svg]:text-common-dark hover:[&_svg]:fill-current hover:[&_svg_*]:text-common-white dark:hover:[&_svg_*]:text-common-dark hover:[&_svg_*]:fill-current ${focusedDropdownIconStateStyles}`;
 
 export const triggerStyles = `max-w-56 text-sm text-main rounded-md bg-transparent hover:bg-primary hover:text-common-white ${focusedControlStateStyles} border shadow-outer-0 hover:border-transparent focus:border-transparent focus-visible:border-transparent border-dropdown-trigger-border group ${dropdownIconStateStyles}`;
 
 export const popoverContentStyles =
     'flex flex-col p-0 rounded-md border border-dropdown-popover-border bg-dropdown-popover-fill';
 
-export const optionStyles = `px-4 py-1 rounded-none w-full justify-normal text-main hover:no-underline hover:bg-dropdown-option-hover-fill ${focusedControlStateStyles} ${dropdownIconStateStyles} disabled:bg-dropdown-option-disabled-fill group`;
+export const optionStyles = `px-4 py-1 rounded-none w-full justify-normal text-main hover:text-main hover:no-underline hover:bg-dropdown-option-hover-fill ${focusVisibleControlStateStyles} ${focusVisibleDropdownIconStateStyles} disabled:bg-dropdown-option-disabled-fill group`;
 
-export const selectorIconStyles =
-    'group-hover:text-common-white dark:group-hover:text-common-dark group-focus:text-common-white group-focus-visible:text-common-white dark:group-focus-visible:text-common-dark';
+export const focusedOptionIconStyles =
+    'group-focus-visible:text-common-white dark:group-focus-visible:text-common-dark';
 
-export const optionIconStyles = selectorIconStyles;
+export const selectorIconStyles = `group-hover:text-common-white dark:group-hover:text-common-dark group-focus:text-common-white dark:group-focus:text-common-dark ${focusedOptionIconStyles}`;
+
+export const optionIconStyles = `group-hover:text-main ${focusedOptionIconStyles}`;
 
 export const tooltipStyles = 'max-w-80 border-0 dark:bg-dropdown-tooltip-fill text-main';


### PR DESCRIPTION
## Description

Fixed the hover state to render the correct colors for the zone selector and simple environment selector.

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves [BED-8997](https://specterops.atlassian.net/browse/BED-8997)

## How Has This Been Tested?
Manually

## Screenshots (optional):
Before:
<img width="1261" height="548" alt="Screenshot 2026-07-16 at 1 09 09 PM" src="https://github.com/user-attachments/assets/90aeac0a-398b-453d-8678-ab48e0b7b8c9" />
<img width="1258" height="612" alt="Screenshot 2026-07-16 at 1 07 14 PM" src="https://github.com/user-attachments/assets/d6e14425-e784-44f0-af07-c4bc67079804" />
After:
<img width="1261" height="659" alt="Screenshot 2026-07-16 at 3 23 48 PM" src="https://github.com/user-attachments/assets/bc86a916-fb54-4afe-b405-23670a20bd89" />
<img width="1259" height="560" alt="Screenshot 2026-07-16 at 3 24 03 PM" src="https://github.com/user-attachments/assets/39b2dc8e-79bd-4312-85ca-678eceae8130" />
<img width="1260" height="570" alt="Screenshot 2026-07-16 at 3 26 53 PM" src="https://github.com/user-attachments/assets/c80c4621-4d34-4bb8-98c5-5424b2bb0d20" />


## Types of changes

<!-- Please remove any items that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


[BED-8997]: https://specterops.atlassian.net/browse/BED-8997?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ