### PR TITLE
test(a11y): add Privilege Zones coverage - BED-8635

### DIFF
--- a/cmd/ui/tests/a11y/PrivilegeZones/history.a11y.spec.ts
+++ b/cmd/ui/tests/a11y/PrivilegeZones/history.a11y.spec.ts
@@ -14,13 +14,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-export * from './asset-group-tags/members';
-export * from './asset-group-tags/labels';
-export * from './asset-group-tags/search';
-export * from './asset-group-tags/selectors';
-export * from './asset-group-tags/tag';
-export * from './asset-group-tags/zone-details';
-export * from './bloodhound-users/mfa';
-export * from './bloodhound-users/secret';
-export * from './graphs/cypher';
-export * from './tokens/index';
+import { test } from '../../fixtures';
+
+test.describe('WCAG A/AA violations - Privilege Zones - History tab', () => {});

--- a/cmd/ui/tests/a11y/PrivilegeZones/labels.a11y.spec.ts
+++ b/cmd/ui/tests/a11y/PrivilegeZones/labels.a11y.spec.ts
@@ -1,0 +1,154 @@
+// Copyright 2026 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { Locator, Page } from '@playwright/test';
+import {
+    installAssetGroupLabelDetailsStub,
+    installAssetGroupLabelMemberStub,
+    installAssetGroupLabelSelectorStub,
+    installAssetGroupLabelsSearchStub,
+    installAssetGroupLabelStub,
+} from 'bh-playwright-testing/stubs';
+import { expectNoAccessibilityViolations, test } from '../../fixtures';
+
+const LABELS_URL = '/ui/privilege-zones/labels/2/details';
+const EDIT_LABEL_URL = '/ui/privilege-zones/labels/2/save';
+const CREATE_RULE_URL = '/ui/privilege-zones/labels/2/rules/save';
+const EDIT_RULE_URL = '/ui/privilege-zones/labels/2/rules/3303/save';
+
+/** Visit the URL, collapse the nav menu (for more space), and wait for locator to be visible */
+const openPage = async (page: Page, url: string, waitFor?: Locator) => {
+    const waitLocator = waitFor ?? page.getByRole('heading', { name: 'Label Details' });
+
+    await page.goto(url);
+    await page.getByRole('button', { name: 'Toggle Navigation' }).click();
+    await waitLocator.waitFor({ state: 'visible' });
+};
+
+test.describe('WCAG A/AA violations - Privilege Zones - Labels tab', () => {
+    test.describe('Label details panel', () => {
+        test('default state', async ({ page, makeAxeBuilder }, testInfo) => {
+            await openPage(page, LABELS_URL);
+
+            const results = await makeAxeBuilder().include('#content-wrapper').analyze();
+            await expectNoAccessibilityViolations(testInfo, results, { page });
+        });
+
+        test('search', async ({ page, makeAxeBuilder }, testInfo) => {
+            await installAssetGroupLabelsSearchStub(page);
+            await openPage(page, LABELS_URL);
+
+            // Type at least 3 characters to trigger the debounced search and open the results popover.
+            await page.getByTestId('privilege-zone-detail-search-bar').fill('ADMIN');
+
+            // Wait for the filtered Objects to render before scanning.
+            await page.getByText('PLAYWRIGHT_LABEL_ADMIN_USER').waitFor({ state: 'visible' });
+
+            const results = await makeAxeBuilder().include('[data-radix-popper-content-wrapper]').analyze();
+            await expectNoAccessibilityViolations(testInfo, results, { page });
+        });
+
+        test('search with no results', async ({ page, makeAxeBuilder }, testInfo) => {
+            await installAssetGroupLabelsSearchStub(page);
+            await openPage(page, LABELS_URL);
+
+            // Type at query that will have no matches
+            await page.getByTestId('privilege-zone-detail-search-bar').fill('XXXYYY');
+
+            // Wait for the filtered Objects to render before scanning.
+            await page.getByText('No results').first().waitFor({ state: 'visible' });
+
+            const results = await makeAxeBuilder().include('[data-radix-popper-content-wrapper]').analyze();
+            await expectNoAccessibilityViolations(testInfo, results, { page });
+        });
+
+        test('expanded rules and objects', async ({ page, makeAxeBuilder }, testInfo) => {
+            // Stub Label data so custom Rules and Objects render deterministically
+            // Labels deliberately do not expose Default Rules.
+            await installAssetGroupLabelDetailsStub(page);
+            await installAssetGroupLabelMemberStub(page);
+            await openPage(page, LABELS_URL);
+
+            const caret = page.getByTestId('privilege-zones_details_Computer-accordion_open-toggle-button');
+            await caret.waitFor({ state: 'visible' });
+            await caret.click();
+
+            const results = await makeAxeBuilder().include('#content-wrapper').analyze();
+            await expectNoAccessibilityViolations(testInfo, results, { page });
+        });
+    });
+
+    test.describe('Side panels', () => {
+        test('Rule side panel tab', async ({ page, makeAxeBuilder }, testInfo) => {
+            // Stub Label Details with custom rules, plus the first rule's detail response.
+            await installAssetGroupLabelDetailsStub(page);
+            await installAssetGroupLabelSelectorStub(page);
+            await openPage(page, LABELS_URL);
+
+            // Selecting the first Custom Rule updates the route and switches the details panel to Rule.
+            await page.getByRole('button', { name: 'PLAYWRIGHT_LABEL_RULE_1' }).click();
+            await page.getByText('Playwright stubbed label rule').waitFor({ state: 'visible' });
+
+            const results = await makeAxeBuilder().include('#content-wrapper').analyze();
+            await expectNoAccessibilityViolations(testInfo, results, { page });
+        });
+
+        test('Object side panel tab', async ({ page, makeAxeBuilder }, testInfo) => {
+            // Stub Label Details with objects grouped by node type, plus the first object's detail response.
+            await installAssetGroupLabelDetailsStub(page);
+            await installAssetGroupLabelMemberStub(page);
+            await openPage(page, LABELS_URL);
+
+            // Open the first node type and select its first object to switch the details panel to Object.
+            await page.getByTestId('privilege-zones_details_Computer-accordion_open-toggle-button').click();
+            await page.getByRole('button', { name: 'PLAYWRIGHT_LABEL_COMPUTER_1' }).click();
+            await page.getByText('Node Type:').waitFor({ state: 'visible' });
+
+            const results = await makeAxeBuilder().include('#content-wrapper').analyze();
+            await expectNoAccessibilityViolations(testInfo, results, { page });
+        });
+    });
+});
+
+test.describe('WCAG A/AA violations - Privilege Zones - Label save pages', () => {
+    test('Edit Label page', async ({ page, makeAxeBuilder }, testInfo) => {
+        // Stub the single label so the Edit Label form fields populate instead of showing a skeleton.
+        await installAssetGroupLabelStub(page);
+        await openPage(page, EDIT_LABEL_URL, page.getByTestId('privilege-zones_save_tag-form_name-input'));
+
+        const results = await makeAxeBuilder().include('#content-wrapper').analyze();
+        await expectNoAccessibilityViolations(testInfo, results, { page });
+    });
+
+    test('Create Label rule page', async ({ page, makeAxeBuilder }, testInfo) => {
+        // Create mode does not fetch a selector; only the tag info is needed for form context.
+        await installAssetGroupLabelStub(page);
+        await openPage(page, CREATE_RULE_URL, page.getByTestId('rule-form'));
+
+        const results = await makeAxeBuilder().include('#content-wrapper').analyze();
+        await expectNoAccessibilityViolations(testInfo, results, { page });
+    });
+
+    test('Edit Label rule page', async ({ page, makeAxeBuilder }, testInfo) => {
+        // Edit mode fetches both the label (for context) and the selector being edited.
+        await installAssetGroupLabelStub(page);
+        await installAssetGroupLabelSelectorStub(page);
+        await openPage(page, EDIT_RULE_URL, page.getByTestId('rule-form'));
+
+        const results = await makeAxeBuilder().include('#content-wrapper').analyze();
+        await expectNoAccessibilityViolations(testInfo, results, { page });
+    });
+});

