### PR TITLE
fix: use explicit columns in identity role/permission reads for deleted_at

### DIFF
--- a/server/identity/internal/appdb/appdb.go
+++ b/server/identity/internal/appdb/appdb.go
@@ -99,7 +99,7 @@ func (s *Store) GetRole(ctx context.Context, id int32) (services.Role, error) {
 		err      error
 	)
 
-	roleSB.Select("*").From(tableRoles).Where(roleSB.Equal("id", id)).Limit(1)
+	roleSB.Select("id", "name", "description", "created_at", "updated_at").From(tableRoles).Where(roleSB.Equal("id", id)).Limit(1)
 	roleQuery, roleArgs := roleSB.Build()
 
 	roleRows, err = s.db.Query(ctx, roleQuery, roleArgs...)
@@ -290,7 +290,7 @@ func (s *Store) ListRoles(ctx context.Context, queryFilters params.Filters, sort
 		err               error
 	)
 
-	roleSB.Select("*").From(tableRoles)
+	roleSB.Select("id", "name", "description", "created_at", "updated_at").From(tableRoles)
 
 	if err = applyRoleFilters(roleSB, queryFilters); err != nil {
 		return nil, err
@@ -339,7 +339,7 @@ func (s *Store) ListRoles(ctx context.Context, queryFilters params.Filters, sort
 
 func (s *Store) GetPermission(ctx context.Context, id int) (services.Permission, error) {
 	sb := sqlbuilder.PostgreSQL.NewSelectBuilder()
-	sb.Select("*")
+	sb.Select("id", "authority", "name", "created_at", "updated_at")
 	sb.From(tablePermissions)
 	sb.Where(sb.Equal("id", id))
 	sb.Limit(1)

--- a/server/identity/internal/appdb/appdb.go
+++ b/server/identity/internal/appdb/appdb.go
@@ -34,6 +34,8 @@ const (
 	tableRolesPermissions = "roles_permissions"
 )
 
+var validRoleColumns = []string{"id", "name", "description", "created_at", "updated_at"}
+
 type queryExecer interface {
 	Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error)
 }
@@ -99,7 +101,7 @@ func (s *Store) GetRole(ctx context.Context, id int32) (services.Role, error) {
 		err      error
 	)
 
-	roleSB.Select("id", "name", "description", "created_at", "updated_at").From(tableRoles).Where(roleSB.Equal("id", id)).Limit(1)
+	roleSB.Select(validRoleColumns...).From(tableRoles).Where(roleSB.Equal("id", id)).Limit(1)
 	roleQuery, roleArgs := roleSB.Build()
 
 	roleRows, err = s.db.Query(ctx, roleQuery, roleArgs...)
@@ -290,7 +292,7 @@ func (s *Store) ListRoles(ctx context.Context, queryFilters params.Filters, sort
 		err               error
 	)
 
-	roleSB.Select("id", "name", "description", "created_at", "updated_at").From(tableRoles)
+	roleSB.Select(validRoleColumns...).From(tableRoles)
 
 	if err = applyRoleFilters(roleSB, queryFilters); err != nil {
 		return nil, err

--- a/server/identity/internal/appdb/appdb_integration_test.go
+++ b/server/identity/internal/appdb/appdb_integration_test.go
@@ -313,12 +313,12 @@ func TestStore_ListRoles_Integration(t *testing.T) {
 	})
 }
 
-// addStrayDeletedAtColumn simulates the shape of an upgraded/GORM-era database by
+// addDeprecatedDeletedAtColumn simulates the shape of an upgraded/GORM-era database by
 // adding a deleted_at column that the current migrations do not create and that the
 // Go structs do not model. Reading from such a table with SELECT * would return an
 // extra column the strict pgx.RowToStructByName mapper cannot place, reproducing the
 // original "struct doesn't have corresponding row field deleted_at" failure.
-func addStrayDeletedAtColumn(t *testing.T, ctx context.Context, pool *pgxpool.Pool, table string) {
+func addDeprecatedDeletedAtColumn(t *testing.T, ctx context.Context, pool *pgxpool.Pool, table string) {
 	t.Helper()
 
 	_, err := pool.Exec(ctx, fmt.Sprintf("ALTER TABLE %s ADD COLUMN deleted_at timestamp with time zone", table))

--- a/server/identity/internal/appdb/appdb_integration_test.go
+++ b/server/identity/internal/appdb/appdb_integration_test.go
@@ -312,3 +312,72 @@ func TestStore_ListRoles_Integration(t *testing.T) {
 		assert.Empty(t, beforeEpoch, "no seeded role was updated before the epoch")
 	})
 }
+
+// addStrayDeletedAtColumn simulates the shape of an upgraded/GORM-era database by
+// adding a deleted_at column that the current migrations do not create and that the
+// Go structs do not model. Reading from such a table with SELECT * would return an
+// extra column the strict pgx.RowToStructByName mapper cannot place, reproducing the
+// original "struct doesn't have corresponding row field deleted_at" failure.
+func addStrayDeletedAtColumn(t *testing.T, ctx context.Context, pool *pgxpool.Pool, table string) {
+	t.Helper()
+
+	_, err := pool.Exec(ctx, fmt.Sprintf("ALTER TABLE %s ADD COLUMN deleted_at timestamp with time zone", table))
+	require.NoError(t, err)
+}
+
+// TestStore_SchemaDrift_DeletedAt_Integration is a regression test for the case where
+// the physical roles/permissions tables carry a stray deleted_at column (as on
+// databases upgraded from the GORM era) that the Go structs do not model. The reads
+// must remain resilient to that schema drift by selecting explicit columns rather than
+// SELECT *. This test fails against the old SELECT * queries and passes against the
+// explicit-column queries.
+func TestStore_SchemaDrift_DeletedAt_Integration(t *testing.T) {
+	t.Run("GetRole succeeds when roles has a stray deleted_at column", func(t *testing.T) {
+		var (
+			ctx         = context.Background()
+			store, pool = setupStoreAndPool(t)
+		)
+
+		addStrayDeletedAtColumn(t, ctx, pool, "roles")
+
+		expected := seededRole(t, ctx, pool)
+
+		retrieved, err := store.GetRole(ctx, expected.ID)
+		require.NoError(t, err)
+		assert.Equal(t, expected.ID, retrieved.ID)
+		assert.Equal(t, expected.Name, retrieved.Name)
+	})
+
+	t.Run("ListRoles succeeds when roles has a stray deleted_at column", func(t *testing.T) {
+		var (
+			ctx         = context.Background()
+			store, pool = setupStoreAndPool(t)
+		)
+
+		addStrayDeletedAtColumn(t, ctx, pool, "roles")
+
+		expectedCount := seededRoleCount(t, ctx, pool)
+		require.NotZero(t, expectedCount, "expected migrations to seed at least one role")
+
+		roles, err := store.ListRoles(ctx, params.Filters{}, params.SortItems{})
+		require.NoError(t, err)
+		assert.Len(t, roles, expectedCount)
+	})
+
+	t.Run("GetPermission succeeds when permissions has a stray deleted_at column", func(t *testing.T) {
+		var (
+			ctx         = context.Background()
+			store, pool = setupStoreAndPool(t)
+		)
+
+		addStrayDeletedAtColumn(t, ctx, pool, "permissions")
+
+		expected := seededPermission(t, ctx, pool)
+
+		retrieved, err := store.GetPermission(ctx, int(expected.ID))
+		require.NoError(t, err)
+		assert.Equal(t, expected.ID, retrieved.ID)
+		assert.Equal(t, expected.Authority, retrieved.Authority)
+		assert.Equal(t, expected.Name, retrieved.Name)
+	})
+}

--- a/server/identity/internal/appdb/appdb_integration_test.go
+++ b/server/identity/internal/appdb/appdb_integration_test.go
@@ -338,7 +338,7 @@ func TestStore_SchemaDrift_DeletedAt_Integration(t *testing.T) {
 			store, pool = setupStoreAndPool(t)
 		)
 
-		addStrayDeletedAtColumn(t, ctx, pool, "roles")
+		addDeprecatedDeletedAtColumn(t, ctx, pool, "roles")
 
 		expected := seededRole(t, ctx, pool)
 
@@ -354,7 +354,7 @@ func TestStore_SchemaDrift_DeletedAt_Integration(t *testing.T) {
 			store, pool = setupStoreAndPool(t)
 		)
 
-		addStrayDeletedAtColumn(t, ctx, pool, "roles")
+		addDeprecatedDeletedAtColumn(t, ctx, pool, "roles")
 
 		expectedCount := seededRoleCount(t, ctx, pool)
 		require.NotZero(t, expectedCount, "expected migrations to seed at least one role")
@@ -370,7 +370,7 @@ func TestStore_SchemaDrift_DeletedAt_Integration(t *testing.T) {
 			store, pool = setupStoreAndPool(t)
 		)
 
-		addStrayDeletedAtColumn(t, ctx, pool, "permissions")
+		addDeprecatedDeletedAtColumn(t, ctx, pool, "permissions")
 
 		expected := seededPermission(t, ctx, pool)
 

--- a/server/identity/internal/appdb/appdb_test.go
+++ b/server/identity/internal/appdb/appdb_test.go
@@ -31,10 +31,10 @@ import (
 )
 
 // expectedGetPermissionSQL is the literal SQL the Store issues for GetPermission.
-const expectedGetPermissionSQL = `SELECT * FROM permissions WHERE id = $1 LIMIT $2`
+const expectedGetPermissionSQL = `SELECT id, authority, name, created_at, updated_at FROM permissions WHERE id = $1 LIMIT $2`
 
 // expectedGetRoleSQL is the literal SQL the Store issues for the roles query in GetRole.
-const expectedGetRoleSQL = `SELECT * FROM roles WHERE id = $1 LIMIT $2`
+const expectedGetRoleSQL = `SELECT id, name, description, created_at, updated_at FROM roles WHERE id = $1 LIMIT $2`
 
 // expectedGetRolePermissionsSQL is the literal SQL the Store issues for the
 // per-role permissions query in GetRole.
@@ -49,19 +49,19 @@ const expectedListRolePermissionsTwoSQL = `SELECT rp.role_id, p.id, p.authority,
 
 // expectedListRolesSQL is the literal SQL the Store issues for the roles query in
 // ListRoles when no filters or sorts are supplied.
-const expectedListRolesSQL = `SELECT * FROM roles`
+const expectedListRolesSQL = `SELECT id, name, description, created_at, updated_at FROM roles`
 
 // expectedListRolesSortedSQL is the literal SQL the Store issues when a single
 // ascending sort on name is supplied.
-const expectedListRolesSortedSQL = `SELECT * FROM roles ORDER BY name ASC`
+const expectedListRolesSortedSQL = `SELECT id, name, description, created_at, updated_at FROM roles ORDER BY name ASC`
 
 // expectedListRolesFilteredSQL is the literal SQL the Store issues when a single
 // equality filter on name is supplied.
-const expectedListRolesFilteredSQL = `SELECT * FROM roles WHERE (name = $1)`
+const expectedListRolesFilteredSQL = `SELECT id, name, description, created_at, updated_at FROM roles WHERE (name = $1)`
 
 // expectedListRolesFilteredByIDSQL is the literal SQL the Store issues when a
 // single greater-than filter on the numeric id column is supplied.
-const expectedListRolesFilteredByIDSQL = `SELECT * FROM roles WHERE (id > $1)`
+const expectedListRolesFilteredByIDSQL = `SELECT id, name, description, created_at, updated_at FROM roles WHERE (id > $1)`
 
 func newTestStore(t *testing.T) (*appdb.Store, pgxmock.PgxPoolIface) {
 	t.Helper()


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

 Fixes a 500 that showed up after we moved ListRoles over to the new architecture. 

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-9237

 When migrating to the new architecture, we switched to pgx/go-sqlbuilder. These queries were using SELECT *, which doesn't work on established databases. `deleted_at` was originally ignored by GORM, so the column sticks around on upgraded databases but isn't present on fresh ones. Which is why this wasn't caught locally. This fix swaps SELECT * for explicit column lists so the reads only ask for the columns the structs actually model.

## How Has This Been Tested?

Updated the unit tests to match the new queries.  Added a regression integration test that adds `deleted_at` column and tests still pass.  

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->


- Bug fix (non-breaking change which fixes an issue)


## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [X] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [X] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [X] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved role and permission data retrieval to remain reliable when database tables contain additional, unrecognized fields.
  * Preserved existing filtering, sorting, permission loading, and error-handling behavior.

* **Tests**
  * Added integration coverage for database schema changes involving additional deletion-tracking fields.
  * Updated query validation to reflect more precise data retrieval behavior across role and permission operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->