### PR TITLE
fix: AZRole node split for Privileged Role Administrator under use_raw_object_id - BED-9046

### DIFF
--- a/packages/go/ein/azure.go
+++ b/packages/go/ein/azure.go
@@ -1992,9 +1992,7 @@ func ConvertAzureRoleEligibilityScheduleInstanceToRel(instance models.RoleEligib
 func ConvertAzureRoleManagementPolicyAssignment(policyAssignment models.RoleManagementPolicyAssignment) (IngestibleNode, []IngestibleRelationship) {
 	var (
 		rels = make([]IngestibleRelationship, 0)
-		// The AZRole identity is left in its raw casing here; node ingestion
-		// (normalizeEinNodeProperties) applies the use_raw_object_id-aware
-		// casing normalization to the node's ObjectID.
+		// Raw casing here; node ingestion applies use_raw_object_id-aware normalization.
 		combinedObjectId = fmt.Sprintf("%s@%s", policyAssignment.RoleDefinitionId, policyAssignment.TenantId)
 	)
 
@@ -2055,11 +2053,10 @@ func ConvertAzureRoleManagementPolicyAssignment(policyAssignment models.RoleMana
 	}
 
 	if len(policyAssignment.EndUserAssignmentUserApprovers) == 0 && len(policyAssignment.EndUserAssignmentGroupApprovers) == 0 {
-		// No users or groups were attached to the policy, we will create the edge from the tenant's PrivilegedRoleAdministratorRole Role node to the target role.
-		// The identity is left in its raw casing here; graphify's relationship ingestion (ingestibleRelationshipsToUpdates)
-		// applies the use_raw_object_id-aware casing normalization to relationship endpoints, matching the casing
-		// applied to the AZRole node's own objectid during node ingestion.
-		combinedObjectId := fmt.Sprintf("%s@%s", azure.PrivilegedRoleAdministratorRole, policyAssignment.TenantId)
+		// No approvers: create the edge from the tenant's PrivilegedRoleAdministratorRole node to the target role.
+		// Uppercase the lowercase well-known constant to match the collector-sourced node objectid; under
+		// use_raw_object_id, relationship ingestion no longer normalizes it, so uppercasing here avoids a split node.
+		combinedObjectId := fmt.Sprintf("%s@%s", strings.ToUpper(azure.PrivilegedRoleAdministratorRole), policyAssignment.TenantId)
 
 		rels = append(rels, NewIngestibleRelationship(IngestibleEndpoint{
 			Value: combinedObjectId,

--- a/packages/go/ein/azure_test.go
+++ b/packages/go/ein/azure_test.go
@@ -434,7 +434,7 @@ func Test_ConvertAzureRoleManagementPolicyAssignment(t *testing.T) {
 		assert.Equal(t, azure.AZRoleApprover, rels[3].RelType)
 	})
 
-	t.Run("No approvers creates AZRoleApprover edge from raw-case PrivilegedRoleAdministratorRole", func(t *testing.T) {
+	t.Run("No approvers creates AZRoleApprover edge from uppercased PrivilegedRoleAdministratorRole", func(t *testing.T) {
 		model.EndUserAssignmentRequiresApproval = true
 		model.EndUserAssignmentUserApprovers = nil
 		model.EndUserAssignmentGroupApprovers = nil
@@ -442,8 +442,8 @@ func Test_ConvertAzureRoleManagementPolicyAssignment(t *testing.T) {
 		_, rels := ein.ConvertAzureRoleManagementPolicyAssignment(model)
 
 		require.Len(t, rels, 1)
-		expectedSource := fmt.Sprintf("%s@%s", azure.PrivilegedRoleAdministratorRole, "tenant-1234")
-		assert.Equal(t, expectedSource, rels[0].Source.Value, "AZRole edge source casing is left to graphify ingestion, not baked in here")
+		expectedSource := fmt.Sprintf("%s@%s", strings.ToUpper(azure.PrivilegedRoleAdministratorRole), "tenant-1234")
+		assert.Equal(t, expectedSource, rels[0].Source.Value, "the well-known role constant is uppercased at the source so the endpoint matches the collector-sourced AZRole node objectid regardless of the use_raw_object_id flag")
 		assert.Equal(t, azure.Role, rels[0].Source.Kind)
 		assert.Equal(t, "role-1234@tenant-1234", rels[0].Target.Value)
 		assert.Equal(t, azure.Role, rels[0].Target.Kind)


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

When the use_raw_object_id flag is ON, the Privileged Role Administrator AZRole node splits into two nodes: the real collector-sourced node (uppercase objectid, full properties, Tier Zero tagged) and an empty stub node (lowercase objectid, no properties).

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves [BED-9046](https://specterops.atlassian.net/browse/BED-9046)

## How Has This Been Tested?
Manual testing and added unit test case

Steps to test with SpecterDev Azure environment

1. Enable use_raw_object_id.
2. Ingest AzureHound v3.0.0 data containing a PIM policy assignment where EndUserAssignmentRequiresApproval = true and both EndUserAssignmentUserApprovers and EndUserAssignmentGroupApprovers are empty.
3. Run this cypher and view only 1 node
`MATCH (r:AZRole)
WHERE toLower(r.objectid) STARTS WITH 'e8611ab8-c189-46e8-94e1-60213ab1f814@'
RETURN r;`

## Screenshots (optional):
Before fix
<img width="1019" height="596" alt="image" src="https://github.com/user-attachments/assets/02e18d5f-eac4-40f8-ba0e-a55617ec41bc" />
<img width="1098" height="463" alt="image" src="https://github.com/user-attachments/assets/94ed2eca-f602-4433-ad4b-fc69774c194c" />
<img width="1031" height="846" alt="image" src="https://github.com/user-attachments/assets/6f2272c4-2302-4c4c-84d6-60cdc8986566" />

After fix
<img width="1655" height="845" alt="image" src="https://github.com/user-attachments/assets/660c78a6-f8e2-48b3-a4d3-d1e6c6f267cc" />

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


[BED-9046]: https://specterops.atlassian.net/browse/BED-9046?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