### PR TITLE
feat: Add Explore snap-to-grid BED-9229

### DIFF
--- a/cmd/ui/src/components/SigmaChart/GraphEvents.test.tsx
+++ b/cmd/ui/src/components/SigmaChart/GraphEvents.test.tsx
@@ -29,14 +29,35 @@ const sigmaMocks = vi.hoisted(() => ({
 }));
 
 const animationMocks = vi.hoisted(() => ({
-    animateNodes: vi.fn(
-        (graph: MultiDirectedGraph, targets: Record<string, { x: number; y: number }>, _options, callback) => {
-            Object.entries(targets).forEach(([id, position]) => graph.mergeNodeAttributes(id, position));
-            callback?.();
-            return vi.fn();
-        }
-    ),
+    pending: [] as Array<{
+        callback?: () => void;
+        cancel: ReturnType<typeof vi.fn>;
+        cancelled: boolean;
+        graph: MultiDirectedGraph;
+        targets: Record<string, { x: number; y: number }>;
+    }>,
+    animateNodes: vi.fn((graph, targets, _options, callback) => {
+        const animation = {
+            callback,
+            cancel: vi.fn(() => {
+                animation.cancelled = true;
+            }),
+            cancelled: false,
+            graph,
+            targets,
+        };
+        animationMocks.pending.push(animation);
+        return animation.cancel;
+    }),
 }));
