### PR TITLE
test(a11y): playwright coverage for explorer - cypher page - bed-8633 

### DIFF
--- a/cmd/ui/tests/a11y/explore-cypher.a11y.spec.ts
+++ b/cmd/ui/tests/a11y/explore-cypher.a11y.spec.ts
@@ -1,0 +1,1243 @@
+// Copyright 2026 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { expect, expectNoAccessibilityViolations, test } from '../fixtures';
+
+test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
+    test.beforeEach(async ({ page }) => {
+        await page.goto('/ui/explore');
+
+        const cypherTab = page.getByRole('tab', { name: 'Cypher' });
+        await cypherTab.click();
+        await expect(cypherTab).toHaveAttribute('aria-selected', 'true');
+    });
+
+    test('Empty query', async ({ page, makeAxeBuilder }, testInfo) => {
+        const cypherEditor = page.getByRole('textbox', {
+            name: 'Cypher Editor',
+        });
+
+        await expect(cypherEditor).toBeVisible();
+        await expect(cypherEditor).toHaveAttribute('contenteditable', 'true');
+
+        const results = await makeAxeBuilder().include('#content-wrapper').analyze();
+
+        await expectNoAccessibilityViolations(testInfo, results, { page });
+    });
+
+    test('With full query', async ({ page, makeAxeBuilder }, testInfo) => {
+        const query = 'MATCH (n) RETURN n LIMIT 10';
+        const cypherEditor = page.getByRole('textbox', {
+            name: 'Cypher Editor',
+        });
+
+        await expect(cypherEditor).toBeVisible();
+        await expect(cypherEditor).toHaveAttribute('contenteditable', 'true');
+
+        await cypherEditor.fill(query);
+        await expect(cypherEditor).toContainText(query);
+
+        const results = await makeAxeBuilder().include('#content-wrapper').analyze();
+
+        await expectNoAccessibilityViolations(testInfo, results, { page });
+    });
+
+    test('Tag Results to Zone dialog', async ({ page, makeAxeBuilder }, testInfo) => {
+        const query = 'MATCH (n) RETURN n LIMIT 10';
+        const cypherEditor = page.getByRole('textbox', {
+            name: 'Cypher Editor',
+        });
+
+        await expect(cypherEditor).toBeVisible();
+        await expect(cypherEditor).toHaveAttribute('contenteditable', 'true');
+
+        await cypherEditor.fill(query);
+        await expect(cypherEditor).toContainText(query);
+
+        const tagButton = page.getByRole('button', { name: 'Tag' });
+        await expect(tagButton).toBeVisible();
+        await expect(tagButton).toBeEnabled();
+        await tagButton.click();
+
+        await page.getByRole('button', { name: 'Zone' }).click();
+
+        const dialog = page.getByRole('dialog', {
+            name: 'Tag Results to Zone',
+        });
+        await expect(dialog).toBeVisible();
+
+        const selectZoneControl = dialog.getByRole('combobox');
+        const cancelButton = dialog.getByRole('button', { name: 'Cancel' });
+        const continueButton = dialog.getByRole('button', {
+            name: 'Continue',
+        });
+
+        await expect(selectZoneControl).toBeVisible();
+        await expect(cancelButton).toBeVisible();
+        await expect(continueButton).toBeVisible();
+        await expect(continueButton).toBeDisabled();
+
+        const results = await makeAxeBuilder().include('#content-wrapper').analyze();
+
+        await expectNoAccessibilityViolations(testInfo, results, { page });
+    });
+
+    test('Tag Results to Label dialog', async ({ page, makeAxeBuilder }, testInfo) => {
+        const query = 'MATCH (n) RETURN n LIMIT 10';
+        const cypherEditor = page.getByRole('textbox', {
+            name: 'Cypher Editor',
+        });
+
+        await expect(cypherEditor).toBeVisible();
+        await expect(cypherEditor).toHaveAttribute('contenteditable', 'true');
+
+        await cypherEditor.fill(query);
+        await expect(cypherEditor).toContainText(query);
+
+        const tagButton = page.getByRole('button', { name: 'Tag' });
+        await expect(tagButton).toBeVisible();
+        await expect(tagButton).toBeEnabled();
+        await tagButton.click();
+
+        await page
+            .getByRole('button', {
+                name: 'Label',
+                exact: true,
+            })
+            .click();
+        const dialog = page.getByRole('dialog', {
+            name: 'Tag Results to Label',
+        });
+        await expect(dialog).toBeVisible();
+
+        const selectLabelControl = dialog.getByRole('combobox');
+        const cancelButton = dialog.getByRole('button', { name: 'Cancel' });
+        const continueButton = dialog.getByRole('button', {
+            name: 'Continue',
+        });
+
+        await expect(selectLabelControl).toBeVisible();
+        await expect(cancelButton).toBeVisible();
+        await expect(continueButton).toBeVisible();
+        await expect(continueButton).toBeDisabled();
+
+        const results = await makeAxeBuilder().include('#content-wrapper').analyze();
+
+        await expectNoAccessibilityViolations(testInfo, results, { page });
+    });
+
+    test('Save Query dialog', async ({ page, makeAxeBuilder }, testInfo) => {
+        const query = 'MATCH (n) RETURN n LIMIT 10';
+        const cypherEditor = page.getByRole('textbox', {
+            name: 'Cypher Editor',
+        });
+
+        await expect(cypherEditor).toBeVisible();
+        await expect(cypherEditor).toHaveAttribute('contenteditable', 'true');
+
+        await cypherEditor.fill(query);
+        await expect(cypherEditor).toContainText(query);
+
+        const saveQueryButton = page.getByRole('button', {
+            name: 'Save query',
+            exact: true,
+        });
+
+        await expect(saveQueryButton).toBeVisible();
+        await expect(saveQueryButton).toBeEnabled();
+        await saveQueryButton.click();
+
+        const dialog = page.getByTestId('save-query-dialog');
+
+        await expect(dialog).toBeVisible();
+
+        const results = await makeAxeBuilder().include('#content-wrapper').analyze();
+
+        await expectNoAccessibilityViolations(testInfo, results, { page });
+    });
+
+    test('Save As New Query dialog', async ({ page, makeAxeBuilder }, testInfo) => {
+        const query = 'MATCH (n) RETURN n LIMIT 10';
+        const cypherEditor = page.getByRole('textbox', {
+            name: 'Cypher Editor',
+        });
+
+        await expect(cypherEditor).toBeVisible();
+        await expect(cypherEditor).toHaveAttribute('contenteditable', 'true');
+
+        await cypherEditor.fill(query);
+        await expect(cypherEditor).toContainText(query);
+
+        const saveQueryButton = page.getByRole('button', {
+            name: 'Save query',
+            exact: true,
+        });
+        const saveQueryOptionsButton = page.getByRole('button', {
+            name: 'Show save query options',
+            exact: true,
+        });
+
+        await expect(saveQueryButton).toBeVisible();
+        await expect(saveQueryButton).toBeEnabled();
+        await expect(saveQueryOptionsButton).toBeVisible();
+        await expect(saveQueryOptionsButton).toBeEnabled();
+        await saveQueryOptionsButton.click();
+
+        const saveAsButton = page.getByRole('button', {
+            name: 'Save As',
+            exact: true,
+        });
+
+        await expect(saveAsButton).toBeVisible();
+        await saveAsButton.click();
+
+        const dialog = page.getByRole('dialog', {
+            name: 'Save As New Query',
+        });
+
+        await expect(dialog).toBeVisible();
+
+        const results = await makeAxeBuilder().include('#content-wrapper').analyze();
+
+        await expectNoAccessibilityViolations(testInfo, results, { page });
+    });
+
+    test('Saved Queries - Search with no results', async ({ page, makeAxeBuilder }, testInfo) => {
+        const savedQueriesButton = page.getByRole('button', {
+            name: 'Saved Queries',
+            exact: true,
+        });
+
+        await expect(savedQueriesButton).toBeVisible();
+        await expect(savedQueriesButton).toBeEnabled();
+        await savedQueriesButton.click();
+
+        const searchTextbox = page.getByRole('textbox', {
+            name: 'Search',
+            exact: true,
+        });
+        const searchTerm = 'a11y-no-results-9f7c2e1b';
+
+        await expect(searchTextbox).toBeVisible();
+        await searchTextbox.fill(searchTerm);
+        await expect(searchTextbox).toHaveValue(searchTerm);
+
+        const noResultsHeading = page.getByRole('heading', {
+            name: 'No Results',
+            exact: true,
+        });
+        await expect(noResultsHeading).toBeVisible();
+
+        const results = await makeAxeBuilder().include('#content-wrapper').analyze();
+
+        await expectNoAccessibilityViolations(testInfo, results, { page });
+    });
+
+    test('Saved Queries - Import dialog', async ({ page, makeAxeBuilder }, testInfo) => {
+        const savedQueriesButton = page.getByRole('button', {
+            name: 'Saved Queries',
+            exact: true,
+        });
+
+        await expect(savedQueriesButton).toBeVisible();
+        await expect(savedQueriesButton).toBeEnabled();
+        await savedQueriesButton.click();
+
+        const importButton = page.getByRole('button', {
+            name: 'Import',
+            exact: true,
+        });
+
+        await expect(importButton).toBeVisible();
+        await expect(importButton).toBeEnabled();
+        await importButton.click();
+
+        const dialog = page.getByRole('dialog');
+
+        await expect(dialog).toBeVisible();
+
+        const results = await makeAxeBuilder().include('#content-wrapper').analyze();
+
+        await expectNoAccessibilityViolations(testInfo, results, { page });
+    });
+
+    test('Saved Queries - Export saved query', async ({ page, makeAxeBuilder }, testInfo) => {
+        const query = 'MATCH (n) RETURN n LIMIT 1';
+        const queryName = `a11y-export-${testInfo.project.name}-${Date.now()}`;
+        const savedQueryAccessibleName = `Run pre-built search query: ${queryName}`;
+        let testError: unknown;
+        let cleanupError: unknown;
+
+        try {
+            const cypherEditor = page.getByRole('textbox', {
+                name: 'Cypher Editor',
+            });
+
+            await expect(cypherEditor).toBeVisible();
+            await expect(cypherEditor).toHaveAttribute('contenteditable', 'true');
+
+            await cypherEditor.fill(query);
+            await expect(cypherEditor).toContainText(query);
+
+            const saveQueryButton = page.getByRole('button', {
+                name: 'Save query',
+                exact: true,
+            });
+
+            await expect(saveQueryButton).toBeVisible();
+            await expect(saveQueryButton).toBeEnabled();
+            await saveQueryButton.click();
+
+            const saveQueryDialog = page.getByTestId('save-query-dialog');
+            const queryNameTextbox = saveQueryDialog.getByRole('textbox', {
+                name: 'Query Name',
+                exact: true,
+            });
+            const saveButton = saveQueryDialog.getByRole('button', {
+                name: 'Save',
+                exact: true,
+            });
+
+            await expect(saveQueryDialog).toBeVisible();
+            await queryNameTextbox.fill(queryName);
+            await expect(saveButton).toBeEnabled();
+            await saveButton.click();
+            await expect(saveQueryDialog).toBeHidden();
+            await page.goto('/ui/explore');
+
+            const cypherTab = page.getByRole('tab', {
+                name: 'Cypher',
+            });
+
+            await cypherTab.click();
+            await expect(cypherTab).toHaveAttribute('aria-selected', 'true');
+
+            const savedQueriesButton = page.getByRole('button', {
+                name: 'Saved Queries',
+                exact: true,
+            });
+
+            await expect(savedQueriesButton).toBeVisible();
+            await expect(savedQueriesButton).toBeEnabled();
+            await savedQueriesButton.click();
+
+            const searchTextbox = page.getByRole('textbox', {
+                name: 'Search',
+                exact: true,
+            });
+
+            await expect(searchTextbox).toBeVisible();
+            await searchTextbox.fill(queryName);
+
+            const savedQueryButton = page.getByRole('button', {
+                name: savedQueryAccessibleName,
+                exact: true,
+            });
+
+            await expect(savedQueryButton).toBeVisible();
+
+            const autoRunCheckbox = page.getByRole('checkbox', {
+                name: 'Auto-run selected query',
+                exact: true,
+            });
+
+            await expect(autoRunCheckbox).toBeVisible();
+
+            if (await autoRunCheckbox.isChecked()) {
+                await autoRunCheckbox.uncheck();
+            }
+
+            await expect(autoRunCheckbox).not.toBeChecked();
+
+            await savedQueryButton.click();
+
+            const results = await makeAxeBuilder().include('#content-wrapper').analyze();
+
+            await expectNoAccessibilityViolations(testInfo, results, { page });
+
+            const exportButtons = page.getByRole('button', {
+                name: 'Export',
+                exact: true,
+            });
+
+            await expect(exportButtons).toHaveCount(2);
+
+            const exportButton = exportButtons.first();
+
+            await expect(exportButton).toBeVisible();
+            await expect(exportButton).toBeEnabled();
+
+            const [download] = await Promise.all([page.waitForEvent('download'), exportButton.click()]);
+            expect(download.suggestedFilename()).toMatch(/\.json$/i);
+        } catch (error) {
+            testError = error;
+        } finally {
+            try {
+                await page.goto('/ui/explore');
+
+                const cypherTab = page.getByRole('tab', {
+                    name: 'Cypher',
+                });
+
+                await cypherTab.click();
+                await expect(cypherTab).toHaveAttribute('aria-selected', 'true');
+
+                const savedQueriesButton = page.getByRole('button', {
+                    name: 'Saved Queries',
+                    exact: true,
+                });
+
+                await expect(savedQueriesButton).toBeVisible();
+                await savedQueriesButton.click();
+
+                const searchTextbox = page.getByRole('textbox', {
+                    name: 'Search',
+                    exact: true,
+                });
+
+                await expect(searchTextbox).toBeVisible();
+                await searchTextbox.fill(queryName);
+
+                const savedQueryButton = page.getByRole('button', {
+                    name: savedQueryAccessibleName,
+                    exact: true,
+                });
+                const noResultsHeading = page.getByRole('heading', {
+                    name: 'No Results',
+                    exact: true,
+                });
+
+                await expect(savedQueryButton.or(noResultsHeading)).toBeVisible();
+
+                if (await savedQueryButton.isVisible()) {
+                    const actionMenuButton = page.getByRole('button', {
+                        name: 'Show saved query actions',
+                        exact: true,
+                    });
+
+                    await expect(actionMenuButton).toBeVisible();
+                    await actionMenuButton.click();
+
+                    const deleteButton = page.getByRole('button', {
+                        name: 'Delete',
+                        exact: true,
+                    });
+
+                    await expect(deleteButton).toBeVisible();
+                    await deleteButton.click();
+
+                    const deleteDialog = page.getByRole('dialog', {
+                        name: 'Delete Query',
+                        exact: true,
+                    });
+                    const confirmButton = deleteDialog.getByRole('button', {
+                        name: 'Confirm',
+                        exact: true,
+                    });
+
+                    await expect(deleteDialog).toBeVisible();
+                    await expect(confirmButton).toBeEnabled();
+                    await confirmButton.click();
+
+                    await expect(deleteDialog).toBeHidden();
+                    await expect(savedQueryButton).toHaveCount(0);
+                }
+            } catch (error) {
+                cleanupError = error;
+            }
+        }
+
+        if (testError !== undefined) {
+            throw testError;
+        }
+
+        if (cleanupError !== undefined) {
+            throw cleanupError;
+        }
+    });
+
+    test('Saved Queries - Filter by Platforms', async ({ page, makeAxeBuilder }, testInfo) => {
+        const savedQueriesButton = page.getByRole('button', {
+            name: 'Saved Queries',
+            exact: true,
+        });
+
+        await expect(savedQueriesButton).toBeVisible();
+        await expect(savedQueriesButton).toBeEnabled();
+        await savedQueriesButton.click();
+
+        const platformsFilter = page.getByRole('combobox', {
+            name: 'Platforms',
+            exact: true,
+        });
+
+        await expect(platformsFilter).toBeVisible();
+        await expect(platformsFilter).toBeEnabled();
+        await platformsFilter.click();
+
+        const activeDirectoryOption = page.getByRole('option', {
+            name: 'Active Directory',
+            exact: true,
+        });
+
+        await expect(activeDirectoryOption).toBeVisible();
+        await activeDirectoryOption.click();
+        const selectedPlatformsFilter = page.getByRole('combobox', {
+            name: /Active Directory/,
+        });
+
+        await expect(selectedPlatformsFilter).toBeVisible();
+        const results = await makeAxeBuilder().include('#content-wrapper').analyze();
+
+        await expectNoAccessibilityViolations(testInfo, results, { page });
+    });
+
+    test('Saved Queries - Filter by Categories', async ({ page, makeAxeBuilder }, testInfo) => {
+        const savedQueriesButton = page.getByRole('button', {
+            name: 'Saved Queries',
+            exact: true,
+        });
+
+        await expect(savedQueriesButton).toBeVisible();
+        await expect(savedQueriesButton).toBeEnabled();
+        await savedQueriesButton.click();
+
+        const categoriesFilter = page.getByRole('combobox', {
+            name: 'Categories',
+            exact: true,
+        });
+
+        await expect(categoriesFilter).toBeVisible();
+        await expect(categoriesFilter).toBeEnabled();
+        await categoriesFilter.click();
+
+        const domainInformationOption = page.getByRole('option', {
+            name: 'Domain Information',
+            exact: true,
+        });
+
+        await expect(domainInformationOption).toBeVisible();
+        await domainInformationOption.click();
+        const results = await makeAxeBuilder().include('#content-wrapper').analyze();
+
+        await expectNoAccessibilityViolations(testInfo, results, { page });
+    });
+
+    test('Saved Queries - Filter by Source', async ({ page, makeAxeBuilder }, testInfo) => {
+        const savedQueriesButton = page.getByRole('button', {
+            name: 'Saved Queries',
+            exact: true,
+        });
+
+        await expect(savedQueriesButton).toBeVisible();
+        await expect(savedQueriesButton).toBeEnabled();
+        await savedQueriesButton.click();
+
+        const sourceFilter = page.getByRole('combobox', {
+            name: 'Source',
+            exact: true,
+        });
+
+        await expect(sourceFilter).toBeVisible();
+        await expect(sourceFilter).toBeEnabled();
+        await sourceFilter.click();
+
+        const prebuiltOption = page.getByRole('option', {
+            name: 'Prebuilt',
+            exact: true,
+        });
+
+        await expect(prebuiltOption).toBeVisible();
+        await prebuiltOption.click();
+
+        const results = await makeAxeBuilder().include('#content-wrapper').analyze();
+
+        await expectNoAccessibilityViolations(testInfo, results, { page });
+    });
+
+    test('Saved Queries - Query dots menu', async ({ page, makeAxeBuilder }, testInfo) => {
+        const query = 'MATCH (n) RETURN n LIMIT 1';
+        const queryName = `a11y-dots-menu-${testInfo.project.name}-${Date.now()}`;
+        const savedQueryAccessibleName = `Run pre-built search query: ${queryName}`;
+        let testError: unknown;
+        let cleanupError: unknown;
+
+        try {
+            const cypherEditor = page.getByRole('textbox', {
+                name: 'Cypher Editor',
+            });
+
+            await expect(cypherEditor).toBeVisible();
+            await expect(cypherEditor).toHaveAttribute('contenteditable', 'true');
+
+            await cypherEditor.fill(query);
+            await expect(cypherEditor).toContainText(query);
+
+            const saveQueryButton = page.getByRole('button', {
+                name: 'Save query',
+                exact: true,
+            });
+
+            await expect(saveQueryButton).toBeVisible();
+            await expect(saveQueryButton).toBeEnabled();
+            await saveQueryButton.click();
+
+            const saveQueryDialog = page.getByTestId('save-query-dialog');
+            const queryNameTextbox = saveQueryDialog.getByRole('textbox', {
+                name: 'Query Name',
+                exact: true,
+            });
+            const saveButton = saveQueryDialog.getByRole('button', {
+                name: 'Save',
+                exact: true,
+            });
+
+            await expect(saveQueryDialog).toBeVisible();
+            await queryNameTextbox.fill(queryName);
+            await expect(saveButton).toBeEnabled();
+            await saveButton.click();
+            await expect(saveQueryDialog).toBeHidden();
+            await page.goto('/ui/explore');
+
+            const cypherTab = page.getByRole('tab', {
+                name: 'Cypher',
+            });
+
+            await cypherTab.click();
+            await expect(cypherTab).toHaveAttribute('aria-selected', 'true');
+
+            const savedQueriesButton = page.getByRole('button', {
+                name: 'Saved Queries',
+                exact: true,
+            });
+
+            await expect(savedQueriesButton).toBeVisible();
+            await expect(savedQueriesButton).toBeEnabled();
+            await savedQueriesButton.click();
+
+            const searchTextbox = page.getByRole('textbox', {
+                name: 'Search',
+                exact: true,
+            });
+
+            await expect(searchTextbox).toBeVisible();
+            await searchTextbox.fill(queryName);
+
+            const savedQueryButton = page.getByRole('button', {
+                name: savedQueryAccessibleName,
+                exact: true,
+            });
+
+            await expect(savedQueryButton).toBeVisible();
+
+            const autoRunCheckbox = page.getByRole('checkbox', {
+                name: 'Auto-run selected query',
+                exact: true,
+            });
+
+            await expect(autoRunCheckbox).toBeVisible();
+
+            if (await autoRunCheckbox.isChecked()) {
+                await autoRunCheckbox.uncheck();
+            }
+
+            await expect(autoRunCheckbox).not.toBeChecked();
+            await savedQueryButton.click();
+
+            const actionMenuButton = page.getByRole('button', {
+                name: 'Show saved query actions',
+                exact: true,
+            });
+
+            await expect(actionMenuButton).toBeVisible();
+            await expect(actionMenuButton).toBeEnabled();
+            await actionMenuButton.click();
+
+            const runButton = page.getByRole('button', {
+                name: 'Run',
+                exact: true,
+            });
+            const editShareButton = page.getByRole('button', {
+                name: 'Edit/Share',
+                exact: true,
+            });
+            const deleteButton = page.getByRole('button', {
+                name: 'Delete',
+                exact: true,
+            });
+
+            await expect(runButton).toBeVisible();
+            await expect(editShareButton).toBeVisible();
+            await expect(deleteButton).toBeVisible();
+
+            const results = await makeAxeBuilder()
+                .include('#content-wrapper')
+                .include('[data-testid="saved-query-action-menu"]')
+                .analyze();
+
+            await expectNoAccessibilityViolations(testInfo, results, { page });
+        } catch (error) {
+            testError = error;
+        } finally {
+            try {
+                await page.goto('/ui/explore');
+
+                const cypherTab = page.getByRole('tab', {
+                    name: 'Cypher',
+                });
+
+                await cypherTab.click();
+                await expect(cypherTab).toHaveAttribute('aria-selected', 'true');
+
+                const savedQueriesButton = page.getByRole('button', {
+                    name: 'Saved Queries',
+                    exact: true,
+                });
+
+                await expect(savedQueriesButton).toBeVisible();
+                await savedQueriesButton.click();
+
+                const searchTextbox = page.getByRole('textbox', {
+                    name: 'Search',
+                    exact: true,
+                });
+
+                await expect(searchTextbox).toBeVisible();
+                await searchTextbox.fill(queryName);
+
+                const savedQueryButton = page.getByRole('button', {
+                    name: savedQueryAccessibleName,
+                    exact: true,
+                });
+                const noResultsHeading = page.getByRole('heading', {
+                    name: 'No Results',
+                    exact: true,
+                });
+
+                await expect(savedQueryButton.or(noResultsHeading)).toBeVisible();
+
+                if (await savedQueryButton.isVisible()) {
+                    const actionMenuButton = page.getByRole('button', {
+                        name: 'Show saved query actions',
+                        exact: true,
+                    });
+
+                    await expect(actionMenuButton).toBeVisible();
+                    await actionMenuButton.click();
+
+                    const deleteButton = page.getByRole('button', {
+                        name: 'Delete',
+                        exact: true,
+                    });
+
+                    await expect(deleteButton).toBeVisible();
+                    await deleteButton.click();
+
+                    const deleteDialog = page.getByRole('dialog', {
+                        name: 'Delete Query',
+                        exact: true,
+                    });
+                    const confirmButton = deleteDialog.getByRole('button', {
+                        name: 'Confirm',
+                        exact: true,
+                    });
+
+                    await expect(deleteDialog).toBeVisible();
+                    await expect(confirmButton).toBeEnabled();
+                    await confirmButton.click();
+
+                    await expect(deleteDialog).toBeHidden();
+                    await expect(savedQueryButton).toHaveCount(0);
+                }
+            } catch (error) {
+                cleanupError = error;
+            }
+        }
+
+        if (testError !== undefined) {
+            throw testError;
+        }
+
+        if (cleanupError !== undefined) {
+            throw cleanupError;
+        }
+    });
+
+    test('Edit Saved Query dialog', async ({ page, makeAxeBuilder }, testInfo) => {
+        const query = 'MATCH (n) RETURN n LIMIT 1';
+        const queryName = `a11y-edit-dialog-${testInfo.project.name}-${Date.now()}`;
+        const savedQueryAccessibleName = `Run pre-built search query: ${queryName}`;
+        let testError: unknown;
+        let cleanupError: unknown;
+
+        try {
+            const cypherEditor = page.getByRole('textbox', {
+                name: 'Cypher Editor',
+            });
+
+            await expect(cypherEditor).toBeVisible();
+            await expect(cypherEditor).toHaveAttribute('contenteditable', 'true');
+
+            await cypherEditor.fill(query);
+            await expect(cypherEditor).toContainText(query);
+
+            const saveQueryButton = page.getByRole('button', {
+                name: 'Save query',
+                exact: true,
+            });
+
+            await expect(saveQueryButton).toBeVisible();
+            await expect(saveQueryButton).toBeEnabled();
+            await saveQueryButton.click();
+
+            const saveQueryDialog = page.getByTestId('save-query-dialog');
+            const queryNameTextbox = saveQueryDialog.getByRole('textbox', {
+                name: 'Query Name',
+                exact: true,
+            });
+            const saveButton = saveQueryDialog.getByRole('button', {
+                name: 'Save',
+                exact: true,
+            });
+
+            await expect(saveQueryDialog).toBeVisible();
+            await queryNameTextbox.fill(queryName);
+            await expect(saveButton).toBeEnabled();
+            await saveButton.click();
+            await expect(saveQueryDialog).toBeHidden();
+            await page.goto('/ui/explore');
+
+            const cypherTab = page.getByRole('tab', {
+                name: 'Cypher',
+            });
+
+            await cypherTab.click();
+            await expect(cypherTab).toHaveAttribute('aria-selected', 'true');
+
+            const savedQueriesButton = page.getByRole('button', {
+                name: 'Saved Queries',
+                exact: true,
+            });
+
+            await expect(savedQueriesButton).toBeVisible();
+            await expect(savedQueriesButton).toBeEnabled();
+            await savedQueriesButton.click();
+
+            const searchTextbox = page.getByRole('textbox', {
+                name: 'Search',
+                exact: true,
+            });
+
+            await expect(searchTextbox).toBeVisible();
+            await searchTextbox.fill(queryName);
+
+            const savedQueryButton = page.getByRole('button', {
+                name: savedQueryAccessibleName,
+                exact: true,
+            });
+
+            await expect(savedQueryButton).toBeVisible();
+
+            const autoRunCheckbox = page.getByRole('checkbox', {
+                name: 'Auto-run selected query',
+                exact: true,
+            });
+
+            await expect(autoRunCheckbox).toBeVisible();
+
+            if (await autoRunCheckbox.isChecked()) {
+                await autoRunCheckbox.uncheck();
+            }
+
+            await expect(autoRunCheckbox).not.toBeChecked();
+            await savedQueryButton.click();
+
+            const actionMenuButton = page.getByRole('button', {
+                name: 'Show saved query actions',
+                exact: true,
+            });
+
+            await expect(actionMenuButton).toBeVisible();
+            await expect(actionMenuButton).toBeEnabled();
+            await actionMenuButton.click();
+
+            const actionMenu = page.getByTestId('saved-query-action-menu');
+            await expect(actionMenu).toBeVisible();
+
+            const editShareButton = page.getByRole('button', {
+                name: 'Edit/Share',
+                exact: true,
+            });
+
+            await expect(editShareButton).toBeVisible();
+            await editShareButton.click();
+
+            const editSavedQueryDialog = page.getByRole('dialog', {
+                name: 'Edit Saved Query',
+                exact: true,
+            });
+
+            await expect(editSavedQueryDialog).toBeVisible();
+
+            const editQueryNameTextbox = editSavedQueryDialog.getByRole('textbox', {
+                name: 'Query Name',
+                exact: true,
+            });
+            const editQueryDescriptionTextbox = editSavedQueryDialog.getByRole('textbox', {
+                name: 'Query Description',
+                exact: true,
+            });
+            const namedCypherQueryEditor = editSavedQueryDialog.getByRole('textbox', {
+                name: 'Cypher Query',
+                exact: true,
+            });
+            const unnamedCypherQueryEditor = editSavedQueryDialog.getByRole('textbox', {
+                name: '',
+                exact: true,
+            });
+            const cypherQueryEditor = namedCypherQueryEditor.or(unnamedCypherQueryEditor);
+            const cancelButton = editSavedQueryDialog.getByRole('button', {
+                name: 'Cancel',
+                exact: true,
+            });
+            const editSaveButton = editSavedQueryDialog.getByRole('button', {
+                name: 'Save',
+                exact: true,
+            });
+
+            await expect(editQueryNameTextbox).toBeVisible();
+            await expect(editQueryDescriptionTextbox).toBeVisible();
+            await expect(cypherQueryEditor).toBeVisible();
+            await expect(cancelButton).toBeVisible();
+            await expect(editSaveButton).toBeVisible();
+
+            const results = await makeAxeBuilder().include('#content-wrapper').include('[role="dialog"]').analyze();
+
+            await expectNoAccessibilityViolations(testInfo, results, { page });
+        } catch (error) {
+            testError = error;
+        } finally {
+            try {
+                await page.goto('/ui/explore');
+
+                const cypherTab = page.getByRole('tab', {
+                    name: 'Cypher',
+                });
+
+                await cypherTab.click();
+                await expect(cypherTab).toHaveAttribute('aria-selected', 'true');
+
+                const savedQueriesButton = page.getByRole('button', {
+                    name: 'Saved Queries',
+                    exact: true,
+                });
+
+                await expect(savedQueriesButton).toBeVisible();
+                await savedQueriesButton.click();
+
+                const searchTextbox = page.getByRole('textbox', {
+                    name: 'Search',
+                    exact: true,
+                });
+
+                await expect(searchTextbox).toBeVisible();
+                await searchTextbox.fill(queryName);
+
+                const savedQueryButton = page.getByRole('button', {
+                    name: savedQueryAccessibleName,
+                    exact: true,
+                });
+                const noResultsHeading = page.getByRole('heading', {
+                    name: 'No Results',
+                    exact: true,
+                });
+
+                await expect(savedQueryButton.or(noResultsHeading)).toBeVisible();
+
+                if (await savedQueryButton.isVisible()) {
+                    const actionMenuButton = page.getByRole('button', {
+                        name: 'Show saved query actions',
+                        exact: true,
+                    });
+
+                    await expect(actionMenuButton).toBeVisible();
+                    await actionMenuButton.click();
+
+                    const deleteButton = page.getByRole('button', {
+                        name: 'Delete',
+                        exact: true,
+                    });
+
+                    await expect(deleteButton).toBeVisible();
+                    await deleteButton.click();
+
+                    const deleteDialog = page.getByRole('dialog', {
+                        name: 'Delete Query',
+                        exact: true,
+                    });
+                    const confirmButton = deleteDialog.getByRole('button', {
+                        name: 'Confirm',
+                        exact: true,
+                    });
+
+                    await expect(deleteDialog).toBeVisible();
+                    await expect(confirmButton).toBeEnabled();
+                    await confirmButton.click();
+
+                    await expect(deleteDialog).toBeHidden();
+                    await expect(savedQueryButton).toHaveCount(0);
+                }
+            } catch (error) {
+                cleanupError = error;
+            }
+        }
+
+        if (testError !== undefined) {
+            throw testError;
+        }
+
+        if (cleanupError !== undefined) {
+            throw cleanupError;
+        }
+    });
+
+    test('Delete Query dialog', async ({ page, makeAxeBuilder }, testInfo) => {
+        const query = 'MATCH (n) RETURN n LIMIT 1';
+        const queryName = `a11y-delete-dialog-${testInfo.project.name}-${Date.now()}`;
+        const savedQueryAccessibleName = `Run pre-built search query: ${queryName}`;
+        let testError: unknown;
+        let cleanupError: unknown;
+
+        try {
+            const cypherEditor = page.getByRole('textbox', {
+                name: 'Cypher Editor',
+            });
+
+            await expect(cypherEditor).toBeVisible();
+            await expect(cypherEditor).toHaveAttribute('contenteditable', 'true');
+
+            await cypherEditor.fill(query);
+            await expect(cypherEditor).toContainText(query);
+
+            const saveQueryButton = page.getByRole('button', {
+                name: 'Save query',
+                exact: true,
+            });
+
+            await expect(saveQueryButton).toBeVisible();
+            await expect(saveQueryButton).toBeEnabled();
+            await saveQueryButton.click();
+
+            const saveQueryDialog = page.getByTestId('save-query-dialog');
+            const queryNameTextbox = saveQueryDialog.getByRole('textbox', {
+                name: 'Query Name',
+                exact: true,
+            });
+            const saveButton = saveQueryDialog.getByRole('button', {
+                name: 'Save',
+                exact: true,
+            });
+
+            await expect(saveQueryDialog).toBeVisible();
+            await queryNameTextbox.fill(queryName);
+            await expect(saveButton).toBeEnabled();
+            await saveButton.click();
+            await expect(saveQueryDialog).toBeHidden();
+            await page.goto('/ui/explore');
+
+            const cypherTab = page.getByRole('tab', {
+                name: 'Cypher',
+            });
+
+            await cypherTab.click();
+            await expect(cypherTab).toHaveAttribute('aria-selected', 'true');
+
+            const savedQueriesButton = page.getByRole('button', {
+                name: 'Saved Queries',
+                exact: true,
+            });
+
+            await expect(savedQueriesButton).toBeVisible();
+            await expect(savedQueriesButton).toBeEnabled();
+            await savedQueriesButton.click();
+
+            const searchTextbox = page.getByRole('textbox', {
+                name: 'Search',
+                exact: true,
+            });
+
+            await expect(searchTextbox).toBeVisible();
+            await searchTextbox.fill(queryName);
+
+            const savedQueryButton = page.getByRole('button', {
+                name: savedQueryAccessibleName,
+                exact: true,
+            });
+
+            await expect(savedQueryButton).toBeVisible();
+
+            const autoRunCheckbox = page.getByRole('checkbox', {
+                name: 'Auto-run selected query',
+                exact: true,
+            });
+
+            await expect(autoRunCheckbox).toBeVisible();
+
+            if (await autoRunCheckbox.isChecked()) {
+                await autoRunCheckbox.uncheck();
+            }
+
+            await expect(autoRunCheckbox).not.toBeChecked();
+            await savedQueryButton.click();
+
+            const actionMenuButton = page.getByRole('button', {
+                name: 'Show saved query actions',
+                exact: true,
+            });
+
+            await expect(actionMenuButton).toBeVisible();
+            await expect(actionMenuButton).toBeEnabled();
+            await actionMenuButton.click();
+
+            const actionMenu = page.getByTestId('saved-query-action-menu');
+            await expect(actionMenu).toBeVisible();
+
+            const deleteButton = page.getByRole('button', {
+                name: 'Delete',
+                exact: true,
+            });
+
+            await expect(deleteButton).toBeVisible();
+            await deleteButton.click();
+
+            const deleteDialog = page.getByRole('dialog', {
+                name: 'Delete Query',
+                exact: true,
+            });
+
+            await expect(deleteDialog).toBeVisible();
+
+            const deleteQueryHeading = deleteDialog.getByRole('heading', {
+                name: 'Delete Query',
+                exact: true,
+            });
+            const confirmationText = deleteDialog.getByText('Are you sure you want to delete this query?', {
+                exact: true,
+            });
+            const cancelButton = deleteDialog.getByRole('button', {
+                name: 'Cancel',
+                exact: true,
+            });
+            const confirmButton = deleteDialog.getByRole('button', {
+                name: 'Confirm',
+                exact: true,
+            });
+
+            await expect(deleteQueryHeading).toBeVisible();
+            await expect(confirmationText).toBeVisible();
+            await expect(cancelButton).toBeVisible();
+            await expect(confirmButton).toBeVisible();
+
+            const results = await makeAxeBuilder().include('#content-wrapper').include('[role="dialog"]').analyze();
+
+            await expectNoAccessibilityViolations(testInfo, results, { page });
+        } catch (error) {
+            testError = error;
+        } finally {
+            try {
+                await page.goto('/ui/explore');
+
+                const cypherTab = page.getByRole('tab', {
+                    name: 'Cypher',
+                });
+
+                await cypherTab.click();
+                await expect(cypherTab).toHaveAttribute('aria-selected', 'true');
+
+                const savedQueriesButton = page.getByRole('button', {
+                    name: 'Saved Queries',
+                    exact: true,
+                });
+
+                await expect(savedQueriesButton).toBeVisible();
+                await savedQueriesButton.click();
+
+                const searchTextbox = page.getByRole('textbox', {
+                    name: 'Search',
+                    exact: true,
+                });
+
+                await expect(searchTextbox).toBeVisible();
+                await searchTextbox.fill(queryName);
+
+                const savedQueryButton = page.getByRole('button', {
+                    name: savedQueryAccessibleName,
+                    exact: true,
+                });
+                const noResultsHeading = page.getByRole('heading', {
+                    name: 'No Results',
+                    exact: true,
+                });
+
+                await expect(savedQueryButton.or(noResultsHeading)).toBeVisible();
+
+                if (await savedQueryButton.isVisible()) {
+                    const actionMenuButton = page.getByRole('button', {
+                        name: 'Show saved query actions',
+                        exact: true,
+                    });
+
+                    await expect(actionMenuButton).toBeVisible();
+                    await actionMenuButton.click();
+
+                    const deleteButton = page.getByRole('button', {
+                        name: 'Delete',
+                        exact: true,
+                    });
+
+                    await expect(deleteButton).toBeVisible();
+                    await deleteButton.click();
+
+                    const deleteDialog = page.getByRole('dialog', {
+                        name: 'Delete Query',
+                        exact: true,
+                    });
+                    const confirmButton = deleteDialog.getByRole('button', {
+                        name: 'Confirm',
+                        exact: true,
+                    });
+
+                    await expect(deleteDialog).toBeVisible();
+                    await expect(confirmButton).toBeEnabled();
+                    await confirmButton.click();
+
+                    await expect(deleteDialog).toBeHidden();
+                    await expect(savedQueryButton).toHaveCount(0);
+                }
+            } catch (error) {
+                cleanupError = error;
+            }
+        }
+
+        if (testError !== undefined) {
+            throw testError;
+        }
+
+        if (cleanupError !== undefined) {
+            throw cleanupError;
+        }
+    });
+});

