### PR TITLE
test(A11y): add coverage for PZ History tab - BED-8635

### DIFF
--- a/cmd/ui/tests/a11y/PrivilegeZones/history.a11y.spec.ts
+++ b/cmd/ui/tests/a11y/PrivilegeZones/history.a11y.spec.ts
@@ -14,6 +14,111 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { test } from '../../fixtures';
+import { Locator, Page } from '@playwright/test';
+import { installAssetGroupTagsHistoryStub } from 'bh-playwright-testing/stubs';
+import { expectNoAccessibilityViolations, test } from '../../fixtures';
 
-test.describe('WCAG A/AA violations - Privilege Zones - History tab', () => {});
+const HISTORY_URL = '/ui/privilege-zones/history';
+
+/** Visit the URL, collapse the nav menu (for more space), and wait for locator to be visible */
+const openPage = async (page: Page, url: string, waitFor?: Locator) => {
+    const waitLocator = waitFor ?? page.getByRole('heading', { name: 'History Log' });
+
+    await page.goto(url);
+    await page.getByRole('button', { name: 'Toggle Navigation' }).click();
+    await waitLocator.waitFor({ state: 'visible' });
+};
+
+test.describe('WCAG A/AA violations - Privilege Zones - History tab', () => {
+    test('empty history', async ({ page, makeAxeBuilder }, testInfo) => {
+        // Return no history records so the History Log renders its empty state.
+        await installAssetGroupTagsHistoryStub(page, { data: { records: [] } });
+        await openPage(page, HISTORY_URL);
+
+        // Wait for the DataTable's empty fallback to render before scanning.
+        await page.getByText('No results.').waitFor({ state: 'visible' });
+
+        const results = await makeAxeBuilder().include('#content-wrapper').analyze();
+        await expectNoAccessibilityViolations(testInfo, results, { page });
+    });
+
+    test('with history', async ({ page, makeAxeBuilder }, testInfo) => {
+        // Default stub data renders a populated History Log table.
+        await installAssetGroupTagsHistoryStub(page);
+        await openPage(page, HISTORY_URL);
+
+        // Wait for a stubbed record's translated action to render before scanning.
+        await page.getByText('Create Tag').waitFor({ state: 'visible' });
+
+        const results = await makeAxeBuilder().include('#content-wrapper').analyze();
+        await expectNoAccessibilityViolations(testInfo, results, { page });
+    });
+
+    test('With open note', async ({ page, makeAxeBuilder }, testInfo) => {
+        // Default stub data includes a record with a note so the Note panel can be opened.
+        await installAssetGroupTagsHistoryStub(page);
+        await openPage(page, HISTORY_URL);
+
+        // Wait for the populated table, then open the first record's note into the side panel.
+        await page.getByText('Create Tag').waitFor({ state: 'visible' });
+        await page.getByRole('button', { name: 'Show note' }).first().click();
+
+        // Wait for the note contents to render in the side panel before scanning.
+        await page.getByText('Created the Playwright zone for accessibility testing.').waitFor({ state: 'visible' });
+
+        const results = await makeAxeBuilder().include('#content-wrapper').analyze();
+        await expectNoAccessibilityViolations(testInfo, results, { page });
+    });
+
+    test('Filter dialog', async ({ page, makeAxeBuilder }, testInfo) => {
+        // Default stub data provides Zone/Label options for the filter dialog.
+        await installAssetGroupTagsHistoryStub(page);
+        await openPage(page, HISTORY_URL);
+
+        // Open the filter dialog and wait for its content to render before scanning.
+        await page.getByTestId('privilege-zones_history_filter-button').click();
+        await page.getByRole('button', { name: 'Clear All' }).waitFor({ state: 'visible' });
+
+        const results = await makeAxeBuilder().include('[role="dialog"]').analyze();
+        await expectNoAccessibilityViolations(testInfo, results, { page });
+    });
+
+    test('Filter dialog with selections', async ({ page, makeAxeBuilder }, testInfo) => {
+        // Default stub data provides Zone/Label options for the filter dialog.
+        await installAssetGroupTagsHistoryStub(page);
+        await openPage(page, HISTORY_URL);
+
+        // Open the filter dialog and wait for its content to render before scanning.
+        await page.getByTestId('privilege-zones_history_filter-button').click();
+        const dialog = page.getByRole('dialog');
+        await page.getByRole('button', { name: 'Clear All' }).waitFor({ state: 'visible' });
+
+        // Select an Action (static option list, no network dependency).
+        const actionSelect = dialog.getByRole('combobox', { name: 'Action' });
+        await actionSelect.click();
+        await page.getByRole('option', { name: 'Create Tag' }).click();
+
+        // Select a Zone/Label (options provided by the stubbed tag list).
+        const tagSelect = dialog.getByRole('combobox', { name: 'Zone/Label' });
+        await tagSelect.click();
+        await page.getByRole('option', { name: 'PLAYWRIGHT_ZONE' }).click();
+
+        // Select a Made By (the BloodHound system option always renders regardless of the users list).
+        const madeBySelect = dialog.getByRole('combobox', { name: 'Made By' });
+        await madeBySelect.click();
+        await page.getByRole('option', { name: 'BloodHound' }).click();
+
+        // Enter a Start Date into the masked date input (local form state, no network dependency).
+        const startDate = dialog.getByLabel('Start Date');
+        await startDate.pressSequentially('2024-01-01');
+
+        // Wait for every selection to reflect in its control before scanning.
+        await actionSelect.getByText('Create Tag').waitFor({ state: 'visible' });
+        await tagSelect.getByText('PLAYWRIGHT_ZONE').waitFor({ state: 'visible' });
+        await madeBySelect.getByText('BloodHound').waitFor({ state: 'visible' });
+        await startDate.and(page.locator('[value="2024-01-01"]')).waitFor({ state: 'visible' });
+
+        const results = await makeAxeBuilder().include('[role="dialog"]').analyze();
+        await expectNoAccessibilityViolations(testInfo, results, { page });
+    });
+});