+
+const completeLatestAnimation = () => {
+    const animation = animationMocks.pending.at(-1);
+    if (!animation || animation.cancelled) return;
+
+    Object.entries(animation.targets).forEach(([id, position]) => animation.graph.mergeNodeAttributes(id, position));
+    animation.callback?.();
+};
 
 const layoutMocks = vi.hoisted(() => ({
     sequentialLayout: vi.fn((graph: MultiDirectedGraph) => {
@@ -125,6 +146,7 @@ describe('GraphEvents snap to grid', () => {
         sigmaMocks.registerEvents.mockClear();
         sigmaMocks.setSettings.mockClear();
         animationMocks.animateNodes.mockClear();
+        animationMocks.pending = [];
         layoutMocks.sequentialLayout.mockClear();
         layoutMocks.standardLayout.mockClear();
     });
@@ -156,6 +178,7 @@ describe('GraphEvents snap to grid', () => {
 
         act(() => {
             sigmaMocks.handlers.mouseup({});
+            completeLatestAnimation();
         });
 
         expect(getPosition(graph, 'bravo')).toEqual(fixedPosition);
@@ -168,6 +191,81 @@ describe('GraphEvents snap to grid', () => {
             expect.any(Function)
         );
         expect(sigmaMocks.sigma.refresh).toHaveBeenCalledOnce();
+    });
+
+    it('keeps a rapid re-grab active after the prior drag reset delay', () => {
+        vi.useFakeTimers();
+        const graph = createGraph();
+        sigmaMocks.sigma = createSigma(graph);
+        render(<GraphEvents highlightedItem={null} snapToGridEnabled />);
+
+        act(() => {
+            sigmaMocks.handlers.downNode({ event: { original: { button: 0 }, x: 0, y: 0 }, node: 'alpha' });
+        });
+        act(() => {
+            sigmaMocks.handlers.mousemovebody({ x: 37, y: 43 });
+        });
+        act(() => {
+            sigmaMocks.handlers.mouseup({});
+        });
+        const firstAnimation = animationMocks.pending[0];
+
+        act(() => {
+            sigmaMocks.handlers.downNode({ event: { original: { button: 0 }, x: 37, y: 43 }, node: 'alpha' });
+        });
+        act(() => {
+            vi.advanceTimersByTime(10);
+            sigmaMocks.handlers.mousemovebody({ x: 71, y: 83 });
+        });
+
+        expect(firstAnimation.cancel).toHaveBeenCalledOnce();
+        expect(getPosition(graph, 'alpha')).toEqual({ x: 71, y: 83 });
+        vi.useRealTimers();
+    });
+
+    it('cancels settlement before disabling snap or applying another layout', () => {
+        const graph = createGraph();
+        const ref = createRef<any>();
+        sigmaMocks.sigma = createSigma(graph);
+        const { rerender } = render(<GraphEvents highlightedItem={null} snapToGridEnabled ref={ref} />);
+
+        act(() => {
+            sigmaMocks.handlers.downNode({ event: { original: { button: 0 }, x: 0, y: 0 }, node: 'alpha' });
+        });
+        act(() => {
+            sigmaMocks.handlers.mousemovebody({ x: 37, y: 43 });
+        });
+        act(() => {
+            sigmaMocks.handlers.mouseup({});
+        });
+        const animationBeforeDisable = animationMocks.pending[0];
+        rerender(<GraphEvents highlightedItem={null} snapToGridEnabled={false} ref={ref} />);
+        const positionAtDisable = getPosition(graph, 'alpha');
+        completeLatestAnimation();
+
+        expect(animationBeforeDisable.cancel).toHaveBeenCalledOnce();
+        expect(getPosition(graph, 'alpha')).toEqual(positionAtDisable);
+
+        rerender(<GraphEvents highlightedItem={null} snapToGridEnabled ref={ref} />);
+        act(() => {
+            sigmaMocks.handlers.downNode({ event: { original: { button: 0 }, x: 0, y: 0 }, node: 'alpha' });
+        });
+        act(() => {
+            sigmaMocks.handlers.mousemovebody({ x: 137, y: 143 });
+        });
+        act(() => {
+            sigmaMocks.handlers.mouseup({});
+        });
+        act(() => {
+            ref.current.runSequentialLayout();
+        });
+        const animationBeforeLayout = animationMocks.pending[1];
+        const positionAfterLayout = getPosition(graph, 'alpha');
+        completeLatestAnimation();
+
+        expect(animationBeforeLayout.cancel).toHaveBeenCalledOnce();
+        expect(getPosition(graph, 'alpha')).toEqual(positionAfterLayout);
+        expectGridAlignedWithoutCollision(graph);
     });
 
     it('resnaps both imperative layouts while enabled', () => {

--- a/cmd/ui/src/components/SigmaChart/GraphEvents.test.tsx
+++ b/cmd/ui/src/components/SigmaChart/GraphEvents.test.tsx
@@ -28,6 +28,16 @@ const sigmaMocks = vi.hoisted(() => ({
     sigma: undefined as any,
 }));
 
+const animationMocks = vi.hoisted(() => ({
+    animateNodes: vi.fn(
+        (graph: MultiDirectedGraph, targets: Record<string, { x: number; y: number }>, _options, callback) => {
+            Object.entries(targets).forEach(([id, position]) => graph.mergeNodeAttributes(id, position));
+            callback?.();
+            return vi.fn();
+        }
+    ),
+}));
+
 const layoutMocks = vi.hoisted(() => ({
     sequentialLayout: vi.fn((graph: MultiDirectedGraph) => {
         graph.setNodeAttribute('alpha', 'x', 12);
@@ -52,6 +62,8 @@ vi.mock('@react-sigma/core', () => ({
 vi.mock('bh-shared-ui', () => ({
     useTheme: () => ({ contrast: '#ffffff', neutral: { primary: '#000000' } }),
 }));
+
+vi.mock('sigma/utils/animate', () => animationMocks);
 
 vi.mock('src/store', () => ({
     useAppSelector: (selector: (state: any) => unknown) =>
@@ -112,6 +124,7 @@ describe('GraphEvents snap to grid', () => {
         sigmaMocks.handlers = {};
         sigmaMocks.registerEvents.mockClear();
         sigmaMocks.setSettings.mockClear();
+        animationMocks.animateNodes.mockClear();
         layoutMocks.sequentialLayout.mockClear();
         layoutMocks.standardLayout.mockClear();
     });
@@ -126,7 +139,7 @@ describe('GraphEvents snap to grid', () => {
         expect(sigmaMocks.sigma.refresh).toHaveBeenCalledOnce();
     });
 
-    it('snaps only the dragged node around occupied cells while enabled', () => {
+    it('moves freely while dragging, then snaps around occupied cells on release', () => {
         const graph = createGraph();
         sigmaMocks.sigma = createSigma(graph);
         render(<GraphEvents highlightedItem={null} snapToGridEnabled />);
@@ -139,9 +152,22 @@ describe('GraphEvents snap to grid', () => {
             sigmaMocks.handlers.mousemovebody({ ...fixedPosition });
         });
 
+        expect(getPosition(graph, 'alpha')).toEqual(fixedPosition);
+
+        act(() => {
+            sigmaMocks.handlers.mouseup({});
+        });
+
         expect(getPosition(graph, 'bravo')).toEqual(fixedPosition);
         expect(getPosition(graph, 'alpha')).not.toEqual(fixedPosition);
         expectGridAlignedWithoutCollision(graph);
+        expect(animationMocks.animateNodes).toHaveBeenCalledWith(
+            graph,
+            { alpha: { x: 0, y: -200 } },
+            { duration: 100, easing: 'quadraticOut' },
+            expect.any(Function)
+        );
+        expect(sigmaMocks.sigma.refresh).toHaveBeenCalledOnce();
     });
 
     it('resnaps both imperative layouts while enabled', () => {

--- a/cmd/ui/src/components/SigmaChart/GraphEvents.test.tsx
+++ b/cmd/ui/src/components/SigmaChart/GraphEvents.test.tsx
@@ -268,6 +268,57 @@ describe('GraphEvents snap to grid', () => {
         expectGridAlignedWithoutCollision(graph);
     });
 
+    it('cancels settlement when the Sigma graph is replaced', () => {
+        const originalGraph = createGraph();
+        sigmaMocks.sigma = createSigma(originalGraph);
+        const { rerender } = render(<GraphEvents highlightedItem={null} snapToGridEnabled />);
+
+        act(() => {
+            sigmaMocks.handlers.downNode({ event: { original: { button: 0 }, x: 0, y: 0 }, node: 'alpha' });
+        });
+        act(() => {
+            sigmaMocks.handlers.mousemovebody({ x: 37, y: 43 });
+        });
+        act(() => {
+            sigmaMocks.handlers.mouseup({});
+        });
+        const pendingAnimation = animationMocks.pending[0];
+        const positionBeforeReplacement = getPosition(originalGraph, 'alpha');
+
+        const replacementGraph = createGraph();
+        sigmaMocks.sigma = createSigma(replacementGraph);
+        rerender(<GraphEvents highlightedItem={null} snapToGridEnabled />);
+        completeLatestAnimation();
+
+        expect(pendingAnimation.cancel).toHaveBeenCalledOnce();
+        expect(getPosition(originalGraph, 'alpha')).toEqual(positionBeforeReplacement);
+        expectGridAlignedWithoutCollision(replacementGraph);
+    });
+
+    it('cancels settlement when unmounted', () => {
+        const graph = createGraph();
+        sigmaMocks.sigma = createSigma(graph);
+        const { unmount } = render(<GraphEvents highlightedItem={null} snapToGridEnabled />);
+
+        act(() => {
+            sigmaMocks.handlers.downNode({ event: { original: { button: 0 }, x: 0, y: 0 }, node: 'alpha' });
+        });
+        act(() => {
+            sigmaMocks.handlers.mousemovebody({ x: 37, y: 43 });
+        });
+        act(() => {
+            sigmaMocks.handlers.mouseup({});
+        });
+        const pendingAnimation = animationMocks.pending[0];
+        const positionBeforeUnmount = getPosition(graph, 'alpha');
+
+        unmount();
+        completeLatestAnimation();
+
+        expect(pendingAnimation.cancel).toHaveBeenCalledOnce();
+        expect(getPosition(graph, 'alpha')).toEqual(positionBeforeUnmount);
+    });
+
     it('resnaps both imperative layouts while enabled', () => {
         const graph = createGraph();
         const ref = createRef<any>();

--- a/cmd/ui/src/components/SigmaChart/GraphEvents.test.tsx
+++ b/cmd/ui/src/components/SigmaChart/GraphEvents.test.tsx
@@ -151,6 +151,10 @@ describe('GraphEvents snap to grid', () => {
         layoutMocks.standardLayout.mockClear();
     });
 
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
     it('aligns the current graph immediately when enabled', () => {
         const graph = createGraph();
         sigmaMocks.sigma = createSigma(graph);
@@ -220,7 +224,6 @@ describe('GraphEvents snap to grid', () => {
 
         expect(firstAnimation.cancel).toHaveBeenCalledOnce();
         expect(getPosition(graph, 'alpha')).toEqual({ x: 71, y: 83 });
-        vi.useRealTimers();
     });
 
     it('cancels settlement before disabling snap or applying another layout', () => {

--- a/cmd/ui/src/components/SigmaChart/GraphEvents.test.tsx
+++ b/cmd/ui/src/components/SigmaChart/GraphEvents.test.tsx
@@ -1,0 +1,183 @@
+// Copyright 2026 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { act, render } from '@testing-library/react';
+import { MultiDirectedGraph } from 'graphology';
+import { createRef } from 'react';
+import { GraphEvents } from './GraphEvents';
+
+const sigmaMocks = vi.hoisted(() => ({
+    handlers: {} as Record<string, (event: any) => void>,
+    registerEvents: vi.fn((handlers: Record<string, (event: any) => void>) => {
+        sigmaMocks.handlers = handlers;
+    }),
+    setSettings: vi.fn(),
+    sigma: undefined as any,
+}));
+
+const layoutMocks = vi.hoisted(() => ({
+    sequentialLayout: vi.fn((graph: MultiDirectedGraph) => {
+        graph.setNodeAttribute('alpha', 'x', 12);
+        graph.setNodeAttribute('alpha', 'y', 12);
+        graph.setNodeAttribute('bravo', 'x', 18);
+        graph.setNodeAttribute('bravo', 'y', 18);
+    }),
+    standardLayout: vi.fn((graph: MultiDirectedGraph) => {
+        graph.setNodeAttribute('alpha', 'x', 22);
+        graph.setNodeAttribute('alpha', 'y', 22);
+        graph.setNodeAttribute('bravo', 'x', 28);
+        graph.setNodeAttribute('bravo', 'y', 28);
+    }),
+}));
+
+vi.mock('@react-sigma/core', () => ({
+    useRegisterEvents: () => sigmaMocks.registerEvents,
+    useSetSettings: () => sigmaMocks.setSettings,
+    useSigma: () => sigmaMocks.sigma,
+}));
+
+vi.mock('bh-shared-ui', () => ({
+    useTheme: () => ({ contrast: '#ffffff', neutral: { primary: '#000000' } }),
+}));
+
+vi.mock('src/store', () => ({
+    useAppSelector: (selector: (state: any) => unknown) =>
+        selector({
+            global: {
+                view: {
+                    darkMode: false,
+                    exploreLayout: undefined,
+                    isExploreGraphHighlight: false,
+                    isExploreGraphLabelClip: false,
+                },
+            },
+        }),
+}));
+
+vi.mock('src/ducks/graph/utils', async (importOriginal) => ({
+    ...(await importOriginal<typeof import('src/ducks/graph/utils')>()),
+    getNodeOffset: () => ({ x: 0, y: 0 }),
+    resetCamera: vi.fn(),
+}));
+
+vi.mock('src/utils', () => ({ preventAllDefaults: vi.fn() }));
+
+vi.mock('src/views/Explore/utils', () => layoutMocks);
+
+const getPosition = (graph: MultiDirectedGraph, id: string) => {
+    const { x, y } = graph.getNodeAttributes(id);
+    return { x, y };
+};
+
+const expectGridAlignedWithoutCollision = (graph: MultiDirectedGraph) => {
+    const alpha = getPosition(graph, 'alpha');
+    const bravo = getPosition(graph, 'bravo');
+
+    expect([alpha.x, alpha.y, bravo.x, bravo.y].every((coordinate) => coordinate % 100 === 0)).toBe(true);
+    expect(alpha).not.toEqual(bravo);
+};
+
+const createGraph = () => {
+    const graph = new MultiDirectedGraph();
+    graph.addNode('alpha', { x: 10, y: 10 });
+    graph.addNode('bravo', { x: 20, y: 20 });
+    return graph;
+};
+
+const createSigma = (graph: MultiDirectedGraph) => ({
+    framedGraphToViewport: vi.fn((position) => position),
+    getCamera: vi.fn(() => ({ animate: vi.fn(), ratio: 1 })),
+    getGraph: () => graph,
+    getNodeDisplayData: vi.fn(),
+    refresh: vi.fn(),
+    scheduleRefresh: vi.fn(),
+    viewportToGraph: vi.fn((position) => position),
+});
+
+describe('GraphEvents snap to grid', () => {
+    beforeEach(() => {
+        sigmaMocks.handlers = {};
+        sigmaMocks.registerEvents.mockClear();
+        sigmaMocks.setSettings.mockClear();
+        layoutMocks.sequentialLayout.mockClear();
+        layoutMocks.standardLayout.mockClear();
+    });
+
+    it('aligns the current graph immediately when enabled', () => {
+        const graph = createGraph();
+        sigmaMocks.sigma = createSigma(graph);
+
+        render(<GraphEvents highlightedItem={null} snapToGridEnabled />);
+
+        expectGridAlignedWithoutCollision(graph);
+        expect(sigmaMocks.sigma.refresh).toHaveBeenCalledOnce();
+    });
+
+    it('snaps only the dragged node around occupied cells while enabled', () => {
+        const graph = createGraph();
+        sigmaMocks.sigma = createSigma(graph);
+        render(<GraphEvents highlightedItem={null} snapToGridEnabled />);
+        const fixedPosition = getPosition(graph, 'bravo');
+
+        act(() => {
+            sigmaMocks.handlers.downNode({ event: { original: { button: 0 }, x: 0, y: 0 }, node: 'alpha' });
+        });
+        act(() => {
+            sigmaMocks.handlers.mousemovebody({ ...fixedPosition });
+        });
+
+        expect(getPosition(graph, 'bravo')).toEqual(fixedPosition);
+        expect(getPosition(graph, 'alpha')).not.toEqual(fixedPosition);
+        expectGridAlignedWithoutCollision(graph);
+    });
+
+    it('resnaps both imperative layouts while enabled', () => {
+        const graph = createGraph();
+        const ref = createRef<any>();
+        sigmaMocks.sigma = createSigma(graph);
+        render(<GraphEvents highlightedItem={null} snapToGridEnabled ref={ref} />);
+
+        act(() => ref.current.runSequentialLayout());
+        expect(layoutMocks.sequentialLayout).toHaveBeenCalledWith(graph);
+        expectGridAlignedWithoutCollision(graph);
+
+        act(() => ref.current.runStandardLayout());
+        expect(layoutMocks.standardLayout).toHaveBeenCalledWith(graph);
+        expectGridAlignedWithoutCollision(graph);
+    });
+
+    it('avoids graph-wide occupancy work and permits free-form dragging while disabled', () => {
+        const graph = createGraph();
+        sigmaMocks.sigma = createSigma(graph);
+        const { rerender } = render(<GraphEvents highlightedItem={null} snapToGridEnabled />);
+        const alignedPosition = getPosition(graph, 'alpha');
+        const nodesSpy = vi.spyOn(graph, 'nodes');
+
+        rerender(<GraphEvents highlightedItem={null} snapToGridEnabled={false} />);
+        expect(getPosition(graph, 'alpha')).toEqual(alignedPosition);
+        nodesSpy.mockClear();
+
+        act(() => {
+            sigmaMocks.handlers.downNode({ event: { original: { button: 0 }, x: 0, y: 0 }, node: 'alpha' });
+        });
+        expect(nodesSpy).not.toHaveBeenCalled();
+
+        act(() => {
+            sigmaMocks.handlers.mousemovebody({ x: 37, y: 43 });
+        });
+        expect(getPosition(graph, 'alpha')).toEqual({ x: 37, y: 43 });
+    });
+});

--- a/cmd/ui/src/components/SigmaChart/GraphEvents.tsx
+++ b/cmd/ui/src/components/SigmaChart/GraphEvents.tsx
@@ -237,7 +237,9 @@ export const GraphEvents = forwardRef(function GraphEvents(
                         id: event.node,
                         offset: getNodeOffset(node, sigma.viewportToGraph(event.event)),
                         origin: { x: node.x, y: node.y },
-                        occupiedGridPoints: getOccupiedGridPoints(getGraphPositions(graph), new Set([event.node])),
+                        occupiedGridPoints: snapToGridEnabled
+                            ? getOccupiedGridPoints(getGraphPositions(graph), new Set([event.node]))
+                            : new Set(),
                     });
                 }
             },

--- a/cmd/ui/src/components/SigmaChart/GraphEvents.tsx
+++ b/cmd/ui/src/components/SigmaChart/GraphEvents.tsx
@@ -18,9 +18,19 @@ import { useRegisterEvents, useSetSettings, useSigma } from '@react-sigma/core';
 import { useTheme } from 'bh-shared-ui';
 import { MultiDirectedGraph } from 'graphology';
 import type { Attributes } from 'graphology-types';
-import { forwardRef, useCallback, useEffect, useImperativeHandle, useLayoutEffect, useMemo, useState } from 'react';
+import {
+    forwardRef,
+    useCallback,
+    useEffect,
+    useImperativeHandle,
+    useLayoutEffect,
+    useMemo,
+    useRef,
+    useState,
+} from 'react';
 import type { SigmaNodeEventPayload } from 'sigma/sigma';
 import type { Coordinates } from 'sigma/types';
+import { animateNodes } from 'sigma/utils/animate';
 import {
     DRAG_THRESHOLD,
     getDistanceBetween,
@@ -128,6 +138,9 @@ export const GraphEvents = forwardRef(function GraphEvents(
 
     const [draggedMeta, setDraggedMeta] = useState<DragMetadata>(DEFAULT_DRAGGED_META);
     const draggedNode = draggedMeta.id && graph.getNodeAttributes(draggedMeta.id);
+    const cancelSnapAnimation = useRef<(() => void) | null>(null);
+
+    useEffect(() => () => cancelSnapAnimation.current?.(), []);
 
     const sigmaChartRef = ref as React.MutableRefObject<SigmaChartRef | null>;
 
@@ -231,6 +244,9 @@ export const GraphEvents = forwardRef(function GraphEvents(
             },
             downNode: (event) => {
                 if (event.event.original.button === MOUSE_BUTTON_PRIMARY) {
+                    cancelSnapAnimation.current?.();
+                    cancelSnapAnimation.current = null;
+
                     const node = graph.getNodeAttributes(event.node);
                     setDraggedMeta({
                         cancelNextClick: false,
@@ -244,7 +260,24 @@ export const GraphEvents = forwardRef(function GraphEvents(
                 }
             },
             mouseup: () => {
-                if (draggedNode) {
+                if (draggedMeta.id) {
+                    if (snapToGridEnabled) {
+                        const { x, y } = graph.getNodeAttributes(draggedMeta.id);
+                        const snappedPosition = snapPositionToGrid({ x, y }, draggedMeta.occupiedGridPoints);
+                        const animationTarget: Record<string, Record<string, number>> = {
+                            [draggedMeta.id]: { x: snappedPosition.x, y: snappedPosition.y },
+                        };
+
+                        cancelSnapAnimation.current = animateNodes(
+                            graph,
+                            animationTarget,
+                            { duration: 100, easing: 'quadraticOut' },
+                            () => {
+                                cancelSnapAnimation.current = null;
+                            }
+                        );
+                    }
+
                     // Timeout prevents state update race conditions between this an mousemovebody.
                     setTimeout(() => setDraggedMeta(DEFAULT_DRAGGED_META), 10);
                 }
@@ -262,9 +295,6 @@ export const GraphEvents = forwardRef(function GraphEvents(
                         x: position.x - draggedMeta.offset.x,
                         y: position.y - draggedMeta.offset.y,
                     };
-                    const displayedPosition = snapToGridEnabled
-                        ? snapPositionToGrid(newPosition, draggedMeta.occupiedGridPoints)
-                        : newPosition;
 
                     // Determine if node has been dragged past click-cancel threshold
                     if (!draggedMeta.cancelNextClick && draggedMeta.origin) {
@@ -274,8 +304,8 @@ export const GraphEvents = forwardRef(function GraphEvents(
                         }
                     }
 
-                    graph.setNodeAttribute(draggedMeta.id, 'x', displayedPosition.x);
-                    graph.setNodeAttribute(draggedMeta.id, 'y', displayedPosition.y);
+                    graph.setNodeAttribute(draggedMeta.id, 'x', newPosition.x);
+                    graph.setNodeAttribute(draggedMeta.id, 'y', newPosition.y);
                 }
             },
             doubleClickNode: (event) => {

--- a/cmd/ui/src/components/SigmaChart/GraphEvents.tsx
+++ b/cmd/ui/src/components/SigmaChart/GraphEvents.tsx
@@ -138,9 +138,22 @@ export const GraphEvents = forwardRef(function GraphEvents(
 
     const [draggedMeta, setDraggedMeta] = useState<DragMetadata>(DEFAULT_DRAGGED_META);
     const draggedNode = draggedMeta.id && graph.getNodeAttributes(draggedMeta.id);
-    const cancelSnapAnimation = useRef<(() => void) | null>(null);
+    const cancelSnapAnimationRef = useRef<(() => void) | null>(null);
+    const dragResetTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const dragGenerationRef = useRef(0);
 
-    useEffect(() => () => cancelSnapAnimation.current?.(), []);
+    const cancelSnapAnimation = useCallback(() => {
+        cancelSnapAnimationRef.current?.();
+        cancelSnapAnimationRef.current = null;
+    }, []);
+
+    useEffect(
+        () => () => {
+            cancelSnapAnimation();
+            if (dragResetTimeoutRef.current) clearTimeout(dragResetTimeoutRef.current);
+        },
+        [cancelSnapAnimation]
+    );
 
     const sigmaChartRef = ref as React.MutableRefObject<SigmaChartRef | null>;
 
@@ -170,24 +183,27 @@ export const GraphEvents = forwardRef(function GraphEvents(
             },
 
             runSequentialLayout: () => {
+                cancelSnapAnimation();
                 sequentialLayout(graph);
                 if (snapToGridEnabled) snapGraphPositions(graph);
                 resetCamera(sigma);
             },
             runStandardLayout: () => {
+                cancelSnapAnimation();
                 standardLayout(graph);
                 if (snapToGridEnabled) snapGraphPositions(graph);
                 resetCamera(sigma);
             },
         };
-    }, [sigma, graph, snapToGridEnabled]);
+    }, [sigma, graph, snapToGridEnabled, cancelSnapAnimation]);
 
     useEffect(() => {
+        cancelSnapAnimation();
         if (!snapToGridEnabled) return;
 
         snapGraphPositions(graph);
         sigma.refresh();
-    }, [graph, sigma, snapToGridEnabled]);
+    }, [graph, sigma, snapToGridEnabled, cancelSnapAnimation]);
 
     const sigmaContainer = document.getElementById('sigma-container');
     const { getControlAtMidpoint, getLineLength, calculateCurveHeight } = bezier;
@@ -244,8 +260,12 @@ export const GraphEvents = forwardRef(function GraphEvents(
             },
             downNode: (event) => {
                 if (event.event.original.button === MOUSE_BUTTON_PRIMARY) {
-                    cancelSnapAnimation.current?.();
-                    cancelSnapAnimation.current = null;
+                    cancelSnapAnimation();
+                    if (dragResetTimeoutRef.current) {
+                        clearTimeout(dragResetTimeoutRef.current);
+                        dragResetTimeoutRef.current = null;
+                    }
+                    dragGenerationRef.current += 1;
 
                     const node = graph.getNodeAttributes(event.node);
                     setDraggedMeta({
@@ -268,18 +288,24 @@ export const GraphEvents = forwardRef(function GraphEvents(
                             [draggedMeta.id]: { x: snappedPosition.x, y: snappedPosition.y },
                         };
 
-                        cancelSnapAnimation.current = animateNodes(
+                        cancelSnapAnimationRef.current = animateNodes(
                             graph,
                             animationTarget,
                             { duration: 100, easing: 'quadraticOut' },
                             () => {
-                                cancelSnapAnimation.current = null;
+                                cancelSnapAnimationRef.current = null;
                             }
                         );
                     }
 
                     // Timeout prevents state update race conditions between this an mousemovebody.
-                    setTimeout(() => setDraggedMeta(DEFAULT_DRAGGED_META), 10);
+                    const releasedGeneration = dragGenerationRef.current;
+                    dragResetTimeoutRef.current = setTimeout(() => {
+                        if (dragGenerationRef.current === releasedGeneration) {
+                            setDraggedMeta(DEFAULT_DRAGGED_META);
+                        }
+                        dragResetTimeoutRef.current = null;
+                    }, 10);
                 }
             },
             mousemovebody: (event) => {
@@ -334,6 +360,7 @@ export const GraphEvents = forwardRef(function GraphEvents(
             clickStage: () => onClickStage?.(),
         });
     }, [
+        cancelSnapAnimation,
         draggedMeta,
         draggedMeta.id,
         draggedMeta.offset,

--- a/cmd/ui/src/components/SigmaChart/GraphEvents.tsx
+++ b/cmd/ui/src/components/SigmaChart/GraphEvents.tsx
@@ -16,24 +16,26 @@
 
 import { useRegisterEvents, useSetSettings, useSigma } from '@react-sigma/core';
 import { useTheme } from 'bh-shared-ui';
+import { MultiDirectedGraph } from 'graphology';
 import type { Attributes } from 'graphology-types';
 import { forwardRef, useCallback, useEffect, useImperativeHandle, useLayoutEffect, useMemo, useState } from 'react';
 import type { SigmaNodeEventPayload } from 'sigma/sigma';
 import type { Coordinates } from 'sigma/types';
 import {
     DRAG_THRESHOLD,
-    MOUSE_BUTTON_PRIMARY,
     getDistanceBetween,
     getEdgeDataFromKey,
     getEdgeSourceAndTargetDisplayData,
     getNodeOffset,
     graphToFramedGraph,
+    MOUSE_BUTTON_PRIMARY,
     resetCamera,
 } from 'src/ducks/graph/utils';
 import { bezier } from 'src/rendering/utils/bezier';
 import { blendHexColors, getNodeRadius } from 'src/rendering/utils/utils';
 import { useAppSelector } from 'src/store';
 import { preventAllDefaults } from 'src/utils';
+import { getOccupiedGridPoints, snapPositionsToGrid, snapPositionToGrid } from 'src/views/Explore/snapToGrid';
 import { sequentialLayout, standardLayout } from 'src/views/Explore/utils';
 import { getFullPathHighlightedEntities, getIsHighlightedItemInGraph } from './utils';
 
@@ -51,6 +53,7 @@ interface GraphEventProps {
     onRightClickNode?: (event: SigmaNodeEventPayload) => void;
     showNodeLabels?: boolean;
     showEdgeLabels?: boolean;
+    snapToGridEnabled?: boolean;
 }
 
 /** Meta info about the currently dragged node */
@@ -72,6 +75,9 @@ type DragMetadata = {
 
     /** Node's original position, for determining how far it's been dragged. */
     origin: Coordinates | null;
+
+    /** Grid cells occupied by every node except the one being dragged. */
+    occupiedGridPoints: Set<string>;
 };
 
 const DEFAULT_DRAGGED_META = {
@@ -79,6 +85,21 @@ const DEFAULT_DRAGGED_META = {
     cancelNextClick: false,
     offset: null,
     origin: null,
+    occupiedGridPoints: new Set<string>(),
+};
+
+const getGraphPositions = (graph: MultiDirectedGraph<Attributes, Attributes, Attributes>) =>
+    Object.fromEntries(
+        graph.nodes().map((id) => {
+            const { x, y } = graph.getNodeAttributes(id);
+            return [id, { x, y }];
+        })
+    );
+
+const snapGraphPositions = (graph: MultiDirectedGraph<Attributes, Attributes, Attributes>) => {
+    const snappedPositions = snapPositionsToGrid(getGraphPositions(graph));
+
+    graph.updateEachNodeAttributes((id, attributes) => ({ ...attributes, ...snappedPositions[id] }));
 };
 
 export const GraphEvents = forwardRef(function GraphEvents(
@@ -89,6 +110,7 @@ export const GraphEvents = forwardRef(function GraphEvents(
         onRightClickNode,
         showNodeLabels = true,
         showEdgeLabels = true,
+        snapToGridEnabled = false,
     }: GraphEventProps,
     ref
 ) {
@@ -136,14 +158,23 @@ export const GraphEvents = forwardRef(function GraphEvents(
 
             runSequentialLayout: () => {
                 sequentialLayout(graph);
+                if (snapToGridEnabled) snapGraphPositions(graph);
                 resetCamera(sigma);
             },
             runStandardLayout: () => {
                 standardLayout(graph);
+                if (snapToGridEnabled) snapGraphPositions(graph);
                 resetCamera(sigma);
             },
         };
-    }, [sigma, graph]);
+    }, [sigma, graph, snapToGridEnabled]);
+
+    useEffect(() => {
+        if (!snapToGridEnabled) return;
+
+        snapGraphPositions(graph);
+        sigma.refresh();
+    }, [graph, sigma, snapToGridEnabled]);
 
     const sigmaContainer = document.getElementById('sigma-container');
     const { getControlAtMidpoint, getLineLength, calculateCurveHeight } = bezier;
@@ -206,6 +237,7 @@ export const GraphEvents = forwardRef(function GraphEvents(
                         id: event.node,
                         offset: getNodeOffset(node, sigma.viewportToGraph(event.event)),
                         origin: { x: node.x, y: node.y },
+                        occupiedGridPoints: getOccupiedGridPoints(getGraphPositions(graph), new Set([event.node])),
                     });
                 }
             },
@@ -228,6 +260,9 @@ export const GraphEvents = forwardRef(function GraphEvents(
                         x: position.x - draggedMeta.offset.x,
                         y: position.y - draggedMeta.offset.y,
                     };
+                    const displayedPosition = snapToGridEnabled
+                        ? snapPositionToGrid(newPosition, draggedMeta.occupiedGridPoints)
+                        : newPosition;
 
                     // Determine if node has been dragged past click-cancel threshold
                     if (!draggedMeta.cancelNextClick && draggedMeta.origin) {
@@ -237,8 +272,8 @@ export const GraphEvents = forwardRef(function GraphEvents(
                         }
                     }
 
-                    graph.setNodeAttribute(draggedMeta.id, 'x', newPosition.x);
-                    graph.setNodeAttribute(draggedMeta.id, 'y', newPosition.y);
+                    graph.setNodeAttribute(draggedMeta.id, 'x', displayedPosition.x);
+                    graph.setNodeAttribute(draggedMeta.id, 'y', displayedPosition.y);
                 }
             },
             doubleClickNode: (event) => {
@@ -278,6 +313,7 @@ export const GraphEvents = forwardRef(function GraphEvents(
         registerEvents,
         sigma,
         sigmaContainer,
+        snapToGridEnabled,
     ]);
 
     const isHighlightedItemInGraph = useMemo(

--- a/cmd/ui/src/components/SigmaChart/SigmaChart.tsx
+++ b/cmd/ui/src/components/SigmaChart/SigmaChart.tsx
@@ -33,7 +33,7 @@ import getNodeGlyphsProgram from 'src/rendering/programs/node.glyphs';
 import { GraphEdgeEvents } from './GraphEdgeEvents';
 import { GraphEvents } from './GraphEvents';
 
-export interface SigmaChartProps {
+interface SigmaChartProps {
     graph?: MultiDirectedGraph<Attributes, Attributes, Attributes>;
     highlightedItem: string | null;
     onClickNode: (id: string) => void;

--- a/cmd/ui/src/components/SigmaChart/SigmaChart.tsx
+++ b/cmd/ui/src/components/SigmaChart/SigmaChart.tsx
@@ -33,7 +33,7 @@ import getNodeGlyphsProgram from 'src/rendering/programs/node.glyphs';
 import { GraphEdgeEvents } from './GraphEdgeEvents';
 import { GraphEvents } from './GraphEvents';
 
-interface SigmaChartProps {
+export interface SigmaChartProps {
     graph?: MultiDirectedGraph<Attributes, Attributes, Attributes>;
     highlightedItem: string | null;
     onClickNode: (id: string) => void;
@@ -42,6 +42,7 @@ interface SigmaChartProps {
     handleContextMenu: (event: SigmaNodeEventPayload) => void;
     showNodeLabels?: boolean;
     showEdgeLabels?: boolean;
+    snapToGridEnabled?: boolean;
 }
 
 const SigmaChart = forwardRef<RefAttributes<HTMLDivElement>, SigmaChartProps>(function SigmaChart(
@@ -54,6 +55,7 @@ const SigmaChart = forwardRef<RefAttributes<HTMLDivElement>, SigmaChartProps>(fu
         handleContextMenu,
         showNodeLabels = true,
         showEdgeLabels = true,
+        snapToGridEnabled = false,
     }: SigmaChartProps,
     ref
 ) {
@@ -106,6 +108,7 @@ const SigmaChart = forwardRef<RefAttributes<HTMLDivElement>, SigmaChartProps>(fu
                     onRightClickNode={handleContextMenu}
                     showNodeLabels={showNodeLabels}
                     showEdgeLabels={showEdgeLabels}
+                    snapToGridEnabled={snapToGridEnabled}
                     ref={ref}
                 />
             </SigmaContainer>

--- a/cmd/ui/src/views/Explore/GraphView.test.tsx
+++ b/cmd/ui/src/views/Explore/GraphView.test.tsx
@@ -195,18 +195,6 @@ describe('GraphView', () => {
             expect(sigmaChartMockState.props?.snapToGridEnabled).toBe(false);
         });
 
-        it('can be disabled without changing the current graph layout', async () => {
-            const user = userEvent.setup();
-            render(<GraphView />, { route: `/explore?searchType=node` });
-
-            const snapButton = await screen.findByRole('button', { name: 'Snap to grid' });
-            await user.click(snapButton);
-            await user.click(snapButton);
-
-            expect(snapButton).toHaveAttribute('aria-pressed', 'false');
-            expect(sigmaChartMockState.props?.snapToGridEnabled).toBe(false);
-        });
-
         it('hides the control while table view is displayed', async () => {
             render(<GraphView />, { route: `/explore?searchType=cypher&cypherSearch=encodedquery` });
 

--- a/cmd/ui/src/views/Explore/GraphView.test.tsx
+++ b/cmd/ui/src/views/Explore/GraphView.test.tsx
@@ -29,12 +29,15 @@ import { setupServer } from 'msw/node';
 import { render, screen, waitFor, within } from 'src/test-utils';
 import GraphView from './GraphView';
 
+const sigmaChartMockState = vi.hoisted(() => ({ props: undefined as { snapToGridEnabled?: boolean } | undefined }));
+
 // Mock sigma here to avoid rendering conflicts in jsdom
 vi.mock('src/components/SigmaChart', async () => {
     const { forwardRef, useImperativeHandle } = await import('react');
 
     return {
-        default: forwardRef((_props, ref) => {
+        default: forwardRef((props: { snapToGridEnabled?: boolean }, ref) => {
+            sigmaChartMockState.props = props;
             useImperativeHandle(ref, () => ({
                 runStandardLayout: vi.fn(),
                 runSequentialLayout: vi.fn(),
@@ -158,7 +161,10 @@ const server = setupServer(
 );
 
 beforeAll(() => server.listen());
-afterEach(() => server.resetHandlers());
+afterEach(() => {
+    server.resetHandlers();
+    sigmaChartMockState.props = undefined;
+});
 afterAll(() => server.close());
 
 describe('GraphView', () => {
@@ -166,6 +172,47 @@ describe('GraphView', () => {
         render(<GraphView />, { route: `/explore?searchType=cypher&cypherSearch=encodedquery` });
         const container = screen.getByTestId('explore');
         expect(container).toBeInTheDocument();
+    });
+
+    describe('Snap to grid', () => {
+        it('starts disabled and communicates its selected state to Sigma', async () => {
+            const user = userEvent.setup();
+            render(<GraphView />, { route: `/explore?searchType=node` });
+
+            const snapButton = await screen.findByRole('button', { name: 'Snap to grid' });
+            expect(snapButton).toHaveAttribute('aria-pressed', 'false');
+            expect(sigmaChartMockState.props?.snapToGridEnabled).toBe(false);
+
+            await user.click(snapButton);
+
+            expect(snapButton).toHaveAttribute('aria-pressed', 'true');
+            expect(snapButton).toHaveClass('!bg-primary', '!text-white');
+            expect(sigmaChartMockState.props?.snapToGridEnabled).toBe(true);
+
+            await user.keyboard('{Enter}');
+
+            expect(snapButton).toHaveAttribute('aria-pressed', 'false');
+            expect(sigmaChartMockState.props?.snapToGridEnabled).toBe(false);
+        });
+
+        it('can be disabled without changing the current graph layout', async () => {
+            const user = userEvent.setup();
+            render(<GraphView />, { route: `/explore?searchType=node` });
+
+            const snapButton = await screen.findByRole('button', { name: 'Snap to grid' });
+            await user.click(snapButton);
+            await user.click(snapButton);
+
+            expect(snapButton).toHaveAttribute('aria-pressed', 'false');
+            expect(sigmaChartMockState.props?.snapToGridEnabled).toBe(false);
+        });
+
+        it('hides the control while table view is displayed', async () => {
+            render(<GraphView />, { route: `/explore?searchType=cypher&cypherSearch=encodedquery` });
+
+            expect(await screen.findByRole('table')).toBeInTheDocument();
+            expect(screen.queryByRole('button', { name: 'Snap to grid' })).not.toBeInTheDocument();
+        });
     });
 
     it('displays an error message', async () => {

--- a/cmd/ui/src/views/Explore/GraphView.tsx
+++ b/cmd/ui/src/views/Explore/GraphView.tsx
@@ -14,12 +14,16 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+import { faBorderAll, faCheck } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { Tooltip } from '@mui/material';
 import {
     BaseExploreLayoutOptions,
     ContextMenuPrivilegeZonesEnabled,
     DEFAULT_PINNED_COLUMN_KEYS,
     ExploreTable,
     FeatureFlag,
+    GraphButton,
     GraphControls,
     GraphItemInformationPanel,
     GraphProgress,
@@ -113,6 +117,7 @@ const GraphView: FC = () => {
 
     const [showNodeLabels, toggleShowNodeLabels] = useToggle(true);
     const [showEdgeLabels, toggleShowEdgeLabels] = useToggle(true);
+    const [isSnapToGridEnabled, setIsSnapToGridEnabled] = useState(false);
 
     const isWebGLEnabledMemo = useMemo(() => isWebGLEnabled(), []);
 
@@ -281,29 +286,53 @@ const GraphView: FC = () => {
                 handleContextMenu={handleContextMenu}
                 showNodeLabels={showNodeLabels}
                 showEdgeLabels={showEdgeLabels}
+                snapToGridEnabled={isSnapToGridEnabled}
                 ref={sigmaChartRef}
             />
 
             <div className='absolute top-0 h-full p-4 flex gap-2 justify-between flex-col pointer-events-none'>
                 <ExploreSearch />
-                <GraphControls
-                    isExploreTableSelected={isExploreTableSelected}
-                    isExploreLayoutSelected={isExploreLayoutSelected}
-                    layoutOptions={baseGraphLayouts}
-                    selectedLayout={exploreLayout ?? defaultGraphLayout}
-                    onLayoutChange={setLayout}
-                    showNodeLabels={showNodeLabels}
-                    onToggleNodeLabels={toggleShowNodeLabels}
-                    showEdgeLabels={showEdgeLabels}
-                    onToggleEdgeLabels={toggleShowEdgeLabels}
-                    jsonData={graphQuery.data}
-                    onReset={() => sigmaChartRef.current?.resetCamera()}
-                    currentNodes={graphQuery.data?.nodes}
-                    onSearchedNodeClick={(node) => {
-                        node.id && setSelectedItem(node.id);
-                        sigmaChartRef?.current?.zoomTo(node.id);
-                    }}
-                />
+                <div className='flex gap-1 items-end pointer-events-auto'>
+                    <GraphControls
+                        isExploreTableSelected={isExploreTableSelected}
+                        isExploreLayoutSelected={isExploreLayoutSelected}
+                        layoutOptions={baseGraphLayouts}
+                        selectedLayout={exploreLayout ?? defaultGraphLayout}
+                        onLayoutChange={setLayout}
+                        showNodeLabels={showNodeLabels}
+                        onToggleNodeLabels={toggleShowNodeLabels}
+                        showEdgeLabels={showEdgeLabels}
+                        onToggleEdgeLabels={toggleShowEdgeLabels}
+                        jsonData={graphQuery.data}
+                        onReset={() => sigmaChartRef.current?.resetCamera()}
+                        currentNodes={graphQuery.data?.nodes}
+                        onSearchedNodeClick={(node) => {
+                            node.id && setSelectedItem(node.id);
+                            sigmaChartRef?.current?.zoomTo(node.id);
+                        }}
+                    />
+                    {!displayTable && (
+                        <Tooltip title={`${isSnapToGridEnabled ? 'Disable' : 'Enable'} snap to grid`} placement='top'>
+                            <span>
+                                <GraphButton
+                                    aria-label='Snap to grid'
+                                    aria-pressed={isSnapToGridEnabled}
+                                    className={isSnapToGridEnabled ? '!bg-primary !text-white' : ''}
+                                    data-testid='explore_graph-controls_snap-to-grid'
+                                    displayText={
+                                        <span className='flex items-center gap-1'>
+                                            <FontAwesomeIcon aria-hidden='true' icon={faBorderAll} />
+                                            {isSnapToGridEnabled && (
+                                                <FontAwesomeIcon aria-hidden='true' icon={faCheck} />
+                                            )}
+                                        </span>
+                                    }
+                                    onClick={() => setIsSnapToGridEnabled((isEnabled) => !isEnabled)}
+                                />
+                            </span>
+                        </Tooltip>
+                    )}
+                </div>
             </div>
             <GraphItemInformationPanel />
             <FeatureFlag

--- a/cmd/ui/src/views/Explore/GraphView.tsx
+++ b/cmd/ui/src/views/Explore/GraphView.tsx
@@ -317,7 +317,7 @@ const GraphView: FC = () => {
                                 <GraphButton
                                     aria-label='Snap to grid'
                                     aria-pressed={isSnapToGridEnabled}
-                                    className={isSnapToGridEnabled ? '!bg-primary !text-white' : ''}
+                                    className={isSnapToGridEnabled ? '!bg-primary !text-white dark:!text-black' : ''}
                                     data-testid='explore_graph-controls_snap-to-grid'
                                     displayText={
                                         <span className='flex items-center gap-1'>

--- a/cmd/ui/src/views/Explore/snapToGrid.test.ts
+++ b/cmd/ui/src/views/Explore/snapToGrid.test.ts
@@ -1,0 +1,82 @@
+// Copyright 2026 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { getOccupiedGridPoints, snapPositionsToGrid, snapPositionToGrid } from './snapToGrid';
+
+describe('snapPositionsToGrid', () => {
+    it('rounds positive and negative coordinates to the nearest grid point', () => {
+        const positions = {
+            positive: { x: 149, y: 150 },
+            negative: { x: -149, y: -150 },
+            origin: { x: -1, y: 1 },
+        };
+
+        expect(snapPositionsToGrid(positions, new Set(), 100)).toEqual({
+            negative: { x: -100, y: -200 },
+            origin: { x: 0, y: 0 },
+            positive: { x: 100, y: 200 },
+        });
+        expect(positions.positive).toEqual({ x: 149, y: 150 });
+    });
+
+    it('uses deterministic neighboring points when nodes collide', () => {
+        const positions = {
+            alpha: { x: 10, y: 10 },
+            bravo: { x: 20, y: 20 },
+            charlie: { x: 30, y: 30 },
+        };
+        const reverseOrder = Object.fromEntries(Object.entries(positions).reverse());
+
+        const snapped = snapPositionsToGrid(positions);
+
+        expect(snapped).toEqual(snapPositionsToGrid(reverseOrder));
+        expect(new Set(Object.values(snapped).map(({ x, y }) => `${x}:${y}`))).toHaveLength(3);
+    });
+
+    it('keeps fixed nodes in place and moves a dragged node to a free point', () => {
+        const positions = {
+            fixed: { x: 0, y: 0 },
+            dragged: { x: 20, y: 20 },
+        };
+
+        expect(snapPositionsToGrid(positions, new Set(['fixed']), 100)).toEqual({
+            fixed: { x: 0, y: 0 },
+            dragged: { x: -100, y: -100 },
+        });
+    });
+
+    it('allocates a dense collision group without duplicate cells', () => {
+        const positions = Object.fromEntries(
+            Array.from({ length: 5_000 }, (_, index) => [`node-${index.toString().padStart(4, '0')}`, { x: 1, y: 1 }])
+        );
+
+        const snapped = snapPositionsToGrid(positions);
+
+        expect(new Set(Object.values(snapped).map(({ x, y }) => `${x}:${y}`))).toHaveLength(5_000);
+    });
+});
+
+describe('snapPositionToGrid', () => {
+    it('snaps a dragged node around occupied graph positions', () => {
+        const positions = {
+            fixed: { x: 0, y: 0 },
+            dragged: { x: 100, y: 0 },
+        };
+        const occupiedGridPoints = getOccupiedGridPoints(positions, new Set(['dragged']), 100);
+
+        expect(snapPositionToGrid({ x: 20, y: 20 }, occupiedGridPoints, 100)).toEqual({ x: -100, y: -100 });
+    });
+});

--- a/cmd/ui/src/views/Explore/snapToGrid.test.ts
+++ b/cmd/ui/src/views/Explore/snapToGrid.test.ts
@@ -67,6 +67,17 @@ describe('snapPositionsToGrid', () => {
 
         expect(new Set(Object.values(snapped).map(({ x, y }) => `${x}:${y}`))).toHaveLength(5_000);
     });
+
+    it('normalizes non-finite coordinates without creating duplicate cells', () => {
+        const snapped = snapPositionsToGrid({
+            nan: { x: Number.NaN, y: Number.NaN },
+            positiveInfinity: { x: Number.POSITIVE_INFINITY, y: Number.POSITIVE_INFINITY },
+            negativeInfinity: { x: Number.NEGATIVE_INFINITY, y: Number.NEGATIVE_INFINITY },
+        });
+
+        expect(Object.values(snapped).every(({ x, y }) => Number.isFinite(x) && Number.isFinite(y))).toBe(true);
+        expect(new Set(Object.values(snapped).map(({ x, y }) => `${x}:${y}`))).toHaveLength(3);
+    });
 });
 
 describe('snapPositionToGrid', () => {

--- a/cmd/ui/src/views/Explore/snapToGrid.test.ts
+++ b/cmd/ui/src/views/Explore/snapToGrid.test.ts
@@ -54,7 +54,7 @@ describe('snapPositionsToGrid', () => {
 
         expect(snapPositionsToGrid(positions, new Set(['fixed']), 100)).toEqual({
             fixed: { x: 0, y: 0 },
-            dragged: { x: -100, y: -100 },
+            dragged: { x: 0, y: -100 },
         });
     });
 
@@ -77,6 +77,6 @@ describe('snapPositionToGrid', () => {
         };
         const occupiedGridPoints = getOccupiedGridPoints(positions, new Set(['dragged']), 100);
 
-        expect(snapPositionToGrid({ x: 20, y: 20 }, occupiedGridPoints, 100)).toEqual({ x: -100, y: -100 });
+        expect(snapPositionToGrid({ x: 20, y: 20 }, occupiedGridPoints, 100)).toEqual({ x: 0, y: -100 });
     });
 });

--- a/cmd/ui/src/views/Explore/snapToGrid.ts
+++ b/cmd/ui/src/views/Explore/snapToGrid.ts
@@ -32,10 +32,19 @@ function* getGridOffsets(): Generator<[number, number], never> {
     yield [0, 0];
 
     for (let radius = 1; ; radius++) {
-        for (let x = -radius; x <= radius; x++) yield [x, -radius];
-        for (let y = -radius + 1; y <= radius; y++) yield [radius, y];
-        for (let x = radius - 1; x >= -radius; x--) yield [x, radius];
-        for (let y = radius - 1; y > -radius; y--) yield [-radius, y];
+        const offsets: [number, number][] = [];
+
+        for (let x = -radius; x <= radius; x++) offsets.push([x, -radius]);
+        for (let y = -radius + 1; y <= radius; y++) offsets.push([radius, y]);
+        for (let x = radius - 1; x >= -radius; x--) offsets.push([x, radius]);
+        for (let y = radius - 1; y > -radius; y--) offsets.push([-radius, y]);
+
+        offsets.sort(
+            ([firstX, firstY], [secondX, secondY]) =>
+                firstX ** 2 + firstY ** 2 - (secondX ** 2 + secondY ** 2) || firstY - secondY || firstX - secondX
+        );
+
+        yield* offsets;
     }
 }
 

--- a/cmd/ui/src/views/Explore/snapToGrid.ts
+++ b/cmd/ui/src/views/Explore/snapToGrid.ts
@@ -19,7 +19,7 @@ import type { Coordinates } from 'sigma/types';
 export const SNAP_TO_GRID_SIZE = 100;
 
 const roundToGrid = (value: number, gridSize: number) => {
-    const scaledValue = value / gridSize;
+    const scaledValue = Number.isFinite(value) ? value / gridSize : 0;
     const roundedValue = scaledValue >= 0 ? Math.floor(scaledValue + 0.5) : Math.ceil(scaledValue - 0.5);
     const result = roundedValue * gridSize;
 

--- a/cmd/ui/src/views/Explore/snapToGrid.ts
+++ b/cmd/ui/src/views/Explore/snapToGrid.ts
@@ -1,0 +1,109 @@
+// Copyright 2026 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Coordinates } from 'sigma/types';
+
+export const SNAP_TO_GRID_SIZE = 100;
+
+const roundToGrid = (value: number, gridSize: number) => {
+    const scaledValue = value / gridSize;
+    const roundedValue = scaledValue >= 0 ? Math.floor(scaledValue + 0.5) : Math.ceil(scaledValue - 0.5);
+    const result = roundedValue * gridSize;
+
+    return Object.is(result, -0) ? 0 : result;
+};
+
+const getGridKey = (x: number, y: number) => `${x}:${y}`;
+
+function* getGridOffsets(): Generator<[number, number], never> {
+    yield [0, 0];
+
+    for (let radius = 1; ; radius++) {
+        for (let x = -radius; x <= radius; x++) yield [x, -radius];
+        for (let y = -radius + 1; y <= radius; y++) yield [radius, y];
+        for (let x = radius - 1; x >= -radius; x--) yield [x, radius];
+        for (let y = radius - 1; y > -radius; y--) yield [-radius, y];
+    }
+}
+
+const findAvailableGridPosition = (
+    position: Coordinates,
+    occupiedGridPoints: Set<string>,
+    gridSize: number,
+    offsets: Generator<[number, number], never>
+): Coordinates => {
+    const targetX = roundToGrid(position.x, gridSize);
+    const targetY = roundToGrid(position.y, gridSize);
+
+    while (true) {
+        const [offsetX, offsetY] = offsets.next().value;
+        const x = targetX + offsetX * gridSize;
+        const y = targetY + offsetY * gridSize;
+
+        if (!occupiedGridPoints.has(getGridKey(x, y))) return { x, y };
+    }
+};
+
+export const getOccupiedGridPoints = (
+    positions: Record<string, Coordinates>,
+    excludedIds: ReadonlySet<string> = new Set(),
+    gridSize = SNAP_TO_GRID_SIZE
+) =>
+    new Set(
+        Object.entries(positions)
+            .filter(([id]) => !excludedIds.has(id))
+            .map(([, position]) => getGridKey(roundToGrid(position.x, gridSize), roundToGrid(position.y, gridSize)))
+    );
+
+export const snapPositionToGrid = (
+    position: Coordinates,
+    occupiedGridPoints: Set<string>,
+    gridSize = SNAP_TO_GRID_SIZE
+) => findAvailableGridPosition(position, occupiedGridPoints, gridSize, getGridOffsets());
+
+export const snapPositionsToGrid = (
+    positions: Record<string, Coordinates>,
+    fixedNodeIds: ReadonlySet<string> = new Set(),
+    gridSize = SNAP_TO_GRID_SIZE
+) => {
+    const snappedPositions: Record<string, Coordinates> = {};
+    const occupiedGridPoints = new Set<string>();
+    const offsetSearches = new Map<string, Generator<[number, number], never>>();
+    const positionIds = Object.keys(positions).sort();
+
+    for (const id of positionIds) {
+        if (!fixedNodeIds.has(id)) continue;
+
+        const position = positions[id];
+        snappedPositions[id] = { ...position };
+        occupiedGridPoints.add(getGridKey(roundToGrid(position.x, gridSize), roundToGrid(position.y, gridSize)));
+    }
+
+    for (const id of positionIds) {
+        if (fixedNodeIds.has(id)) continue;
+
+        const position = positions[id];
+        const targetKey = getGridKey(roundToGrid(position.x, gridSize), roundToGrid(position.y, gridSize));
+        const offsets = offsetSearches.get(targetKey) ?? getGridOffsets();
+        offsetSearches.set(targetKey, offsets);
+
+        const snappedPosition = findAvailableGridPosition(position, occupiedGridPoints, gridSize, offsets);
+        snappedPositions[id] = snappedPosition;
+        occupiedGridPoints.add(getGridKey(snappedPosition.x, snappedPosition.y));
+    }
+
+    return snappedPositions;
+};


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

Related BHE implementation: https://github.com/SpecterOps/bloodhound-enterprise/pull/1726

## Description

Adds an optional, session-local **Snap to grid** control to the Explore graph. When enabled, the current graph aligns to a deterministic grid, nodes follow the pointer freely while dragged, and released nodes settle visibly into the nearest collision-free grid cell.

The implementation uses BHCE's native Sigma and Graphology capabilities. It preserves free-form behavior while disabled, re-applies grid alignment after supported layout operations and graph replacement, and cancels stale settlement transitions during rapid re-grab, disable, layout changes, graph replacement, and unmount.

**Blast radius / risk:** Limited to client-side Explore graph controls, Sigma drag handling, layout coordination, and node positioning. The state is not persisted. There are no API, database, migration, authorization, or collection changes. Primary risks are interaction regressions during drag/settlement and additional positioning work when enabled; disabled-mode tests verify that graph-wide occupancy work is avoided.

**Test changes:** Adds focused coverage for grid rounding, deterministic collision resolution, dense collision allocation, pointer-following drag behavior, animated settlement, rapid re-grab, enable/disable behavior, graph replacement, unmount cleanup, layout integration, control state and styling, keyboard operation, and table-view visibility. No expectations were weakened or removed to accommodate product regressions; one redundant toggle test that did not assert its claimed layout behavior was removed before submission.

**Rollback:** Revert this PR. The feature stores no persistent state and requires no migration, configuration rollback, or deployment ordering.

Review size: 770 reviewable changed lines — 291 product and 479 tests. Independent review accepted this as one cohesive interaction change with its renderer and lifecycle coverage.

## Motivation and Context

Resolves BED-9229

Explore users need a way to organize manually manipulated graphs without losing the existing free-form workflow. This adds a desktop-icon-style grid mode while keeping free-form positioning as the default.

## How Has This Been Tested?

- `yarn workspace bloodhound-ui test GraphEvents.test.tsx GraphView.test.tsx snapToGrid.test.ts --run` — 29/29 passed.
- Direct UI TypeScript, ESLint, and Prettier checks passed.
- `just prepare-for-codereview` passed on clean head `5f73cb16ef39eff8c20c25f9234a588dc1b4e27d`.
- Seeded local Sigma/WebGL browser validation confirmed graph rendering, keyboard toggle behavior, selected-state semantics, drag/settlement behavior, session reset, table-view behavior, and no browser errors on the product-equivalent predecessor head. Subsequent commits only added direct lifecycle tests and removed one redundant test.
- Independent enterprise review passed on the exact submitted head with no blocking, important, minor, or follow-up findings.

Not directly validated: touch-specific dragging, release outside the Sigma canvas, large real-world graph profiling, and narrow-viewport layout.

## Screenshots (optional):

Not included because no stable PR-accessible capture URL is available. Browser interaction evidence is summarized above.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional snap-to-grid mode for graph layouts.
  * Added a toggle control in the Explore graph view, including keyboard support.
  * Graph nodes now align to a consistent grid while avoiding overlapping positions.
  * Dragged nodes smoothly settle into available grid positions.
  * Fixed-position nodes remain unchanged during snapping.

* **Bug Fixes**
  * Improved drag handling, animation cancellation, and cleanup during rapid interactions or view changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->