### PR TITLE
test(A11y): coverage for Administration: SSO, bloodhound configuration, EA - BED-8639, BED-8639

### DIFF
--- a/cmd/ui/tests/a11y/Administration/bloodhound-configuration.a11y.spec.ts
+++ b/cmd/ui/tests/a11y/Administration/bloodhound-configuration.a11y.spec.ts
@@ -14,7 +14,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { expect, expectNoAccessibilityViolations, test } from '../../fixtures';
+import { hideBySelector } from 'bh-playwright-testing/axe';
+import { expectNoAccessibilityViolations, test } from '../../fixtures';
 
 test.describe('Administration - BloodHound Configuration - has no detectable WCAG A/AA violations', () => {
     test.beforeEach(async ({ page }) => {
@@ -45,10 +46,11 @@ test.describe('Administration - BloodHound Configuration - has no detectable WCA
 
     test('page', async ({ page, makeAxeBuilder }, testInfo) => {
         await page.goto('/ui/administration/bloodhound-configuration');
-        await expect(page.getByRole('heading', { name: 'BloodHound Configuration' })).toBeVisible();
-        await expect(page.getByRole('heading', { name: 'Run Analysis Now' })).toBeVisible();
-        await expect(page.getByRole('heading', { name: 'Citrix RDP Support' })).toBeVisible();
-        await expect(page.getByRole('button', { name: 'Analyze Now' })).toBeEnabled();
+
+        await page.getByRole('heading', { name: 'BloodHound Configuration' }).waitFor({ state: 'visible' });
+        await page.getByRole('heading', { name: 'Run Analysis Now' }).waitFor({ state: 'visible' });
+        await page.getByRole('heading', { name: 'Citrix RDP Support' }).waitFor({ state: 'visible' });
+        await page.getByRole('button', { name: 'Analyze Now' }).waitFor({ state: 'visible' });
 
         const results = await makeAxeBuilder().include('#content-wrapper').analyze();
         await expectNoAccessibilityViolations(testInfo, results, { page });
@@ -57,12 +59,15 @@ test.describe('Administration - BloodHound Configuration - has no detectable WCA
     test('Analyze Now dialog', async ({ page, makeAxeBuilder }, testInfo) => {
         await page.goto('/ui/administration/bloodhound-configuration');
         await page.getByRole('button', { name: 'Analyze Now' }).click();
-        await expect(page.getByRole('dialog', { name: 'Confirm re-run analysis' })).toBeVisible();
-        await expect(page.getByText(/Analysis may take some time/)).toBeVisible();
-        await expect(page.getByRole('button', { name: 'Cancel' })).toBeVisible();
-        await expect(page.getByRole('button', { name: 'Confirm' })).toBeVisible();
 
-        const results = await makeAxeBuilder().include('#content-wrapper').include('[role="dialog"]').analyze();
+        await hideBySelector(page, '#content-wrapper');
+
+        await page.getByRole('dialog', { name: 'Confirm re-run analysis' }).waitFor({ state: 'visible' });
+        await page.getByText(/Analysis may take some time/).waitFor({ state: 'visible' });
+        await page.getByRole('button', { name: 'Cancel' }).waitFor({ state: 'visible' });
+        await page.getByRole('button', { name: 'Confirm' }).waitFor({ state: 'visible' });
+
+        const results = await makeAxeBuilder().include('[role="dialog"]').analyze();
         await expectNoAccessibilityViolations(testInfo, results, { page });
     });
 });

--- a/cmd/ui/tests/a11y/Administration/bloodhound-configuration.a11y.spec.ts
+++ b/cmd/ui/tests/a11y/Administration/bloodhound-configuration.a11y.spec.ts
@@ -60,12 +60,13 @@ test.describe('Administration - BloodHound Configuration - has no detectable WCA
         await page.goto('/ui/administration/bloodhound-configuration');
         await page.getByRole('button', { name: 'Analyze Now' }).click();
 
-        await hideBySelector(page, '#content-wrapper');
-
         await page.getByRole('dialog', { name: 'Confirm re-run analysis' }).waitFor({ state: 'visible' });
         await page.getByText(/Analysis may take some time/).waitFor({ state: 'visible' });
         await page.getByRole('button', { name: 'Cancel' }).waitFor({ state: 'visible' });
         await page.getByRole('button', { name: 'Confirm' }).waitFor({ state: 'visible' });
+
+        // This dialog is mixed in with the page content rather than on its own portal
+        await hideBySelector(page, '[data-aria-hidden="true"]');
 
         const results = await makeAxeBuilder().include('[role="dialog"]').analyze();
         await expectNoAccessibilityViolations(testInfo, results, { page });

--- a/cmd/ui/tests/a11y/Administration/bloodhound-configuration.a11y.spec.ts
+++ b/cmd/ui/tests/a11y/Administration/bloodhound-configuration.a11y.spec.ts
@@ -1,0 +1,68 @@
+// Copyright 2026 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { expect, expectNoAccessibilityViolations, test } from '../../fixtures';
+
+test.describe('Administration - BloodHound Configuration - has no detectable WCAG A/AA violations', () => {
+    test.beforeEach(async ({ page }) => {
+        await page.route('**/api/v2/datapipe/status', async (route) => {
+            if (route.request().method() !== 'GET') {
+                return route.fallback();
+            }
+
+            await route.fulfill({ json: { data: { status: 'idle' } } });
+        });
+        await page.route('**/api/v2/config', async (route) => {
+            if (route.request().method() !== 'GET') {
+                return route.fallback();
+            }
+
+            await route.fulfill({
+                json: {
+                    data: [
+                        {
+                            key: 'analysis.citrix_rdp_support',
+                            value: { enabled: false },
+                        },
+                    ],
+                },
+            });
+        });
+    });
+
+    test('page', async ({ page, makeAxeBuilder }, testInfo) => {
+        await page.goto('/ui/administration/bloodhound-configuration');
+        await expect(page.getByRole('heading', { name: 'BloodHound Configuration' })).toBeVisible();
+        await expect(page.getByRole('heading', { name: 'Run Analysis Now' })).toBeVisible();
+        await expect(page.getByRole('heading', { name: 'Citrix RDP Support' })).toBeVisible();
+        await expect(page.getByRole('button', { name: 'Analyze Now' })).toBeEnabled();
+
+        const results = await makeAxeBuilder().include('#content-wrapper').analyze();
+        await expectNoAccessibilityViolations(testInfo, results, { page });
+    });
+
+    test('Analyze Now dialog', async ({ page, makeAxeBuilder }, testInfo) => {
+        await page.goto('/ui/administration/bloodhound-configuration');
+        await page.getByRole('button', { name: 'Analyze Now' }).click();
+        await expect(page.getByRole('dialog', { name: 'Confirm re-run analysis' })).toBeVisible();
+        await expect(page.getByText(/Analysis may take some time/)).toBeVisible();
+        await expect(page.getByRole('button', { name: 'Cancel' })).toBeVisible();
+        await expect(page.getByRole('button', { name: 'Confirm' })).toBeVisible();
+
+        const results = await makeAxeBuilder().include('#content-wrapper').include('[role="dialog"]').analyze();
+        await expectNoAccessibilityViolations(testInfo, results, { page });
+    });
+});

--- a/cmd/ui/tests/a11y/Administration/early-access-features.a11y.spec.ts
+++ b/cmd/ui/tests/a11y/Administration/early-access-features.a11y.spec.ts
@@ -1,0 +1,93 @@
+// Copyright 2026 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { expect, expectNoAccessibilityViolations, test } from '../../fixtures';
+
+const earlyAccessFeature = {
+    id: 1,
+    name: 'Example Early Access Feature',
+    key: 'example_early_access_feature',
+    description: 'Enables an example feature available for early access testing.',
+    enabled: false,
+    user_updatable: true,
+};
+
+test.describe('Administration - Early Access Features - has no detectable WCAG A/AA violations', () => {
+    test.beforeEach(async ({ page }) => {
+        await page.route('**/api/v2/self', async (route) => {
+            if (route.request().method() !== 'GET') {
+                return route.fallback();
+            }
+
+            await route.fulfill({
+                json: {
+                    data: {
+                        AuthSecret: {
+                            expires_at: '9999-01-01T00:00:00Z',
+                        },
+                        roles: [{ permissions: [{ authority: 'app', name: 'WriteAppConfig' }] }],
+                        first_name: 'Test',
+                        last_name: 'Administrator',
+                        email_address: 'test-admin@example.com',
+                        principal_name: 'test_admin',
+                        is_disabled: false,
+                        eula_accepted: true,
+                        id: 'user-1',
+                    },
+                },
+            });
+        });
+        await page.route('**/api/v2/features', async (route) => {
+            if (route.request().method() !== 'GET') {
+                return route.fallback();
+            }
+
+            await route.fulfill({ json: { data: [earlyAccessFeature] } });
+        });
+        await page.route('**/api/v2/config', async (route) => {
+            if (route.request().method() !== 'GET') {
+                return route.fallback();
+            }
+
+            await route.fulfill({ json: { data: [] } });
+        });
+    });
+
+    test('Heads up dialog', async ({ page, makeAxeBuilder }, testInfo) => {
+        await page.goto('/ui/administration/early-access-features');
+        await page.getByRole('heading', { name: 'Heads up!' }).waitFor({ state: 'visible' });
+        await expect(page.getByRole('button', { name: 'Take me back' })).toBeVisible();
+        await expect(page.getByRole('button', { name: 'I understand, show me the new stuff!' })).toBeVisible();
+
+        await expect(page.getByRole('dialog')).toBeVisible();
+
+        const results = await makeAxeBuilder().include('#content-wrapper').include('[role="dialog"]').analyze();
+        await expectNoAccessibilityViolations(testInfo, results, { page });
+    });
+
+    test('page', async ({ page, makeAxeBuilder }, testInfo) => {
+        await page.goto('/ui/administration/early-access-features');
+        await page.getByRole('heading', { name: 'Heads up!' }).waitFor({ state: 'visible' });
+        await page.getByRole('button', { name: 'I understand, show me the new stuff!' }).click();
+        await expect(page.getByRole('heading', { name: 'Heads up!' })).not.toBeVisible();
+        await expect(page.getByRole('heading', { name: 'Early Access Features' })).toBeVisible();
+        await expect(page.getByText(earlyAccessFeature.name)).toBeVisible();
+        await expect(page.getByText(earlyAccessFeature.description)).toBeVisible();
+
+        const results = await makeAxeBuilder().include('#content-wrapper').analyze();
+        await expectNoAccessibilityViolations(testInfo, results, { page });
+    });
+});

--- a/cmd/ui/tests/a11y/Administration/early-access-features.a11y.spec.ts
+++ b/cmd/ui/tests/a11y/Administration/early-access-features.a11y.spec.ts
@@ -14,8 +14,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { expect, expectNoAccessibilityViolations, test } from '../../fixtures';
-
+import { hideBySelector } from 'bh-playwright-testing/axe';
+import { expectNoAccessibilityViolations, test } from '../../fixtures';
 const earlyAccessFeature = {
     id: 1,
     name: 'Example Early Access Feature',
@@ -68,24 +68,30 @@ test.describe('Administration - Early Access Features - has no detectable WCAG A
 
     test('Heads up dialog', async ({ page, makeAxeBuilder }, testInfo) => {
         await page.goto('/ui/administration/early-access-features');
+
+        await hideBySelector(page, '#content-wrapper');
+
         await page.getByRole('heading', { name: 'Heads up!' }).waitFor({ state: 'visible' });
-        await expect(page.getByRole('button', { name: 'Take me back' })).toBeVisible();
-        await expect(page.getByRole('button', { name: 'I understand, show me the new stuff!' })).toBeVisible();
+        await page.getByRole('button', { name: 'Take me back' }).waitFor({ state: 'visible' });
+        await page.getByRole('button', { name: 'I understand, show me the new stuff!' }).waitFor({ state: 'visible' });
 
-        await expect(page.getByRole('dialog')).toBeVisible();
+        const results = await makeAxeBuilder()
+            .include('[data-testid="early-access-features-warning-dialog"]')
+            .analyze();
 
-        const results = await makeAxeBuilder().include('#content-wrapper').include('[role="dialog"]').analyze();
         await expectNoAccessibilityViolations(testInfo, results, { page });
     });
 
     test('page', async ({ page, makeAxeBuilder }, testInfo) => {
         await page.goto('/ui/administration/early-access-features');
+
         await page.getByRole('heading', { name: 'Heads up!' }).waitFor({ state: 'visible' });
         await page.getByRole('button', { name: 'I understand, show me the new stuff!' }).click();
-        await expect(page.getByRole('heading', { name: 'Heads up!' })).not.toBeVisible();
-        await expect(page.getByRole('heading', { name: 'Early Access Features' })).toBeVisible();
-        await expect(page.getByText(earlyAccessFeature.name)).toBeVisible();
-        await expect(page.getByText(earlyAccessFeature.description)).toBeVisible();
+
+        await page.getByRole('heading', { name: 'Heads up!' }).waitFor({ state: 'hidden' });
+        await page.getByRole('heading', { name: 'Early Access Features' }).waitFor({ state: 'visible' });
+        await page.getByText(earlyAccessFeature.name).waitFor({ state: 'visible' });
+        await page.getByText(earlyAccessFeature.description).waitFor({ state: 'visible' });
 
         const results = await makeAxeBuilder().include('#content-wrapper').analyze();
         await expectNoAccessibilityViolations(testInfo, results, { page });

--- a/cmd/ui/tests/a11y/Administration/sso-configuration.a11y.spec.ts
+++ b/cmd/ui/tests/a11y/Administration/sso-configuration.a11y.spec.ts
@@ -14,8 +14,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { expect, expectNoAccessibilityViolations, test } from '../../fixtures';
-
+import { hideBySelector } from 'bh-playwright-testing/axe';
+import { expectNoAccessibilityViolations, test } from '../../fixtures';
 const authenticatedUser = {
     AuthSecret: {
         expires_at: '9999-01-01T00:00:00Z',
@@ -108,8 +108,9 @@ test.describe('Administration - SSO Configuration - has no detectable WCAG A/AA 
 
     test('page with no providers', async ({ page, makeAxeBuilder }, testInfo) => {
         await page.goto('/ui/administration/sso-configuration');
-        await expect(page.getByRole('heading', { name: 'SSO Configuration' })).toBeVisible();
-        await expect(page.getByText('No SSO Providers found')).toBeVisible();
+
+        await page.getByRole('heading', { name: 'SSO Configuration' }).waitFor({ state: 'visible' });
+        await page.getByText('No SSO Providers found').waitFor({ state: 'visible' });
 
         const results = await makeAxeBuilder().include('#content-wrapper').analyze();
         await expectNoAccessibilityViolations(testInfo, results, { page });
@@ -118,10 +119,13 @@ test.describe('Administration - SSO Configuration - has no detectable WCAG A/AA 
     test('create providers menu', async ({ page, makeAxeBuilder }, testInfo) => {
         await page.goto('/ui/administration/sso-configuration');
         await page.getByRole('button', { name: 'Create Provider' }).click();
-        await expect(page.getByRole('menuitem', { name: 'SAML Provider' })).toBeVisible();
-        await expect(page.getByRole('menuitem', { name: 'OIDC Provider' })).toBeVisible();
 
-        const results = await makeAxeBuilder().include('#content-wrapper').include('[role="menu"]').analyze();
+        await hideBySelector(page, '#content-wrapper');
+
+        await page.getByRole('menuitem', { name: 'SAML Provider' }).waitFor({ state: 'visible' });
+        await page.getByRole('menuitem', { name: 'OIDC Provider' }).waitFor({ state: 'visible' });
+
+        const results = await makeAxeBuilder().include('[role="menu"]').analyze();
         await expectNoAccessibilityViolations(testInfo, results, { page });
     });
 
@@ -129,10 +133,14 @@ test.describe('Administration - SSO Configuration - has no detectable WCAG A/AA 
         await page.goto('/ui/administration/sso-configuration');
         await page.getByRole('button', { name: 'Create Provider' }).click();
         await page.getByRole('menuitem', { name: 'SAML Provider' }).click();
-        await expect(page.getByRole('dialog', { name: 'Create SAML Provider' })).toBeVisible();
-        await expect(page.getByLabel('SAML Provider Name')).toBeVisible();
 
-        const results = await makeAxeBuilder().include('#content-wrapper').include('[role="dialog"]').analyze();
+        await hideBySelector(page, '#content-wrapper');
+
+        await page.getByRole('dialog', { name: 'Create SAML Provider' }).waitFor({ state: 'visible' });
+        await page.getByLabel('SAML Provider Name').waitFor({ state: 'visible' });
+
+        const results = await makeAxeBuilder().include('[data-testid="create-saml-provider-dialog"]').analyze();
+
         await expectNoAccessibilityViolations(testInfo, results, { page });
     });
 
@@ -140,10 +148,14 @@ test.describe('Administration - SSO Configuration - has no detectable WCAG A/AA 
         await page.goto('/ui/administration/sso-configuration');
         await page.getByRole('button', { name: 'Create Provider' }).click();
         await page.getByRole('menuitem', { name: 'OIDC Provider' }).click();
-        await expect(page.getByRole('dialog', { name: 'Create OIDC Provider' })).toBeVisible();
-        await expect(page.getByLabel('OIDC Provider Name')).toBeVisible();
 
-        const results = await makeAxeBuilder().include('#content-wrapper').include('[role="dialog"]').analyze();
+        await hideBySelector(page, '#content-wrapper');
+
+        await page.getByRole('dialog', { name: 'Create OIDC Provider' }).waitFor({ state: 'visible' });
+        await page.getByLabel('OIDC Provider Name').waitFor({ state: 'visible' });
+
+        const results = await makeAxeBuilder().include('[data-testid="create-oidc-provider-dialog"]').analyze();
+
         await expectNoAccessibilityViolations(testInfo, results, { page });
     });
 
@@ -155,9 +167,11 @@ test.describe('Administration - SSO Configuration - has no detectable WCAG A/AA 
 
             await route.fulfill({ json: { data: [samlProvider] } });
         });
+
         await page.goto('/ui/administration/sso-configuration');
-        await expect(page.getByRole('button', { name: 'Test IDP 1' })).toBeVisible();
-        await expect(page.getByRole('cell', { name: 'SAML' })).toBeVisible();
+
+        await page.getByRole('button', { name: 'Test IDP 1' }).waitFor({ state: 'visible' });
+        await page.getByRole('cell', { name: 'SAML' }).waitFor({ state: 'visible' });
 
         const results = await makeAxeBuilder().include('#content-wrapper').analyze();
         await expectNoAccessibilityViolations(testInfo, results, { page });

--- a/cmd/ui/tests/a11y/Administration/sso-configuration.a11y.spec.ts
+++ b/cmd/ui/tests/a11y/Administration/sso-configuration.a11y.spec.ts
@@ -1,0 +1,165 @@
+// Copyright 2026 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { expect, expectNoAccessibilityViolations, test } from '../../fixtures';
+
+const authenticatedUser = {
+    AuthSecret: {
+        expires_at: '9999-01-01T00:00:00Z',
+    },
+    roles: [{ permissions: [{ authority: 'auth', name: 'ManageProviders' }] }],
+    first_name: 'Test',
+    last_name: 'Administrator',
+    email_address: 'test-admin@example.com',
+    principal_name: 'test_admin',
+    is_disabled: false,
+    eula_accepted: true,
+    id: 'user-1',
+};
+
+const roles = [
+    { id: 1, name: 'Read-Only' },
+    { id: 2, name: 'Power User' },
+    { id: 3, name: 'Administrator' },
+    { id: 4, name: 'Upload-Only' },
+];
+
+const samlProvider = {
+    id: 1,
+    type: 'SAML',
+    slug: 'test-idp-1',
+    name: 'Test IDP 1',
+    details: {
+        idp_issuer_uri: 'http://test-idp-1:8081/metadata',
+        idp_sso_uri: 'http://test-idp-1.localhost/sso',
+        principal_attribute_mappings: null,
+        sp_issuer_uri: 'http://bloodhound.localhost/api/v2/login/saml/test-idp-1',
+        sp_sso_uri: 'http://bloodhound.localhost/api/v2/login/saml/test-idp-1/sso',
+        sp_metadata_uri: 'http://bloodhound.localhost/api/v2/login/saml/test-idp-1/metadata',
+        sp_acs_uri: 'http://bloodhound.localhost/api/v2/login/saml/test-idp-1/acs',
+    },
+    login_uri: '',
+    callback_uri: '',
+    created_at: '2022-02-24T23:38:41.420271Z',
+    updated_at: '2022-02-24T23:38:41.420271Z',
+    config: {
+        auto_provision: { enabled: false, role_provision: false, default_role_id: 1 },
+    },
+};
+
+test.describe('Administration - SSO Configuration - has no detectable WCAG A/AA violations', () => {
+    test.beforeEach(async ({ page }) => {
+        await page.route('**/api/v2/self', async (route) => {
+            if (route.request().method() !== 'GET') {
+                return route.fallback();
+            }
+
+            await route.fulfill({ json: { data: authenticatedUser } });
+        });
+        await page.route('**/api/v2/roles', async (route) => {
+            if (route.request().method() !== 'GET') {
+                return route.fallback();
+            }
+
+            await route.fulfill({ json: { data: { roles } } });
+        });
+        await page.route('**/api/v2/features', async (route) => {
+            if (route.request().method() !== 'GET') {
+                return route.fallback();
+            }
+
+            await route.fulfill({
+                json: {
+                    data: [
+                        {
+                            id: 1,
+                            key: 'oidc_support',
+                            name: 'OIDC Support',
+                            description: 'Enables OIDC identity providers.',
+                            enabled: true,
+                            user_updatable: false,
+                        },
+                    ],
+                },
+            });
+        });
+
+        await page.route('**/api/v2/sso-providers', async (route) => {
+            if (route.request().method() !== 'GET') {
+                return route.fallback();
+            }
+
+            await route.fulfill({ json: { data: [] } });
+        });
+    });
+
+    test('page with no providers', async ({ page, makeAxeBuilder }, testInfo) => {
+        await page.goto('/ui/administration/sso-configuration');
+        await expect(page.getByRole('heading', { name: 'SSO Configuration' })).toBeVisible();
+        await expect(page.getByText('No SSO Providers found')).toBeVisible();
+
+        const results = await makeAxeBuilder().include('#content-wrapper').analyze();
+        await expectNoAccessibilityViolations(testInfo, results, { page });
+    });
+
+    test('create providers menu', async ({ page, makeAxeBuilder }, testInfo) => {
+        await page.goto('/ui/administration/sso-configuration');
+        await page.getByRole('button', { name: 'Create Provider' }).click();
+        await expect(page.getByRole('menuitem', { name: 'SAML Provider' })).toBeVisible();
+        await expect(page.getByRole('menuitem', { name: 'OIDC Provider' })).toBeVisible();
+
+        const results = await makeAxeBuilder().include('#content-wrapper').include('[role="menu"]').analyze();
+        await expectNoAccessibilityViolations(testInfo, results, { page });
+    });
+
+    test('create SAML provider dialog', async ({ page, makeAxeBuilder }, testInfo) => {
+        await page.goto('/ui/administration/sso-configuration');
+        await page.getByRole('button', { name: 'Create Provider' }).click();
+        await page.getByRole('menuitem', { name: 'SAML Provider' }).click();
+        await expect(page.getByRole('dialog', { name: 'Create SAML Provider' })).toBeVisible();
+        await expect(page.getByLabel('SAML Provider Name')).toBeVisible();
+
+        const results = await makeAxeBuilder().include('#content-wrapper').include('[role="dialog"]').analyze();
+        await expectNoAccessibilityViolations(testInfo, results, { page });
+    });
+
+    test('create OIDC provider dialog', async ({ page, makeAxeBuilder }, testInfo) => {
+        await page.goto('/ui/administration/sso-configuration');
+        await page.getByRole('button', { name: 'Create Provider' }).click();
+        await page.getByRole('menuitem', { name: 'OIDC Provider' }).click();
+        await expect(page.getByRole('dialog', { name: 'Create OIDC Provider' })).toBeVisible();
+        await expect(page.getByLabel('OIDC Provider Name')).toBeVisible();
+
+        const results = await makeAxeBuilder().include('#content-wrapper').include('[role="dialog"]').analyze();
+        await expectNoAccessibilityViolations(testInfo, results, { page });
+    });
+
+    test('page with providers', async ({ page, makeAxeBuilder }, testInfo) => {
+        await page.route('**/api/v2/sso-providers', async (route) => {
+            if (route.request().method() !== 'GET') {
+                return route.fallback();
+            }
+
+            await route.fulfill({ json: { data: [samlProvider] } });
+        });
+        await page.goto('/ui/administration/sso-configuration');
+        await expect(page.getByRole('button', { name: 'Test IDP 1' })).toBeVisible();
+        await expect(page.getByRole('cell', { name: 'SAML' })).toBeVisible();
+
+        const results = await makeAxeBuilder().include('#content-wrapper').analyze();
+        await expectNoAccessibilityViolations(testInfo, results, { page });
+    });
+});


### PR DESCRIPTION
Adds accessibility tests for the Administration sso configuration, bloodhound configuration, and early access features pages, to verify compliance with accessibility standards.


<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

This change was needed to ensure the Administration sso configuration, bloodhound configuration, and early access features pages adhere to accessibility standards.

## Motivation and Context

Resolves bed-8639

*Why is this change required? What problem does it solve?*

## How Has This Been Tested?

The tests were run locally.

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- New feature (non-breaking change which adds functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [X] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [X] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [X] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added automated accessibility coverage for BloodHound Configuration administration workflows.
  * Added accessibility checks for Early Access Features, including introductory dialogs and page navigation.
  * Added accessibility checks for SSO Configuration empty states, provider creation dialogs, and provider listings.
  * Verified page and dialog experiences against WCAG A/AA criteria.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->