### PR TITLE
feat: Modernize Explore Graph Toolbar BED-9043

### DIFF
--- a/cmd/ui/src/views/Explore/GraphView.test.tsx
+++ b/cmd/ui/src/views/Explore/GraphView.test.tsx
@@ -405,7 +405,7 @@ describe('GraphView', () => {
             });
 
             const user = userEvent.setup();
-            const layoutMenu = await screen.findByText('Layout');
+            const layoutMenu = await screen.findByRole('button', { name: 'Layout' });
             await user.click(layoutMenu);
 
             const standardOption = await screen.findByTestId('explore_graph-controls_standard-buttonLabel');
@@ -433,7 +433,7 @@ describe('GraphView', () => {
             });
 
             const user = userEvent.setup();
-            const layoutMenu = await screen.findByText('Layout');
+            const layoutMenu = await screen.findByRole('button', { name: 'Layout' });
             await user.click(layoutMenu);
 
             const standardOption = await screen.findByTestId('explore_graph-controls_standard-buttonLabel');
@@ -468,7 +468,7 @@ describe('GraphView', () => {
             expect(await screen.findByRole('table')).toBeInTheDocument();
 
             const user = userEvent.setup();
-            const layoutMenu = screen.getByText('Layout');
+            const layoutMenu = screen.getByRole('button', { name: 'Layout' });
             await user.click(layoutMenu);
 
             const closeTableBtn = await screen.findByTestId('close-button');

--- a/packages/javascript/bh-shared-ui/src/components/GraphButton/GraphButton.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/GraphButton/GraphButton.tsx
@@ -16,7 +16,7 @@
 
 import { Button, ButtonProps } from '@mui/material';
 import makeStyles from '@mui/styles/makeStyles';
-import { FC, ReactNode } from 'react';
+import { forwardRef, ReactNode } from 'react';
 
 const useStyles = makeStyles((theme) => ({
     button: {
@@ -44,17 +44,19 @@ export interface GraphButtonProps extends ButtonProps {
     displayText: string | ReactNode;
 }
 
-const GraphButton: FC<GraphButtonProps> = (props) => {
+const GraphButton = forwardRef<HTMLButtonElement, GraphButtonProps>((props, ref) => {
     const { displayText } = props;
     const attributes = { ...props };
     delete attributes.displayText;
     const styles = useStyles();
 
     return (
-        <Button {...attributes} disableRipple classes={{ root: styles.button }}>
+        <Button {...attributes} ref={ref} disableRipple classes={{ root: styles.button }}>
             {displayText}
         </Button>
     );
-};
+});
+
+GraphButton.displayName = 'GraphButton';
 
 export default GraphButton;

--- a/packages/javascript/bh-shared-ui/src/components/GraphControls/GraphControls.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/GraphControls/GraphControls.test.tsx
@@ -115,11 +115,75 @@ describe('GraphControls', () => {
         return { user };
     };
 
+    describe('Accessible icon controls', () => {
+        it('provides concise names without visible label text', () => {
+            setup();
+
+            for (const name of ['Reset Graph', 'Hide Labels', 'Layout', 'Export', 'Search']) {
+                const control = screen.getByRole('button', { name });
+
+                expect(control).toBeInTheDocument();
+                expect(control).not.toHaveTextContent(name);
+            }
+        });
+
+        it('shows matching tooltips on hover and keyboard focus', async () => {
+            const { user } = setup();
+            const reset = screen.getByRole('button', { name: 'Reset Graph' });
+            const layout = screen.getByRole('button', { name: 'Layout' });
+
+            await user.hover(reset);
+            expect(await screen.findByRole('tooltip', { name: 'Reset Graph' })).toBeVisible();
+
+            await user.unhover(reset);
+            reset.focus();
+            await user.tab();
+            await user.tab();
+            expect(layout).toHaveFocus();
+            expect(await screen.findByRole('tooltip', { name: 'Layout' })).toBeVisible();
+        });
+
+        it('keeps stable menu relationships and restores focus after Escape', async () => {
+            const { user } = setup();
+            const layout = screen.getByRole('button', { name: 'Layout' });
+
+            expect(layout).toHaveAttribute('id', 'graph-layout-button');
+            expect(layout).toHaveAttribute('aria-haspopup', 'menu');
+            expect(layout).toHaveAttribute('aria-expanded', 'false');
+            expect(layout).toHaveAttribute('aria-controls', 'graph-layout-menu');
+
+            layout.focus();
+            await user.keyboard('{Enter}');
+
+            const menu = await screen.findByRole('menu');
+            expect(menu).toHaveAttribute('id', 'graph-layout-menu');
+            expect(menu).toHaveAttribute('aria-labelledby', 'graph-layout-button');
+            expect(layout).toHaveAttribute('aria-expanded', 'true');
+
+            await user.keyboard('{Escape}');
+
+            expect(layout).toHaveAttribute('aria-expanded', 'false');
+            expect(layout).toHaveAttribute('aria-controls', 'graph-layout-menu');
+            expect(layout).toHaveFocus();
+        });
+
+        it('closes a menu and restores focus after selection', async () => {
+            const { user } = setup();
+            const layout = screen.getByRole('button', { name: 'Layout' });
+
+            await user.click(layout);
+            await user.click(await screen.findByText(layoutOptions[0]));
+
+            expect(layout).toHaveAttribute('aria-expanded', 'false');
+            expect(layout).toHaveFocus();
+        });
+    });
+
     describe('Resetting graph', () => {
         it('calls the onReset prop when the crop button is clicked', async () => {
             const { user } = setup();
 
-            const crop = screen.getByText('crop-simple');
+            const crop = screen.getByRole('button', { name: 'Reset Graph' });
             await user.click(crop);
 
             expect(onResetFn).toBeCalled();
@@ -129,7 +193,7 @@ describe('GraphControls', () => {
     describe('Toggling labels', () => {
         it('calls onToggleNodeLabels when click show all node labels', async () => {
             const { user } = setup();
-            const labelMenu = screen.getByText('Hide Labels');
+            const labelMenu = screen.getByRole('button', { name: 'Hide Labels' });
             await user.click(labelMenu);
 
             const hideNodeLabels = await screen.findByText('Hide Node Labels');
@@ -139,7 +203,7 @@ describe('GraphControls', () => {
         });
         it('calls onToggleEdgeLabels when click show all edge labels', async () => {
             const { user } = setup();
-            const labelMenu = screen.getByText('Hide Labels');
+            const labelMenu = screen.getByRole('button', { name: 'Hide Labels' });
             await user.click(labelMenu);
 
             const hideEdgeLabels = await screen.findByText('Hide Edge Labels');
@@ -158,7 +222,7 @@ describe('GraphControls', () => {
                 const { user } = setup({ showEdgeLabels, showNodeLabels });
 
                 const menuLabel = !showNodeLabels || !showEdgeLabels ? 'Show Labels' : 'Hide Labels';
-                await user.click(screen.getByText(menuLabel));
+                await user.click(screen.getByRole('button', { name: menuLabel }));
 
                 const allLabelsController = await screen.findByRole('menuitem', { name: /All Labels/i });
                 await user.click(allLabelsController);
@@ -178,7 +242,7 @@ describe('GraphControls', () => {
         it('calls onLayoutChange with the selected layout', async () => {
             const { user } = setup();
 
-            const layoutMenu = screen.getByText('Layout');
+            const layoutMenu = screen.getByRole('button', { name: 'Layout' });
             await user.click(layoutMenu);
 
             const selectedLayout = layoutOptions[0];
@@ -191,7 +255,7 @@ describe('GraphControls', () => {
         it('does not highlight any layout option on first load when no layout has been manually selected', async () => {
             const { user } = setup({ isExploreLayoutSelected: false });
 
-            const layoutMenu = screen.getByText('Layout');
+            const layoutMenu = screen.getByRole('button', { name: 'Layout' });
             await user.click(layoutMenu);
 
             for (const option of layoutOptions) {
@@ -203,7 +267,7 @@ describe('GraphControls', () => {
         it('highlights the selectedLayout when isExploreLayoutSelected is true', async () => {
             const { user } = setup({ isExploreLayoutSelected: true });
 
-            const layoutMenu = screen.getByText('Layout');
+            const layoutMenu = screen.getByRole('button', { name: 'Layout' });
             await user.click(layoutMenu);
 
             const selected = await screen.findByTestId(`explore_graph-controls_${preselectedLayout}-buttonLabel`);
@@ -219,7 +283,7 @@ describe('GraphControls', () => {
         it('calls onLayoutChange with the same layout when the currently selected option is clicked, enabling de-selection', async () => {
             const { user } = setup({ isExploreLayoutSelected: true });
 
-            const layoutMenu = screen.getByText('Layout');
+            const layoutMenu = screen.getByRole('button', { name: 'Layout' });
             await user.click(layoutMenu);
 
             const selected = await screen.findByTestId(`explore_graph-controls_${preselectedLayout}-buttonLabel`);
@@ -233,7 +297,7 @@ describe('GraphControls', () => {
             // selectedLayout may still be present. No option should appear selected.
             const { user } = setup({ isExploreLayoutSelected: false, selectedLayout: preselectedLayout });
 
-            const layoutMenu = screen.getByText('Layout');
+            const layoutMenu = screen.getByRole('button', { name: 'Layout' });
             await user.click(layoutMenu);
 
             for (const option of layoutOptions) {
@@ -255,7 +319,7 @@ describe('GraphControls', () => {
                 route: '/?searchType=cypher',
             });
 
-            const layoutMenu = screen.getByText('Layout');
+            const layoutMenu = screen.getByRole('button', { name: 'Layout' });
             await user.click(layoutMenu);
 
             const tableItem = await screen.findByTestId('explore_graph-controls_table-buttonLabel');
@@ -274,7 +338,7 @@ describe('GraphControls', () => {
                 route: '/?searchType=cypher',
             });
 
-            const layoutMenu = screen.getByText('Layout');
+            const layoutMenu = screen.getByRole('button', { name: 'Layout' });
             await user.click(layoutMenu);
 
             for (const option of layoutOptionsWithTable) {
@@ -292,7 +356,7 @@ describe('GraphControls', () => {
                 route: '/?searchType=node',
             });
 
-            const layoutMenu = screen.getByText('Layout');
+            const layoutMenu = screen.getByRole('button', { name: 'Layout' });
             await user.click(layoutMenu);
 
             const sequentialItem = await screen.findByTestId('explore_graph-controls_sequential-buttonLabel');
@@ -306,7 +370,7 @@ describe('GraphControls', () => {
         it('disables the JSON button if the JSON is empty', async () => {
             const { user } = setup();
 
-            const exportMenu = screen.getByText('Export');
+            const exportMenu = screen.getByRole('button', { name: 'Export' });
             await user.click(exportMenu);
 
             const jsonButton = await screen.findByText('JSON');
@@ -320,7 +384,7 @@ describe('GraphControls', () => {
             const json = { test: 'data' };
             const { user } = setup({ json });
 
-            const exportMenu = screen.getByText('Export');
+            const exportMenu = screen.getByRole('button', { name: 'Export' });
             await user.click(exportMenu);
 
             const jsonButton = await screen.findByText('JSON');
@@ -330,17 +394,18 @@ describe('GraphControls', () => {
         });
     });
     describe('Searching current results', () => {
-        it('renders GraphButton with correct text', async () => {
+        it('renders an icon button with an accessible name', async () => {
             setup();
-            const searchResultsMenu = await screen.findByText('Search');
+            const searchResultsMenu = await screen.findByRole('button', { name: 'Search' });
 
             expect(searchResultsMenu).toBeInTheDocument();
+            expect(searchResultsMenu).not.toHaveTextContent('Search');
         });
 
         it('disables GraphButton when isCurrentSearchOpen is true', async () => {
             const { user } = setup();
 
-            const searchResultsMenu = screen.getByText('Search');
+            const searchResultsMenu = screen.getByRole('button', { name: 'Search' });
             await user.click(searchResultsMenu);
 
             expect(searchResultsMenu).toBeDisabled();
@@ -351,7 +416,7 @@ describe('GraphControls', () => {
 
             expect(screen.queryByTestId('explore_graph-controls_search-current-nodes-popper')).not.toBeInTheDocument();
 
-            const searchResultsMenu = screen.getByText('Search');
+            const searchResultsMenu = screen.getByRole('button', { name: 'Search' });
             await user.click(searchResultsMenu);
 
             expect(screen.getByTestId('explore_graph-controls_search-current-nodes-popper')).toBeInTheDocument();
@@ -370,7 +435,7 @@ describe('GraphControls', () => {
         it('sets the selectedItem param and closes popper when a node is selected', async () => {
             const { user } = setup();
 
-            const searchResultsMenu = screen.getByText('Search');
+            const searchResultsMenu = screen.getByRole('button', { name: 'Search' });
 
             await user.click(searchResultsMenu);
 

--- a/packages/javascript/bh-shared-ui/src/components/GraphControls/GraphControls.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/GraphControls/GraphControls.test.tsx
@@ -18,7 +18,7 @@ import { rest } from 'msw';
 import { setupServer } from 'msw/node';
 import { act, render, screen } from '../../test-utils';
 import * as exportUtils from '../../utils/exportGraphData';
-import GraphControls from './GraphControls';
+import GraphControls, { type GraphExportAction } from './GraphControls';
 
 const exportToJsonSpy = vi.spyOn(exportUtils, 'exportToJson');
 
@@ -60,6 +60,12 @@ describe('GraphControls', () => {
     const onToggleNodeLabelsFn = vi.fn();
     const onToggleEdgeLabelsFn = vi.fn();
     const onSearchedNodeClickFn = vi.fn();
+    const onAdditionalExportActionOne = vi.fn();
+    const onAdditionalExportActionTwo = vi.fn();
+    const additionalExportActions: readonly GraphExportAction[] = [
+        { id: 'additional-one', label: 'Additional action one', onSelect: onAdditionalExportActionOne },
+        { id: 'additional-two', label: 'Additional action two', onSelect: onAdditionalExportActionTwo },
+    ];
 
     afterEach(() => {
         onResetFn.mockClear();
@@ -67,6 +73,8 @@ describe('GraphControls', () => {
         onToggleNodeLabelsFn.mockClear();
         onToggleEdgeLabelsFn.mockClear();
         onSearchedNodeClickFn.mockClear();
+        onAdditionalExportActionOne.mockClear();
+        onAdditionalExportActionTwo.mockClear();
     });
 
     type SetupOptions = {
@@ -77,6 +85,7 @@ describe('GraphControls', () => {
         layoutOptionsOverride?: readonly string[];
         isExploreLayoutSelected?: boolean;
         isExploreTableSelected?: boolean;
+        additionalExportActions?: readonly GraphExportAction[];
         route?: string;
     };
 
@@ -88,6 +97,7 @@ describe('GraphControls', () => {
         layoutOptionsOverride,
         isExploreLayoutSelected,
         isExploreTableSelected,
+        additionalExportActions,
         route = '/',
     }: SetupOptions = {}) => {
         const options = layoutOptionsOverride ?? layoutOptions;
@@ -105,6 +115,7 @@ describe('GraphControls', () => {
                 selectedLayout={selectedLayout}
                 isExploreLayoutSelected={isExploreLayoutSelected}
                 isExploreTableSelected={isExploreTableSelected}
+                additionalExportActions={additionalExportActions}
                 currentNodes={currentNodes}
             />,
             { route }
@@ -367,6 +378,16 @@ describe('GraphControls', () => {
         });
     });
     describe('Exporting json', () => {
+        it('renders only the JSON action when no additional actions are supplied', async () => {
+            const { user } = setup();
+
+            await user.click(screen.getByRole('button', { name: 'Export' }));
+
+            const menuItems = await screen.findAllByRole('menuitem');
+            expect(menuItems).toHaveLength(1);
+            expect(menuItems[0]).toHaveAccessibleName('JSON');
+        });
+
         it('disables the JSON button if the JSON is empty', async () => {
             const { user } = setup();
 
@@ -391,6 +412,78 @@ describe('GraphControls', () => {
             await user.click(jsonButton);
 
             expect(exportToJsonSpy).toBeCalledWith(json);
+        });
+
+        it('renders additional actions before JSON in the supplied order', async () => {
+            const { user } = setup({ additionalExportActions });
+
+            await user.click(screen.getByRole('button', { name: 'Export' }));
+
+            const menuItems = await screen.findAllByRole('menuitem');
+            expect(menuItems.map((item) => item.textContent)).toEqual([
+                'Additional action one',
+                'Additional action two',
+                'JSON',
+            ]);
+        });
+
+        it('invokes only the selected additional action, closes the menu, and restores focus', async () => {
+            const { user } = setup({ additionalExportActions });
+            const exportMenu = screen.getByRole('button', { name: 'Export' });
+
+            await user.click(exportMenu);
+            await user.click(await screen.findByRole('menuitem', { name: 'Additional action one' }));
+
+            expect(onAdditionalExportActionOne).toHaveBeenCalledOnce();
+            expect(onAdditionalExportActionTwo).not.toHaveBeenCalled();
+            expect(exportMenu).toHaveAttribute('aria-expanded', 'false');
+            expect(exportMenu).toHaveFocus();
+        });
+
+        it('exposes disabled additional actions and prevents keyboard activation', async () => {
+            const disabledExportActions = [{ ...additionalExportActions[0], disabled: true }];
+            const { user } = setup({ additionalExportActions: disabledExportActions });
+            const exportMenu = screen.getByRole('button', { name: 'Export' });
+
+            await user.click(exportMenu);
+            const disabledAction = await screen.findByRole('menuitem', { name: 'Additional action one' });
+            expect(disabledAction).toHaveAttribute('aria-disabled', 'true');
+
+            disabledAction.focus();
+            await user.keyboard('{Enter}');
+
+            expect(onAdditionalExportActionOne).not.toHaveBeenCalled();
+            expect(exportMenu).toHaveAttribute('aria-expanded', 'true');
+        });
+
+        it('supports keyboard activation of additional actions', async () => {
+            const { user } = setup({ additionalExportActions: additionalExportActions.slice(0, 1) });
+            const exportMenu = screen.getByRole('button', { name: 'Export' });
+
+            exportMenu.focus();
+            await user.keyboard('{Enter}');
+            const additionalAction = await screen.findByRole('menuitem', { name: 'Additional action one' });
+            expect(additionalAction).toHaveFocus();
+
+            await user.keyboard('{Enter}');
+
+            expect(onAdditionalExportActionOne).toHaveBeenCalledOnce();
+            expect(exportMenu).toHaveAttribute('aria-expanded', 'false');
+            expect(exportMenu).toHaveFocus();
+        });
+
+        it('closes the Export menu with Escape and restores focus', async () => {
+            const { user } = setup({ additionalExportActions: additionalExportActions.slice(0, 1) });
+            const exportMenu = screen.getByRole('button', { name: 'Export' });
+
+            exportMenu.focus();
+            await user.keyboard('{Enter}');
+            expect(await screen.findByRole('menuitem', { name: 'Additional action one' })).toBeVisible();
+
+            await user.keyboard('{Escape}');
+
+            expect(exportMenu).toHaveAttribute('aria-expanded', 'false');
+            expect(exportMenu).toHaveFocus();
         });
     });
     describe('Searching current results', () => {

--- a/packages/javascript/bh-shared-ui/src/components/GraphControls/GraphControls.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/GraphControls/GraphControls.tsx
@@ -14,10 +14,16 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { faCropAlt } from '@fortawesome/free-solid-svg-icons';
+import {
+    faCropAlt,
+    faDiagramProject,
+    faDownload,
+    faEye,
+    faEyeSlash,
+    faMagnifyingGlass,
+} from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { MenuItem, Popper } from '@mui/material';
-import { TooltipContent, TooltipPortal, TooltipProvider, TooltipRoot, TooltipTrigger } from 'doodle-ui';
+import { MenuItem, Popper, Tooltip } from '@mui/material';
 import capitalize from 'lodash/capitalize';
 import isEmpty from 'lodash/isEmpty';
 import { useRef, useState } from 'react';
@@ -85,34 +91,40 @@ function GraphControls<T extends readonly string[]>(props: GraphControlsProps<T>
         }
     };
 
+    const searchButton = (
+        <GraphButton
+            aria-label='Search'
+            onClick={() => setIsCurrentSearchOpen(true)}
+            displayText={<FontAwesomeIcon aria-hidden='true' icon={faMagnifyingGlass} />}
+            disabled={isCurrentSearchOpen}
+            data-testid='explore_graph-controls_search-current-results'
+        />
+    );
+
     return (
         <>
             <div
                 data-testid='explore_graph-controls'
                 className='flex gap-1 pointer-events-auto'
                 ref={currentSearchAnchorElement}>
-                <TooltipProvider>
-                    <TooltipRoot>
-                        <TooltipTrigger className='pointer-events-auto'>
-                            {/* tooltip won't show without this wrapper div for some reason */}
-                            <div>
-                                <GraphButton
-                                    aria-label='Reset Graph'
-                                    onClick={onReset}
-                                    displayText={<FontAwesomeIcon aria-label='reset graph view' icon={faCropAlt} />}
-                                    data-testid='explore_graph-controls_reset-button'
-                                />
-                            </div>
-                        </TooltipTrigger>
-                        <TooltipPortal>
-                            <TooltipContent className='dark:bg-neutral-dark-5 border-0'>
-                                <span>Reset Graph</span>
-                            </TooltipContent>
-                        </TooltipPortal>
-                    </TooltipRoot>
-                </TooltipProvider>
+                <Tooltip placement='top' title='Reset Graph'>
+                    <GraphButton
+                        aria-label='Reset Graph'
+                        onClick={onReset}
+                        displayText={<FontAwesomeIcon aria-hidden='true' icon={faCropAlt} />}
+                        data-testid='explore_graph-controls_reset-button'
+                    />
+                </Tooltip>
 
-                <GraphMenu label={`${!showNodeLabels || !showEdgeLabels ? 'Show' : 'Hide'} Labels`}>
+                <GraphMenu
+                    controlId='labels'
+                    displayText={
+                        <FontAwesomeIcon
+                            aria-hidden='true'
+                            icon={!showNodeLabels || !showEdgeLabels ? faEyeSlash : faEye}
+                        />
+                    }
+                    label={`${!showNodeLabels || !showEdgeLabels ? 'Show' : 'Hide'} Labels`}>
                     <MenuItem
                         aria-label={`${!showEdgeLabels ? 'Show' : 'Hide'} All Labels Toggle`}
                         data-testid='explore_graph-controls_all-labels-toggle'
@@ -133,7 +145,10 @@ function GraphControls<T extends readonly string[]>(props: GraphControlsProps<T>
                     </MenuItem>
                 </GraphMenu>
 
-                <GraphMenu label='Layout'>
+                <GraphMenu
+                    controlId='layout'
+                    displayText={<FontAwesomeIcon aria-hidden='true' icon={faDiagramProject} />}
+                    label='Layout'>
                     {layoutOptions.map((buttonLabel) => {
                         const tableViewIsSelected = isExploreTableSelected && searchType === 'cypher';
                         const isSelected = tableViewIsSelected
@@ -153,19 +168,18 @@ function GraphControls<T extends readonly string[]>(props: GraphControlsProps<T>
                     })}
                 </GraphMenu>
 
-                <GraphMenu label='Export'>
+                <GraphMenu
+                    controlId='export'
+                    displayText={<FontAwesomeIcon aria-hidden='true' icon={faDownload} />}
+                    label='Export'>
                     <MenuItem onClick={() => exportToJson(jsonData)} disabled={isEmpty(jsonData)}>
                         JSON
                     </MenuItem>
                 </GraphMenu>
 
-                <GraphButton
-                    aria-label='Search node in results'
-                    onClick={() => setIsCurrentSearchOpen(true)}
-                    displayText={'Search'}
-                    disabled={isCurrentSearchOpen}
-                    data-testid='explore_graph-controls_search-current-results'
-                />
+                <Tooltip placement='top' title='Search'>
+                    {searchButton}
+                </Tooltip>
             </div>
             <Popper
                 open={isCurrentSearchOpen}

--- a/packages/javascript/bh-shared-ui/src/components/GraphControls/GraphControls.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/GraphControls/GraphControls.tsx
@@ -34,6 +34,13 @@ import GraphButton from '../GraphButton';
 import GraphMenu from '../GraphMenu';
 import SearchCurrentNodes, { FlatNode } from '../SearchCurrentNodes';
 
+export interface GraphExportAction {
+    id: string;
+    label: string;
+    onSelect: () => void;
+    disabled?: boolean;
+}
+
 interface GraphControlsProps<T extends readonly string[]> {
     onReset: () => void;
     onLayoutChange: (layout: T[number]) => void;
@@ -48,6 +55,7 @@ interface GraphControlsProps<T extends readonly string[]> {
     showEdgeLabels: boolean;
     jsonData: Record<string, any> | undefined;
     currentNodes: Record<string, any> | undefined;
+    additionalExportActions?: readonly GraphExportAction[];
 }
 
 function GraphControls<T extends readonly string[]>(props: GraphControlsProps<T>) {
@@ -65,6 +73,7 @@ function GraphControls<T extends readonly string[]>(props: GraphControlsProps<T>
         showEdgeLabels,
         jsonData,
         currentNodes = {},
+        additionalExportActions = [],
     } = props;
     const { searchType } = useExploreParams();
     const [isCurrentSearchOpen, setIsCurrentSearchOpen] = useState(false);
@@ -172,6 +181,11 @@ function GraphControls<T extends readonly string[]>(props: GraphControlsProps<T>
                     controlId='export'
                     displayText={<FontAwesomeIcon aria-hidden='true' icon={faDownload} />}
                     label='Export'>
+                    {additionalExportActions.map((action) => (
+                        <MenuItem key={action.id} onClick={action.onSelect} disabled={action.disabled}>
+                            {action.label}
+                        </MenuItem>
+                    ))}
                     <MenuItem onClick={() => exportToJson(jsonData)} disabled={isEmpty(jsonData)}>
                         JSON
                     </MenuItem>

--- a/packages/javascript/bh-shared-ui/src/components/GraphControls/index.ts
+++ b/packages/javascript/bh-shared-ui/src/components/GraphControls/index.ts
@@ -15,3 +15,4 @@
 // SPDX-License-Identifier: Apache-2.0
 
 export { default as GraphControls } from './GraphControls';
+export type { GraphExportAction } from './GraphControls';

--- a/packages/javascript/bh-shared-ui/src/components/GraphMenu/GraphMenu.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/GraphMenu/GraphMenu.tsx
@@ -14,42 +14,58 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { Menu } from '@mui/material';
-import React, { Children, FC, JSXElementConstructor, ReactElement, useState } from 'react';
+import { Menu, Tooltip } from '@mui/material';
+import React, { Children, FC, ReactNode, useState } from 'react';
 import GraphButton from '../GraphButton';
 
-type RenderableChild = ReactElement<any, string | JSXElementConstructor<any>>;
 type Attributes = Partial<React.HTMLAttributes<Element>>;
 
 const GraphMenu: FC<{
+    controlId: string;
     label: string;
-    children: RenderableChild | RenderableChild[];
-}> = ({ children, label }) => {
+    displayText?: ReactNode;
+    children: ReactNode;
+}> = ({ children, controlId, displayText, label }) => {
     const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
 
     const open = Boolean(anchorEl);
+    const buttonId = `graph-${controlId}-button`;
+    const menuId = `graph-${controlId}-menu`;
 
     const handleClose = () => setAnchorEl(null);
 
+    const menuButton = (
+        <GraphButton
+            id={buttonId}
+            aria-label={label}
+            data-testid={`explore_graph-controls_${controlId}-menu`}
+            onClick={(event: React.MouseEvent<HTMLButtonElement>) => {
+                setAnchorEl(event.currentTarget);
+            }}
+            aria-controls={menuId}
+            aria-haspopup='menu'
+            aria-expanded={open}
+            displayText={displayText ?? label}
+        />
+    );
+
     return (
         <>
-            <GraphButton
-                aria-label={label}
-                data-testid={`explore_graph-controls_${label.toLowerCase().split(' ').join('-')}-menu`}
-                onClick={(event: React.MouseEvent<HTMLButtonElement>) => {
-                    setAnchorEl(event.currentTarget);
-                }}
-                aria-controls={open ? `${label}-menu` : undefined}
-                aria-haspopup='true'
-                aria-expanded={open ? 'true' : undefined}
-                displayText={label}></GraphButton>
+            {displayText ? (
+                <Tooltip placement='top' title={label}>
+                    {menuButton}
+                </Tooltip>
+            ) : (
+                menuButton
+            )}
             <Menu
-                id={`${label}-menu`}
                 open={open}
                 anchorEl={anchorEl}
                 onClose={handleClose}
+                keepMounted
                 MenuListProps={{
-                    'aria-labelledby': `${label}-button`,
+                    id: menuId,
+                    'aria-labelledby': buttonId,
                 }}
                 anchorOrigin={{
                     vertical: 'top',


### PR DESCRIPTION
## Summary

- replace the retained Explore graph toolbar controls with recognizable icons
- add matching accessible names and hover/focus tooltips
- provide stable menu relationships, expanded state, and focus restoration
- preserve Reset Graph, Labels, Layout, JSON Export, and Search behavior
- allow consumers to supply optional, generic actions in the existing Export menu
- preserve JSON-only BHCE behavior when no additional actions are supplied

The generic Export-action interface enables the later BED-9132 BHE feature. This PR does not add PNG, SVG, or other image-export behavior to BHCE.

Jira: [BED-9043](https://specterops.atlassian.net/browse/BED-9043)

## Accessibility

- decorative icons are excluded from the accessibility tree
- icon controls have concise accessible names
- tooltips work on hover and keyboard focus
- menu buttons expose stable ARIA relationships and state
- contributed actions expose understandable names and disabled state
- Escape and item selection close menus and restore trigger focus
- keyboard activation, light/dark presentation, visible focus, target sizing, and CSS-equivalent 200% zoom were validated

Actual browser-chrome 200% zoom, screen-reader output, and canvas/WebGL accessibility remain manual validation items. DOM testing does not establish canvas accessibility.

## Validation

- focused GraphButton, GraphControls, and JSON utility tests: 36/36
- BHCE Explore GraphView: 14/14
- BHE consumer type check: passed
- BHE Explore GraphView: 7/11; four known stale visible-text Layout selectors remain for the separate BHE consumer/pointer PR
- shared UI and BHCE UI type, lint, and formatting checks
- `just prepare-for-codereview`
- isolated BHE Playwright in light and dark modes
- JSON-only Export menu confirmed in the current consumer
- no browser page or console errors
- Explore endpoint returned HTTP 200

## Parity

BHE/BHCE disposition: matched. Both products remain JSON-only until a consumer supplies additional actions. Updating the BHE submodule pointer and its four stale consumer-test selectors remains intentionally deferred to the separate BHE PR.


[BED-9043]: https://specterops.atlassian.net/browse/BED-9043?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