### PR TITLE
feat: Display privilege zone graph context

### DIFF
--- a/cmd/api/src/api/bloodhoundgraph/bloodhoundgraph_test.go
+++ b/cmd/api/src/api/bloodhoundgraph/bloodhoundgraph_test.go
@@ -138,7 +138,7 @@ func TestSetFontIcon(t *testing.T) {
 	})
 }
 
-func TestNodeToBloodHoundGraph_PrivilegeZonesUseHumanDisplayName(t *testing.T) {
+func TestNodeToBloodHoundGraph_PrivilegeZonesUseStandardName(t *testing.T) {
 	t.Parallel()
 
 	node := &graph.Node{
@@ -153,23 +153,5 @@ func TestNodeToBloodHoundGraph_PrivilegeZonesUseHumanDisplayName(t *testing.T) {
 	result := NodeToBloodHoundGraph(nil, node)
 
 	require.NotNil(t, result.Label)
-	require.Equal(t, "Tier Zero in PHANTOM.CORP", result.Label.Text)
-}
-
-func TestNodeToBloodHoundGraph_NonPrivilegeZonePreservesLegacyNamePriority(t *testing.T) {
-	t.Parallel()
-
-	node := &graph.Node{
-		Kinds: graph.Kinds{graph.StringKind("CustomKind")},
-		Properties: graph.AsProperties(map[string]any{
-			common.Name.String():        "LEGACY NAME",
-			common.DisplayName.String(): "Human Name",
-			common.ObjectID.String():    "custom:1",
-		}),
-	}
-
-	result := NodeToBloodHoundGraph(nil, node)
-
-	require.NotNil(t, result.Label)
-	require.Equal(t, "LEGACY NAME", result.Label.Text)
+	require.Equal(t, "TIER ZERO IN PHANTOM.CORP", result.Label.Text)
 }

--- a/cmd/api/src/api/bloodhoundgraph/bloodhoundgraph_test.go
+++ b/cmd/api/src/api/bloodhoundgraph/bloodhoundgraph_test.go
@@ -155,3 +155,12 @@ func TestNodeToBloodHoundGraph_PrivilegeZonesUseStandardName(t *testing.T) {
 	require.NotNil(t, result.Label)
 	require.Equal(t, "TIER ZERO IN PHANTOM.CORP", result.Label.Text)
 }
+
+func TestRelationshipToBloodHoundGraph_PrivilegeZoneLabel(t *testing.T) {
+	t.Parallel()
+
+	result := RelationshipToBloodHoundGraph(&graph.Relationship{Kind: graph.StringKind("PZ_InZone")})
+
+	require.NotNil(t, result.Label)
+	require.Equal(t, "In Zone", result.Label.Text)
+}

--- a/cmd/api/src/api/bloodhoundgraph/bloodhoundgraph_test.go
+++ b/cmd/api/src/api/bloodhoundgraph/bloodhoundgraph_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/specterops/bloodhound/packages/go/graphschema"
+	"github.com/specterops/bloodhound/packages/go/graphschema/common"
 	"github.com/specterops/dawgs/graph"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -135,4 +136,40 @@ func TestSetFontIcon(t *testing.T) {
 		assert.Equal(t, "/ui/meta.png", node.Image)
 		assert.Nil(t, node.FontIcon)
 	})
+}
+
+func TestNodeToBloodHoundGraph_PrivilegeZonesUseHumanDisplayName(t *testing.T) {
+	t.Parallel()
+
+	node := &graph.Node{
+		Kinds: graph.Kinds{graph.StringKind("PZ_PrivilegeZoneEnvironment")},
+		Properties: graph.AsProperties(map[string]any{
+			common.Name.String():        "TIER ZERO IN PHANTOM.CORP",
+			common.DisplayName.String(): "Tier Zero in PHANTOM.CORP",
+			common.ObjectID.String():    "pz:1:env",
+		}),
+	}
+
+	result := NodeToBloodHoundGraph(nil, node)
+
+	require.NotNil(t, result.Label)
+	require.Equal(t, "Tier Zero in PHANTOM.CORP", result.Label.Text)
+}
+
+func TestNodeToBloodHoundGraph_NonPrivilegeZonePreservesLegacyNamePriority(t *testing.T) {
+	t.Parallel()
+
+	node := &graph.Node{
+		Kinds: graph.Kinds{graph.StringKind("CustomKind")},
+		Properties: graph.AsProperties(map[string]any{
+			common.Name.String():        "LEGACY NAME",
+			common.DisplayName.String(): "Human Name",
+			common.ObjectID.String():    "custom:1",
+		}),
+	}
+
+	result := NodeToBloodHoundGraph(nil, node)
+
+	require.NotNil(t, result.Label)
+	require.Equal(t, "LEGACY NAME", result.Label.Text)
 }

--- a/cmd/api/src/api/bloodhoundgraph/conversions.go
+++ b/cmd/api/src/api/bloodhoundgraph/conversions.go
@@ -32,7 +32,7 @@ const (
 func NodeToBloodHoundGraph(primaryDisplayKinds graphschema.PrimaryDisplayKinds, node *graph.Node) BloodHoundGraphNode {
 	var (
 		nodeKindLabel       = graphschema.GetNodeKindDisplayLabel(primaryDisplayKinds, node)
-		name                = getNodeDisplayName(node)
+		name, _             = node.Properties.GetWithFallback(common.Name.String(), graphschema.DefaultMissingName, common.DisplayName.String(), common.ObjectID.String()).String()
 		bloodHoundGraphNode = BloodHoundGraphNode{
 			BloodHoundGraphItem: &BloodHoundGraphItem{
 				Data: getNodeDisplayProperties(primaryDisplayKinds, node),
@@ -53,16 +53,6 @@ func NodeToBloodHoundGraph(primaryDisplayKinds graphschema.PrimaryDisplayKinds, 
 	bloodHoundGraphNode.SetFontIcon(nodeKindLabel, primaryDisplayKinds)
 
 	return bloodHoundGraphNode
-}
-
-func getNodeDisplayName(node *graph.Node) string {
-	if node.Kinds.ContainsOneOf(graph.StringKind("PZ_PrivilegeZone"), graph.StringKind("PZ_PrivilegeZoneEnvironment")) {
-		name, _ := node.Properties.GetWithFallback(common.DisplayName.String(), graphschema.DefaultMissingName, common.Name.String(), common.ObjectID.String()).String()
-		return name
-	}
-
-	name, _ := node.Properties.GetWithFallback(common.Name.String(), graphschema.DefaultMissingName, common.DisplayName.String(), common.ObjectID.String()).String()
-	return name
 }
 
 func RelationshipToBloodHoundGraph(rel *graph.Relationship) BloodHoundGraphLink {

--- a/cmd/api/src/api/bloodhoundgraph/conversions.go
+++ b/cmd/api/src/api/bloodhoundgraph/conversions.go
@@ -69,13 +69,24 @@ func RelationshipToBloodHoundGraph(rel *graph.Relationship) BloodHoundGraphLink 
 			Data:  relProperties,
 		},
 		Label: &BloodHoundGraphLinkLabel{
-			Text: rel.Kind.String(),
+			Text: relationshipDisplayName(rel.Kind.String()),
 		},
 		End2: &BloodHoundGraphLinkEnd{
 			Arrow: true,
 		},
 		ID1: rel.StartID.String(),
 		ID2: rel.EndID.String(),
+	}
+}
+
+func relationshipDisplayName(kind string) string {
+	switch kind {
+	case "PZ_InZone":
+		return "In Zone"
+	case "PZ_PartOfZone":
+		return "Part Of Zone"
+	default:
+		return kind
 	}
 }
 

--- a/cmd/api/src/api/bloodhoundgraph/conversions.go
+++ b/cmd/api/src/api/bloodhoundgraph/conversions.go
@@ -32,7 +32,7 @@ const (
 func NodeToBloodHoundGraph(primaryDisplayKinds graphschema.PrimaryDisplayKinds, node *graph.Node) BloodHoundGraphNode {
 	var (
 		nodeKindLabel       = graphschema.GetNodeKindDisplayLabel(primaryDisplayKinds, node)
-		name, _             = node.Properties.GetWithFallback(common.Name.String(), graphschema.DefaultMissingName, common.DisplayName.String(), common.ObjectID.String()).String()
+		name                = getNodeDisplayName(node)
 		bloodHoundGraphNode = BloodHoundGraphNode{
 			BloodHoundGraphItem: &BloodHoundGraphItem{
 				Data: getNodeDisplayProperties(primaryDisplayKinds, node),
@@ -53,6 +53,16 @@ func NodeToBloodHoundGraph(primaryDisplayKinds graphschema.PrimaryDisplayKinds, 
 	bloodHoundGraphNode.SetFontIcon(nodeKindLabel, primaryDisplayKinds)
 
 	return bloodHoundGraphNode
+}
+
+func getNodeDisplayName(node *graph.Node) string {
+	if node.Kinds.ContainsOneOf(graph.StringKind("PZ_PrivilegeZone"), graph.StringKind("PZ_PrivilegeZoneEnvironment")) {
+		name, _ := node.Properties.GetWithFallback(common.DisplayName.String(), graphschema.DefaultMissingName, common.Name.String(), common.ObjectID.String()).String()
+		return name
+	}
+
+	name, _ := node.Properties.GetWithFallback(common.Name.String(), graphschema.DefaultMissingName, common.DisplayName.String(), common.ObjectID.String()).String()
+	return name
 }
 
 func RelationshipToBloodHoundGraph(rel *graph.Relationship) BloodHoundGraphLink {

--- a/cmd/api/src/api/v2/etac.go
+++ b/cmd/api/src/api/v2/etac.go
@@ -142,21 +142,38 @@ func filterETACGraph(graphResponse model.UnifiedGraph, user model.User) (model.U
 
 	filteredResponse := model.UnifiedGraph{}
 	filteredNodes := make(map[string]model.UnifiedNode)
+	accessibleNodeIDs := make(map[string]struct{})
 
 	environmentKeys := []string{ad.DomainSID.String(), azure.TenantID.String(), graphschema.EnvironmentIDKey}
 
-	// filter nodes based on environment access
+	// Resolve directly accessible environment-scoped nodes first.
 	for id, node := range graphResponse.Nodes {
-		include := false
 		for _, key := range environmentKeys {
 			if val, ok := node.Properties[key]; ok {
 				if envStr, ok := val.(string); ok && slices.Contains(accessList, envStr) {
-					include = true
+					accessibleNodeIDs[id] = struct{}{}
 					break
 				}
 			}
 		}
+	}
 
+	// Canonical Privilege Zone nodes span environments. Expose one only when this
+	// response also contains an authorized environment-specific zone connected to it.
+	for _, edge := range graphResponse.Edges {
+		if edge.Kind != "PZ_PartOfZone" {
+			continue
+		}
+		if _, accessible := accessibleNodeIDs[edge.Source]; accessible {
+			if node, present := graphResponse.Nodes[edge.Target]; present && slices.Contains(node.Kinds, "PZ_PrivilegeZone") {
+				accessibleNodeIDs[edge.Target] = struct{}{}
+			}
+		}
+	}
+
+	// Filter nodes based on resolved environment access.
+	for id, node := range graphResponse.Nodes {
+		_, include := accessibleNodeIDs[id]
 		if include {
 			// user has access, we keep original node
 			filteredNodes[id] = node

--- a/cmd/api/src/api/v2/etac_internal_test.go
+++ b/cmd/api/src/api/v2/etac_internal_test.go
@@ -1,0 +1,76 @@
+// Copyright 2026 Specter Ops, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package v2
+
+import (
+	"testing"
+
+	"github.com/specterops/bloodhound/cmd/api/src/model"
+	"github.com/specterops/bloodhound/packages/go/graphschema"
+	"github.com/specterops/dawgs/graph"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrivilegeZoneEnvironmentNodeETAC(t *testing.T) {
+	t.Parallel()
+
+	node := graph.PrepareNode(graph.AsProperties(map[string]any{
+		graphschema.EnvironmentIDKey: "allowed-environment",
+	}), graph.StringKind("PZ_PrivilegeZoneEnvironment"))
+
+	assert.False(t, nodeGatedByETAC([]string{"allowed-environment"}, node))
+	assert.True(t, nodeGatedByETAC([]string{"other-environment"}, node))
+}
+
+func TestFilterETACGraphPrivilegeZoneCanonicalVisibility(t *testing.T) {
+	t.Parallel()
+
+	graphResponse := model.UnifiedGraph{
+		Nodes: map[string]model.UnifiedNode{
+			"allowed": {
+				Kinds:      []string{"PZ_PrivilegeZoneEnvironment"},
+				Properties: map[string]any{graphschema.EnvironmentIDKey: "allowed-environment"},
+			},
+			"denied": {
+				Kinds:      []string{"PZ_PrivilegeZoneEnvironment"},
+				Properties: map[string]any{graphschema.EnvironmentIDKey: "denied-environment"},
+			},
+			"canonical": {Kinds: []string{"PZ_PrivilegeZone"}, Properties: map[string]any{}},
+		},
+		Edges: []model.UnifiedEdge{
+			{Source: "allowed", Target: "canonical", Kind: "PZ_PartOfZone", Label: "Part Of Zone"},
+			{Source: "denied", Target: "canonical", Kind: "PZ_PartOfZone", Label: "Part Of Zone"},
+		},
+	}
+	user := model.User{EnvironmentTargetedAccessControl: []model.EnvironmentTargetedAccessControl{{EnvironmentID: "allowed-environment"}}}
+
+	filtered, err := filterETACGraph(graphResponse, user)
+	require.NoError(t, err)
+	assert.False(t, filtered.Nodes["allowed"].Hidden)
+	assert.True(t, filtered.Nodes["denied"].Hidden)
+	assert.False(t, filtered.Nodes["canonical"].Hidden)
+	assert.Equal(t, "PZ_PartOfZone", filtered.Edges[0].Kind)
+	assert.Equal(t, "HIDDEN", filtered.Edges[1].Kind)
+}
+
+func TestFilterETACGraphHidesCanonicalZoneWithoutAuthorizedEnvironment(t *testing.T) {
+	t.Parallel()
+
+	graphResponse := model.UnifiedGraph{
+		Nodes: map[string]model.UnifiedNode{
+			"denied": {
+				Kinds:      []string{"PZ_PrivilegeZoneEnvironment"},
+				Properties: map[string]any{graphschema.EnvironmentIDKey: "denied-environment"},
+			},
+			"canonical": {Kinds: []string{"PZ_PrivilegeZone"}, Properties: map[string]any{}},
+		},
+		Edges: []model.UnifiedEdge{{Source: "denied", Target: "canonical", Kind: "PZ_PartOfZone"}},
+	}
+	user := model.User{EnvironmentTargetedAccessControl: []model.EnvironmentTargetedAccessControl{{EnvironmentID: "allowed-environment"}}}
+
+	filtered, err := filterETACGraph(graphResponse, user)
+	require.NoError(t, err)
+	assert.True(t, filtered.Nodes["canonical"].Hidden)
+}

--- a/cmd/api/src/api/v2/search.go
+++ b/cmd/api/src/api/v2/search.go
@@ -88,7 +88,7 @@ func filterAndFormatSearchResults(nodes []*graph.Node, etacAllowedList []string,
 
 func graphNodeToSearchResult(node *graph.Node, primaryDisplayKinds graphschema.PrimaryDisplayKinds) model.SearchResult {
 	var (
-		name, _              = node.Properties.GetWithFallback(common.Name.String(), graphschema.DefaultMissingName, common.DisplayName.String(), common.ObjectID.String()).String()
+		name                 = getNodeSearchResultName(node)
 		objectID, _          = node.Properties.GetOrDefault(common.ObjectID.String(), graphschema.DefaultMissingObjectId).String()
 		distinguishedName, _ = node.Properties.GetOrDefault(ad.DistinguishedName.String(), "").String()
 		systemTags, _        = node.Properties.GetOrDefault(common.SystemTags.String(), "").String()
@@ -102,6 +102,16 @@ func graphNodeToSearchResult(node *graph.Node, primaryDisplayKinds graphschema.P
 		DistinguishedName: distinguishedName,
 		SystemTags:        systemTags,
 	}
+}
+
+func getNodeSearchResultName(node *graph.Node) string {
+	if node.Kinds.ContainsOneOf(graph.StringKind("PZ_PrivilegeZone"), graph.StringKind("PZ_PrivilegeZoneEnvironment")) {
+		name, _ := node.Properties.GetWithFallback(common.DisplayName.String(), graphschema.DefaultMissingName, common.Name.String(), common.ObjectID.String()).String()
+		return name
+	}
+
+	name, _ := node.Properties.GetWithFallback(common.Name.String(), graphschema.DefaultMissingName, common.DisplayName.String(), common.ObjectID.String()).String()
+	return name
 }
 
 // getSearchableNodeKinds returns the kinds that should be searched based on the OpenGraphSearch feature flag and the primary display kinds.

--- a/cmd/api/src/api/v2/search.go
+++ b/cmd/api/src/api/v2/search.go
@@ -88,7 +88,7 @@ func filterAndFormatSearchResults(nodes []*graph.Node, etacAllowedList []string,
 
 func graphNodeToSearchResult(node *graph.Node, primaryDisplayKinds graphschema.PrimaryDisplayKinds) model.SearchResult {
 	var (
-		name                 = getNodeSearchResultName(node)
+		name, _              = node.Properties.GetWithFallback(common.Name.String(), graphschema.DefaultMissingName, common.DisplayName.String(), common.ObjectID.String()).String()
 		objectID, _          = node.Properties.GetOrDefault(common.ObjectID.String(), graphschema.DefaultMissingObjectId).String()
 		distinguishedName, _ = node.Properties.GetOrDefault(ad.DistinguishedName.String(), "").String()
 		systemTags, _        = node.Properties.GetOrDefault(common.SystemTags.String(), "").String()
@@ -102,16 +102,6 @@ func graphNodeToSearchResult(node *graph.Node, primaryDisplayKinds graphschema.P
 		DistinguishedName: distinguishedName,
 		SystemTags:        systemTags,
 	}
-}
-
-func getNodeSearchResultName(node *graph.Node) string {
-	if node.Kinds.ContainsOneOf(graph.StringKind("PZ_PrivilegeZone"), graph.StringKind("PZ_PrivilegeZoneEnvironment")) {
-		name, _ := node.Properties.GetWithFallback(common.DisplayName.String(), graphschema.DefaultMissingName, common.Name.String(), common.ObjectID.String()).String()
-		return name
-	}
-
-	name, _ := node.Properties.GetWithFallback(common.Name.String(), graphschema.DefaultMissingName, common.DisplayName.String(), common.ObjectID.String()).String()
-	return name
 }
 
 // getSearchableNodeKinds returns the kinds that should be searched based on the OpenGraphSearch feature flag and the primary display kinds.

--- a/cmd/api/src/api/v2/search_internal_test.go
+++ b/cmd/api/src/api/v2/search_internal_test.go
@@ -195,6 +195,49 @@ func Test_filterAndFormatSearchResults_default(t *testing.T) {
 	require.Equal(t, expectedDistinguishedName, actual[0].DistinguishedName)
 }
 
+func Test_filterAndFormatSearchResults_PrivilegeZonesUseHumanDisplayName(t *testing.T) {
+	t.Parallel()
+
+	for _, kind := range []graph.Kind{
+		graph.StringKind("PZ_PrivilegeZone"),
+		graph.StringKind("PZ_PrivilegeZoneEnvironment"),
+	} {
+		t.Run(kind.String(), func(t *testing.T) {
+			node := &graph.Node{
+				Kinds: graph.Kinds{kind},
+				Properties: graph.AsProperties(map[string]any{
+					common.Name.String():        "TIER ZERO IN PHANTOM.CORP",
+					common.DisplayName.String(): "Tier Zero in PHANTOM.CORP",
+					common.ObjectID.String():    "pz:test",
+				}),
+			}
+
+			results := filterAndFormatSearchResults([]*graph.Node{node}, nil, nil)
+
+			require.Len(t, results, 1)
+			require.Equal(t, "Tier Zero in PHANTOM.CORP", results[0].Name)
+		})
+	}
+}
+
+func Test_filterAndFormatSearchResults_NonPrivilegeZonePreservesLegacyNamePriority(t *testing.T) {
+	t.Parallel()
+
+	node := &graph.Node{
+		Kinds: graph.Kinds{graph.StringKind("CustomKind")},
+		Properties: graph.AsProperties(map[string]any{
+			common.Name.String():        "LEGACY NAME",
+			common.DisplayName.String(): "Human Name",
+			common.ObjectID.String():    "custom:test",
+		}),
+	}
+
+	results := filterAndFormatSearchResults([]*graph.Node{node}, nil, nil)
+
+	require.Len(t, results, 1)
+	require.Equal(t, "LEGACY NAME", results[0].Name)
+}
+
 func Test_filterAndFormatSearchResults_includeOpenGraphNodes(t *testing.T) {
 	var (
 		customKind     = "CustomKind"

--- a/cmd/api/src/api/v2/search_internal_test.go
+++ b/cmd/api/src/api/v2/search_internal_test.go
@@ -195,7 +195,7 @@ func Test_filterAndFormatSearchResults_default(t *testing.T) {
 	require.Equal(t, expectedDistinguishedName, actual[0].DistinguishedName)
 }
 
-func Test_filterAndFormatSearchResults_PrivilegeZonesUseHumanDisplayName(t *testing.T) {
+func Test_filterAndFormatSearchResults_PrivilegeZonesUseStandardName(t *testing.T) {
 	t.Parallel()
 
 	for _, kind := range []graph.Kind{
@@ -215,27 +215,9 @@ func Test_filterAndFormatSearchResults_PrivilegeZonesUseHumanDisplayName(t *test
 			results := filterAndFormatSearchResults([]*graph.Node{node}, nil, nil)
 
 			require.Len(t, results, 1)
-			require.Equal(t, "Tier Zero in PHANTOM.CORP", results[0].Name)
+			require.Equal(t, "TIER ZERO IN PHANTOM.CORP", results[0].Name)
 		})
 	}
-}
-
-func Test_filterAndFormatSearchResults_NonPrivilegeZonePreservesLegacyNamePriority(t *testing.T) {
-	t.Parallel()
-
-	node := &graph.Node{
-		Kinds: graph.Kinds{graph.StringKind("CustomKind")},
-		Properties: graph.AsProperties(map[string]any{
-			common.Name.String():        "LEGACY NAME",
-			common.DisplayName.String(): "Human Name",
-			common.ObjectID.String():    "custom:test",
-		}),
-	}
-
-	results := filterAndFormatSearchResults([]*graph.Node{node}, nil, nil)
-
-	require.Len(t, results, 1)
-	require.Equal(t, "LEGACY NAME", results[0].Name)
 }
 
 func Test_filterAndFormatSearchResults_includeOpenGraphNodes(t *testing.T) {

--- a/cmd/api/src/api/v2/search_internal_test.go
+++ b/cmd/api/src/api/v2/search_internal_test.go
@@ -419,6 +419,27 @@ func Test_filterAndFormatSearchResults_filterEnvironmentsOG(t *testing.T) {
 	require.Equal(t, "objectid3", actual[0].ObjectID)
 }
 
+func TestFilterAndFormatSearchResultsPrivilegeZoneEnvironmentETAC(t *testing.T) {
+	t.Parallel()
+
+	node := &graph.Node{
+		ID:    4,
+		Kinds: graph.Kinds{graph.StringKind("PZ_PrivilegeZoneEnvironment")},
+		Properties: graph.AsProperties(map[string]any{
+			common.ObjectID.String():     "pze:1:allowed",
+			common.Name.String():         "TIER ZERO IN ALLOWED",
+			graphschema.EnvironmentIDKey: "allowed-environment",
+		}),
+	}
+
+	allowed := filterAndFormatSearchResults([]*graph.Node{node}, []string{"allowed-environment"}, nil)
+	denied := filterAndFormatSearchResults([]*graph.Node{node}, []string{"other-environment"}, nil)
+
+	require.Len(t, allowed, 1)
+	assert.Equal(t, "pze:1:allowed", allowed[0].ObjectID)
+	assert.Empty(t, denied)
+}
+
 func Test_getSearchableNodeKinds(t *testing.T) {
 	tests := []struct {
 		name                   string

--- a/cmd/api/src/model/unified_graph.go
+++ b/cmd/api/src/model/unified_graph.go
@@ -89,7 +89,7 @@ func FromDAWGSNode(primaryDisplayKinds graphschema.PrimaryDisplayKinds, node *gr
 	var (
 		props       = node.Properties
 		objectId    = getTypedPropertyOrDefault(props, common.ObjectID.String(), "")
-		label       = getNodeDisplayName(node, objectId)
+		label       = getTypedPropertyOrDefault(props, common.Name.String(), objectId)
 		lastSeen    = getTypedPropertyOrDefault(props, common.LastSeen.String(), time.Now())
 		primaryKind = getTypedPropertyOrDefault(props, common.PrimaryKind.String(), "")
 	)
@@ -115,16 +115,6 @@ func FromDAWGSNode(primaryDisplayKinds graphschema.PrimaryDisplayKinds, node *gr
 		LastSeen:      lastSeen,
 		Properties:    properties,
 	}
-}
-
-func getNodeDisplayName(node *graph.Node, defaultValue string) string {
-	if node.Kinds.ContainsOneOf(graph.StringKind("PZ_PrivilegeZone"), graph.StringKind("PZ_PrivilegeZoneEnvironment")) {
-		if displayName := getTypedPropertyOrDefault(node.Properties, common.DisplayName.String(), ""); displayName != "" {
-			return displayName
-		}
-	}
-
-	return getTypedPropertyOrDefault(node.Properties, common.Name.String(), defaultValue)
 }
 
 // This is being used with slices.Map so it is necessary to return a closure

--- a/cmd/api/src/model/unified_graph.go
+++ b/cmd/api/src/model/unified_graph.go
@@ -74,6 +74,17 @@ type UnifiedEdge struct {
 	Properties map[string]any `json:"properties,omitempty"`
 }
 
+func getRelationshipDisplayName(kind string) string {
+	switch kind {
+	case "PZ_InZone":
+		return "In Zone"
+	case "PZ_PartOfZone":
+		return "Part Of Zone"
+	default:
+		return kind
+	}
+}
+
 func FromDAWGSNode(primaryDisplayKinds graphschema.PrimaryDisplayKinds, node *graph.Node, includeProperties bool) UnifiedNode {
 	var (
 		props       = node.Properties
@@ -109,7 +120,10 @@ func FromDAWGSNode(primaryDisplayKinds graphschema.PrimaryDisplayKinds, node *gr
 // This is being used with slices.Map so it is necessary to return a closure
 func FromDAWGSRelationship(includeProperties bool) func(*graph.Relationship) UnifiedEdge {
 	return func(rel *graph.Relationship) UnifiedEdge {
-		var properties map[string]any
+		var (
+			properties   map[string]any
+			relationship = rel.Kind.String()
+		)
 
 		if includeProperties {
 			properties = rel.Properties.Map
@@ -119,8 +133,8 @@ func FromDAWGSRelationship(includeProperties bool) func(*graph.Relationship) Uni
 			ID:         rel.ID.String(),
 			Source:     rel.StartID.String(),
 			Target:     rel.EndID.String(),
-			Kind:       rel.Kind.String(),
-			Label:      rel.Kind.String(),
+			Kind:       relationship,
+			Label:      getRelationshipDisplayName(relationship),
 			LastSeen:   getTypedPropertyOrDefault(rel.Properties, common.LastSeen.String(), time.Now()),
 			Properties: properties,
 		}

--- a/cmd/api/src/model/unified_graph.go
+++ b/cmd/api/src/model/unified_graph.go
@@ -89,7 +89,7 @@ func FromDAWGSNode(primaryDisplayKinds graphschema.PrimaryDisplayKinds, node *gr
 	var (
 		props       = node.Properties
 		objectId    = getTypedPropertyOrDefault(props, common.ObjectID.String(), "")
-		label       = getTypedPropertyOrDefault(props, common.Name.String(), objectId)
+		label       = getNodeDisplayName(node, objectId)
 		lastSeen    = getTypedPropertyOrDefault(props, common.LastSeen.String(), time.Now())
 		primaryKind = getTypedPropertyOrDefault(props, common.PrimaryKind.String(), "")
 	)
@@ -115,6 +115,16 @@ func FromDAWGSNode(primaryDisplayKinds graphschema.PrimaryDisplayKinds, node *gr
 		LastSeen:      lastSeen,
 		Properties:    properties,
 	}
+}
+
+func getNodeDisplayName(node *graph.Node, defaultValue string) string {
+	if node.Kinds.ContainsOneOf(graph.StringKind("PZ_PrivilegeZone"), graph.StringKind("PZ_PrivilegeZoneEnvironment")) {
+		if displayName := getTypedPropertyOrDefault(node.Properties, common.DisplayName.String(), ""); displayName != "" {
+			return displayName
+		}
+	}
+
+	return getTypedPropertyOrDefault(node.Properties, common.Name.String(), defaultValue)
 }
 
 // This is being used with slices.Map so it is necessary to return a closure

--- a/cmd/api/src/model/unified_graph_test.go
+++ b/cmd/api/src/model/unified_graph_test.go
@@ -232,7 +232,7 @@ func TestFromDAWGSRelationship(t *testing.T) {
 	}
 }
 
-func TestFromDAWGSNode_PrivilegeZonesUseHumanDisplayName(t *testing.T) {
+func TestFromDAWGSNode_PrivilegeZonesUseStandardName(t *testing.T) {
 	t.Parallel()
 
 	node := &graph.Node{
@@ -246,22 +246,5 @@ func TestFromDAWGSNode_PrivilegeZonesUseHumanDisplayName(t *testing.T) {
 
 	result := FromDAWGSNode(nil, node, false)
 
-	require.Equal(t, "Tier Zero", result.Label)
-}
-
-func TestFromDAWGSNode_NonPrivilegeZonePreservesLegacyNamePriority(t *testing.T) {
-	t.Parallel()
-
-	node := &graph.Node{
-		Kinds: graph.Kinds{graph.StringKind("CustomKind")},
-		Properties: graph.AsProperties(map[string]any{
-			common.Name.String():        "LEGACY NAME",
-			common.DisplayName.String(): "Human Name",
-			common.ObjectID.String():    "custom:1",
-		}),
-	}
-
-	result := FromDAWGSNode(nil, node, false)
-
-	require.Equal(t, "LEGACY NAME", result.Label)
+	require.Equal(t, "TIER ZERO", result.Label)
 }

--- a/cmd/api/src/model/unified_graph_test.go
+++ b/cmd/api/src/model/unified_graph_test.go
@@ -231,3 +231,37 @@ func TestFromDAWGSRelationship(t *testing.T) {
 		})
 	}
 }
+
+func TestFromDAWGSNode_PrivilegeZonesUseHumanDisplayName(t *testing.T) {
+	t.Parallel()
+
+	node := &graph.Node{
+		Kinds: graph.Kinds{graph.StringKind("PZ_PrivilegeZone")},
+		Properties: graph.AsProperties(map[string]any{
+			common.Name.String():        "TIER ZERO",
+			common.DisplayName.String(): "Tier Zero",
+			common.ObjectID.String():    "pz:1",
+		}),
+	}
+
+	result := FromDAWGSNode(nil, node, false)
+
+	require.Equal(t, "Tier Zero", result.Label)
+}
+
+func TestFromDAWGSNode_NonPrivilegeZonePreservesLegacyNamePriority(t *testing.T) {
+	t.Parallel()
+
+	node := &graph.Node{
+		Kinds: graph.Kinds{graph.StringKind("CustomKind")},
+		Properties: graph.AsProperties(map[string]any{
+			common.Name.String():        "LEGACY NAME",
+			common.DisplayName.String(): "Human Name",
+			common.ObjectID.String():    "custom:1",
+		}),
+	}
+
+	result := FromDAWGSNode(nil, node, false)
+
+	require.Equal(t, "LEGACY NAME", result.Label)
+}

--- a/cmd/api/src/model/unified_graph_test.go
+++ b/cmd/api/src/model/unified_graph_test.go
@@ -202,3 +202,32 @@ func TestUnifiedGraph_AddPathSet(t *testing.T) {
 		require.Equal(t, len(testGraph.Edges), len(testGraph.Edges))
 	})
 }
+
+func TestFromDAWGSRelationship(t *testing.T) {
+	testCases := []struct {
+		name          string
+		kind          string
+		expectedLabel string
+	}{
+		{name: "privilege zone membership", kind: "PZ_InZone", expectedLabel: "In Zone"},
+		{name: "privilege zone rollup", kind: "PZ_PartOfZone", expectedLabel: "Part Of Zone"},
+		{name: "unmapped relationship", kind: "CustomEdge", expectedLabel: "CustomEdge"},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			relationship := &graph.Relationship{
+				ID:         1,
+				StartID:    2,
+				EndID:      3,
+				Kind:       graph.StringKind(testCase.kind),
+				Properties: graph.NewProperties(),
+			}
+
+			result := FromDAWGSRelationship(false)(relationship)
+
+			require.Equal(t, testCase.kind, result.Kind)
+			require.Equal(t, testCase.expectedLabel, result.Label)
+		})
+	}
+}

--- a/cmd/api/src/queries/graph_integration_test.go
+++ b/cmd/api/src/queries/graph_integration_test.go
@@ -533,6 +533,46 @@ func TestSearchByNameOrObjectID_UseRawObjectID_StartsWith_NameCasing(t *testing.
 	})
 }
 
+func TestPrivilegeZoneSearchWithNormalizedName(t *testing.T) {
+	var (
+		testSuite  = setupGraphDb(t)
+		graphQuery = queries.NewGraphQuery(testSuite.GraphDB, cache.Cache{}, config.Configuration{})
+		zoneKind   = graph.StringKind("PZ_PrivilegeZone")
+	)
+	defer teardownIntegrationTestSuite(t, &testSuite)
+
+	err := testSuite.GraphDB.WriteTransaction(testSuite.Context, func(tx graph.Transaction) error {
+		_, err := tx.CreateNode(graph.AsProperties(graph.PropertyMap{
+			common.Name:        "TIER ZERO",
+			common.DisplayName: "Tier Zero",
+			common.ObjectID:    "pz:1",
+		}), zoneKind)
+		return err
+	})
+	require.NoError(t, err)
+
+	t.Run("Explore search finds mixed-case fuzzy term", func(t *testing.T) {
+		results, err := graphQuery.SearchNodesByNameOrObjectId(testSuite.Context, nil, "Tier Ze", 0, 10, false)
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		require.True(t, results[0].Kinds.ContainsOneOf(zoneKind))
+	})
+
+	t.Run("pathfinding search finds mixed-case exact term", func(t *testing.T) {
+		results, err := graphQuery.SearchByNameOrObjectID(testSuite.Context, true, false, "Tier Zero", queries.SearchTypeExact)
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		require.True(t, results.Slice()[0].Kinds.ContainsOneOf(zoneKind))
+	})
+
+	t.Run("pathfinding search finds mixed-case fuzzy term", func(t *testing.T) {
+		results, err := graphQuery.SearchByNameOrObjectID(testSuite.Context, true, false, "Tier Ze", queries.SearchTypeFuzzy)
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		require.True(t, results.Slice()[0].Kinds.ContainsOneOf(zoneKind))
+	})
+}
+
 func TestGetEntityResults(t *testing.T) {
 	dbInst := integration.SetupDB(t)
 	testContext := integration.NewGraphTestContext(t, schema.DefaultGraphSchema())

--- a/packages/javascript/bh-shared-ui/src/components/EntityInfo/EntityObjectInformation.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/EntityInfo/EntityObjectInformation.test.tsx
@@ -83,4 +83,30 @@ describe('EntityObjectInformation', () => {
             consoleErrorSpy.mockRestore();
         }
     });
+
+    it('uses privilege zone labels only for privilege zone nodes', async () => {
+        const selectedNode: NodeDetails = {
+            node_id: 3,
+            kinds: [{ name: 'PZ_PrivilegeZoneEnvironment', node_kind_id: 2 }],
+            properties: { objectid: 'pz-environment', environment_name: 'contoso.local', member_count: 42 },
+        };
+
+        render(<EntityObjectInformationWithProvider selectedNode={selectedNode} />);
+
+        expect(await screen.findByText('Environment:')).toBeInTheDocument();
+        expect(screen.getByText('Members in environment:')).toBeInTheDocument();
+    });
+
+    it('keeps generic labels for unrelated nodes', async () => {
+        const selectedNode: NodeDetails = {
+            node_id: 4,
+            kinds: [{ name: ActiveDirectoryNodeKind.User, node_kind_id: 1 }],
+            properties: { objectid: 'generic-user', environment_name: 'contoso.local', member_count: 42 },
+        };
+
+        render(<EntityObjectInformationWithProvider selectedNode={selectedNode} />);
+
+        expect(await screen.findByText('Environment Name:')).toBeInTheDocument();
+        expect(screen.getByText('Member Count:')).toBeInTheDocument();
+    });
 });

--- a/packages/javascript/bh-shared-ui/src/components/EntityInfo/EntityObjectInformation.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/EntityInfo/EntityObjectInformation.tsx
@@ -17,7 +17,7 @@ import { NodeDetails, NodeDetailsWithInfo } from 'js-client-library';
 import { useEffect } from 'react';
 import { kindObjectsToKindNames, useExploreParams, usePreviousValue, usePrimaryKind, useTagsQuery } from '../../hooks';
 import { getZoneNameFromKinds } from '../../hooks/useAssetGroupTags';
-import { EntityField, formatObjectInfoFields } from '../../utils';
+import { EntityField, formatObjectInfoFields, privilegeZonePropertyDisplayNames } from '../../utils';
 import { BasicObjectInfoFields } from '../../views/Explore/BasicObjectInfoFields';
 import { SearchValue } from '../../views/Explore/ExploreSearch';
 import { FieldsContainer, ObjectInfoFields } from '../../views/Explore/fragments';
@@ -51,7 +51,13 @@ export default function EntityObjectInformation({ selectedNode }: EntityObjectIn
         setIsObjectInfoPanelOpen(!isObjectInfoPanelOpen);
     };
 
-    const formattedObjectFields: EntityField[] = formatObjectInfoFields(selectedNode.properties);
+    const isPrivilegeZoneNode = kindNames.some((kind) =>
+        ['PZ_PrivilegeZone', 'PZ_PrivilegeZoneEnvironment'].includes(kind)
+    );
+    const formattedObjectFields: EntityField[] = formatObjectInfoFields(
+        selectedNode.properties,
+        isPrivilegeZoneNode ? privilegeZonePropertyDisplayNames : undefined
+    );
 
     const handleSourceNodeSelected = (sourceNode: SearchValue) => {
         setExploreParams({ primarySearch: sourceNode.objectid, searchType: 'node' });

--- a/packages/javascript/bh-shared-ui/src/utils/entityInfoDisplay.test.ts
+++ b/packages/javascript/bh-shared-ui/src/utils/entityInfoDisplay.test.ts
@@ -219,7 +219,7 @@ describe('Evaluating the entity display name from a given entity', () => {
         ).toBe('foo');
     });
     it.each(['PZ_PrivilegeZone', 'PZ_PrivilegeZoneEnvironment'])(
-        'should prefer the human display name for %s entities',
+        'should use the standard name for %s entities',
         (kind) => {
             expect(
                 getEntityName({
@@ -227,16 +227,7 @@ describe('Evaluating the entity display name from a given entity', () => {
                     kinds: [{ name: kind, node_kind_id: 1 }],
                     properties: { name: 'TIER ZERO', displayname: 'Tier Zero' },
                 })
-            ).toBe('Tier Zero');
+            ).toBe('TIER ZERO');
         }
     );
-    it('should preserve name priority for non-Privilege Zone entities', () => {
-        expect(
-            getEntityName({
-                node_id: 1,
-                kinds: [{ name: ActiveDirectoryNodeKind.User, node_kind_id: 1 }],
-                properties: { name: 'LEGACY NAME', displayname: 'Human Name' },
-            })
-        ).toBe('LEGACY NAME');
-    });
 });

--- a/packages/javascript/bh-shared-ui/src/utils/entityInfoDisplay.test.ts
+++ b/packages/javascript/bh-shared-ui/src/utils/entityInfoDisplay.test.ts
@@ -218,4 +218,25 @@ describe('Evaluating the entity display name from a given entity', () => {
             })
         ).toBe('foo');
     });
+    it.each(['PZ_PrivilegeZone', 'PZ_PrivilegeZoneEnvironment'])(
+        'should prefer the human display name for %s entities',
+        (kind) => {
+            expect(
+                getEntityName({
+                    node_id: 1,
+                    kinds: [{ name: kind, node_kind_id: 1 }],
+                    properties: { name: 'TIER ZERO', displayname: 'Tier Zero' },
+                })
+            ).toBe('Tier Zero');
+        }
+    );
+    it('should preserve name priority for non-Privilege Zone entities', () => {
+        expect(
+            getEntityName({
+                node_id: 1,
+                kinds: [{ name: ActiveDirectoryNodeKind.User, node_kind_id: 1 }],
+                properties: { name: 'LEGACY NAME', displayname: 'Human Name' },
+            })
+        ).toBe('LEGACY NAME');
+    });
 });

--- a/packages/javascript/bh-shared-ui/src/utils/entityInfoDisplay.test.ts
+++ b/packages/javascript/bh-shared-ui/src/utils/entityInfoDisplay.test.ts
@@ -31,11 +31,35 @@ import {
     formatDateString,
     formatList,
     formatNumber,
+    formatPotentiallyUnknownLabel,
     formatPrimitive,
+    formatRelationshipKind,
     getEntityName,
     NoEntitySelectedHeader,
     validateProperty,
 } from './entityInfoDisplay';
+
+describe('Formatting privilege zone graph labels', () => {
+    it.each([
+        ['PZ_InZone', 'In Zone'],
+        ['PZ_PartOfZone', 'Part Of Zone'],
+        ['CustomEdge', 'CustomEdge'],
+    ])('formats relationship kind %s as %s', (kind, expected) => {
+        expect(formatRelationshipKind(kind)).toBe(expected);
+    });
+
+    it.each([
+        ['relationship', 'Relationship'],
+        ['source_object', 'Source object'],
+        ['zone_name', 'Zone'],
+        ['environment_name', 'Environment'],
+        ['member_count', 'Members in environment'],
+        ['source', 'Source'],
+        ['custom_property', 'Custom Property'],
+    ])('formats property %s as %s', (property, expected) => {
+        expect(formatPotentiallyUnknownLabel(property)).toBe(expected);
+    });
+});
 
 describe('Handling value formatting for Active Directory entity properties lastlogon, lastlogontimestamp, whencreated, and pwdlastset', () => {
     test('whencreated', () => {

--- a/packages/javascript/bh-shared-ui/src/utils/entityInfoDisplay.test.ts
+++ b/packages/javascript/bh-shared-ui/src/utils/entityInfoDisplay.test.ts
@@ -36,6 +36,7 @@ import {
     formatRelationshipKind,
     getEntityName,
     NoEntitySelectedHeader,
+    privilegeZonePropertyDisplayNames,
     validateProperty,
 } from './entityInfoDisplay';
 
@@ -49,15 +50,22 @@ describe('Formatting privilege zone graph labels', () => {
     });
 
     it.each([
+        ['environment_name', 'Environment Name'],
+        ['member_count', 'Member Count'],
+        ['custom_property', 'Custom Property'],
+    ])('keeps generic property %s formatted as %s', (property, expected) => {
+        expect(formatPotentiallyUnknownLabel(property)).toBe(expected);
+    });
+
+    it.each([
         ['relationship', 'Relationship'],
         ['source_object', 'Source object'],
         ['zone_name', 'Zone'],
         ['environment_name', 'Environment'],
         ['member_count', 'Members in environment'],
         ['source', 'Source'],
-        ['custom_property', 'Custom Property'],
-    ])('formats property %s as %s', (property, expected) => {
-        expect(formatPotentiallyUnknownLabel(property)).toBe(expected);
+    ])('formats privilege zone property %s as %s', (property, expected) => {
+        expect(formatPotentiallyUnknownLabel(property, privilegeZonePropertyDisplayNames)).toBe(expected);
     });
 });
 

--- a/packages/javascript/bh-shared-ui/src/utils/entityInfoDisplay.ts
+++ b/packages/javascript/bh-shared-ui/src/utils/entityInfoDisplay.ts
@@ -41,8 +41,6 @@ const privilegeZoneRelationshipDisplayNames: Record<string, string> = {
     PZ_PartOfZone: 'Part Of Zone',
 };
 
-const privilegeZoneNodeKinds = new Set(['PZ_PrivilegeZone', 'PZ_PrivilegeZoneEnvironment']);
-
 export const privilegeZonePropertyDisplayNames: Record<string, string> = {
     relationship: 'Relationship',
     source_object: 'Source object',
@@ -217,10 +215,7 @@ export const NoEntitySelectedHeader = 'None Selected';
 export const getEntityName = (selectedEntity: NodeDetails | NodeDetailsWithInfo | undefined) => {
     if (!selectedEntity) return NoEntitySelectedHeader;
 
-    const isPrivilegeZone = selectedEntity.kinds.some(({ name }) => privilegeZoneNodeKinds.has(name));
-    const name = isPrivilegeZone
-        ? selectedEntity.properties.displayname || selectedEntity.properties.name || selectedEntity.properties.objectid
-        : selectedEntity.properties.name || selectedEntity.properties.objectid;
+    const name = selectedEntity.properties.name || selectedEntity.properties.objectid;
 
     if (!name) return 'Name not found';
 

--- a/packages/javascript/bh-shared-ui/src/utils/entityInfoDisplay.ts
+++ b/packages/javascript/bh-shared-ui/src/utils/entityInfoDisplay.ts
@@ -36,10 +36,28 @@ import { MappedStringLiteral } from '../types';
 import { EntityKinds } from './content';
 import { LuxonFormat } from './datetime';
 
+const privilegeZoneRelationshipDisplayNames: Record<string, string> = {
+    PZ_InZone: 'In Zone',
+    PZ_PartOfZone: 'Part Of Zone',
+};
+
+const privilegeZonePropertyDisplayNames: Record<string, string> = {
+    relationship: 'Relationship',
+    source_object: 'Source object',
+    zone_name: 'Zone',
+    environment_name: 'Environment',
+    member_count: 'Members in environment',
+    source: 'Source',
+};
+
+export const formatRelationshipKind = (kind: string): string => privilegeZoneRelationshipDisplayNames[kind] ?? kind;
+
 export const formatPotentiallyUnknownLabel = (propKey: string) => {
     const { kind, isKnownProperty } = validateProperty(propKey);
 
-    return isKnownProperty ? getFieldLabel(kind!, propKey) : `${startCase(propKey)}`;
+    return isKnownProperty
+        ? getFieldLabel(kind!, propKey)
+        : privilegeZonePropertyDisplayNames[propKey] ?? `${startCase(propKey)}`;
 };
 
 export const formatObjectInfoFields = (props: any): EntityField[] => {

--- a/packages/javascript/bh-shared-ui/src/utils/entityInfoDisplay.ts
+++ b/packages/javascript/bh-shared-ui/src/utils/entityInfoDisplay.ts
@@ -41,6 +41,8 @@ const privilegeZoneRelationshipDisplayNames: Record<string, string> = {
     PZ_PartOfZone: 'Part Of Zone',
 };
 
+const privilegeZoneNodeKinds = new Set(['PZ_PrivilegeZone', 'PZ_PrivilegeZoneEnvironment']);
+
 export const privilegeZonePropertyDisplayNames: Record<string, string> = {
     relationship: 'Relationship',
     source_object: 'Source object',
@@ -215,7 +217,10 @@ export const NoEntitySelectedHeader = 'None Selected';
 export const getEntityName = (selectedEntity: NodeDetails | NodeDetailsWithInfo | undefined) => {
     if (!selectedEntity) return NoEntitySelectedHeader;
 
-    const name = selectedEntity.properties.name || selectedEntity.properties.objectid;
+    const isPrivilegeZone = selectedEntity.kinds.some(({ name }) => privilegeZoneNodeKinds.has(name));
+    const name = isPrivilegeZone
+        ? selectedEntity.properties.displayname || selectedEntity.properties.name || selectedEntity.properties.objectid
+        : selectedEntity.properties.name || selectedEntity.properties.objectid;
 
     if (!name) return 'Name not found';
 

--- a/packages/javascript/bh-shared-ui/src/utils/entityInfoDisplay.ts
+++ b/packages/javascript/bh-shared-ui/src/utils/entityInfoDisplay.ts
@@ -41,7 +41,7 @@ const privilegeZoneRelationshipDisplayNames: Record<string, string> = {
     PZ_PartOfZone: 'Part Of Zone',
 };
 
-const privilegeZonePropertyDisplayNames: Record<string, string> = {
+export const privilegeZonePropertyDisplayNames: Record<string, string> = {
     relationship: 'Relationship',
     source_object: 'Source object',
     zone_name: 'Zone',
@@ -52,15 +52,16 @@ const privilegeZonePropertyDisplayNames: Record<string, string> = {
 
 export const formatRelationshipKind = (kind: string): string => privilegeZoneRelationshipDisplayNames[kind] ?? kind;
 
-export const formatPotentiallyUnknownLabel = (propKey: string) => {
+export const formatPotentiallyUnknownLabel = (propKey: string, propertyDisplayNames: Record<string, string> = {}) => {
     const { kind, isKnownProperty } = validateProperty(propKey);
 
-    return isKnownProperty
-        ? getFieldLabel(kind!, propKey)
-        : privilegeZonePropertyDisplayNames[propKey] ?? `${startCase(propKey)}`;
+    return isKnownProperty ? getFieldLabel(kind!, propKey) : propertyDisplayNames[propKey] ?? `${startCase(propKey)}`;
 };
 
-export const formatObjectInfoFields = (props: any): EntityField[] => {
+export const formatObjectInfoFields = (
+    props: any,
+    propertyDisplayNames: Record<string, string> = {}
+): EntityField[] => {
     let mappedFields: EntityField[] = [];
     const propKeys = Object.keys(props || {});
 
@@ -83,7 +84,7 @@ export const formatObjectInfoFields = (props: any): EntityField[] => {
 
         mappedFields.push({
             kind: kind,
-            label: `${formatPotentiallyUnknownLabel(key)}:`,
+            label: `${formatPotentiallyUnknownLabel(key, propertyDisplayNames)}:`,
             value: value,
             keyprop: key,
         });

--- a/packages/javascript/bh-shared-ui/src/views/Explore/EdgeInfo/EdgeInfoPane.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/Explore/EdgeInfo/EdgeInfoPane.tsx
@@ -16,7 +16,7 @@
 import { RelationshipDetails, RelationshipDetailsWithInfo } from 'js-client-library';
 import React, { HTMLProps } from 'react';
 import { RoleBasedFilterBadge } from '../../../components/RoleBasedFilterBadge';
-import { cn } from '../../../utils';
+import { cn, formatRelationshipKind } from '../../../utils';
 import { ObjectInfoPanelContextProvider } from '../providers';
 import EdgeInfoContent from './EdgeInfoContent';
 import Header from './EdgeInfoHeader';
@@ -37,7 +37,7 @@ const EdgeInfoPane: React.FC<EdgeInfoPaneProps> = ({ className, selectedEdge }) 
             <RoleBasedFilterBadge />
             <>
                 <div className='bg-neutral-2 pointer-events-auto rounded-lg shadow-outer-1'>
-                    <Header name={selectedEdge.kind.name} />
+                    <Header name={formatRelationshipKind(selectedEdge.kind.name)} />
                 </div>
                 <div className='bg-neutral-2 mt-2 overflow-x-hidden overflow-y-auto py-1 px-4 pointer-events-auto rounded-lg shadow-outer-1'>
                     <EdgeInfoContent selectedEdge={selectedEdge} />

--- a/packages/javascript/bh-shared-ui/src/views/Explore/EdgeInfo/EdgeObjectInformation.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/Explore/EdgeInfo/EdgeObjectInformation.test.tsx
@@ -38,9 +38,9 @@ const mockTargetNode: NodeDetails = {
     properties: { objectid: 'target-objectid', name: 'target_node', lastSeen: '2023-09-07T11:10:33.664596893Z' },
 };
 
-const EdgeObjectInformationWithProvider = () => (
+const EdgeObjectInformationWithProvider = ({ edge = selectedEdge }: { edge?: RelationshipDetails }) => (
     <ObjectInfoPanelContextProvider>
-        <EdgeObjectInformation selectedEdge={selectedEdge} sourceNode={mockSourceNode} targetNode={mockTargetNode} />
+        <EdgeObjectInformation selectedEdge={edge} sourceNode={mockSourceNode} targetNode={mockTargetNode} />
     </ObjectInfoPanelContextProvider>
 );
 
@@ -58,5 +58,32 @@ describe('EdgeObjectInformation', () => {
         expect(screen.getByText(/Is ACL:/)).toBeInTheDocument();
         expect(screen.getByText(/FALSE/)).toBeInTheDocument();
         expect(screen.getByText(/Last Seen by BloodHound:/)).toBeInTheDocument();
+    });
+
+    test('uses privilege zone labels only for privilege zone relationships', async () => {
+        const edge: RelationshipDetails = {
+            ...selectedEdge,
+            relationship_id: 2,
+            kind: { name: 'PZ_InZone', relationship_kind_id: 2 },
+            properties: { ...selectedEdge.properties, environment_name: 'contoso.local', member_count: 42 },
+        };
+
+        render(<EdgeObjectInformationWithProvider edge={edge} />);
+
+        expect(await screen.findByText('Environment:')).toBeInTheDocument();
+        expect(screen.getByText('Members in environment:')).toBeInTheDocument();
+    });
+
+    test('keeps generic labels for unrelated relationships', async () => {
+        const edge: RelationshipDetails = {
+            ...selectedEdge,
+            relationship_id: 3,
+            properties: { ...selectedEdge.properties, environment_name: 'contoso.local', member_count: 42 },
+        };
+
+        render(<EdgeObjectInformationWithProvider edge={edge} />);
+
+        expect(await screen.findByText('Environment Name:')).toBeInTheDocument();
+        expect(screen.getByText('Member Count:')).toBeInTheDocument();
     });
 });

--- a/packages/javascript/bh-shared-ui/src/views/Explore/EdgeInfo/EdgeObjectInformation.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/Explore/EdgeInfo/EdgeObjectInformation.tsx
@@ -16,7 +16,7 @@
 import { NodeDetails, RelationshipDetails } from 'js-client-library';
 import { FC, useEffect } from 'react';
 import { usePreviousValue } from '../../../hooks';
-import { EntityField, formatObjectInfoFields } from '../../../utils';
+import { EntityField, formatObjectInfoFields, privilegeZonePropertyDisplayNames } from '../../../utils';
 import { FieldsContainer, ObjectInfoFields } from '../fragments';
 import { useObjectInfoPanelContext } from '../providers';
 import EdgeInfoCollapsibleSection from './EdgeInfoCollapsibleSection';
@@ -48,12 +48,16 @@ const EdgeObjectInformation: FC<EdgeObjectInformationProps> = ({ selectedEdge, s
         value: targetNode?.properties.name || targetNode?.properties.objectid || '',
     };
 
+    const isPrivilegeZoneRelationship = ['PZ_InZone', 'PZ_PartOfZone'].includes(selectedEdge.kind.name);
     const formattedObjectFields: EntityField[] = [
         sourceNodeField,
         targetNodeField,
-        ...formatObjectInfoFields({
-            ...selectedEdge.properties,
-        }),
+        ...formatObjectInfoFields(
+            {
+                ...selectedEdge.properties,
+            },
+            isPrivilegeZoneRelationship ? privilegeZonePropertyDisplayNames : undefined
+        ),
     ];
 
     const sectionLabel = 'Relationship Information';


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated Jira ticket or GitHub issue. -->

## Description

> **Paired BHE PR:** https://github.com/SpecterOps/bloodhound-enterprise/pull/1750
>
> **Merge blocker:** Blocked until the paired BHE PR is approved and ready. This BHCE PR merges first, but neither sister merges until both are approved, green, and free of unresolved review threads other than this ordering blocker.
>
> **Stack:** Layer 1 of 3.

### Intent

Add the shared graph, Search, ETAC, and Explore behavior needed to consume Enterprise Privilege Zone graph context consistently with ordinary graph entities.

### Implementation

- Uses standard uppercase names so existing Search and pathfinding discover the two `PZ` node kinds without a special search path.
- Converts the PZ node and relationship kinds into standard graph responses with human-readable labels.
- Scopes PZ property/relationship labels so unrelated OpenGraph entities retain existing formatting.
- Applies ETAC so an environment-specific zone follows its environment and a canonical zone is exposed only through an authorized linked environment node.

### Blast Radius / Risk

Shared Search, graph conversion, unified graph, ETAC, and Explore detail paths change only for `PZ_PrivilegeZone`, `PZ_PrivilegeZoneEnvironment`, `PZ_InZone`, and `PZ_PartOfZone`. An ETAC defect could hide authorized context or expose canonical context without an authorized environment; focused tests cover both directions. BHCE adds no producer, migration, or standalone CE analysis behavior.

### BHE/BHCE Parity

`matched` for shared graph behavior; the paired BHE runtime producer is intentionally Enterprise-only.

### Reviewability / Reviewer Brief

Review size: 446 reviewable changed lines — 109 product and 337 tests. The author approved this cohesive Search/conversion/ETAC/UI exception over 400 lines; reviewer agreement is still required. Suggested order: ETAC; API conversions; Search; shared UI formatting; tests.

### Test Changes

Added or updated tests for uppercase names, normalized Search, relationship labels, graph conversion, authorized/unauthorized canonical-zone ETAC behavior, PZ-specific property labels, and preservation of generic formatting. No tests were removed or weakened.

### Rollback

After reverting the paired BHE producer, revert this BHCE PR. BHCE has no migration or persisted-data change. Reverting BHCE first would leave generated PZ entities without intended Search, ETAC, and display handling.

## Motivation and Context

Enterprise materializes Privilege Zone graph objects; shared BHCE layers must render, search, traverse, and authorize them consistently. No Jira or GitHub issue is associated with this prototype, by author request.

Resolves N/A — prototype authorized without a ticket.

## How Has This Been Tested?

### Validation / Evidence

At BHCE `09e0f244ebe61914a9d2772990c733a41acac834` and paired BHE `f2a35cf75a8f1ed552fe4f760d64af38e7ab0bc7`:

- Focused graph-conversion, Search, unified-graph, ETAC, and query Go suites passed.
- Forty shared-UI tests, typecheck, and lint passed.
- Tagged integration packages compiled.
- Full clean `just prepare-for-codereview`, parity, and enterprise review passed.
- Browser validation covered Search, pathfinding, labels, and detail panels in the paired BHE stack.

### Explicitly Not Validated

- Configured database-backed tagged integration execution.
- Production-scale Search/pathfinding performance.
- A dedicated WCAG 2.2 AA audit.
- Current-target revalidation after the latest BHCE `main` movement; this draft branch is one commit behind live `main` and must be refreshed before readiness.

## Screenshots (optional):

![Privilege Zone environment node and membership context](https://github.com/SpecterOps/bloodhound-enterprise/blob/pr-assets/privilege-zone-prototype/.github/pr-assets/privilege-zone-graph-context.png?raw=1)

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist:

- [ ] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: N/A by author request
  - Read the Contributing guide
- [x] I have ensured that related documentation is up-to-date
- [x] I have followed proper test practices