--- a/cmd/ui/tests/a11y/PrivilegeZones/zones.a11y.spec.ts
+++ b/cmd/ui/tests/a11y/PrivilegeZones/zones.a11y.spec.ts
@@ -1,0 +1,159 @@
+// Copyright 2026 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { Locator, Page } from '@playwright/test';
+import {
+    installAssetGroupTagMemberStub,
+    installAssetGroupTagSelectorStub,
+    installAssetGroupTagStub,
+    installAssetGroupTagsSearchStub,
+    installAssetGroupTagsZoneDetailsStub,
+} from 'bh-playwright-testing/stubs';
+import { expectNoAccessibilityViolations, test } from '../../fixtures';
+
+const ZONES_URL = '/ui/privilege-zones/zones/1/details';
+const EDIT_ZONE_URL = '/ui/privilege-zones/zones/1/save';
+const CREATE_RULE_URL = '/ui/privilege-zones/zones/1/rules/save';
+const EDIT_RULE_URL = '/ui/privilege-zones/zones/1/rules/3003/save';
+
+/** Visit the URL, collapse the nav menu (for more space), and wait for locator to be visible */
+const openPage = async (page: Page, url: string, waitFor?: Locator) => {
+    const waitLocator = waitFor ?? page.getByRole('heading', { name: 'Zone Details' });
+
+    await page.goto(url);
+    await page.getByRole('button', { name: 'Toggle Navigation' }).click();
+    await waitLocator.waitFor({ state: 'visible' });
+};
+
+test.describe('WCAG A/AA violations - Privilege Zones - Zones tab', () => {
+    test.describe('Zone details panel', () => {
+        test('default state', async ({ page, makeAxeBuilder }, testInfo) => {
+            await openPage(page, ZONES_URL);
+
+            const results = await makeAxeBuilder().include('#content-wrapper').analyze();
+            await expectNoAccessibilityViolations(testInfo, results, { page });
+        });
+
+        test('search', async ({ page, makeAxeBuilder }, testInfo) => {
+            await installAssetGroupTagsSearchStub(page);
+            await openPage(page, ZONES_URL);
+
+            // Type at least 3 characters to trigger the debounced search and open the results popover.
+            await page.getByTestId('privilege-zone-detail-search-bar').fill('ADMIN');
+
+            // Wait for the filtered Objects to render before scanning.
+            await page.getByText('PLAYWRIGHT_ADMIN_USER').waitFor({ state: 'visible' });
+
+            const results = await makeAxeBuilder().include('[data-radix-popper-content-wrapper]').analyze();
+            await expectNoAccessibilityViolations(testInfo, results, { page });
+        });
+
+        test('search with no results', async ({ page, makeAxeBuilder }, testInfo) => {
+            await installAssetGroupTagsSearchStub(page);
+            await openPage(page, ZONES_URL);
+
+            // Type at query that will have no matches
+            await page.getByTestId('privilege-zone-detail-search-bar').fill('XXXYYY');
+
+            // Wait for the filtered Objects to render before scanning.
+            await page.getByText('No results').first().waitFor({ state: 'visible' });
+
+            const results = await makeAxeBuilder().include('[data-radix-popper-content-wrapper]').analyze();
+            await expectNoAccessibilityViolations(testInfo, results, { page });
+        });
+
+        test('expanded rules and objects', async ({ page, makeAxeBuilder }, testInfo) => {
+            // Stub the Zone Details data so Rules (including Default Rules) and Objects
+            // (Computers, Domains, Groups) render deterministically, then reload to apply the routes.
+            await installAssetGroupTagsZoneDetailsStub(page);
+            await openPage(page, ZONES_URL);
+
+            // Expand the Computers objects accordion and wait for a stubbed computer to render.
+            await page.getByTestId('privilege-zones_details_Computer-accordion_open-toggle-button').click();
+            await page.getByText('PLAYWRIGHT_COMPUTER_1').waitFor({ state: 'visible' });
+
+            const results = await makeAxeBuilder().include('#content-wrapper').analyze();
+            await expectNoAccessibilityViolations(testInfo, results, { page });
+        });
+    });
+
+    test.describe('Side panels', () => {
+        test('Rule side panel tab', async ({ page, makeAxeBuilder }, testInfo) => {
+            // Stub the single tag + selector so the Rule tab renders deterministic rule details.
+            await installAssetGroupTagStub(page);
+            await installAssetGroupTagSelectorStub(page);
+            await openPage(page, ZONES_URL);
+
+            // Selecting the first Default Rule updates the route and switches the details panel to Rule.
+            await page.getByTestId('privilege-zones_details_default_selectors-accordion_open-toggle-button').click();
+            await page.getByRole('button', { name: 'Account Operators' }).click();
+            await page.getByText('Playwright stubbed rule').waitFor({ state: 'visible' });
+
+            const results = await makeAxeBuilder().include('#content-wrapper').analyze();
+            await expectNoAccessibilityViolations(testInfo, results, { page });
+        });
+
+        test('Object side panel tab', async ({ page, makeAxeBuilder }, testInfo) => {
+            // Stub Zone Details with objects grouped by node type, plus the first object's detail response.
+            await installAssetGroupTagsZoneDetailsStub(page);
+            await installAssetGroupTagMemberStub(page);
+            await openPage(page, ZONES_URL);
+
+            // Open the first node type and select its first object to switch the details panel to Object.
+            await page.getByTestId('privilege-zones_details_Computer-accordion_open-toggle-button').click();
+
+            const computer = page.getByRole('button', { name: 'PLAYWRIGHT_COMPUTER_1' });
+            await computer.waitFor({ state: 'visible' });
+            await computer.click();
+
+            // Once the selected computer's node data resolves, the Object tab renders its details.
+            await page.getByText('Node Type:').waitFor({ state: 'visible' });
+
+            const results = await makeAxeBuilder().include('#content-wrapper').analyze();
+            await expectNoAccessibilityViolations(testInfo, results, { page });
+        });
+    });
+});
+
+test.describe('WCAG A/AA violations - Privilege Zones - Save pages', () => {
+    test('Edit Zone page', async ({ page, makeAxeBuilder }, testInfo) => {
+        // Stub the single tag so the Edit Zone form fields populate instead of showing a skeleton.
+        await installAssetGroupTagStub(page);
+        await openPage(page, EDIT_ZONE_URL, page.getByTestId('privilege-zones_save_tag-form_name-input'));
+
+        const results = await makeAxeBuilder().include('#content-wrapper').analyze();
+        await expectNoAccessibilityViolations(testInfo, results, { page });
+    });
+
+    test('Create rule page', async ({ page, makeAxeBuilder }, testInfo) => {
+        // Create mode does not fetch a selector; only the tag info is needed for form context.
+        await installAssetGroupTagStub(page);
+        await openPage(page, CREATE_RULE_URL, page.getByTestId('privilege-zones_save_rule-form_name-input'));
+
+        const results = await makeAxeBuilder().include('#content-wrapper').analyze();
+        await expectNoAccessibilityViolations(testInfo, results, { page });
+    });
+
+    test('Edit rule page', async ({ page, makeAxeBuilder }, testInfo) => {
+        // Edit mode fetches both the tag (for context) and the selector being edited.
+        await installAssetGroupTagStub(page);
+        await installAssetGroupTagSelectorStub(page);
+        await openPage(page, EDIT_RULE_URL, page.getByTestId('privilege-zones_save_rule-form_name-input'));
+
+        const results = await makeAxeBuilder().include('#content-wrapper').analyze();
+        await expectNoAccessibilityViolations(testInfo, results, { page });
+    });
+});

