### PR TITLE
fix: omit propertyNames usage in api spec BED-9042

### DIFF
--- a/packages/go/openapi/doc/openapi.json
+++ b/packages/go/openapi/doc/openapi.json
@@ -22746,11 +22746,7 @@
       },
       "model.graph-extension.kind-info-definition": {
         "type": "object",
-        "description": "A map of named info panels used in extension definitions.\nEach property key is a stable panel identifier, and each property value\nmust be a valid KindInfo object with title, position, and content.\n",
-        "propertyNames": {
-          "pattern": "^[a-z0-9_-]{1,128}$",
-          "description": "Keys may only include lowercase alphanumeric characters, hyphens, and underscores"
-        },
+        "description": "A map of named info panels used in extension definitions.\nEach property key is a stable panel identifier and must match the pattern\n`^[a-z0-9_-]{1,128}$` (lowercase alphanumeric characters, hyphens, and underscores only).\nEach property value must be a valid KindInfo object with title, position, and content.\n",
         "additionalProperties": {
           "type": "object",
           "required": [

--- a/packages/go/openapi/src/schemas/model.graph-extension.kind-info-definition.yaml
+++ b/packages/go/openapi/src/schemas/model.graph-extension.kind-info-definition.yaml
@@ -16,11 +16,9 @@
 type: object
 description: |
   A map of named info panels used in extension definitions.
-  Each property key is a stable panel identifier, and each property value
-  must be a valid KindInfo object with title, position, and content.
-propertyNames:
-  pattern: '^[a-z0-9_-]{1,128}$'
-  description: "Keys may only include lowercase alphanumeric characters, hyphens, and underscores"
+  Each property key is a stable panel identifier and must match the pattern
+  `^[a-z0-9_-]{1,128}$` (lowercase alphanumeric characters, hyphens, and underscores only).
+  Each property value must be a valid KindInfo object with title, position, and content.
 additionalProperties:
   type: object
   required: [title, position]


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

propertyNames keyword usage folded into description in open api spec.

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-9042

Recent updates to our API spec used the new propertyNames keyword for kind info documentation which is not supported for our documented v3.0.3 open api version. 

    Root cause: propertyNames is a JSON Schema draft-6 keyword. OpenAPI 3.0.x Schema Objects are derived from JSON Schema draft-4 (with some OAS-specific additions), which does not include propertyNames. Using it makes the spec technically non-compliant with OAS 3.0.3.

A valid spec enables consumption of the API documentation with various tooling.

## How Has This Been Tested?

*Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc.*

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
