### PR TITLE
fix: adding map and log for FileServiceConfiguration - BED-9174

### DIFF
--- a/cmd/api/src/config/config.go
+++ b/cmd/api/src/config/config.go
@@ -227,9 +227,11 @@ type BucketConfiguration struct {
 	Region string `json:"region"`
 }
 
+type FileServiceConfigurationMap map[string]FileServiceConfiguration
+
 type StorageConfiguration struct {
-	InstanceBucket BucketConfiguration                 `json:"instance_bucket"`
-	FileServices   map[string]FileServiceConfiguration `json:"file_services"`
+	InstanceBucket BucketConfiguration         `json:"instance_bucket"`
+	FileServices   FileServiceConfigurationMap `json:"file_services"`
 }
 
 type Configuration struct {

--- a/cmd/api/src/services/storage/fileserviceresolver.go
+++ b/cmd/api/src/services/storage/fileserviceresolver.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -192,6 +193,12 @@ func resolveFileServiceDefinitions(cfg config.Configuration, definitions []FileS
 		definitionsByName[definition.Name] = struct{}{}
 
 		if serviceConfiguration, configured = cfg.Storage.FileServices[string(definition.Name)]; configured {
+			slog.Info(fmt.Sprintf(
+				"file service %s configured using storage configuration with provider %s and prefix %s",
+				definition.Name,
+				serviceConfiguration.Provider,
+				serviceConfiguration.Prefix,
+			))
 			provider, err = parseFileServiceProvider(serviceConfiguration.Provider)
 			if err != nil {
 				return nil, false, fmt.Errorf("file service %q: %w", definition.Name, err)
@@ -212,6 +219,7 @@ func resolveFileServiceDefinitions(cfg config.Configuration, definitions []FileS
 			s3Prefixes[prefix] = definition.Name
 		}
 
+		slog.Info(fmt.Sprintf("resolved file service definition for %s with provider %s", definition.Name, provider))
 		resolvedDefinitions = append(resolvedDefinitions, resolvedFileServiceDefinition{
 			definition: definition,
 			provider:   provider,
@@ -279,6 +287,7 @@ func NewDefaultFileServices(ctx context.Context, cfg config.Configuration, addit
 	}
 
 	if s3Required {
+		slog.InfoContext(ctx, "S3 Client is required, instantiating client")
 		if s3Client, err = createS3Client(ctx, cfg.Storage.InstanceBucket); err != nil {
 			return nil, err
 		}
@@ -292,6 +301,7 @@ func NewDefaultFileServices(ctx context.Context, cfg config.Configuration, addit
 				resolvedDefinition.prefix,
 				s3Client,
 			)
+			slog.InfoContext(ctx, fmt.Sprintf("FileService %s created using S3 backing", resolvedDefinition.definition.Name))
 		case fileServiceProviderLocal:
 			localStore, fileService, err = createLocalStore(resolvedDefinition.definition.LocalPath)
 			if err != nil {
@@ -300,6 +310,7 @@ func NewDefaultFileServices(ctx context.Context, cfg config.Configuration, addit
 
 			openedStores = append(openedStores, localStore)
 			fileServices[resolvedDefinition.definition.Name] = fileService
+			slog.InfoContext(ctx, fmt.Sprintf("FileService %s created using local storage backing", resolvedDefinition.definition.Name))
 		}
 	}
 


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Adding logging around feature for FileServiceConfiguration

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-9174

*Why is this change required? What problem does it solve?*

## How Has This Been Tested?

*Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc.*

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer diagnostic logging when configuring file storage services.
  * Added logging for S3 client setup and local or S3 storage service creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->