--- a/packages/javascript/bh-playwright-testing/src/stubs/asset-group-tags/labels.ts
+++ b/packages/javascript/bh-playwright-testing/src/stubs/asset-group-tags/labels.ts
@@ -1,0 +1,200 @@
+// Copyright 2026 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Page } from '@playwright/test';
+import { installAssetGroupTagMemberStub } from './members';
+import { installAssetGroupTagsSearchStub } from './search';
+import { installAssetGroupTagSelectorStub } from './selectors';
+import { installAssetGroupTagStub } from './tag';
+import { installAssetGroupTagsZoneDetailsStub } from './zone-details';
+
+const labelTag = {
+    id: 2,
+    name: 'PLAYWRIGHT_LABEL',
+    type: 2,
+    position: 2,
+    description: 'Playwright stubbed label',
+    analysis_enabled: false,
+    require_certify: false,
+};
+
+/** Installs deterministic Label data for a single Label request. */
+export async function installAssetGroupLabelStub(page: Page): Promise<void> {
+    await installAssetGroupTagStub(page, { data: { tag: labelTag } });
+}
+
+/** Installs a deterministic Label rule for a single rule request. */
+export async function installAssetGroupLabelSelectorStub(page: Page): Promise<void> {
+    await installAssetGroupTagSelectorStub(page, {
+        data: {
+            selector: {
+                id: 3303,
+                asset_group_tag_id: labelTag.id,
+                name: 'PLAYWRIGHT_LABEL_RULE_1',
+                description: 'Playwright stubbed label rule',
+                seeds: [{ selector_id: 3303, type: 1, value: 'S-1-5-21-PW-4401' }],
+            },
+        },
+    });
+}
+
+/** Installs deterministic Label member and node data for a single member request. */
+export async function installAssetGroupLabelMemberStub(page: Page): Promise<void> {
+    await installAssetGroupTagMemberStub(page, {
+        data: {
+            member: {
+                asset_group_tag_id: labelTag.id,
+                id: 4401,
+                name: 'PLAYWRIGHT_LABEL_COMPUTER_1',
+                object_id: 'S-1-5-21-PW-4401',
+                properties: {
+                    name: 'PLAYWRIGHT_LABEL_COMPUTER_1',
+                    objectid: 'S-1-5-21-PW-4401',
+                },
+                selectors: [{ id: 3303, asset_group_tag_id: labelTag.id, name: 'PLAYWRIGHT_LABEL_RULE_1' }],
+            },
+        },
+    });
+
+    await page.route(/\/api\/v2\/nodes\/\d+(\?.*)?$/, async (route) => {
+        if (route.request().method() !== 'GET') return route.fallback();
+        return route.fulfill({
+            json: {
+                data: {
+                    node_id: 4401,
+                    kinds: [{ name: 'Computer', node_kind_id: null }],
+                    properties: {
+                        name: 'PLAYWRIGHT_LABEL_COMPUTER_1',
+                        objectid: 'S-1-5-21-PW-4401',
+                    },
+                },
+            },
+        });
+    });
+
+    // The shared Object Information panel loads count data for each Computer relationship section.
+    // Return empty results for all of them so the panel does not render request-error indicators.
+    await page.route(/\/api\/v2\/computers\/[^/?]+\/[^/?]+(\?.*)?$/, async (route) => {
+        if (route.request().method() !== 'GET') return route.fallback();
+        return route.fulfill({ json: { data: [], count: 0, limit: 128, skip: 0 } });
+    });
+}
+
+/** Installs Label-specific search results. */
+export async function installAssetGroupLabelsSearchStub(page: Page): Promise<void> {
+    await installAssetGroupTagsSearchStub(page, {
+        data: {
+            tags: [{ id: labelTag.id, name: labelTag.name }],
+            selectors: [{ id: 3303, asset_group_tag_id: labelTag.id, name: 'PLAYWRIGHT_LABEL_ADMIN_RULE' }],
+            members: [
+                {
+                    asset_group_tag_id: labelTag.id,
+                    id: 4401,
+                    primary_kind: 'User',
+                    object_id: 'S-1-5-21-PW-4401',
+                    name: 'PLAYWRIGHT_LABEL_ADMIN_USER',
+                    source: 1,
+                },
+            ],
+        },
+    });
+}
+
+/**
+ * Installs deterministic Label detail data. Labels have custom rules and objects, but never
+ * Default Rules, unlike Privilege Zones.
+ */
+export async function installAssetGroupLabelDetailsStub(page: Page): Promise<void> {
+    const rules = [
+        {
+            id: 3303,
+            asset_group_tag_id: labelTag.id,
+            name: 'PLAYWRIGHT_LABEL_RULE_1',
+            description: 'Playwright stubbed label rule',
+            is_default: false,
+            allow_disable: true,
+            auto_certify: false,
+            seeds: [],
+            created_at: '2024-01-01T00:00:00Z',
+            updated_at: '2024-01-02T00:00:00Z',
+            disabled_at: null,
+        },
+        {
+            id: 3304,
+            asset_group_tag_id: labelTag.id,
+            name: 'PLAYWRIGHT_LABEL_RULE_2',
+            description: 'Playwright stubbed label rule',
+            is_default: false,
+            allow_disable: true,
+            auto_certify: false,
+            seeds: [],
+            created_at: '2024-01-01T00:00:00Z',
+            updated_at: '2024-01-02T00:00:00Z',
+            disabled_at: null,
+        },
+    ];
+    const objects = [
+        {
+            asset_group_tag_id: labelTag.id,
+            id: 4401,
+            primary_kind: 'Computer',
+            object_id: 'S-1-5-21-PW-4401',
+            name: 'PLAYWRIGHT_LABEL_COMPUTER_1',
+            source: 1,
+        },
+        {
+            asset_group_tag_id: labelTag.id,
+            id: 4402,
+            primary_kind: 'Computer',
+            object_id: 'S-1-5-21-PW-4402',
+            name: 'PLAYWRIGHT_LABEL_COMPUTER_2',
+            source: 1,
+        },
+        {
+            asset_group_tag_id: labelTag.id,
+            id: 4403,
+            primary_kind: 'Group',
+            object_id: 'S-1-5-21-PW-4403',
+            name: 'PLAYWRIGHT_LABEL_GROUP_1',
+            source: 1,
+        },
+    ];
+
+    await installAssetGroupTagsZoneDetailsStub(page, {
+        data: {
+            tag: {
+                ...labelTag,
+                kind_id: 10,
+                glyph: null,
+                created_at: '2024-01-01T00:00:00Z',
+                created_by: 'playwright',
+                updated_at: '2024-01-02T00:00:00Z',
+                updated_by: 'playwright',
+                deleted_at: null,
+                deleted_by: null,
+                counts: {
+                    selectors: rules.length,
+                    custom_selectors: rules.length,
+                    default_selectors: 0,
+                    disabled_selectors: 0,
+                    members: objects.length,
+                },
+            },
+            rules,
+            objects,
+        },
+    });
+}

