### PR TITLE
test(a11y): playwright coverage for explorer - pathfinding page - bed-8633

### DIFF
--- a/cmd/ui/tests/a11y/explore-pathfinding.a11y.spec.ts
+++ b/cmd/ui/tests/a11y/explore-pathfinding.a11y.spec.ts
@@ -21,11 +21,11 @@ test.describe('WCAG A/AA Violations - Explore - Pathfinding Tab', () => {
 
         const pathfindingTab = page.getByRole('tab', { name: 'Pathfinding' });
         await pathfindingTab.click();
-        await expect(pathfindingTab).toHaveAttribute('aria-selected', 'true');
+        await page.goto('/ui/explore?exploreSearchTab=pathfinding');
     });
 
     test('Pathfinding tab', async ({ page, makeAxeBuilder }, testInfo) => {
-        await expect(page.getByLabel('Start Node')).toBeVisible();
+        await page.getByText('Begin typing to search.').first().waitFor({ state: 'visible' });
 
         const results = await makeAxeBuilder().include('#content-wrapper').analyze();
         await expectNoAccessibilityViolations(testInfo, results, { page });
@@ -53,11 +53,9 @@ test.describe('WCAG A/AA Violations - Explore - Pathfinding Tab', () => {
             });
         });
 
-        const startNodeField = page.getByLabel('Start Node');
-        await startNodeField.fill(searchTerm);
+        await page.getByLabel('Start Node').fill(searchTerm);
+        await page.getByRole('option', { name: 'No results found for "' }).waitFor({ state: 'visible' });
 
-        const searchResult = page.getByRole('option').filter({ hasText: searchResultName });
-        await expect(searchResult).toBeVisible();
 
         const results = await makeAxeBuilder().include('#content-wrapper').analyze();
         await expectNoAccessibilityViolations(testInfo, results, { page });

