### PR TITLE
fix: respond with source kind only as fallback BED-9059

### DIFF
--- a/cmd/api/src/api/v2/search_internal_test.go
+++ b/cmd/api/src/api/v2/search_internal_test.go
@@ -122,7 +122,7 @@ func Test_filterAndFormatSearchResults(t *testing.T) {
 		}
 		primaryDisplayKinds = make(graphschema.PrimaryDisplayKinds)
 	)
-	primaryDisplayKinds.Add("Person", "person-half-dress", "ff91af", graphschema.DisplayNodeTypeFontAwesome)
+	primaryDisplayKinds.Add("Person", "person-half-dress", "ff91af", graphschema.DisplayNodeTypeFontAwesome, false)
 
 	actual := filterAndFormatSearchResults(input, nil, primaryDisplayKinds)
 
@@ -147,7 +147,7 @@ func Test_filterAndFormatSearchResults_default(t *testing.T) {
 
 		primaryDisplayKinds = make(graphschema.PrimaryDisplayKinds)
 	)
-	primaryDisplayKinds.Add("Person", "person-half-dress", "ff91af", graphschema.DisplayNodeTypeFontAwesome)
+	primaryDisplayKinds.Add("Person", "person-half-dress", "ff91af", graphschema.DisplayNodeTypeFontAwesome, false)
 
 	actual := filterAndFormatSearchResults(input, nil, primaryDisplayKinds)
 
@@ -169,7 +169,7 @@ func Test_filterAndFormatSearchResults_includeOpenGraphNodes(t *testing.T) {
 		}
 		primaryDisplayKinds = make(graphschema.PrimaryDisplayKinds)
 	)
-	primaryDisplayKinds.Add("CustomKind", "person-half-dress", "ff91af", graphschema.DisplayNodeTypeFontAwesome)
+	primaryDisplayKinds.Add("CustomKind", "person-half-dress", "ff91af", graphschema.DisplayNodeTypeFontAwesome, false)
 
 	actual := filterAndFormatSearchResults(input, nil, primaryDisplayKinds)
 
@@ -205,7 +205,7 @@ func Test_filterAndFormatSearchResults_filterEnvironments(t *testing.T) {
 
 		primaryDisplayKinds = make(graphschema.PrimaryDisplayKinds)
 	)
-	primaryDisplayKinds.Add("Person", "person-half-dress", "ff91af", graphschema.DisplayNodeTypeFontAwesome)
+	primaryDisplayKinds.Add("Person", "person-half-dress", "ff91af", graphschema.DisplayNodeTypeFontAwesome, false)
 
 	actual := filterAndFormatSearchResults(input, []string{"54321"}, primaryDisplayKinds)
 
@@ -246,7 +246,7 @@ func Test_filterAndFormatSearchResults_filterEnvironmentsEmpty(t *testing.T) {
 
 		primaryDisplayKinds = make(graphschema.PrimaryDisplayKinds)
 	)
-	primaryDisplayKinds.Add("Person", "person-half-dress", "ff91af", graphschema.DisplayNodeTypeFontAwesome)
+	primaryDisplayKinds.Add("Person", "person-half-dress", "ff91af", graphschema.DisplayNodeTypeFontAwesome, false)
 
 	actual := filterAndFormatSearchResults(input, []string{}, primaryDisplayKinds)
 
@@ -280,7 +280,7 @@ func Test_filterAndFormatSearchResults_filterEnvironments_domainSIDFail(t *testi
 		input               = []*graph.Node{&inputNodeProp1, &inputNodeProp2, &inputNodeProp3}
 		primaryDisplayKinds = make(graphschema.PrimaryDisplayKinds)
 	)
-	primaryDisplayKinds.Add("Person", "person-half-dress", "ff91af", graphschema.DisplayNodeTypeFontAwesome)
+	primaryDisplayKinds.Add("Person", "person-half-dress", "ff91af", graphschema.DisplayNodeTypeFontAwesome, false)
 
 	result := filterAndFormatSearchResults(input, []string{"54321"}, primaryDisplayKinds)
 	require.Len(t, result, 0)
@@ -314,7 +314,7 @@ func Test_filterAndFormatSearchResults_filterEnvironments_tenantIDFail(t *testin
 
 		primaryDisplayKinds = make(graphschema.PrimaryDisplayKinds)
 	)
-	primaryDisplayKinds.Add("Person", "person-half-dress", "ff91af", graphschema.DisplayNodeTypeFontAwesome)
+	primaryDisplayKinds.Add("Person", "person-half-dress", "ff91af", graphschema.DisplayNodeTypeFontAwesome, false)
 
 	result := filterAndFormatSearchResults(input, []string{"azure12345"}, primaryDisplayKinds)
 	require.Len(t, result, 0)
