### PR TITLE
docs: Document the finding risk calculation contract

### DIFF
--- a/packages/go/openapi/doc/openapi.json
+++ b/packages/go/openapi/doc/openapi.json
@@ -24158,6 +24158,100 @@
           "finding_assets"
         ]
       },
+      "model.finding-risk-score-calculation": {
+        "type": "object",
+        "required": [
+          "stored_exposure",
+          "effective_exposure",
+          "impact",
+          "aggregate_score",
+          "zones"
+        ],
+        "properties": {
+          "stored_exposure": {
+            "type": "string",
+            "pattern": "^\\d+$"
+          },
+          "effective_exposure": {
+            "type": "string",
+            "pattern": "^\\d+$",
+            "description": "Exposure used by score math, with a minimum value of one."
+          },
+          "impact": {
+            "type": "string",
+            "pattern": "^\\d+$"
+          },
+          "aggregate_score": {
+            "type": "string",
+            "pattern": "^\\d+$"
+          },
+          "zones": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "asset_group_tag_id",
+                "zone_name",
+                "environment_id",
+                "hop_count",
+                "hop_count_reason",
+                "hop_divisor",
+                "source_principal_count",
+                "source_principal_count_reason",
+                "contribution"
+              ],
+              "properties": {
+                "asset_group_tag_id": {
+                  "type": "integer",
+                  "format": "int32"
+                },
+                "zone_name": {
+                  "type": "string"
+                },
+                "environment_id": {
+                  "type": "string"
+                },
+                "hop_count": {
+                  "type": "integer",
+                  "format": "int32",
+                  "minimum": 0
+                },
+                "hop_count_reason": {
+                  "type": "string",
+                  "enum": [
+                    "target_is_zone",
+                    "shortest_path",
+                    "fallback_missing_zone",
+                    "fallback_no_path",
+                    "fallback_query_error"
+                  ]
+                },
+                "hop_divisor": {
+                  "type": "integer",
+                  "format": "int32",
+                  "minimum": 1
+                },
+                "source_principal_count": {
+                  "type": "string",
+                  "pattern": "^\\d+$"
+                },
+                "source_principal_count_reason": {
+                  "type": "string",
+                  "enum": [
+                    "single_object",
+                    "transitive_group_members",
+                    "fallback_group_query_error"
+                  ]
+                },
+                "contribution": {
+                  "type": "string",
+                  "pattern": "^\\d+$"
+                }
+              }
+            }
+          }
+        }
+      },
       "model.relationship-finding": {
         "allOf": [
           {
@@ -24236,6 +24330,9 @@
                 "pattern": "^\\d+$",
                 "description": "Exact non-negative integer risk score encoded as a decimal string to preserve arbitrary precision."
               },
+              "risk_score_calculation": {
+                "$ref": "#/components/schemas/model.finding-risk-score-calculation"
+              },
               "Severity": {
                 "type": "string",
                 "enum": [
@@ -24295,6 +24392,9 @@
                 "type": "string",
                 "pattern": "^\\d+$",
                 "description": "Exact non-negative integer risk score encoded as a decimal string to preserve arbitrary precision."
+              },
+              "risk_score_calculation": {
+                "$ref": "#/components/schemas/model.finding-risk-score-calculation"
               },
               "Severity": {
                 "type": "string",

--- a/packages/go/openapi/src/schemas/model.finding-risk-score-calculation.yaml
+++ b/packages/go/openapi/src/schemas/model.finding-risk-score-calculation.yaml
@@ -1,0 +1,74 @@
+# Copyright 2026 Specter Ops, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+type: object
+required:
+  - stored_exposure
+  - effective_exposure
+  - impact
+  - aggregate_score
+  - zones
+properties:
+  stored_exposure:
+    type: string
+    pattern: '^\d+$'
+  effective_exposure:
+    type: string
+    pattern: '^\d+$'
+    description: Exposure used by score math, with a minimum value of one.
+  impact:
+    type: string
+    pattern: '^\d+$'
+  aggregate_score:
+    type: string
+    pattern: '^\d+$'
+  zones:
+    type: array
+    items:
+      type: object
+      required:
+        - asset_group_tag_id
+        - zone_name
+        - environment_id
+        - hop_count
+        - hop_count_reason
+        - hop_divisor
+        - source_principal_count
+        - source_principal_count_reason
+        - contribution
+      properties:
+        asset_group_tag_id:
+          type: integer
+          format: int32
+        zone_name:
+          type: string
+        environment_id:
+          type: string
+        hop_count:
+          type: integer
+          format: int32
+          minimum: 0
+        hop_count_reason:
+          type: string
+          enum:
+            - target_is_zone
+            - shortest_path
+            - fallback_missing_zone
+            - fallback_no_path
+            - fallback_query_error
+        hop_divisor:
+          type: integer
+          format: int32
+          minimum: 1
+        source_principal_count:
+          type: string
+          pattern: '^\d+$'
+        source_principal_count_reason:
+          type: string
+          enum:
+            - single_object
+            - transitive_group_members
+            - fallback_group_query_error
+        contribution:
+          type: string
+          pattern: '^\d+$'

--- a/packages/go/openapi/src/schemas/model.list-finding.yaml
+++ b/packages/go/openapi/src/schemas/model.list-finding.yaml
@@ -44,6 +44,8 @@ allOf:
         type: string
         pattern: '^\d+$'
         description: Exact non-negative integer risk score encoded as a decimal string to preserve arbitrary precision.
+      risk_score_calculation:
+        $ref: './model.finding-risk-score-calculation.yaml'
       Severity:
         type: string
         enum:

--- a/packages/go/openapi/src/schemas/model.relationship-finding.yaml
+++ b/packages/go/openapi/src/schemas/model.relationship-finding.yaml
@@ -66,6 +66,8 @@ allOf:
         type: string
         pattern: '^\d+$'
         description: Exact non-negative integer risk score encoded as a decimal string to preserve arbitrary precision.
+      risk_score_calculation:
+        $ref: './model.finding-risk-score-calculation.yaml'
       Severity:
         type: string
         enum:


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated Jira ticket or GitHub issue. -->

## Description

> **Sister BHE PR:** https://github.com/SpecterOps/bloodhound-enterprise/pull/1752
>
> **Depends on layer 2:** https://github.com/SpecterOps/BloodHound/pull/3151 and https://github.com/SpecterOps/bloodhound-enterprise/pull/1751
>
> **Merge blocker:** PR2 must land first. This BHCE PR merges before its BHE sister, but neither merges until both are non-draft, approved, green, and free of unresolved review threads other than this ordering blocker.

### Intent

Document the optional persisted calculation evidence used by BHE to render an auditable risk-score explanation without recomputing historical graph state in the browser.

### Implementation

Adds optional `risk_score_calculation` schemas for stored/effective exposure, impact, aggregate score, and ordered per-zone zone/environment, hop/reason/divisor, source-principal count/reason, and contribution evidence. Arbitrary-precision values remain decimal strings. The bundled OpenAPI document is regenerated. There are no BHCE runtime, database, UI, graph, or migration changes.

### Blast Radius / Risk

This is an additive optional contract. Generated consumers may expose the new object; enums and decimal strings must remain synchronized with BHE. Existing clients that ignore unknown optional properties should be unaffected. Deploying BHE without this shared contract would leave repository documentation/generated artifacts inconsistent.

### BHE/BHCE Parity

`matched`: BHCE owns the additive schema; BHE owns hydration, JSON projection, and UI. The object is intentionally optional and scoped to list/relationship detail responses.

### Reviewability

Review size: 78 reviewable schema lines. Excluded mechanical/generated material: 100 generated `openapi.json` lines.

### Test Changes

No BHCE behavioral tests were added because this is schema-only. Schema generation, formatting/linting, and cleanliness were validated; the paired BHE PR covers projection and UI behavior. No tests were removed.

### Rollback

Revert this schema/generated-document commit after or with the paired BHE consumer. No database, feature flag, configuration, persisted-data, or graph cleanup is involved.

## Motivation and Context

The BHE sister renders exact persisted factors so analysts can audit the aggregate. No Jira or GitHub issue is associated with this prototype, by author request.

Resolves N/A — prototype authorized without a ticket.

## How Has This Been Tested?

### Validation / Evidence

At BHCE `0bbdee2044804359a7290c958f1ef0ee88c97dcf` and BHE `9cc730c67072a92533a8190e4acfeb6731bec7f8`:

- OpenAPI generation and full clean `just prepare-for-codereview` passed.
- Paired BHE backend/API and 50 focused UI tests passed.
- Parity and independent enterprise review passed.

### Explicitly Not Validated

- No standalone BHCE runtime test, because runtime behavior does not change.
- External generated clients were not separately regenerated/compatibility-tested.
- Production-scale BHE hydration benchmarking remains unvalidated in the paired PR.

## Screenshots (optional):

Runtime evidence from the paired BHE PR:

![Human-readable persisted risk-score calculation](https://github.com/SpecterOps/bloodhound-enterprise/blob/pr-assets/privilege-zone-prototype/.github/pr-assets/finding-risk-calculation-popover.png?raw=1)

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist:

- [ ] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: N/A by author request
  - Read the Contributing guide
- [x] I have ensured that related documentation is up-to-date
- [x] I have followed proper test practices
