### PR TITLE
fix: return session and local group completeness under their own keys

### DIFF
--- a/cmd/api/src/api/v2/dataquality.go
+++ b/cmd/api/src/api/v2/dataquality.go
@@ -56,13 +56,13 @@ func (s Resources) GetDatabaseCompleteness(response http.ResponseWriter, request
 		if userSessionCompleteness, err := ad.FetchUserSessionCompleteness(tx); err != nil {
 			return err
 		} else {
-			result["LocalGroupCompleteness"] = userSessionCompleteness
+			result["SessionCompleteness"] = userSessionCompleteness
 		}
 
 		if localGroupCompleteness, err := ad.FetchLocalGroupCompleteness(tx); err != nil {
 			return err
 		} else {
-			result["SessionCompleteness"] = localGroupCompleteness
+			result["LocalGroupCompleteness"] = localGroupCompleteness
 		}
 
 		return nil

--- a/cmd/api/src/api/v2/dataquality_test.go
+++ b/cmd/api/src/api/v2/dataquality_test.go
@@ -26,6 +26,7 @@ import (
 	"net/url"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/specterops/bloodhound/cmd/api/src/utils"
 	"github.com/specterops/bloodhound/cmd/api/src/utils/test"
@@ -38,6 +39,9 @@ import (
 	"github.com/specterops/bloodhound/cmd/api/src/database/mocks"
 	"github.com/specterops/bloodhound/cmd/api/src/model"
 	"github.com/specterops/bloodhound/cmd/api/src/services/dogtags"
+	"github.com/specterops/bloodhound/packages/go/graphschema/ad"
+	"github.com/specterops/bloodhound/packages/go/graphschema/common"
+	"github.com/specterops/dawgs/graph"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -1803,6 +1807,116 @@ func TestGetDataQualityAggregations_Success(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestResources_GetDatabaseCompleteness_ResponseKeys drives the read transaction delegate with a graph
+// holding a known session completeness and a known, different local group completeness, so that the two
+// values cannot be transposed in the response without failing the assertion.
+func TestResources_GetDatabaseCompleteness_ResponseKeys(t *testing.T) {
+	t.Parallel()
+
+	var (
+		ctrl          = gomock.NewController(t)
+		mockGraph     = graphmocks.NewMockDatabase(ctrl)
+		mockTx        = graphmocks.NewMockTransaction(ctrl)
+		userQuery     = graphmocks.NewMockNodeQuery(ctrl)
+		computerQuery = graphmocks.NewMockNodeQuery(ctrl)
+		relQuery      = graphmocks.NewMockRelationshipQuery(ctrl)
+		lastLogon     = time.Now()
+	)
+
+	newActiveNode := func(id graph.ID, nodeKind graph.Kind) *graph.Node {
+		return graph.NewNode(id, graph.AsProperties(graph.PropertyMap{
+			common.Enabled:         true,
+			common.OperatingSystem: "Windows Server 2022",
+			ad.LastLogonTimestamp:  lastLogon,
+		}), nodeKind)
+	}
+
+	nodeCursor := func(nodes ...*graph.Node) graph.Cursor[*graph.Node] {
+		cursor := graphmocks.NewMockCursor[*graph.Node](ctrl)
+		channel := make(chan *graph.Node, len(nodes))
+
+		for _, node := range nodes {
+			channel <- node
+		}
+		close(channel)
+
+		cursor.EXPECT().Chan().Return(channel).AnyTimes()
+		cursor.EXPECT().Error().Return(nil).AnyTimes()
+
+		return cursor
+	}
+
+	relationshipCursor := func(relationships ...*graph.Relationship) graph.Cursor[*graph.Relationship] {
+		cursor := graphmocks.NewMockCursor[*graph.Relationship](ctrl)
+		channel := make(chan *graph.Relationship, len(relationships))
+
+		for _, relationship := range relationships {
+			channel <- relationship
+		}
+		close(channel)
+
+		cursor.EXPECT().Chan().Return(channel).AnyTimes()
+		cursor.EXPECT().Error().Return(nil).AnyTimes()
+
+		return cursor
+	}
+
+	// Four active users, one of which has a session: session completeness is 0.25.
+	userQuery.EXPECT().Filterf(gomock.Any()).Return(userQuery)
+	userQuery.EXPECT().Fetch(gomock.Any()).DoAndReturn(func(delegate func(graph.Cursor[*graph.Node]) error, _ ...graph.Criteria) error {
+		return delegate(nodeCursor(
+			newActiveNode(graph.ID(1), ad.User),
+			newActiveNode(graph.ID(2), ad.User),
+			newActiveNode(graph.ID(3), ad.User),
+			newActiveNode(graph.ID(4), ad.User),
+		))
+	})
+
+	// Two active computers, one of which has an admin: local group completeness is 0.5.
+	computerQuery.EXPECT().Filterf(gomock.Any()).Return(computerQuery)
+	computerQuery.EXPECT().Fetch(gomock.Any()).DoAndReturn(func(delegate func(graph.Cursor[*graph.Node]) error, _ ...graph.Criteria) error {
+		return delegate(nodeCursor(
+			newActiveNode(graph.ID(5), ad.Computer),
+			newActiveNode(graph.ID(6), ad.Computer),
+		))
+	})
+
+	gomock.InOrder(
+		mockTx.EXPECT().Nodes().Return(userQuery),
+		mockTx.EXPECT().Nodes().Return(computerQuery),
+	)
+
+	relQuery.EXPECT().Filterf(gomock.Any()).Return(relQuery).Times(2)
+	gomock.InOrder(
+		relQuery.EXPECT().Fetch(gomock.Any()).DoAndReturn(func(delegate func(graph.Cursor[*graph.Relationship]) error) error {
+			return delegate(relationshipCursor(&graph.Relationship{StartID: graph.ID(5), EndID: graph.ID(1), Kind: ad.HasSession}))
+		}),
+		relQuery.EXPECT().Fetch(gomock.Any()).DoAndReturn(func(delegate func(graph.Cursor[*graph.Relationship]) error) error {
+			return delegate(relationshipCursor(&graph.Relationship{StartID: graph.ID(1), EndID: graph.ID(5), Kind: ad.AdminTo}))
+		}),
+	)
+	mockTx.EXPECT().Relationships().Return(relQuery).Times(2)
+
+	mockGraph.EXPECT().ReadTransaction(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, delegate func(tx graph.Transaction) error, _ ...graph.TransactionOption) error {
+		return delegate(mockTx)
+	})
+
+	var (
+		resources = v2.Resources{Graph: mockGraph}
+		request   = &http.Request{URL: &url.URL{Path: "/api/v2/completeness"}, Method: http.MethodGet}
+		response  = httptest.NewRecorder()
+		router    = mux.NewRouter()
+	)
+
+	router.HandleFunc("/api/v2/completeness", resources.GetDatabaseCompleteness).Methods(request.Method)
+	router.ServeHTTP(response, request)
+
+	status, _, body := test.ProcessResponse(t, response)
+
+	assert.Equal(t, http.StatusOK, status)
+	assert.JSONEq(t, `{"data":{"SessionCompleteness":0.25,"LocalGroupCompleteness":0.5}}`, body)
 }
 
 func TestResources_GetDatabaseCompleteness(t *testing.T) {


### PR DESCRIPTION
### Description

`GetDatabaseCompleteness` (`GET /api/v2/completeness`) returns the two completeness percentages under each other's names:

```go
result["LocalGroupCompleteness"] = userSessionCompleteness // session value
result["SessionCompleteness"]    = localGroupCompleteness  // local group value
```

`FetchUserSessionCompleteness` is the fraction of active users with at least one session, and `FetchLocalGroupCompleteness` is the fraction of active computers with at least one local-admin relationship. The handler assigns each to the other key, so an API consumer reading `SessionCompleteness` gets local group completeness, and vice versa.

The historical stats path in `cmd/api/src/services/dataquality/dataquality.go` (lines 228–245, 262–271) assigns the same two values correctly, so the two code paths disagree with each other. The UI data quality view reads the historical path, which is why this is not visible in the product UI.

The assignment appears unchanged since the initial public commit of the repository.

### Motivation and Context

The endpoint is part of the documented public API (`packages/go/openapi/src/paths/data-quality.completeness.yaml`), and any consumer using it for collection-quality reporting gets the two figures swapped. I hit this while measuring collection completeness against a local BHCE v9.5.1 instance through the API — every prediction was inverted, and it traced back to this handler.

### How Has This Been Tested?

Added `TestResources_GetDatabaseCompleteness_ResponseKeys` in `cmd/api/src/api/v2/dataquality_test.go`. The existing test mocks `ReadTransaction` to return without running the delegate, so the mapping itself was never exercised. The new test drives the delegate with a mocked transaction over a graph where the two metrics differ (4 active users, 1 with a session → `0.25`; 2 active computers, 1 with an admin → `0.5`) and asserts the response body.

Against the current code the test fails exactly as expected:

```
- "LocalGroupCompleteness": (float64) 0.5,
- "SessionCompleteness": (float64) 0.25
+ "LocalGroupCompleteness": (float64) 0.25,
+ "SessionCompleteness": (float64) 0.5
```

`go test ./cmd/api/src/api/v2/...` passes with the fix; `gofmt` clean. I was not able to run `just prepare-for-codereview` in full, but this change touches no models, mocks, or route definitions, and the OpenAPI schema for this endpoint is an untyped `additionalProperties: number` map, so no spec change is required.

### Note on compatibility

This changes observable API output. Anyone who has compensated for the transposition on the client side would need to drop that workaround — flagging it in case you would rather land it behind a release note.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected database completeness results so session and local-group completeness values are displayed in their appropriate fields.
  * Added validation to ensure completeness responses return accurate, distinct values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->