### PR TITLE
fix: fixed focus state rings for table buttons BED-9173

### DIFF
--- a/packages/javascript/bh-shared-ui/src/components/ExploreTable/ManageColumnsComboBox/ManageColumnsComboBox.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/ExploreTable/ManageColumnsComboBox/ManageColumnsComboBox.tsx
@@ -138,10 +138,7 @@ export const ManageColumnsComboBox = ({
     return (
         <>
             <div className='mb-1'>
-                <Button
-                    disabled={disabled}
-                    onClick={handleManageColumnsClick}
-                    className='hover:bg-gray-300 cursor-pointer bg-slate-200 h-8 text-black rounded-full text-sm text-center'>
+                <Button disabled={disabled} onClick={handleManageColumnsClick}>
                     Columns
                 </Button>
             </div>

--- a/packages/javascript/bh-shared-ui/src/components/ExploreTable/TableControls.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/ExploreTable/TableControls.tsx
@@ -17,13 +17,11 @@
 import { faClose, faDownload, faExpand, faSearch } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { ColumnDef } from '@tanstack/react-table';
-import { Input, InputProps, Label, Menu, MenuContent, MenuItem, MenuTrigger, IconButton } from 'doodle-ui';
+import { IconButton, Input, InputProps, Label, Menu, MenuContent, MenuItem, MenuTrigger } from 'doodle-ui';
 import { useMemo } from 'react';
 import { cn, formatPotentiallyUnknownLabel } from '../../utils';
 import { ManageColumnsComboBox, ManageColumnsComboBoxOption } from './ManageColumnsComboBox/ManageColumnsComboBox';
 import { ExportColumns } from './explore-table-utils';
-
-const ICON_CLASSES = 'cursor-pointer bg-slate-200 p-2 h-4 w-4 rounded-full dark:text-black';
 
 type TableControlsProps<TData, TValue> = {
     SearchInputProps?: InputProps;

--- a/packages/javascript/bh-shared-ui/src/components/ExploreTable/TableControls.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/ExploreTable/TableControls.tsx
@@ -17,14 +17,13 @@
 import { faClose, faDownload, faExpand, faSearch } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { ColumnDef } from '@tanstack/react-table';
-import { Input, InputProps, Label, Menu, MenuContent, MenuItem, MenuTrigger, TextButton } from 'doodle-ui';
+import { Input, InputProps, Label, Menu, MenuContent, MenuItem, MenuTrigger, IconButton } from 'doodle-ui';
 import { useMemo } from 'react';
 import { cn, formatPotentiallyUnknownLabel } from '../../utils';
 import { ManageColumnsComboBox, ManageColumnsComboBoxOption } from './ManageColumnsComboBox/ManageColumnsComboBox';
 import { ExportColumns } from './explore-table-utils';
 
 const ICON_CLASSES = 'cursor-pointer bg-slate-200 p-2 h-4 w-4 rounded-full dark:text-black';
-const FOCUS_CLASSES = 'size-8 rounded-full p-0';
 
 type TableControlsProps<TData, TValue> = {
     SearchInputProps?: InputProps;
@@ -102,14 +101,14 @@ const TableControls = <TData, TValue>({
                 {onDownloadClick && (
                     <Menu>
                         <MenuTrigger asChild>
-                            <TextButton
+                            <IconButton
+                                variant='secondary'
                                 aria-disabled={noResults}
                                 data-testid='download-button'
                                 aria-label='Download CSV'
-                                className={cn(FOCUS_CLASSES, { [DISABLED_CLASSNAME]: noResults })}
                                 disabled={noResults}>
-                                <FontAwesomeIcon className={ICON_CLASSES} icon={faDownload} />
-                            </TextButton>
+                                <FontAwesomeIcon icon={faDownload} />
+                            </IconButton>
                         </MenuTrigger>
                         <MenuContent align='start'>
                             <MenuItem onSelect={() => handleConfirmExport('all')}>All Columns</MenuItem>
@@ -118,13 +117,13 @@ const TableControls = <TData, TValue>({
                     </Menu>
                 )}
                 {onExpandClick && (
-                    <TextButton
+                    <IconButton
+                        variant='secondary'
                         onClick={onExpandClick}
                         data-testid='expand-button'
-                        className={FOCUS_CLASSES}
                         aria-label='Expand table view'>
-                        <FontAwesomeIcon className={ICON_CLASSES} icon={faExpand} />
-                    </TextButton>
+                        <FontAwesomeIcon icon={faExpand} />
+                    </IconButton>
                 )}
                 {onManageColumnsChange && (
                     <ManageColumnsComboBox
@@ -137,13 +136,13 @@ const TableControls = <TData, TValue>({
                     />
                 )}
                 {onCloseClick && (
-                    <TextButton
+                    <IconButton
+                        variant='secondary'
                         onClick={onCloseClick}
                         data-testid='close-button'
-                        className={FOCUS_CLASSES}
                         aria-label='Close table view'>
-                        <FontAwesomeIcon className={ICON_CLASSES} icon={faClose} />
-                    </TextButton>
+                        <FontAwesomeIcon icon={faClose} />
+                    </IconButton>
                 )}
             </div>
         </div>

--- a/packages/javascript/bh-shared-ui/src/components/ExploreTable/TableControls.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/ExploreTable/TableControls.tsx
@@ -20,11 +20,11 @@ import { ColumnDef } from '@tanstack/react-table';
 import { Input, InputProps, Label, Menu, MenuContent, MenuItem, MenuTrigger, TextButton } from 'doodle-ui';
 import { useMemo } from 'react';
 import { cn, formatPotentiallyUnknownLabel } from '../../utils';
-import { adaptClickHandlerToKeyDown } from '../../utils/adaptClickHandlerToKeyDown';
 import { ManageColumnsComboBox, ManageColumnsComboBoxOption } from './ManageColumnsComboBox/ManageColumnsComboBox';
 import { ExportColumns } from './explore-table-utils';
 
 const ICON_CLASSES = 'cursor-pointer bg-slate-200 p-2 h-4 w-4 rounded-full dark:text-black';
+const FOCUS_CLASSES = 'size-8 rounded-full p-0';
 
 type TableControlsProps<TData, TValue> = {
     SearchInputProps?: InputProps;
@@ -102,14 +102,14 @@ const TableControls = <TData, TValue>({
                 {onDownloadClick && (
                     <Menu>
                         <MenuTrigger asChild>
-                            <button
+                            <TextButton
                                 aria-disabled={noResults}
                                 data-testid='download-button'
                                 aria-label='Download CSV'
-                                className={cn({ [DISABLED_CLASSNAME]: noResults })}
+                                className={cn(FOCUS_CLASSES, { [DISABLED_CLASSNAME]: noResults })}
                                 disabled={noResults}>
                                 <FontAwesomeIcon className={ICON_CLASSES} icon={faDownload} />
-                            </button>
+                            </TextButton>
                         </MenuTrigger>
                         <MenuContent align='start'>
                             <MenuItem onSelect={() => handleConfirmExport('all')}>All Columns</MenuItem>
@@ -118,15 +118,13 @@ const TableControls = <TData, TValue>({
                     </Menu>
                 )}
                 {onExpandClick && (
-                    <div
-                        role='button'
-                        tabIndex={0}
+                    <TextButton
                         onClick={onExpandClick}
-                        onKeyDown={adaptClickHandlerToKeyDown(onExpandClick)}
                         data-testid='expand-button'
+                        className={FOCUS_CLASSES}
                         aria-label='Expand table view'>
                         <FontAwesomeIcon className={ICON_CLASSES} icon={faExpand} />
-                    </div>
+                    </TextButton>
                 )}
                 {onManageColumnsChange && (
                     <ManageColumnsComboBox
@@ -138,12 +136,11 @@ const TableControls = <TData, TValue>({
                         onResetColumnSize={onResetColumnSize}
                     />
                 )}
-                {/* TODO - fix focus state in this component BED-9173 */}
                 {onCloseClick && (
                     <TextButton
                         onClick={onCloseClick}
-                        onKeyDown={adaptClickHandlerToKeyDown(onCloseClick)}
                         data-testid='close-button'
+                        className={FOCUS_CLASSES}
                         aria-label='Close table view'>
                         <FontAwesomeIcon className={ICON_CLASSES} icon={faClose} />
                     </TextButton>

--- a/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/Details/RulesAccordion.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/Details/RulesAccordion.tsx
@@ -20,8 +20,8 @@ import { Accordion, AccordionContent, AccordionItem, IconButton, Skeleton, TextB
 import { AssetGroupTagSelector, CustomRulesKey, DefaultRulesKey, DisabledRulesKey, RulesKey } from 'js-client-library';
 import { useEffect, useRef, useState } from 'react';
 import { FixedSizeList } from 'react-window';
-import { optionStyles } from '../../..';
 import { SortableHeader } from '../../../components/ColumnHeaders';
+import { optionStyles } from '../../../components/DropdownSelector/constants';
 import { InfiniteQueryFixedList, InfiniteQueryFixedListProps } from '../../../components/InfiniteQueryFixedList';
 import { useRuleInfo, useRulesInfiniteQuery } from '../../../hooks/useAssetGroupTags';
 import { useEnvironmentIdList } from '../../../hooks/useEnvironmentIdList';


### PR DESCRIPTION
## Description

This fixes the focus ring for the table controls to all be consistent.

## Motivation and Context

Resolves [BED-9173](https://specterops.atlassian.net/browse/BED-9173)

## How Has This Been Tested?

Manually

## Screenshots (optional):
<img width="1512" height="765" alt="Screenshot 2026-08-12 at 3 13 16 PM" src="https://github.com/user-attachments/assets/9d558b47-f8f9-44e4-b691-ba33725d2eac" />

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


[BED-9173]: https://specterops.atlassian.net/browse/BED-9173?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Standardized table control buttons with consistent secondary styling.
  - Updated the Columns button to use the default button appearance.
  - Simplified download, expand, and close controls for a more consistent interface.
  - Improved visual consistency across table and privilege-management controls.
  - Streamlined control interactions while preserving existing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->