--- a/packages/javascript/bh-playwright-testing/src/stubs/asset-group-tags/members.ts
+++ b/packages/javascript/bh-playwright-testing/src/stubs/asset-group-tags/members.ts
@@ -1,0 +1,103 @@
+// Copyright 2026 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Page } from '@playwright/test';
+
+type StubMemberSelector = {
+    id: number;
+    asset_group_tag_id: number;
+    name: string;
+};
+
+type StubMember = {
+    asset_group_tag_id: number;
+    id: number;
+    primary_kind: string;
+    object_id: string;
+    name: string;
+    source: number;
+    properties: Record<string, unknown>;
+    selectors: StubMemberSelector[];
+};
+
+export type AssetGroupTagMemberStubData = {
+    member?: Partial<StubMember>;
+    /** Entity kinds returned by the graph-node endpoint (`GET /api/v2/nodes/:nodeId`). */
+    entityKinds?: string[];
+    /** Entity properties returned by the graph-node endpoint. */
+    entityProperties?: Record<string, unknown>;
+};
+
+const buildMember = (overrides: Partial<StubMember> = {}): StubMember => ({
+    asset_group_tag_id: 1,
+    id: 4001,
+    primary_kind: 'Computer',
+    object_id: 'S-1-5-21-PW-4001',
+    name: 'PLAYWRIGHT_COMPUTER_1',
+    source: 1,
+    properties: {
+        name: 'PLAYWRIGHT_COMPUTER_1',
+        objectid: 'S-1-5-21-PW-4001',
+    },
+    selectors: [{ id: 3003, asset_group_tag_id: 1, name: 'PLAYWRIGHT_CUSTOM_RULE_1' }],
+    ...overrides,
+});
+
+export type AssetGroupTagMemberStubOptions = {
+    data?: AssetGroupTagMemberStubData;
+};
+
+/**
+ * Stubs the single-member endpoint (`GET /api/v2/asset-group-tags/:tagId/members/:memberId`) plus
+ * the graph-node endpoint the shared Entity Info panel resolves for the selected member
+ * (`GET /api/v2/nodes/:nodeId`, via `useGetNodeById(member.id)`), and the relationship-count
+ * endpoints the Object Information panel loads for each section (`GET /api/v2/computers/:id/:section`).
+ * Together these let the Object side panel render deterministic member info and its "Rules" section
+ * without hitting the real backend. Non-GET traffic falls through to any lower-priority route handlers.
+ */
+export async function installAssetGroupTagMemberStub(
+    page: Page,
+    opts: AssetGroupTagMemberStubOptions = {}
+): Promise<void> {
+    const member = buildMember(opts.data?.member);
+    const kinds = opts.data?.entityKinds ?? [member.primary_kind, 'Base'];
+    const properties = opts.data?.entityProperties ?? member.properties;
+
+    await page.route(/\/api\/v2\/asset-group-tags\/\d+\/members\/\d+(\?.*)?$/, async (route) => {
+        if (route.request().method() !== 'GET') return route.fallback();
+        return route.fulfill({ json: { data: { member } } });
+    });
+
+    await page.route(/\/api\/v2\/nodes\/\d+(\?.*)?$/, async (route) => {
+        if (route.request().method() !== 'GET') return route.fallback();
+        return route.fulfill({
+            json: {
+                data: {
+                    node_id: member.id,
+                    kinds: kinds.map((name) => ({ name, node_kind_id: null })),
+                    properties,
+                },
+            },
+        });
+    });
+
+    // The shared Object Information panel loads count data for each relationship section.
+    // Return empty results for all of them so the panel does not render request-error indicators.
+    await page.route(/\/api\/v2\/computers\/[^/?]+\/[^/?]+(\?.*)?$/, async (route) => {
+        if (route.request().method() !== 'GET') return route.fallback();
+        return route.fulfill({ json: { data: [], count: 0, limit: 128, skip: 0 } });
+    });
+}

