### PR TITLE
fix: restore table height virtualization classname (BED-9057)

### DIFF
--- a/packages/javascript/bh-shared-ui/src/components/ExploreTable/ExploreTable.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/ExploreTable/ExploreTable.tsx
@@ -223,6 +223,7 @@ const ExploreTable = ({
                         onColumnOrderChange={(newOrder) => {
                             setColumnOrder(newOrder);
                         }}
+                        className='overflow-auto h-[calc(50vh-72px)]'
                         growLastColumn
                         enableResizing
                         enableDragAndDrop

--- a/packages/javascript/bh-shared-ui/src/components/ExploreTable/ExploreTable.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/ExploreTable/ExploreTable.tsx
@@ -177,6 +177,15 @@ const ExploreTable = ({
         [onChangePinnedColumns]
     );
 
+    const className = useMemo(
+        () =>
+            cn('overflow-auto', {
+                'h-[calc(50vh-72px)]': !isExpanded,
+                'h-[calc(100vh-72px)]': !isExpanded,
+            }),
+        [isExpanded]
+    );
+
     return (
         <div
             data-testid='explore-table-container-wrapper'
@@ -222,11 +231,7 @@ const ExploreTable = ({
                     onColumnOrderChange={(newOrder) => {
                         setColumnOrder(newOrder);
                     }}
-                    className={cn('overflow-auto', {
-                        // TODO: why is header disappearing on bottom scroll? One extra overflow element somewhere
-                        'h-[calc(50vh-72px)]': !isExpanded,
-                        'h-[calc(100vh-72px)]': !isExpanded,
-                    })}
+                    className={className}
                     growLastColumn
                     enableResizing
                 />

--- a/packages/javascript/bh-shared-ui/src/components/ExploreTable/ExploreTable.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/ExploreTable/ExploreTable.tsx
@@ -14,7 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { DataTable, ScrollArea } from 'doodle-ui';
+import { DataTable } from 'doodle-ui';
 import fileDownload from 'js-file-download';
 import { json2csv } from 'json-2-csv';
 import { ChangeEvent, memo, useCallback, useMemo, useState } from 'react';
@@ -203,32 +203,33 @@ const ExploreTable = ({
                     resultsCount={resultsCount}
                     SearchInputProps={searchInputProps}
                 />
-                <ScrollArea>
-                    <MemoDataTable
-                        TableHeaderProps={tableHeaderProps}
-                        TableHeadProps={tableHeadProps}
-                        TableProps={tableProps}
-                        TableCellProps={tableCellProps}
-                        columnPinning={columnPinning}
-                        setColumnPinning={handleSetColumnPinning}
-                        onRowClick={handleRowClick}
-                        selectedRow={selectedItem || undefined}
-                        data={sortedFilteredRows}
-                        columns={tableColumns as DataTableProps['columns']}
-                        tableOptions={tableOptions}
-                        virtualizationOptions={virtualizationOptions}
-                        columnSizing={columnSizing}
-                        onColumnSizingChange={setColumnSizing}
-                        columnOrder={columnOrder}
-                        onColumnOrderChange={(newOrder) => {
-                            setColumnOrder(newOrder);
-                        }}
-                        className='overflow-auto h-[calc(50vh-72px)]'
-                        growLastColumn
-                        enableResizing
-                        enableDragAndDrop
-                    />
-                </ScrollArea>
+                <MemoDataTable
+                    TableHeaderProps={tableHeaderProps}
+                    TableHeadProps={tableHeadProps}
+                    TableProps={tableProps}
+                    TableCellProps={tableCellProps}
+                    columnPinning={columnPinning}
+                    setColumnPinning={handleSetColumnPinning}
+                    onRowClick={handleRowClick}
+                    selectedRow={selectedItem || undefined}
+                    data={sortedFilteredRows}
+                    columns={tableColumns as DataTableProps['columns']}
+                    tableOptions={tableOptions}
+                    virtualizationOptions={virtualizationOptions}
+                    columnSizing={columnSizing}
+                    onColumnSizingChange={setColumnSizing}
+                    columnOrder={columnOrder}
+                    onColumnOrderChange={(newOrder) => {
+                        setColumnOrder(newOrder);
+                    }}
+                    className={cn('overflow-auto', {
+                        // TODO: why is header disappearing on bottom scroll? One extra overflow element somewhere
+                        'h-[calc(50vh-72px)]': !isExpanded,
+                        'h-[calc(100vh-72px)]': !isExpanded,
+                    })}
+                    growLastColumn
+                    enableResizing
+                />
             </div>
         </div>
     );

--- a/packages/javascript/bh-shared-ui/src/components/ExploreTable/ExploreTable.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/ExploreTable/ExploreTable.tsx
@@ -234,6 +234,7 @@ const ExploreTable = ({
                     className={className}
                     growLastColumn
                     enableResizing
+                    enableDragAndDrop
                 />
             </div>
         </div>

--- a/packages/javascript/bh-shared-ui/src/components/ExploreTable/ExploreTable.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/ExploreTable/ExploreTable.tsx
@@ -177,15 +177,6 @@ const ExploreTable = ({
         [onChangePinnedColumns]
     );
 
-    const className = useMemo(
-        () =>
-            cn('overflow-auto', {
-                'h-[calc(50vh-72px)]': !isExpanded,
-                'h-[calc(100vh-72px)]': !isExpanded,
-            }),
-        [isExpanded]
-    );
-
     return (
         <div
             data-testid='explore-table-container-wrapper'
@@ -231,7 +222,7 @@ const ExploreTable = ({
                     onColumnOrderChange={(newOrder) => {
                         setColumnOrder(newOrder);
                     }}
-                    className={className}
+                    className='overflow-auto h-full'
                     growLastColumn
                     enableResizing
                     enableDragAndDrop


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

It looks like we lost a fixed height and overflow-scroll somewhere along the way, and DataTable virtualization depends on these properties. This PR restores those CSS properties and removes the custom scrollbars, to be restored in a later ticket (https://specterops.atlassian.net/browse/BED-9074)

https://github.com/user-attachments/assets/50539e70-1b46-43f9-993b-7204e2e011a7


*Describe your changes in detail*

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves  BED-9057

*Why is this change required? What problem does it solve?*

## How Has This Been Tested?

*Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc.*

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)
- Database Migrations

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [ ] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [ ] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [ ] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary of changes

* **Bug Fixes**
  * Improved the Explore table’s scrolling behavior by simplifying the layout wrapper and explicitly controlling overflow and height, helping the table stay readable in smaller window sizes.
  * Ensured existing Explore table interactions, including drag-and-drop, continue to work as before.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->