@@ -348,7 +348,7 @@ func Test_filterAndFormatSearchResults_filterEnvironmentsOG(t *testing.T) {
 
 		primaryDisplayKinds = make(graphschema.PrimaryDisplayKinds)
 	)
-	primaryDisplayKinds.Add("Person", "person-half-dress", "ff91af", graphschema.DisplayNodeTypeFontAwesome)
+	primaryDisplayKinds.Add("Person", "person-half-dress", "ff91af", graphschema.DisplayNodeTypeFontAwesome, false)
 
 	actual := filterAndFormatSearchResults(input, []string{"og-12345"}, primaryDisplayKinds)
 

--- a/cmd/api/src/database/graphschema.go
+++ b/cmd/api/src/database/graphschema.go
@@ -1366,23 +1366,34 @@ func (s *BloodhoundDB) DeletePrincipalKind(ctx context.Context, environmentId in
 // GetPrimaryDisplayKinds - returns a map of all node kinds that are display kinds. custom_node_kinds is the single source
 // of truth for display node kinds. Schema-backed display kinds are mirrored there on extension upsert, and schemaless kinds encountered
 // during ingest are also upserted.
+//
+// Source kinds (from the source_kinds registry, e.g. Base, AZBase, or an OpenGraph source kind like GithubBase) are also
+// included in the map and flagged with IsSourceKind. This allows PrimaryDisplayKind to generically treat any source kind as
+// a base/fallback kind rather than relying on hardcoded knowledge of the built-in AD and Azure base kinds.
 func (s *BloodhoundDB) GetPrimaryDisplayKinds(ctx context.Context) (graphschema.PrimaryDisplayKinds, error) {
+	var (
+		primaryDisplayKinds = make(graphschema.PrimaryDisplayKinds)
+		isSourceKind        = false
+	)
+
 	if customNodeKinds, err := s.GetCustomNodeKinds(ctx); err != nil {
 		return nil, err
 	} else {
-		var primaryDisplayKinds = make(graphschema.PrimaryDisplayKinds)
 		for _, customNodeKind := range customNodeKinds {
-			primaryDisplayKinds[graph.StringKind(customNodeKind.KindName)] = graphschema.DisplayKind{
-				Name: customNodeKind.KindName,
-				Icon: graphschema.DisplayNodeIcon{
-					Name:  customNodeKind.Config.Icon.Name,
-					Type:  customNodeKind.Config.Icon.Type,
-					Color: customNodeKind.Config.Icon.Color,
-				},
-			}
+			primaryDisplayKinds.Add(customNodeKind.KindName, customNodeKind.Config.Icon.Name, customNodeKind.Config.Icon.Color, customNodeKind.Config.Icon.Type, isSourceKind)
 		}
-		return primaryDisplayKinds, nil
 	}
+
+	if sourceKinds, err := s.GetSourceKinds(ctx); err != nil {
+		return nil, err
+	} else {
+		isSourceKind = true
+		for _, sourceKind := range sourceKinds {
+			primaryDisplayKinds.Add(sourceKind.Name, "", "", "", isSourceKind)
+		}
+	}
+
+	return primaryDisplayKinds, nil
 }
 
 // entity panel vars

--- a/packages/go/graphschema/primarykind.go
+++ b/packages/go/graphschema/primarykind.go
@@ -51,6 +51,12 @@ func buildValidKinds() PrimaryDisplayKinds {
 		}
 	}
 
+	// ad.Entity ("Base") and azure.Entity ("AZBase") are the built-in source kinds. They are seeded in the
+	// source_kinds table and represent the origin/category of a node rather than a primary display kind.
+	for _, sourceKind := range []graph.Kind{ad.Entity, azure.Entity} {
+		validKinds[sourceKind] = DisplayKind{IsSourceKind: true}
+	}
+
 	return validKinds
 }
 
