### PR TITLE
feat: enable opengraph_extension_management flag by default BED-9051

### DIFF
--- a/cmd/api/src/database/migration/migrations/20260730224920_v9_enable_opengraph_extension_management_flag_by_default.sql
+++ b/cmd/api/src/database/migration/migrations/20260730224920_v9_enable_opengraph_extension_management_flag_by_default.sql
@@ -1,0 +1,20 @@
+-- Copyright 2026 Specter Ops, Inc.
+--
+-- Licensed under the Apache License, Version 2.0
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- SPDX-License-Identifier: Apache-2.0
+-- +goose Up
+UPDATE feature_flags SET enabled = true WHERE key = 'opengraph_extension_management';
+
+-- +goose Down
+UPDATE feature_flags SET enabled = false WHERE key = 'opengraph_extension_management';


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Enable the `opengraph_extension_management` flag by default

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-9051

## How Has This Been Tested?

Ran the migration up and down locally and verified it changes the flag value

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- New feature (non-breaking change which adds functionality)
- Database Migrations

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled OpenGraph extension management by default for upgraded installations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->