--- a/packages/javascript/bh-playwright-testing/src/stubs/asset-group-tags/search.ts
+++ b/packages/javascript/bh-playwright-testing/src/stubs/asset-group-tags/search.ts
@@ -1,0 +1,120 @@
+// Copyright 2026 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Page } from '@playwright/test';
+
+type StubSearchMember = {
+    asset_group_tag_id: number;
+    id: number;
+    primary_kind: string;
+    object_id: string;
+    name: string;
+    source: number;
+};
+
+type StubSearchSelector = {
+    id: number;
+    asset_group_tag_id: number;
+    name: string;
+};
+
+type StubSearchTag = {
+    id: number;
+    name: string;
+};
+
+export type AssetGroupTagsSearchStubData = {
+    tags?: StubSearchTag[];
+    selectors?: StubSearchSelector[];
+    members?: StubSearchMember[];
+};
+
+const DEFAULT_MEMBERS: StubSearchMember[] = [
+    {
+        asset_group_tag_id: 1,
+        id: 1001,
+        primary_kind: 'User',
+        object_id: 'S-1-5-21-PLAYWRIGHT-1001',
+        name: 'PLAYWRIGHT_ADMIN_USER',
+        source: 1,
+    },
+    {
+        asset_group_tag_id: 1,
+        id: 1002,
+        primary_kind: 'Group',
+        object_id: 'S-1-5-21-PLAYWRIGHT-1002',
+        name: 'PLAYWRIGHT_ADMIN_GROUP',
+        source: 1,
+    },
+    {
+        asset_group_tag_id: 1,
+        id: 1003,
+        primary_kind: 'Computer',
+        object_id: 'S-1-5-21-PLAYWRIGHT-1003',
+        name: 'PLAYWRIGHT_WORKSTATION',
+        source: 1,
+    },
+];
+
+const DEFAULT_SELECTORS: StubSearchSelector[] = [{ id: 2001, asset_group_tag_id: 1, name: 'PLAYWRIGHT_ADMIN_RULE' }];
+
+const DEFAULT_TAGS: StubSearchTag[] = [{ id: 1, name: 'PLAYWRIGHT_ZONE' }];
+
+const DEFAULT_DATA: Required<AssetGroupTagsSearchStubData> = {
+    tags: DEFAULT_TAGS,
+    selectors: DEFAULT_SELECTORS,
+    members: DEFAULT_MEMBERS,
+};
+
+const matchesQuery = (name: string, query: string): boolean => name.toLowerCase().includes(query.toLowerCase());
+
+export type AssetGroupTagsSearchStubOptions = {
+    data?: AssetGroupTagsSearchStubData;
+};
+
+/**
+ * Stubs the Privilege Zones search endpoint (`POST /api/v2/asset-group-tags/search`) so the detail
+ * page search bar can load Objects (members), Rules (selectors), and tags without touching real
+ * data. The handler reads the `query` from the request body and returns only the entries whose
+ * name contains that query (case-insensitive), so the stubbed response reflects the search input.
+ * Non-POST traffic falls through to any lower-priority route handlers.
+ */
+export async function installAssetGroupTagsSearchStub(
+    page: Page,
+    opts: AssetGroupTagsSearchStubOptions = {}
+): Promise<void> {
+    const tags = opts.data?.tags ?? DEFAULT_DATA.tags;
+    const selectors = opts.data?.selectors ?? DEFAULT_DATA.selectors;
+    const members = opts.data?.members ?? DEFAULT_DATA.members;
+
+    await page.route(/\/api\/v2\/asset-group-tags\/search(\?|$)/, async (route) => {
+        if (route.request().method() !== 'POST') {
+            return route.fallback();
+        }
+
+        const query: string = route.request().postDataJSON()?.query ?? '';
+
+        return route.fulfill({
+            json: {
+                data: {
+                    tags: tags.filter((tag) => matchesQuery(tag.name, query)),
+                    selectors: selectors.filter((selector) => matchesQuery(selector.name, query)),
+                    members: members.filter((member) => matchesQuery(member.name, query)),
+                },
+            },
+        });
+    });
+}