--- a/cmd/ui/tests/a11y/explore-cypher.a11y.spec.ts
+++ b/cmd/ui/tests/a11y/explore-cypher.a11y.spec.ts
@@ -90,8 +90,7 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
         await expect(continueButton).toBeVisible();
         await expect(continueButton).toBeDisabled();
 
-        const results = await makeAxeBuilder().include('#content-wrapper').analyze();
-
+        const results = await makeAxeBuilder().include('#content-wrapper').include('[role="dialog"]').analyze();
         await expectNoAccessibilityViolations(testInfo, results, { page });
     });
 
@@ -134,8 +133,7 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
         await expect(continueButton).toBeVisible();
         await expect(continueButton).toBeDisabled();
 
-        const results = await makeAxeBuilder().include('#content-wrapper').analyze();
-
+        const results = await makeAxeBuilder().include('#content-wrapper').include('[role="dialog"]').analyze();
         await expectNoAccessibilityViolations(testInfo, results, { page });
     });
 
@@ -164,8 +162,7 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
 
         await expect(dialog).toBeVisible();
 
-        const results = await makeAxeBuilder().include('#content-wrapper').analyze();
-
+        const results = await makeAxeBuilder().include('#content-wrapper').include('[role="dialog"]').analyze();
         await expectNoAccessibilityViolations(testInfo, results, { page });
     });
 
