### PR TITLE
fix: Remove square outlines from graph node icons BED-9251

### DIFF
--- a/cmd/ui/src/views/Explore/svgIcons.test.ts
+++ b/cmd/ui/src/views/Explore/svgIcons.test.ts
@@ -1,0 +1,42 @@
+// Copyright 2026 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { ActiveDirectoryNodeKind, DEFAULT_ICON_COLOR, IconDictionary, NODE_SCALE } from 'bh-shared-ui';
+
+const getModifiedSvgUrlFromIconMock = vi.hoisted(() => vi.fn(() => 'blob:test-icon'));
+
+vi.mock('bh-shared-ui', async (importOriginal) => ({
+    ...(await importOriginal<typeof import('bh-shared-ui')>()),
+    getModifiedSvgUrlFromIcon: getModifiedSvgUrlFromIconMock,
+}));
+
+import { NODE_ICONS, transformIconDictionary } from './svgIcons';
+
+describe('Explore SVG icons', () => {
+    it('creates transparent node icon images', () => {
+        getModifiedSvgUrlFromIconMock.mockClear();
+        const groupIcon = NODE_ICONS[ActiveDirectoryNodeKind.Group].icon;
+        const icons: IconDictionary = { Group: { icon: groupIcon, color: '#DBE617' } };
+
+        transformIconDictionary(icons);
+
+        expect(getModifiedSvgUrlFromIconMock).toHaveBeenCalledOnce();
+        expect(getModifiedSvgUrlFromIconMock).toHaveBeenCalledWith(groupIcon, {
+            styles: { color: DEFAULT_ICON_COLOR, scale: NODE_SCALE },
+        });
+        expect(icons.Group.url).toBe('blob:test-icon');
+    });
+});

--- a/cmd/ui/src/views/Explore/svgIcons.ts
+++ b/cmd/ui/src/views/Explore/svgIcons.ts
@@ -30,7 +30,7 @@ const appendIconSvgUrls = (icons: IconDictionary): void => {
         if (value.url) return;
 
         icons[type].url = getModifiedSvgUrlFromIcon(value.icon, {
-            styles: { color: DEFAULT_ICON_COLOR, scale: NODE_SCALE, 'background-color': value.color },
+            styles: { color: DEFAULT_ICON_COLOR, scale: NODE_SCALE },
         });
     });
 };


### PR DESCRIPTION
## Description

Removes the node background color from SVG textures generated for Explore graph icons. The graph renderer continues to draw the circular node background, preventing rectangular texture bounds from appearing around glyphs at low zoom levels.

Adds focused regression coverage that verifies transformed icons use only the foreground color and scale, invoke SVG generation exactly once, and receive the generated URL.

## Motivation and Context

Resolves BED-9251

Zoomed-out graph nodes could display a square outline around their glyphs because the generated SVG texture embedded the node background color. The issue applies to standard and custom node icons processed through the Explore icon dictionary, although it was initially reported on a User node.

## How Has This Been Tested?

- Ran the focused UI regression test:
  - `yarn workspace bloodhound-ui test --run src/views/Explore/svgIcons.test.ts`
- Ran ESLint against the changed source and test files.
- Ran Prettier validation against the changed source and test files.
- Ran the BloodHound UI TypeScript check with `tsc --noEmit`.
- Ran `just prepare-for-codereview` successfully from a clean repository.
- Validated against an isolated BHCE stack with official AD and Entra sample data. A Playwright zoom scenario passed with no page errors and confirmed that node glyphs render without rectangular backgrounds while circular node colors remain intact.

## Screenshots (optional):

The before-state screenshot is attached to BED-9251.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: BED-9251
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs: not applicable
  - Code comments: no updates required
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All applicable tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Explore icon rendering by consistently applying the default icon color and node scale.
  * Removed unintended background-color styling from generated SVG icon URLs.

* **Tests**
  * Added coverage verifying that Explore node icons are transformed with the expected color, scale, and resulting URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->