--- a/packages/javascript/bh-playwright-testing/src/stubs/asset-group-tags/selectors.ts
+++ b/packages/javascript/bh-playwright-testing/src/stubs/asset-group-tags/selectors.ts
@@ -1,0 +1,85 @@
+// Copyright 2026 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Page } from '@playwright/test';
+
+type StubSeed = {
+    selector_id: number;
+    type: number;
+    value: string;
+};
+
+type StubSelector = {
+    id: number;
+    asset_group_tag_id: number;
+    name: string;
+    description: string;
+    is_default: boolean;
+    allow_disable: boolean;
+    auto_certify: number;
+    seeds: StubSeed[];
+    created_at: string;
+    created_by: string;
+    updated_at: string;
+    updated_by: string;
+    disabled_at: string | null;
+    disabled_by: string | null;
+};
+
+export type AssetGroupTagSelectorStubData = {
+    selector?: Partial<StubSelector>;
+};
+
+const buildSelector = (overrides: Partial<StubSelector> = {}): StubSelector => ({
+    id: 3003,
+    asset_group_tag_id: 1,
+    name: 'PLAYWRIGHT_CUSTOM_RULE_1',
+    description: 'Playwright stubbed rule',
+    is_default: false,
+    allow_disable: true,
+    auto_certify: 0,
+    seeds: [{ selector_id: 3003, type: 1, value: 'S-1-5-21-PW-4001' }],
+    created_at: '2024-01-01T00:00:00Z',
+    created_by: 'playwright',
+    updated_at: '2024-01-02T00:00:00Z',
+    updated_by: 'playwright',
+    disabled_at: null,
+    disabled_by: null,
+    ...overrides,
+});
+
+export type AssetGroupTagSelectorStubOptions = {
+    data?: AssetGroupTagSelectorStubData;
+};
+
+/**
+ * Stubs the single-selector endpoint (`GET /api/v2/asset-group-tags/:tagId/selectors/:ruleId`) so
+ * the Rule side panel (`useRuleInfo`) and the Edit Rule form render deterministic rule data instead
+ * of hitting the real backend. The stubbed seed uses an object-id seed (`type: 1`) so the details
+ * card renders without mounting the cypher editor. Non-GET traffic falls through to any
+ * lower-priority route handlers.
+ */
+export async function installAssetGroupTagSelectorStub(
+    page: Page,
+    opts: AssetGroupTagSelectorStubOptions = {}
+): Promise<void> {
+    const selector = buildSelector(opts.data?.selector);
+
+    await page.route(/\/api\/v2\/asset-group-tags\/\d+\/selectors\/\d+(\?.*)?$/, async (route) => {
+        if (route.request().method() !== 'GET') return route.fallback();
+        return route.fulfill({ json: { data: { selector } } });
+    });
+}

