### PR TITLE
feat: Display Associated Labels in Explore Entity Panel BED-9168

### DIFF
--- a/packages/javascript/bh-shared-ui/src/components/EntityInfo/EntityInfoContent.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/EntityInfo/EntityInfoContent.test.tsx
@@ -13,7 +13,7 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
-import { NodeDetails } from 'js-client-library';
+import { AssetGroupTagTypeLabel, AssetGroupTagTypeOwned, AssetGroupTagTypeZone, NodeDetails } from 'js-client-library';
 import { rest } from 'msw';
 import { setupServer } from 'msw/node';
 import { ActiveDirectoryNodeKind, AzureNodeKind } from '../../graphSchema';
@@ -74,6 +74,48 @@ afterEach(() => server.resetHandlers());
 afterAll(() => server.close());
 
 describe('EntityInfoContent', () => {
+    it('displays all associated custom labels in the object information section', async () => {
+        server.use(
+            rest.get('/api/v2/features', (_req, res, ctx) => {
+                return res(ctx.json({ data: [{ key: 'tier_management_engine', enabled: true }] }));
+            }),
+            rest.get('/api/v2/asset-group-tags', (_req, res, ctx) => {
+                return res(
+                    ctx.json({
+                        data: {
+                            tags: [
+                                { id: 1, name: 'Tier Zero', type: AssetGroupTagTypeZone },
+                                { id: 2, name: 'Crown Jewels', type: AssetGroupTagTypeLabel },
+                                { id: 3, name: 'Incident Response', type: AssetGroupTagTypeLabel },
+                                { id: 4, name: 'Owned', type: AssetGroupTagTypeOwned },
+                                { id: 5, name: 'Not Associated', type: AssetGroupTagTypeLabel },
+                            ],
+                        },
+                    })
+                );
+            })
+        );
+
+        const selectedNode = {
+            node_id: 1,
+            kinds: [
+                { name: 'CustomUser', node_kind_id: 1 },
+                { name: 'Tag_Tier_Zero', node_kind_id: 2 },
+                { name: 'Tag_Crown_Jewels', node_kind_id: 3 },
+                { name: 'Tag_Incident_Response', node_kind_id: 4 },
+                { name: 'Tag_Owned', node_kind_id: 5 },
+            ],
+            properties: { objectid: 'test-user' },
+        };
+
+        render(<EntityInfoContentWithProvider selectedNode={selectedNode} />);
+
+        expect(await screen.findByText('Labels:')).toBeInTheDocument();
+        expect(screen.getByText('Crown Jewels, Incident Response')).toBeInTheDocument();
+        expect(screen.queryByText('Owned')).not.toBeInTheDocument();
+        expect(screen.queryByText('Not Associated')).not.toBeInTheDocument();
+    });
+
     it('AZRole information panel will not display a section for PIM Assignments', async () => {
         const testId = '1';
         const nodeType = AzureNodeKind.Role;

--- a/packages/javascript/bh-shared-ui/src/components/EntityInfo/EntityObjectInformation.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/EntityInfo/EntityObjectInformation.tsx
@@ -16,7 +16,7 @@
 import { NodeDetails, NodeDetailsWithInfo } from 'js-client-library';
 import { useEffect } from 'react';
 import { kindObjectsToKindNames, useExploreParams, usePreviousValue, usePrimaryKind, useTagsQuery } from '../../hooks';
-import { getZoneNameFromKinds } from '../../hooks/useAssetGroupTags';
+import { getLabelNamesFromKinds, getZoneNameFromKinds } from '../../hooks/useAssetGroupTags';
 import { EntityField, formatObjectInfoFields } from '../../utils';
 import { BasicObjectInfoFields } from '../../views/Explore/BasicObjectInfoFields';
 import { SearchValue } from '../../views/Explore/ExploreSearch';
@@ -40,6 +40,7 @@ export default function EntityObjectInformation({ selectedNode }: EntityObjectIn
 
     const tagsQuery = useTagsQuery();
     const zoneName = getZoneNameFromKinds(tagsQuery?.data, kindNames);
+    const labelNames = getLabelNamesFromKinds(tagsQuery?.data, kindNames);
 
     useEffect(() => {
         if (!previousEntity || !selectedNode.node_id || previousEntity !== selectedNode.node_id) {
@@ -65,6 +66,7 @@ export default function EntityObjectInformation({ selectedNode }: EntityObjectIn
                     handleSourceNodeSelected={handleSourceNodeSelected}
                     nodeType={primaryKind}
                     zone={zoneName}
+                    labels={labelNames}
                 />
                 <ObjectInfoFields fields={formattedObjectFields} />
             </FieldsContainer>

--- a/packages/javascript/bh-shared-ui/src/hooks/useAssetGroupTags/useAssetGroupTags.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/hooks/useAssetGroupTags/useAssetGroupTags.test.tsx
@@ -87,6 +87,26 @@ afterEach(() => server.resetHandlers());
 afterAll(() => server.close());
 
 describe('the useAssetGroupTags utilities', () => {
+    it('returns the label names associated with a node and excludes non-label tags', () => {
+        const tags = [
+            { name: 'Tier Zero', type: AssetGroupTagTypeZone },
+            { name: 'Owned', type: AssetGroupTagTypeOwned },
+            { name: 'Crown Jewels', type: AssetGroupTagTypeLabel },
+            { name: 'Incident Response', type: AssetGroupTagTypeLabel },
+            { name: 'Not Associated', type: AssetGroupTagTypeLabel },
+        ] as AssetGroupTag[];
+
+        expect(
+            agtHook.getLabelNamesFromKinds(tags, [
+                'User',
+                'Tag_Tier_Zero',
+                'Tag_Owned',
+                'Tag_Crown_Jewels',
+                'Tag_Incident_Response',
+            ])
+        ).toEqual(['Crown Jewels', 'Incident Response']);
+    });
+
     it('enables returning a list of tags', async () => {
         const { result } = renderHook(() => agtHook.useTagsQuery());
 

--- a/packages/javascript/bh-shared-ui/src/hooks/useAssetGroupTags/useAssetGroupTags.tsx
+++ b/packages/javascript/bh-shared-ui/src/hooks/useAssetGroupTags/useAssetGroupTags.tsx
@@ -97,6 +97,21 @@ export const getZoneNameFromKinds = (
     return match?.name;
 };
 
+export const getLabelNamesFromKinds = (tags: AssetGroupTag[] | undefined, kinds: string[] | undefined): string[] => {
+    const kindsSet = new Set(kinds);
+
+    return (
+        tags
+            ?.filter((tag) => {
+                if (tag.type !== AssetGroupTagTypeLabel) return false;
+
+                const tagKind = tagNameToKind(tag.name);
+                return kindsSet.has(tagKind);
+            })
+            .map((tag) => tag.name) ?? []
+    );
+};
+
 export const getOwnedTag = (tags: AssetGroupTag[]) => tags.find((tag) => tag.type === AssetGroupTagTypeOwned);
 
 export const getTierZeroTag = (tags: AssetGroupTag[]) => tags.find((tag) => tag.position === HighestPrivilegePosition);

--- a/packages/javascript/bh-shared-ui/src/views/Explore/BasicObjectInfoFields.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/Explore/BasicObjectInfoFields.tsx
@@ -33,6 +33,7 @@ interface BasicObjectInfoFieldsProps {
         service_principal_id?: string;
         federatedidentitycredentialappid?: string;
     };
+    labels?: string[];
     handleSourceNodeSelected?: (sourceNode: SearchValue) => void;
     nodeType?: string;
     zone?: string;
@@ -68,20 +69,22 @@ const RelatedKindField = (
 
 const basicObjectFields = [
     'zone',
+    'labels',
     'nodeType',
     'isTierZero',
     'isOwnedObject',
     CommonKindProperties.DisplayName,
     CommonKindProperties.ObjectID,
-] satisfies (KnownNodeProperties | CommonKindProperties | 'zone')[];
+] satisfies (KnownNodeProperties | CommonKindProperties | 'zone' | 'labels')[];
 
 export const BasicObjectInfoFields: React.FC<BasicObjectInfoFieldsProps> = ({
     properties: props,
     handleSourceNodeSelected,
+    labels,
     nodeType,
     zone,
 }): JSX.Element => {
-    const fieldValues = { ...props, nodeType, zone };
+    const fieldValues = { ...props, labels: labels?.join(', '), nodeType, zone };
     return (
         <>
             {basicObjectFields.map((field) => {


### PR DESCRIPTION
## Description

Displays every custom label associated with the selected entity in Explore's Object Information panel.

The shared UI derives associated label-type asset-group tags from the selected node's kinds, excludes zone, ownership, and unrelated tags, and renders multiple labels comma-separated on one row with natural wrapping when horizontal space is unavailable.

Review size: 23 production-code additions and 3 deletions, plus 63 test additions and 1 test deletion.

## Motivation and Context

Resolves BED-9168

Analysts currently cannot see an entity's associated custom labels from the Explore entity panel. They must leave their investigation context or use another workflow to determine how the entity has been categorized.

Displaying the labels alongside the existing object information makes this context immediately available without changing the underlying label or asset-group behavior.

## How Has This Been Tested?

Environment:

- Isolated local BloodHound Enterprise development stack
- Official Active Directory and Entra ID sample data
- Entity with three associated labels for multi-label rendering coverage

Automated validation:

- `just prepare-for-codereview`
- Focused shared UI unit tests: 11 passed
- Shared UI TypeScript type checking
- Playwright entity-panel regression coverage

Manual browser validation:

- Confirmed all three associated labels appear in the Object Information panel
- Confirmed only associated label-type tags are displayed
- Confirmed labels are comma-separated on the same row when space permits
- Confirmed labels naturally wrap when the row is constrained
- Confirmed the entity panel remains usable at 200% browser zoom
- Confirmed no browser console errors and successful UI/API responses

## Screenshots (optional):

### Explore context

![Explore context](https://gist.githubusercontent.com/justin-prime1/6bbc4a75070034ff27778d707cef6b37/raw/c94cf68d7dab017f2a1647805b205426bf64e4aa/explore-entity-labels-context.png)

### Entity panel

![Entity panel](https://gist.githubusercontent.com/justin-prime1/6bbc4a75070034ff27778d707cef6b37/raw/c94cf68d7dab017f2a1647805b205426bf64e4aa/entity-panel-labels-standard.png)

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: BED-9168
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - No OpenAPI or user-facing documentation changes are required
  - Existing code comments and JSDoc remain accurate
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All relevant new and existing tests passed
