### PR TITLE
chore: Clarify variable analysis intent logs - BED-9119

### DIFF
--- a/packages/go/analysis/analysis.go
+++ b/packages/go/analysis/analysis.go
@@ -208,11 +208,11 @@ func (s analysisPipeline) String() string {
 	return strings.Join(steps, ",")
 }
 
-// IntentString returns a comma-separated list of each step and its intent
+// AnalysisStepsIntentString returns a comma-separated list of each step and its intent
 // (execute or skipped) for the given analysisSteps bitmask. This mirrors the
 // shape of the pipeline result String() used for the "Finished" log line, but
 // communicates intent before dispatch rather than completion.
-func (s analysisPipeline) IntentString(analysisSteps model.AnalysisSteps) string {
+func (s analysisPipeline) AnalysisStepsIntentString(analysisSteps model.AnalysisSteps) string {
 	steps := make([]string, 0, len(s))
 
 	for _, pipelineStep := range s {
@@ -406,7 +406,7 @@ func RunAnalysisOperations(ctx context.Context, db database.Database, graphDB gr
 		slog.String("namespace", "analysis"),
 		slog.String("fn", "RunAnalysisOperations"),
 		slog.Int("analysis_steps_bits", analysisSteps.Bits()),
-		slog.String("pipeline_steps", pipeline.IntentString(analysisSteps)),
+		slog.String("pipeline_steps", pipeline.AnalysisStepsIntentString(analysisSteps)),
 	)
 
 	pipelineResult := pipeline.dispatchAnalysisSteps(analysisPipelineRun{

--- a/packages/go/analysis/analysis.go
+++ b/packages/go/analysis/analysis.go
@@ -139,6 +139,14 @@ const (
 	pipelineStepStatusSkipped        = "skipped"
 )
 
+// pipelineStepIntent communicates whether a step is expected to run before dispatch.
+type pipelineStepIntent string
+
+const (
+	pipelineStepIntentExecute pipelineStepIntent = "execute"
+	pipelineStepIntentSkip    pipelineStepIntent = "skip"
+)
+
 type analysisErrors struct {
 	adPost      bool
 	azurePost   bool
@@ -195,6 +203,25 @@ func (s analysisPipeline) String() string {
 
 	for _, pipelineStep := range s {
 		steps = append(steps, pipelineStep.String())
+	}
+
+	return strings.Join(steps, ",")
+}
+
+// IntentString returns a comma-separated list of each step and its intent
+// (execute or skipped) for the given analysisSteps bitmask. This mirrors the
+// shape of the pipeline result String() used for the "Finished" log line, but
+// communicates intent before dispatch rather than completion.
+func (s analysisPipeline) IntentString(analysisSteps model.AnalysisSteps) string {
+	steps := make([]string, 0, len(s))
+
+	for _, pipelineStep := range s {
+		intent := pipelineStepIntentSkip
+		if pipelineStep.shouldRun(analysisSteps) {
+			intent = pipelineStepIntentExecute
+		}
+
+		steps = append(steps, fmt.Sprintf("%s:%s", pipelineStep.String(), intent))
 	}
 
 	return strings.Join(steps, ",")
@@ -379,7 +406,7 @@ func RunAnalysisOperations(ctx context.Context, db database.Database, graphDB gr
 		slog.String("namespace", "analysis"),
 		slog.String("fn", "RunAnalysisOperations"),
 		slog.Int("analysis_steps_bits", analysisSteps.Bits()),
-		slog.String("pipeline_steps", pipeline.String()),
+		slog.String("pipeline_steps", pipeline.IntentString(analysisSteps)),
 	)
 
 	pipelineResult := pipeline.dispatchAnalysisSteps(analysisPipelineRun{

--- a/packages/go/analysis/analysis_test.go
+++ b/packages/go/analysis/analysis_test.go
@@ -194,8 +194,8 @@ func TestAnalysisPipelineIntentString(t *testing.T) {
 		{name: DataQuality},
 	}
 
-	assert.Equal(t, "ad_post_processing:execute,azure_post_processing:execute,tagging:execute,data_quality:execute", pipeline.IntentString(model.AnalysisStepsFull()))
-	assert.Equal(t, "ad_post_processing:skip,azure_post_processing:skip,tagging:execute,data_quality:execute", pipeline.IntentString(model.AnalysisStepsNoPostProcessing()))
+	assert.Equal(t, "ad_post_processing:execute,azure_post_processing:execute,tagging:execute,data_quality:execute", pipeline.AnalysisStepsIntentString(model.AnalysisStepsFull()))
+	assert.Equal(t, "ad_post_processing:skip,azure_post_processing:skip,tagging:execute,data_quality:execute", pipeline.AnalysisStepsIntentString(model.AnalysisStepsNoPostProcessing()))
 }
 
 func TestAnalysisPipelineStepResultString(t *testing.T) {

--- a/packages/go/analysis/analysis_test.go
+++ b/packages/go/analysis/analysis_test.go
@@ -184,6 +184,20 @@ func TestAnalysisPipelineString(t *testing.T) {
 	assert.Equal(t, "ad_post_processing,tagging,data_quality", pipeline.String())
 }
 
+func TestAnalysisPipelineIntentString(t *testing.T) {
+	t.Parallel()
+
+	pipeline := analysisPipeline{
+		{analysisStep: model.AnalysisStepADPostProcessing()},
+		{analysisStep: model.AnalysisStepAzurePostProcessing()},
+		{analysisStep: model.AnalysisStepTagging()},
+		{name: DataQuality},
+	}
+
+	assert.Equal(t, "ad_post_processing:execute,azure_post_processing:execute,tagging:execute,data_quality:execute", pipeline.IntentString(model.AnalysisStepsFull()))
+	assert.Equal(t, "ad_post_processing:skip,azure_post_processing:skip,tagging:execute,data_quality:execute", pipeline.IntentString(model.AnalysisStepsNoPostProcessing()))
+}
+
 func TestAnalysisPipelineStepResultString(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Clarifies the intent during "Running Analysis Operations" log line to indicate what steps will run during the process, versus what is potentially available.

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-9119

*Why is this change required? What problem does it solve?*

## How Has This Been Tested?

Validated locally and additional tests added

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [X] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [X] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [X] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer tracking of analysis pipeline steps, showing whether each step will execute or be skipped.
  * Analysis operation logs now display the intended action for every pipeline step.

* **Bug Fixes**
  * Improved visibility into pipeline execution decisions before analysis runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->