--- a/packages/javascript/bh-playwright-testing/src/stubs/asset-group-tags/tag.ts
+++ b/packages/javascript/bh-playwright-testing/src/stubs/asset-group-tags/tag.ts
@@ -1,0 +1,79 @@
+// Copyright 2026 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Page } from '@playwright/test';
+
+type StubTag = {
+    id: number;
+    name: string;
+    kind_id: number;
+    type: number;
+    position: number;
+    require_certify: boolean;
+    description: string;
+    analysis_enabled: boolean;
+    glyph: string | null;
+    created_at: string;
+    created_by: string;
+    updated_at: string;
+    updated_by: string;
+    deleted_at: string | null;
+    deleted_by: string | null;
+};
+
+export type AssetGroupTagStubData = {
+    tag?: Partial<StubTag>;
+};
+
+const buildTag = (overrides: Partial<StubTag> = {}): StubTag => ({
+    id: 1,
+    name: 'PLAYWRIGHT_ZONE',
+    kind_id: 10,
+    type: 1,
+    position: 1,
+    require_certify: false,
+    description: 'Playwright stubbed zone',
+    analysis_enabled: true,
+    glyph: null,
+    created_at: '2024-01-01T00:00:00Z',
+    created_by: 'playwright',
+    updated_at: '2024-01-02T00:00:00Z',
+    updated_by: 'playwright',
+    deleted_at: null,
+    deleted_by: null,
+    ...overrides,
+});
+
+export type AssetGroupTagStubOptions = {
+    data?: AssetGroupTagStubData;
+};
+
+/**
+ * Stubs the single-tag endpoint (`GET /api/v2/asset-group-tags/:tagId`) so components that call
+ * `useAssetGroupTagInfo` (the Zone side panel, the Edit Zone form, and both Rule forms) render
+ * deterministic tag data instead of hitting the real backend. The route intentionally matches only
+ * a trailing numeric id so it does not collide with the tag-list route or nested sub-resource
+ * routes (e.g. `/selectors`, `/members`). Non-GET traffic falls through to any lower-priority route
+ * handlers.
+ */
+export async function installAssetGroupTagStub(page: Page, opts: AssetGroupTagStubOptions = {}): Promise<void> {
+    const tag = buildTag(opts.data?.tag);
+
+    await page.route(/\/api\/v2\/asset-group-tags\/\d+(\?.*)?$/, async (route) => {
+        if (route.request().method() !== 'GET') return route.fallback();
+        return route.fulfill({ json: { data: { tag } } });
+    });
+}

