### PR TITLE
feat: Enable optimization by default, add logs - BED-9170

### DIFF
--- a/cmd/api/src/daemons/datapipe/pipeline.go
+++ b/cmd/api/src/daemons/datapipe/pipeline.go
@@ -366,6 +366,13 @@ func (s *BHCEPipeline) Optimize(ctx context.Context) error {
 		}
 	}
 
+	defer measure.LogAndMeasure(
+		slog.LevelInfo,
+		"Graph Storage Optimization",
+		attr.Namespace("optimize"),
+		attr.Function("Optimize"),
+	)()
+
 	start := time.Now()
 	if err := s.graphdb.OptimizeStorage(ctx); err != nil {
 		slog.ErrorContext(ctx, "Error optimizing graph storage after analysis", attr.Error(err))
@@ -397,6 +404,13 @@ func (s *BHCEPipeline) OptimizeOnBoot(ctx context.Context) error {
 			return nil
 		}
 	}
+
+	defer measure.LogAndMeasure(
+		slog.LevelInfo,
+		"Graph Storage Optimization",
+		attr.Namespace("optimize"),
+		attr.Function("OptimizeOnBoot"),
+	)()
 
 	start := time.Now()
 	if err := s.graphdb.OptimizeStorage(ctx); err != nil {

--- a/cmd/api/src/database/migration/migrations/20260805120000_v9_default_enable_graph_storage_optimization.sql
+++ b/cmd/api/src/database/migration/migrations/20260805120000_v9_default_enable_graph_storage_optimization.sql
@@ -30,3 +30,7 @@ ALTER TABLE datapipe_status
     ADD COLUMN IF NOT EXISTS last_complete_optimize_at timestamp with time zone;
 
 -- +goose Down
+ALTER TABLE datapipe_status
+    DROP COLUMN IF EXISTS last_complete_optimize_at;
+
+DELETE FROM parameters WHERE key = 'analysis.graph_storage_optimization';

--- a/cmd/api/src/database/migration/migrations/20260805120000_v9_default_enable_graph_storage_optimization.sql
+++ b/cmd/api/src/database/migration/migrations/20260805120000_v9_default_enable_graph_storage_optimization.sql
@@ -15,10 +15,18 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 -- +goose Up
--- Intentionally empty - see 20260805120000_v9_default_enable_graph_storage_optimization.sql for the up migration
+INSERT INTO parameters (key, name, description, value, created_at, updated_at)
+VALUES (
+    'analysis.graph_storage_optimization',
+    'When to run graph storage optimization',
+    'This configuration parameter controls which pipeline stages trigger graph storage optimization (vacuum/analyze) on the graph database. Each stage can be independently enabled or disabled.',
+    '{"after_boot": true, "after_analysis": true, "min_interval_seconds": 86400}',
+    current_timestamp,
+    current_timestamp
+)
+ON CONFLICT DO NOTHING;
+
+ALTER TABLE datapipe_status
+    ADD COLUMN IF NOT EXISTS last_complete_optimize_at timestamp with time zone;
 
 -- +goose Down
-ALTER TABLE datapipe_status
-    DROP COLUMN IF EXISTS last_complete_optimize_at;
-
-DELETE FROM parameters WHERE key = 'analysis.graph_storage_optimization';


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Default-enables optimization and adds logging to optimize calls.

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-9170

*Why is this change required? What problem does it solve?*

## How Has This Been Tested?

Validated in local environment.

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- New feature (non-breaking change which adds functionality)
- Database Migrations

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [X] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [X] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [X] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Graph storage optimization is now enabled by default with configurable processing stages and scheduling intervals.
  * Added tracking for the most recently completed optimization.

* **Improvements**
  * Optimization stages now provide structured measurement details, improving visibility into processing progress and performance.
  * Optimization behavior and error handling remain unchanged while reporting becomes more consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->