### PR TITLE
test(a11y): components coverage; nav & env selector - BED-8641

### DIFF
--- a/cmd/ui/tests/a11y/Shared/nav.a11y.spec.ts
+++ b/cmd/ui/tests/a11y/Shared/nav.a11y.spec.ts
@@ -1,0 +1,55 @@
+// Copyright 2026 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { hideBySelector } from 'bh-playwright-testing/axe';
+import { expectNoAccessibilityViolations, test } from '../../fixtures';
+
+const MAIN_NAV_SCOPE = '#app-root > nav';
+
+test.describe('Shared navigation - has no detectable WCAG A/AA violations', () => {
+    test.beforeEach(async ({ page }) => {
+        await page.goto('/ui/administration/data-quality');
+        await page.getByRole('heading', { name: 'Data Quality', exact: true }).waitFor({ state: 'visible' });
+        await page.locator(MAIN_NAV_SCOPE).waitFor({ state: 'visible' });
+        await page.getByRole('button', { name: 'Administration', exact: true }).waitFor({ state: 'visible' });
+        await hideBySelector(page, '#content-wrapper');
+    });
+
+    test('nav menu', async ({ page, makeAxeBuilder }, testInfo) => {
+        await page.getByRole('button', { name: 'Toggle Navigation', expanded: true }).waitFor({ state: 'visible' });
+
+        const results = await makeAxeBuilder().include(MAIN_NAV_SCOPE).analyze();
+        await expectNoAccessibilityViolations(testInfo, results, { page });
+    });
+
+    test('collapsed nav menu', async ({ page, makeAxeBuilder }, testInfo) => {
+        await page.getByRole('button', { name: 'Toggle Navigation', expanded: true }).click();
+        await page.getByRole('button', { name: 'Toggle Navigation', expanded: false }).waitFor({ state: 'visible' });
+
+        const results = await makeAxeBuilder().include(MAIN_NAV_SCOPE).analyze();
+        await expectNoAccessibilityViolations(testInfo, results, { page });
+    });
+
+    test('administration subnav menu visible', async ({ page, makeAxeBuilder }, testInfo) => {
+        await page.getByRole('button', { name: 'Administration', exact: true }).click();
+        const subNav = page.getByTestId('sub-nav');
+        await subNav.waitFor({ state: 'visible' });
+        await subNav.getByText('File Ingest', { exact: true }).waitFor({ state: 'visible' });
+
+        const results = await makeAxeBuilder().include(MAIN_NAV_SCOPE).analyze();
+        await expectNoAccessibilityViolations(testInfo, results, { page });
+    });
+});

--- a/cmd/ui/tests/a11y/Shared/simple-environment-selector.a11y.spec.ts
+++ b/cmd/ui/tests/a11y/Shared/simple-environment-selector.a11y.spec.ts
@@ -1,0 +1,104 @@
+// Copyright 2026 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { expectNoAccessibilityViolations, test } from '../../fixtures';
+
+test.describe('Simple Environment Selector - has no detectable WCAG A/AA violations', () => {
+    test.beforeEach(async ({ page }) => {
+        await page.route('**/api/v2/available-domains', async (route) => {
+            if (route.request().method() !== 'GET') {
+                return route.fallback();
+            }
+
+            await route.fulfill({
+                json: {
+                    data: [
+                        {
+                            collected: true,
+                            exposures: [],
+                            hygiene_attack_paths: 0,
+                            id: 'example-domain-id',
+                            impactValue: 0,
+                            name: 'EXAMPLE.COM',
+                            type: 'active-directory',
+                        },
+                    ],
+                },
+            });
+        });
+
+        await page.goto('/ui/administration/data-quality');
+        await page.getByRole('heading', { name: 'Data Quality', exact: true }).waitFor({ state: 'visible' });
+        await page.getByRole('button', { name: 'EXAMPLE.COM', exact: true }).waitFor({ state: 'visible' });
+    });
+
+    test('no query', async ({ page, makeAxeBuilder }, testInfo) => {
+        await page.getByRole('button', { name: 'EXAMPLE.COM', exact: true }).click();
+
+        const popover = page.getByTestId('data-quality_context-selector-popover');
+        await popover.waitFor({ state: 'visible' });
+        await popover.getByRole('textbox', { name: 'Search' }).waitFor({ state: 'visible' });
+        await popover.getByRole('button', { name: 'EXAMPLE.COM', exact: true }).waitFor({ state: 'visible' });
+
+        const results = await makeAxeBuilder()
+            .include('[data-testid="data-quality_context-selector-popover"]')
+            .analyze();
+
+        await expectNoAccessibilityViolations(testInfo, results, { page });
+    });
+
+    test('with query', async ({ page, makeAxeBuilder }, testInfo) => {
+        await page.getByRole('button', { name: 'EXAMPLE.COM', exact: true }).click();
+
+        const popover = page.getByTestId('data-quality_context-selector-popover');
+        await popover.waitFor({ state: 'visible' });
+
+        const searchInput = popover.getByRole('textbox', { name: 'Search' });
+        await searchInput.waitFor({ state: 'visible' });
+        await searchInput.fill('EXAMPLE');
+
+        await searchInput.and(page.locator('[value="EXAMPLE"]')).waitFor({ state: 'visible' });
+        await popover.getByRole('button', { name: 'EXAMPLE.COM', exact: true }).waitFor({ state: 'visible' });
+
+        const results = await makeAxeBuilder()
+            .include('[data-testid="data-quality_context-selector-popover"]')
+            .analyze();
+
+        await expectNoAccessibilityViolations(testInfo, results, { page });
+    });
+
+    test('no results query', async ({ page, makeAxeBuilder }, testInfo) => {
+        const query = 'zzzznonexistentenvironment9999';
+
+        await page.getByRole('button', { name: 'EXAMPLE.COM', exact: true }).click();
+
+        const popover = page.getByTestId('data-quality_context-selector-popover');
+        await popover.waitFor({ state: 'visible' });
+
+        const searchInput = popover.getByRole('textbox', { name: 'Search' });
+        await searchInput.waitFor({ state: 'visible' });
+        await searchInput.fill(query);
+
+        await searchInput.and(page.locator(`[value="${query}"]`)).waitFor({ state: 'visible' });
+        await popover.getByRole('button', { name: 'EXAMPLE.COM', exact: true }).waitFor({ state: 'hidden' });
+
+        const results = await makeAxeBuilder()
+            .include('[data-testid="data-quality_context-selector-popover"]')
+            .analyze();
+
+        await expectNoAccessibilityViolations(testInfo, results, { page });
+    });
+});


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Adds accessibility tests for the share components - nav menu and environment selector, to verify compliance with accessibility standards.

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-8641

This change was needed to ensure the share components - nav menu and environment selector pages adhere to accessibility standards.

## How Has This Been Tested?

The tests were run locally.

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- New feature (non-breaking change which adds functionality)


## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [X] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [X] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [X] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Tests**
  * Added accessibility coverage for shared navigation, including expanded, collapsed, and Administration submenu states.
  * Added accessibility coverage for the environment selector, including empty, matching, and non-matching searches.
  * Automated WCAG A/AA checks across navigation and selector interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->