### PR TITLE
fix: adjust tooltip z-index to fix hidden node labels in Explore search/pathfinding - BED-9077

### DIFF
--- a/packages/javascript/doodle-ui/src/components/Tooltip/Tooltip.tsx
+++ b/packages/javascript/doodle-ui/src/components/Tooltip/Tooltip.tsx
@@ -78,7 +78,7 @@ const TooltipContent = React.forwardRef<React.ElementRef<typeof TooltipPrimitive
                 sideOffset={sideOffset}
                 className={cn(
                     'TooltipContent',
-                    'z-50 overflow-hidden rounded-md border bg-neutral-light-2 px-3 py-1.5 text-xs text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+                    'z-[1500] overflow-hidden rounded-md border bg-neutral-light-2 px-3 py-1.5 text-xs text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
                     className,
                     widthOptions[contentWidth]
                 )}


### PR DESCRIPTION
Hovering over a node kind icon in search or pathfinding rendered the label underneath the results list instead of over it. This is because TooltipContent used z-50, which sits below the app's overlay layers. the Explore search dropdown alone uses z-index 1300. 

Proposed fix changes this to z-[1500], matching the other floating content in doodle-ui (Select content, DatePicker popover, Dialog content).

## Description

Single file, one line modification, change z-50 to z-[1500]

## Motivation and Context

Resolves BED-9077

*Why is this change required? What problem does it solve?*

## How Has This Been Tested?

Tested locally in CE. Search for a node in Explore, hover over the node icon, you should see a tooltip/label for the node type. 

## Screenshots (optional):
Before: 
<img width="442" height="268" alt="image" src="https://github.com/user-attachments/assets/7ff4ea95-822c-4e43-ac65-30ac60ae4d71" />


After: 
<img width="482" height="223" alt="image" src="https://github.com/user-attachments/assets/efafe5f1-fc0b-496c-8ddd-ba02967c11a7" />

## Types of changes


- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x ] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tooltip visibility by ensuring tooltips appear above other interface elements when overlapping content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->