--- a/packages/javascript/bh-playwright-testing/src/stubs/asset-group-tags/history.ts
+++ b/packages/javascript/bh-playwright-testing/src/stubs/asset-group-tags/history.ts
@@ -1,0 +1,125 @@
+// Copyright 2026 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Page } from '@playwright/test';
+
+type StubHistoryRecord = {
+    id: number;
+    created_at: string;
+    actor: string;
+    email: string | null;
+    action: string;
+    target: string;
+    asset_group_tag_id: number;
+    environment_id: string | null;
+    note: string | null;
+};
+
+type StubHistoryTag = {
+    id: number;
+    name: string;
+};
+
+export type AssetGroupTagsHistoryStubData = {
+    records?: StubHistoryRecord[];
+    tags?: StubHistoryTag[];
+};
+
+const DEFAULT_TAGS: StubHistoryTag[] = [
+    { id: 1, name: 'PLAYWRIGHT_ZONE' },
+    { id: 2, name: 'PLAYWRIGHT_LABEL' },
+];
+
+const DEFAULT_RECORDS: StubHistoryRecord[] = [
+    {
+        id: 5001,
+        created_at: '2024-01-03T12:00:00Z',
+        actor: 'playwright',
+        email: 'playwright@specterops.io',
+        action: 'CreateTag',
+        target: 'PLAYWRIGHT_ZONE',
+        asset_group_tag_id: 1,
+        environment_id: null,
+        note: 'Created the Playwright zone for accessibility testing.',
+    },
+    {
+        id: 5002,
+        created_at: '2024-01-04T09:30:00Z',
+        actor: 'playwright',
+        email: 'playwright@specterops.io',
+        action: 'UpdateSelector',
+        target: 'PLAYWRIGHT_ADMIN_RULE',
+        asset_group_tag_id: 1,
+        environment_id: null,
+        note: null,
+    },
+    {
+        id: 5003,
+        created_at: '2024-01-05T15:45:00Z',
+        actor: 'playwright',
+        email: 'playwright@specterops.io',
+        action: 'CreateSelector',
+        target: 'PLAYWRIGHT_LABEL_RULE',
+        asset_group_tag_id: 2,
+        environment_id: null,
+        note: 'Added a rule to the Playwright label.',
+    },
+];
+
+export type AssetGroupTagsHistoryStubOptions = {
+    data?: AssetGroupTagsHistoryStubData;
+};
+
+/**
+ * Stubs the Privilege Zones History Log endpoint (`GET` and `POST /api/v2/asset-group-tags-history`)
+ * so the History tab renders deterministic history records without touching real data. The route is
+ * anchored to the `-history` suffix so it does not collide with the tag-list route
+ * (`/api/v2/asset-group-tags`). Both GET (no search) and POST (search) return the same records; the
+ * search input is not filtered here so tests control the rendered rows entirely through `records`.
+ *
+ * The tag-list route (`GET /api/v2/asset-group-tags`) is also stubbed so the History table can
+ * resolve each record's Zone/Label name (`tagName`) and so the filter dialog's Zone/Label select
+ * renders deterministic options. Pass `data.records: []` to exercise the empty state, or override
+ * `data.records`/`data.tags` to shape the loaded state.
+ *
+ * Non-matching HTTP methods fall through to any lower-priority route handlers.
+ */
+export async function installAssetGroupTagsHistoryStub(
+    page: Page,
+    opts: AssetGroupTagsHistoryStubOptions = {}
+): Promise<void> {
+    const records = opts.data?.records ?? DEFAULT_RECORDS;
+    const tags = opts.data?.tags ?? DEFAULT_TAGS;
+
+    await page.route(/\/api\/v2\/asset-group-tags-history(\?.*)?$/, async (route) => {
+        const method = route.request().method();
+        if (method !== 'GET' && method !== 'POST') return route.fallback();
+
+        return route.fulfill({
+            json: {
+                data: { records },
+                count: records.length,
+                limit: records.length,
+                skip: 0,
+            },
+        });
+    });
+
+    await page.route(/\/api\/v2\/asset-group-tags(\?.*)?$/, async (route) => {
+        if (route.request().method() !== 'GET') return route.fallback();
+        return route.fulfill({ json: { data: { tags } } });
+    });
+}

--- a/packages/javascript/bh-playwright-testing/src/stubs/index.ts
+++ b/packages/javascript/bh-playwright-testing/src/stubs/index.ts
@@ -15,6 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 export * from './asset-group-tags/members';
+export * from './asset-group-tags/history';
 export * from './asset-group-tags/labels';
 export * from './asset-group-tags/search';
 export * from './asset-group-tags/selectors';


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Adds Playwright coverage for Privilege Zone's History tab

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-8635


## How Has This Been Tested?

Ran manually with Playwright

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- New feature (non-breaking change which adds functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Accessibility**
  - Expanded accessibility coverage for the Privilege Zones History tab, including empty and populated states, note panels, and filter dialogs.
  - Added checks for multiple filter selections to help ensure accessible experiences across common workflows.

- **Tests**
  - Improved automated test coverage for history and tag-list interactions with consistent sample data across supported scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->