### PR TITLE
chore: protect custom_node_kinds from modifications if they are associated with an extension BED-8537

### DIFF
--- a/cmd/api/src/api/v2/customnode.go
+++ b/cmd/api/src/api/v2/customnode.go
@@ -57,6 +57,10 @@ type CreateCustomNodeRequest struct {
 }
 
 func validateCreateCustomNodeRequest(customNodeKindRequest CreateCustomNodeRequest) error {
+	if len(customNodeKindRequest.CustomTypes) == 0 {
+		return fmt.Errorf("custom_types must contain at least 1 entry")
+	}
+
 	for key, config := range customNodeKindRequest.CustomTypes {
 		if key == "" {
 			return fmt.Errorf("custom_types contains an entry with an empty string as a key. please remove or replace the empty key")

--- a/cmd/api/src/api/v2/customnode.go
+++ b/cmd/api/src/api/v2/customnode.go
@@ -77,6 +77,10 @@ func (s *Resources) CreateCustomNodeKind(response http.ResponseWriter, request *
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, api.ErrorResponsePayloadUnmarshalError, request), response)
 	} else if err := validateCreateCustomNodeRequest(customNodeKindRequest); err != nil {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, fmt.Sprintf("%s: %s", api.ErrorResponseCodeBadRequest, err), request), response)
+	} else if allKinds, err := s.DB.GetCustomNodeKinds(request.Context()); err != nil {
+		api.HandleDatabaseError(request, response, err)
+	} else if isCnkAssociatedWithSchema(allKinds, customNodeKindRequest.CustomTypes) {
+		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusConflict, fmt.Sprintf("%s: kind name is owned by a schema extension", api.ErrorResponseConflict), request), response)
 	} else if kinds, err := s.DB.CreateCustomNodeKinds(request.Context(), convertCreateCustomNodeRequest(customNodeKindRequest)); errors.Is(err, database.ErrDuplicateCustomNodeKindName) {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusConflict, fmt.Sprintf("%s: duplicate kind name", api.ErrorResponseConflict), request), response)
 	} else if err != nil {
@@ -86,6 +90,17 @@ func (s *Resources) CreateCustomNodeKind(response http.ResponseWriter, request *
 	} else {
 		api.WriteBasicResponse(request.Context(), kinds, http.StatusCreated, response)
 	}
+}
+
+// isCnkAssociatedWithSchema reports whether any key in customTypes matches a kind that is owned by a schema extension.
+func isCnkAssociatedWithSchema(allKinds []model.CustomNodeKind, customTypes map[string]model.CustomNodeKindConfig) bool {
+	for _, kind := range allKinds {
+		if _, requested := customTypes[kind.KindName]; requested && kind.SchemaNodeKindId != nil {
+			return true
+		}
+	}
+
+	return false
 }
 
 func convertCreateCustomNodeRequest(request CreateCustomNodeRequest) []model.CustomNodeKind {
@@ -123,6 +138,10 @@ func (s *Resources) UpdateCustomNodeKind(response http.ResponseWriter, request *
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, api.ErrorResponsePayloadUnmarshalError, request), response)
 	} else if err := customNodeKindRequest.Config.Validate(); err != nil {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, fmt.Sprintf("%s: %s", api.ErrorResponseCodeBadRequest, err), request), response)
+	} else if existing, err := s.DB.GetCustomNodeKind(request.Context(), paramId); err != nil {
+		api.HandleDatabaseError(request, response, err)
+	} else if existing.SchemaNodeKindId != nil {
+		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusConflict, fmt.Sprintf("%s: kind name is owned by a schema extension", api.ErrorResponseConflict), request), response)
 	} else if kind, err := s.DB.UpdateCustomNodeKind(request.Context(), model.CustomNodeKind{KindName: paramId, Config: assignColorDefault(customNodeKindRequest.Config)}); err != nil {
 		api.HandleDatabaseError(request, response, err)
 	} else {

--- a/cmd/api/src/api/v2/customnode.go
+++ b/cmd/api/src/api/v2/customnode.go
@@ -17,7 +17,6 @@
 package v2
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -78,10 +77,6 @@ func (s *Resources) CreateCustomNodeKind(response http.ResponseWriter, request *
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, api.ErrorResponsePayloadUnmarshalError, request), response)
 	} else if err := validateCreateCustomNodeRequest(customNodeKindRequest); err != nil {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, fmt.Sprintf("%s: %s", api.ErrorResponseCodeBadRequest, err), request), response)
