### PR TITLE
feat: Support additional graph export actions BED-9132

### DIFF
--- a/packages/javascript/bh-shared-ui/src/components/GraphControls/GraphControls.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/GraphControls/GraphControls.test.tsx
@@ -18,7 +18,7 @@ import { rest } from 'msw';
 import { setupServer } from 'msw/node';
 import { act, render, screen } from '../../test-utils';
 import * as exportUtils from '../../utils/exportGraphData';
-import GraphControls from './GraphControls';
+import GraphControls, { GraphControlsExportAction } from './GraphControls';
 
 const exportToJsonSpy = vi.spyOn(exportUtils, 'exportToJson');
 
@@ -60,6 +60,8 @@ describe('GraphControls', () => {
     const onToggleNodeLabelsFn = vi.fn();
     const onToggleEdgeLabelsFn = vi.fn();
     const onSearchedNodeClickFn = vi.fn();
+    const onAdditionalActionOneFn = vi.fn();
+    const onAdditionalActionTwoFn = vi.fn();
 
     afterEach(() => {
         onResetFn.mockClear();
@@ -67,6 +69,8 @@ describe('GraphControls', () => {
         onToggleNodeLabelsFn.mockClear();
         onToggleEdgeLabelsFn.mockClear();
         onSearchedNodeClickFn.mockClear();
+        onAdditionalActionOneFn.mockClear();
+        onAdditionalActionTwoFn.mockClear();
     });
 
     type SetupOptions = {
@@ -78,6 +82,7 @@ describe('GraphControls', () => {
         isExploreLayoutSelected?: boolean;
         isExploreTableSelected?: boolean;
         route?: string;
+        additionalExportActions?: readonly GraphControlsExportAction[];
     };
 
     const setup = ({
@@ -89,6 +94,7 @@ describe('GraphControls', () => {
         isExploreLayoutSelected,
         isExploreTableSelected,
         route = '/',
+        additionalExportActions,
     }: SetupOptions = {}) => {
         const options = layoutOptionsOverride ?? layoutOptions;
         render(
@@ -106,6 +112,7 @@ describe('GraphControls', () => {
                 isExploreLayoutSelected={isExploreLayoutSelected}
                 isExploreTableSelected={isExploreTableSelected}
                 currentNodes={currentNodes}
+                additionalExportActions={additionalExportActions}
             />,
             { route }
         );
@@ -366,7 +373,94 @@ describe('GraphControls', () => {
             expect(tableItem).not.toHaveClass('Mui-selected');
         });
     });
-    describe('Exporting json', () => {
+    describe('Exporting', () => {
+        it('only renders the JSON action when no additional actions are supplied', async () => {
+            const { user } = setup();
+
+            await user.click(screen.getByRole('button', { name: 'Export' }));
+
+            expect(await screen.findAllByRole('menuitem')).toHaveLength(1);
+            expect(screen.getByRole('menuitem', { name: 'JSON' })).toBeInTheDocument();
+        });
+
+        it('renders additional actions in caller order before JSON', async () => {
+            const { user } = setup({
+                additionalExportActions: [
+                    { label: 'Additional action one', onSelect: onAdditionalActionOneFn },
+                    { label: 'Additional action two', onSelect: onAdditionalActionTwoFn },
+                ],
+            });
+
+            await user.click(screen.getByRole('button', { name: 'Export' }));
+
+            expect((await screen.findAllByRole('menuitem')).map(({ textContent }) => textContent)).toEqual([
+                'Additional action one',
+                'Additional action two',
+                'JSON',
+            ]);
+        });
+
+        it('invokes only the selected additional action and closes the menu', async () => {
+            const { user } = setup({
+                additionalExportActions: [
+                    { label: 'Additional action one', onSelect: onAdditionalActionOneFn },
+                    { label: 'Additional action two', onSelect: onAdditionalActionTwoFn },
+                ],
+            });
+
+            await user.click(screen.getByRole('button', { name: 'Export' }));
+            await user.click(await screen.findByRole('menuitem', { name: 'Additional action two' }));
+
+            expect(onAdditionalActionOneFn).not.toHaveBeenCalled();
+            expect(onAdditionalActionTwoFn).toHaveBeenCalledOnce();
+            expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+        });
+
+        it('skips disabled additional actions during keyboard selection', async () => {
+            const { user } = setup({
+                additionalExportActions: [
+                    { label: 'Additional action one', onSelect: onAdditionalActionOneFn, disabled: true },
+                    { label: 'Additional action two', onSelect: onAdditionalActionTwoFn },
+                ],
+            });
+
+            await user.click(screen.getByRole('button', { name: 'Export' }));
+            const disabledAction = await screen.findByRole('menuitem', { name: 'Additional action one' });
+            expect(disabledAction).toHaveAttribute('aria-disabled', 'true');
+            await user.keyboard('{Enter}');
+
+            expect(onAdditionalActionOneFn).not.toHaveBeenCalled();
+            expect(onAdditionalActionTwoFn).toHaveBeenCalledOnce();
+        });
+
+        it('supports keyboard selection for additional actions', async () => {
+            const { user } = setup({
+                additionalExportActions: [{ label: 'Additional action one', onSelect: onAdditionalActionOneFn }],
+            });
+            const exportMenu = screen.getByRole('button', { name: 'Export' });
+
+            exportMenu.focus();
+            await user.keyboard('{Enter}');
+            await user.keyboard('{Enter}');
+
+            expect(onAdditionalActionOneFn).toHaveBeenCalledOnce();
+            expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+        });
+
+        it('closes on Escape and restores focus to the Export trigger', async () => {
+            const { user } = setup({
+                additionalExportActions: [{ label: 'Additional action one', onSelect: onAdditionalActionOneFn }],
+            });
+            const exportMenu = screen.getByRole('button', { name: 'Export' });
+
+            await user.click(exportMenu);
+            expect(await screen.findByRole('menu')).toBeInTheDocument();
+            await user.keyboard('{Escape}');
+
+            expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+            expect(exportMenu).toHaveFocus();
+        });
+
         it('disables the JSON button if the JSON is empty', async () => {
             const { user } = setup();
 

--- a/packages/javascript/bh-shared-ui/src/components/GraphControls/GraphControls.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/GraphControls/GraphControls.tsx
@@ -34,6 +34,12 @@ import GraphButton from '../GraphButton';
 import GraphMenu from '../GraphMenu';
 import SearchCurrentNodes, { FlatNode } from '../SearchCurrentNodes';
 
+export interface GraphControlsExportAction {
+    label: string;
+    onSelect: () => void;
+    disabled?: boolean;
+}
+
 interface GraphControlsProps<T extends readonly string[]> {
     onReset: () => void;
     onLayoutChange: (layout: T[number]) => void;
@@ -48,6 +54,7 @@ interface GraphControlsProps<T extends readonly string[]> {
     showEdgeLabels: boolean;
     jsonData: Record<string, any> | undefined;
     currentNodes: Record<string, any> | undefined;
+    additionalExportActions?: readonly GraphControlsExportAction[];
 }
 
 function GraphControls<T extends readonly string[]>(props: GraphControlsProps<T>) {
@@ -65,6 +72,7 @@ function GraphControls<T extends readonly string[]>(props: GraphControlsProps<T>
         showEdgeLabels,
         jsonData,
         currentNodes = {},
+        additionalExportActions = [],
     } = props;
     const { searchType } = useExploreParams();
     const [isCurrentSearchOpen, setIsCurrentSearchOpen] = useState(false);
@@ -172,6 +180,11 @@ function GraphControls<T extends readonly string[]>(props: GraphControlsProps<T>
                     controlId='export'
                     displayText={<FontAwesomeIcon aria-hidden='true' icon={faDownload} />}
                     label='Export'>
+                    {additionalExportActions.map(({ label, onSelect, disabled }) => (
+                        <MenuItem key={label} onClick={onSelect} disabled={disabled}>
+                            {label}
+                        </MenuItem>
+                    ))}
                     <MenuItem onClick={() => exportToJson(jsonData)} disabled={isEmpty(jsonData)}>
                         JSON
                     </MenuItem>

--- a/packages/javascript/bh-shared-ui/src/components/GraphControls/index.ts
+++ b/packages/javascript/bh-shared-ui/src/components/GraphControls/index.ts
@@ -15,3 +15,4 @@
 // SPDX-License-Identifier: Apache-2.0
 
 export { default as GraphControls } from './GraphControls';
+export type { GraphControlsExportAction } from './GraphControls';


### PR DESCRIPTION
## Summary

Add a small, generic extension point that lets `GraphControls` consumers contribute actions to the existing Export menu.

- Export the `GraphControlsExportAction` type.
- Accept optional, read-only `additionalExportActions`.
- Render contributed actions in caller order before the existing JSON action.
- Support disabled contributed actions.
- Preserve the current JSON export behavior and JSON-only default.

BHCE does not gain PNG, SVG, ReGraph, current-view, full-graph, filename, or image-download behavior. Those BED-9132 details remain scoped to a separate BHE implementation.

## Jira context

BED-9132 adds PNG and SVG graph exports to BHE Explore. This PR is the shared-component prerequisite: BHE needs a neutral way to add its image-export actions without exposing those product-specific options in BHCE.

## Testing

- 34 focused `GraphControls` and JSON-export tests
- `bh-shared-ui` type-check
- `bh-shared-ui` lint and formatting
- BHE consumer TypeScript compile
- `just prepare-for-codereview`
- Focused Playwright against a task-owned isolated BHE stack:
  - JSON-only default menu and JSON download
  - contributed-action ordering, selection, and disabled behavior through unit coverage
  - keyboard operation, Escape, and focus restoration
  - light and dark themes
  - compact viewport and 200% zoom
  - no unexpected browser console errors or page errors

## Accessibility

The Export trigger retains its accessible name, tooltip, decorative-icon treatment, menu state, keyboard interaction, visible focus, and Escape focus restoration. Settled icon, tooltip, and focus-indicator contrast checks passed in light and dark modes.

## Dependency

This PR is intentionally based on #3036. After #3036 merges, retarget this PR to `main`. The separate BHE image-export PR should begin only after this prerequisite and the BHE toolbar-consumer PR merge.