@@ -210,7 +207,7 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
 
         await expect(dialog).toBeVisible();
 
-        const results = await makeAxeBuilder().include('#content-wrapper').analyze();
+        const results = await makeAxeBuilder().include('#content-wrapper').include('[role="dialog"]').analyze();
 
         await expectNoAccessibilityViolations(testInfo, results, { page });
     });
@@ -242,7 +239,6 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
         await expect(noResultsHeading).toBeVisible();
 
         const results = await makeAxeBuilder().include('#content-wrapper').analyze();
-
         await expectNoAccessibilityViolations(testInfo, results, { page });
     });
 
@@ -269,7 +265,7 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
 
         await expect(dialog).toBeVisible();
 
-        const results = await makeAxeBuilder().include('#content-wrapper').analyze();
+        const results = await makeAxeBuilder().include('#content-wrapper').include('[role="dialog"]').analyze();
 
         await expectNoAccessibilityViolations(testInfo, results, { page });
     });
@@ -367,7 +363,6 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
             const results = await makeAxeBuilder().include('#content-wrapper').analyze();
 
             await expectNoAccessibilityViolations(testInfo, results, { page });
-
             const exportButtons = page.getByRole('button', {
                 name: 'Export',
                 exact: true,
@@ -500,6 +495,7 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
         });
 
         await expect(selectedPlatformsFilter).toBeVisible();