-	} else if protected, err := checkSchemaProtection(request.Context(), s.DB, customNodeKindRequest.CustomTypes); err != nil {
-		api.HandleDatabaseError(request, response, err)
-	} else if protected {
-		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusConflict, fmt.Sprintf("%s: kind name is owned by a schema extension", api.ErrorResponseConflict), request), response)
 	} else if kinds, err := s.DB.CreateCustomNodeKinds(request.Context(), convertCreateCustomNodeRequest(customNodeKindRequest)); errors.Is(err, database.ErrDuplicateCustomNodeKindName) {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusConflict, fmt.Sprintf("%s: duplicate kind name", api.ErrorResponseConflict), request), response)
 	} else if err != nil {
@@ -91,21 +86,6 @@ func (s *Resources) CreateCustomNodeKind(response http.ResponseWriter, request *
 	} else {
 		api.WriteBasicResponse(request.Context(), kinds, http.StatusCreated, response)
 	}
-}
-
-// checkSchemaProtection reports whether any of the kind names in customTypes are owned by a schema extension.
-func checkSchemaProtection(ctx context.Context, db database.CustomNodeKindData, customTypes map[string]model.CustomNodeKindConfig) (bool, error) {
-	for kindName := range customTypes {
-		if existing, err := db.GetCustomNodeKind(ctx, kindName); errors.Is(err, database.ErrNotFound) {
-			continue
-		} else if err != nil {
-			return false, err
-		} else if existing.SchemaNodeKindId != nil {
-			return true, nil
-		}
-	}
-
-	return false, nil
 }
 
 func convertCreateCustomNodeRequest(request CreateCustomNodeRequest) []model.CustomNodeKind {

--- a/cmd/api/src/api/v2/customnode.go
+++ b/cmd/api/src/api/v2/customnode.go
@@ -17,6 +17,7 @@
 package v2
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -77,9 +78,9 @@ func (s *Resources) CreateCustomNodeKind(response http.ResponseWriter, request *
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, api.ErrorResponsePayloadUnmarshalError, request), response)
 	} else if err := validateCreateCustomNodeRequest(customNodeKindRequest); err != nil {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, fmt.Sprintf("%s: %s", api.ErrorResponseCodeBadRequest, err), request), response)
-	} else if allKinds, err := s.DB.GetCustomNodeKinds(request.Context()); err != nil {
+	} else if protected, err := checkSchemaProtection(request.Context(), s.DB, customNodeKindRequest.CustomTypes); err != nil {
 		api.HandleDatabaseError(request, response, err)
-	} else if isCnkAssociatedWithSchema(allKinds, customNodeKindRequest.CustomTypes) {
+	} else if protected {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusConflict, fmt.Sprintf("%s: kind name is owned by a schema extension", api.ErrorResponseConflict), request), response)
 	} else if kinds, err := s.DB.CreateCustomNodeKinds(request.Context(), convertCreateCustomNodeRequest(customNodeKindRequest)); errors.Is(err, database.ErrDuplicateCustomNodeKindName) {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusConflict, fmt.Sprintf("%s: duplicate kind name", api.ErrorResponseConflict), request), response)
@@ -92,15 +93,19 @@ func (s *Resources) CreateCustomNodeKind(response http.ResponseWriter, request *
 	}
 }
 
