### PR TITLE
feat: improve node kind display labels BED-9025

### DIFF
--- a/cmd/api/src/api/v2/kinds.go
+++ b/cmd/api/src/api/v2/kinds.go
@@ -28,7 +28,15 @@ import (
 )
 
 type ListKindsResponse struct {
-	Kinds graph.Kinds `json:"kinds"`
+	Kinds     graph.Kinds         `json:"kinds"`
+	NodeKinds ListNodeKindDetails `json:"node_kinds,omitempty"`
+}
+
+type ListNodeKindDetails []ListNodeKindDetail
+
+type ListNodeKindDetail struct {
+	Name        string `json:"name"`
+	DisplayName string `json:"display_name,omitempty"`
 }
 
 // ListKinds returns all node kinds, edge kinds, and tier tags present in the system.
@@ -54,12 +62,13 @@ func (s Resources) ListKinds(response http.ResponseWriter, request *http.Request
 			}
 		}
 
+		var schemaNodeKinds model.GraphSchemaNodeKinds
 		if len(queryFilters) > 0 {
 			if filters, ok := queryFilters["type"]; ok {
 				validNodeKinds := make(map[graph.Kind]bool)
 
 				// Schema based node kinds
-				if schemaNodeKinds, _, err := s.DB.GetGraphSchemaNodeKinds(ctx, model.Filters{}, model.Sort{}, 0, 0); err != nil {
+				if schemaNodeKinds, _, err = s.DB.GetGraphSchemaNodeKinds(ctx, model.Filters{}, model.Sort{}, 0, 0); err != nil {
 					api.HandleDatabaseError(request, response, err)
 					return
 				} else {
@@ -120,14 +129,44 @@ func (s Resources) ListKinds(response http.ResponseWriter, request *http.Request
 				kinds = filteredKinds
 			}
 		}
+		if schemaNodeKinds == nil {
+			if schemaNodeKindsResult, _, err := s.DB.GetGraphSchemaNodeKinds(ctx, model.Filters{}, model.Sort{}, 0, 0); err != nil {
+				api.HandleDatabaseError(request, response, err)
+				return
+			} else {
+				schemaNodeKinds = schemaNodeKindsResult
+			}
+		}
 
 		// Alpha sort
 		slices.SortFunc(kinds, func(a, b graph.Kind) int {
 			return strings.Compare(a.String(), b.String())
 		})
 
-		api.WriteBasicResponse(request.Context(), ListKindsResponse{Kinds: kinds}, http.StatusOK, response)
+		api.WriteBasicResponse(request.Context(), ListKindsResponse{Kinds: kinds, NodeKinds: buildNodeKindDetails(kinds, schemaNodeKinds)}, http.StatusOK, response)
 	}
+}
+
+func buildNodeKindDetails(kinds graph.Kinds, schemaNodeKinds model.GraphSchemaNodeKinds) ListNodeKindDetails {
+	var (
+		detailsByName = make(map[string]ListNodeKindDetail, len(schemaNodeKinds))
+		details       = make(ListNodeKindDetails, 0, len(schemaNodeKinds))
+	)
+
+	for _, schemaNodeKind := range schemaNodeKinds {
+		detailsByName[schemaNodeKind.Name] = ListNodeKindDetail{
+			Name:        schemaNodeKind.Name,
+			DisplayName: schemaNodeKind.DisplayName,
+		}
+	}
+
+	for _, kind := range kinds {
+		if detail, ok := detailsByName[kind.String()]; ok {
+			details = append(details, detail)
+		}
+	}
+
+	return details
 }
 
 type ListSourceKindsResponse struct {

--- a/cmd/api/src/api/v2/kinds_test.go
+++ b/cmd/api/src/api/v2/kinds_test.go
@@ -68,7 +68,7 @@ func TestResources_ListKinds(t *testing.T) {
 			customNodeKind,
 		}
 
-		mockSchemaNodeKindsResp = model.GraphSchemaNodeKinds{{Name: ad.User.String()}}
+		mockSchemaNodeKindsResp = model.GraphSchemaNodeKinds{{Name: ad.User.String(), DisplayName: "User Display"}}
 		mockCustomNodeKindsResp = []model.CustomNodeKind{{KindName: customNodeKind.String()}}
 		mockSrcKindsResp        = []model.SourceKind{{ID: 1, Name: azure.Entity.String()}}
 	)
@@ -227,11 +227,12 @@ func TestResources_ListKinds(t *testing.T) {
 			},
 			setupMocks: func(t *testing.T, mock *mock) {
 				mock.mockGraph.EXPECT().FetchKinds(gomock.Any()).Return(mockKindsResp, nil)
+				mock.mockDB.EXPECT().GetGraphSchemaNodeKinds(gomock.Any(), model.Filters{}, model.Sort{}, 0, 0).Return(mockSchemaNodeKindsResp, 0, nil)
 			},
 			expected: expected{
 				responseCode:   http.StatusOK,
 				responseHeader: http.Header{"Content-Type": []string{"application/json"}},
-				responseBody:   `{"data":{"kinds":["AZBase", "AZHasRole", "DCSync", "MigrationData", "Tag_Tier_Zero", "User", "Villain"]}}`,
+				responseBody:   `{"data":{"kinds":["AZBase", "AZHasRole", "DCSync", "MigrationData", "Tag_Tier_Zero", "User", "Villain"],"node_kinds":[{"name":"User","display_name":"User Display"}]}}`,
 			},
 		},
 		{
@@ -254,7 +255,7 @@ func TestResources_ListKinds(t *testing.T) {
 			expected: expected{
 				responseCode:   http.StatusOK,
 				responseHeader: http.Header{"Content-Type": []string{"application/json"}},
-				responseBody:   `{"data":{"kinds":["AZBase","MigrationData","Tag_Tier_Zero","User","Villain"]}}`,
+				responseBody:   `{"data":{"kinds":["AZBase","MigrationData","Tag_Tier_Zero","User","Villain"],"node_kinds":[{"name":"User","display_name":"User Display"}]}}`,
 			},
 		},
 		{

--- a/cmd/api/src/database/migration/migrations/20260723120000_v9_update_node_kind_display_names_bed_9025.sql
+++ b/cmd/api/src/database/migration/migrations/20260723120000_v9_update_node_kind_display_names_bed_9025.sql
@@ -1,0 +1,99 @@
+-- Copyright 2026 Specter Ops, Inc.
+--
+-- Licensed under the Apache License, Version 2.0
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- SPDX-License-Identifier: Apache-2.0
+
+-- +goose Up
+UPDATE schema_node_kinds AS snk
+SET display_name = display_names.display_name,
+    updated_at = NOW()
+FROM kind AS k,
+    (VALUES
+        ('GPO', 'Group Policy Object'),
+        ('Base', 'Entity'),
+        ('OU', 'Organizational Unit'),
+        ('ADLocalGroup', 'AD Local Group'),
+        ('ADLocalUser', 'AD Local User'),
+        ('AIACA', 'AIA Certificate Authority'),
+        ('RootCA', 'Root Certificate Authority'),
+        ('EnterpriseCA', 'Enterprise Certificate Authority'),
+        ('NTAuthStore', 'NTAuth Store'),
+        ('CertTemplate', 'Certificate Template'),
+        ('IssuancePolicy', 'Issuance Policy'),
+        ('AZBase', 'Azure Entity'),
+        ('AZVMScaleSet', 'Azure VM Scale Set'),
+        ('AZApp', 'Azure Application'),
+        ('AZRole', 'Azure Role'),
+        ('AZDevice', 'Azure Device'),
+        ('AZFunctionApp', 'Azure Function App'),
+        ('AZGroup', 'Azure Group'),
+        ('AZKeyVault', 'Azure Key Vault'),
+        ('AZManagementGroup', 'Azure Management Group'),
+        ('AZResourceGroup', 'Azure Resource Group'),
+        ('AZServicePrincipal', 'Azure Service Principal'),
+        ('AZSubscription', 'Azure Subscription'),
+        ('AZTenant', 'Azure Tenant'),
+        ('AZUser', 'Azure User'),
+        ('AZVM', 'Azure Virtual Machine'),
+        ('AZManagedCluster', 'Azure Managed Cluster'),
+        ('AZContainerRegistry', 'Azure Container Registry'),
+        ('AZWebApp', 'Azure Web App'),
+        ('AZLogicApp', 'Azure Logic App'),
+        ('AZAutomationAccount', 'Azure Automation Account'),
+        ('AZFederatedIdentityCredential', 'Azure Federated Identity Credential')
+    ) AS display_names(name, display_name)
+WHERE snk.kind_id = k.id
+  AND k.name = display_names.name;
+
+-- +goose Down
+UPDATE schema_node_kinds AS snk
+SET display_name = raw_names.name,
+    updated_at = NOW()
+FROM kind AS k,
+    (VALUES
+        ('GPO'),
+        ('Base'),
+        ('OU'),
+        ('ADLocalGroup'),
+        ('ADLocalUser'),
+        ('AIACA'),
+        ('RootCA'),
+        ('EnterpriseCA'),
+        ('NTAuthStore'),
+        ('CertTemplate'),
+        ('IssuancePolicy'),
+        ('AZBase'),
+        ('AZVMScaleSet'),
+        ('AZApp'),
+        ('AZRole'),
+        ('AZDevice'),
+        ('AZFunctionApp'),
+        ('AZGroup'),
+        ('AZKeyVault'),
+        ('AZManagementGroup'),
+        ('AZResourceGroup'),
+        ('AZServicePrincipal'),
+        ('AZSubscription'),
+        ('AZTenant'),
+        ('AZUser'),
+        ('AZVM'),
+        ('AZManagedCluster'),
+        ('AZContainerRegistry'),
+        ('AZWebApp'),
+        ('AZLogicApp'),
+        ('AZAutomationAccount'),
+        ('AZFederatedIdentityCredential')
+    ) AS raw_names(name)
+WHERE snk.kind_id = k.id
+  AND k.name = raw_names.name;

--- a/packages/go/openapi/doc/openapi.json
+++ b/packages/go/openapi/doc/openapi.json
@@ -7052,6 +7052,21 @@
                           "items": {
                             "type": "string"
                           }
+                        },
+                        "node_kinds": {
+                          "type": "array",
+                          "description": "Canonical node kind metadata for node kinds included in the kinds array.",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "display_name": {
+                                "type": "string"
+                              }
+                            }
+                          }
                         }
                       }
                     }

