### PR TITLE
feat: reject older azurehound versions when use_raw_object_id flag is enabled - BED-9020

### DIFF
--- a/cmd/api/src/utils/util.go
+++ b/cmd/api/src/utils/util.go
@@ -37,6 +37,7 @@ var (
 	ErrInvalidSharpHoundVersion   = errors.New("invalid sharphound version string")
 	ErrInvalidCollectorVersion    = errors.New("invalid collector version string")
 	ErrRecommendSharphoundVersion = errors.New("please upgrade to sharphound v2.0.3 or above")
+	ErrRecommendAzureHoundVersion = errors.New("please upgrade to azurehound v3.0.0 or above")
 	ErrInvalidClientType          = errors.New("invalid client type")
 	ErrInvalidUUID                = errors.New("invalid UUID")
 )
@@ -60,12 +61,16 @@ type ClientVersion struct {
 }
 
 // IsValidClientVersion checks the version from a user agent to ensure it's a valid UserAgent and that
-// the version of the client is not EOL (currently SHS v1.x and SHS < v2.0.3).
+// the version of the client is not EOL (currently SHS v1.x and SHS < v2.0.3). When useRawObjectIDsEnabled
+// is true, AzureHound versions below v3.0.0 are also rejected.
 // Returns the parsed ClientVersion and an error when invalid.
