### PR TITLE
fix: user input spread as props page crash BED-9076

### DIFF
--- a/packages/javascript/bh-shared-ui/src/components/EntityInfo/EntityObjectInformation.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/EntityInfo/EntityObjectInformation.test.tsx
@@ -61,24 +61,26 @@ describe('EntityObjectInformation', () => {
     it('does not throw a React useRef error when a property is named "ref"', async () => {
         const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
 
-        const selectedNode: NodeDetails = {
-            node_id: 2,
-            kinds: [{ name: ActiveDirectoryNodeKind.User, node_kind_id: 1 }],
-            properties: { objectid: 'ref-object-id', ref: 'a-property-named-ref' },
-        };
+        try {
+            const selectedNode: NodeDetails = {
+                node_id: 2,
+                kinds: [{ name: ActiveDirectoryNodeKind.User, node_kind_id: 1 }],
+                properties: { objectid: 'ref-object-id', ref: 'a-property-named-ref' },
+            };
 
-        expect(() => render(<EntityObjectInformationWithProvider selectedNode={selectedNode} />)).not.toThrow();
+            expect(() => render(<EntityObjectInformationWithProvider selectedNode={selectedNode} />)).not.toThrow();
 
-        // The value of the "ref" property should render as a normal field value.
-        expect(await screen.findByText('a-property-named-ref')).toBeInTheDocument();
+            // The value of the "ref" property should render as a normal field value.
+            expect(await screen.findByText('a-property-named-ref')).toBeInTheDocument();
 
-        // React logs ref-related warnings/errors (e.g. useRef, forwardRef, "Function
-        // components cannot be given refs") through console.error. Ensure none occurred.
-        const refRelatedErrors = consoleErrorSpy.mock.calls.filter((args) =>
-            args.some((arg) => typeof arg === 'string' && /useRef|forwardRef|given refs/i.test(arg))
-        );
-        expect(refRelatedErrors).toHaveLength(0);
-
-        consoleErrorSpy.mockRestore();
+            // React logs ref-related warnings/errors (e.g. useRef, forwardRef, "Function
+            // components cannot be given refs") through console.error. Ensure none occurred.
+            const refRelatedErrors = consoleErrorSpy.mock.calls.filter((args) =>
+                args.some((arg) => typeof arg === 'string' && /useRef|forwardRef|given refs/i.test(arg))
+            );
+            expect(refRelatedErrors).toHaveLength(0);
+        } finally {
+            consoleErrorSpy.mockRestore();
+        }
     });
 });

--- a/packages/javascript/bh-shared-ui/src/components/EntityInfo/EntityObjectInformation.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/EntityInfo/EntityObjectInformation.test.tsx
@@ -1,0 +1,84 @@
+// Copyright 2026 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { NodeDetails } from 'js-client-library';
+import { rest } from 'msw';
+import { setupServer } from 'msw/node';
+import { ActiveDirectoryNodeKind } from '../../graphSchema';
+import { mockSourceKindsHandler } from '../../mocks';
+import { render, screen } from '../../test-utils';
+import { ObjectInfoPanelContextProvider } from '../../views';
+import EntityObjectInformation from './EntityObjectInformation';
+
+const server = setupServer(
+    rest.get('/api/v2/features', (_req, res, ctx) => {
+        return res(ctx.json({ data: [] }));
+    }),
+    rest.get('/api/v2/asset-group-tags', (_req, res, ctx) => {
+        return res(ctx.json({ data: { tags: [] } }));
+    }),
+    mockSourceKindsHandler()
+);
+
+const EntityObjectInformationWithProvider = ({ selectedNode }: { selectedNode: NodeDetails }) => (
+    <ObjectInfoPanelContextProvider>
+        <EntityObjectInformation selectedNode={selectedNode} />
+    </ObjectInfoPanelContextProvider>
+);
+
+beforeAll(() => server.listen());
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+describe('EntityObjectInformation', () => {
+    it('renders the Object Information section and node properties', async () => {
+        const selectedNode: NodeDetails = {
+            node_id: 1,
+            kinds: [{ name: ActiveDirectoryNodeKind.User, node_kind_id: 1 }],
+            properties: { objectid: 'test-object-id', description: 'a test description' },
+        };
+
+        render(<EntityObjectInformationWithProvider selectedNode={selectedNode} />);
+
+        expect(await screen.findByText('Object Information')).toBeInTheDocument();
+        expect(screen.getByText('test-object-id')).toBeInTheDocument();
+        expect(screen.getByText('a test description')).toBeInTheDocument();
+    });
+
+    it('does not throw a React useRef error when a property is named "ref"', async () => {
+        const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+        const selectedNode: NodeDetails = {
+            node_id: 2,
+            kinds: [{ name: ActiveDirectoryNodeKind.User, node_kind_id: 1 }],
+            properties: { objectid: 'ref-object-id', ref: 'a-property-named-ref' },
+        };
+
+        expect(() => render(<EntityObjectInformationWithProvider selectedNode={selectedNode} />)).not.toThrow();
+
+        // The value of the "ref" property should render as a normal field value.
+        expect(await screen.findByText('a-property-named-ref')).toBeInTheDocument();
+
+        // React logs ref-related warnings/errors (e.g. useRef, forwardRef, "Function
+        // components cannot be given refs") through console.error. Ensure none occurred.
+        const refRelatedErrors = consoleErrorSpy.mock.calls.filter((args) =>
+            args.some((arg) => typeof arg === 'string' && /useRef|forwardRef|given refs/i.test(arg))
+        );
+        expect(refRelatedErrors).toHaveLength(0);
+
+        consoleErrorSpy.mockRestore();
+    });
+});

