### PR TITLE
chore: Certification UI: EnvironmentId should stay on the URL when navigating to a different view BED-8926

### DIFF
--- a/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/PrivilegeZones.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/PrivilegeZones.tsx
@@ -145,9 +145,7 @@ const PrivilegeZones: FC = () => {
                             const id = value === zonesPath ? tagId : ownedId;
                             switch (value) {
                                 case certificationsPath:
-                                    return navigate(`/${privilegeZonesPath}/${certificationsPath}`, {
-                                        discardQueryParams: true,
-                                    });
+                                    return navigate(`/${privilegeZonesPath}/${certificationsPath}`);
                                 case historyPath:
                                     return navigate(`/${privilegeZonesPath}/${historyPath}`, {
                                         discardQueryParams: true,


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

On Privilege Zones, EnvironmentID should stay on the URL when navigating into Certifications.

## Motivation and Context


Resolves BED-8926



## How Has This Been Tested?

Tested locally

## Screenshots (optional):
Video added in the Jira ticket comments

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)


## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [ ] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
