### PR TITLE
fix(data quality): OpenGraph Total Relationship Count BED-9045

### DIFF
--- a/packages/javascript/bh-shared-ui/src/views/DataQuality/OpenGraphInfo.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/DataQuality/OpenGraphInfo.test.tsx
@@ -85,15 +85,16 @@ describe('getLatestMetricStats', () => {
         expect(nodeStats[0]).toBe(newer);
     });
 
-    it('splits mixed node and relationship stats', () => {
+    it('splits mixed node stats and totals relationship stats', () => {
         const node1 = testNodeStat({ kind_id: 1, metric_name: 'User' });
         const node2 = testNodeStat({ kind_id: 2, metric_name: 'Group' });
-        const relationship = testRelationshipStat({ kind_id: 100 });
+        const relationship = testRelationshipStat({ kind_id: 100, metric_value: 50 });
+        const otherRelationship = testRelationshipStat({ kind_id: 101, metric_value: 25 });
 
-        const { nodeStats, relationshipStat } = getLatestMetricStats([node1, node2, relationship]);
+        const { nodeStats, relationshipStat } = getLatestMetricStats([node1, node2, relationship, otherRelationship]);
 
         expect(nodeStats).toEqual([node1, node2]);
-        expect(relationshipStat).toBe(relationship);
+        expect(relationshipStat?.metric_value).toBe(75);
     });
 
     it('returns undefined relationship stats when only node stats are present', () => {
@@ -201,13 +202,14 @@ describe('OpenGraphPlatformInfo', () => {
         respondWith(AGGREGATION_URL, [
             ogStat({ id: 1, kind_id: 1, metric_name: 'User', metric_value: 10 }),
             ogStat({ id: 2, kind_id: 100, metric_type: 'relationship', metric_value: 50 }),
+            ogStat({ id: 3, kind_id: 101, metric_type: 'relationship', metric_value: 25 }),
         ]);
 
         render(<OpenGraphPlatformInfo contextKindId={101} />);
 
         expect(await screen.findByText('User')).toBeInTheDocument();
         expect(screen.getByText('Relationships')).toBeInTheDocument();
-        expect(screen.getByText('50')).toBeInTheDocument();
+        expect(screen.getByText('75')).toBeInTheDocument();
     });
 
     it('calls onDataError and renders nothing when the aggregation request fails', async () => {

--- a/packages/javascript/bh-shared-ui/src/views/DataQuality/OpenGraphInfo.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/DataQuality/OpenGraphInfo.test.tsx
@@ -18,7 +18,12 @@ import { OpenGraphDataQualityStat } from 'js-client-library';
 import { rest } from 'msw';
 import { setupServer } from 'msw/node';
 import { render, screen, waitFor } from '../../test-utils';
-import OpenGraphInfo, { OpenGraphPlatformInfo, getLatestMetricStats } from './OpenGraphInfo';
+import OpenGraphInfo, {
+    getLatestStatsByMetricKind,
+    getMetricStatsByType,
+    getRelationshipsTotalCount,
+    OpenGraphPlatformInfo,
+} from './OpenGraphInfo';
 
 const baseStat = (overrides: Partial<OpenGraphDataQualityStat> = {}): OpenGraphDataQualityStat => ({
     id: 1,
@@ -48,73 +53,65 @@ const testRelationshipStat = (overrides: Partial<OpenGraphDataQualityStat> = {})
         ...overrides,
     });
 
-describe('getLatestMetricStats', () => {
-    it('returns empty node stats and undefined relationship stats for empty input', () => {
-        const { nodeStats, relationshipStat } = getLatestMetricStats([]);
-
-        expect(nodeStats).toEqual([]);
-        expect(relationshipStat).toBeUndefined();
-    });
-
-    it('returns a single node stat and no relationship stat', () => {
-        const stat = testNodeStat();
-
-        const { nodeStats, relationshipStat } = getLatestMetricStats([stat]);
-
-        expect(nodeStats).toEqual([stat]);
-        expect(relationshipStat).toBeUndefined();
-    });
-
+describe('getLatestStatsByMetricKind', () => {
     it('keeps only the latest stat per kind_id by created_at', () => {
         const older = testNodeStat({ created_at: '2026-01-01T00:00:00.000Z', metric_value: 10 });
         const newer = testNodeStat({ created_at: '2026-01-02T00:00:00.000Z', metric_value: 25 });
 
-        const { nodeStats } = getLatestMetricStats([older, newer]);
+        const stats = getLatestStatsByMetricKind([older, newer]);
 
-        expect(nodeStats).toHaveLength(1);
-        expect(nodeStats[0]).toBe(newer);
+        expect(stats).toEqual([newer]);
     });
 
     it('keeps the latest regardless of input ordering', () => {
         const older = testNodeStat({ created_at: '2026-01-01T00:00:00.000Z', metric_value: 10 });
         const newer = testNodeStat({ created_at: '2026-01-02T00:00:00.000Z', metric_value: 25 });
 
-        const { nodeStats } = getLatestMetricStats([newer, older]);
+        const stats = getLatestStatsByMetricKind([newer, older]);
 
-        expect(nodeStats).toHaveLength(1);
-        expect(nodeStats[0]).toBe(newer);
+        expect(stats).toEqual([newer]);
     });
 
-    it('splits mixed node stats and totals relationship stats', () => {
+    it('keeps the first-seen stat when created_at values are missing or invalid', () => {
+        const first = testNodeStat({ created_at: undefined, metric_value: 10 });
+        const second = testNodeStat({ created_at: undefined, metric_value: 25 });
+
+        const stats = getLatestStatsByMetricKind([first, second]);
+
+        expect(stats).toEqual([first]);
+    });
+});
+
+describe('getMetricStatsByType', () => {
+    it('returns empty arrays for empty input', () => {
+        const statsByType = getMetricStatsByType([]);
+
+        expect(statsByType).toEqual({ nodeStats: [], relationshipStats: [] });
+    });
+
+    it('separates node and relationship stats', () => {
         const node1 = testNodeStat({ kind_id: 1, metric_name: 'User' });
         const node2 = testNodeStat({ kind_id: 2, metric_name: 'Group' });
         const relationship = testRelationshipStat({ kind_id: 100, metric_value: 50 });
         const otherRelationship = testRelationshipStat({ kind_id: 101, metric_value: 25 });
 
-        const { nodeStats, relationshipStat } = getLatestMetricStats([node1, node2, relationship, otherRelationship]);
+        const { nodeStats, relationshipStats } = getMetricStatsByType([node1, node2, relationship, otherRelationship]);
 
         expect(nodeStats).toEqual([node1, node2]);
-        expect(relationshipStat?.metric_value).toBe(75);
+        expect(relationshipStats).toEqual([relationship, otherRelationship]);
+    });
+});
+
+describe('getRelationshipsTotalCount', () => {
+    it('returns zero for empty input', () => {
+        expect(getRelationshipsTotalCount([])).toBe(0);
     });
 
-    it('returns undefined relationship stats when only node stats are present', () => {
-        const node1 = testNodeStat({ kind_id: 1 });
-        const node2 = testNodeStat({ kind_id: 2 });
+    it('sums all relationship metric values', () => {
+        const relationship = testRelationshipStat({ kind_id: 100, metric_value: 50 });
+        const otherRelationship = testRelationshipStat({ kind_id: 101, metric_value: 25 });
 
-        const { nodeStats, relationshipStat } = getLatestMetricStats([node1, node2]);
-
-        expect(nodeStats).toEqual([node1, node2]);
-        expect(relationshipStat).toBeUndefined();
-    });
-
-    it('keeps the first-seen stat when created_at values are missing/invalid', () => {
-        const first = testNodeStat({ created_at: undefined, metric_value: 10 });
-        const second = testNodeStat({ created_at: undefined, metric_value: 25 });
-
-        const { nodeStats } = getLatestMetricStats([first, second]);
-
-        expect(nodeStats).toHaveLength(1);
-        expect(nodeStats[0]).toBe(first);
+        expect(getRelationshipsTotalCount([relationship, otherRelationship])).toBe(75);
     });
 });
 

--- a/packages/javascript/bh-shared-ui/src/views/DataQuality/OpenGraphInfo.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/DataQuality/OpenGraphInfo.tsx
@@ -36,29 +36,32 @@ const useStyles = makeStyles((theme) => ({
     },
 }));
 
-// getLatestMetricStats keeps only the latest stat per kind_id (by created_at) and
-// splits the result into node stats and the total relationship stat.
-export const getLatestMetricStats = (
-    data: OpenGraphDataQualityStat[]
-): { nodeStats: OpenGraphDataQualityStat[]; relationshipStat: OpenGraphDataQualityStat } => {
-    const latestStatsByMetricKind = new Map<number, any>();
+export const getLatestStatsByMetricKind = (data: OpenGraphDataQualityStat[]): OpenGraphDataQualityStat[] => {
+    const latestStatsByMetricKind = new Map<number, OpenGraphDataQualityStat>();
+
     for (const stat of data) {
         const existing = latestStatsByMetricKind.get(stat.kind_id);
-        const isLatest = new Date(stat?.created_at).getTime() > new Date(existing?.created_at).getTime();
+        const isLatest = new Date(stat.created_at ?? '').getTime() > new Date(existing?.created_at ?? '').getTime();
+
         if (!existing || isLatest) {
             latestStatsByMetricKind.set(stat.kind_id, stat);
         }
     }
 
-    const stats = Array.from(latestStatsByMetricKind.values());
-    const nodeStats = stats.filter((stat) => stat.metric_type === 'node');
-    const relationshipStats = stats.filter((stat) => stat.metric_type === 'relationship');
-    const relationshipStat = relationshipStats.reduce(
-        (total, stat) => ({ ...stat, metric_value: (total?.metric_value ?? 0) + stat.metric_value }),
-        undefined
-    );
+    return Array.from(latestStatsByMetricKind.values());
+};
 
-    return { nodeStats, relationshipStat };
+export const getMetricStatsByType = (
+    stats: OpenGraphDataQualityStat[]
+): { nodeStats: OpenGraphDataQualityStat[]; relationshipStats: OpenGraphDataQualityStat[] } => {
+    return {
+        nodeStats: stats.filter((stat) => stat.metric_type === 'node'),
+        relationshipStats: stats.filter((stat) => stat.metric_type === 'relationship'),
+    };
+};
+
+export const getRelationshipsTotalCount = (relationshipStats: OpenGraphDataQualityStat[]): number => {
+    return relationshipStats.reduce((totalCount, stat) => totalCount + stat.metric_value, 0);
 };
 
 export const OpenGraphInfo: React.FC<{ contextId: string; onDataError?: () => void }> = ({
@@ -72,16 +75,18 @@ export const OpenGraphInfo: React.FC<{ contextId: string; onDataError?: () => vo
     }, [isError, onDataError]);
 
     if (isLoading) {
-        return <Layout nodeStats={null} relationshipStat={null} isLoading={true} />;
+        return <Layout nodeStats={null} relationshipTotalCount={null} isLoading={true} />;
     }
 
     if (isError || !openGraphData || !openGraphData.data.length) {
         return null;
     }
 
-    const { nodeStats, relationshipStat } = getLatestMetricStats(openGraphData.data);
+    const latestStats = getLatestStatsByMetricKind(openGraphData.data);
+    const { nodeStats, relationshipStats } = getMetricStatsByType(latestStats);
+    const relationshipTotalCount = getRelationshipsTotalCount(relationshipStats);
 
-    return <Layout nodeStats={nodeStats} relationshipStat={relationshipStat} isLoading={false} />;
+    return <Layout nodeStats={nodeStats} relationshipTotalCount={relationshipTotalCount} isLoading={false} />;
 };
 
 export const OpenGraphPlatformInfo: React.FC<{
@@ -95,16 +100,18 @@ export const OpenGraphPlatformInfo: React.FC<{
     }, [isError, onDataError]);
 
     if (isLoading) {
-        return <Layout nodeStats={null} relationshipStat={null} isLoading={true} />;
+        return <Layout nodeStats={null} relationshipTotalCount={null} isLoading={true} />;
     }
 
     if (isError || !platformData || !platformData.data.length) {
         return null;
     }
 
-    const { nodeStats, relationshipStat } = getLatestMetricStats(platformData.data);
+    const latestStats = getLatestStatsByMetricKind(platformData.data);
+    const { nodeStats, relationshipStats } = getMetricStatsByType(latestStats);
+    const relationshipTotalCount = getRelationshipsTotalCount(relationshipStats);
 
-    return <Layout nodeStats={nodeStats} relationshipStat={relationshipStat} isLoading={false} />;
+    return <Layout nodeStats={nodeStats} relationshipTotalCount={relationshipTotalCount} isLoading={false} />;
 };
 
 const MetricIcon: React.FC<{ metricName: string; metricType: any }> = ({ metricName, metricType }) => {
@@ -117,10 +124,10 @@ const MetricIcon: React.FC<{ metricName: string; metricType: any }> = ({ metricN
 
 const Layout: React.FC<{
     nodeStats: OpenGraphDataQualityStat[] | null;
-    relationshipStat: OpenGraphDataQualityStat | null;
+    relationshipTotalCount: number | null;
     isLoading: boolean;
     headers?: boolean;
-}> = ({ nodeStats, relationshipStat, isLoading }) => {
+}> = ({ nodeStats, relationshipTotalCount, isLoading }) => {
     const classes = useStyles();
 
     return (
@@ -148,7 +155,7 @@ const Layout: React.FC<{
                         <LoadContainer
                             icon={<FontAwesomeIcon icon={faUsers} />}
                             display='Relationships'
-                            value={relationshipStat?.metric_value ?? 0}
+                            value={relationshipTotalCount ?? 0}
                             isLoading={isLoading}
                         />
                     </TableBody>

--- a/packages/javascript/bh-shared-ui/src/views/DataQuality/OpenGraphInfo.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/DataQuality/OpenGraphInfo.tsx
@@ -37,7 +37,7 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 // getLatestMetricStats keeps only the latest stat per kind_id (by created_at) and
-// splits the result into node stats and the latest relationship stat.
+// splits the result into node stats and the total relationship stat.
 export const getLatestMetricStats = (
     data: OpenGraphDataQualityStat[]
 ): { nodeStats: OpenGraphDataQualityStat[]; relationshipStat: OpenGraphDataQualityStat } => {
@@ -52,7 +52,11 @@ export const getLatestMetricStats = (
 
     const stats = Array.from(latestStatsByMetricKind.values());
     const nodeStats = stats.filter((stat) => stat.metric_type === 'node');
-    const relationshipStat = stats.find((stat) => stat.metric_type === 'relationship');
+    const relationshipStats = stats.filter((stat) => stat.metric_type === 'relationship');
+    const relationshipStat = relationshipStats.reduce(
+        (total, stat) => ({ ...stat, metric_value: (total?.metric_value ?? 0) + stat.metric_value }),
+        undefined
+    );
 
     return { nodeStats, relationshipStat };
 };


### PR DESCRIPTION

<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

This updates the `relationship` count for OG environments to sum the total `metric_value` for each `metric_type: relationship`

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves: BED-9045

*Why is this change required? What problem does it solve?*

## How Has This Been Tested?

Unit tests updates to reflect the new counting method
Observed counting on local UI

See associated BED ticket comments for testing screenshot

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
