### PR TITLE
feat: expose artifact metadata on management operations (BED-9186)

### DIFF
--- a/packages/javascript/js-client-library/src/responses.ts
+++ b/packages/javascript/js-client-library/src/responses.ts
@@ -357,12 +357,22 @@ export enum ManagementOperationStatus {
     CANCELED = 'canceled',
 }
 
+export enum ArtifactStatus {
+    PENDING = 'pending',
+    UPLOADING = 'uploading',
+    COMPLETE = 'complete',
+    FAILED = 'failed',
+    CANCELED = 'canceled',
+}
+
 export type ManagementOperation = {
     id: string;
     client_id: string;
     artifact_id: string | null;
+    // total byte size of the artifact to download
+    artifact_size: number | null;
+    artifact_status: ArtifactStatus | null;
     type: 'support_bundle';
-    status: ManagementOperationStatus;
     requested_by_user_id: string | null;
     created_at: string;
     started_at: string | null;

--- a/packages/javascript/js-client-library/src/responses.ts
+++ b/packages/javascript/js-client-library/src/responses.ts
@@ -373,6 +373,7 @@ export type ManagementOperation = {
     artifact_size: number | null;
     artifact_status: ArtifactStatus | null;
     type: 'support_bundle';
+    status: ManagementOperationStatus;
     requested_by_user_id: string | null;
     created_at: string;
     started_at: string | null;


### PR DESCRIPTION
## Description

- Add an `ArtifactStatus` enum for support bundle artifacts.
- Expose nullable `artifact_size` (in bytes) and `artifact_status` fields on `ManagementOperation` responses.
- Align the client response type with the artifact metadata returned by the management API.

## Motivation and Context

Resolves BED-9186

BHE needs artifact size metadata before starting a support bundle download so that very large bundles can be handled safely.

## How Has This Been Tested?

No testing necessary here - this was tested in BHE, which is all that uses this type

## Screenshots (optional):

See BHE PR for screenshots/video

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added detailed artifact status tracking with pending, uploading, complete, failed, and canceled states.
  - Added artifact size information to management operation responses.

- **Updates**
  - Management operation responses now report artifact status and size when available, providing clearer visibility into artifact processing progress and transfer outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->