--- a/packages/javascript/bh-shared-ui/src/components/EntityInfo/EntityObjectInformation.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/EntityInfo/EntityObjectInformation.tsx
@@ -61,9 +61,9 @@ export default function EntityObjectInformation({ selectedNode }: EntityObjectIn
         <EntityInfoCollapsibleSection onChange={handleOnChange} isExpanded={isObjectInfoPanelOpen} label={sectionLabel}>
             <FieldsContainer>
                 <BasicObjectInfoFields
-                    nodeType={primaryKind}
+                    properties={selectedNode.properties}
                     handleSourceNodeSelected={handleSourceNodeSelected}
-                    {...selectedNode.properties}
+                    nodeType={primaryKind}
                     zone={zoneName}
                 />
                 <ObjectInfoFields fields={formattedObjectFields} />

--- a/packages/javascript/bh-shared-ui/src/views/Explore/BasicObjectInfoFields.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/Explore/BasicObjectInfoFields.tsx
@@ -22,18 +22,20 @@ import { SearchValue } from './ExploreSearch/types';
 import { Field } from './fragments';
 
 interface BasicObjectInfoFieldsProps {
-    zone?: string;
-    displayname?: string;
-    grouplinkid?: string;
+    properties: Record<string, any> & {
+        displayname?: string;
+        grouplinkid?: string;
+        isOwnedObject?: boolean;
+        isTierZero?: boolean;
+        name?: string;
+        noderesourcegroupid?: string;
+        objectid?: string;
+        service_principal_id?: string;
+        federatedidentitycredentialappid?: string;
+    };
     handleSourceNodeSelected?: (sourceNode: SearchValue) => void;
-    isOwnedObject?: boolean;
-    isTierZero?: boolean;
-    name?: string;
-    noderesourcegroupid?: string;
     nodeType?: string;
-    objectid?: string;
-    service_principal_id?: string;
-    federatedidentitycredentialappid?: string;
+    zone?: string;
 }
 
 const RelatedKindField = (
@@ -73,20 +75,26 @@ const basicObjectFields = [
     CommonKindProperties.ObjectID,
 ] satisfies (KnownNodeProperties | CommonKindProperties | 'zone')[];
 
-export const BasicObjectInfoFields: React.FC<BasicObjectInfoFieldsProps> = (props): JSX.Element => {
+export const BasicObjectInfoFields: React.FC<BasicObjectInfoFieldsProps> = ({
+    properties: props,
+    handleSourceNodeSelected,
+    nodeType,
+    zone,
+}): JSX.Element => {
+    const fieldValues = { ...props, nodeType, zone };
     return (
         <>
             {basicObjectFields.map((field) => {
-                const value = props[field];
+                const value = fieldValues[field];
                 if (value === undefined) return null; // <Field /> doesn't support undefined values
 
                 return <Field key={field} label={`${formatPotentiallyUnknownLabel(field) ?? field}:`} value={value} />;
             })}
-            {props.handleSourceNodeSelected && (
+            {handleSourceNodeSelected && (
                 <>
                     {props.service_principal_id &&
                         RelatedKindField(
-                            props.handleSourceNodeSelected,
+                            handleSourceNodeSelected,
                             'Service Principal ID:',
                             AzureNodeKind.ServicePrincipal,
                             props.service_principal_id,
@@ -94,7 +102,7 @@ export const BasicObjectInfoFields: React.FC<BasicObjectInfoFieldsProps> = (prop
                         )}
                     {props.federatedidentitycredentialappid &&
                         RelatedKindField(
-                            props.handleSourceNodeSelected,
+                            handleSourceNodeSelected,
                             'Federated Identity Credential Application ID:',
                             AzureNodeKind.App,
                             props.federatedidentitycredentialappid,
@@ -102,7 +110,7 @@ export const BasicObjectInfoFields: React.FC<BasicObjectInfoFieldsProps> = (prop
                         )}
                     {props.noderesourcegroupid &&
                         RelatedKindField(
-                            props.handleSourceNodeSelected,
+                            handleSourceNodeSelected,
                             'Node Resource Group ID:',
                             AzureNodeKind.ResourceGroup,
                             props.noderesourcegroupid,
@@ -110,7 +118,7 @@ export const BasicObjectInfoFields: React.FC<BasicObjectInfoFieldsProps> = (prop
                         )}
                     {props.grouplinkid &&
                         RelatedKindField(
-                            props.handleSourceNodeSelected,
+                            handleSourceNodeSelected,
                             'Linked Group ID:',
                             ActiveDirectoryNodeKind.Group,
                             props.grouplinkid,


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Fixes an error being thrown due to user derived ref props as string values.

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-9076

Entity properties were being spread directly into a component to be used as props. The influx of new data sources and shapes has revealed this as a faulty and error prone approach as the UI would crash on a React error about passing a string based ref prop. The properties are now passed explicitly under a prop named `properties` which avoids the potential collision with any special react props.

## How Has This Been Tested?

Regression testing added. Local check

## Screenshots (optional):

<img width="840" height="856" alt="image" src="https://github.com/user-attachments/assets/3c401908-2b71-461f-96e8-b8f9c2e26714" />


## Types of changes

<!-- Please remove any items that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the Object Information panel to reliably display selected node property values, including properties literally named “ref.”
  * Prevented React ref-related warnings/errors when rendering properties with the name “ref.”

* **Tests**
  * Added React Testing Library coverage for the Object Information section and selected node properties.
  * Added a regression test ensuring “ref”-named properties render as normal text without React ref warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->