+        await expect(selectedPlatformsFilter).toContainText('Active Directory');
         const results = await makeAxeBuilder().include('#content-wrapper').analyze();
 
         await expectNoAccessibilityViolations(testInfo, results, { page });
@@ -530,7 +526,13 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
         });
 
         await expect(domainInformationOption).toBeVisible();
-        await domainInformationOption.click();
+        const selectedCategoriesFilter = page.getByRole('combobox', {
+            name: /Domain Information/,
+        });
+
+        await expect(selectedCategoriesFilter).toBeVisible();
+        await expect(selectedCategoriesFilter).toContainText('Domain Information');
+
         const results = await makeAxeBuilder().include('#content-wrapper').analyze();
 
         await expectNoAccessibilityViolations(testInfo, results, { page });
@@ -561,7 +563,12 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
         });
 
         await expect(prebuiltOption).toBeVisible();
-        await prebuiltOption.click();
+        const selectedSourceFilter = page.getByRole('combobox', {
+            name: /Prebuilt/,
+        });
+
+        await expect(selectedSourceFilter).toBeVisible();
+        await expect(selectedSourceFilter).toContainText('Prebuilt');
 
         const results = await makeAxeBuilder().include('#content-wrapper').analyze();
 

--- a/cmd/ui/tests/a11y/explore-cypher.a11y.spec.ts
+++ b/cmd/ui/tests/a11y/explore-cypher.a11y.spec.ts
@@ -22,7 +22,7 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
 
         const cypherTab = page.getByRole('tab', { name: 'Cypher' });
         await cypherTab.click();
