### PR TITLE
chore(alerts): update OpenAPI docs for GET alert events endpoint BED-8994

### DIFF
--- a/packages/go/openapi/src/paths/alerts.alert-events.yaml
+++ b/packages/go/openapi/src/paths/alerts.alert-events.yaml
@@ -34,7 +34,7 @@ get:
         $ref: './../schemas/api.params.query.sort-by.yaml'
     - name: type
       in: query
-      description: Supported operators are `eq` and `neq`. If matching with `eq`, must provide a valid alert event type.
+      description: Supported operators are `eq` and `neq`. Must provide valid alert event types.
       schema:
         $ref: './../schemas/api.params.predicate.filter.string.yaml'
     - $ref: './../parameters/query.created-at.yaml'

--- a/packages/go/openapi/src/paths/alerts.alert-events.yaml
+++ b/packages/go/openapi/src/paths/alerts.alert-events.yaml
@@ -34,6 +34,7 @@ get:
         $ref: './../schemas/api.params.query.sort-by.yaml'
     - name: type
       in: query
+      description: Supported operators are `eq` and `neq`. If matching with `eq`, must provide a valid alert event type.
       schema:
         $ref: './../schemas/api.params.predicate.filter.string.yaml'
     - $ref: './../parameters/query.created-at.yaml'


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Adds clarification to the docs for the GET `alert-events` endpoint

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-8994

*Why is this change required? What problem does it solve?*

## How Has This Been Tested?

Nothing to test, just a documentation change

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)


## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified the `type` query parameter’s supported `eq` and `neq` operators.
  * Documented that `eq` requires a valid alert event type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->