--- a/packages/javascript/bh-playwright-testing/src/stubs/asset-group-tags/zone-details.ts
+++ b/packages/javascript/bh-playwright-testing/src/stubs/asset-group-tags/zone-details.ts
@@ -1,0 +1,241 @@
+// Copyright 2026 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Page } from '@playwright/test';
+
+type StubZoneCounts = {
+    selectors: number;
+    custom_selectors: number;
+    default_selectors: number;
+    disabled_selectors: number;
+    members: number;
+};
+
+type StubZoneTag = {
+    id: number;
+    name: string;
+    kind_id: number;
+    type: number;
+    position: number;
+    require_certify: boolean;
+    description: string;
+    analysis_enabled: boolean;
+    glyph: string | null;
+    created_at: string;
+    created_by: string;
+    updated_at: string;
+    updated_by: string;
+    deleted_at: string | null;
+    deleted_by: string | null;
+    counts: StubZoneCounts;
+};
+
+type StubRule = {
+    id: number;
+    asset_group_tag_id: number;
+    name: string;
+    description: string;
+    is_default: boolean;
+    allow_disable: boolean;
+    auto_certify: boolean;
+    seeds: unknown[];
+    created_at: string;
+    updated_at: string;
+    disabled_at: string | null;
+};
+
+type StubObject = {
+    asset_group_tag_id: number;
+    id: number;
+    primary_kind: string;
+    object_id: string;
+    name: string;
+    source: number;
+};
+
+export type AssetGroupTagsZoneDetailsStubData = {
+    tag?: StubZoneTag;
+    rules?: StubRule[];
+    objects?: StubObject[];
+};
+
+const buildRule = (overrides: Partial<StubRule> & Pick<StubRule, 'id' | 'name' | 'is_default'>): StubRule => ({
+    asset_group_tag_id: 1,
+    description: 'Playwright stubbed rule',
+    allow_disable: true,
+    auto_certify: false,
+    seeds: [],
+    created_at: '2024-01-01T00:00:00Z',
+    updated_at: '2024-01-02T00:00:00Z',
+    disabled_at: null,
+    ...overrides,
+});
+
+const DEFAULT_RULES: StubRule[] = [
+    buildRule({ id: 3001, name: 'PLAYWRIGHT_DEFAULT_RULE_1', is_default: true }),
+    buildRule({ id: 3002, name: 'PLAYWRIGHT_DEFAULT_RULE_2', is_default: true }),
+    buildRule({ id: 3003, name: 'PLAYWRIGHT_CUSTOM_RULE_1', is_default: false }),
+    buildRule({ id: 3004, name: 'PLAYWRIGHT_CUSTOM_RULE_2', is_default: false }),
+];
+
+const DEFAULT_OBJECTS: StubObject[] = [
+    {
+        asset_group_tag_id: 1,
+        id: 4001,
+        primary_kind: 'Computer',
+        object_id: 'S-1-5-21-PW-4001',
+        name: 'PLAYWRIGHT_COMPUTER_1',
+        source: 1,
+    },
+    {
+        asset_group_tag_id: 1,
+        id: 4002,
+        primary_kind: 'Computer',
+        object_id: 'S-1-5-21-PW-4002',
+        name: 'PLAYWRIGHT_COMPUTER_2',
+        source: 1,
+    },
+    {
+        asset_group_tag_id: 1,
+        id: 4003,
+        primary_kind: 'Computer',
+        object_id: 'S-1-5-21-PW-4003',
+        name: 'PLAYWRIGHT_COMPUTER_3',
+        source: 1,
+    },
+    {
+        asset_group_tag_id: 1,
+        id: 4004,
+        primary_kind: 'Domain',
+        object_id: 'S-1-5-21-PW-4004',
+        name: 'PLAYWRIGHT_DOMAIN_1',
+        source: 1,
+    },
+    {
+        asset_group_tag_id: 1,
+        id: 4005,
+        primary_kind: 'Domain',
+        object_id: 'S-1-5-21-PW-4005',
+        name: 'PLAYWRIGHT_DOMAIN_2',
+        source: 1,
+    },
+    {
+        asset_group_tag_id: 1,
+        id: 4006,
+        primary_kind: 'Group',
+        object_id: 'S-1-5-21-PW-4006',
+        name: 'PLAYWRIGHT_GROUP_1',
+        source: 1,
+    },
+    {
+        asset_group_tag_id: 1,
+        id: 4007,
+        primary_kind: 'Group',
+        object_id: 'S-1-5-21-PW-4007',
+        name: 'PLAYWRIGHT_GROUP_2',
+        source: 1,
+    },
+];
+
+const buildCounts = (rules: StubRule[], objects: StubObject[]): StubZoneCounts => ({
+    selectors: rules.length,
+    custom_selectors: rules.filter((rule) => !rule.is_default && rule.disabled_at === null).length,
+    default_selectors: rules.filter((rule) => rule.is_default && rule.disabled_at === null).length,
+    disabled_selectors: rules.filter((rule) => rule.disabled_at !== null).length,
+    members: objects.length,
+});
+
+const buildTag = (rules: StubRule[], objects: StubObject[]): StubZoneTag => ({
+    id: 1,
+    name: 'PLAYWRIGHT_ZONE',
+    kind_id: 10,
+    type: 1,
+    position: 1,
+    require_certify: false,
+    description: 'Playwright stubbed zone',
+    analysis_enabled: true,
+    glyph: null,
+    created_at: '2024-01-01T00:00:00Z',
+    created_by: 'playwright',
+    updated_at: '2024-01-02T00:00:00Z',
+    updated_by: 'playwright',
+    deleted_at: null,
+    deleted_by: null,
+    counts: buildCounts(rules, objects),
+});
+
+export type AssetGroupTagsZoneDetailsStubOptions = {
+    data?: AssetGroupTagsZoneDetailsStubData;
+};
+
+/**
+ * Stubs the Privilege Zones "Zone Details" data endpoints so the detail page renders deterministic
+ * Rules (including Default Rules) and Objects (Computers, Domains, Groups) without touching real
+ * data. It installs handlers for the tag list (`GET /api/v2/asset-group-tags`), object counts
+ * (`.../:id/members/counts`), rules (`.../:id/selectors`), and members (`.../:id/members`). The
+ * selectors handler honors the `is_default`/`disabled_at` filters and the members handler honors the
+ * `primary_kind` filter so expanding a section returns the matching entries. Non-GET traffic falls
+ * through to any lower-priority route handlers.
+ */
+export async function installAssetGroupTagsZoneDetailsStub(
+    page: Page,
+    opts: AssetGroupTagsZoneDetailsStubOptions = {}
+): Promise<void> {
+    const rules = opts.data?.rules ?? DEFAULT_RULES;
+    const objects = opts.data?.objects ?? DEFAULT_OBJECTS;
+    const tag = opts.data?.tag ?? buildTag(rules, objects);
+
+    await page.route(/\/api\/v2\/asset-group-tags(\?.*)?$/, async (route) => {
+        if (route.request().method() !== 'GET') return route.fallback();
+        return route.fulfill({ json: { data: { tags: [tag] } } });
+    });
+
+    await page.route(/\/api\/v2\/asset-group-tags\/\d+\/members\/counts(\?.*)?$/, async (route) => {
+        if (route.request().method() !== 'GET') return route.fallback();
+        const counts = objects.reduce<Record<string, number>>((acc, object) => {
+            acc[object.primary_kind] = (acc[object.primary_kind] ?? 0) + 1;
+            return acc;
+        }, {});
+        return route.fulfill({ json: { data: { total_count: objects.length, counts } } });
+    });
+
+    await page.route(/\/api\/v2\/asset-group-tags\/\d+\/selectors(\?.*)?$/, async (route) => {
+        if (route.request().method() !== 'GET') return route.fallback();
+        const params = new URL(route.request().url()).searchParams;
+        const isDefault = params.get('is_default');
+        const disabledAt = params.get('disabled_at');
+        const filtered = rules.filter((rule) => {
+            if (isDefault === 'eq:true' && !rule.is_default) return false;
+            if (isDefault === 'eq:false' && rule.is_default) return false;
+            if (disabledAt === 'eq:null' && rule.disabled_at !== null) return false;
+            if (disabledAt === 'neq:null' && rule.disabled_at === null) return false;
+            return true;
+        });
+        return route.fulfill({
+            json: { data: { selectors: filtered }, count: filtered.length, limit: filtered.length, skip: 0 },
+        });
+    });
+
+    await page.route(/\/api\/v2\/asset-group-tags\/\d+\/members(\?.*)?$/, async (route) => {
+        if (route.request().method() !== 'GET') return route.fallback();
+        const primaryKind = new URL(route.request().url()).searchParams.get('primary_kind');
+        const kind = primaryKind?.startsWith('eq:') ? primaryKind.slice(3) : primaryKind;
+        const filtered = kind ? objects.filter((object) => object.primary_kind === kind) : objects;
+        return route.fulfill({
+            json: { data: { members: filtered }, count: filtered.length, limit: filtered.length, skip: 0 },
+        });
+    });
+}


### PR DESCRIPTION
## Description

Add A11y Playwright coverage for Privilege Zones, Zone and Labels tab.

** NOTE **: This only addresses half of the AC in the original story, but is separated due to size.

## Motivation and Context

Resolves BED-8635

## How Has This Been Tested?

Playwright

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added accessibility test coverage for Privilege Zones, including Zone details, Rule/Object panels, search behaviors, and save workflows (plus new tab-focused suites).
  * Added reusable Playwright stubs for Asset Group Tag APIs (tag, selectors, members, search, and zone details) to support deterministic UI testing.
* **Tests**
  * Added WCAG A/AA accessibility checks using Axe scans scoped to the Privilege Zones experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->