-        await expect(cypherTab).toHaveAttribute('aria-selected', 'true');
+        await page.getByRole('textbox', { name: 'Cypher Editor' }).waitFor({ state: 'visible' });
     });
 
     test('Empty query', async ({ page, makeAxeBuilder }, testInfo) => {
@@ -30,8 +30,7 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
             name: 'Cypher Editor',
         });
 
-        await expect(cypherEditor).toBeVisible();
-        await expect(cypherEditor).toHaveAttribute('contenteditable', 'true');
+        await cypherEditor.waitFor({ state: 'visible' });
 
         const results = await makeAxeBuilder().include('#content-wrapper').analyze();
 
@@ -44,11 +43,9 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
             name: 'Cypher Editor',
         });
 
-        await expect(cypherEditor).toBeVisible();
-        await expect(cypherEditor).toHaveAttribute('contenteditable', 'true');
+        await cypherEditor.waitFor({ state: 'visible' });
 
         await cypherEditor.fill(query);
-        await expect(cypherEditor).toContainText(query);
 
         const results = await makeAxeBuilder().include('#content-wrapper').analyze();
 
@@ -61,15 +58,12 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
             name: 'Cypher Editor',
         });
 
-        await expect(cypherEditor).toBeVisible();
-        await expect(cypherEditor).toHaveAttribute('contenteditable', 'true');
+        await cypherEditor.waitFor({ state: 'visible' });
 
         await cypherEditor.fill(query);
-        await expect(cypherEditor).toContainText(query);
 
         const tagButton = page.getByRole('button', { name: 'Tag' });
-        await expect(tagButton).toBeVisible();
-        await expect(tagButton).toBeEnabled();
+        await tagButton.waitFor({ state: 'visible' });
         await tagButton.click();
 
         await page.getByRole('button', { name: 'Zone' }).click();
@@ -77,7 +71,7 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
         const dialog = page.getByRole('dialog', {
             name: 'Tag Results to Zone',
         });
-        await expect(dialog).toBeVisible();
+        await dialog.waitFor({ state: 'visible' });
 
         const selectZoneControl = dialog.getByRole('combobox');
         const cancelButton = dialog.getByRole('button', { name: 'Cancel' });
@@ -85,10 +79,9 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
             name: 'Continue',
         });
 
-        await expect(selectZoneControl).toBeVisible();
-        await expect(cancelButton).toBeVisible();
-        await expect(continueButton).toBeVisible();
-        await expect(continueButton).toBeDisabled();
+        await selectZoneControl.waitFor({ state: 'visible' });
+        await cancelButton.waitFor({ state: 'visible' });
+        await continueButton.waitFor({ state: 'visible' });
 
         const results = await makeAxeBuilder().include('#content-wrapper').include('[role="dialog"]').analyze();
         await expectNoAccessibilityViolations(testInfo, results, { page });
@@ -100,15 +93,12 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
             name: 'Cypher Editor',
         });
 
-        await expect(cypherEditor).toBeVisible();
-        await expect(cypherEditor).toHaveAttribute('contenteditable', 'true');
+        await cypherEditor.waitFor({ state: 'visible' });
 
         await cypherEditor.fill(query);
-        await expect(cypherEditor).toContainText(query);
 
         const tagButton = page.getByRole('button', { name: 'Tag' });
-        await expect(tagButton).toBeVisible();
-        await expect(tagButton).toBeEnabled();
+        await tagButton.waitFor({ state: 'visible' });
         await tagButton.click();
 
         await page
@@ -120,7 +110,7 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
         const dialog = page.getByRole('dialog', {
             name: 'Tag Results to Label',
         });
-        await expect(dialog).toBeVisible();
+        await dialog.waitFor({ state: 'visible' });
 
         const selectLabelControl = dialog.getByRole('combobox');
         const cancelButton = dialog.getByRole('button', { name: 'Cancel' });
@@ -128,10 +118,9 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
             name: 'Continue',
         });
 
-        await expect(selectLabelControl).toBeVisible();
-        await expect(cancelButton).toBeVisible();
-        await expect(continueButton).toBeVisible();
-        await expect(continueButton).toBeDisabled();
+        await selectLabelControl.waitFor({ state: 'visible' });
+        await cancelButton.waitFor({ state: 'visible' });
+        await continueButton.waitFor({ state: 'visible' });
 
         const results = await makeAxeBuilder().include('#content-wrapper').include('[role="dialog"]').analyze();
         await expectNoAccessibilityViolations(testInfo, results, { page });
@@ -143,24 +132,21 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
             name: 'Cypher Editor',
         });
 
-        await expect(cypherEditor).toBeVisible();
-        await expect(cypherEditor).toHaveAttribute('contenteditable', 'true');
+        await cypherEditor.waitFor({ state: 'visible' });
 
         await cypherEditor.fill(query);
-        await expect(cypherEditor).toContainText(query);
 
         const saveQueryButton = page.getByRole('button', {
             name: 'Save query',
             exact: true,
         });
 
-        await expect(saveQueryButton).toBeVisible();
-        await expect(saveQueryButton).toBeEnabled();
+        await saveQueryButton.waitFor({ state: 'visible' });
         await saveQueryButton.click();
 
         const dialog = page.getByTestId('save-query-dialog');
 
-        await expect(dialog).toBeVisible();
+        await dialog.waitFor({ state: 'visible' });
 
         const results = await makeAxeBuilder().include('#content-wrapper').include('[role="dialog"]').analyze();
         await expectNoAccessibilityViolations(testInfo, results, { page });
@@ -172,11 +158,9 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
             name: 'Cypher Editor',
         });
 
-        await expect(cypherEditor).toBeVisible();
-        await expect(cypherEditor).toHaveAttribute('contenteditable', 'true');
+        await cypherEditor.waitFor({ state: 'visible' });
 
         await cypherEditor.fill(query);
-        await expect(cypherEditor).toContainText(query);
 
         const saveQueryButton = page.getByRole('button', {
             name: 'Save query',
@@ -187,10 +171,8 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
             exact: true,
         });
 
-        await expect(saveQueryButton).toBeVisible();
-        await expect(saveQueryButton).toBeEnabled();
-        await expect(saveQueryOptionsButton).toBeVisible();
-        await expect(saveQueryOptionsButton).toBeEnabled();
+        await saveQueryButton.waitFor({ state: 'visible' });
+        await saveQueryOptionsButton.waitFor({ state: 'visible' });
         await saveQueryOptionsButton.click();
 
         const saveAsButton = page.getByRole('button', {
@@ -198,14 +180,14 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
             exact: true,
         });
 
-        await expect(saveAsButton).toBeVisible();
+        await saveAsButton.waitFor({ state: 'visible' });
         await saveAsButton.click();
 
         const dialog = page.getByRole('dialog', {
             name: 'Save As New Query',
         });
 
-        await expect(dialog).toBeVisible();
+        await dialog.waitFor({ state: 'visible' });
 
         const results = await makeAxeBuilder().include('#content-wrapper').include('[role="dialog"]').analyze();
 
@@ -218,8 +200,7 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
             exact: true,
         });
 
-        await expect(savedQueriesButton).toBeVisible();
-        await expect(savedQueriesButton).toBeEnabled();
+        await savedQueriesButton.waitFor({ state: 'visible' });
         await savedQueriesButton.click();
 
         const searchTextbox = page.getByRole('textbox', {
@@ -228,15 +209,14 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
         });
         const searchTerm = 'a11y-no-results-9f7c2e1b';
 
-        await expect(searchTextbox).toBeVisible();
+        await searchTextbox.waitFor({ state: 'visible' });
         await searchTextbox.fill(searchTerm);
-        await expect(searchTextbox).toHaveValue(searchTerm);
 
         const noResultsHeading = page.getByRole('heading', {
             name: 'No Results',
             exact: true,
         });
-        await expect(noResultsHeading).toBeVisible();
+        await noResultsHeading.waitFor({ state: 'visible' });
 
         const results = await makeAxeBuilder().include('#content-wrapper').analyze();
         await expectNoAccessibilityViolations(testInfo, results, { page });
@@ -248,8 +228,7 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
             exact: true,
         });
 
-        await expect(savedQueriesButton).toBeVisible();
-        await expect(savedQueriesButton).toBeEnabled();
+        await savedQueriesButton.waitFor({ state: 'visible' });
         await savedQueriesButton.click();
 
         const importButton = page.getByRole('button', {
@@ -257,13 +236,12 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
             exact: true,
         });
 
-        await expect(importButton).toBeVisible();
-        await expect(importButton).toBeEnabled();
+        await importButton.waitFor({ state: 'visible' });
         await importButton.click();
 
         const dialog = page.getByRole('dialog');
 
-        await expect(dialog).toBeVisible();
+        await dialog.waitFor({ state: 'visible' });
 
         const results = await makeAxeBuilder().include('#content-wrapper').include('[role="dialog"]').analyze();
 