--- a/packages/go/openapi/src/paths/graph.kinds.yaml
+++ b/packages/go/openapi/src/paths/graph.kinds.yaml
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 parameters:
-  - $ref: './../parameters/header.prefer.yaml'
+  - $ref: "./../parameters/header.prefer.yaml"
 get:
   operationId: GetKinds
   summary: Get kinds
@@ -30,7 +30,7 @@ get:
       description: Filter by type, valid types are node or edge, e.g. "eq:node"
       required: false
       schema:
-        $ref: './../schemas/api.params.predicate.filter.string-strict.yaml'
+        $ref: "./../schemas/api.params.predicate.filter.string-strict.yaml"
   responses:
     200:
       description: OK
@@ -46,13 +46,23 @@ get:
                     type: array
                     items:
                       type: string
+                  node_kinds:
+                    type: array
+                    description: Canonical node kind metadata for node kinds included in the kinds array.
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        display_name:
+                          type: string
     400:
-      $ref: './../responses/bad-request.yaml'
+      $ref: "./../responses/bad-request.yaml"
     401:
-      $ref: './../responses/unauthorized.yaml'
+      $ref: "./../responses/unauthorized.yaml"
     403:
-      $ref: './../responses/forbidden.yaml'
+      $ref: "./../responses/forbidden.yaml"
     429:
-      $ref: './../responses/too-many-requests.yaml'
+      $ref: "./../responses/too-many-requests.yaml"
     500:
-      $ref: './../responses/internal-server-error.yaml'
+      $ref: "./../responses/internal-server-error.yaml"

--- a/packages/javascript/bh-shared-ui/src/components/AssetGroupEdit/AssetGroupEdit.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/AssetGroupEdit/AssetGroupEdit.test.tsx
@@ -73,6 +73,29 @@ describe('AssetGroupEdit', () => {
         expect(count).toBe(memberCounts.total_count.toString());
     });
 