@@ -69,18 +75,38 @@ type DisplayNodeIcon struct {
 type DisplayKind struct {
 	Name string
 	Icon DisplayNodeIcon
+	// IsSourceKind marks a kind as a source/base kind (e.g. ad.Entity, azure.Entity, or an OpenGraph source
+	// kind such as GithubBase). Source kinds represent the origin of a node and are only used as a fallback
+	// display kind when no other primary display kind is present.
+	IsSourceKind bool
 }
 
 type PrimaryDisplayKinds map[graph.Kind]DisplayKind
 
-func (s PrimaryDisplayKinds) Add(kindName, iconName, iconColor string, iconType DisplayNodeType) {
-	s[graph.StringKind(kindName)] = DisplayKind{
+// Add - registers a display kind under the given kind name, keyed by its graph.StringKind form. It builds a
+// DisplayKind from the provided name, icon attributes (name, color, and type), and the isSourceKind flag, which
+// marks the kind as a source/base kind used only as a fallback display kind.
+func (s PrimaryDisplayKinds) Add(kindName, iconName, iconColor string, iconType DisplayNodeType, isSourceKind bool) {
+	var graphKind = graph.StringKind(kindName)
+
+	if displayKind, exists := s[graphKind]; exists {
+		iconName = displayKind.Icon.Name
+		iconColor = displayKind.Icon.Color
+		iconType = displayKind.Icon.Type
+
+		if displayKind.IsSourceKind {
+			isSourceKind = displayKind.IsSourceKind
+		}
+	}
+
+	s[graphKind] = DisplayKind{
 		Name: kindName,
 		Icon: DisplayNodeIcon{
 			Type:  iconType,
 			Name:  iconName,
 			Color: iconColor,
 		},
+		IsSourceKind: isSourceKind,
 	}
 }
 
@@ -89,9 +115,10 @@ func (s PrimaryDisplayKinds) Add(kindName, iconName, iconColor string, iconType 
 // It accepts a primaryDisplayKinds map[graph.Kind]DisplayKind that contains primary display kinds.
 // This allows devs to validate kinds against an OpenGraph extension's kinds.
 // It will return the first meta kind or the first primary kind it finds. During processing, if
-// a source kind is found it will set the base kind to the source kind. If a primary/meta kind is not
-// found, it will return the base kind which will be the "unknown" kind if no known base kinds are
-// present.
+// a source kind is found (any kind flagged with IsSourceKind, such as ad.Entity, azure.Entity, or an
+// OpenGraph source kind like GithubBase) it will set the base kind to that source kind. If a primary/meta
+// kind is not found, it will return the base kind which will be the "unknown" kind if no known base kinds
+// are present.
 func PrimaryDisplayKind(primaryDisplayKinds PrimaryDisplayKinds, kinds graph.Kinds) graph.Kind {
 	var (
 		resultKind = UnknownKind
@@ -106,15 +133,20 @@ func PrimaryDisplayKind(primaryDisplayKinds PrimaryDisplayKinds, kinds graph.Kin
 		// If this is a BHE meta kind, return early
 		if kind.Is(metaKinds...) {
 			return Meta
-		} else if kind.Is(ad.Entity, azure.Entity) {
-			baseKind = kind
 		} else if kind.Is(ad.LocalGroup) {
-			// Allow ad.LocalGroup to overwrite NodeKindUnknown, but nothing else
+			// Allow ad.LocalGroup to overwrite NodeKindUnknown, but nothing else. This is checked before the
+			// generic display-kind lookup so that a higher-priority primary kind appearing later in the array
+			// still wins over ad.LocalGroup.
 			if resultKind == UnknownKind {
 				resultKind = kind
 			}
-		} else if _, ok := primaryDisplayKinds[kind]; ok {
-			return kind
+		} else if displayKind, ok := primaryDisplayKinds[kind]; ok {
+			if displayKind.IsSourceKind {
+				// Source/base kinds are only used as a fallback when no other primary kind is present
+				baseKind = kind
+			} else {
+				return kind
+			}
 		}
 	}
 

--- a/packages/go/graphschema/primarykind_test.go
+++ b/packages/go/graphschema/primarykind_test.go
@@ -58,4 +58,93 @@ func Test_PrimaryNodeKind(t *testing.T) {
 		}, graph.Kinds{graph.StringKind("Hero"), graph.StringKind("Villain")})
 		require.Equal(t, graph.StringKind("Hero"), primaryKind)
 	})
+
+	t.Run("returns open graph display kind over its source kind", func(t *testing.T) {
+		var (
+			dogparkEntity       = graph.StringKind("dogpark_Entity")
+			dogparkLargeDogArea = graph.StringKind("dogpark_LargeDogArea")
+		)
+
+		primaryKind := PrimaryDisplayKind(PrimaryDisplayKinds{
+			dogparkEntity:       DisplayKind{Name: "dogpark_Entity", IsSourceKind: true},
+			dogparkLargeDogArea: DisplayKind{Name: "dogpark_LargeDogArea"},
+		}, graph.Kinds{dogparkEntity, dogparkLargeDogArea})
+		require.Equal(t, dogparkLargeDogArea, primaryKind)
+	})
+
+	t.Run("falls back to open graph source kind when no display kind is present", func(t *testing.T) {
+		dogparkEntity := graph.StringKind("dogpark_Entity")
+
+		primaryKind := PrimaryDisplayKind(PrimaryDisplayKinds{
+			dogparkEntity: DisplayKind{Name: "dogpark_Entity", IsSourceKind: true},
+		}, graph.Kinds{dogparkEntity, graph.StringKind("dogpark_Squirrel")})
+		require.Equal(t, dogparkEntity, primaryKind)
+	})
+}
+
+func Test_PrimaryDisplayKinds_Add(t *testing.T) {
+	t.Run("adds a new display kind with its icon", func(t *testing.T) {
+		primaryDisplayKinds := make(PrimaryDisplayKinds)
+
+		primaryDisplayKinds.Add("dogpark_LargeDogArea", "dog", "blue", DisplayNodeTypeFontAwesome, false)
+
+		require.Equal(t, DisplayKind{
+			Name: "dogpark_LargeDogArea",
+			Icon: DisplayNodeIcon{
+				Type:  DisplayNodeTypeFontAwesome,
+				Name:  "dog",
+				Color: "blue",
+			},
+			IsSourceKind: false,
+		}, primaryDisplayKinds[graph.StringKind("dogpark_LargeDogArea")])
+	})
+
+	t.Run("adds a new source kind flagged with IsSourceKind", func(t *testing.T) {
+		primaryDisplayKinds := make(PrimaryDisplayKinds)
+
+		primaryDisplayKinds.Add("dogpark_Entity", "", "", "", true)
+
+		require.Equal(t, DisplayKind{
+			Name:         "dogpark_Entity",
+			IsSourceKind: true,
+		}, primaryDisplayKinds[graph.StringKind("dogpark_Entity")])
+	})
+
+	t.Run("adding an overlapping source kind after a custom kind preserves existing icon and updates isSourceKind", func(t *testing.T) {
+		primaryDisplayKinds := make(PrimaryDisplayKinds)
+
+		// A custom node kind is added first with its icon attributes.
+		primaryDisplayKinds.Add("dogpark_Entity", "dog", "blue", DisplayNodeTypeFontAwesome, false)
+		// A source kind with the same name is then added with empty icon attributes.
+		primaryDisplayKinds.Add("dogpark_Entity", "", "", "", true)
+
+		require.Equal(t, DisplayKind{
+			Name: "dogpark_Entity",
+			Icon: DisplayNodeIcon{
+				Type:  DisplayNodeTypeFontAwesome,
+				Name:  "dog",
+				Color: "blue",
+			},
+			IsSourceKind: true,
+		}, primaryDisplayKinds[graph.StringKind("dogpark_Entity")])
+	})
+
+	t.Run("adding an overlapping custom kind after a source kind preserves existing icon and maintains the original isSourceKind value", func(t *testing.T) {
+		primaryDisplayKinds := make(PrimaryDisplayKinds)
+
+		// A source kind is added first with an icon.
+		primaryDisplayKinds.Add("dogpark_Entity", "dog", "blue", DisplayNodeTypeFontAwesome, true)
+		// A custom node kind with the same name is then added with empty icon attributes.
+		primaryDisplayKinds.Add("dogpark_Entity", "", "", "", false)
+
+		require.Equal(t, DisplayKind{
+			Name: "dogpark_Entity",
+			Icon: DisplayNodeIcon{
+				Type:  DisplayNodeTypeFontAwesome,
+				Name:  "dog",
+				Color: "blue",
+			},
+			IsSourceKind: true,
+		}, primaryDisplayKinds[graph.StringKind("dogpark_Entity")])
+	})
 }


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Fixes kind resolution in some API responses.

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-9059

Primary kind resolution was resolving to source kinds when a more specific kind was available. Source kinds lack icon information and so the UI is unable to render the appropriate display with the information provided in responses where only one kind is returned. Primary kind resolution is extended to handle source kinds based on the DB values instead of just the code based constants for AD an Azure.

## How Has This Been Tested?

Unit tests added. Local check

## Screenshots (optional):

<img width="1496" height="642" alt="image" src="https://github.com/user-attachments/assets/10adffd8-9923-4acf-ad38-169aec26d979" />


## Types of changes

<!-- Please remove any items that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Expanded primary display-kind resolution to include source kinds alongside custom kinds.
  - Added explicit identification of source/base kinds and improved how primary display kinds are selected.
  - Updated open graph kind handling to prefer matching display kinds, with a fallback to source kinds when no display kind exists.

- **Bug Fixes**
  - Improved primary display-kind map initialization and augmentation to ensure source kinds are always incorporated.

- **Tests**
  - Added coverage for open graph precedence and fallback behavior.
  - Updated test setups to reflect the new source-kind flag behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->