@@ -282,19 +260,16 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
                 name: 'Cypher Editor',
             });
 
-            await expect(cypherEditor).toBeVisible();
-            await expect(cypherEditor).toHaveAttribute('contenteditable', 'true');
+            await cypherEditor.waitFor({ state: 'visible' });
 
             await cypherEditor.fill(query);
-            await expect(cypherEditor).toContainText(query);
 
             const saveQueryButton = page.getByRole('button', {
                 name: 'Save query',
                 exact: true,
             });
 
-            await expect(saveQueryButton).toBeVisible();
-            await expect(saveQueryButton).toBeEnabled();
+            await saveQueryButton.waitFor({ state: 'visible' });
             await saveQueryButton.click();
 
             const saveQueryDialog = page.getByTestId('save-query-dialog');
@@ -307,11 +282,10 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
                 exact: true,
             });
 
-            await expect(saveQueryDialog).toBeVisible();
+            await saveQueryDialog.waitFor({ state: 'visible' });
             await queryNameTextbox.fill(queryName);
-            await expect(saveButton).toBeEnabled();
             await saveButton.click();
-            await expect(saveQueryDialog).toBeHidden();
+            await saveQueryDialog.waitFor({ state: 'hidden' });
             await page.goto('/ui/explore');
 
             const cypherTab = page.getByRole('tab', {
@@ -319,15 +293,14 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
             });
 
             await cypherTab.click();
-            await expect(cypherTab).toHaveAttribute('aria-selected', 'true');
+            await page.getByRole('textbox', { name: 'Cypher Editor' }).waitFor({ state: 'visible' });
 
             const savedQueriesButton = page.getByRole('button', {
                 name: 'Saved Queries',
                 exact: true,
             });
 
-            await expect(savedQueriesButton).toBeVisible();
-            await expect(savedQueriesButton).toBeEnabled();
+            await savedQueriesButton.waitFor({ state: 'visible' });
             await savedQueriesButton.click();
 
             const searchTextbox = page.getByRole('textbox', {
@@ -335,7 +308,7 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
                 exact: true,
             });
 
-            await expect(searchTextbox).toBeVisible();
+            await searchTextbox.waitFor({ state: 'visible' });
             await searchTextbox.fill(queryName);
 
             const savedQueryButton = page.getByRole('button', {
@@ -343,20 +316,18 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
                 exact: true,
             });
 
-            await expect(savedQueryButton).toBeVisible();
+            await savedQueryButton.waitFor({ state: 'visible' });
 
             const autoRunCheckbox = page.getByRole('checkbox', {
                 name: 'Auto-run selected query',
                 exact: true,
             });
 
-            await expect(autoRunCheckbox).toBeVisible();
+            await autoRunCheckbox.waitFor({ state: 'visible' });
 
             if (await autoRunCheckbox.isChecked()) {
                 await autoRunCheckbox.uncheck();
             }
-
-            await expect(autoRunCheckbox).not.toBeChecked();
 
             await savedQueryButton.click();
 
@@ -368,12 +339,9 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
                 exact: true,
             });
 
-            await expect(exportButtons).toHaveCount(2);
-
             const exportButton = exportButtons.first();
 
-            await expect(exportButton).toBeVisible();
-            await expect(exportButton).toBeEnabled();
+            await exportButton.waitFor({ state: 'visible' });
 
             const [download] = await Promise.all([page.waitForEvent('download'), exportButton.click()]);
             expect(download.suggestedFilename()).toMatch(/\.json$/i);
@@ -388,14 +356,14 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
                 });
 
                 await cypherTab.click();
-                await expect(cypherTab).toHaveAttribute('aria-selected', 'true');
+                await page.getByRole('textbox', { name: 'Cypher Editor' }).waitFor({ state: 'visible' });
 
                 const savedQueriesButton = page.getByRole('button', {
                     name: 'Saved Queries',
                     exact: true,
                 });
 
-                await expect(savedQueriesButton).toBeVisible();
+                await savedQueriesButton.waitFor({ state: 'visible' });
                 await savedQueriesButton.click();
 
                 const searchTextbox = page.getByRole('textbox', {
@@ -403,7 +371,7 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
                     exact: true,
                 });
 
-                await expect(searchTextbox).toBeVisible();
+                await searchTextbox.waitFor({ state: 'visible' });
                 await searchTextbox.fill(queryName);
 
                 const savedQueryButton = page.getByRole('button', {
@@ -415,7 +383,7 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
                     exact: true,
                 });
 
-                await expect(savedQueryButton.or(noResultsHeading)).toBeVisible();
+                await savedQueryButton.or(noResultsHeading).waitFor({ state: 'visible' });
 
                 if (await savedQueryButton.isVisible()) {
                     const actionMenuButton = page.getByRole('button', {
@@ -423,7 +391,7 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
                         exact: true,
                     });
 
-                    await expect(actionMenuButton).toBeVisible();
+                    await actionMenuButton.waitFor({ state: 'visible' });
                     await actionMenuButton.click();
 
                     const deleteButton = page.getByRole('button', {
@@ -431,7 +399,7 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
                         exact: true,
                     });
 
-                    await expect(deleteButton).toBeVisible();
+                    await deleteButton.waitFor({ state: 'visible' });
                     await deleteButton.click();
 
                     const deleteDialog = page.getByRole('dialog', {
@@ -443,12 +411,11 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
                         exact: true,
                     });
 
-                    await expect(deleteDialog).toBeVisible();
-                    await expect(confirmButton).toBeEnabled();
+                    await deleteDialog.waitFor({ state: 'visible' });
                     await confirmButton.click();
 
-                    await expect(deleteDialog).toBeHidden();
-                    await expect(savedQueryButton).toHaveCount(0);
+                    await deleteDialog.waitFor({ state: 'hidden' });
+                    await savedQueryButton.waitFor({ state: 'detached' });
                 }
             } catch (error) {
                 cleanupError = error;
@@ -470,8 +437,7 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
             exact: true,
         });
 
-        await expect(savedQueriesButton).toBeVisible();
-        await expect(savedQueriesButton).toBeEnabled();
+        await savedQueriesButton.waitFor({ state: 'visible' });
         await savedQueriesButton.click();
 
         const platformsFilter = page.getByRole('combobox', {
@@ -479,8 +445,7 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
             exact: true,
         });
 
-        await expect(platformsFilter).toBeVisible();
-        await expect(platformsFilter).toBeEnabled();
+        await platformsFilter.waitFor({ state: 'visible' });
         await platformsFilter.click();
 
         const activeDirectoryOption = page.getByRole('option', {
@@ -488,14 +453,13 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
             exact: true,
         });
 
-        await expect(activeDirectoryOption).toBeVisible();
+        await activeDirectoryOption.waitFor({ state: 'visible' });
         await activeDirectoryOption.click();
         const selectedPlatformsFilter = page.getByRole('combobox', {
             name: /Active Directory/,
         });
 
-        await expect(selectedPlatformsFilter).toBeVisible();
-        await expect(selectedPlatformsFilter).toContainText('Active Directory');
+        await selectedPlatformsFilter.waitFor({ state: 'visible' });
         const results = await makeAxeBuilder().include('#content-wrapper').analyze();
 
         await expectNoAccessibilityViolations(testInfo, results, { page });
@@ -507,8 +471,7 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
             exact: true,
         });
 
-        await expect(savedQueriesButton).toBeVisible();
-        await expect(savedQueriesButton).toBeEnabled();
+        await savedQueriesButton.waitFor({ state: 'visible' });
         await savedQueriesButton.click();
 
         const categoriesFilter = page.getByRole('combobox', {
@@ -516,8 +479,7 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
             exact: true,
         });
 
-        await expect(categoriesFilter).toBeVisible();
-        await expect(categoriesFilter).toBeEnabled();
+        await categoriesFilter.waitFor({ state: 'visible' });
         await categoriesFilter.click();
 
         const domainInformationOption = page.getByRole('option', {
@@ -525,13 +487,12 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
             exact: true,
         });
 
-        await expect(domainInformationOption).toBeVisible();
+        await domainInformationOption.waitFor({ state: 'visible' });
         const selectedCategoriesFilter = page.getByRole('combobox', {
             name: /Domain Information/,
         });
 
-        await expect(selectedCategoriesFilter).toBeVisible();
-        await expect(selectedCategoriesFilter).toContainText('Domain Information');
+        await selectedCategoriesFilter.waitFor({ state: 'visible' });
 
         const results = await makeAxeBuilder().include('#content-wrapper').analyze();
 
@@ -544,8 +505,7 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
             exact: true,
         });
 
-        await expect(savedQueriesButton).toBeVisible();
-        await expect(savedQueriesButton).toBeEnabled();
+        await savedQueriesButton.waitFor({ state: 'visible' });
         await savedQueriesButton.click();
 
         const sourceFilter = page.getByRole('combobox', {
@@ -553,8 +513,7 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
             exact: true,
         });
 
-        await expect(sourceFilter).toBeVisible();
-        await expect(sourceFilter).toBeEnabled();
+        await sourceFilter.waitFor({ state: 'visible' });
         await sourceFilter.click();
 
         const prebuiltOption = page.getByRole('option', {
@@ -562,13 +521,12 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
             exact: true,
         });
 
-        await expect(prebuiltOption).toBeVisible();
+        await prebuiltOption.waitFor({ state: 'visible' });
         const selectedSourceFilter = page.getByRole('combobox', {
             name: /Prebuilt/,
         });
 
-        await expect(selectedSourceFilter).toBeVisible();
-        await expect(selectedSourceFilter).toContainText('Prebuilt');
+        await selectedSourceFilter.waitFor({ state: 'visible' });
 
         const results = await makeAxeBuilder().include('#content-wrapper').analyze();
 
@@ -587,19 +545,16 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
                 name: 'Cypher Editor',
             });
 
-            await expect(cypherEditor).toBeVisible();
-            await expect(cypherEditor).toHaveAttribute('contenteditable', 'true');
+            await cypherEditor.waitFor({ state: 'visible' });
 
             await cypherEditor.fill(query);
-            await expect(cypherEditor).toContainText(query);
 
             const saveQueryButton = page.getByRole('button', {
                 name: 'Save query',
                 exact: true,
             });
 
-            await expect(saveQueryButton).toBeVisible();
-            await expect(saveQueryButton).toBeEnabled();
+            await saveQueryButton.waitFor({ state: 'visible' });
             await saveQueryButton.click();
 
             const saveQueryDialog = page.getByTestId('save-query-dialog');
@@ -612,11 +567,10 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
                 exact: true,
             });
 
-            await expect(saveQueryDialog).toBeVisible();
+            await saveQueryDialog.waitFor({ state: 'visible' });
             await queryNameTextbox.fill(queryName);