-func IsValidClientVersion(userAgent string) (ClientVersion, error) {
+func IsValidClientVersion(userAgent string, useRawObjectIDsEnabled bool) (ClientVersion, error) {
 	if version, err := ParseClientVersion(userAgent); err != nil {
 		return version, fmt.Errorf("error parsing client version: %w", err)
 	} else if version.ClientType == ClientTypeAzureHound {
+		if version.Major < 3 && useRawObjectIDsEnabled {
+			return version, fmt.Errorf("azurehound version below v3.0.0 detected and Use Raw Object ID flag is enabled: %w", ErrRecommendAzureHoundVersion)
+		}
 		return version, nil
 	} else if version.ClientType == ClientTypeOpenHound {
 		return version, nil

--- a/cmd/api/src/utils/util_test.go
+++ b/cmd/api/src/utils/util_test.go
@@ -36,7 +36,7 @@ func TestIsValidClientVersion(t *testing.T) {
 		err error
 	)
 
-	azureHoundVersion, err := utils.IsValidClientVersion("azurehound/0.0.0")
+	azureHoundVersion, err := utils.IsValidClientVersion("azurehound/0.0.0", false)
 	require.Nil(t, err)
 	require.Equal(t, utils.ClientTypeAzureHound, azureHoundVersion.ClientType)
 	require.Equal(t, 0, azureHoundVersion.Major)
@@ -44,7 +44,7 @@ func TestIsValidClientVersion(t *testing.T) {
 	require.Equal(t, 0, azureHoundVersion.Patch)
 	require.Empty(t, azureHoundVersion.BuildMetadata)
 
-	azureHoundDockerVersion, err := utils.IsValidClientVersion("azurehound/0.0.0+docker")
+	azureHoundDockerVersion, err := utils.IsValidClientVersion("azurehound/0.0.0+docker", false)
 	require.Nil(t, err)
 	require.Equal(t, utils.ClientTypeAzureHound, azureHoundDockerVersion.ClientType)
 	require.Equal(t, 0, azureHoundDockerVersion.Major)
@@ -53,7 +53,7 @@ func TestIsValidClientVersion(t *testing.T) {
 	require.Empty(t, azureHoundDockerVersion.Prerelease)
 	require.Equal(t, "docker", azureHoundDockerVersion.BuildMetadata)
 
-	azureHoundRCVersion, err := utils.IsValidClientVersion("azurehound/0.0.0-rc1")
+	azureHoundRCVersion, err := utils.IsValidClientVersion("azurehound/0.0.0-rc1", false)
 	require.Nil(t, err)
 	require.Equal(t, utils.ClientTypeAzureHound, azureHoundRCVersion.ClientType)
 	require.Equal(t, 0, azureHoundRCVersion.Major)
@@ -62,10 +62,10 @@ func TestIsValidClientVersion(t *testing.T) {
 	require.Equal(t, "rc1", azureHoundRCVersion.Prerelease)
 	require.Empty(t, azureHoundRCVersion.BuildMetadata)
 
-	_, err = utils.IsValidClientVersion("azurehound/0.0.0+notdocker")
+	_, err = utils.IsValidClientVersion("azurehound/0.0.0+notdocker", false)
 	require.ErrorIs(t, err, utils.ErrInvalidCollectorVersion)
 
-	azureHoundRCDockerVersion, err := utils.IsValidClientVersion("azurehound/0.0.0-rc1+docker")
+	azureHoundRCDockerVersion, err := utils.IsValidClientVersion("azurehound/0.0.0-rc1+docker", false)
 	require.Nil(t, err)
 	require.Equal(t, utils.ClientTypeAzureHound, azureHoundRCDockerVersion.ClientType)
 	require.Equal(t, 0, azureHoundRCDockerVersion.Major)
@@ -74,16 +74,25 @@ func TestIsValidClientVersion(t *testing.T) {
 	require.Equal(t, "rc1", azureHoundRCDockerVersion.Prerelease)
 	require.Equal(t, "docker", azureHoundRCDockerVersion.BuildMetadata)
 
-	_, err = utils.IsValidClientVersion("azurehound/0.0.0-rc1+notdocker")
+	_, err = utils.IsValidClientVersion("azurehound/0.0.0-rc1+notdocker", false)
 	require.ErrorIs(t, err, utils.ErrInvalidCollectorVersion)
 
-	_, err = utils.IsValidClientVersion("azurehound/0.0.0-rcfoo")
+	_, err = utils.IsValidClientVersion("azurehound/0.0.0-rcfoo", false)
 	require.ErrorIs(t, err, utils.ErrInvalidCollectorVersion)
 
-	_, err = utils.IsValidClientVersion("azurehound/0.0.0-alpha")
+	_, err = utils.IsValidClientVersion("azurehound/0.0.0-alpha", false)
 	require.ErrorIs(t, err, utils.ErrInvalidCollectorVersion)
 
-	sharpHoundversion, err := utils.IsValidClientVersion("sharphound/2.0.3.0")
+	// When the UseRawObjectIDs flag is enabled, AzureHound versions below v3.0.0 are rejected.
+	_, err = utils.IsValidClientVersion("azurehound/2.9.9", true)
+	require.ErrorIs(t, err, utils.ErrRecommendAzureHoundVersion)
+
+	azureHoundV3Version, err := utils.IsValidClientVersion("azurehound/3.0.0", true)
+	require.Nil(t, err)
+	require.Equal(t, utils.ClientTypeAzureHound, azureHoundV3Version.ClientType)
+	require.Equal(t, 3, azureHoundV3Version.Major)
+
+	sharpHoundversion, err := utils.IsValidClientVersion("sharphound/2.0.3.0", false)
 	require.Nil(t, err)
 	require.Equal(t, utils.ClientTypeSharpHound, sharpHoundversion.ClientType)
 	require.Equal(t, 2, sharpHoundversion.Major)
@@ -92,7 +101,7 @@ func TestIsValidClientVersion(t *testing.T) {
 	require.Equal(t, 0, sharpHoundversion.Extra)
 	require.Empty(t, sharpHoundversion.Prerelease)
 
-	sharpHoundRCVersion, err := utils.IsValidClientVersion("sharphound/2.0.3.0-rc1")
+	sharpHoundRCVersion, err := utils.IsValidClientVersion("sharphound/2.0.3.0-rc1", false)
 	require.Nil(t, err)
 	require.Equal(t, utils.ClientTypeSharpHound, sharpHoundRCVersion.ClientType)
 	require.Equal(t, 2, sharpHoundRCVersion.Major)
@@ -101,25 +110,25 @@ func TestIsValidClientVersion(t *testing.T) {
 	require.Equal(t, 0, sharpHoundRCVersion.Extra)
 	require.Equal(t, "rc1", sharpHoundRCVersion.Prerelease)
 
-	_, err = utils.IsValidClientVersion("sharphound/2X0Y3Z0")
+	_, err = utils.IsValidClientVersion("sharphound/2X0Y3Z0", false)
 	require.NotNil(t, err)
 	require.ErrorIs(t, err, utils.ErrInvalidSharpHoundVersion)
 
-	_, err = utils.IsValidClientVersion("sharphound/2.0.3.0-rcfoo")
+	_, err = utils.IsValidClientVersion("sharphound/2.0.3.0-rcfoo", false)
 	require.ErrorIs(t, err, utils.ErrInvalidSharpHoundVersion)
 
-	_, err = utils.IsValidClientVersion("sharphound/2.0.3.0-alpha")
+	_, err = utils.IsValidClientVersion("sharphound/2.0.3.0-alpha", false)
 	require.ErrorIs(t, err, utils.ErrInvalidSharpHoundVersion)
 
-	_, err = utils.IsValidClientVersion("sharphound/2.0.2.0")
-	require.NotNil(t, err)
-	require.ErrorIs(t, err, utils.ErrRecommendSharphoundVersion)
-
-	_, err = utils.IsValidClientVersion("sharphound/1.9.3.0")
+	_, err = utils.IsValidClientVersion("sharphound/2.0.2.0", false)
 	require.NotNil(t, err)
 	require.ErrorIs(t, err, utils.ErrRecommendSharphoundVersion)
 
-	openHoundVersion, err := utils.IsValidClientVersion("openhound/0.0.0")
+	_, err = utils.IsValidClientVersion("sharphound/1.9.3.0", false)
+	require.NotNil(t, err)
+	require.ErrorIs(t, err, utils.ErrRecommendSharphoundVersion)
+
+	openHoundVersion, err := utils.IsValidClientVersion("openhound/0.0.0", false)
 	require.Nil(t, err)
 	require.Equal(t, utils.ClientTypeOpenHound, openHoundVersion.ClientType)
 	require.Equal(t, 0, openHoundVersion.Major)
@@ -128,7 +137,7 @@ func TestIsValidClientVersion(t *testing.T) {
 	require.Empty(t, openHoundVersion.Prerelease)
 	require.Empty(t, openHoundVersion.BuildMetadata)
 
-	openHoundRCVersion, err := utils.IsValidClientVersion("openhound/0.0.0-rc1")
+	openHoundRCVersion, err := utils.IsValidClientVersion("openhound/0.0.0-rc1", false)
 	require.Nil(t, err)
 	require.Equal(t, utils.ClientTypeOpenHound, openHoundRCVersion.ClientType)
 	require.Equal(t, 0, openHoundRCVersion.Major)
@@ -137,36 +146,36 @@ func TestIsValidClientVersion(t *testing.T) {
 	require.Equal(t, "rc1", openHoundRCVersion.Prerelease)
 	require.Empty(t, openHoundRCVersion.BuildMetadata)
 
-	_, err = utils.IsValidClientVersion("openhound/0.0.0+docker")
+	_, err = utils.IsValidClientVersion("openhound/0.0.0+docker", false)
 	require.ErrorIs(t, err, utils.ErrInvalidCollectorVersion)
 
-	_, err = utils.IsValidClientVersion("openhound/0.0.0-rcfoo")
+	_, err = utils.IsValidClientVersion("openhound/0.0.0-rcfoo", false)
 	require.ErrorIs(t, err, utils.ErrInvalidCollectorVersion)
 
-	_, err = utils.IsValidClientVersion("openhound/0.0.0-alpha")
+	_, err = utils.IsValidClientVersion("openhound/0.0.0-alpha", false)
 	require.ErrorIs(t, err, utils.ErrInvalidCollectorVersion)
 
-	_, err = utils.IsValidClientVersion("openhound/1X0Y1")
+	_, err = utils.IsValidClientVersion("openhound/1X0Y1", false)
 	require.NotNil(t, err)
 	require.ErrorIs(t, err, utils.ErrInvalidCollectorVersion)
 
 	// Unknown client type
-	_, err = utils.IsValidClientVersion("unknown/0.0.0")
+	_, err = utils.IsValidClientVersion("unknown/0.0.0", false)
 	require.NotNil(t, err)
 	require.ErrorIs(t, err, utils.ErrInvalidClientType)
 
 	// Client type without slash is not a valid user agent
-	_, err = utils.IsValidClientVersion("azurehound")
+	_, err = utils.IsValidClientVersion("azurehound", false)
 	require.NotNil(t, err)
 	require.ErrorIs(t, err, utils.ErrInvalidClientType)
 
 	// Client type without slash is not a valid user agent
-	_, err = utils.IsValidClientVersion("openhound")
+	_, err = utils.IsValidClientVersion("openhound", false)
 	require.NotNil(t, err)
 	require.ErrorIs(t, err, utils.ErrInvalidClientType)
 
 	// Invalid UA
-	_, err = utils.IsValidClientVersion("garbage")
+	_, err = utils.IsValidClientVersion("garbage", false)
 	require.NotNil(t, err)
 	require.ErrorIs(t, err, utils.ErrInvalidClientType)
 }


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

BloodHound should reject data from older versions of collectors that do not perform client-side uppercasing when Use Raw Object ID flag is enabled

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves [BED-9020](https://specterops.atlassian.net/browse/BED-9020)

## How Has This Been Tested?

Updated unit tests 

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


[BED-9020]: https://specterops.atlassian.net/browse/BED-9020?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation for AzureHound client versions when raw object ID support is enabled.
  * AzureHound versions below 3.0.0 now receive an upgrade recommendation.
* **Bug Fixes**
  * Preserved existing client version validation for OpenHound and SharpHound, including version-specific recommendations.
  * Improved handling of invalid and unknown client identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->