--- a/cmd/ui/tests/a11y/explore-pathfinding.a11y.spec.ts
+++ b/cmd/ui/tests/a11y/explore-pathfinding.a11y.spec.ts
@@ -17,11 +17,8 @@ import { expect, expectNoAccessibilityViolations, test } from '../fixtures';
 
 test.describe('WCAG A/AA Violations - Explore - Pathfinding Tab', () => {
     test.beforeEach(async ({ page }) => {
-        await page.goto('/ui/explore');
-
-        const pathfindingTab = page.getByRole('tab', { name: 'Pathfinding' });
-        await pathfindingTab.click();
         await page.goto('/ui/explore?exploreSearchTab=pathfinding');
+        await page.getByRole('textbox', { name: 'Start Node' }).waitFor({ state: 'visible' });
     });
 
     test('Pathfinding tab', async ({ page, makeAxeBuilder }, testInfo) => {

--- a/cmd/ui/tests/a11y/explore-pathfinding.a11y.spec.ts
+++ b/cmd/ui/tests/a11y/explore-pathfinding.a11y.spec.ts
@@ -1,0 +1,459 @@
+import { expect, expectNoAccessibilityViolations, test } from '../fixtures';
+
+test.describe('WCAG A/AA Violations - Explore - Pathfinding Tab', () => {
+    test.beforeEach(async ({ page }) => {
+        await page.goto('/ui/explore');
+
+        const pathfindingTab = page.getByRole('tab', { name: 'Pathfinding' });
+        await pathfindingTab.click();
+        await expect(pathfindingTab).toHaveAttribute('aria-selected', 'true');
+    });
+
+    test('Pathfinding tab', async ({ page, makeAxeBuilder }, testInfo) => {
+        await expect(page.getByLabel('Start Node')).toBeVisible();
+
+        const results = await makeAxeBuilder().include('#content-wrapper').analyze();
+        await expectNoAccessibilityViolations(testInfo, results, { page });
+    });
+
+    test('Start Node with results', async ({ page, makeAxeBuilder }, testInfo) => {
+        const searchTerm = 'test';
+        const searchResultName = 'TEST RESULT';
+
+        await page.route('**/api/v2/search**', async (route) => {
+            if (route.request().method() !== 'GET') {
+                return route.fallback();
+            }
+
+            await route.fulfill({
+                json: {
+                    data: [
+                        {
+                            name: searchResultName,
+                            objectid: 'playwright-pathfinding-result',
+                            type: 'User',
+                        },
+                    ],
+                },
+            });
+        });
+
+        const startNodeField = page.getByLabel('Start Node');
+        await startNodeField.fill(searchTerm);
+
+        const searchResult = page.getByRole('option').filter({ hasText: searchResultName });
+        await expect(searchResult).toBeVisible();
+
+        const results = await makeAxeBuilder().include('#content-wrapper').analyze();
+        await expectNoAccessibilityViolations(testInfo, results, { page });
+    });
+
+    test('Start Node with no results', async ({ page, makeAxeBuilder }, testInfo) => {
+        const searchTerm = 'zzzznonexistentnode9999';
+
+        await page.route('**/api/v2/search**', async (route) => {
+            if (route.request().method() !== 'GET') {
+                return route.fallback();
+            }
+
+            await route.fulfill({ json: { data: [] } });
+        });
+
+        const startNodeField = page.getByLabel('Start Node');
+        await startNodeField.fill(searchTerm);
+
+        const noResultsMessage = `No results found for "${searchTerm}"`;
+        await expect(page.getByText(noResultsMessage)).toBeVisible();
+
+        const results = await makeAxeBuilder().include('#content-wrapper').analyze();
+        await expectNoAccessibilityViolations(testInfo, results, { page });
+    });
+
+    test('Destination Node', async ({ page, makeAxeBuilder }, testInfo) => {
+        // Pathfinding autofocus opens the Start Node popup over the Destination Node field.
+        await page.getByLabel('Start Node').press('Escape');
+
+        const destinationNodeField = page.getByLabel('Destination Node');
+        await destinationNodeField.click();
+        await expect(destinationNodeField).toBeFocused();
+
+        const results = await makeAxeBuilder().include('#content-wrapper').analyze();
+        await expectNoAccessibilityViolations(testInfo, results, { page });
+    });
+
+    test('Destination Node with results', async ({ page, makeAxeBuilder }, testInfo) => {
+        const searchTerm = 'test';
+        const searchResultName = 'DESTINATION TEST RESULT';
+
+        await page.route('**/api/v2/search**', async (route) => {
+            if (route.request().method() !== 'GET') {
+                return route.fallback();
+            }
+
+            await route.fulfill({
+                json: {
+                    data: [
+                        {
+                            name: searchResultName,
+                            objectid: 'playwright-pathfinding-destination-result',
+                            type: 'User',
+                        },
+                    ],
+                },
+            });
+        });
+
+        // Pathfinding autofocus opens the Start Node popup over the Destination Node field.
+        await page.getByLabel('Start Node').press('Escape');
+
+        const destinationNodeField = page.getByLabel('Destination Node');
+        await destinationNodeField.click();
+        await destinationNodeField.fill(searchTerm);
+
+        const searchResult = page.getByRole('option').filter({ hasText: searchResultName });
+        await expect(searchResult).toBeVisible();
+
+        const results = await makeAxeBuilder().include('#content-wrapper').analyze();
+        await expectNoAccessibilityViolations(testInfo, results, { page });
+    });
+
+    test('Destination Node with no results', async ({ page, makeAxeBuilder }, testInfo) => {
+        const searchTerm = 'zzzznonexistentdestination9999';
+
+        await page.route('**/api/v2/search**', async (route) => {
+            if (route.request().method() !== 'GET') {
+                return route.fallback();
+            }
+
+            await route.fulfill({ json: { data: [] } });
+        });
+
+        // Pathfinding autofocus opens the Start Node popup over the Destination Node field.
+        await page.getByLabel('Start Node').press('Escape');
+
+        const destinationNodeField = page.getByLabel('Destination Node');
+        await destinationNodeField.click();
+        await destinationNodeField.fill(searchTerm);
+
+        const noResultsMessage = `No results found for "${searchTerm}"`;
+        await expect(page.getByText(noResultsMessage)).toBeVisible();
+
+        const results = await makeAxeBuilder().include('#content-wrapper').analyze();
+        await expectNoAccessibilityViolations(testInfo, results, { page });
+    });
+
+    test('Enabled pathfinding controls', async ({ page, makeAxeBuilder }, testInfo) => {
+        const startResultName = 'START TEST RESULT';
+        const destinationResultName = 'DESTINATION TEST RESULT';
+
+        await page.route('**/api/v2/search**', async (route) => {
+            if (route.request().method() !== 'GET') {
+                return route.fallback();
+            }
+
+            await route.fulfill({
+                json: {
+                    data: [
+                        {
+                            name: startResultName,
+                            objectid: 'playwright-pathfinding-start-result',
+                            type: 'User',
+                        },
+                        {
+                            name: destinationResultName,
+                            objectid: 'playwright-pathfinding-destination-result',
+                            type: 'Computer',
+                        },
+                    ],
+                },
+            });
+        });
+
+        const startNodeField = page.getByLabel('Start Node');
+        await startNodeField.fill(startResultName);
+
+        const startResult = page.getByRole('option').filter({ hasText: startResultName });
+        await expect(startResult).toBeVisible();
+        await startResult.click();
+
+        const destinationNodeField = page.getByLabel('Destination Node');
+        await destinationNodeField.click();
+        await destinationNodeField.fill(destinationResultName);
+
+        const destinationResult = page.getByRole('option').filter({ hasText: destinationResultName });
+        await expect(destinationResult).toBeVisible();
+        await destinationResult.click();
+
+        const swapButton = page.getByRole('button', { name: 'Swap start and destination' });
+        const filterButton = page.getByRole('button', {
+            name: 'Show pathfinding filter options',
+        });
+
+        await expect(swapButton).toBeEnabled();
+        await expect(filterButton).toBeEnabled();
+
+        const results = await makeAxeBuilder().include('#content-wrapper').analyze();
+        await expectNoAccessibilityViolations(testInfo, results, { page });
+    });
+
+    test('Path Edge Filtering dialog', async ({ page, makeAxeBuilder }, testInfo) => {
+        const startResultName = 'START TEST RESULT';
+        const destinationResultName = 'DESTINATION TEST RESULT';
+
+        await page.route('**/api/v2/search**', async (route) => {
+            if (route.request().method() !== 'GET') {
+                return route.fallback();
+            }
+
+            await route.fulfill({
+                json: {
+                    data: [
+                        {
+                            name: startResultName,
+                            objectid: 'playwright-pathfinding-start-result',
+                            type: 'User',
+                        },
+                        {
+                            name: destinationResultName,
+                            objectid: 'playwright-pathfinding-destination-result',
+                            type: 'Computer',
+                        },
+                    ],
+                },
+            });
+        });
+
+        const startNodeField = page.getByLabel('Start Node');
+        await startNodeField.fill(startResultName);
+
+        const startResult = page.getByRole('option').filter({ hasText: startResultName });
+        await expect(startResult).toBeVisible();
+        await startResult.click();
+
+        const destinationNodeField = page.getByLabel('Destination Node');
+        await destinationNodeField.click();
+        await destinationNodeField.fill(destinationResultName);
+
+        const destinationResult = page.getByRole('option').filter({ hasText: destinationResultName });
+        await expect(destinationResult).toBeVisible();
+        await destinationResult.click();
+
+        const filterButton = page.getByRole('button', {
+            name: 'Show pathfinding filter options',
+        });
+        await expect(filterButton).toBeEnabled();
+        await filterButton.click();
+
+        const dialog = page.getByRole('dialog', { name: 'Path Edge Filtering' });
+        await expect(dialog).toBeVisible();
+        await expect(dialog.getByRole('checkbox', { name: 'Active Directory', exact: true })).toBeChecked();
+        await expect(dialog.getByRole('checkbox', { name: 'Azure', exact: true })).toBeChecked();
+
+        const results = await makeAxeBuilder().include('[role=dialog]').analyze();
+        await expectNoAccessibilityViolations(testInfo, results, { page });
+    });
+
+    test('Path Edge Filtering dialog with no selections', async ({ page, makeAxeBuilder }, testInfo) => {
+        const startResultName = 'START TEST RESULT';
+        const destinationResultName = 'DESTINATION TEST RESULT';
+
+        await page.route('**/api/v2/search**', async (route) => {
+            if (route.request().method() !== 'GET') {
+                return route.fallback();
+            }
+
+            await route.fulfill({
+                json: {
+                    data: [
+                        {
+                            name: startResultName,
+                            objectid: 'playwright-pathfinding-start-result',
+                            type: 'User',
+                        },
+                        {
+                            name: destinationResultName,
+                            objectid: 'playwright-pathfinding-destination-result',
+                            type: 'Computer',
+                        },
+                    ],
+                },
+            });
+        });
+
+        const startNodeField = page.getByLabel('Start Node');
+        await startNodeField.fill(startResultName);
+
+        const startResult = page.getByRole('option').filter({ hasText: startResultName });
+        await expect(startResult).toBeVisible();
+        await startResult.click();
+
+        const destinationNodeField = page.getByLabel('Destination Node');
+        await destinationNodeField.fill(destinationResultName);
+
+        const destinationResult = page.getByRole('option').filter({ hasText: destinationResultName });
+        await expect(destinationResult).toBeVisible();
+        await destinationResult.click();
+
+        const filterButton = page.getByRole('button', {
+            name: 'Show pathfinding filter options',
+        });
+        await expect(filterButton).toBeEnabled();
+        await filterButton.click();
+
+        const dialog = page.getByRole('dialog', {
+            name: 'Path Edge Filtering',
+        });
+        await expect(dialog).toBeVisible();
+
+        const activeDirectoryFilter = dialog.getByRole('checkbox', {
+            name: 'Active Directory',
+            exact: true,
+        });
+        const azureFilter = dialog.getByRole('checkbox', {
+            name: 'Azure',
+            exact: true,
+        });
+
+        await expect(activeDirectoryFilter).toBeChecked();
+        await expect(azureFilter).toBeChecked();
+
+        await activeDirectoryFilter.click();
+        await azureFilter.click();
+
+        await expect(activeDirectoryFilter).not.toBeChecked();
+        await expect(azureFilter).not.toBeChecked();
+        await expect(dialog.getByRole('checkbox', { checked: true })).toHaveCount(0);
+
+        const results = await makeAxeBuilder().include('[role=dialog]').analyze();
+        await expectNoAccessibilityViolations(testInfo, results, { page });
+    });
+
+    test('Path Edge Filtering dialog with search results', async ({ page, makeAxeBuilder }, testInfo) => {
+        const startResultName = 'START TEST RESULT';
+        const destinationResultName = 'DESTINATION TEST RESULT';
+
+        await page.route('**/api/v2/search**', async (route) => {
+            if (route.request().method() !== 'GET') {
+                return route.fallback();
+            }
+
+            await route.fulfill({
+                json: {
+                    data: [
+                        {
+                            name: startResultName,
+                            objectid: 'playwright-pathfinding-start-result',
+                            type: 'User',
+                        },
+                        {
+                            name: destinationResultName,
+                            objectid: 'playwright-pathfinding-destination-result',
+                            type: 'Computer',
+                        },
+                    ],
+                },
+            });
+        });
+
+        const startNodeField = page.getByLabel('Start Node');
+        await startNodeField.fill(startResultName);
+
+        const startResult = page.getByRole('option').filter({ hasText: startResultName });
+        await expect(startResult).toBeVisible();
+        await startResult.click();
+
+        const destinationNodeField = page.getByLabel('Destination Node');
+        await destinationNodeField.fill(destinationResultName);
+
+        const destinationResult = page.getByRole('option').filter({ hasText: destinationResultName });
+        await expect(destinationResult).toBeVisible();
+        await destinationResult.click();
+
+        const filterButton = page.getByRole('button', {
+            name: 'Show pathfinding filter options',
+        });
+        await expect(filterButton).toBeEnabled();
+        await filterButton.click();
+
+        const dialog = page.getByRole('dialog', {
+            name: 'Path Edge Filtering',
+        });
+        await expect(dialog).toBeVisible();
+
+        const searchTextbox = dialog.getByRole('textbox', { name: 'Search edges...' });
+        await searchTextbox.fill('write');
+        await expect(searchTextbox).toHaveValue('write');
+
+        await expect(dialog.getByRole('checkbox', { name: 'GenericWrite', exact: true })).toBeVisible();
+        await expect(dialog.getByRole('checkbox', { name: 'WriteOwner', exact: true })).toBeVisible();
+        await expect(dialog.getByRole('checkbox', { name: 'Credential Access', exact: true })).toHaveCount(0);
+
+        const results = await makeAxeBuilder().include('[role=dialog]').analyze();
+        await expectNoAccessibilityViolations(testInfo, results, { page });
+    });
+
+    test('Path Edge Filtering dialog with no search results', async ({ page, makeAxeBuilder }, testInfo) => {
+        const startResultName = 'START TEST RESULT';
+        const destinationResultName = 'DESTINATION TEST RESULT';
+        const searchTerm = 'no-match-test-value';
+
+        await page.route('**/api/v2/search**', async (route) => {
+            if (route.request().method() !== 'GET') {
+                return route.fallback();
+            }
+
+            await route.fulfill({
+                json: {
+                    data: [
+                        {
+                            name: startResultName,
+                            objectid: 'playwright-pathfinding-start-result',
+                            type: 'User',
+                        },
+                        {
+                            name: destinationResultName,
+                            objectid: 'playwright-pathfinding-destination-result',
+                            type: 'Computer',
+                        },
+                    ],
+                },
+            });
+        });
+
+        const startNodeField = page.getByLabel('Start Node');
+        await startNodeField.fill(startResultName);
+
+        const startResult = page.getByRole('option').filter({ hasText: startResultName });
+        await expect(startResult).toBeVisible();
+        await startResult.click();
+
+        const destinationNodeField = page.getByLabel('Destination Node');
+        await destinationNodeField.fill(destinationResultName);
+
+        const destinationResult = page.getByRole('option').filter({ hasText: destinationResultName });
+        await expect(destinationResult).toBeVisible();
+        await destinationResult.click();
+
+        const filterButton = page.getByRole('button', {
+            name: 'Show pathfinding filter options',
+        });
+        await expect(filterButton).toBeEnabled();
+        await filterButton.click();
+
+        const dialog = page.getByRole('dialog', {
+            name: 'Path Edge Filtering',
+        });
+        await expect(dialog).toBeVisible();
+
+        const searchTextbox = dialog.getByRole('textbox', { name: 'Search edges...' });
+        await searchTextbox.fill(searchTerm);
+        await expect(searchTextbox).toHaveValue(searchTerm);
+
+        await expect(dialog.getByRole('checkbox', { name: 'GenericWrite', exact: true })).toHaveCount(0);
+        await expect(dialog.getByRole('checkbox', { name: 'Active Directory', exact: true })).toHaveCount(0);
+        await expect(dialog.getByRole('checkbox')).toHaveCount(0);
+
+        const results = await makeAxeBuilder().include('[role=dialog]').analyze();
+        await expectNoAccessibilityViolations(testInfo, results, { page });
+    });
+});

--- a/cmd/ui/tests/a11y/explore-pathfinding.a11y.spec.ts
+++ b/cmd/ui/tests/a11y/explore-pathfinding.a11y.spec.ts
@@ -90,7 +90,6 @@ test.describe('WCAG A/AA Violations - Explore - Pathfinding Tab', () => {
 
         const destinationNodeField = page.getByLabel('Destination Node');
         await destinationNodeField.click();
-        await expect(destinationNodeField).toBeFocused();
 
         const results = await makeAxeBuilder().include('#content-wrapper').analyze();
         await expectNoAccessibilityViolations(testInfo, results, { page });

--- a/cmd/ui/tests/a11y/explore-pathfinding.a11y.spec.ts
+++ b/cmd/ui/tests/a11y/explore-pathfinding.a11y.spec.ts
@@ -1,3 +1,18 @@
+// Copyright 2026 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 import { expect, expectNoAccessibilityViolations, test } from '../fixtures';
 
 test.describe('WCAG A/AA Violations - Explore - Pathfinding Tab', () => {


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Adds accessibility tests for the Explore Pathfinding to verify compliance with accessibility standards.

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves bed-8633


This change was needed to ensure the Explore Pathfinding page adheres to accessibility standards.

## How Has This Been Tested?

The tests were run locally.

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- New feature (non-breaking change which adds functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [X ] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [X ] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [X ] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded automated accessibility (WCAG) coverage for the Explore → Pathfinding flow.
  * Navigate directly to the Pathfinding tab and verify the Start Node prompt and Start/Destination node behaviors, including keyboard focus handling (Escape).
  * Confirm swap and filter controls enable after selecting both nodes.
  * Add page- and dialog-scoped accessibility checks for the “Path Edge Filtering” dialog, including default permission states, clearing selections, filtering via search, and the no-matching-results experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->