+    it('should display human-readable node kind count labels', async () => {
+        const screen = await act(async () => {
+            return render(
+                <AssetGroupEdit
+                    assetGroup={assetGroup}
+                    filter={{}}
+                    memberCounts={{
+                        total_count: 3,
+                        counts: {
+                            AZApp: 1,
+                            CertTemplate: 2,
+                        },
+                    }}
+                    isEditable={false}
+                />
+            );
+        });
+
+        expect(screen.getByText('Azure Application')).toBeInTheDocument();
+        expect(screen.getByText('Certificate Template')).toBeInTheDocument();
+        expect(screen.queryByText('AZApp')).not.toBeInTheDocument();
+    });
+
     it('should display search results when the user enters text', async () => {
         const { screen, user } = await setup();
         const input = screen.getByRole('combobox');

--- a/packages/javascript/bh-shared-ui/src/components/AssetGroupEdit/AssetGroupEdit.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/AssetGroupEdit/AssetGroupEdit.test.tsx
@@ -26,9 +26,13 @@ import AssetGroupEdit from './AssetGroupEdit';
 const assetGroup = createMockAssetGroup();
 const searchResults = createMockSearchResults();
 const memberCounts = createMockMemberCounts();
+const nodeKindDisplayNames = {
+    AZApp: 'Azure Application',
+    CertTemplate: 'Certificate Template',
+};
 
 const server = setupServer(
-    mockKindsHandler(),
+    mockKindsHandler(undefined, undefined, nodeKindDisplayNames),
     mockGetConfigurationHandler(),
     rest.get('/api/v2/search', (req, res, ctx) => {
         return res(

--- a/packages/javascript/bh-shared-ui/src/components/AssetGroupEdit/AssetGroupEdit.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/AssetGroupEdit/AssetGroupEdit.tsx
@@ -25,7 +25,7 @@ import { FC, useEffect, useState } from 'react';
 import { useMutation, useQueryClient } from 'react-query';
 import { useTheme } from '../../hooks/useTheme';
 import { useNotifications } from '../../providers';
-import { apiClient } from '../../utils';
+import { apiClient, getNodeKindDisplayLabel } from '../../utils';
 import { SubHeader } from '../../views/Explore/fragments';
 import AssetGroupAutocomplete from './AssetGroupAutocomplete';
 import AssetGroupChangelogTable from './AssetGroupChangelogTable';
@@ -115,7 +115,7 @@ const AssetGroupEdit: FC<{
                 </>
             )}
             {Object.entries(memberCounts?.counts ?? {}).map(([kind, count]) => {
-                return <SubHeader key={kind} label={kind} count={count} />;
+                return <SubHeader key={kind} label={getNodeKindDisplayLabel(kind)} count={count} />;
             })}
         </Box>
     );

--- a/packages/javascript/bh-shared-ui/src/components/AssetGroupEdit/AssetGroupEdit.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/AssetGroupEdit/AssetGroupEdit.tsx
@@ -23,9 +23,10 @@ import {
 } from 'js-client-library';
 import { FC, useEffect, useState } from 'react';
 import { useMutation, useQueryClient } from 'react-query';
+import { useGraphNodeKinds } from '../../hooks';
 import { useTheme } from '../../hooks/useTheme';
 import { useNotifications } from '../../providers';
-import { apiClient, getNodeKindDisplayLabel } from '../../utils';
+import { apiClient, createNodeKindDisplayLabelMap, getNodeKindDisplayLabel } from '../../utils';
 import { SubHeader } from '../../views/Explore/fragments';
 import AssetGroupAutocomplete from './AssetGroupAutocomplete';
 import AssetGroupChangelogTable from './AssetGroupChangelogTable';
@@ -43,6 +44,8 @@ const AssetGroupEdit: FC<{
     const { addNotification } = useNotifications();
     const theme = useTheme();
     const queryClient = useQueryClient();
+    const nodeKindsQuery = useGraphNodeKinds();
+    const nodeKindDisplayLabels = createNodeKindDisplayLabelMap(nodeKindsQuery.data?.node_kinds);
 
     const handleUpdateAssetGroupChangelog = (_event: any, changelogEntry: AssetGroupChangelogEntry) => {
         if (changelogEntry.action === ChangelogAction.ADD || changelogEntry.action === ChangelogAction.REMOVE) {
@@ -115,7 +118,9 @@ const AssetGroupEdit: FC<{
                 </>
             )}
             {Object.entries(memberCounts?.counts ?? {}).map(([kind, count]) => {
-                return <SubHeader key={kind} label={getNodeKindDisplayLabel(kind)} count={count} />;
+                return (
+                    <SubHeader key={kind} label={getNodeKindDisplayLabel(kind, nodeKindDisplayLabels)} count={count} />
+                );
             })}
         </Box>
     );

--- a/packages/javascript/bh-shared-ui/src/components/AssetGroupFilters/AssetGroupFilters.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/AssetGroupFilters/AssetGroupFilters.test.tsx
@@ -20,14 +20,19 @@ import { rest } from 'msw';
 import { setupServer } from 'msw/node';
 import { ActiveDirectoryNodeKind } from '../../graphSchema';
 import { createMockAssetGroupMemberParams, createMockMemberCounts } from '../../mocks/factories';
+import { mockKindsHandler } from '../../mocks/handlers';
 import { act, render, screen, waitFor } from '../../test-utils';
 import AssetGroupFilters, { FILTERABLE_PARAMS } from './AssetGroupFilters';
 
 const filterParams = createMockAssetGroupMemberParams();
 const memberCounts = createMockMemberCounts();
+const nodeKindDisplayNames = {
+    AZApp: 'Azure Application',
+};
 
 describe('AssetGroupEdit', () => {
     const server = setupServer(
+        mockKindsHandler(undefined, undefined, nodeKindDisplayNames),
         rest.get(`/api/v2/custom-nodes`, async (req, res, ctx) => {
             return res(
                 ctx.json({

--- a/packages/javascript/bh-shared-ui/src/components/AssetGroupFilters/AssetGroupFilters.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/AssetGroupFilters/AssetGroupFilters.test.tsx
@@ -52,7 +52,7 @@ describe('AssetGroupEdit', () => {
                 <AssetGroupFilters
                     filterParams={options?.filterParams ?? {}}
                     handleFilterChange={handleFilterChange}
-                    memberCounts={memberCounts}
+                    memberCounts={options?.memberCounts ?? memberCounts}
                 />
             );
         });
@@ -126,6 +126,24 @@ describe('AssetGroupEdit', () => {
 
             expect(handleFilterChange).toBeCalledTimes(1);
             expect(handleFilterChange).toHaveBeenCalledWith('primary_kind', `eq:${expectedNodeKind}`);
+        });
+
+        it('shows human-readable node kind labels while preserving filter values', async () => {
+            const { user, handleFilterChange } = await setup({
+                memberCounts: {
+                    total_count: 1,
+                    counts: {
+                        AZApp: 1,
+                    },
+                },
+            });
+
+            await user.click(screen.getByTestId('display-filters-button'));
+            await user.click(screen.getByLabelText('Node Type'));
+            await user.click(screen.getByText('Azure Application'));
+
+            expect(screen.queryByText('AZApp')).not.toBeInTheDocument();
+            expect(handleFilterChange).toHaveBeenCalledWith('primary_kind', 'eq:AZApp');
         });
     });
 

--- a/packages/javascript/bh-shared-ui/src/components/AssetGroupFilters/AssetGroupFilters.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/AssetGroupFilters/AssetGroupFilters.tsx
@@ -31,8 +31,9 @@ import { Button, Typography } from 'doodle-ui';
 import { AssetGroupMemberCounts } from 'js-client-library';
 import { AssetGroupMemberParams } from 'js-client-library/dist/types';
 import { FC, useState } from 'react';
+import { useGraphNodeKinds } from '../../hooks';
 import { useTheme } from '../../hooks/useTheme';
-import { cn, getNodeKindDisplayLabel } from '../../utils';
+import { cn, createNodeKindDisplayLabelMap, getNodeKindDisplayLabel } from '../../utils';
 import NodeIcon from '../NodeIcon';
 
 export const FILTERABLE_PARAMS: Array<keyof Pick<AssetGroupMemberParams, 'primary_kind' | 'custom_member'>> = [
@@ -49,6 +50,8 @@ interface Props {
 const AssetGroupFilters: FC<Props> = ({ filterParams, handleFilterChange, memberCounts = { counts: {} } }) => {
     const [displayFilters, setDisplayFilters] = useState(false);
     const theme = useTheme();
+    const nodeKindsQuery = useGraphNodeKinds();
+    const nodeKindDisplayLabels = createNodeKindDisplayLabelMap(nodeKindsQuery.data?.node_kinds);
 
     const handleClearFilters = () => {
         for (const filter of FILTERABLE_PARAMS) {
@@ -97,7 +100,7 @@ const AssetGroupFilters: FC<Props> = ({ filterParams, handleFilterChange, member
                                     return (
                                         <MenuItem value={`eq:${value}`} key={value}>
                                             <NodeIcon nodeType={value} />
-                                            {getNodeKindDisplayLabel(value)}
+                                            {getNodeKindDisplayLabel(value, nodeKindDisplayLabels)}
                                         </MenuItem>
                                     );
                                 })}

--- a/packages/javascript/bh-shared-ui/src/components/AssetGroupFilters/AssetGroupFilters.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/AssetGroupFilters/AssetGroupFilters.tsx
@@ -32,7 +32,7 @@ import { AssetGroupMemberCounts } from 'js-client-library';
 import { AssetGroupMemberParams } from 'js-client-library/dist/types';
 import { FC, useState } from 'react';
 import { useTheme } from '../../hooks/useTheme';
-import { cn } from '../../utils';
+import { cn, getNodeKindDisplayLabel } from '../../utils';
 import NodeIcon from '../NodeIcon';
 
 export const FILTERABLE_PARAMS: Array<keyof Pick<AssetGroupMemberParams, 'primary_kind' | 'custom_member'>> = [
@@ -97,7 +97,7 @@ const AssetGroupFilters: FC<Props> = ({ filterParams, handleFilterChange, member
                                     return (
                                         <MenuItem value={`eq:${value}`} key={value}>
                                             <NodeIcon nodeType={value} />
-                                            {value}
+                                            {getNodeKindDisplayLabel(value)}
                                         </MenuItem>
                                     );
                                 })}

--- a/packages/javascript/bh-shared-ui/src/hooks/index.ts
+++ b/packages/javascript/bh-shared-ui/src/hooks/index.ts
@@ -39,6 +39,7 @@ export * from './useFileUploadQuery';
 export * from './useFinishedJobs';
 export * from './useGraphHasData';
 export * from './useGraphItem/useGraphItem';
+export * from './useGraphKinds';
 export * from './useInfiniteScroll';
 export * from './useInitialEnvironment';
 export * from './useIsMouseDragging';

--- a/packages/javascript/bh-shared-ui/src/mocks/factories/graphKinds.ts
+++ b/packages/javascript/bh-shared-ui/src/mocks/factories/graphKinds.ts
@@ -25,9 +25,16 @@ const createNodeKinds = (): GraphKindsResponse['data']['kinds'] => {
     return faker.helpers.uniqueArray(faker.random.word, 10);
 };
 
-export const createGraphKinds = (nodeKinds?: string[], edgeKinds?: string[]): GraphKindsResponse['data'] => {
-    const node_kinds = nodeKinds ?? createNodeKinds();
+export const createGraphKinds = (
+    nodeKinds?: string[],
+    edgeKinds?: string[],
+    nodeKindDisplayNames: Record<string, string> = {}
+): GraphKindsResponse['data'] => {
+    const node_kinds = nodeKinds ?? [...Object.keys(nodeKindDisplayNames), ...createNodeKinds()];
     const edge_kinds = edgeKinds ?? createEdgeKinds();
 
-    return { kinds: [...edge_kinds, ...node_kinds] };
+    return {
+        kinds: [...edge_kinds, ...node_kinds],
+        node_kinds: node_kinds.map((name) => ({ name, display_name: nodeKindDisplayNames[name] })),
+    };
 };

--- a/packages/javascript/bh-shared-ui/src/mocks/handlers/graphKinds.ts
+++ b/packages/javascript/bh-shared-ui/src/mocks/handlers/graphKinds.ts
@@ -17,19 +17,23 @@
 import { rest } from 'msw';
 import { createGraphKinds } from '../factories/graphKinds';
 
-export const mockKindsHandler = (nodeKinds?: string[], edgeKinds?: string[]) =>
+export const mockKindsHandler = (
+    nodeKinds?: string[],
+    edgeKinds?: string[],
+    nodeKindDisplayNames: Record<string, string> = {}
+) =>
     rest.get('/api/v2/graphs/kinds', async (req, res, ctx) => {
         const filter = req.url.searchParams.get('type')?.split(':')[1];
 
         if (filter === 'node') {
-            return res(ctx.json({ data: createGraphKinds(nodeKinds, []) }));
+            return res(ctx.json({ data: createGraphKinds(nodeKinds, [], nodeKindDisplayNames) }));
         }
 
         if (filter === 'edge' || filter === 'relationship') {
-            return res(ctx.json({ data: createGraphKinds([], edgeKinds) }));
+            return res(ctx.json({ data: createGraphKinds([], edgeKinds, nodeKindDisplayNames) }));
         }
 
-        return res(ctx.json({ data: createGraphKinds(nodeKinds, edgeKinds) }));
+        return res(ctx.json({ data: createGraphKinds(nodeKinds, edgeKinds, nodeKindDisplayNames) }));
     });
 
 export const mockSourceKindsHandler = () =>

--- a/packages/javascript/bh-shared-ui/src/mocks/handlers/zoneHandlers.ts
+++ b/packages/javascript/bh-shared-ui/src/mocks/handlers/zoneHandlers.ts
@@ -19,6 +19,12 @@ import { rest } from 'msw';
 import * as tierMocks from '../factories/privilegeZones';
 import { mockKindsHandler } from './graphKinds';
 
+const nodeKindDisplayNames = {
+    AZApp: 'Azure Application',
+    AZServicePrincipal: 'Azure Service Principal',
+    CertTemplate: 'Certificate Template',
+};
+
 const zoneHandlers = [
     rest.get('/api/v2/features', async (_req, res, ctx) => {
         return res(
@@ -45,7 +51,7 @@ const zoneHandlers = [
         );
     }),
     // GET Kinds
-    mockKindsHandler(),
+    mockKindsHandler(undefined, undefined, nodeKindDisplayNames),
 
     rest.get('/api/v2/available-domains', async (_req, res, ctx) => {
         return res(

--- a/packages/javascript/bh-shared-ui/src/utils/index.ts
+++ b/packages/javascript/bh-shared-ui/src/utils/index.ts
@@ -30,6 +30,7 @@ export * from './freeIconsList';
 export * from './icons';
 export * from './jobs';
 export * from './luxon';
+export * from './nodeKindDisplay';
 export * from './number';
 export * from './numberFormatting';
 export * from './object';

--- a/packages/javascript/bh-shared-ui/src/utils/nodeKindDisplay.test.ts
+++ b/packages/javascript/bh-shared-ui/src/utils/nodeKindDisplay.test.ts
@@ -1,0 +1,33 @@
+// Copyright 2026 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest';
+import { getNodeKindDisplayLabel } from './nodeKindDisplay';
+
+describe('getNodeKindDisplayLabel', () => {
+    it('returns human-readable labels for built-in node kinds', () => {
+        expect(getNodeKindDisplayLabel('AIACA')).toBe('AIA Certificate Authority');
+        expect(getNodeKindDisplayLabel('AZApp')).toBe('Azure Application');
+        expect(getNodeKindDisplayLabel('AZServicePrincipal')).toBe('Azure Service Principal');
+        expect(getNodeKindDisplayLabel('CertTemplate')).toBe('Certificate Template');
+        expect(getNodeKindDisplayLabel('EnterpriseCA')).toBe('Enterprise Certificate Authority');
+        expect(getNodeKindDisplayLabel('GPO')).toBe('Group Policy Object');
+    });
+
+    it('falls back to the raw kind for custom or unknown kinds', () => {
+        expect(getNodeKindDisplayLabel('CustomNodeKind')).toBe('CustomNodeKind');
+    });
+});

--- a/packages/javascript/bh-shared-ui/src/utils/nodeKindDisplay.test.ts
+++ b/packages/javascript/bh-shared-ui/src/utils/nodeKindDisplay.test.ts
@@ -15,19 +15,26 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, expect, it } from 'vitest';
-import { getNodeKindDisplayLabel } from './nodeKindDisplay';
+import { createNodeKindDisplayLabelMap, getNodeKindDisplayLabel } from './nodeKindDisplay';
 
 describe('getNodeKindDisplayLabel', () => {
-    it('returns human-readable labels for built-in node kinds', () => {
-        expect(getNodeKindDisplayLabel('AIACA')).toBe('AIA Certificate Authority');
-        expect(getNodeKindDisplayLabel('AZApp')).toBe('Azure Application');
-        expect(getNodeKindDisplayLabel('AZServicePrincipal')).toBe('Azure Service Principal');
-        expect(getNodeKindDisplayLabel('CertTemplate')).toBe('Certificate Template');
-        expect(getNodeKindDisplayLabel('EnterpriseCA')).toBe('Enterprise Certificate Authority');
-        expect(getNodeKindDisplayLabel('GPO')).toBe('Group Policy Object');
+    it('returns display labels from graph kind metadata', () => {
+        const displayLabels = createNodeKindDisplayLabelMap([
+            { name: 'AIACA', display_name: 'AIA Certificate Authority' },
+            { name: 'AZApp', display_name: 'Azure Application' },
+        ]);
+
+        expect(getNodeKindDisplayLabel('AIACA', displayLabels)).toBe('AIA Certificate Authority');
+        expect(getNodeKindDisplayLabel('AZApp', displayLabels)).toBe('Azure Application');
     });
 
     it('falls back to the raw kind for custom or unknown kinds', () => {
         expect(getNodeKindDisplayLabel('CustomNodeKind')).toBe('CustomNodeKind');
+    });
+
+    it('falls back to the raw kind when metadata has no display name', () => {
+        const displayLabels = createNodeKindDisplayLabelMap([{ name: 'CustomNodeKind' }]);
+
+        expect(getNodeKindDisplayLabel('CustomNodeKind', displayLabels)).toBe('CustomNodeKind');
     });
 });

--- a/packages/javascript/bh-shared-ui/src/utils/nodeKindDisplay.ts
+++ b/packages/javascript/bh-shared-ui/src/utils/nodeKindDisplay.ts
@@ -14,46 +14,18 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { ActiveDirectoryNodeKind, AzureNodeKind } from '../graphSchema';
+import type { GraphKindsResponse } from 'js-client-library';
 
-const NODE_KIND_DISPLAY_LABELS: Record<string, string> = {
-    [ActiveDirectoryNodeKind.Entity]: 'Entity',
-    [ActiveDirectoryNodeKind.User]: 'User',
-    [ActiveDirectoryNodeKind.Computer]: 'Computer',
-    [ActiveDirectoryNodeKind.Group]: 'Group',
-    [ActiveDirectoryNodeKind.GPO]: 'Group Policy Object',
-    [ActiveDirectoryNodeKind.OU]: 'Organizational Unit',
-    [ActiveDirectoryNodeKind.Container]: 'Container',
-    [ActiveDirectoryNodeKind.Domain]: 'Domain',
-    [ActiveDirectoryNodeKind.LocalGroup]: 'AD Local Group',
-    [ActiveDirectoryNodeKind.LocalUser]: 'AD Local User',
-    [ActiveDirectoryNodeKind.AIACA]: 'AIA Certificate Authority',
-    [ActiveDirectoryNodeKind.RootCA]: 'Root Certificate Authority',
-    [ActiveDirectoryNodeKind.EnterpriseCA]: 'Enterprise Certificate Authority',
-    [ActiveDirectoryNodeKind.NTAuthStore]: 'NTAuth Store',
-    [ActiveDirectoryNodeKind.CertTemplate]: 'Certificate Template',
-    [ActiveDirectoryNodeKind.IssuancePolicy]: 'Issuance Policy',
-    [AzureNodeKind.Entity]: 'Azure Entity',
-    [AzureNodeKind.VMScaleSet]: 'Azure VM Scale Set',
-    [AzureNodeKind.App]: 'Azure Application',
-    [AzureNodeKind.Role]: 'Azure Role',
-    [AzureNodeKind.Device]: 'Azure Device',
-    [AzureNodeKind.FunctionApp]: 'Azure Function App',
-    [AzureNodeKind.Group]: 'Azure Group',
-    [AzureNodeKind.KeyVault]: 'Azure Key Vault',
-    [AzureNodeKind.ManagementGroup]: 'Azure Management Group',
-    [AzureNodeKind.ResourceGroup]: 'Azure Resource Group',
-    [AzureNodeKind.ServicePrincipal]: 'Azure Service Principal',
-    [AzureNodeKind.Subscription]: 'Azure Subscription',
-    [AzureNodeKind.Tenant]: 'Azure Tenant',
-    [AzureNodeKind.User]: 'Azure User',
-    [AzureNodeKind.VM]: 'Azure Virtual Machine',
-    [AzureNodeKind.ManagedCluster]: 'Azure Managed Cluster',
-    [AzureNodeKind.ContainerRegistry]: 'Azure Container Registry',
-    [AzureNodeKind.WebApp]: 'Azure Web App',
-    [AzureNodeKind.LogicApp]: 'Azure Logic App',
-    [AzureNodeKind.AutomationAccount]: 'Azure Automation Account',
-    [AzureNodeKind.FederatedIdentityCredential]: 'Azure Federated Identity Credential',
+export type NodeKindDisplayLabel = NonNullable<GraphKindsResponse['data']['node_kinds']>[number];
+export type NodeKindDisplayLabelMap = Record<string, string>;
+
+export const createNodeKindDisplayLabelMap = (
+    nodeKinds: NodeKindDisplayLabel[] | undefined
+): NodeKindDisplayLabelMap => {
+    return Object.fromEntries(
+        nodeKinds?.map(({ name, display_name }) => [name, display_name || name]) ?? []
+    ) as NodeKindDisplayLabelMap;
 };
 
-export const getNodeKindDisplayLabel = (kind: string): string => NODE_KIND_DISPLAY_LABELS[kind] ?? kind;
+export const getNodeKindDisplayLabel = (kind: string, displayLabels: NodeKindDisplayLabelMap = {}): string =>
+    displayLabels[kind] ?? kind;

--- a/packages/javascript/bh-shared-ui/src/utils/nodeKindDisplay.ts
+++ b/packages/javascript/bh-shared-ui/src/utils/nodeKindDisplay.ts
@@ -1,0 +1,59 @@
+// Copyright 2026 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { ActiveDirectoryNodeKind, AzureNodeKind } from '../graphSchema';
+
+const NODE_KIND_DISPLAY_LABELS: Record<string, string> = {
+    [ActiveDirectoryNodeKind.Entity]: 'Entity',
+    [ActiveDirectoryNodeKind.User]: 'User',
+    [ActiveDirectoryNodeKind.Computer]: 'Computer',
+    [ActiveDirectoryNodeKind.Group]: 'Group',
+    [ActiveDirectoryNodeKind.GPO]: 'Group Policy Object',
+    [ActiveDirectoryNodeKind.OU]: 'Organizational Unit',
+    [ActiveDirectoryNodeKind.Container]: 'Container',
+    [ActiveDirectoryNodeKind.Domain]: 'Domain',
+    [ActiveDirectoryNodeKind.LocalGroup]: 'AD Local Group',
+    [ActiveDirectoryNodeKind.LocalUser]: 'AD Local User',
+    [ActiveDirectoryNodeKind.AIACA]: 'AIA Certificate Authority',
+    [ActiveDirectoryNodeKind.RootCA]: 'Root Certificate Authority',
+    [ActiveDirectoryNodeKind.EnterpriseCA]: 'Enterprise Certificate Authority',
+    [ActiveDirectoryNodeKind.NTAuthStore]: 'NTAuth Store',
+    [ActiveDirectoryNodeKind.CertTemplate]: 'Certificate Template',
+    [ActiveDirectoryNodeKind.IssuancePolicy]: 'Issuance Policy',
+    [AzureNodeKind.Entity]: 'Azure Entity',
+    [AzureNodeKind.VMScaleSet]: 'Azure VM Scale Set',
+    [AzureNodeKind.App]: 'Azure Application',
+    [AzureNodeKind.Role]: 'Azure Role',
+    [AzureNodeKind.Device]: 'Azure Device',
+    [AzureNodeKind.FunctionApp]: 'Azure Function App',
+    [AzureNodeKind.Group]: 'Azure Group',
+    [AzureNodeKind.KeyVault]: 'Azure Key Vault',
+    [AzureNodeKind.ManagementGroup]: 'Azure Management Group',
+    [AzureNodeKind.ResourceGroup]: 'Azure Resource Group',
+    [AzureNodeKind.ServicePrincipal]: 'Azure Service Principal',
+    [AzureNodeKind.Subscription]: 'Azure Subscription',
+    [AzureNodeKind.Tenant]: 'Azure Tenant',
+    [AzureNodeKind.User]: 'Azure User',
+    [AzureNodeKind.VM]: 'Azure Virtual Machine',
+    [AzureNodeKind.ManagedCluster]: 'Azure Managed Cluster',
+    [AzureNodeKind.ContainerRegistry]: 'Azure Container Registry',
+    [AzureNodeKind.WebApp]: 'Azure Web App',
+    [AzureNodeKind.LogicApp]: 'Azure Logic App',
+    [AzureNodeKind.AutomationAccount]: 'Azure Automation Account',
+    [AzureNodeKind.FederatedIdentityCredential]: 'Azure Federated Identity Credential',
+};
+
+export const getNodeKindDisplayLabel = (kind: string): string => NODE_KIND_DISPLAY_LABELS[kind] ?? kind;

--- a/packages/javascript/bh-shared-ui/src/views/Explore/ExploreSearch/SavedQueries/CommonSearches.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/Explore/ExploreSearch/SavedQueries/CommonSearches.test.tsx
@@ -86,6 +86,7 @@ describe('CommonSearches', () => {
 
         const header = screen.getByText(/Saved Queries/i);
         expect(header).toBeInTheDocument();
+        expect(screen.getByTestId('common-queries-toggle')).toHaveClass('text-contrast');
     });
 
     it('should display filter dropwdowns', async () => {

--- a/packages/javascript/bh-shared-ui/src/views/Explore/ExploreSearch/SavedQueries/CommonSearches.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/Explore/ExploreSearch/SavedQueries/CommonSearches.tsx
@@ -181,7 +181,7 @@ const CommonSearches = ({
             <div className='flex items-center'>
                 <Button
                     onClick={onToggleCommonQueries}
-                    className='flex justify-start items-center w-full pl-0'
+                    className='flex justify-start items-center w-full pl-0 text-contrast'
                     data-testid='common-queries-toggle'
                     variant={'text'}>
                     <FontAwesomeIcon className='px-2 mr-2' icon={showCommonQueries ? faChevronDown : faChevronUp} />

--- a/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/Details/ObjectCountPanel.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/Details/ObjectCountPanel.test.tsx
@@ -52,7 +52,7 @@ describe('ObjectCountPanel', () => {
                     ctx.json({
                         data: {
                             total_count: 100,
-                            counts: { 'Object A': 50, 'Object B': 30, 'Object C': 20 },
+                            counts: { AZApp: 50, AZServicePrincipal: 30, CertTemplate: 20 },
                         },
                     })
                 );
@@ -63,11 +63,11 @@ describe('ObjectCountPanel', () => {
 
         expect(screen.getByText('Total Count')).toBeInTheDocument();
         expect(await screen.findByText('100')).toBeInTheDocument();
-        expect(screen.getByText('Object A')).toBeInTheDocument();
+        expect(screen.getByText('Azure Application')).toBeInTheDocument();
         expect(screen.getByText('50')).toBeInTheDocument();
-        expect(screen.getByText('Object B')).toBeInTheDocument();
+        expect(screen.getByText('Azure Service Principal')).toBeInTheDocument();
         expect(screen.getByText('30')).toBeInTheDocument();
-        expect(screen.getByText('Object C')).toBeInTheDocument();
+        expect(screen.getByText('Certificate Template')).toBeInTheDocument();
         expect(screen.getByText('20')).toBeInTheDocument();
     });
 });

--- a/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/Details/ObjectCountPanel.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/Details/ObjectCountPanel.tsx
@@ -18,6 +18,7 @@ import { Badge, Card, Skeleton } from 'doodle-ui';
 import { FC } from 'react';
 import { NodeIcon } from '../../../components';
 import { useObjectCounts } from '../../../hooks/useAssetGroupTags/useObjectCounts';
+import { getNodeKindDisplayLabel } from '../../../utils';
 
 const ObjectCountPanel: FC = () => {
     const objectsCountQuery = useObjectCounts();
@@ -60,19 +61,21 @@ const ObjectCountPanel: FC = () => {
                     <p>Total Count</p>
                     <Badge label={objectsCountQuery.data.total_count.toLocaleString()} />
                 </div>
-                {Object.entries(objectsCountQuery.data.counts).map(([key, value]) => {
-                    return (
-                        <div
-                            className='flex justify-between mt-4 items-center rounded-lg px-2 py-1 -mx-2 hover:bg-neutral-light-4 dark:hover:bg-neutral-dark-4'
-                            key={key}>
-                            <div className='flex gap-1'>
-                                <NodeIcon nodeType={key} />
-                                {key}
+                {Object.entries(objectsCountQuery.data.counts)
+                    .sort(([a], [b]) => getNodeKindDisplayLabel(a).localeCompare(getNodeKindDisplayLabel(b)))
+                    .map(([key, value]) => {
+                        return (
+                            <div
+                                className='flex justify-between mt-4 items-center rounded-lg px-2 py-1 -mx-2 hover:bg-neutral-light-4 dark:hover:bg-neutral-dark-4'
+                                key={key}>
+                                <div className='flex gap-1'>
+                                    <NodeIcon nodeType={key} />
+                                    {getNodeKindDisplayLabel(key)}
+                                </div>
+                                <Badge label={value.toLocaleString()} />
                             </div>
-                            <Badge label={value.toLocaleString()} />
-                        </div>
-                    );
-                })}
+                        );
+                    })}
             </Card>
         );
     }

--- a/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/Details/ObjectCountPanel.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/Details/ObjectCountPanel.tsx
@@ -17,11 +17,14 @@
 import { Badge, Card, Skeleton } from 'doodle-ui';
 import { FC } from 'react';
 import { NodeIcon } from '../../../components';
+import { useGraphNodeKinds } from '../../../hooks';
 import { useObjectCounts } from '../../../hooks/useAssetGroupTags/useObjectCounts';
-import { getNodeKindDisplayLabel } from '../../../utils';
+import { createNodeKindDisplayLabelMap, getNodeKindDisplayLabel } from '../../../utils';
 
 const ObjectCountPanel: FC = () => {
     const objectsCountQuery = useObjectCounts();
+    const nodeKindsQuery = useGraphNodeKinds();
+    const nodeKindDisplayLabels = createNodeKindDisplayLabelMap(nodeKindsQuery.data?.node_kinds);
 
     if (objectsCountQuery.isLoading) {
         return (
@@ -62,7 +65,11 @@ const ObjectCountPanel: FC = () => {
                     <Badge label={objectsCountQuery.data.total_count.toLocaleString()} />
                 </div>
                 {Object.entries(objectsCountQuery.data.counts)
-                    .sort(([a], [b]) => getNodeKindDisplayLabel(a).localeCompare(getNodeKindDisplayLabel(b)))
+                    .sort(([a], [b]) =>
+                        getNodeKindDisplayLabel(a, nodeKindDisplayLabels).localeCompare(
+                            getNodeKindDisplayLabel(b, nodeKindDisplayLabels)
+                        )
+                    )
                     .map(([key, value]) => {
                         return (
                             <div
@@ -70,7 +77,7 @@ const ObjectCountPanel: FC = () => {
                                 key={key}>
                                 <div className='flex gap-1'>
                                     <NodeIcon nodeType={key} />
-                                    {getNodeKindDisplayLabel(key)}
+                                    {getNodeKindDisplayLabel(key, nodeKindDisplayLabels)}
                                 </div>
                                 <Badge label={value.toLocaleString()} />
                             </div>

--- a/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/Details/ObjectsAccordion.tag.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/Details/ObjectsAccordion.tag.test.tsx
@@ -99,7 +99,7 @@ describe('ObjectsAccordion', () => {
             />
         );
 
-        expect(screen.getByText('Azure Application')).toBeInTheDocument();
+        expect(await screen.findByText('Azure Application')).toBeInTheDocument();
         expect(screen.getByText('Azure Service Principal')).toBeInTheDocument();
         expect(screen.getByText('Certificate Template')).toBeInTheDocument();
         expect(screen.queryByText('AZApp')).not.toBeInTheDocument();

--- a/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/Details/ObjectsAccordion.tag.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/Details/ObjectsAccordion.tag.test.tsx
@@ -89,6 +89,29 @@ describe('ObjectsAccordion', () => {
         expect(within(userAccordionItem as HTMLElement).getByText('User')).toBeInTheDocument();
     });
 
+    it('renders human-readable node kind labels while preserving raw kind values', async () => {
+        render(
+            <ObjectsAccordion
+                tagId={'42'}
+                onObjectClick={vi.fn()}
+                kindCounts={{ AZApp: 2, AZServicePrincipal: 3, CertTemplate: 4 }}
+                totalCount={9}
+            />
+        );
+
+        expect(screen.getByText('Azure Application')).toBeInTheDocument();
+        expect(screen.getByText('Azure Service Principal')).toBeInTheDocument();
+        expect(screen.getByText('Certificate Template')).toBeInTheDocument();
+        expect(screen.queryByText('AZApp')).not.toBeInTheDocument();
+
+        const azureApplicationHeader = screen.getByTestId('privilege-zones_details_AZApp-accordion-item');
+        const sortButton = within(azureApplicationHeader).getByTestId('column-header_sort-button');
+
+        await userEvent.click(sortButton);
+
+        expect(useTagMembersInfiniteQuerySpy).toBeCalledWith('42', 'asc', ['env-1'], 'AZApp', false);
+    });
+
     it('toggles sort order when clicking sortable header', async () => {
         render(<ObjectsAccordion tagId={'42'} onObjectClick={vi.fn()} kindCounts={testKindCounts} totalCount={15} />);
 

--- a/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/Details/ObjectsAccordion.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/Details/ObjectsAccordion.tsx
@@ -26,7 +26,7 @@ import { useRuleMembersInfiniteQuery, useTagMembersInfiniteQuery } from '../../.
 import { useEnvironmentIdList } from '../../../hooks/useEnvironmentIdList';
 import { ENVIRONMENT_AGGREGATION_SUPPORTED_ROUTES } from '../../../routes';
 import { SortOrder } from '../../../types';
-import { cn } from '../../../utils';
+import { cn, getNodeKindDisplayLabel } from '../../../utils';
 import { SelectedHighlight } from './SelectedHighlight';
 
 export interface ObjectsAccordionProps {
@@ -63,7 +63,7 @@ export const ObjectsAccordion: React.FC<ObjectsAccordionProps> = ({
                 className='w-full min-w-0 rounded-none bg-neutral-2'
                 data-testid='privilege-zones_details_objects-accordion'>
                 {Object.entries(kindCounts)
-                    .sort((a, b) => a[0].localeCompare(b[0]))
+                    .sort((a, b) => getNodeKindDisplayLabel(a[0]).localeCompare(getNodeKindDisplayLabel(b[0])))
                     .map(([kind, count]) => (
                         <ObjectAccordionItem
                             key={kind}
@@ -113,6 +113,7 @@ const ObjectAccordionItem: React.FC<ObjectAccordionItemProps> = ({
     onObjectClick,
 }) => {
     const [sortOrder, setSortOrder] = useState<SortOrder>('asc');
+    const kindDisplayLabel = getNodeKindDisplayLabel(kind);
 
     const environments = useEnvironmentIdList(ENVIRONMENT_AGGREGATION_SUPPORTED_ROUTES, false);
 
@@ -154,7 +155,7 @@ const ObjectAccordionItem: React.FC<ObjectAccordionItemProps> = ({
             <div className='w-full flex items-center justify-between border-b border-neutral-3'>
                 <div className='w-full flex items-center'>
                     <Button
-                        className='w-6'
+                        className='w-6 text-contrast'
                         variant='text'
                         data-testid={`privilege-zones_details_${kind}-accordion_open-toggle-button`}
                         onClick={() => {
@@ -165,14 +166,14 @@ const ObjectAccordionItem: React.FC<ObjectAccordionItemProps> = ({
                     <div className='flex flex-1 items-center gap-2'>
                         <NodeIcon nodeType={kind} />
                         <SortableHeader
-                            title={kind}
+                            title={kindDisplayLabel}
                             onSort={() => {
                                 setSortOrder(sortOrder === 'asc' ? 'desc' : 'asc');
                             }}
                             sortOrder={sortOrder}
                             classes={{
                                 container: cn('flex-1', { 'pointer-events-none cursor-default': !isOpen }),
-                                button: cn('font-bold text-base', {
+                                button: cn('font-bold text-base text-contrast', {
                                     '[&>svg]:hidden': !isOpen,
                                 }),
                             }}

--- a/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/Details/ObjectsAccordion.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/Details/ObjectsAccordion.tsx
@@ -24,9 +24,10 @@ import { InfiniteQueryFixedList, InfiniteQueryFixedListProps } from '../../../co
 import NodeIcon from '../../../components/NodeIcon';
 import { useRuleMembersInfiniteQuery, useTagMembersInfiniteQuery } from '../../../hooks/useAssetGroupTags';
 import { useEnvironmentIdList } from '../../../hooks/useEnvironmentIdList';
+import { useGraphNodeKinds } from '../../../hooks/useGraphKinds';
 import { ENVIRONMENT_AGGREGATION_SUPPORTED_ROUTES } from '../../../routes';
 import { SortOrder } from '../../../types';
-import { cn, getNodeKindDisplayLabel } from '../../../utils';
+import { cn, createNodeKindDisplayLabelMap, getNodeKindDisplayLabel, NodeKindDisplayLabelMap } from '../../../utils';
 import { SelectedHighlight } from './SelectedHighlight';
 
 export interface ObjectsAccordionProps {
@@ -47,6 +48,8 @@ export const ObjectsAccordion: React.FC<ObjectsAccordionProps> = ({
     onObjectClick,
 }) => {
     const [openAccordion, setOpenAccordion] = useState('');
+    const nodeKindsQuery = useGraphNodeKinds();
+    const nodeKindDisplayLabels = createNodeKindDisplayLabelMap(nodeKindsQuery.data?.node_kinds);
 
     return (
         <div>
@@ -63,7 +66,11 @@ export const ObjectsAccordion: React.FC<ObjectsAccordionProps> = ({
                 className='w-full min-w-0 rounded-none bg-neutral-2'
                 data-testid='privilege-zones_details_objects-accordion'>
                 {Object.entries(kindCounts)
-                    .sort((a, b) => getNodeKindDisplayLabel(a[0]).localeCompare(getNodeKindDisplayLabel(b[0])))
+                    .sort((a, b) =>
+                        getNodeKindDisplayLabel(a[0], nodeKindDisplayLabels).localeCompare(
+                            getNodeKindDisplayLabel(b[0], nodeKindDisplayLabels)
+                        )
+                    )
                     .map(([kind, count]) => (
                         <ObjectAccordionItem
                             key={kind}
@@ -75,6 +82,7 @@ export const ObjectsAccordion: React.FC<ObjectsAccordionProps> = ({
                             isOpen={kind === openAccordion}
                             onOpen={setOpenAccordion}
                             onObjectClick={onObjectClick}
+                            nodeKindDisplayLabels={nodeKindDisplayLabels}
                         />
                     ))}
             </Accordion>
@@ -91,6 +99,7 @@ interface ObjectAccordionItemProps {
     objectId?: string;
     onOpen: React.Dispatch<React.SetStateAction<string>>;
     onObjectClick: (object: AssetGroupTagMemberListItem) => void;
+    nodeKindDisplayLabels: NodeKindDisplayLabelMap;
 }
 
 const LoadingRow = (_: number, style: React.CSSProperties) => (
@@ -111,9 +120,10 @@ const ObjectAccordionItem: React.FC<ObjectAccordionItemProps> = ({
     isOpen,
     onOpen,
     onObjectClick,
+    nodeKindDisplayLabels,
 }) => {
     const [sortOrder, setSortOrder] = useState<SortOrder>('asc');
-    const kindDisplayLabel = getNodeKindDisplayLabel(kind);
+    const kindDisplayLabel = getNodeKindDisplayLabel(kind, nodeKindDisplayLabels);
 
     const environments = useEnvironmentIdList(ENVIRONMENT_AGGREGATION_SUPPORTED_ROUTES, false);
 

--- a/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/Details/RulesAccordion.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/Details/RulesAccordion.tsx
@@ -229,7 +229,7 @@ const RuleAccordionItem: React.FC<RuleAccordionItemProps> = ({ section: filterKe
             <div className='w-full flex items-center justify-between border-b border-neutral-3'>
                 <div className='w-full flex items-center gap-2'>
                     <Button
-                        className='w-6 max-xl:px-2 max-lg:px-6 text-contrast'
+                        className='w-6 text-contrast'
                         variant='text'
                         disabled={isAccordionDisabled}
                         data-testid={`privilege-zones_details_${filterKey}-accordion_open-toggle-button`}

--- a/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/Details/RulesAccordion.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/Details/RulesAccordion.tsx
@@ -229,7 +229,7 @@ const RuleAccordionItem: React.FC<RuleAccordionItemProps> = ({ section: filterKe
             <div className='w-full flex items-center justify-between border-b border-neutral-3'>
                 <div className='w-full flex items-center gap-2'>
                     <Button
-                        className='w-6 max-xl:px-2 max-lg:px-6'
+                        className='w-6 max-xl:px-2 max-lg:px-6 text-contrast'
                         variant='text'
                         disabled={isAccordionDisabled}
                         data-testid={`privilege-zones_details_${filterKey}-accordion_open-toggle-button`}
@@ -250,7 +250,7 @@ const RuleAccordionItem: React.FC<RuleAccordionItemProps> = ({ section: filterKe
                             sortOrder={sortOrder}
                             classes={{
                                 container: cn({ 'pointer-events-none cursor-default': !isOpen }),
-                                button: cn('font-bold text-base', {
+                                button: cn('font-bold text-base text-contrast', {
                                     '[&>svg]:hidden': !isOpen || isAccordionDisabled,
                                     'opacity-50': isAccordionDisabled,
                                 }),

--- a/packages/javascript/js-client-library/src/responses.ts
+++ b/packages/javascript/js-client-library/src/responses.ts
@@ -406,7 +406,10 @@ export type FindingSchema = {
 
 export type FindingSchemaResponse = PaginatedResponse<{ findings: FindingSchema[] }>;
 
-export type GraphKindsResponse = BasicResponse<{ kinds: string[] }>;
+export type GraphKindsResponse = BasicResponse<{
+    kinds: string[];
+    node_kinds?: Pick<NodeKindResponse, 'name' | 'display_name'>[];
+}>;
 
 export type UnifiedFinding = {
     severity: string;


### PR DESCRIPTION
## Description

Updates node type labels in Privilege Zones and related asset group UI surfaces to use human-readable names instead of raw graph kind values.

The display labels now come from `schema_node_kinds.display_name` via `/api/v2/graphs/kinds`, rather than a frontend-only hardcoded map. Raw graph kind values are still preserved for icons, test IDs, filtering, sorting inputs, and API calls.

## Motivation and Context

Resolves https://specterops.atlassian.net/browse/BED-9025

Raw graph kind labels like `AZApp`, `AZServicePrincipal`, `CertTemplate`, and `AIACA` are difficult for first-time users to understand. Moving the labels into schema metadata gives the UI a shared backend-backed source of truth while keeping raw kinds available for graph/query behavior.

## Implementation Notes

- Adds `node_kinds` metadata to `/api/v2/graphs/kinds`
- Adds a migration to update built-in `schema_node_kinds.display_name` values
- Updates OpenAPI and JS client response types
- Updates Asset Group and Privilege Zone node-kind displays to consume graph kind metadata
- Keeps unknown/custom node kinds falling back to their raw value

## How Has This Been Tested?

- `just prepare-for-codereview`
- `go test ./cmd/api/src/api/v2 -run TestResources_ListKinds`
- `yarn workspace bh-shared-ui test src/utils/nodeKindDisplay.test.ts src/components/AssetGroupEdit/AssetGroupEdit.test.tsx src/components/AssetGroupFilters/AssetGroupFilters.test.tsx src/views/PrivilegeZones/Details/ObjectCountPanel.test.tsx src/views/PrivilegeZones/Details/ObjectsAccordion.tag.test.tsx`
- `yarn workspace bh-shared-ui check-types`
- `yarn workspace js-client-library build`
- `git diff --check`

## Screenshots (optional):

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have met the contributing prerequisites
  - Associated ticket: https://specterops.atlassian.net/browse/BED-9025
- [x] I have ensured that related documentation is up-to-date
  - OpenAPI docs were updated
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - Relevant tests passed locally
