### PR TITLE
test(a11y): playwright coverage for explorer - search page - bed-8633

### DIFF
--- a/cmd/ui/tests/a11y/explore-search.a11y.spec.ts
+++ b/cmd/ui/tests/a11y/explore-search.a11y.spec.ts
@@ -1,0 +1,78 @@
+// Copyright 2026 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { expect, expectNoAccessibilityViolations, test } from '../fixtures';
+
+test.describe('Explore page accessibility', () => {
+    test('focuses the node search field on navigation', async ({ page }) => {
+        await page.goto('/ui/explore');
+
+        await expect(page.getByLabel('Search Nodes')).toBeFocused();
+    });
+
+    test('node search results state has no detectable WCAG A/AA violations', async ({
+        page,
+        makeAxeBuilder,
+    }, testInfo) => {
+        const searchTerm = 'test';
+        const searchResultName = 'TEST RESULT';
+        await page.route('**/api/v2/search**', async (route) => {
+            if (route.request().method() !== 'GET') {
+                return route.fallback();
+            }
+            await route.fulfill({
+                json: {
+                    data: [{ name: searchResultName, objectid: 'playwright-search-result', type: 'User' }],
+                },
+            });
+        });
+        await page.goto('/ui/explore');
+
+        const searchField = page.getByLabel('Search Nodes');
+        await searchField.fill(searchTerm);
+        const searchResult = page.getByRole('option').filter({ hasText: searchResultName });
+
+        await expect(searchResult).toBeVisible();
+        const results = await makeAxeBuilder().include('#content-wrapper').analyze();
+        await expectNoAccessibilityViolations(testInfo, results, { page });
+    });
+
+    test('node search no-results state has no detectable WCAG A/AA violations', async ({
+        page,
+        makeAxeBuilder,
+    }, testInfo) => {
+        const searchTerm = 'zzzznonexistentnode9999';
+
+        await page.route('**/api/v2/search**', async (route) => {
+            if (route.request().method() !== 'GET') {
+                return route.fallback();
+            }
+
+            await route.fulfill({ json: { data: [] } });
+        });
+
+        await page.goto('/ui/explore');
+
+        const searchField = page.getByLabel('Search Nodes');
+        await expect(searchField).toBeVisible();
+        await searchField.fill(searchTerm);
+
+        const noResultsMessage = `No results found for "${searchTerm}"`;
+        await expect(page.getByText(noResultsMessage)).toBeVisible();
+
+        const results = await makeAxeBuilder().include('#content-wrapper').analyze();
+        await expectNoAccessibilityViolations(testInfo, results, { page });
+    });
+});

--- a/cmd/ui/tests/a11y/explore-search.a11y.spec.ts
+++ b/cmd/ui/tests/a11y/explore-search.a11y.spec.ts
@@ -15,44 +15,45 @@
 // SPDX-License-Identifier: Apache-2.0
 import { expect, expectNoAccessibilityViolations, test } from '../fixtures';
 
-test.describe('Explore page accessibility', () => {
-    test('focuses the node search field on navigation', async ({ page }) => {
+test.describe('WCAG A/AA Violations - Explore - Search Tab', () => {
+    test.beforeEach(async ({ page }) => {
         await page.goto('/ui/explore');
-
-        await expect(page.getByLabel('Search Nodes')).toBeFocused();
     });
 
-    test('node search results state has no detectable WCAG A/AA violations', async ({
-        page,
-        makeAxeBuilder,
-    }, testInfo) => {
+    test('Search tab', async ({ page, makeAxeBuilder }, testInfo) => {
+        await page.getByText('Begin typing to search').waitFor({ state: 'visible' });
+
+        const results = await makeAxeBuilder().include('#content-wrapper').analyze();
+        await expectNoAccessibilityViolations(testInfo, results, { page });
+    });
+
+    test('Search with results', async ({ page, makeAxeBuilder }, testInfo) => {
         const searchTerm = 'test';
         const searchResultName = 'TEST RESULT';
+
         await page.route('**/api/v2/search**', async (route) => {
             if (route.request().method() !== 'GET') {
                 return route.fallback();
             }
+
             await route.fulfill({
                 json: {
                     data: [{ name: searchResultName, objectid: 'playwright-search-result', type: 'User' }],
                 },
             });
         });
-        await page.goto('/ui/explore');
 
         const searchField = page.getByLabel('Search Nodes');
         await searchField.fill(searchTerm);
-        const searchResult = page.getByRole('option').filter({ hasText: searchResultName });
 
+        const searchResult = page.getByRole('option').filter({ hasText: searchResultName });
         await expect(searchResult).toBeVisible();
+
         const results = await makeAxeBuilder().include('#content-wrapper').analyze();
         await expectNoAccessibilityViolations(testInfo, results, { page });
     });
 
-    test('node search no-results state has no detectable WCAG A/AA violations', async ({
-        page,
-        makeAxeBuilder,
-    }, testInfo) => {
+    test('Search with no results', async ({ page, makeAxeBuilder }, testInfo) => {
         const searchTerm = 'zzzznonexistentnode9999';
 
         await page.route('**/api/v2/search**', async (route) => {
@@ -62,8 +63,6 @@ test.describe('Explore page accessibility', () => {
 
             await route.fulfill({ json: { data: [] } });
         });
-
-        await page.goto('/ui/explore');
 
         const searchField = page.getByLabel('Search Nodes');
         await expect(searchField).toBeVisible();


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Adds accessibility tests for the Explore Search page to verify compliance with accessibility standards.


## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves bed-8633

This change was needed to ensure the Explore Search page adheres to accessibility standards.


## How Has This Been Tested?

The tests were run locally.

## Screenshots (optional): n/a

## Types of changes

<!-- Please remove any items that do not apply. -->


- New feature (non-breaking change which adds functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x ] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labelsx
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x ] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x ] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Tests**
  * Added a Playwright accessibility spec for the Explore page.
  * Verified search tab behavior, including focus and the search prompt.
  * Added coverage for search results and no-results states, including visible UI messaging.
  * Included WCAG A/AA accessibility checks for the scoped search experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->