-            await expect(saveButton).toBeEnabled();
             await saveButton.click();
-            await expect(saveQueryDialog).toBeHidden();
+            await saveQueryDialog.waitFor({ state: 'hidden' });
             await page.goto('/ui/explore');
 
             const cypherTab = page.getByRole('tab', {
@@ -624,15 +578,14 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
             });
 
             await cypherTab.click();
-            await expect(cypherTab).toHaveAttribute('aria-selected', 'true');
+            await page.getByRole('textbox', { name: 'Cypher Editor' }).waitFor({ state: 'visible' });
 
             const savedQueriesButton = page.getByRole('button', {
                 name: 'Saved Queries',
                 exact: true,
             });
 
-            await expect(savedQueriesButton).toBeVisible();
-            await expect(savedQueriesButton).toBeEnabled();
+            await savedQueriesButton.waitFor({ state: 'visible' });
             await savedQueriesButton.click();
 
             const searchTextbox = page.getByRole('textbox', {
@@ -640,7 +593,7 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
                 exact: true,
             });
 
-            await expect(searchTextbox).toBeVisible();
+            await searchTextbox.waitFor({ state: 'visible' });
             await searchTextbox.fill(queryName);
 
             const savedQueryButton = page.getByRole('button', {
@@ -648,20 +601,18 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
                 exact: true,
             });
 
-            await expect(savedQueryButton).toBeVisible();
+            await savedQueryButton.waitFor({ state: 'visible' });
 
             const autoRunCheckbox = page.getByRole('checkbox', {
                 name: 'Auto-run selected query',
                 exact: true,
             });
 
-            await expect(autoRunCheckbox).toBeVisible();
+            await autoRunCheckbox.waitFor({ state: 'visible' });
 
             if (await autoRunCheckbox.isChecked()) {
                 await autoRunCheckbox.uncheck();
             }
-
-            await expect(autoRunCheckbox).not.toBeChecked();
             await savedQueryButton.click();
 
             const actionMenuButton = page.getByRole('button', {
@@ -669,8 +620,7 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
                 exact: true,
             });
 
-            await expect(actionMenuButton).toBeVisible();
-            await expect(actionMenuButton).toBeEnabled();
+            await actionMenuButton.waitFor({ state: 'visible' });
             await actionMenuButton.click();
 
             const runButton = page.getByRole('button', {
@@ -686,9 +636,9 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
                 exact: true,
             });
 
-            await expect(runButton).toBeVisible();
-            await expect(editShareButton).toBeVisible();
-            await expect(deleteButton).toBeVisible();
+            await runButton.waitFor({ state: 'visible' });
+            await editShareButton.waitFor({ state: 'visible' });
+            await deleteButton.waitFor({ state: 'visible' });
 
             const results = await makeAxeBuilder()
                 .include('#content-wrapper')
@@ -707,14 +657,14 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
                 });
 
                 await cypherTab.click();
-                await expect(cypherTab).toHaveAttribute('aria-selected', 'true');
+                await page.getByRole('textbox', { name: 'Cypher Editor' }).waitFor({ state: 'visible' });
 
                 const savedQueriesButton = page.getByRole('button', {
                     name: 'Saved Queries',
                     exact: true,
                 });
 
-                await expect(savedQueriesButton).toBeVisible();
+                await savedQueriesButton.waitFor({ state: 'visible' });
                 await savedQueriesButton.click();
 
                 const searchTextbox = page.getByRole('textbox', {
@@ -722,7 +672,7 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
                     exact: true,
                 });
 
-                await expect(searchTextbox).toBeVisible();
+                await searchTextbox.waitFor({ state: 'visible' });
                 await searchTextbox.fill(queryName);
 
                 const savedQueryButton = page.getByRole('button', {
@@ -734,7 +684,7 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
                     exact: true,
                 });
 
-                await expect(savedQueryButton.or(noResultsHeading)).toBeVisible();
+                await savedQueryButton.or(noResultsHeading).waitFor({ state: 'visible' });
 
                 if (await savedQueryButton.isVisible()) {
                     const actionMenuButton = page.getByRole('button', {
@@ -742,7 +692,7 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
                         exact: true,
                     });
 
-                    await expect(actionMenuButton).toBeVisible();
+                    await actionMenuButton.waitFor({ state: 'visible' });
                     await actionMenuButton.click();
 
                     const deleteButton = page.getByRole('button', {
@@ -750,7 +700,7 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
                         exact: true,
                     });
 
-                    await expect(deleteButton).toBeVisible();
+                    await deleteButton.waitFor({ state: 'visible' });
                     await deleteButton.click();
 
                     const deleteDialog = page.getByRole('dialog', {
@@ -762,12 +712,11 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
                         exact: true,
                     });
 
-                    await expect(deleteDialog).toBeVisible();
-                    await expect(confirmButton).toBeEnabled();
+                    await deleteDialog.waitFor({ state: 'visible' });
                     await confirmButton.click();
 
-                    await expect(deleteDialog).toBeHidden();
-                    await expect(savedQueryButton).toHaveCount(0);
+                    await deleteDialog.waitFor({ state: 'hidden' });
+                    await savedQueryButton.waitFor({ state: 'detached' });
                 }
             } catch (error) {
                 cleanupError = error;
@@ -795,19 +744,16 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
                 name: 'Cypher Editor',
             });
 
-            await expect(cypherEditor).toBeVisible();
-            await expect(cypherEditor).toHaveAttribute('contenteditable', 'true');
+            await cypherEditor.waitFor({ state: 'visible' });
 
             await cypherEditor.fill(query);
-            await expect(cypherEditor).toContainText(query);
 
             const saveQueryButton = page.getByRole('button', {
                 name: 'Save query',
                 exact: true,
             });
 
-            await expect(saveQueryButton).toBeVisible();
-            await expect(saveQueryButton).toBeEnabled();
+            await saveQueryButton.waitFor({ state: 'visible' });
             await saveQueryButton.click();
 
             const saveQueryDialog = page.getByTestId('save-query-dialog');
@@ -820,11 +766,10 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
                 exact: true,
             });
 
-            await expect(saveQueryDialog).toBeVisible();
+            await saveQueryDialog.waitFor({ state: 'visible' });
             await queryNameTextbox.fill(queryName);
-            await expect(saveButton).toBeEnabled();
             await saveButton.click();
-            await expect(saveQueryDialog).toBeHidden();
+            await saveQueryDialog.waitFor({ state: 'hidden' });
             await page.goto('/ui/explore');
 
             const cypherTab = page.getByRole('tab', {
@@ -832,15 +777,14 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
             });
 
             await cypherTab.click();
-            await expect(cypherTab).toHaveAttribute('aria-selected', 'true');
+            await page.getByRole('textbox', { name: 'Cypher Editor' }).waitFor({ state: 'visible' });
 
             const savedQueriesButton = page.getByRole('button', {
                 name: 'Saved Queries',
                 exact: true,
             });
 
-            await expect(savedQueriesButton).toBeVisible();
-            await expect(savedQueriesButton).toBeEnabled();
+            await savedQueriesButton.waitFor({ state: 'visible' });
             await savedQueriesButton.click();
 
             const searchTextbox = page.getByRole('textbox', {
@@ -848,7 +792,7 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
                 exact: true,
             });
 
-            await expect(searchTextbox).toBeVisible();
+            await searchTextbox.waitFor({ state: 'visible' });
             await searchTextbox.fill(queryName);
 
             const savedQueryButton = page.getByRole('button', {
@@ -856,20 +800,18 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
                 exact: true,
             });
 
-            await expect(savedQueryButton).toBeVisible();
+            await savedQueryButton.waitFor({ state: 'visible' });
 
             const autoRunCheckbox = page.getByRole('checkbox', {
                 name: 'Auto-run selected query',
                 exact: true,
             });
 
-            await expect(autoRunCheckbox).toBeVisible();
+            await autoRunCheckbox.waitFor({ state: 'visible' });
 
             if (await autoRunCheckbox.isChecked()) {
                 await autoRunCheckbox.uncheck();
             }
-
-            await expect(autoRunCheckbox).not.toBeChecked();
             await savedQueryButton.click();
 
             const actionMenuButton = page.getByRole('button', {
@@ -877,19 +819,18 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
                 exact: true,
             });
 
-            await expect(actionMenuButton).toBeVisible();
-            await expect(actionMenuButton).toBeEnabled();
+            await actionMenuButton.waitFor({ state: 'visible' });
             await actionMenuButton.click();
 
             const actionMenu = page.getByTestId('saved-query-action-menu');
-            await expect(actionMenu).toBeVisible();
+            await actionMenu.waitFor({ state: 'visible' });
 
             const editShareButton = page.getByRole('button', {
                 name: 'Edit/Share',
                 exact: true,
             });
 
-            await expect(editShareButton).toBeVisible();
+            await editShareButton.waitFor({ state: 'visible' });
             await editShareButton.click();
 
             const editSavedQueryDialog = page.getByRole('dialog', {
@@ -897,7 +838,7 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
                 exact: true,
             });
 
-            await expect(editSavedQueryDialog).toBeVisible();
+            await editSavedQueryDialog.waitFor({ state: 'visible' });
 
             const editQueryNameTextbox = editSavedQueryDialog.getByRole('textbox', {
                 name: 'Query Name',
@@ -920,11 +861,11 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
                 exact: true,
             });
 
-            await expect(editQueryNameTextbox).toBeVisible();
-            await expect(editQueryDescriptionTextbox).toBeVisible();
-            await expect(cypherQueryEditor).toBeVisible();
-            await expect(cancelButton).toBeVisible();
-            await expect(editSaveButton).toBeVisible();
+            await editQueryNameTextbox.waitFor({ state: 'visible' });
+            await editQueryDescriptionTextbox.waitFor({ state: 'visible' });
+            await cypherQueryEditor.waitFor({ state: 'visible' });
+            await cancelButton.waitFor({ state: 'visible' });
+            await editSaveButton.waitFor({ state: 'visible' });
 
             const results = await makeAxeBuilder().include('#content-wrapper').include('[role="dialog"]').analyze();
 
@@ -940,14 +881,14 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
                 });
 
                 await cypherTab.click();
-                await expect(cypherTab).toHaveAttribute('aria-selected', 'true');
+                await page.getByRole('textbox', { name: 'Cypher Editor' }).waitFor({ state: 'visible' });
 
                 const savedQueriesButton = page.getByRole('button', {
                     name: 'Saved Queries',
                     exact: true,
                 });
 
