### PR TITLE
feat(harness): Conditionally Create Default Admin Account BED-9232 

### DIFF
--- a/cmd/api/src/bootstrap/server.go
+++ b/cmd/api/src/bootstrap/server.go
@@ -73,7 +73,7 @@ func MigrateDB(ctx context.Context, cfg config.Configuration, db database.Databa
 	// Only create the default admin if specified in the config
 	// This should be enabled by default for local dev environments
 	if cfg.DefaultAdmin.Enabled {
-		slog.InfoContext(ctx, "Default admin enabled, creating admin account using default credentials")
+		slog.InfoContext(ctx, "Default admin enabled, creating admin account")
 		return CreateDefaultAdmin(ctx, cfg, db, defaultAdminFunc)
 	} else {
 		slog.InfoContext(ctx, "Default admin disabled")

--- a/cmd/api/src/bootstrap/server.go
+++ b/cmd/api/src/bootstrap/server.go
@@ -74,9 +74,15 @@ func MigrateDB(ctx context.Context, cfg config.Configuration, db database.Databa
 	// This should be enabled by default for local dev environments
 	if cfg.DefaultAdmin.Enabled {
 		slog.InfoContext(ctx, "Default admin enabled, creating admin account")
-		return CreateDefaultAdmin(ctx, cfg, db, defaultAdminFunc)
+		if err := CreateDefaultAdmin(ctx, cfg, db, defaultAdminFunc); err != nil {
+			return fmt.Errorf("error creating default admin: %w", err)
+		}
 	} else {
 		slog.InfoContext(ctx, "Default admin disabled")
+	}
+
+	if _, err := db.CreateInstallation(ctx); err != nil {
+		return fmt.Errorf("error creating new installation: %w", err)
 	}
 
 	return nil

--- a/cmd/api/src/bootstrap/server.go
+++ b/cmd/api/src/bootstrap/server.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"os/signal"
 	"strings"
@@ -69,7 +70,16 @@ func MigrateDB(ctx context.Context, cfg config.Configuration, db database.Databa
 		return nil
 	}
 
-	return CreateDefaultAdmin(ctx, cfg, db, defaultAdminFunc)
+	// Only create the default admin if specified in the config
+	// This should be enabled by default for local dev environments
+	if cfg.DefaultAdmin.Enabled {
+		slog.InfoContext(ctx, "Default admin enabled, creating admin account using default credentials")
+		return CreateDefaultAdmin(ctx, cfg, db, defaultAdminFunc)
+	} else {
+		slog.InfoContext(ctx, "Default admin disabled")
+	}
+
+	return nil
 }
 
 func PopulateExtensionData(ctx context.Context, db database.Database) error {
@@ -121,7 +131,7 @@ func CreateDefaultAdmin(ctx context.Context, cfg config.Configuration, db databa
 		needsLog       bool
 	)
 
-	//Populate any missing fields of the admin configuration using our defaults
+	// Populate any missing fields of the admin configuration using our defaults
 	if populatedConfig, needsLogInner, err := FillAndPopulateDefaultAdminInfo(cfg.DefaultAdmin, defaultAdminFunction); err != nil {
 		return fmt.Errorf("error while populating default admin info: %w", err)
 	} else {

--- a/cmd/api/src/bootstrap/server_test.go
+++ b/cmd/api/src/bootstrap/server_test.go
@@ -17,13 +17,20 @@
 package bootstrap_test
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/specterops/bloodhound/cmd/api/src/auth"
 	"github.com/specterops/bloodhound/cmd/api/src/bootstrap"
 	"github.com/specterops/bloodhound/cmd/api/src/config"
+	"github.com/specterops/bloodhound/cmd/api/src/database"
+	"github.com/specterops/bloodhound/cmd/api/src/database/mocks"
+	"github.com/specterops/bloodhound/cmd/api/src/model"
+	"github.com/specterops/bloodhound/cmd/api/src/model/appcfg"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 )
 
 func TestFillAndPopulateDefaultAdminInfo(t *testing.T) {
@@ -105,4 +112,70 @@ func requireDirectoryExists(t *testing.T, path string) {
 	info, err := os.Stat(path)
 	require.NoError(t, err)
 	require.True(t, info.IsDir())
+}
+
+func TestMigrateDB(t *testing.T) {
+	tests := []struct {
+		name  string
+		cfg   config.DefaultAdminConfiguration
+		mocks func(mockDb *mocks.MockDatabase)
+	}{
+		{
+			name: "Success - default admin created when enabled in config",
+			cfg: config.DefaultAdminConfiguration{
+				Enabled:  true,
+				Password: "SFdzJoW2GT7Fn68aEieKn7S1S2DLdXnw",
+			},
+			mocks: func(mockDb *mocks.MockDatabase) {
+				mockDb.EXPECT().GetAllRoles(gomock.Any(), gomock.Any(), gomock.Any()).Return(model.Roles{
+					{
+						Name:        auth.RoleAdministrator,
+						Description: "Admin For Testing",
+						Permissions: model.Permissions{},
+						Serial:      model.Serial{},
+					},
+				}, nil)
+				mockDb.EXPECT().LookupUser(gomock.Any(), gomock.Any()).Return(model.User{}, database.ErrNotFound)
+				mockDb.EXPECT().GetConfigurationParameter(gomock.Any(), appcfg.PasswordExpirationWindow).Return(appcfg.Parameter{}, nil)
+				mockDb.EXPECT().InitializeSecretAuth(gomock.Any(), gomock.Any(), gomock.Any()).Return(model.Installation{}, nil).Times(1)
+			},
+		},
+		{
+			name: "Success - default admin not created when disabled in config",
+			cfg: config.DefaultAdminConfiguration{
+				Enabled: false,
+			},
+			mocks: func(mockDb *mocks.MockDatabase) {
+				mockDb.EXPECT().InitializeSecretAuth(gomock.Any(), gomock.Any(), gomock.Any()).Return(model.Installation{}, nil).Times(0)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			mockDb := mocks.NewMockDatabase(mockCtrl)
+			defer mockCtrl.Finish()
+
+			mockDb.EXPECT().Migrate(gomock.Any()).Return(nil).Times(1)
+			mockDb.EXPECT().HasInstallation(gomock.Any()).Return(false, nil).Times(1)
+
+			tt.mocks(mockDb)
+
+			err := bootstrap.MigrateDB(context.Background(), config.Configuration{
+				Crypto: config.CryptoConfiguration{
+					Argon2: config.Argon2Configuration{
+						MemoryKibibytes: 16,
+						NumIterations:   2,
+						NumThreads:      1,
+					},
+				},
+				DefaultAdmin: tt.cfg,
+			}, mockDb, func() (config.DefaultAdminConfiguration, error) {
+				return config.DefaultAdminConfiguration{}, nil
+			})
+
+			require.NoError(t, err)
+		})
+	}
 }

--- a/cmd/api/src/bootstrap/server_test.go
+++ b/cmd/api/src/bootstrap/server_test.go
@@ -159,6 +159,7 @@ func TestMigrateDB(t *testing.T) {
 
 			mockDb.EXPECT().Migrate(gomock.Any()).Return(nil).Times(1)
 			mockDb.EXPECT().HasInstallation(gomock.Any()).Return(false, nil).Times(1)
+			mockDb.EXPECT().CreateInstallation(gomock.Any()).Return(model.Installation{}, nil).Times(1)
 
 			tt.mocks(mockDb)
 

--- a/cmd/api/src/config/config.go
+++ b/cmd/api/src/config/config.go
@@ -209,6 +209,7 @@ type TeleportConfiguration struct {
 }
 
 type DefaultAdminConfiguration struct {
+	Enabled       bool   `json:"enabled"`
 	PrincipalName string `json:"principal_name"`
 	Password      string `json:"password"`
 	EmailAddress  string `json:"email_address"`

--- a/cmd/api/src/config/config_test.go
+++ b/cmd/api/src/config/config_test.go
@@ -223,3 +223,53 @@ func TestParseConfiguration_Storage(t *testing.T) {
 		Provider: "local",
 	}, configuration.Storage.FileServices["work"])
 }
+
+func TestParseConfiguration_DefaultAdminEnabled(t *testing.T) {
+	var testCases = []struct {
+		name            string
+		configuration   string
+		expectedEnabled bool
+	}{
+		{
+			name:            "default admin section omitted",
+			configuration:   `{}`,
+			expectedEnabled: true,
+		},
+		{
+			name: "enabled setting omitted",
+			configuration: `{
+				"default_admin": {
+					"principal_name": "admin"
+				}
+			}`,
+			expectedEnabled: true,
+		},
+		{
+			name: "default admin explicitly enabled",
+			configuration: `{
+				"default_admin": {
+					"enabled": true
+				}
+			}`,
+			expectedEnabled: true,
+		},
+		{
+			name: "default admin explicitly disabled",
+			configuration: `{
+				"default_admin": {
+					"enabled": false
+				}
+			}`,
+			expectedEnabled: false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			configuration, err := config.ParseConfiguration([]byte(testCase.configuration))
+
+			require.NoError(t, err)
+			require.Equal(t, testCase.expectedEnabled, configuration.DefaultAdmin.Enabled)
+		})
+	}
+}

--- a/cmd/api/src/config/default.go
+++ b/cmd/api/src/config/default.go
@@ -86,6 +86,9 @@ func NewDefaultConfiguration() (Configuration, error) {
 			TLS:                             TLSConfiguration{},
 			SAML:                            SAMLConfiguration{},
 			GraphDriver:                     neo4j.DriverName, // Default to PG as the graph driver
+			DefaultAdmin: DefaultAdminConfiguration{
+				Enabled: true,
+			},
 			Database: DatabaseConfiguration{
 				MaxConcurrentSessions: 10,
 			},

--- a/cmd/api/src/database/auth.go
+++ b/cmd/api/src/database/auth.go
@@ -138,7 +138,7 @@ func (s *BloodhoundDB) GetPermission(ctx context.Context, id int) (model.Permiss
 	return permission, CheckError(result)
 }
 
-// InitializeSecretAuth creates new AuthSecret, User and Installation entries based on the input provided
+// InitializeSecretAuth creates new AuthSecret and User entries based on the input provided
 func (s *BloodhoundDB) InitializeSecretAuth(ctx context.Context, adminUser model.User, authSecret model.AuthSecret) (model.Installation, error) {
 	var (
 		updatedAdminUser  = adminUser
@@ -147,16 +147,6 @@ func (s *BloodhoundDB) InitializeSecretAuth(ctx context.Context, adminUser model
 	)
 
 	err := s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		if newInstallationID, err := uuid.NewV4(); err != nil {
-			return err
-		} else {
-			newInstallation.ID = newInstallationID
-
-			if result := tx.Create(&newInstallation); result.Error != nil {
-				return CheckError(result)
-			}
-		}
-
 		if newUserID, err := uuid.NewV4(); err != nil {
 			return err
 		} else {

--- a/debian/bhapi.json.default
+++ b/debian/bhapi.json.default
@@ -8,6 +8,7 @@
     "connection": "postgresql://"
   },
   "default_admin": {
+    "enabled": true,
     "principal_name": "admin",
     "password": "admin",
     "first_name": "BloodHound",

--- a/examples/docker-compose/bloodhound.config.json
+++ b/examples/docker-compose/bloodhound.config.json
@@ -12,6 +12,7 @@
   },
   "collectors_base_path": "/etc/bloodhound/collectors",
   "default_admin": {
+    "enabled": true,
     "principal_name": "admin",
     "first_name": "BloodHound",
     "last_name": "Admin",

--- a/examples/helm/templates/cmbh.yaml
+++ b/examples/helm/templates/cmbh.yaml
@@ -36,6 +36,7 @@ data:
       },
       "collectors_base_path": "/etc/bloodhound/collectors",
       "default_admin": {
+        "enabled": true,
         "principal_name": "admin",
         "first_name": "BloodHound",
         "last_name": "Admin",

--- a/local-harnesses/build.config.json.template
+++ b/local-harnesses/build.config.json.template
@@ -16,6 +16,7 @@
     },
     "graph_driver": "neo4j",
     "default_admin": {
+        "enabled": true,
         "principal_name": "admin",
         "email_address": "admin@example.com",
         "password": "SFdzJoW2GT7Fn68aEieKn7S1S2DLdXnw",

--- a/local-harnesses/integration.config.json.template
+++ b/local-harnesses/integration.config.json.template
@@ -16,6 +16,7 @@
         "connection": "neo4j://neo4j:bloodhoundcommunityedition@localhost:37687/"
     },
     "default_admin": {
+        "enabled": true,
         "principal_name": "admin",
         "password": "admin",
         "first_name": "BloodHound",


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

With our Enterprise account creation switching to an alternative platform for our support to access, we no longer need the default admin account for Enterprise customers
Adding this check allows our dev environments to still create the admin account, but our customer deployments will have this flag disabled - preventing default admin creation on initialization

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-9232

*Why is this change required? What problem does it solve?*

## How Has This Been Tested?

*Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc.*

This was tested by setting the flag to `true` and verifying that the default account was created on initialization
Similarly, by setting the flag to `false` I was able to verify that no account was created

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- New feature (non-breaking change which adds functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configuration option to enable or disable automatic creation of the default administrator account.
  * Enabled the default administrator in standard, Debian, Docker, local, and integration configurations.

* **Bug Fixes**
  * Improved startup handling and logging for default administrator creation.
  * Prevented administrator creation when disabled.
  * Improved installation setup during startup to avoid duplicate or incomplete initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->