### PR TITLE
test(a11y): playwright coverage for api-explorer - bed-8640

### DIFF
--- a/cmd/ui/tests/a11y/api-explore.a11y.spec.ts
+++ b/cmd/ui/tests/a11y/api-explore.a11y.spec.ts
@@ -14,7 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { expectNoAccessibilityViolations, test } from '../fixtures';
+import { expect, expectNoAccessibilityViolations, test } from '../fixtures';
 
 test.describe('API Explorer page accessibility', () => {
     test('explore page has no detectable WCAG A/AA violations', async ({ page, makeAxeBuilder }, testInfo) => {
@@ -22,6 +22,70 @@ test.describe('API Explorer page accessibility', () => {
 
         // Wait for the filter input to load
         await page.getByRole('textbox', { name: 'Filter by tag or path' }).waitFor({ state: 'visible' });
+
+        const results = await makeAxeBuilder().include('#content-wrapper').analyze();
+        await expectNoAccessibilityViolations(testInfo, results, { page });
+    });
+
+    test('expanded resource', async ({ page, makeAxeBuilder }, testInfo) => {
+        await page.goto('/ui/api-explorer');
+
+        // Wait for the filter input to load
+        await page.getByRole('textbox', { name: 'Filter by tag or path' }).waitFor({ state: 'visible' });
+
+        const resourceButton = page.getByTestId('api-explorer').getByRole('button', { name: /^get.*api.*version$/i });
+
+        await resourceButton.click();
+        await expect(resourceButton).toHaveAttribute('aria-expanded', 'true');
+
+        const results = await makeAxeBuilder().include('#content-wrapper').analyze();
+        await expectNoAccessibilityViolations(testInfo, results, { page });
+    });
+
+    test('expanded disabled resource', async ({ page, makeAxeBuilder }, testInfo) => {
+        await page.goto('/ui/api-explorer');
+
+        // Wait for the filter input to load
+        await page.getByRole('textbox', { name: 'Filter by tag or path' }).waitFor({ state: 'visible' });
+
+        const resourceButton = page
+            .getByTestId('api-explorer')
+            .getByRole('button', { name: /^put.*api.*v2.*accept-eula$/i });
+
+        await resourceButton.click();
+        await expect(resourceButton).toHaveAttribute('aria-expanded', 'true');
+
+        const results = await makeAxeBuilder().include('#content-wrapper').analyze();
+        await expectNoAccessibilityViolations(testInfo, results, { page });
+    });
+
+    test('filter with no results', async ({ page, makeAxeBuilder }, testInfo) => {
+        await page.goto('/ui/api-explorer');
+
+        // Wait for the filter input to load
+        const filterInput = page.getByRole('textbox', { name: 'Filter by tag or path' });
+        await filterInput.waitFor({ state: 'visible' });
+
+        await filterInput.fill('no-matching-api-resource');
+
+        const apiExplorer = page.getByTestId('api-explorer');
+        await expect(
+            apiExplorer.getByRole('button', { name: /^(delete|get|head|options|patch|post|put|trace)\b/i })
+        ).toHaveCount(0);
+
+        const results = await makeAxeBuilder().include('#content-wrapper').analyze();
+        await expectNoAccessibilityViolations(testInfo, results, { page });
+    });
+
+    test('expanded Schemas', async ({ page, makeAxeBuilder }, testInfo) => {
+        await page.goto('/ui/api-explorer');
+
+        // Wait for the filter input to load
+        await page.getByRole('textbox', { name: 'Filter by tag or path' }).waitFor({ state: 'visible' });
+
+        const schemasButton = page.getByTestId('api-explorer').getByRole('button', { name: 'Schemas' });
+
+        await expect(schemasButton).toHaveAttribute('aria-expanded', 'true');
 
         const results = await makeAxeBuilder().include('#content-wrapper').analyze();
         await expectNoAccessibilityViolations(testInfo, results, { page });

--- a/cmd/ui/tests/a11y/api-explore.a11y.spec.ts
+++ b/cmd/ui/tests/a11y/api-explore.a11y.spec.ts
@@ -16,21 +16,19 @@
 
 import { expectNoAccessibilityViolations, test } from '../fixtures';
 
-test.describe('API Explorer page accessibility', () => {
+test.describe('WCAG A/AA Violations - Explore - API Explorer', () => {
     test.beforeEach(async ({ page }) => {
         await page.goto('/ui/api-explorer');
-
         await page.getByRole('textbox', { name: 'Filter by tag or path' }).waitFor({ state: 'visible' });
     });
 
-    test('default state has no detectable WCAG A/AA violations', async ({ page, makeAxeBuilder }, testInfo) => {
+    test('default state', async ({ page, makeAxeBuilder }, testInfo) => {
         const results = await makeAxeBuilder().include('#content-wrapper').analyze();
         await expectNoAccessibilityViolations(testInfo, results, { page });
     });
 
     test('expanded resource', async ({ page, makeAxeBuilder }, testInfo) => {
         await page.getByRole('button', { name: 'get /api/version' }).click();
-
         await page.getByText('Returns the supported API versions.').waitFor({ state: 'visible' });
 
         const results = await makeAxeBuilder().include('#content-wrapper').analyze();
@@ -39,7 +37,6 @@ test.describe('API Explorer page accessibility', () => {
 
     test('expanded disabled resource', async ({ page, makeAxeBuilder }, testInfo) => {
         await page.getByRole('button', { name: 'get /api/v2/saml', exact: true }).click();
-
         await page.getByText('Deprecated: This endpoint').waitFor({ state: 'visible' });
 
         const results = await makeAxeBuilder().include('#content-wrapper').analyze();
@@ -47,10 +44,7 @@ test.describe('API Explorer page accessibility', () => {
     });
 
     test('filter with no results', async ({ page, makeAxeBuilder }, testInfo) => {
-        const filterInput = page.getByRole('textbox', { name: 'Filter by tag or path' });
-
-        await filterInput.fill('no-matching-api-resource');
-
+        await page.getByRole('textbox', { name: 'Filter by tag or path' }).fill('no-matching-api-resource');
         await page.getByRole('heading', { name: 'No operations defined in spec!' }).waitFor({ state: 'visible' });
 
         const results = await makeAxeBuilder().include('#content-wrapper').analyze();
@@ -58,7 +52,14 @@ test.describe('API Explorer page accessibility', () => {
     });
 
     test('expanded Schemas', async ({ page, makeAxeBuilder }, testInfo) => {
-        await page.getByText('api.error-detail', { exact: true }).waitFor({ state: 'visible' });
+        // Set filter for empty reponse for easier view of Schemas
+        await page.getByRole('textbox', { name: 'Filter by tag or path' }).fill('no-matching-api-resource');
+
+        // Expand a schema and its property
+        await page.getByRole('button', { name: 'api.error-detail' }).click();
+        await page.getByRole('button', { name: '[...]' }).first().click();
+
+        await page.getByText('The context in which the').waitFor({ state: 'visible' });
 
         const results = await makeAxeBuilder().include('#content-wrapper').analyze();
         await expectNoAccessibilityViolations(testInfo, results, { page });

--- a/cmd/ui/tests/a11y/api-explore.a11y.spec.ts
+++ b/cmd/ui/tests/a11y/api-explore.a11y.spec.ts
@@ -14,78 +14,51 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { expect, expectNoAccessibilityViolations, test } from '../fixtures';
+import { expectNoAccessibilityViolations, test } from '../fixtures';
 
 test.describe('API Explorer page accessibility', () => {
-    test('explore page has no detectable WCAG A/AA violations', async ({ page, makeAxeBuilder }, testInfo) => {
+    test.beforeEach(async ({ page }) => {
         await page.goto('/ui/api-explorer');
 
-        // Wait for the filter input to load
         await page.getByRole('textbox', { name: 'Filter by tag or path' }).waitFor({ state: 'visible' });
+    });
 
+    test('default state has no detectable WCAG A/AA violations', async ({ page, makeAxeBuilder }, testInfo) => {
         const results = await makeAxeBuilder().include('#content-wrapper').analyze();
         await expectNoAccessibilityViolations(testInfo, results, { page });
     });
 
     test('expanded resource', async ({ page, makeAxeBuilder }, testInfo) => {
-        await page.goto('/ui/api-explorer');
+        await page.getByRole('button', { name: 'get /api/version' }).click();
 
-        // Wait for the filter input to load
-        await page.getByRole('textbox', { name: 'Filter by tag or path' }).waitFor({ state: 'visible' });
-
-        const resourceButton = page.getByTestId('api-explorer').getByRole('button', { name: /^get.*api.*version$/i });
-
-        await resourceButton.click();
-        await expect(resourceButton).toHaveAttribute('aria-expanded', 'true');
+        await page.getByText('Returns the supported API versions.').waitFor({ state: 'visible' });
 
         const results = await makeAxeBuilder().include('#content-wrapper').analyze();
         await expectNoAccessibilityViolations(testInfo, results, { page });
     });
 
     test('expanded disabled resource', async ({ page, makeAxeBuilder }, testInfo) => {
-        await page.goto('/ui/api-explorer');
+        await page.getByRole('button', { name: 'get /api/v2/saml', exact: true }).click();
 
-        // Wait for the filter input to load
-        await page.getByRole('textbox', { name: 'Filter by tag or path' }).waitFor({ state: 'visible' });
-
-        const resourceButton = page
-            .getByTestId('api-explorer')
-            .getByRole('button', { name: /^put.*api.*v2.*accept-eula$/i });
-
-        await resourceButton.click();
-        await expect(resourceButton).toHaveAttribute('aria-expanded', 'true');
+        await page.getByText('Deprecated: This endpoint').waitFor({ state: 'visible' });
 
         const results = await makeAxeBuilder().include('#content-wrapper').analyze();
         await expectNoAccessibilityViolations(testInfo, results, { page });
     });
 
     test('filter with no results', async ({ page, makeAxeBuilder }, testInfo) => {
-        await page.goto('/ui/api-explorer');
-
-        // Wait for the filter input to load
         const filterInput = page.getByRole('textbox', { name: 'Filter by tag or path' });
-        await filterInput.waitFor({ state: 'visible' });
 
         await filterInput.fill('no-matching-api-resource');
 
-        const apiExplorer = page.getByTestId('api-explorer');
-        await expect(
-            apiExplorer.getByRole('button', { name: /^(delete|get|head|options|patch|post|put|trace)\b/i })
-        ).toHaveCount(0);
+        await page.getByRole('heading', { name: 'No operations defined in spec!' }).waitFor({ state: 'visible' });
 
         const results = await makeAxeBuilder().include('#content-wrapper').analyze();
         await expectNoAccessibilityViolations(testInfo, results, { page });
     });
 
     test('expanded Schemas', async ({ page, makeAxeBuilder }, testInfo) => {
-        await page.goto('/ui/api-explorer');
-
-        // Wait for the filter input to load
-        await page.getByRole('textbox', { name: 'Filter by tag or path' }).waitFor({ state: 'visible' });
-
-        const schemasButton = page.getByTestId('api-explorer').getByRole('button', { name: 'Schemas' });
-
-        await expect(schemasButton).toHaveAttribute('aria-expanded', 'true');
+        await page.getByText('api.error-detail', { exact: true }).waitFor({ state: 'visible' });
 
         const results = await makeAxeBuilder().include('#content-wrapper').analyze();
         await expectNoAccessibilityViolations(testInfo, results, { page });


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Adds accessibility tests for the API Explorer page to verify compliance with accessibility standards.

## Motivation and Context

Resolves BED-8640

*Why is this change required? What problem does it solve?*

This change was needed to ensure the API Explorer page adheres to accessibility standards.

## How Has This Been Tested?

The tests were run locally.

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- New feature (non-breaking change which adds functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [X] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [X] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [X] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded accessibility coverage for API Explorer’s default, expanded, disabled-resource, empty-filter, and Schemas views.
  * Added validation for navigation, filtering, and resource expansion states before accessibility analysis.
  * Improved confidence that API Explorer remains accessible and usable across common interactions and UI states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->