-                await expect(savedQueriesButton).toBeVisible();
+                await savedQueriesButton.waitFor({ state: 'visible' });
                 await savedQueriesButton.click();
 
                 const searchTextbox = page.getByRole('textbox', {
@@ -955,7 +896,7 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
                     exact: true,
                 });
 
-                await expect(searchTextbox).toBeVisible();
+                await searchTextbox.waitFor({ state: 'visible' });
                 await searchTextbox.fill(queryName);
 
                 const savedQueryButton = page.getByRole('button', {
@@ -967,7 +908,7 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
                     exact: true,
                 });
 
-                await expect(savedQueryButton.or(noResultsHeading)).toBeVisible();
+                await savedQueryButton.or(noResultsHeading).waitFor({ state: 'visible' });
 
                 if (await savedQueryButton.isVisible()) {
                     const actionMenuButton = page.getByRole('button', {
@@ -975,7 +916,7 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
                         exact: true,
                     });
 
-                    await expect(actionMenuButton).toBeVisible();
+                    await actionMenuButton.waitFor({ state: 'visible' });
                     await actionMenuButton.click();
 
                     const deleteButton = page.getByRole('button', {
@@ -983,7 +924,7 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
                         exact: true,
                     });
 
-                    await expect(deleteButton).toBeVisible();
+                    await deleteButton.waitFor({ state: 'visible' });
                     await deleteButton.click();
 
                     const deleteDialog = page.getByRole('dialog', {
@@ -995,12 +936,11 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
                         exact: true,
                     });
 
-                    await expect(deleteDialog).toBeVisible();
-                    await expect(confirmButton).toBeEnabled();
+                    await deleteDialog.waitFor({ state: 'visible' });
                     await confirmButton.click();
 
-                    await expect(deleteDialog).toBeHidden();
-                    await expect(savedQueryButton).toHaveCount(0);
+                    await deleteDialog.waitFor({ state: 'hidden' });
+                    await savedQueryButton.waitFor({ state: 'detached' });
                 }
             } catch (error) {
                 cleanupError = error;
@@ -1028,19 +968,16 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
                 name: 'Cypher Editor',
             });
 
-            await expect(cypherEditor).toBeVisible();
-            await expect(cypherEditor).toHaveAttribute('contenteditable', 'true');
+            await cypherEditor.waitFor({ state: 'visible' });
 
             await cypherEditor.fill(query);
-            await expect(cypherEditor).toContainText(query);
 
             const saveQueryButton = page.getByRole('button', {
                 name: 'Save query',
                 exact: true,
             });
 
-            await expect(saveQueryButton).toBeVisible();
-            await expect(saveQueryButton).toBeEnabled();
+            await saveQueryButton.waitFor({ state: 'visible' });
             await saveQueryButton.click();
 
             const saveQueryDialog = page.getByTestId('save-query-dialog');
@@ -1053,11 +990,10 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
                 exact: true,
             });
 
-            await expect(saveQueryDialog).toBeVisible();
+            await saveQueryDialog.waitFor({ state: 'visible' });
             await queryNameTextbox.fill(queryName);
-            await expect(saveButton).toBeEnabled();
             await saveButton.click();
-            await expect(saveQueryDialog).toBeHidden();
+            await saveQueryDialog.waitFor({ state: 'hidden' });
             await page.goto('/ui/explore');
 
             const cypherTab = page.getByRole('tab', {
@@ -1065,15 +1001,14 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
             });
 
             await cypherTab.click();
-            await expect(cypherTab).toHaveAttribute('aria-selected', 'true');
+            await page.getByRole('textbox', { name: 'Cypher Editor' }).waitFor({ state: 'visible' });
 
             const savedQueriesButton = page.getByRole('button', {
                 name: 'Saved Queries',
                 exact: true,
             });
 
-            await expect(savedQueriesButton).toBeVisible();
-            await expect(savedQueriesButton).toBeEnabled();
+            await savedQueriesButton.waitFor({ state: 'visible' });
             await savedQueriesButton.click();
 
             const searchTextbox = page.getByRole('textbox', {
@@ -1081,7 +1016,7 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
                 exact: true,
             });
 
-            await expect(searchTextbox).toBeVisible();
+            await searchTextbox.waitFor({ state: 'visible' });
             await searchTextbox.fill(queryName);
 
             const savedQueryButton = page.getByRole('button', {
@@ -1089,20 +1024,18 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
                 exact: true,
             });
 
-            await expect(savedQueryButton).toBeVisible();
+            await savedQueryButton.waitFor({ state: 'visible' });
 
             const autoRunCheckbox = page.getByRole('checkbox', {
                 name: 'Auto-run selected query',
                 exact: true,
             });
 
-            await expect(autoRunCheckbox).toBeVisible();
+            await autoRunCheckbox.waitFor({ state: 'visible' });
 
             if (await autoRunCheckbox.isChecked()) {
                 await autoRunCheckbox.uncheck();
             }
-
-            await expect(autoRunCheckbox).not.toBeChecked();
             await savedQueryButton.click();
 
             const actionMenuButton = page.getByRole('button', {
@@ -1110,19 +1043,18 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
                 exact: true,
             });
 
-            await expect(actionMenuButton).toBeVisible();
-            await expect(actionMenuButton).toBeEnabled();
+            await actionMenuButton.waitFor({ state: 'visible' });
             await actionMenuButton.click();
 
             const actionMenu = page.getByTestId('saved-query-action-menu');
-            await expect(actionMenu).toBeVisible();
+            await actionMenu.waitFor({ state: 'visible' });
 
             const deleteButton = page.getByRole('button', {
                 name: 'Delete',
                 exact: true,
             });
 
-            await expect(deleteButton).toBeVisible();
+            await deleteButton.waitFor({ state: 'visible' });
             await deleteButton.click();
 
             const deleteDialog = page.getByRole('dialog', {
@@ -1130,7 +1062,7 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
                 exact: true,
             });
 
-            await expect(deleteDialog).toBeVisible();
+            await deleteDialog.waitFor({ state: 'visible' });
 
             const deleteQueryHeading = deleteDialog.getByRole('heading', {
                 name: 'Delete Query',
@@ -1148,10 +1080,10 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
                 exact: true,
             });
 
-            await expect(deleteQueryHeading).toBeVisible();
-            await expect(confirmationText).toBeVisible();
-            await expect(cancelButton).toBeVisible();
-            await expect(confirmButton).toBeVisible();
+            await deleteQueryHeading.waitFor({ state: 'visible' });
+            await confirmationText.waitFor({ state: 'visible' });
+            await cancelButton.waitFor({ state: 'visible' });
+            await confirmButton.waitFor({ state: 'visible' });
 
             const results = await makeAxeBuilder().include('#content-wrapper').include('[role="dialog"]').analyze();
 
@@ -1167,14 +1099,14 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
                 });
 
                 await cypherTab.click();
-                await expect(cypherTab).toHaveAttribute('aria-selected', 'true');
+                await page.getByRole('textbox', { name: 'Cypher Editor' }).waitFor({ state: 'visible' });
 
                 const savedQueriesButton = page.getByRole('button', {
                     name: 'Saved Queries',
                     exact: true,
                 });
 
-                await expect(savedQueriesButton).toBeVisible();
+                await savedQueriesButton.waitFor({ state: 'visible' });
                 await savedQueriesButton.click();
 
                 const searchTextbox = page.getByRole('textbox', {
@@ -1182,7 +1114,7 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
                     exact: true,
                 });
 
-                await expect(searchTextbox).toBeVisible();
+                await searchTextbox.waitFor({ state: 'visible' });
                 await searchTextbox.fill(queryName);
 
                 const savedQueryButton = page.getByRole('button', {
@@ -1194,7 +1126,7 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
                     exact: true,
                 });
 
-                await expect(savedQueryButton.or(noResultsHeading)).toBeVisible();
+                await savedQueryButton.or(noResultsHeading).waitFor({ state: 'visible' });
 
                 if (await savedQueryButton.isVisible()) {
                     const actionMenuButton = page.getByRole('button', {
@@ -1202,7 +1134,7 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
                         exact: true,
                     });
 
-                    await expect(actionMenuButton).toBeVisible();
+                    await actionMenuButton.waitFor({ state: 'visible' });
                     await actionMenuButton.click();
 
                     const deleteButton = page.getByRole('button', {
@@ -1210,7 +1142,7 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
                         exact: true,
                     });
 
-                    await expect(deleteButton).toBeVisible();
+                    await deleteButton.waitFor({ state: 'visible' });
                     await deleteButton.click();
 
                     const deleteDialog = page.getByRole('dialog', {
@@ -1222,12 +1154,11 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
                         exact: true,
                     });
 
-                    await expect(deleteDialog).toBeVisible();
-                    await expect(confirmButton).toBeEnabled();
+                    await deleteDialog.waitFor({ state: 'visible' });
                     await confirmButton.click();
 
-                    await expect(deleteDialog).toBeHidden();
-                    await expect(savedQueryButton).toHaveCount(0);
+                    await deleteDialog.waitFor({ state: 'hidden' });
+                    await savedQueryButton.waitFor({ state: 'detached' });
                 }
             } catch (error) {
                 cleanupError = error;

--- a/cmd/ui/tests/a11y/explore-cypher.a11y.spec.ts
+++ b/cmd/ui/tests/a11y/explore-cypher.a11y.spec.ts
@@ -907,15 +907,10 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
                 name: 'Query Description',
                 exact: true,
             });
-            const namedCypherQueryEditor = editSavedQueryDialog.getByRole('textbox', {
+            const cypherQueryEditor = editSavedQueryDialog.getByRole('textbox', {
                 name: 'Cypher Query',
                 exact: true,
             });
-            const unnamedCypherQueryEditor = editSavedQueryDialog.getByRole('textbox', {
-                name: '',
-                exact: true,
-            });
-            const cypherQueryEditor = namedCypherQueryEditor.or(unnamedCypherQueryEditor);
             const cancelButton = editSavedQueryDialog.getByRole('button', {
                 name: 'Cancel',
                 exact: true,


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Adds accessibility tests for the Explore - Cypher to verify compliance with accessibility standards.

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves bed-8633

This change was needed to ensure the Explore Cypher page adheres to accessibility standards.

## How Has This Been Tested?

The tests were run locally.

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- New feature (non-breaking change which adds functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [X] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [X] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [X] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a new accessibility test suite for the Explore page’s Cypher tab.
  * Covers empty and populated Cypher editors, tag-to-zone and tag-to-label dialogs, and saved-query workflows.
  * Validates save, import/export, search, filtering, action menus, editing, and deletion.
  * Includes accessibility checks across relevant dialogs, menus, and page content to help prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->