-// isCnkAssociatedWithSchema reports whether any key in customTypes matches a kind that is owned by a schema extension.
-func isCnkAssociatedWithSchema(allKinds []model.CustomNodeKind, customTypes map[string]model.CustomNodeKindConfig) bool {
-	for _, kind := range allKinds {
-		if _, requested := customTypes[kind.KindName]; requested && kind.SchemaNodeKindId != nil {
-			return true
+// checkSchemaProtection reports whether any of the kind names in customTypes are owned by a schema extension.
+func checkSchemaProtection(ctx context.Context, db database.CustomNodeKindData, customTypes map[string]model.CustomNodeKindConfig) (bool, error) {
+	for kindName := range customTypes {
+		if existing, err := db.GetCustomNodeKind(ctx, kindName); errors.Is(err, database.ErrNotFound) {
+			continue
+		} else if err != nil {
+			return false, err
+		} else if existing.SchemaNodeKindId != nil {
+			return true, nil
 		}
 	}
 
-	return false
+	return false, nil
 }
 
 func convertCreateCustomNodeRequest(request CreateCustomNodeRequest) []model.CustomNodeKind {

--- a/cmd/api/src/api/v2/customnode_test.go
+++ b/cmd/api/src/api/v2/customnode_test.go
@@ -260,6 +260,37 @@ func TestResources_CreateCustomNodeKindsTest(t *testing.T) {
 			},
 		},
 		{
+			name: "Error: request body is empty",
+			buildRequest: func() *http.Request {
+				request := &http.Request{
+					URL: &url.URL{
+						Path: "/api/v2/custom-nodes",
+					},
+					Method: http.MethodPost,
+					Header: http.Header{},
+				}
+
+				payload := &v2.CreateCustomNodeRequest{
+					CustomTypes: map[string]model.CustomNodeKindConfig{},
+				}
+				jsonPayload, err := json.Marshal(payload)
+				if err != nil {
+					t.Fatalf("error occurred while marshaling payload necessary for test: %v", err)
+				}
+
+				request.Header.Add(headers.ContentType.String(), "application/json")
+				request.Body = io.NopCloser(bytes.NewReader(jsonPayload))
+
+				return request
+			},
+			setupMocks: func(t *testing.T, mocks *mock) {},
+			expected: expected{
+				responseCode:   http.StatusBadRequest,
+				responseBody:   `{"errors":[{"context":"","message":"BadRequest: custom_types must contain at least 1 entry"}],"http_status":400,"request_id":"","timestamp":"0001-01-01T00:00:00Z"}`,
+				responseHeader: http.Header{"Content-Type": []string{"application/json"}},
+			},
+		},
+		{
 			name: "Error: custom_types has a top-level empty key",
 			buildRequest: func() *http.Request {
 				request := &http.Request{

--- a/cmd/api/src/api/v2/customnode_test.go
+++ b/cmd/api/src/api/v2/customnode_test.go
@@ -181,8 +181,6 @@ func TestResources_CreateCustomNodeKindsTest(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mocks *mock) {
 				t.Helper()
-				// checkSchemaProtection calls GetCustomNodeKind for each submitted kind name; return ErrNotFound to indicate none are schema-protected.
-				mocks.mockDatabase.EXPECT().GetCustomNodeKind(gomock.Any(), gomock.Any()).Return(model.CustomNodeKind{}, database.ErrNotFound).AnyTimes()
 				mocks.mockDatabase.EXPECT().CreateCustomNodeKinds(gomock.Any(), gomock.Any()).Return(model.CustomNodeKinds{
 					{
 						ID:       1,
@@ -251,62 +249,9 @@ func TestResources_CreateCustomNodeKindsTest(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mocks *mock) {
 				t.Helper()
-				// checkSchemaProtection calls GetCustomNodeKind; return ErrNotFound so the kind is not schema-protected.
-				mocks.mockDatabase.EXPECT().GetCustomNodeKind(gomock.Any(), "DuplicateKind").Return(model.CustomNodeKind{}, database.ErrNotFound)
 				mocks.mockDatabase.EXPECT().
 					CreateCustomNodeKinds(gomock.Any(), gomock.Any()).
 					Return(model.CustomNodeKinds{}, database.ErrDuplicateCustomNodeKindName)
-			},
-			expected: expected{
-				responseCode:   http.StatusConflict,
-				responseHeader: http.Header{"Content-Type": []string{"application/json"}},
-				// responseBody intentionally omitted — status code is the contract under test
-			},
-		},
-		{
-			name: "Error: schema-protected kind name",
-			buildRequest: func() *http.Request {
-				request := &http.Request{
-					URL: &url.URL{
-						Path: "/api/v2/custom-nodes",
-					},
-					Method: http.MethodPost,
-					Header: http.Header{},
-				}
-
-				payload := &v2.CreateCustomNodeRequest{
-					CustomTypes: map[string]model.CustomNodeKindConfig{
-						"User": {
-							Icon: graphschema.DisplayNodeIcon{
-								Type:  graphschema.DisplayNodeTypeFontAwesome,
-								Name:  "user",
-								Color: "#FFFFFF",
-							},
-						},
-					},
-				}
-				jsonPayload, err := json.Marshal(payload)
-				if err != nil {
-					t.Fatalf("error occurred while marshaling payload necessary for test: %v", err)
-				}
-
-				request.Header.Add(headers.ContentType.String(), "application/json")
-				request.Body = io.NopCloser(bytes.NewReader(jsonPayload))
-
-				return request
-			},
-			setupMocks: func(t *testing.T, mocks *mock) {
-				t.Helper()
-				schemaNodeKindId := int32(1)
-				// checkSchemaProtection calls GetCustomNodeKind; return the schema-owned "User" kind to trigger the 409.
-				mocks.mockDatabase.EXPECT().
-					GetCustomNodeKind(gomock.Any(), "User").
-					Return(model.CustomNodeKind{
-						ID:               1,
-						KindId:           1,
-						KindName:         "User",
-						SchemaNodeKindId: &schemaNodeKindId,
-					}, nil)
 			},
 			expected: expected{
 				responseCode:   http.StatusConflict,

--- a/cmd/api/src/api/v2/customnode_test.go
+++ b/cmd/api/src/api/v2/customnode_test.go
@@ -181,7 +181,8 @@ func TestResources_CreateCustomNodeKindsTest(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mocks *mock) {
 				t.Helper()
-				mocks.mockDatabase.EXPECT().GetCustomNodeKinds(gomock.Any()).Return([]model.CustomNodeKind{}, nil)
+				// checkSchemaProtection calls GetCustomNodeKind for each submitted kind name; return ErrNotFound to indicate none are schema-protected.
+				mocks.mockDatabase.EXPECT().GetCustomNodeKind(gomock.Any(), gomock.Any()).Return(model.CustomNodeKind{}, database.ErrNotFound).AnyTimes()
 				mocks.mockDatabase.EXPECT().CreateCustomNodeKinds(gomock.Any(), gomock.Any()).Return(model.CustomNodeKinds{
 					{
 						ID:       1,
@@ -250,7 +251,8 @@ func TestResources_CreateCustomNodeKindsTest(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mocks *mock) {
 				t.Helper()
-				mocks.mockDatabase.EXPECT().GetCustomNodeKinds(gomock.Any()).Return([]model.CustomNodeKind{}, nil)
+				// checkSchemaProtection calls GetCustomNodeKind; return ErrNotFound so the kind is not schema-protected.
+				mocks.mockDatabase.EXPECT().GetCustomNodeKind(gomock.Any(), "DuplicateKind").Return(model.CustomNodeKind{}, database.ErrNotFound)
 				mocks.mockDatabase.EXPECT().
 					CreateCustomNodeKinds(gomock.Any(), gomock.Any()).
 					Return(model.CustomNodeKinds{}, database.ErrDuplicateCustomNodeKindName)
@@ -296,15 +298,15 @@ func TestResources_CreateCustomNodeKindsTest(t *testing.T) {
 			setupMocks: func(t *testing.T, mocks *mock) {
 				t.Helper()
 				schemaNodeKindId := int32(1)
-				// GetCustomNodeKinds returns the schema-owned "User" kind, triggering the protection check.
-				mocks.mockDatabase.EXPECT().GetCustomNodeKinds(gomock.Any()).Return([]model.CustomNodeKind{
-					{
+				// checkSchemaProtection calls GetCustomNodeKind; return the schema-owned "User" kind to trigger the 409.
+				mocks.mockDatabase.EXPECT().
+					GetCustomNodeKind(gomock.Any(), "User").
+					Return(model.CustomNodeKind{
 						ID:               1,
 						KindId:           1,
 						KindName:         "User",
 						SchemaNodeKindId: &schemaNodeKindId,
-					},
-				}, nil)
+					}, nil)
 			},
 			expected: expected{
 				responseCode:   http.StatusConflict,

--- a/cmd/api/src/api/v2/customnode_test.go
+++ b/cmd/api/src/api/v2/customnode_test.go
@@ -181,6 +181,7 @@ func TestResources_CreateCustomNodeKindsTest(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mocks *mock) {
 				t.Helper()
+				mocks.mockDatabase.EXPECT().GetCustomNodeKinds(gomock.Any()).Return([]model.CustomNodeKind{}, nil)
 				mocks.mockDatabase.EXPECT().CreateCustomNodeKinds(gomock.Any(), gomock.Any()).Return(model.CustomNodeKinds{
 					{
 						ID:       1,
@@ -249,9 +250,61 @@ func TestResources_CreateCustomNodeKindsTest(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mocks *mock) {
 				t.Helper()
+				mocks.mockDatabase.EXPECT().GetCustomNodeKinds(gomock.Any()).Return([]model.CustomNodeKind{}, nil)
 				mocks.mockDatabase.EXPECT().
 					CreateCustomNodeKinds(gomock.Any(), gomock.Any()).
 					Return(model.CustomNodeKinds{}, database.ErrDuplicateCustomNodeKindName)
+			},
+			expected: expected{
+				responseCode:   http.StatusConflict,
+				responseHeader: http.Header{"Content-Type": []string{"application/json"}},
+				// responseBody intentionally omitted — status code is the contract under test
+			},
+		},
+		{
+			name: "Error: schema-protected kind name",
+			buildRequest: func() *http.Request {
+				request := &http.Request{
+					URL: &url.URL{
+						Path: "/api/v2/custom-nodes",
+					},
+					Method: http.MethodPost,
+					Header: http.Header{},
+				}
+
+				payload := &v2.CreateCustomNodeRequest{
+					CustomTypes: map[string]model.CustomNodeKindConfig{
+						"User": {
+							Icon: graphschema.DisplayNodeIcon{
+								Type:  graphschema.DisplayNodeTypeFontAwesome,
+								Name:  "user",
+								Color: "#FFFFFF",
+							},
+						},
+					},
+				}
+				jsonPayload, err := json.Marshal(payload)
+				if err != nil {
+					t.Fatalf("error occurred while marshaling payload necessary for test: %v", err)
+				}
+
+				request.Header.Add(headers.ContentType.String(), "application/json")
+				request.Body = io.NopCloser(bytes.NewReader(jsonPayload))
+
+				return request
+			},
+			setupMocks: func(t *testing.T, mocks *mock) {
+				t.Helper()
+				schemaNodeKindId := int32(1)
+				// GetCustomNodeKinds returns the schema-owned "User" kind, triggering the protection check.
+				mocks.mockDatabase.EXPECT().GetCustomNodeKinds(gomock.Any()).Return([]model.CustomNodeKind{
+					{
+						ID:               1,
+						KindId:           1,
+						KindName:         "User",
+						SchemaNodeKindId: &schemaNodeKindId,
+					},
+				}, nil)
 			},
 			expected: expected{
 				responseCode:   http.StatusConflict,
@@ -472,6 +525,12 @@ func TestResources_UpdateCustomNodeKindsTest(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mocks *mock) {
 				t.Helper()
+				mocks.mockDatabase.EXPECT().GetCustomNodeKind(gomock.Any(), "kind").Return(model.CustomNodeKind{
+					ID:       1,
+					KindId:   1,
+					KindName: "kind",
+					// SchemaNodeKindId is nil: this is a user-managed kind, update is allowed
+				}, nil)
 				mocks.mockDatabase.EXPECT().UpdateCustomNodeKind(gomock.Any(), gomock.Any()).Return(model.CustomNodeKind{
 					ID:       1,
 					KindId:   1,
@@ -488,6 +547,57 @@ func TestResources_UpdateCustomNodeKindsTest(t *testing.T) {
 			expected: expected{
 				responseCode:   http.StatusOK,
 				responseBody:   `{"data":{"id":1,"kindId":1,"kindName":"KindA","config":{"icon":{"type":"font-awesome","name":"coffee","color":"#FFFFFF"}}}}`,
+				responseHeader: http.Header{"Content-Type": []string{"application/json"}},
+			},
+		},
+		{
+			name: "Error: schema-protected kind name",
+			buildRequest: func() *http.Request {
+				request := &http.Request{
+					URL: &url.URL{
+						Path: "/api/v2/custom-nodes/User",
+					},
+					Method: http.MethodPut,
+					Header: http.Header{
+						headers.ContentType.String(): []string{
+							"application/json",
+						},
+					},
+				}
+
+				payload := &v2.UpdateCustomNodeKindRequest{
+					Config: model.CustomNodeKindConfig{
+						Icon: graphschema.DisplayNodeIcon{
+							Type:  graphschema.DisplayNodeTypeFontAwesome,
+							Name:  "user",
+							Color: "#FFFFFF",
+						},
+					},
+				}
+
+				jsonPayload, err := json.Marshal(payload)
+				if err != nil {
+					t.Fatalf("error occurred while marshaling payload necessary for test: %v", err)
+				}
+
+				request.Body = io.NopCloser(bytes.NewReader(jsonPayload))
+
+				return request
+			},
+			setupMocks: func(t *testing.T, mocks *mock) {
+				t.Helper()
+				schemaNodeKindId := int32(1)
+				mocks.mockDatabase.EXPECT().GetCustomNodeKind(gomock.Any(), "User").Return(model.CustomNodeKind{
+					ID:               1,
+					KindId:           1,
+					KindName:         "User",
+					SchemaNodeKindId: &schemaNodeKindId,
+				}, nil)
+				// UpdateCustomNodeKind should not be called since we returned a cnk with a non-nil SchemaNodeKindId, indicating it is schema-protected.
+			},
+			expected: expected{
+				responseCode:   http.StatusConflict,
+				responseBody:   `{"errors":[{"context":"","message":"Conflict: kind name is owned by a schema extension"}],"http_status":409,"request_id":"","timestamp":"0001-01-01T00:00:00Z"}`,
 				responseHeader: http.Header{"Content-Type": []string{"application/json"}},
 			},
 		},

--- a/packages/go/openapi/doc/openapi.json
+++ b/packages/go/openapi/doc/openapi.json
@@ -3295,6 +3295,27 @@
           "404": {
             "$ref": "#/components/responses/not-found"
           },
+          "409": {
+            "description": "**Conflict**\nKind name is owned by a schema extension\n",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/api.error-wrapper"
+                },
+                "example": {
+                  "http_status": 409,
+                  "timestamp": "2024-02-19T19:27:43.866Z",
+                  "request_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+                  "errors": [
+                    {
+                      "context": "customnodes",
+                      "message": "Conflict: kind name is owned by a schema extension"
+                    }
+                  ]
+                }
+              }
+            }
+          },
           "500": {
             "$ref": "#/components/responses/internal-server-error"
           }

--- a/packages/go/openapi/src/paths/custom-nodes.custom-nodes.name.yaml
+++ b/packages/go/openapi/src/paths/custom-nodes.custom-nodes.name.yaml
@@ -91,6 +91,21 @@ put:
       $ref: './../responses/unauthorized.yaml'
     404:
       $ref: './../responses/not-found.yaml'
+    409:
+      description: |
+        **Conflict**
+        Kind name is owned by a schema extension
+      content:
+        application/json:
+          schema:
+            $ref: './../schemas/api.error-wrapper.yaml'
+          example:
+            http_status: 409
+            timestamp: 2024-02-19T19:27:43.866Z
+            request_id: 3fa85f64-5717-4562-b3fc-2c963f66afa6
+            errors:
+              - context: customnodes
+                message: "Conflict: kind name is owned by a schema extension"
     500:
       $ref: './../responses/internal-server-error.yaml'
 delete:


### PR DESCRIPTION
## Description

We want to protect custom_node_kinds from changes if that particular row is associated with an extension - indicated by a non-null schema node kind ID. 

## Motivation and Context

Resolves https://specterops.atlassian.net/browse/BED-8537

## How Has This Been Tested?

unit tests have been added. 

## Screenshots (optional):

## Types of changes

- Chore (a change that does not modify the application functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Rejected custom node creation requests when `custom_types` is empty (returns HTTP 400).
  * Prevented updating schema-owned custom node kinds; returns HTTP **409 Conflict** with a detailed error.
* **Tests**
  * Added coverage for empty `POST /api/v2/custom-nodes` payloads returning the expected **400** error.
  * Added coverage for update behavior for both user-managed and schema-protected kinds, including **409** conflict responses.
* **Documentation**
  * Updated OpenAPI docs to include **409 Conflict** responses for these custom node kind update operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->