### PR TITLE
test(a11y): admin file ingest, data quality coverage - BED-8639

### DIFF
--- a/cmd/ui/tests/a11y/Administration/data-quality.a11y.spec.ts
+++ b/cmd/ui/tests/a11y/Administration/data-quality.a11y.spec.ts
@@ -16,8 +16,8 @@
 
 import { expect, expectNoAccessibilityViolations, test } from '../../fixtures';
 
-test.describe('WCAG A/AA Violations - Administration - Data Quality', () => {
-    test('empty page', async ({ page, makeAxeBuilder }, testInfo) => {
+test.describe('Administration - Data Quality - has no detectable WCAG A/AA violations', () => {
+        test('empty page', async ({ page, makeAxeBuilder }, testInfo) => {
         await page.route('**/api/v2/available-domains', async (route) => {
             if (route.request().method() !== 'GET') {
                 return route.fallback();

--- a/cmd/ui/tests/a11y/Administration/data-quality.a11y.spec.ts
+++ b/cmd/ui/tests/a11y/Administration/data-quality.a11y.spec.ts
@@ -1,0 +1,103 @@
+// Copyright 2026 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { expect, expectNoAccessibilityViolations, test } from '../../fixtures';
+
+test.describe('WCAG A/AA Violations - Administration - Data Quality', () => {
+    test('empty page', async ({ page, makeAxeBuilder }, testInfo) => {
+        await page.route('**/api/v2/available-domains', async (route) => {
+            if (route.request().method() !== 'GET') {
+                return route.fallback();
+            }
+
+            await route.fulfill({ json: { data: [] } });
+        });
+
+        await page.goto('/ui/administration/data-quality');
+        await expect(page.getByText('No Domain or Tenant Selected', { exact: true })).toBeVisible();
+
+        const results = await makeAxeBuilder().include('#content-wrapper').analyze();
+        await expectNoAccessibilityViolations(testInfo, results, { page });
+    });
+
+    test('page with results', async ({ page, makeAxeBuilder }, testInfo) => {
+        await page.route('**/api/v2/available-domains', async (route) => {
+            if (route.request().method() !== 'GET') {
+                return route.fallback();
+            }
+
+            await route.fulfill({
+                json: {
+                    data: [
+                        {
+                            collected: true,
+                            exposures: [],
+                            hygiene_attack_paths: 0,
+                            id: 'example-domain-id',
+                            impactValue: 0,
+                            name: 'EXAMPLE.COM',
+                            type: 'active-directory',
+                        },
+                    ],
+                },
+            });
+        });
+        await page.route('**/api/v2/ad-domains/example-domain-id/data-quality-stats**', async (route) => {
+            if (route.request().method() !== 'GET') {
+                return route.fallback();
+            }
+
+            await route.fulfill({
+                json: {
+                    count: 1,
+                    data: [
+                        {
+                            acls: 34,
+                            aiacas: 1,
+                            certtemplates: 8,
+                            computers: 12,
+                            containers: 5,
+                            created_at: '2026-08-01T12:00:00Z',
+                            deleted_at: { Time: '0001-01-01T00:00:00Z', Valid: false },
+                            domains: 1,
+                            enterprisecas: 1,
+                            gpos: 4,
+                            groups: 9,
+                            issuancepolicies: 2,
+                            local_group_completeness: 0.75,
+                            ntauthstores: 1,
+                            ous: 6,
+                            relationships: 56,
+                            rootcas: 1,
+                            session_completeness: 0.5,
+                            sessions: 23,
+                            updated_at: '2026-08-01T12:00:00Z',
+                            users: 10,
+                        },
+                    ],
+                    limit: 1,
+                    skip: 0,
+                },
+            });
+        });
+
+        await page.goto('/ui/administration/data-quality');
+        await expect(page.getByText('Group Completeness')).toBeVisible();
+
+        const results = await makeAxeBuilder().include('#content-wrapper').analyze();
+        await expectNoAccessibilityViolations(testInfo, results, { page });
+    });
+});

--- a/cmd/ui/tests/a11y/Administration/data-quality.a11y.spec.ts
+++ b/cmd/ui/tests/a11y/Administration/data-quality.a11y.spec.ts
@@ -14,10 +14,34 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { expect, expectNoAccessibilityViolations, test } from '../../fixtures';
+import { expectNoAccessibilityViolations, test } from '../../fixtures';
+
+const dataQualityResult = {
+    acls: 34,
+    aiacas: 1,
+    certtemplates: 8,
+    computers: 12,
+    containers: 5,
+    created_at: '2026-08-01T12:00:00Z',
+    deleted_at: { Time: '0001-01-01T00:00:00Z', Valid: false },
+    domains: 1,
+    enterprisecas: 1,
+    gpos: 4,
+    groups: 9,
+    issuancepolicies: 2,
+    local_group_completeness: 0.75,
+    ntauthstores: 1,
+    ous: 6,
+    relationships: 56,
+    rootcas: 1,
+    session_completeness: 0.5,
+    sessions: 23,
+    updated_at: '2026-08-01T12:00:00Z',
+    users: 10,
+};
 
 test.describe('Administration - Data Quality - has no detectable WCAG A/AA violations', () => {
-        test('empty page', async ({ page, makeAxeBuilder }, testInfo) => {
+    test('empty page', async ({ page, makeAxeBuilder }, testInfo) => {
         await page.route('**/api/v2/available-domains', async (route) => {
             if (route.request().method() !== 'GET') {
                 return route.fallback();
@@ -27,8 +51,7 @@ test.describe('Administration - Data Quality - has no detectable WCAG A/AA viola
         });
 
         await page.goto('/ui/administration/data-quality');
-        await expect(page.getByText('No Domain or Tenant Selected', { exact: true })).toBeVisible();
-
+        await page.getByText('No Domain or Tenant Selected', { exact: true }).waitFor();
         const results = await makeAxeBuilder().include('#content-wrapper').analyze();
         await expectNoAccessibilityViolations(testInfo, results, { page });
     });
@@ -63,31 +86,7 @@ test.describe('Administration - Data Quality - has no detectable WCAG A/AA viola
             await route.fulfill({
                 json: {
                     count: 1,
-                    data: [
-                        {
-                            acls: 34,
-                            aiacas: 1,
-                            certtemplates: 8,
-                            computers: 12,
-                            containers: 5,
-                            created_at: '2026-08-01T12:00:00Z',
-                            deleted_at: { Time: '0001-01-01T00:00:00Z', Valid: false },
-                            domains: 1,
-                            enterprisecas: 1,
-                            gpos: 4,
-                            groups: 9,
-                            issuancepolicies: 2,
-                            local_group_completeness: 0.75,
-                            ntauthstores: 1,
-                            ous: 6,
-                            relationships: 56,
-                            rootcas: 1,
-                            session_completeness: 0.5,
-                            sessions: 23,
-                            updated_at: '2026-08-01T12:00:00Z',
-                            users: 10,
-                        },
-                    ],
+                    data: [dataQualityResult],
                     limit: 1,
                     skip: 0,
                 },
@@ -95,7 +94,7 @@ test.describe('Administration - Data Quality - has no detectable WCAG A/AA viola
         });
 
         await page.goto('/ui/administration/data-quality');
-        await expect(page.getByText('Group Completeness')).toBeVisible();
+        await page.getByText('Group Completeness').waitFor();
 
         const results = await makeAxeBuilder().include('#content-wrapper').analyze();
         await expectNoAccessibilityViolations(testInfo, results, { page });

--- a/cmd/ui/tests/a11y/Administration/file-ingest.a11y.spec.ts
+++ b/cmd/ui/tests/a11y/Administration/file-ingest.a11y.spec.ts
@@ -14,8 +14,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { expect, expectNoAccessibilityViolations, test } from '../../fixtures';
-
+import { hideBySelector } from 'bh-playwright-testing/axe';
+import { expectNoAccessibilityViolations, test } from '../../fixtures';
 const completedIngest = {
     created_at: '2026-08-01T12:00:00Z',
     deleted_at: { Time: '0001-01-01T00:00:00Z', Valid: false },
@@ -41,7 +41,7 @@ const failedIngest = {
 };
 
 test.describe('Administration - File Ingest - has no detectable WCAG A/AA violations', () => {
-        test.beforeEach(async ({ page }) => {
+    test.beforeEach(async ({ page }) => {
         await page.route('**/api/v2/features', async (route) => {
             if (route.request().method() !== 'GET') {
                 return route.fallback();
@@ -68,9 +68,8 @@ test.describe('Administration - File Ingest - has no detectable WCAG A/AA violat
         });
 
         await page.goto('/ui/administration/file-ingest');
-        await expect(page.getByRole('columnheader', { name: 'ID / User / Status' })).toBeVisible();
-        await expect(page.getByText('0–0 of 0')).toBeVisible();
-
+        await page.getByRole('columnheader', { name: 'ID / User / Status' }).waitFor({ state: 'visible' });
+        await page.getByText('0–0 of 0').waitFor({ state: 'visible' });
         const results = await makeAxeBuilder().include('#content-wrapper').analyze();
         await expectNoAccessibilityViolations(testInfo, results, { page });
     });
@@ -88,8 +87,7 @@ test.describe('Administration - File Ingest - has no detectable WCAG A/AA violat
         });
 
         await page.goto('/ui/administration/file-ingest');
-        await expect(page.getByRole('button', { name: 'View ingest 1 details' })).toBeVisible();
-
+        await page.getByRole('button', { name: 'View ingest 1 details' }).waitFor({ state: 'visible' });
         const results = await makeAxeBuilder().include('#content-wrapper').analyze();
         await expectNoAccessibilityViolations(testInfo, results, { page });
     });
@@ -129,8 +127,7 @@ test.describe('Administration - File Ingest - has no detectable WCAG A/AA violat
 
         await page.goto('/ui/administration/file-ingest');
         await page.getByRole('button', { name: 'View ingest 1 details' }).click();
-        await expect(page.getByText('bloodhound-data.zip')).toBeVisible();
-
+        await page.getByText('bloodhound-data.zip').waitFor({ state: 'visible' });
         const results = await makeAxeBuilder().include('#content-wrapper').analyze();
         await expectNoAccessibilityViolations(testInfo, results, { page });
     });
@@ -172,8 +169,7 @@ test.describe('Administration - File Ingest - has no detectable WCAG A/AA violat
         await page.goto('/ui/administration/file-ingest');
         await page.getByRole('button', { name: 'View ingest 2 details' }).click();
         await page.getByRole('button', { name: /invalid-data\.json Failure/ }).click();
-        await expect(page.getByText('The uploaded file could not be parsed.')).toBeVisible();
-
+        await page.getByText('The uploaded file could not be parsed.').waitFor({ state: 'visible' });
         const results = await makeAxeBuilder().include('#content-wrapper').analyze();
         await expectNoAccessibilityViolations(testInfo, results, { page });
     });
@@ -199,9 +195,12 @@ test.describe('Administration - File Ingest - has no detectable WCAG A/AA violat
 
         await page.goto('/ui/administration/file-ingest');
         await page.getByTestId('file_ingest_log-open_filter_dialog').click();
-        await expect(page.getByRole('heading', { name: 'Filter' })).toBeVisible();
 
-        const results = await makeAxeBuilder().include('#content-wrapper').include('[role="dialog"]').analyze();
+        await hideBySelector(page, '#content-wrapper');
+
+        await page.getByRole('heading', { name: 'Filter' }).waitFor({ state: 'visible' });
+
+        const results = await makeAxeBuilder().include('[role="dialog"]').analyze();
         await expectNoAccessibilityViolations(testInfo, results, { page });
     });
 });

--- a/cmd/ui/tests/a11y/Administration/file-ingest.a11y.spec.ts
+++ b/cmd/ui/tests/a11y/Administration/file-ingest.a11y.spec.ts
@@ -1,0 +1,207 @@
+// Copyright 2026 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { expect, expectNoAccessibilityViolations, test } from '../../fixtures';
+
+const completedIngest = {
+    created_at: '2026-08-01T12:00:00Z',
+    deleted_at: { Time: '0001-01-01T00:00:00Z', Valid: false },
+    end_time: '2026-08-01T12:01:00Z',
+    failed_files: 0,
+    id: 1,
+    last_ingest: '2026-08-01T12:01:00Z',
+    start_time: '2026-08-01T12:00:00Z',
+    status: 2,
+    status_message: 'Completed',
+    total_files: 1,
+    updated_at: '2026-08-01T12:01:00Z',
+    user_email_address: 'analyst@example.com',
+    user_id: 'user-1',
+};
+
+const failedIngest = {
+    ...completedIngest,
+    failed_files: 1,
+    id: 2,
+    status: 5,
+    status_message: 'Failed',
+};
+
+test.describe('WCAG A/AA Violations - Administration - File Ingest', () => {
+    test.beforeEach(async ({ page }) => {
+        await page.route('**/api/v2/features', async (route) => {
+            if (route.request().method() !== 'GET') {
+                return route.fallback();
+            }
+
+            await route.fulfill({
+                json: {
+                    data: [{ key: 'open_graph_phase_2', enabled: true }],
+                },
+            });
+        });
+    });
+
+    test('empty history', async ({ page, makeAxeBuilder }, testInfo) => {
+        await page.route('**/api/v2/file-upload**', async (route) => {
+            if (
+                route.request().method() !== 'GET' ||
+                new URL(route.request().url()).pathname !== '/api/v2/file-upload'
+            ) {
+                return route.fallback();
+            }
+
+            await route.fulfill({ json: { count: 0, data: [], limit: 10, skip: 0 } });
+        });
+
+        await page.goto('/ui/administration/file-ingest');
+        await expect(page.getByRole('columnheader', { name: 'ID / User / Status' })).toBeVisible();
+        await expect(page.getByText('0–0 of 0')).toBeVisible();
+
+        const results = await makeAxeBuilder().include('#content-wrapper').analyze();
+        await expectNoAccessibilityViolations(testInfo, results, { page });
+    });
+
+    test('with history', async ({ page, makeAxeBuilder }, testInfo) => {
+        await page.route('**/api/v2/file-upload**', async (route) => {
+            if (
+                route.request().method() !== 'GET' ||
+                new URL(route.request().url()).pathname !== '/api/v2/file-upload'
+            ) {
+                return route.fallback();
+            }
+
+            await route.fulfill({ json: { count: 1, data: [completedIngest], limit: 10, skip: 0 } });
+        });
+
+        await page.goto('/ui/administration/file-ingest');
+        await expect(page.getByRole('button', { name: 'View ingest 1 details' })).toBeVisible();
+
+        const results = await makeAxeBuilder().include('#content-wrapper').analyze();
+        await expectNoAccessibilityViolations(testInfo, results, { page });
+    });
+    test('with ingest selected', async ({ page, makeAxeBuilder }, testInfo) => {
+        await page.route('**/api/v2/file-upload**', async (route) => {
+            if (
+                route.request().method() !== 'GET' ||
+                new URL(route.request().url()).pathname !== '/api/v2/file-upload'
+            ) {
+                return route.fallback();
+            }
+
+            await route.fulfill({ json: { count: 1, data: [completedIngest], limit: 10, skip: 0 } });
+        });
+        await page.route('**/api/v2/file-upload/1/completed-tasks', async (route) => {
+            if (route.request().method() !== 'GET') {
+                return route.fallback();
+            }
+
+            await route.fulfill({
+                json: {
+                    data: [
+                        {
+                            created_at: '2026-08-01T12:01:00Z',
+                            deleted_at: { Time: '0001-01-01T00:00:00Z', Valid: false },
+                            errors: [],
+                            file_name: 'bloodhound-data.zip',
+                            id: 1,
+                            parent_file_name: '',
+                            updated_at: '2026-08-01T12:01:00Z',
+                            warnings: [],
+                        },
+                    ],
+                },
+            });
+        });
+
+        await page.goto('/ui/administration/file-ingest');
+        await page.getByRole('button', { name: 'View ingest 1 details' }).click();
+        await expect(page.getByText('bloodhound-data.zip')).toBeVisible();
+
+        const results = await makeAxeBuilder().include('#content-wrapper').analyze();
+        await expectNoAccessibilityViolations(testInfo, results, { page });
+    });
+
+    test('with errored ingest selected', async ({ page, makeAxeBuilder }, testInfo) => {
+        await page.route('**/api/v2/file-upload**', async (route) => {
+            if (
+                route.request().method() !== 'GET' ||
+                new URL(route.request().url()).pathname !== '/api/v2/file-upload'
+            ) {
+                return route.fallback();
+            }
+
+            await route.fulfill({ json: { count: 1, data: [failedIngest], limit: 10, skip: 0 } });
+        });
+        await page.route('**/api/v2/file-upload/2/completed-tasks', async (route) => {
+            if (route.request().method() !== 'GET') {
+                return route.fallback();
+            }
+
+            await route.fulfill({
+                json: {
+                    data: [
+                        {
+                            created_at: '2026-08-01T12:01:00Z',
+                            deleted_at: { Time: '0001-01-01T00:00:00Z', Valid: false },
+                            errors: ['The uploaded file could not be parsed.'],
+                            file_name: 'invalid-data.json',
+                            id: 2,
+                            parent_file_name: '',
+                            updated_at: '2026-08-01T12:01:00Z',
+                            warnings: [],
+                        },
+                    ],
+                },
+            });
+        });
+
+        await page.goto('/ui/administration/file-ingest');
+        await page.getByRole('button', { name: 'View ingest 2 details' }).click();
+        await page.getByRole('button', { name: /invalid-data\.json Failure/ }).click();
+        await expect(page.getByText('The uploaded file could not be parsed.')).toBeVisible();
+
+        const results = await makeAxeBuilder().include('#content-wrapper').analyze();
+        await expectNoAccessibilityViolations(testInfo, results, { page });
+    });
+
+    test('ingest filter', async ({ page, makeAxeBuilder }, testInfo) => {
+        await page.route('**/api/v2/file-upload**', async (route) => {
+            if (
+                route.request().method() !== 'GET' ||
+                new URL(route.request().url()).pathname !== '/api/v2/file-upload'
+            ) {
+                return route.fallback();
+            }
+
+            await route.fulfill({ json: { count: 0, data: [], limit: 10, skip: 0 } });
+        });
+        await page.route('**/api/v2/bloodhound-users-minimal', async (route) => {
+            if (route.request().method() !== 'GET') {
+                return route.fallback();
+            }
+
+            await route.fulfill({ json: { data: { users: [] } } });
+        });
+
+        await page.goto('/ui/administration/file-ingest');
+        await page.getByTestId('file_ingest_log-open_filter_dialog').click();
+        await expect(page.getByRole('heading', { name: 'Filter' })).toBeVisible();
+
+        const results = await makeAxeBuilder().include('#content-wrapper').include('[role="dialog"]').analyze();
+        await expectNoAccessibilityViolations(testInfo, results, { page });
+    });
+});

--- a/cmd/ui/tests/a11y/Administration/file-ingest.a11y.spec.ts
+++ b/cmd/ui/tests/a11y/Administration/file-ingest.a11y.spec.ts
@@ -40,8 +40,8 @@ const failedIngest = {
     status_message: 'Failed',
 };
 
-test.describe('WCAG A/AA Violations - Administration - File Ingest', () => {
-    test.beforeEach(async ({ page }) => {
+test.describe('Administration - File Ingest - has no detectable WCAG A/AA violations', () => {
+        test.beforeEach(async ({ page }) => {
         await page.route('**/api/v2/features', async (route) => {
             if (route.request().method() !== 'GET') {
                 return route.fallback();


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

Adds accessibility tests for the Administration file ingest and data quality pages, to verify compliance with accessibility standards.

## Motivation and Context


Resolves bed-8639

*Why is this change required? What problem does it solve?*

This change was needed to ensure the Administration file ingest and data quality pages adhere to accessibility standards.

## How Has This Been Tested?

The tests were run locally.

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- New feature (non-breaking change which adds functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [X] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [X] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [X] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added accessibility coverage for the Administration Data Quality page, including empty and populated states.
  * Added accessibility coverage for the Administration File Ingest page, including history states, ingest details, and filtering.
  * Added checks to help ensure key page areas and dialogs meet accessibility standards across common user workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->