### PR TITLE
chore: Text color regression for sortable column headers BED-9107

### DIFF
--- a/packages/javascript/bh-shared-ui/src/components/ColumnHeaders/ColumnHeaders.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/ColumnHeaders/ColumnHeaders.tsx
@@ -59,7 +59,8 @@ export const SortableHeader: React.FC<SortableHeaderProps> = (props) => {
     let IconComponent = AppIcon.SortEmpty;
     if (sortOrder === 'asc') IconComponent = AppIcon.SortAsc;
     if (sortOrder === 'desc') IconComponent = AppIcon.SortDesc;
-
+    const headerClass =
+        'text-neutral-dark-5 dark:text-neutral-light-5 hover:text-secondary active:text-primary-variant focus-visible:text-secondary';
     return (
         <TooltipProvider>
             <TooltipRoot>
@@ -68,7 +69,11 @@ export const SortableHeader: React.FC<SortableHeaderProps> = (props) => {
                         <Button
                             disabled={disable}
                             aria-label={`Sort by ${title}`}
-                            className={cn('p-0 font-semibold text-base hover:no-underline relative', buttonClass)}
+                            className={cn(
+                                'p-0 font-semibold text-base hover:no-underline relative',
+                                headerClass,
+                                buttonClass
+                            )}
                             onClick={onSort}
                             onKeyDown={adaptClickHandlerToKeyDown(onSort)}
                             tabIndex={0}


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Sortable header text was displaying in the primary color instead of the intended neutral color. 

## Motivation and Context


Resolves BED-9107


## How Has This Been Tested?

Tested locally

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->


- Bug fix (non-breaking change which fixes an issue)


## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [ ] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [ ] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
