### PR TITLE
test(a11y): playwright coverage for administration - database management and manage users' pages - bed-8639

### DIFF
--- a/cmd/ui/tests/a11y/Administration/database-management.a11y.spec.ts
+++ b/cmd/ui/tests/a11y/Administration/database-management.a11y.spec.ts
@@ -14,7 +14,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { expect, expectNoAccessibilityViolations, test } from '../../fixtures';
+import { hideBySelector } from 'bh-playwright-testing/axe';
+import { expectNoAccessibilityViolations, test } from '../../fixtures';
 
 test.describe('Administration - Database Management - has no detectable WCAG A/AA violations', () => {
     test.beforeEach(async ({ page }) => {
@@ -91,8 +92,8 @@ test.describe('Administration - Database Management - has no detectable WCAG A/A
 
     test('page', async ({ page, makeAxeBuilder }, testInfo) => {
         await page.goto('/ui/administration/database-management');
-        await expect(page.getByRole('heading', { name: 'Database Management' })).toBeVisible();
-        await expect(page.getByRole('checkbox', { name: 'All graph data' })).toBeVisible();
+        await page.getByRole('heading', { name: 'Database Management' }).waitFor({ state: 'visible' });
+        await page.getByRole('checkbox', { name: 'All graph data' }).waitFor({ state: 'visible' });
 
         const results = await makeAxeBuilder().include('#content-wrapper').analyze();
         await expectNoAccessibilityViolations(testInfo, results, { page });
@@ -102,9 +103,14 @@ test.describe('Administration - Database Management - has no detectable WCAG A/A
         await page.goto('/ui/administration/database-management');
         await page.getByRole('checkbox', { name: 'All asset group selectors' }).check();
         await page.getByRole('button', { name: 'Delete' }).click();
-        await expect(page.getByRole('dialog', { name: 'Delete data from the current environment?' })).toBeVisible();
+        await hideBySelector(page, '#content-wrapper');
 
-        const results = await makeAxeBuilder().include('#content-wrapper').include('[role="dialog"]').analyze();
+        await page
+            .getByRole('dialog', { name: 'Delete data from the current environment?' })
+            .waitFor({ state: 'visible' });
+
+        const results = await makeAxeBuilder().include('[role="dialog"]').analyze();
+
         await expectNoAccessibilityViolations(testInfo, results, { page });
     });
 });

--- a/cmd/ui/tests/a11y/Administration/database-management.a11y.spec.ts
+++ b/cmd/ui/tests/a11y/Administration/database-management.a11y.spec.ts
@@ -1,0 +1,110 @@
+// Copyright 2026 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { expect, expectNoAccessibilityViolations, test } from '../../fixtures';
+
+test.describe('Administration - Database Management - has no detectable WCAG A/AA violations', () => {
+    test.beforeEach(async ({ page }) => {
+        await page.route('**/api/v2/graphs/source-kinds', async (route) => {
+            if (route.request().method() !== 'GET') {
+                return route.fallback();
+            }
+
+            await route.fulfill({
+                json: {
+                    data: {
+                        kinds: [
+                            { id: 1, name: 'Base' },
+                            { id: 2, name: 'AZBase' },
+                            { id: 3, name: 'ACustomBase' },
+                            { id: 0, name: 'Sourceless' },
+                        ],
+                    },
+                },
+            });
+        });
+        await page.route('**/api/v2/features', async (route) => {
+            if (route.request().method() !== 'GET') {
+                return route.fallback();
+            }
+
+            await route.fulfill({
+                json: {
+                    data: [
+                        {
+                            id: 1,
+                            key: 'clear_graph_data',
+                            name: 'Clear Graph Data',
+                            description: 'Enables the ability to delete all nodes and edges from the graph database.',
+                            enabled: true,
+                            user_updatable: true,
+                        },
+                    ],
+                },
+            });
+        });
+        await page.route('**/api/v2/self', async (route) => {
+            if (route.request().method() !== 'GET') {
+                return route.fallback();
+            }
+
+            await route.fulfill({
+                json: {
+                    data: {
+                        sso_provider_id: null,
+                        AuthSecret: null,
+                        roles: [
+                            {
+                                name: 'Administrator',
+                                permissions: [{ authority: 'db', name: 'Wipe' }],
+                                id: 4,
+                            },
+                        ],
+                        first_name: 'Test',
+                        last_name: 'Administrator',
+                        email_address: 'test-admin@example.com',
+                        principal_name: 'test_admin',
+                        is_disabled: false,
+                        eula_accepted: true,
+                        id: 'user-1',
+                        created_at: '2026-01-01T12:00:00Z',
+                        updated_at: '2026-01-01T12:00:00Z',
+                        deleted_at: { Time: '0001-01-01T00:00:00Z', Valid: false },
+                    },
+                },
+            });
+        });
+    });
+
+    test('page', async ({ page, makeAxeBuilder }, testInfo) => {
+        await page.goto('/ui/administration/database-management');
+        await expect(page.getByRole('heading', { name: 'Database Management' })).toBeVisible();
+        await expect(page.getByRole('checkbox', { name: 'All graph data' })).toBeVisible();
+
+        const results = await makeAxeBuilder().include('#content-wrapper').analyze();
+        await expectNoAccessibilityViolations(testInfo, results, { page });
+    });
+
+    test('delete confirmation dialog', async ({ page, makeAxeBuilder }, testInfo) => {
+        await page.goto('/ui/administration/database-management');
+        await page.getByRole('checkbox', { name: 'All asset group selectors' }).check();
+        await page.getByRole('button', { name: 'Delete' }).click();
+        await expect(page.getByRole('dialog', { name: 'Delete data from the current environment?' })).toBeVisible();
+
+        const results = await makeAxeBuilder().include('#content-wrapper').include('[role="dialog"]').analyze();
+        await expectNoAccessibilityViolations(testInfo, results, { page });
+    });
+});

--- a/cmd/ui/tests/a11y/Administration/manage-users.a11y.spec.ts
+++ b/cmd/ui/tests/a11y/Administration/manage-users.a11y.spec.ts
@@ -1,0 +1,267 @@
+// Copyright 2026 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Page } from '@playwright/test';
+import { expect, expectNoAccessibilityViolations, test } from '../../fixtures';
+
+const administrator = {
+    sso_provider_id: null,
+    AuthSecret: {
+        digest_method: 'argon2',
+        expires_at: '2027-01-01T12:00:00Z',
+        totp_activated: false,
+        id: 31,
+        created_at: '2026-01-01T12:00:00Z',
+        updated_at: '2026-01-01T12:00:00Z',
+        deleted_at: { Time: '0001-01-01T00:00:00Z', Valid: false },
+    },
+    roles: [
+        {
+            name: 'Administrator',
+            description: 'Administrator',
+            permissions: [{ authority: 'auth', name: 'ManageUsers' }],
+            id: 4,
+            created_at: '2026-01-01T12:00:00Z',
+            updated_at: '2026-01-01T12:00:00Z',
+            deleted_at: { Time: '0001-01-01T00:00:00Z', Valid: false },
+        },
+    ],
+    first_name: 'Test',
+    last_name: 'Administrator',
+    email_address: 'test-admin@example.com',
+    principal_name: 'test_admin',
+    last_login: '0001-01-01T00:00:00Z',
+    is_disabled: false,
+    eula_accepted: true,
+    id: 'user-1',
+    created_at: '2026-01-01T12:00:00Z',
+    updated_at: '2026-01-01T12:00:00Z',
+    deleted_at: { Time: '0001-01-01T00:00:00Z', Valid: false },
+};
+
+const token = {
+    name: 'automation token',
+    hmac_method: 'hmac-sha2-256',
+    last_access: '2026-01-02T12:00:00Z',
+    id: 'token-1',
+    created_at: '2026-01-01T12:00:00Z',
+    updated_at: '2026-01-01T12:00:00Z',
+    deleted_at: { Time: '0001-01-01T00:00:00Z', Valid: false },
+    expires_at: null,
+};
+
+const routeUsers = async (page: Page, users: (typeof administrator)[]) => {
+    await page.route('**/api/v2/bloodhound-users**', async (route) => {
+        if (route.request().method() !== 'GET') {
+            return route.fallback();
+        }
+
+        const pathname = new URL(route.request().url()).pathname;
+        if (pathname === '/api/v2/bloodhound-users') {
+            return route.fulfill({ json: { data: { users } } });
+        }
+
+        const user = users.find(({ id }) => pathname === `/api/v2/bloodhound-users/${id}`);
+        if (user) {
+            return route.fulfill({ json: { data: user } });
+        }
+
+        await route.fallback();
+    });
+};
+
+const openUserActions = async (page: Page) => {
+    await page
+        .getByRole('row', { name: /test_admin/ })
+        .getByRole('button', { name: 'Show user actions' })
+        .click();
+};
+
+const openTokenManagement = async (page: Page) => {
+    await openUserActions(page);
+    await page.getByRole('menuitem', { name: 'Generate / Revoke API Tokens' }).click();
+};
+
+test.describe('Administration - Manage Users - has no detectable WCAG A/AA violations', () => {
+    test.beforeEach(async ({ page }) => {
+        await page.route('**/api/v2/self', async (route) => {
+            if (route.request().method() !== 'GET') return route.fallback();
+            await route.fulfill({ json: { data: administrator } });
+        });
+        await page.route('**/api/v2/config**', async (route) => {
+            if (route.request().method() !== 'GET') return route.fallback();
+            await route.fulfill({
+                json: {
+                    data: [
+                        { key: 'auth.api_tokens', value: { enabled: true } },
+                        { key: 'auth.api_token_expiration', value: { enabled: false, expiration_period: '90' } },
+                    ],
+                },
+            });
+        });
+        await page.route('**/api/v2/sso-providers', async (route) => {
+            if (route.request().method() !== 'GET') return route.fallback();
+            await route.fulfill({ json: { data: [] } });
+        });
+        await page.route('**/api/v2/roles**', async (route) => {
+            if (route.request().method() !== 'GET') return route.fallback();
+            await route.fulfill({ json: { data: { roles: administrator.roles } } });
+        });
+        await page.route('**/api/v2/available-domains', async (route) => {
+            if (route.request().method() !== 'GET') return route.fallback();
+            await route.fulfill({ json: { data: [] } });
+        });
+    });
+
+    test('empty page', async ({ page, makeAxeBuilder }, testInfo) => {
+        await routeUsers(page, []);
+        await page.goto('/ui/administration/manage-users');
+        await expect(page.getByRole('heading', { name: 'Manage Users' })).toBeVisible();
+        await expect(page.getByRole('columnheader', { name: 'Username' })).toBeVisible();
+        await expect(page.getByRole('row')).toHaveCount(1);
+
+        const results = await makeAxeBuilder().include('#content-wrapper').analyze();
+        await expectNoAccessibilityViolations(testInfo, results, { page });
+    });
+
+    test('page with users', async ({ page, makeAxeBuilder }, testInfo) => {
+        await routeUsers(page, [administrator]);
+        await page.goto('/ui/administration/manage-users');
+        await expect(page.getByText('test_admin', { exact: true })).toBeVisible();
+
+        const results = await makeAxeBuilder().include('#content-wrapper').analyze();
+        await expectNoAccessibilityViolations(testInfo, results, { page });
+    });
+
+    test('user actions menu displayed', async ({ page, makeAxeBuilder }, testInfo) => {
+        await routeUsers(page, [administrator]);
+        await page.goto('/ui/administration/manage-users');
+        await openUserActions(page);
+        await expect(page.getByRole('menuitem', { name: 'Update User' })).toBeVisible();
+
+        const results = await makeAxeBuilder().include('#content-wrapper').include('[role="menu"]').analyze();
+        await expectNoAccessibilityViolations(testInfo, results, { page });
+    });
+
+    test('update user dialog', async ({ page, makeAxeBuilder }, testInfo) => {
+        await routeUsers(page, [administrator]);
+        await page.goto('/ui/administration/manage-users');
+        await openUserActions(page);
+        await page.getByRole('menuitem', { name: 'Update User' }).click();
+        await expect(page.getByRole('dialog', { name: 'Update User Dialog' })).toBeVisible();
+        await expect(page.getByLabel('Email Address')).toBeVisible();
+
+        const results = await makeAxeBuilder().include('#content-wrapper').include('[role="dialog"]').analyze();
+        await expectNoAccessibilityViolations(testInfo, results, { page });
+    });
+
+    test('change password dialog', async ({ page, makeAxeBuilder }, testInfo) => {
+        await routeUsers(page, [administrator]);
+        await page.goto('/ui/administration/manage-users');
+        await openUserActions(page);
+        await page.getByRole('menuitem', { name: 'Change Password' }).click();
+        await expect(page.getByRole('dialog', { name: 'Change Password' })).toBeVisible();
+        await expect(page.getByLabel('New Password', { exact: true })).toBeVisible();
+
+        const results = await makeAxeBuilder().include('#content-wrapper').include('[role="dialog"]').analyze();
+        await expectNoAccessibilityViolations(testInfo, results, { page });
+    });
+
+    test('generate/revoke API tokens dialog - no tokens', async ({ page, makeAxeBuilder }, testInfo) => {
+        await routeUsers(page, [administrator]);
+        await page.route('**/api/v2/tokens**', async (route) => {
+            if (route.request().method() !== 'GET') return route.fallback();
+            await route.fulfill({ json: { data: { tokens: [] } } });
+        });
+        await page.goto('/ui/administration/manage-users');
+        await openTokenManagement(page);
+        await expect(page.getByRole('dialog', { name: 'Generate/Revoke API Tokens' })).toBeVisible();
+        await expect(page.getByText('No tokens available')).toBeVisible();
+
+        const results = await makeAxeBuilder().include('#content-wrapper').include('[role="dialog"]').analyze();
+        await expectNoAccessibilityViolations(testInfo, results, { page });
+    });
+
+    test('create token dialog and auth token dialog', async ({ page, makeAxeBuilder }, testInfo) => {
+        await routeUsers(page, [administrator]);
+        await page.route('**/api/v2/tokens**', async (route) => {
+            const method = route.request().method();
+            if (method === 'GET') return route.fulfill({ json: { data: { tokens: [] } } });
+            if (method === 'POST' && new URL(route.request().url()).pathname === '/api/v2/tokens') {
+                return route.fulfill({ json: { data: { ...token, key: 'generated-auth-token-key' } } });
+            }
+            await route.fallback();
+        });
+        await page.goto('/ui/administration/manage-users');
+        await openTokenManagement(page);
+        await page.getByRole('button', { name: 'Create Token' }).click();
+        await expect(page.getByRole('dialog', { name: 'Create User Token' })).toBeVisible();
+
+        let results = await makeAxeBuilder().include('#content-wrapper').include('[role="dialog"]').analyze();
+        await expectNoAccessibilityViolations(testInfo, results, { page });
+
+        await page.getByLabel('Token Name').fill(token.name);
+        await page.getByRole('dialog', { name: 'Create User Token' }).getByRole('button', { name: 'Save' }).click();
+        await expect(page.getByRole('dialog', { name: 'Auth Token' })).toBeVisible();
+        await expect(page.getByText('Key: generated-auth-token-key')).toBeVisible();
+
+        results = await makeAxeBuilder().include('#content-wrapper').include('[role="dialog"]').analyze();
+        await expectNoAccessibilityViolations(testInfo, results, { page });
+    });
+
+    test('generate/revoke API tokens dialog - with token', async ({ page, makeAxeBuilder }, testInfo) => {
+        await routeUsers(page, [administrator]);
+        await page.route('**/api/v2/tokens**', async (route) => {
+            if (route.request().method() !== 'GET') return route.fallback();
+            await route.fulfill({ json: { data: { tokens: [token] } } });
+        });
+        await page.goto('/ui/administration/manage-users');
+        await openTokenManagement(page);
+        await expect(page.getByRole('row', { name: /automation token/ })).toBeVisible();
+
+        const results = await makeAxeBuilder().include('#content-wrapper').include('[role="dialog"]').analyze();
+        await expectNoAccessibilityViolations(testInfo, results, { page });
+    });
+
+    test('revoke token dialog', async ({ page, makeAxeBuilder }, testInfo) => {
+        await routeUsers(page, [administrator]);
+        await page.route('**/api/v2/tokens**', async (route) => {
+            if (route.request().method() !== 'GET') return route.fallback();
+            await route.fulfill({ json: { data: { tokens: [token] } } });
+        });
+        await page.goto('/ui/administration/manage-users');
+        await openTokenManagement(page);
+        await page
+            .getByRole('row', { name: /automation token/ })
+            .getByRole('button', { name: 'Revoke' })
+            .click();
+        await expect(page.getByRole('dialog', { name: 'Revoke "automation token" Auth Token' })).toBeVisible();
+
+        const results = await makeAxeBuilder().include('#content-wrapper').include('[role="dialog"]').analyze();
+        await expectNoAccessibilityViolations(testInfo, results, { page });
+    });
+
+    test('create user form', async ({ page, makeAxeBuilder }, testInfo) => {
+        await routeUsers(page, [administrator]);
+        await page.goto('/ui/administration/manage-users');
+        await page.getByRole('button', { name: 'Create User' }).click();
+        await expect(page.getByRole('dialog', { name: 'Create User' })).toBeVisible();
+        await expect(page.getByLabel('Email Address')).toBeVisible();
+
+        const results = await makeAxeBuilder().include('#content-wrapper').include('[role="dialog"]').analyze();
+        await expectNoAccessibilityViolations(testInfo, results, { page });
+    });
+});

--- a/cmd/ui/tests/a11y/Administration/manage-users.a11y.spec.ts
+++ b/cmd/ui/tests/a11y/Administration/manage-users.a11y.spec.ts
@@ -15,7 +15,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { Page } from '@playwright/test';
-import { expect, expectNoAccessibilityViolations, test } from '../../fixtures';
+import { hideBySelector } from 'bh-playwright-testing/axe';
+import { expectNoAccessibilityViolations, test } from '../../fixtures';
 
 const administrator = {
     sso_provider_id: null,
@@ -101,6 +102,7 @@ test.describe('Administration - Manage Users - has no detectable WCAG A/AA viola
             if (route.request().method() !== 'GET') return route.fallback();
             await route.fulfill({ json: { data: administrator } });
         });
+
         await page.route('**/api/v2/config**', async (route) => {
             if (route.request().method() !== 'GET') return route.fallback();
             await route.fulfill({
@@ -112,14 +114,17 @@ test.describe('Administration - Manage Users - has no detectable WCAG A/AA viola
                 },
             });
         });
+
         await page.route('**/api/v2/sso-providers', async (route) => {
             if (route.request().method() !== 'GET') return route.fallback();
             await route.fulfill({ json: { data: [] } });
         });
+
         await page.route('**/api/v2/roles**', async (route) => {
             if (route.request().method() !== 'GET') return route.fallback();
             await route.fulfill({ json: { data: { roles: administrator.roles } } });
         });
+
         await page.route('**/api/v2/available-domains', async (route) => {
             if (route.request().method() !== 'GET') return route.fallback();
             await route.fulfill({ json: { data: [] } });
@@ -129,9 +134,10 @@ test.describe('Administration - Manage Users - has no detectable WCAG A/AA viola
     test('empty page', async ({ page, makeAxeBuilder }, testInfo) => {
         await routeUsers(page, []);
         await page.goto('/ui/administration/manage-users');
-        await expect(page.getByRole('heading', { name: 'Manage Users' })).toBeVisible();
-        await expect(page.getByRole('columnheader', { name: 'Username' })).toBeVisible();
-        await expect(page.getByRole('row')).toHaveCount(1);
+
+        await page.getByRole('heading', { name: 'Manage Users' }).waitFor({ state: 'visible' });
+        await page.getByRole('columnheader', { name: 'Username' }).waitFor({ state: 'visible' });
+        await page.getByRole('row').nth(1).waitFor({ state: 'hidden' });
 
         const results = await makeAxeBuilder().include('#content-wrapper').analyze();
         await expectNoAccessibilityViolations(testInfo, results, { page });
@@ -140,7 +146,8 @@ test.describe('Administration - Manage Users - has no detectable WCAG A/AA viola
     test('page with users', async ({ page, makeAxeBuilder }, testInfo) => {
         await routeUsers(page, [administrator]);
         await page.goto('/ui/administration/manage-users');
-        await expect(page.getByText('test_admin', { exact: true })).toBeVisible();
+
+        await page.getByText('test_admin', { exact: true }).waitFor({ state: 'visible' });
 
         const results = await makeAxeBuilder().include('#content-wrapper').analyze();
         await expectNoAccessibilityViolations(testInfo, results, { page });
@@ -150,9 +157,12 @@ test.describe('Administration - Manage Users - has no detectable WCAG A/AA viola
         await routeUsers(page, [administrator]);
         await page.goto('/ui/administration/manage-users');
         await openUserActions(page);
-        await expect(page.getByRole('menuitem', { name: 'Update User' })).toBeVisible();
 
-        const results = await makeAxeBuilder().include('#content-wrapper').include('[role="menu"]').analyze();
+        await hideBySelector(page, '#content-wrapper');
+
+        await page.getByRole('menuitem', { name: 'Update User' }).waitFor({ state: 'visible' });
+
+        const results = await makeAxeBuilder().include('[role="menu"]').analyze();
         await expectNoAccessibilityViolations(testInfo, results, { page });
     });
 
@@ -161,10 +171,13 @@ test.describe('Administration - Manage Users - has no detectable WCAG A/AA viola
         await page.goto('/ui/administration/manage-users');
         await openUserActions(page);
         await page.getByRole('menuitem', { name: 'Update User' }).click();
-        await expect(page.getByRole('dialog', { name: 'Update User Dialog' })).toBeVisible();
-        await expect(page.getByLabel('Email Address')).toBeVisible();
 
-        const results = await makeAxeBuilder().include('#content-wrapper').include('[role="dialog"]').analyze();
+        await hideBySelector(page, '#content-wrapper');
+
+        await page.getByRole('dialog', { name: 'Update User Dialog' }).waitFor({ state: 'visible' });
+        await page.getByLabel('Email Address').waitFor({ state: 'visible' });
+
+        const results = await makeAxeBuilder().include('[data-testid="update-user-dialog"]').analyze();
         await expectNoAccessibilityViolations(testInfo, results, { page });
     });
 
@@ -173,84 +186,125 @@ test.describe('Administration - Manage Users - has no detectable WCAG A/AA viola
         await page.goto('/ui/administration/manage-users');
         await openUserActions(page);
         await page.getByRole('menuitem', { name: 'Change Password' }).click();
-        await expect(page.getByRole('dialog', { name: 'Change Password' })).toBeVisible();
-        await expect(page.getByLabel('New Password', { exact: true })).toBeVisible();
 
-        const results = await makeAxeBuilder().include('#content-wrapper').include('[role="dialog"]').analyze();
+        await hideBySelector(page, '#content-wrapper');
+
+        await page.getByRole('dialog', { name: 'Change Password' }).waitFor({ state: 'visible' });
+
+        await page.getByLabel('New Password', { exact: true }).waitFor({ state: 'visible' });
+
+        const results = await makeAxeBuilder().include('[data-testid="password-dialog"]').analyze();
+
         await expectNoAccessibilityViolations(testInfo, results, { page });
     });
 
     test('generate/revoke API tokens dialog - no tokens', async ({ page, makeAxeBuilder }, testInfo) => {
         await routeUsers(page, [administrator]);
+
         await page.route('**/api/v2/tokens**', async (route) => {
             if (route.request().method() !== 'GET') return route.fallback();
             await route.fulfill({ json: { data: { tokens: [] } } });
         });
+
         await page.goto('/ui/administration/manage-users');
         await openTokenManagement(page);
-        await expect(page.getByRole('dialog', { name: 'Generate/Revoke API Tokens' })).toBeVisible();
-        await expect(page.getByText('No tokens available')).toBeVisible();
 
-        const results = await makeAxeBuilder().include('#content-wrapper').include('[role="dialog"]').analyze();
+        await hideBySelector(page, '#content-wrapper');
+
+        await page.getByRole('dialog', { name: 'Generate/Revoke API Tokens' }).waitFor({ state: 'visible' });
+        await page.getByText('No tokens available').waitFor({ state: 'visible' });
+
+        const results = await makeAxeBuilder().include('[data-testid="user-token-management-dialog"]').analyze();
+
         await expectNoAccessibilityViolations(testInfo, results, { page });
     });
 
     test('create token dialog and auth token dialog', async ({ page, makeAxeBuilder }, testInfo) => {
         await routeUsers(page, [administrator]);
+
         await page.route('**/api/v2/tokens**', async (route) => {
             const method = route.request().method();
-            if (method === 'GET') return route.fulfill({ json: { data: { tokens: [] } } });
+
+            if (method === 'GET') {
+                return route.fulfill({ json: { data: { tokens: [] } } });
+            }
+
             if (method === 'POST' && new URL(route.request().url()).pathname === '/api/v2/tokens') {
                 return route.fulfill({ json: { data: { ...token, key: 'generated-auth-token-key' } } });
             }
+
             await route.fallback();
         });
+
         await page.goto('/ui/administration/manage-users');
         await openTokenManagement(page);
-        await page.getByRole('button', { name: 'Create Token' }).click();
-        await expect(page.getByRole('dialog', { name: 'Create User Token' })).toBeVisible();
 
-        let results = await makeAxeBuilder().include('#content-wrapper').include('[role="dialog"]').analyze();
+        await hideBySelector(page, '#content-wrapper');
+
+        await page.getByRole('button', { name: 'Create Token' }).click();
+        await page.getByRole('dialog', { name: 'Create User Token' }).waitFor({ state: 'visible' });
+
+        await hideBySelector(page, '[data-testid="user-token-management-dialog"]');
+
+        let results = await makeAxeBuilder().include('[data-testid="create-user-token-dialog"]').analyze();
+
         await expectNoAccessibilityViolations(testInfo, results, { page });
 
         await page.getByLabel('Token Name').fill(token.name);
         await page.getByRole('dialog', { name: 'Create User Token' }).getByRole('button', { name: 'Save' }).click();
-        await expect(page.getByRole('dialog', { name: 'Auth Token' })).toBeVisible();
-        await expect(page.getByText('Key: generated-auth-token-key')).toBeVisible();
 
-        results = await makeAxeBuilder().include('#content-wrapper').include('[role="dialog"]').analyze();
+        await page.getByRole('dialog', { name: 'Auth Token' }).waitFor({ state: 'visible' });
+        await page.getByText('Key: generated-auth-token-key').waitFor({ state: 'visible' });
+
+        results = await makeAxeBuilder().include('[data-testid="user-token-dialog"]').analyze();
+
         await expectNoAccessibilityViolations(testInfo, results, { page });
     });
 
     test('generate/revoke API tokens dialog - with token', async ({ page, makeAxeBuilder }, testInfo) => {
         await routeUsers(page, [administrator]);
+
         await page.route('**/api/v2/tokens**', async (route) => {
             if (route.request().method() !== 'GET') return route.fallback();
             await route.fulfill({ json: { data: { tokens: [token] } } });
         });
+
         await page.goto('/ui/administration/manage-users');
         await openTokenManagement(page);
-        await expect(page.getByRole('row', { name: /automation token/ })).toBeVisible();
 
-        const results = await makeAxeBuilder().include('#content-wrapper').include('[role="dialog"]').analyze();
+        await hideBySelector(page, '#content-wrapper');
+
+        await page.getByRole('row', { name: /automation token/ }).waitFor({ state: 'visible' });
+
+        const results = await makeAxeBuilder().include('[data-testid="user-token-management-dialog"]').analyze();
+
         await expectNoAccessibilityViolations(testInfo, results, { page });
     });
 
     test('revoke token dialog', async ({ page, makeAxeBuilder }, testInfo) => {
         await routeUsers(page, [administrator]);
+
         await page.route('**/api/v2/tokens**', async (route) => {
             if (route.request().method() !== 'GET') return route.fallback();
             await route.fulfill({ json: { data: { tokens: [token] } } });
         });
+
         await page.goto('/ui/administration/manage-users');
         await openTokenManagement(page);
+
+        await hideBySelector(page, '#content-wrapper');
+
         await page
             .getByRole('row', { name: /automation token/ })
             .getByRole('button', { name: 'Revoke' })
             .click();
-        await expect(page.getByRole('dialog', { name: 'Revoke "automation token" Auth Token' })).toBeVisible();
 
-        const results = await makeAxeBuilder().include('#content-wrapper').include('[role="dialog"]').analyze();
+        await hideBySelector(page, '[data-testid="user-token-management-dialog"]');
+
+        await page.getByRole('dialog', { name: 'Revoke "automation token" Auth Token' }).waitFor({ state: 'visible' });
+
+        const results = await makeAxeBuilder().include('[data-testid="token-revoke-dialog"]').analyze();
+
         await expectNoAccessibilityViolations(testInfo, results, { page });
     });
 
@@ -258,10 +312,13 @@ test.describe('Administration - Manage Users - has no detectable WCAG A/AA viola
         await routeUsers(page, [administrator]);
         await page.goto('/ui/administration/manage-users');
         await page.getByRole('button', { name: 'Create User' }).click();
-        await expect(page.getByRole('dialog', { name: 'Create User' })).toBeVisible();
-        await expect(page.getByLabel('Email Address')).toBeVisible();
 
-        const results = await makeAxeBuilder().include('#content-wrapper').include('[role="dialog"]').analyze();
+        await hideBySelector(page, '#content-wrapper');
+
+        await page.getByRole('dialog', { name: 'Create User' }).waitFor({ state: 'visible' });
+        await page.getByLabel('Email Address').waitFor({ state: 'visible' });
+
+        const results = await makeAxeBuilder().include('[data-testid="create-user-dialog_form"]').analyze();
         await expectNoAccessibilityViolations(testInfo, results, { page });
     });
 });

--- a/cmd/ui/tests/a11y/Administration/manage-users.a11y.spec.ts
+++ b/cmd/ui/tests/a11y/Administration/manage-users.a11y.spec.ts
@@ -64,24 +64,9 @@ const token = {
     expires_at: null,
 };
 
-const routeUsers = async (page: Page, users: (typeof administrator)[]) => {
-    await page.route('**/api/v2/bloodhound-users**', async (route) => {
-        if (route.request().method() !== 'GET') {
-            return route.fallback();
-        }
-
-        const pathname = new URL(route.request().url()).pathname;
-        if (pathname === '/api/v2/bloodhound-users') {
-            return route.fulfill({ json: { data: { users } } });
-        }
-
-        const user = users.find(({ id }) => pathname === `/api/v2/bloodhound-users/${id}`);
-        if (user) {
-            return route.fulfill({ json: { data: user } });
-        }
-
-        await route.fallback();
-    });
+const openPage = async (page: Page) => {
+    await page.goto('/ui/administration/manage-users');
+    await page.getByRole('button', { name: 'Toggle Navigation' }).click();
 };
 
 const openUserActions = async (page: Page) => {
@@ -129,12 +114,47 @@ test.describe('Administration - Manage Users - has no detectable WCAG A/AA viola
             if (route.request().method() !== 'GET') return route.fallback();
             await route.fulfill({ json: { data: [] } });
         });
+
+        await page.route('**/api/v2/bloodhound-users**', async (route) => {
+            if (route.request().method() !== 'GET') {
+                return route.fallback();
+            }
+            const users = [administrator];
+            const pathname = new URL(route.request().url()).pathname;
+            if (pathname === '/api/v2/bloodhound-users') {
+                return route.fulfill({ json: { data: { users } } });
+            }
+
+            const user = users.find(({ id }) => pathname === `/api/v2/bloodhound-users/${id}`);
+            if (user) {
+                return route.fulfill({ json: { data: user } });
+            }
+
+            await route.fallback();
+        });
     });
 
     test('empty page', async ({ page, makeAxeBuilder }, testInfo) => {
-        await routeUsers(page, []);
-        await page.goto('/ui/administration/manage-users');
+        // Override the users call to be empty users list
+        await page.route('**/api/v2/bloodhound-users**', async (route) => {
+            if (route.request().method() !== 'GET') {
+                return route.fallback();
+            }
+            const users: (typeof administrator)[] = [];
+            const pathname = new URL(route.request().url()).pathname;
+            if (pathname === '/api/v2/bloodhound-users') {
+                return route.fulfill({ json: { data: { users } } });
+            }
 
+            const user = users.find(({ id }) => pathname === `/api/v2/bloodhound-users/${id}`);
+            if (user) {
+                return route.fulfill({ json: { data: user } });
+            }
+
+            await route.fallback();
+        });
+
+        await openPage(page);
         await page.getByRole('heading', { name: 'Manage Users' }).waitFor({ state: 'visible' });
         await page.getByRole('columnheader', { name: 'Username' }).waitFor({ state: 'visible' });
         await page.getByRole('row').nth(1).waitFor({ state: 'hidden' });
@@ -144,8 +164,7 @@ test.describe('Administration - Manage Users - has no detectable WCAG A/AA viola
     });
 
     test('page with users', async ({ page, makeAxeBuilder }, testInfo) => {
-        await routeUsers(page, [administrator]);
-        await page.goto('/ui/administration/manage-users');
+        await openPage(page);
 
         await page.getByText('test_admin', { exact: true }).waitFor({ state: 'visible' });
 
@@ -154,8 +173,7 @@ test.describe('Administration - Manage Users - has no detectable WCAG A/AA viola
     });
 
     test('user actions menu displayed', async ({ page, makeAxeBuilder }, testInfo) => {
-        await routeUsers(page, [administrator]);
-        await page.goto('/ui/administration/manage-users');
+        await openPage(page);
         await openUserActions(page);
 
         await hideBySelector(page, '#content-wrapper');
@@ -167,8 +185,7 @@ test.describe('Administration - Manage Users - has no detectable WCAG A/AA viola
     });
 
     test('update user dialog', async ({ page, makeAxeBuilder }, testInfo) => {
-        await routeUsers(page, [administrator]);
-        await page.goto('/ui/administration/manage-users');
+        await openPage(page);
         await openUserActions(page);
         await page.getByRole('menuitem', { name: 'Update User' }).click();
 
@@ -182,8 +199,7 @@ test.describe('Administration - Manage Users - has no detectable WCAG A/AA viola
     });
 
     test('change password dialog', async ({ page, makeAxeBuilder }, testInfo) => {
-        await routeUsers(page, [administrator]);
-        await page.goto('/ui/administration/manage-users');
+        await openPage(page);
         await openUserActions(page);
         await page.getByRole('menuitem', { name: 'Change Password' }).click();
 
@@ -199,14 +215,12 @@ test.describe('Administration - Manage Users - has no detectable WCAG A/AA viola
     });
 
     test('generate/revoke API tokens dialog - no tokens', async ({ page, makeAxeBuilder }, testInfo) => {
-        await routeUsers(page, [administrator]);
-
         await page.route('**/api/v2/tokens**', async (route) => {
             if (route.request().method() !== 'GET') return route.fallback();
             await route.fulfill({ json: { data: { tokens: [] } } });
         });
 
-        await page.goto('/ui/administration/manage-users');
+        await openPage(page);
         await openTokenManagement(page);
 
         await hideBySelector(page, '#content-wrapper');
@@ -219,9 +233,28 @@ test.describe('Administration - Manage Users - has no detectable WCAG A/AA viola
         await expectNoAccessibilityViolations(testInfo, results, { page });
     });
 
-    test('create token dialog and auth token dialog', async ({ page, makeAxeBuilder }, testInfo) => {
-        await routeUsers(page, [administrator]);
+    test('create token dialog', async ({ page, makeAxeBuilder }, testInfo) => {
+        await page.route('**/api/v2/tokens**', async (route) => {
+            if (route.request().method() !== 'GET') return route.fallback();
+            await route.fulfill({ json: { data: { tokens: [] } } });
+        });
 
+        await openPage(page);
+        await openTokenManagement(page);
+
+        await hideBySelector(page, '#content-wrapper');
+
+        await page.getByRole('button', { name: 'Create Token' }).click();
+        await page.getByRole('dialog', { name: 'Create User Token' }).waitFor({ state: 'visible' });
+
+        await hideBySelector(page, '[data-testid="user-token-management-dialog"]');
+
+        const results = await makeAxeBuilder().include('[data-testid="create-user-token-dialog"]').analyze();
+
+        await expectNoAccessibilityViolations(testInfo, results, { page });
+    });
+
+    test('auth token dialog', async ({ page, makeAxeBuilder }, testInfo) => {
         await page.route('**/api/v2/tokens**', async (route) => {
             const method = route.request().method();
 
@@ -236,7 +269,7 @@ test.describe('Administration - Manage Users - has no detectable WCAG A/AA viola
             await route.fallback();
         });
 
-        await page.goto('/ui/administration/manage-users');
+        await openPage(page);
         await openTokenManagement(page);
 
         await hideBySelector(page, '#content-wrapper');
@@ -246,30 +279,24 @@ test.describe('Administration - Manage Users - has no detectable WCAG A/AA viola
 
         await hideBySelector(page, '[data-testid="user-token-management-dialog"]');
 
-        let results = await makeAxeBuilder().include('[data-testid="create-user-token-dialog"]').analyze();
-
-        await expectNoAccessibilityViolations(testInfo, results, { page });
-
         await page.getByLabel('Token Name').fill(token.name);
         await page.getByRole('dialog', { name: 'Create User Token' }).getByRole('button', { name: 'Save' }).click();
 
         await page.getByRole('dialog', { name: 'Auth Token' }).waitFor({ state: 'visible' });
         await page.getByText('Key: generated-auth-token-key').waitFor({ state: 'visible' });
 
-        results = await makeAxeBuilder().include('[data-testid="user-token-dialog"]').analyze();
+        const results = await makeAxeBuilder().include('[data-testid="user-token-dialog"]').analyze();
 
         await expectNoAccessibilityViolations(testInfo, results, { page });
     });
 
     test('generate/revoke API tokens dialog - with token', async ({ page, makeAxeBuilder }, testInfo) => {
-        await routeUsers(page, [administrator]);
-
         await page.route('**/api/v2/tokens**', async (route) => {
             if (route.request().method() !== 'GET') return route.fallback();
             await route.fulfill({ json: { data: { tokens: [token] } } });
         });
 
-        await page.goto('/ui/administration/manage-users');
+        await openPage(page);
         await openTokenManagement(page);
 
         await hideBySelector(page, '#content-wrapper');
@@ -282,14 +309,12 @@ test.describe('Administration - Manage Users - has no detectable WCAG A/AA viola
     });
 
     test('revoke token dialog', async ({ page, makeAxeBuilder }, testInfo) => {
-        await routeUsers(page, [administrator]);
-
         await page.route('**/api/v2/tokens**', async (route) => {
             if (route.request().method() !== 'GET') return route.fallback();
             await route.fulfill({ json: { data: { tokens: [token] } } });
         });
 
-        await page.goto('/ui/administration/manage-users');
+        await openPage(page);
         await openTokenManagement(page);
 
         await hideBySelector(page, '#content-wrapper');
@@ -309,8 +334,7 @@ test.describe('Administration - Manage Users - has no detectable WCAG A/AA viola
     });
 
     test('create user form', async ({ page, makeAxeBuilder }, testInfo) => {
-        await routeUsers(page, [administrator]);
-        await page.goto('/ui/administration/manage-users');
+        await openPage(page);
         await page.getByRole('button', { name: 'Create User' }).click();
 
         await hideBySelector(page, '#content-wrapper');


### PR DESCRIPTION

<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Adds accessibility tests for the Administration - database management and manage users' pages, to verify compliance with accessibility standards.

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves bed-8639

*Why is this change required? What problem does it solve?*

This change was needed to ensure the Administration -database management and manage users' pages adhere to accessibility standards.

## How Has This Been Tested?

The tests were run locally.

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- New feature (non-breaking change which adds functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [X ] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [X] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [X] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added accessibility coverage for Administration’s Database Management page, including its delete confirmation dialog.
  - Added WCAG A/AA accessibility checks for Manage Users workflows, including user lists, action menus, dialogs, token management, and user creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->