### PR TITLE
feat: DB support for creating PZ rules via OG extension management (BED-9331)

### DIFF
--- a/cmd/api/src/api/error.go
+++ b/cmd/api/src/api/error.go
@@ -76,6 +76,7 @@ const (
 	ErrorResponseAssetGroupTagExceededNameLimit                      = "asset group tag name is limited to 250 characters"
 	ErrorResponseAssetGroupTagDuplicateKindName                      = "asset group tag name must be unique"
 	ErrorResponseAssetGroupTagSelectorDuplicateName                  = "asset group tag selector name must be unique"
+	ErrorAssetGroupTagSelectorReadOnlyField                          = "request contains read-only fields"
 	ErrorResponseAssetGroupTagInvalid                                = "valid tag_type is required"
 	ErrorResponseAssetGroupTagExceededTagLimit                       = "tag limit has been exceeded"
 	ErrorResponseAssetGroupTagInvalidFields                          = "position and require_certify are only allowed for tiers"

--- a/cmd/api/src/api/tools/dbswitch.go
+++ b/cmd/api/src/api/tools/dbswitch.go
@@ -25,10 +25,10 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/specterops/bloodhound/cmd/api/src/config"
+	"github.com/specterops/bloodhound/cmd/api/src/database"
 )
 
 const (
-	pgErrorUniqueViolationCode           = "23505"
 	pgErrorUniqueViolationConstraintName = "pg_type_typname_nsp_index"
 )
 
@@ -85,7 +85,7 @@ func ResolveGraphDriver(ctx context.Context, cfg config.Configuration) (string, 
 	} else {
 		defer pgxConn.Close(ctx)
 		if _, err := pgxConn.Exec(ctx, `create table if not exists database_switch (driver text not null, primary key(driver));`); err != nil {
-			if pgError, ok := errors.AsType[*pgconn.PgError](err); ok && pgError.Code == pgErrorUniqueViolationCode && pgError.ConstraintName == pgErrorUniqueViolationConstraintName {
+			if pgError, ok := errors.AsType[*pgconn.PgError](err); ok && pgError.Code == database.PostgresUniqueViolationCode && pgError.ConstraintName == pgErrorUniqueViolationConstraintName {
 				slog.InfoContext(ctx, "Concurrent database_switch table CREATE; falling back to primary")
 			} else {
 				return "", err

--- a/cmd/api/src/api/v2/assetgrouptags.go
+++ b/cmd/api/src/api/v2/assetgrouptags.go
@@ -60,6 +60,8 @@ const (
 
 	includeProperties = true
 	excludeProperties = false
+
+	assetGroupTagSelectorReadOnlyFieldError = "request contains read-only fields"
 )
 
 func maybeAddEnvironmentIdFilter(filters []graph.Criteria, environmentIds []string) []graph.Criteria {
@@ -87,6 +89,12 @@ type assetGroupTagSelectorRequest struct {
 	AutoCertify *model.SelectorAutoCertifyMethod `json:"auto_certify"`
 	Description *string                          `json:"description"`
 	Disabled    *bool                            `json:"disabled"`
+	ExtensionId *int32                           `json:"extension_id"`
+	RuleKey     *string                          `json:"rule_key"`
+}
+
+func (s assetGroupTagSelectorRequest) hasReadOnlyFields() bool {
+	return s.ExtensionId != nil || s.RuleKey != nil
 }
 
 func (s Resources) GetAssetGroupTags(response http.ResponseWriter, request *http.Request) {
@@ -209,6 +217,8 @@ func (s *Resources) CreateAssetGroupTagSelector(response http.ResponseWriter, re
 		api.HandleDatabaseError(request, response, err)
 	} else if err := json.NewDecoder(request.Body).Decode(&createSelectorRequest); err != nil {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, api.ErrorResponsePayloadUnmarshalError, request), response)
+	} else if createSelectorRequest.hasReadOnlyFields() {
+		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, assetGroupTagSelectorReadOnlyFieldError, request), response)
 	} else if errs := validation.Validate(createSelectorRequest.AssetGroupTagSelector); len(errs) > 0 {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, errs.Error(), request), response)
 	} else if actor, isUser := auth.GetUserFromAuthCtx(bhctx.FromRequest(request).AuthCtx); !isUser {
@@ -232,7 +242,15 @@ func (s *Resources) CreateAssetGroupTagSelector(response http.ResponseWriter, re
 			description = *createSelectorRequest.Description
 		}
 
-		if selector, err := s.DB.CreateAssetGroupTagSelector(request.Context(), assetTagId, actor, createSelectorRequest.Name, description, false, true, autoCertify, createSelectorRequest.Seeds); errors.Is(err, database.ErrDuplicateAGTagSelectorName) {
+		if selector, err := s.DB.CreateAssetGroupTagSelector(request.Context(), actor, model.AssetGroupTagSelector{
+			AssetGroupTagId: assetTagId,
+			Name:            createSelectorRequest.Name,
+			Description:     description,
+			IsDefault:       false,
+			AllowDisable:    true,
+			AutoCertify:     autoCertify,
+			Seeds:           createSelectorRequest.Seeds,
+		}); errors.Is(err, database.ErrDuplicateAGTagSelectorName) {
 			api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusConflict, api.ErrorResponseAssetGroupTagSelectorDuplicateName, request), response)
 		} else if err != nil {
 			api.HandleDatabaseError(request, response, err)
@@ -273,6 +291,8 @@ func (s *Resources) UpdateAssetGroupTagSelector(response http.ResponseWriter, re
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusNotFound, "selector is not part of asset group tag", request), response)
 	} else if err := json.NewDecoder(request.Body).Decode(&selUpdateReq); err != nil {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, api.ErrorResponsePayloadUnmarshalError, request), response)
+	} else if selUpdateReq.hasReadOnlyFields() {
+		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, assetGroupTagSelectorReadOnlyFieldError, request), response)
 	} else {
 		// we can update DisabledAt on a default selector
 		if selUpdateReq.Disabled != nil {

--- a/cmd/api/src/api/v2/assetgrouptags.go
+++ b/cmd/api/src/api/v2/assetgrouptags.go
@@ -60,8 +60,6 @@ const (
 
 	includeProperties = true
 	excludeProperties = false
-
-	assetGroupTagSelectorReadOnlyFieldError = "request contains read-only fields"
 )
 
 func maybeAddEnvironmentIdFilter(filters []graph.Criteria, environmentIds []string) []graph.Criteria {
@@ -218,7 +216,7 @@ func (s *Resources) CreateAssetGroupTagSelector(response http.ResponseWriter, re
 	} else if err := json.NewDecoder(request.Body).Decode(&createSelectorRequest); err != nil {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, api.ErrorResponsePayloadUnmarshalError, request), response)
 	} else if createSelectorRequest.hasReadOnlyFields() {
-		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, assetGroupTagSelectorReadOnlyFieldError, request), response)
+		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, api.ErrorAssetGroupTagSelectorReadOnlyField, request), response)
 	} else if errs := validation.Validate(createSelectorRequest.AssetGroupTagSelector); len(errs) > 0 {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, errs.Error(), request), response)
 	} else if actor, isUser := auth.GetUserFromAuthCtx(bhctx.FromRequest(request).AuthCtx); !isUser {
@@ -292,7 +290,7 @@ func (s *Resources) UpdateAssetGroupTagSelector(response http.ResponseWriter, re
 	} else if err := json.NewDecoder(request.Body).Decode(&selUpdateReq); err != nil {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, api.ErrorResponsePayloadUnmarshalError, request), response)
 	} else if selUpdateReq.hasReadOnlyFields() {
-		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, assetGroupTagSelectorReadOnlyFieldError, request), response)
+		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, api.ErrorAssetGroupTagSelectorReadOnlyField, request), response)
 	} else {
 		// we can update DisabledAt on a default selector
 		if selUpdateReq.Disabled != nil {

--- a/cmd/api/src/api/v2/assetgrouptags.go
+++ b/cmd/api/src/api/v2/assetgrouptags.go
@@ -91,7 +91,7 @@ type assetGroupTagSelectorRequest struct {
 	RuleKey     *string                          `json:"rule_key"`
 }
 
-func (s assetGroupTagSelectorRequest) hasReadOnlyFields() bool {
+func (s assetGroupTagSelectorRequest) hasExtensionOnlyFields() bool {
 	return s.ExtensionId != nil || s.RuleKey != nil
 }
 
@@ -215,7 +215,7 @@ func (s *Resources) CreateAssetGroupTagSelector(response http.ResponseWriter, re
 		api.HandleDatabaseError(request, response, err)
 	} else if err := json.NewDecoder(request.Body).Decode(&createSelectorRequest); err != nil {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, api.ErrorResponsePayloadUnmarshalError, request), response)
-	} else if createSelectorRequest.hasReadOnlyFields() {
+	} else if createSelectorRequest.hasExtensionOnlyFields() {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, api.ErrorAssetGroupTagSelectorReadOnlyField, request), response)
 	} else if errs := validation.Validate(createSelectorRequest.AssetGroupTagSelector); len(errs) > 0 {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, errs.Error(), request), response)
@@ -289,7 +289,7 @@ func (s *Resources) UpdateAssetGroupTagSelector(response http.ResponseWriter, re
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusNotFound, "selector is not part of asset group tag", request), response)
 	} else if err := json.NewDecoder(request.Body).Decode(&selUpdateReq); err != nil {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, api.ErrorResponsePayloadUnmarshalError, request), response)
-	} else if selUpdateReq.hasReadOnlyFields() {
+	} else if selUpdateReq.hasExtensionOnlyFields() {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, api.ErrorAssetGroupTagSelectorReadOnlyField, request), response)
 	} else {
 		// we can update DisabledAt on a default selector

--- a/cmd/api/src/api/v2/assetgrouptags_test.go
+++ b/cmd/api/src/api/v2/assetgrouptags_test.go
@@ -528,8 +528,16 @@ func TestResources_CreateAssetGroupTagSelector(t *testing.T) {
 					mockGraphDb.EXPECT().
 						PrepareCypherQuery(gomock.Any(), int64(-3)).
 						Return(queries.PreparedQuery{}, nil).Times(1)
-					mockDB.EXPECT().
-						CreateAssetGroupTagSelector(gomock.Any(), 1, user, testSelector.Name, testSelector.Description, false, true, testSelector.AutoCertify, testSelector.Seeds).
+					mockDB.EXPECT().CreateAssetGroupTagSelector(
+						gomock.Any(), user, model.AssetGroupTagSelector{
+							AssetGroupTagId: 1,
+							Name:            testSelector.Name,
+							Description:     testSelector.Description,
+							IsDefault:       false,
+							AllowDisable:    true,
+							AutoCertify:     testSelector.AutoCertify,
+							Seeds:           testSelector.Seeds,
+						}).
 						Return(model.AssetGroupTagSelector{}, errors.New("failure")).Times(1)
 					mockDB.EXPECT().GetAssetGroupTag(gomock.Any(), 1).
 						Return(model.AssetGroupTag{}, nil).Times(1)
@@ -552,13 +560,60 @@ func TestResources_CreateAssetGroupTagSelector(t *testing.T) {
 					mockGraphDb.EXPECT().
 						PrepareCypherQuery("this should be a string of cypher", int64(-3)).
 						Return(queries.PreparedQuery{}, nil).Times(1)
-					mockDB.EXPECT().
-						CreateAssetGroupTagSelector(gomock.Any(), 1, user, testSelector.Name, testSelector.Description, false, true, testSelector.AutoCertify, testSelector.Seeds).
+					mockDB.EXPECT().CreateAssetGroupTagSelector(
+						gomock.Any(), user, model.AssetGroupTagSelector{
+							AssetGroupTagId: 1,
+							Name:            testSelector.Name,
+							Description:     testSelector.Description,
+							IsDefault:       false,
+							AllowDisable:    true,
+							AutoCertify:     testSelector.AutoCertify,
+							Seeds:           testSelector.Seeds,
+						}).
 						Return(model.AssetGroupTagSelector{}, database.ErrDuplicateAGTagSelectorName).Times(1)
 				},
 				Test: func(output apitest.Output) {
 					apitest.StatusCode(output, http.StatusConflict)
 					apitest.BodyContains(output, api.ErrorResponseAssetGroupTagSelectorDuplicateName)
+				},
+			},
+			{
+				Name: "RejectExtensionId",
+				Input: func(input *apitest.Input) {
+					apitest.SetContext(input, userCtx)
+					apitest.SetURLVar(input, api.URIPathVariableAssetGroupTagID, "1")
+					apitest.BodyString(input, `{"name":"TestSelector","extension_id":7,"seeds":[{"type":1,"value":"S-1-5-21-1234"}]}`)
+				},
+				Setup: func() {
+					mockDB.EXPECT().GetAssetGroupTag(gomock.Any(), 1).
+						Return(model.AssetGroupTag{}, nil).Times(1)
+				},
+				Test: func(output apitest.Output) {
+					apitest.StatusCode(output, http.StatusBadRequest)
+				},
+			},
+			{
+				Name: "RejectRuleKey",
+				Input: func(input *apitest.Input) {
+					apitest.SetContext(input, userCtx)
+					apitest.SetURLVar(input, api.URIPathVariableAssetGroupTagID, "1")
+					apitest.BodyStruct(input, model.AssetGroupTagSelector{
+						Name:        "TestSelector",
+						Description: "Test selector description",
+						RuleKey:     null.StringFrom("test.rule"),
+						Seeds: []model.SelectorSeed{
+							{Type: model.SelectorTypeObjectId, Value: "S-1-5-21-1234"},
+						},
+						IsDefault:   false,
+						AutoCertify: model.SelectorAutoCertifyMethodDisabled,
+					})
+				},
+				Setup: func() {
+					mockDB.EXPECT().GetAssetGroupTag(gomock.Any(), 1).
+						Return(model.AssetGroupTag{}, nil).Times(1)
+				},
+				Test: func(output apitest.Output) {
+					apitest.StatusCode(output, http.StatusBadRequest)
 				},
 			},
 			{
@@ -663,8 +718,16 @@ func TestResources_CreateAssetGroupTagSelector(t *testing.T) {
 					mockDB.EXPECT().
 						GetConfigurationParameter(gomock.Any(), appcfg.ScheduledAnalysis).
 						Return(appcfg.Parameter{Key: appcfg.ScheduledAnalysis, Value: value}, nil).Times(1)
-					mockDB.EXPECT().
-						CreateAssetGroupTagSelector(gomock.Any(), 1, user, testSelector.Name, testSelector.Description, false, true, testSelector.AutoCertify, testSelector.Seeds).
+					mockDB.EXPECT().CreateAssetGroupTagSelector(
+						gomock.Any(), user, model.AssetGroupTagSelector{
+							AssetGroupTagId: 1,
+							Name:            testSelector.Name,
+							Description:     testSelector.Description,
+							IsDefault:       false,
+							AllowDisable:    true,
+							AutoCertify:     testSelector.AutoCertify,
+							Seeds:           testSelector.Seeds,
+						}).
 						Return(model.AssetGroupTagSelector{Name: "TestSelector"}, nil).Times(1)
 					mockDB.EXPECT().GetAssetGroupTag(gomock.Any(), 1).
 						Return(model.AssetGroupTag{Type: model.AssetGroupTagTypeTier}, nil).Times(1)
@@ -674,6 +737,8 @@ func TestResources_CreateAssetGroupTagSelector(t *testing.T) {
 				},
 				Test: func(output apitest.Output) {
 					apitest.StatusCode(output, http.StatusCreated)
+					apitest.BodyContains(output, `"rule_key":null`)
+					apitest.BodyContains(output, `"extension_id":null`)
 				},
 			},
 			{
@@ -695,9 +760,17 @@ func TestResources_CreateAssetGroupTagSelector(t *testing.T) {
 					mockDB.EXPECT().
 						GetConfigurationParameter(gomock.Any(), appcfg.ScheduledAnalysis).
 						Return(appcfg.Parameter{Key: appcfg.ScheduledAnalysis, Value: value}, nil).Times(1)
-					mockDB.EXPECT().
-						CreateAssetGroupTagSelector(gomock.Any(), 1, user, testSelector.Name, testSelector.Description, false, true, testSelector.AutoCertify, []model.SelectorSeed{
-							{Type: model.SelectorTypeObjectId, Value: "this should be a string of an object id"},
+					mockDB.EXPECT().CreateAssetGroupTagSelector(
+						gomock.Any(), user, model.AssetGroupTagSelector{
+							AssetGroupTagId: 1,
+							Name:            testSelector.Name,
+							Description:     testSelector.Description,
+							IsDefault:       false,
+							AllowDisable:    true,
+							AutoCertify:     testSelector.AutoCertify,
+							Seeds: []model.SelectorSeed{
+								{Type: model.SelectorTypeObjectId, Value: "this should be a string of an object id"},
+							},
 						}).
 						Return(model.AssetGroupTagSelector{Name: "TestSelector"}, nil).Times(1)
 					mockDB.EXPECT().GetAssetGroupTag(gomock.Any(), 1).
@@ -1184,6 +1257,44 @@ func TestResources_UpdateAssetGroupTagSelector(t *testing.T) {
 				Test: func(output apitest.Output) {
 					apitest.StatusCode(output, http.StatusBadRequest)
 					apitest.BodyContains(output, api.ErrorResponseAssetGroupAutoCertifyOnlyAvailableForPrivilegeZones)
+				},
+			},
+			{
+				Name: "RejectExtensionId",
+				Input: func(input *apitest.Input) {
+					apitest.SetContext(input, userCtx)
+					apitest.SetURLVar(input, api.URIPathVariableAssetGroupTagID, "1")
+					apitest.SetURLVar(input, api.URIPathVariableAssetGroupTagSelectorID, "1")
+					apitest.BodyString(input, `{"extension_id": 7}`)
+				},
+				Setup: func() {
+					mockDB.EXPECT().GetAssetGroupTag(gomock.Any(), 1).
+						Return(model.AssetGroupTag{ID: 1}, nil).Times(1)
+					mockDB.EXPECT().GetAssetGroupTagSelectorBySelectorId(gomock.Any(), 1).
+						Return(model.AssetGroupTagSelector{AssetGroupTagId: 1}, nil).Times(1)
+				},
+				Test: func(output apitest.Output) {
+					apitest.StatusCode(output, http.StatusBadRequest)
+				},
+			},
+			{
+				Name: "RejectRuleKey",
+				Input: func(input *apitest.Input) {
+					apitest.SetContext(input, userCtx)
+					apitest.SetURLVar(input, api.URIPathVariableAssetGroupTagID, "1")
+					apitest.SetURLVar(input, api.URIPathVariableAssetGroupTagSelectorID, "1")
+					apitest.BodyStruct(input, model.AssetGroupTagSelector{
+						RuleKey: null.StringFrom("test.rule"),
+					})
+				},
+				Setup: func() {
+					mockDB.EXPECT().GetAssetGroupTag(gomock.Any(), 1).
+						Return(model.AssetGroupTag{ID: 1}, nil).Times(1)
+					mockDB.EXPECT().GetAssetGroupTagSelectorBySelectorId(gomock.Any(), 1).
+						Return(model.AssetGroupTagSelector{AssetGroupTagId: 1}, nil).Times(1)
+				},
+				Test: func(output apitest.Output) {
+					apitest.StatusCode(output, http.StatusBadRequest)
 				},
 			},
 			{

--- a/cmd/api/src/api/v2/assetgrouptags_test.go
+++ b/cmd/api/src/api/v2/assetgrouptags_test.go
@@ -590,6 +590,7 @@ func TestResources_CreateAssetGroupTagSelector(t *testing.T) {
 				},
 				Test: func(output apitest.Output) {
 					apitest.StatusCode(output, http.StatusBadRequest)
+					apitest.BodyContains(output, api.ErrorAssetGroupTagSelectorReadOnlyField)
 				},
 			},
 			{
@@ -614,6 +615,7 @@ func TestResources_CreateAssetGroupTagSelector(t *testing.T) {
 				},
 				Test: func(output apitest.Output) {
 					apitest.StatusCode(output, http.StatusBadRequest)
+					apitest.BodyContains(output, api.ErrorAssetGroupTagSelectorReadOnlyField)
 				},
 			},
 			{

--- a/cmd/api/src/daemons/changelog/ingestion_internal_test.go
+++ b/cmd/api/src/daemons/changelog/ingestion_internal_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/specterops/bloodhound/cmd/api/src/database"
 	graphmocks "github.com/specterops/bloodhound/cmd/api/src/vendormocks/dawgs/graph"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
@@ -215,7 +216,7 @@ func TestIsDeadlockError(t *testing.T) {
 		},
 		{
 			name:     "pg error with different code",
-			err:      &pgconn.PgError{Code: "23505"},
+			err:      &pgconn.PgError{Code: database.PostgresUniqueViolationCode},
 			expected: false,
 		},
 	}

--- a/cmd/api/src/database/assetgrouptags.go
+++ b/cmd/api/src/database/assetgrouptags.go
@@ -323,12 +323,14 @@ func (s *BloodhoundDB) UpdateOpenGraphAssetGroupTagSelector(ctx context.Context,
 			return checkAssetGroupTagSelectorMutationError(result)
 		} else if result.RowsAffected == 0 {
 			return ErrNotFound
-		} else if result := tx.Exec(fmt.Sprintf("DELETE FROM %s WHERE selector_id = ?", model.SelectorSeed{}.TableName()), selector.ID); result.Error != nil {
-			return CheckError(result)
-		} else if seeds, err := insertSelectorSeeds(tx, selector.ID, input.Seeds); err != nil {
-			return err
-		} else {
-			selector.Seeds = seeds
+		} else if input.Seeds != nil {
+			if result := tx.Exec(fmt.Sprintf("DELETE FROM %s WHERE selector_id = ?", model.SelectorSeed{}.TableName()), selector.ID); result.Error != nil {
+				return CheckError(result)
+			} else if seeds, err := insertSelectorSeeds(tx, selector.ID, input.Seeds); err != nil {
+				return err
+			} else {
+				selector.Seeds = seeds
+			}
 		}
 
 		return bhdb.CreateAssetGroupHistoryRecord(ctx, model.AssetGroupActorOpenGraphExtensionManagement, "", selector.Name, model.AssetGroupHistoryActionUpdateSelector, selector.AssetGroupTagId, null.String{}, null.String{})

--- a/cmd/api/src/database/assetgrouptags.go
+++ b/cmd/api/src/database/assetgrouptags.go
@@ -48,7 +48,7 @@ type AssetGroupTagData interface {
 
 // AssetGroupTagSelectorData defines the methods required to interact with the asset_group_tag_selectors and asset_group_tag_selector_seeds tables
 type AssetGroupTagSelectorData interface {
-	CreateAssetGroupTagSelector(ctx context.Context, assetGroupTagId int, user model.User, name string, description string, isDefault bool, allowDisable bool, autoCertify model.SelectorAutoCertifyMethod, seeds []model.SelectorSeed) (model.AssetGroupTagSelector, error)
+	CreateAssetGroupTagSelector(ctx context.Context, user model.User, selector model.AssetGroupTagSelector) (model.AssetGroupTagSelector, error)
 	GetAssetGroupTagSelectorBySelectorId(ctx context.Context, assetGroupTagSelectorId int) (model.AssetGroupTagSelector, error)
 	UpdateAssetGroupTagSelector(ctx context.Context, actorId, email string, selector model.AssetGroupTagSelector) (model.AssetGroupTagSelector, error)
 	DeleteAssetGroupTagSelector(ctx context.Context, user model.User, selector model.AssetGroupTagSelector) error
@@ -57,6 +57,43 @@ type AssetGroupTagSelectorData interface {
 	GetAssetGroupTagSelectorsByTagIdFilteredAndPaginated(ctx context.Context, assetGroupTagId int, selectorSqlFilter, selectorSeedSqlFilter model.SQLFilter, sort model.Sort, skip, limit int) (model.AssetGroupTagSelectors, int, error)
 	GetCustomAssetGroupTagSelectorsToMigrate(ctx context.Context) (model.AssetGroupTagSelectors, error)
 	GetAssetGroupTagSelectors(ctx context.Context, sqlFilter model.SQLFilter, limit int) (model.AssetGroupTagSelectors, error)
+	GetAssetGroupTagSelectorsByExtensionId(ctx context.Context, extensionId int32) (model.AssetGroupTagSelectors, error)
+}
+
+// The create/update paths share the same selector unique constraints; keep their error mapping in one place.
+func checkAssetGroupTagSelectorMutationError(result *gorm.DB) error {
+	if result.Error == nil {
+		return nil
+	}
+
+	var pgErr *pgconn.PgError
+	if errors.As(result.Error, &pgErr) && pgErr.Code == "23505" {
+		// Prefer structured Postgres fields when available. The switch maps exact constraint names.
+		switch pgErr.ConstraintName {
+		case "asset_group_tag_selectors_unique_name_asset_group_tag":
+			return fmt.Errorf("%w: %v", ErrDuplicateAGTagSelectorName, result.Error)
+		case "idx_asset_group_tag_selectors_rule_key":
+			return fmt.Errorf("%w: %v", ErrDuplicateAGTagSelectorRuleKey, result.Error)
+		}
+	}
+
+	// Fall back to the existing string-match style that only have formatted errors.
+	if strings.Contains(result.Error.Error(), "duplicate key value violates unique constraint \"asset_group_tag_selectors_unique_name_asset_group_tag\"") {
+		return fmt.Errorf("%w: %v", ErrDuplicateAGTagSelectorName, result.Error)
+	} else if strings.Contains(result.Error.Error(), "duplicate key value violates unique constraint \"idx_asset_group_tag_selectors_rule_key\"") {
+		return fmt.Errorf("%w: %v", ErrDuplicateAGTagSelectorRuleKey, result.Error)
+	}
+
+	return CheckError(result)
+}
+
+func assetGroupHistoryActorFromUser(user model.User) (string, string) {
+	// OpenGraph management is a system actor, not a UUID-backed user.
+	if user.PrincipalName == model.AssetGroupActorOpenGraphExtensionManagement {
+		return model.AssetGroupActorOpenGraphExtensionManagement, ""
+	}
+
+	return user.ID.String(), user.EmailAddress.ValueOrZero()
 }
 
 // AssetGroupTagSelectorNodeData defines the methods required to interact with the asset_group_tag_selector_nodes table
@@ -82,43 +119,39 @@ func insertSelectorSeeds(tx *gorm.DB, selectorId int, seeds []model.SelectorSeed
 	return seeds, nil
 }
 
-func (s *BloodhoundDB) CreateAssetGroupTagSelector(ctx context.Context, assetGroupTagId int, user model.User, name string, description string, isDefault bool, allowDisable bool, autoCertify model.SelectorAutoCertifyMethod, seeds []model.SelectorSeed) (model.AssetGroupTagSelector, error) {
+func (s *BloodhoundDB) CreateAssetGroupTagSelector(ctx context.Context, user model.User, selector model.AssetGroupTagSelector) (model.AssetGroupTagSelector, error) {
 	var (
-		userIdStr = user.ID.String()
-		selector  = model.AssetGroupTagSelector{
-			AssetGroupTagId: assetGroupTagId,
-			CreatedBy:       userIdStr,
-			UpdatedBy:       userIdStr,
-			Name:            name,
-			Description:     description,
-			IsDefault:       isDefault,
-			AllowDisable:    allowDisable,
-			AutoCertify:     autoCertify,
-		}
-
-		auditEntry = model.AuditEntry{
+		actorId, emailAddress = assetGroupHistoryActorFromUser(user)
+		seeds                 = selector.Seeds
+		auditEntry            = model.AuditEntry{
 			Action: model.AuditLogActionCreateAssetGroupTagSelector,
 			Model:  &selector, // Pointer is required to ensure success log contains updated fields after transaction
 		}
 	)
 
+	selector.CreatedBy = actorId
+	selector.UpdatedBy = actorId
+
 	if err := s.AuditableTransaction(ctx, auditEntry, func(tx *gorm.DB) error {
 		bhdb := NewBloodhoundDB(tx, s.pool, s.idResolver, s.config)
 		if result := tx.Raw(fmt.Sprintf(`
-			INSERT INTO %s (asset_group_tag_id, created_at, created_by, updated_at, updated_by, name, description, is_default, allow_disable, auto_certify)
-			VALUES (?, NOW(), ?, NOW(), ?, ?, ?, ?, ?, ?)
-			RETURNING id, asset_group_tag_id, created_at, created_by, updated_at, updated_by, disabled_at, disabled_by, name, description, is_default, allow_disable, auto_certify`,
+				INSERT INTO %s (
+					asset_group_tag_id, extension_id, rule_key, created_at, created_by, updated_at, updated_by,
+					disabled_at, disabled_by, name, description, is_default, allow_disable, auto_certify
+				)
+				VALUES (?, ?, ?, NOW(), ?, NOW(), ?, ?, ?, ?, ?, ?, ?, ?)
+				RETURNING id, asset_group_tag_id, created_at, created_by, updated_at, updated_by,
+					disabled_at, disabled_by, name, description, is_default, allow_disable,
+					auto_certify, rule_key, extension_id`,
 			selector.TableName()),
-			assetGroupTagId, userIdStr, userIdStr, name, description, isDefault, allowDisable, autoCertify).Scan(&selector); result.Error != nil {
-			if strings.Contains(result.Error.Error(), "duplicate key value violates unique constraint") {
-				return fmt.Errorf("%w: %v", ErrDuplicateAGTagSelectorName, result.Error)
-			}
-			return CheckError(result)
+			selector.AssetGroupTagId, selector.ExtensionId, selector.RuleKey, selector.CreatedBy, selector.UpdatedBy,
+			selector.DisabledAt, selector.DisabledBy, selector.Name, selector.Description, selector.IsDefault, selector.AllowDisable, selector.AutoCertify).Scan(&selector); result.Error != nil {
+			return checkAssetGroupTagSelectorMutationError(result)
 		} else {
 			var err error
 			if selector.Seeds, err = insertSelectorSeeds(tx, selector.ID, seeds); err != nil {
 				return err
-			} else if err := bhdb.CreateAssetGroupHistoryRecord(ctx, user.ID.String(), user.EmailAddress.ValueOrZero(), name, model.AssetGroupHistoryActionCreateSelector, assetGroupTagId, null.String{}, null.String{}); err != nil {
+			} else if err := bhdb.CreateAssetGroupHistoryRecord(ctx, actorId, emailAddress, selector.Name, model.AssetGroupHistoryActionCreateSelector, selector.AssetGroupTagId, null.String{}, null.String{}); err != nil {
 				return err
 			}
 		}
@@ -139,7 +172,9 @@ func (s *BloodhoundDB) GetAssetGroupTagSelectorBySelectorId(ctx context.Context,
 
 	if err := s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		if result := tx.Raw(fmt.Sprintf(`
-			SELECT id, asset_group_tag_id, created_at, created_by, updated_at, updated_by, disabled_at, disabled_by, name, description, is_default, allow_disable, auto_certify
+			SELECT id, asset_group_tag_id, created_at, created_by, updated_at, updated_by,
+				disabled_at, disabled_by, name, description, is_default, allow_disable,
+				auto_certify, rule_key, extension_id
 			FROM %s WHERE id = ?`,
 			selector.TableName()),
 			assetGroupTagSelectorId).First(&selector); result.Error != nil {
@@ -170,7 +205,7 @@ func (s *BloodhoundDB) UpdateAssetGroupTagSelector(ctx context.Context, actorId,
 			WHERE id = ?`,
 			selector.TableName()),
 			actorId, selector.Name, selector.Description, selector.DisabledAt, selector.DisabledBy, selector.AutoCertify, selector.ID); result.Error != nil {
-			return CheckError(result)
+			return checkAssetGroupTagSelectorMutationError(result)
 		} else {
 			if selector.Seeds != nil {
 				// delete old seeds and re-insert the new ones
@@ -194,7 +229,8 @@ func (s *BloodhoundDB) UpdateAssetGroupTagSelector(ctx context.Context, actorId,
 
 func (s *BloodhoundDB) DeleteAssetGroupTagSelector(ctx context.Context, user model.User, selector model.AssetGroupTagSelector) error {
 	var (
-		auditEntry = model.AuditEntry{
+		actorId, emailAddress = assetGroupHistoryActorFromUser(user)
+		auditEntry            = model.AuditEntry{
 			Action: model.AuditLogActionDeleteAssetGroupTagSelector,
 			Model:  &selector, // Pointer is required to ensure success log contains updated fields after transaction
 		}
@@ -204,7 +240,7 @@ func (s *BloodhoundDB) DeleteAssetGroupTagSelector(ctx context.Context, user mod
 		bhdb := NewBloodhoundDB(tx, s.pool, s.idResolver, s.config)
 		if result := tx.Exec(fmt.Sprintf(`DELETE FROM %s WHERE id = ?`, selector.TableName()), selector.ID); result.Error != nil {
 			return CheckError(result)
-		} else if err := bhdb.CreateAssetGroupHistoryRecord(ctx, user.ID.String(), user.EmailAddress.ValueOrZero(), selector.Name, model.AssetGroupHistoryActionDeleteSelector, selector.AssetGroupTagId, null.String{}, null.String{}); err != nil {
+		} else if err := bhdb.CreateAssetGroupHistoryRecord(ctx, actorId, emailAddress, selector.Name, model.AssetGroupHistoryActionDeleteSelector, selector.AssetGroupTagId, null.String{}, null.String{}); err != nil {
 			return err
 		}
 		return nil
@@ -213,6 +249,59 @@ func (s *BloodhoundDB) DeleteAssetGroupTagSelector(ctx context.Context, user mod
 	}
 
 	return nil
+}
+
+func (s *BloodhoundDB) UpdateOpenGraphAssetGroupTagSelector(ctx context.Context, extensionId int32, input model.AssetGroupTagSelector) (model.AssetGroupTagSelector, error) {
+	var (
+		selector = model.AssetGroupTagSelector{
+			Name:         input.Name,
+			Description:  input.Description,
+			AutoCertify:  input.AutoCertify,
+			IsDefault:    input.IsDefault,
+			AllowDisable: input.AllowDisable,
+			RuleKey:      null.StringFrom(strings.TrimSpace(input.RuleKey.String)),
+			DisabledAt:   input.DisabledAt,
+			DisabledBy:   input.DisabledBy,
+			UpdatedBy:    model.AssetGroupActorOpenGraphExtensionManagement,
+			Seeds:        input.Seeds,
+		}
+	)
+
+	auditEntry := model.AuditEntry{
+		Action: model.AuditLogActionUpdateAssetGroupTagSelector,
+		Model:  &selector,
+	}
+
+	if err := s.AuditableTransaction(ctx, auditEntry, func(tx *gorm.DB) error {
+		bhdb := NewBloodhoundDB(tx, s.pool, s.idResolver, s.config)
+		if result := tx.Raw(fmt.Sprintf(`
+			UPDATE %s
+			SET updated_at = NOW(), updated_by = ?, name = ?, description = ?, disabled_at = ?, disabled_by = ?,
+				auto_certify = ?, is_default = ?, allow_disable = ?
+			WHERE rule_key = ? AND extension_id = ?
+			RETURNING id, asset_group_tag_id, created_at, created_by, updated_at, updated_by,
+				disabled_at, disabled_by, name, description, is_default, allow_disable,
+				auto_certify, rule_key, extension_id`,
+			selector.TableName()),
+			selector.UpdatedBy, selector.Name, selector.Description, selector.DisabledAt, selector.DisabledBy,
+			selector.AutoCertify, selector.IsDefault, selector.AllowDisable, selector.RuleKey, extensionId).Scan(&selector); result.Error != nil {
+			return checkAssetGroupTagSelectorMutationError(result)
+		} else if result.RowsAffected == 0 {
+			return ErrNotFound
+		} else if result := tx.Exec(fmt.Sprintf("DELETE FROM %s WHERE selector_id = ?", model.SelectorSeed{}.TableName()), selector.ID); result.Error != nil {
+			return CheckError(result)
+		} else if seeds, err := insertSelectorSeeds(tx, selector.ID, input.Seeds); err != nil {
+			return err
+		} else {
+			selector.Seeds = seeds
+		}
+
+		return bhdb.CreateAssetGroupHistoryRecord(ctx, model.AssetGroupActorOpenGraphExtensionManagement, "", selector.Name, model.AssetGroupHistoryActionUpdateSelector, selector.AssetGroupTagId, null.String{}, null.String{})
+	}); err != nil {
+		return model.AssetGroupTagSelector{}, err
+	}
+
+	return selector, nil
 }
 
 func (s *BloodhoundDB) GetAssetGroupTag(ctx context.Context, assetGroupTagId int) (model.AssetGroupTag, error) {
@@ -613,7 +702,10 @@ func (s *BloodhoundDB) GetAssetGroupTagSelectorsByTagIdFilteredAndPaginated(ctx 
 	var (
 		baseSqlStr = fmt.Sprintf(`
 			WITH selectors AS (
-				SELECT id, asset_group_tag_id, created_at, created_by, updated_at, updated_by, disabled_at, disabled_by, name, description, is_default, allow_disable, auto_certify FROM %s WHERE asset_group_tag_id = ?%s
+				SELECT id, asset_group_tag_id, created_at, created_by, updated_at, updated_by,
+					disabled_at, disabled_by, name, description, is_default, allow_disable,
+					auto_certify, rule_key, extension_id
+				FROM %s WHERE asset_group_tag_id = ?%s
 			), seeds AS (
 				SELECT selector_id, type, value FROM %s %s
 			)`,
@@ -670,7 +762,10 @@ func (s *BloodhoundDB) GetCustomAssetGroupTagSelectorsToMigrate(ctx context.Cont
 
 	sqlStr := fmt.Sprintf(`
 		WITH selectors AS (
-			SELECT id, asset_group_tag_id, created_at, created_by, updated_at, updated_by, disabled_at, disabled_by, name, description, is_default, allow_disable, auto_certify FROM %s WHERE created_at = updated_at AND created_at < '2025-05-28' AND is_default = false
+			SELECT id, asset_group_tag_id, created_at, created_by, updated_at, updated_by,
+				disabled_at, disabled_by, name, description, is_default, allow_disable,
+				auto_certify, rule_key, extension_id
+			FROM %s WHERE created_at = updated_at AND created_at < '2025-05-28' AND is_default = false
 		), seeds AS (
 			SELECT selector_id, type, value FROM %s WHERE type = 1
 		)
@@ -1351,7 +1446,10 @@ func (s *BloodhoundDB) GetAssetGroupTagSelectors(ctx context.Context, sqlFilter 
 
 	if result := s.db.WithContext(ctx).Raw(
 		fmt.Sprintf(
-			"SELECT id, asset_group_tag_id, created_at, created_by, updated_at, updated_by, disabled_at, disabled_by, name, description, is_default, allow_disable, auto_certify FROM %s %s ORDER BY name ASC, asset_group_tag_id ASC, id ASC %s",
+			`SELECT id, asset_group_tag_id, created_at, created_by, updated_at, updated_by,
+				disabled_at, disabled_by, name, description, is_default, allow_disable,
+				auto_certify, rule_key, extension_id
+			FROM %s %s ORDER BY name ASC, asset_group_tag_id ASC, id ASC %s`,
 			model.AssetGroupTagSelector{}.TableName(),
 			sqlFilter.SQLString,
 			limitStr,
@@ -1362,6 +1460,10 @@ func (s *BloodhoundDB) GetAssetGroupTagSelectors(ctx context.Context, sqlFilter 
 	}
 
 	return selectors, nil
+}
+
+func (s *BloodhoundDB) GetAssetGroupTagSelectorsByExtensionId(ctx context.Context, extensionId int32) (model.AssetGroupTagSelectors, error) {
+	return s.GetAssetGroupTagSelectors(ctx, model.SQLFilter{SQLString: "extension_id = ?", Params: []any{extensionId}}, 0)
 }
 
 func (s *BloodhoundDB) GetAssetGroupSelectorNodeExpandedOrderedByIdAndPosition(ctx context.Context, nodeIds ...int) ([]model.AssetGroupSelectorNodeExpanded, error) {

--- a/cmd/api/src/database/assetgrouptags.go
+++ b/cmd/api/src/database/assetgrouptags.go
@@ -51,6 +51,7 @@ type AssetGroupTagSelectorData interface {
 	CreateAssetGroupTagSelector(ctx context.Context, user model.User, selector model.AssetGroupTagSelector) (model.AssetGroupTagSelector, error)
 	GetAssetGroupTagSelectorBySelectorId(ctx context.Context, assetGroupTagSelectorId int) (model.AssetGroupTagSelector, error)
 	UpdateAssetGroupTagSelector(ctx context.Context, actorId, email string, selector model.AssetGroupTagSelector) (model.AssetGroupTagSelector, error)
+	UpdateOpenGraphAssetGroupTagSelector(ctx context.Context, extensionId int32, input model.AssetGroupTagSelector) (model.AssetGroupTagSelector, error)
 	DeleteAssetGroupTagSelector(ctx context.Context, user model.User, selector model.AssetGroupTagSelector) error
 	GetAssetGroupTagSelectorCounts(ctx context.Context, tagIds []int) (model.AssetGroupTagCountsMap, error)
 	GetAssetGroupTagSelectorsByTagId(ctx context.Context, assetGroupTagId int) (model.AssetGroupTagSelectors, int, error)
@@ -67,7 +68,7 @@ func checkAssetGroupTagSelectorMutationError(result *gorm.DB) error {
 	}
 
 	var pgErr *pgconn.PgError
-	if errors.As(result.Error, &pgErr) && pgErr.Code == "23505" {
+	if errors.As(result.Error, &pgErr) && pgErr.Code == PostgresUniqueViolationCode {
 		// Prefer structured Postgres fields when available. The switch maps exact constraint names.
 		switch pgErr.ConstraintName {
 		case "asset_group_tag_selectors_unique_name_asset_group_tag":
@@ -127,6 +128,8 @@ func (s *BloodhoundDB) CreateAssetGroupTagSelector(ctx context.Context, user mod
 			Action: model.AuditLogActionCreateAssetGroupTagSelector,
 			Model:  &selector, // Pointer is required to ensure success log contains updated fields after transaction
 		}
+		sqlArgs  map[string]any
+		sqlQuery string
 	)
 
 	selector.CreatedBy = actorId
@@ -134,18 +137,35 @@ func (s *BloodhoundDB) CreateAssetGroupTagSelector(ctx context.Context, user mod
 
 	if err := s.AuditableTransaction(ctx, auditEntry, func(tx *gorm.DB) error {
 		bhdb := NewBloodhoundDB(tx, s.pool, s.idResolver, s.config)
-		if result := tx.Raw(fmt.Sprintf(`
+		sqlArgs = map[string]any{
+			"allow_disable":      selector.AllowDisable,
+			"asset_group_tag_id": selector.AssetGroupTagId,
+			"auto_certify":       selector.AutoCertify,
+			"created_by":         selector.CreatedBy,
+			"description":        selector.Description,
+			"disabled_at":        selector.DisabledAt,
+			"disabled_by":        selector.DisabledBy,
+			"extension_id":       selector.ExtensionId,
+			"is_default":         selector.IsDefault,
+			"name":               selector.Name,
+			"rule_key":           selector.RuleKey,
+			"updated_by":         selector.UpdatedBy,
+		}
+		sqlQuery = fmt.Sprintf(`
 				INSERT INTO %s (
 					asset_group_tag_id, extension_id, rule_key, created_at, created_by, updated_at, updated_by,
 					disabled_at, disabled_by, name, description, is_default, allow_disable, auto_certify
 				)
-				VALUES (?, ?, ?, NOW(), ?, NOW(), ?, ?, ?, ?, ?, ?, ?, ?)
+				VALUES (
+					@asset_group_tag_id, @extension_id, @rule_key, NOW(), @created_by, NOW(), @updated_by,
+					@disabled_at, @disabled_by, @name, @description, @is_default, @allow_disable, @auto_certify
+				)
 				RETURNING id, asset_group_tag_id, created_at, created_by, updated_at, updated_by,
 					disabled_at, disabled_by, name, description, is_default, allow_disable,
 					auto_certify, rule_key, extension_id`,
-			selector.TableName()),
-			selector.AssetGroupTagId, selector.ExtensionId, selector.RuleKey, selector.CreatedBy, selector.UpdatedBy,
-			selector.DisabledAt, selector.DisabledBy, selector.Name, selector.Description, selector.IsDefault, selector.AllowDisable, selector.AutoCertify).Scan(&selector); result.Error != nil {
+			selector.TableName())
+
+		if result := tx.Raw(sqlQuery, sqlArgs).Scan(&selector); result.Error != nil {
 			return checkAssetGroupTagSelectorMutationError(result)
 		} else {
 			var err error
@@ -265,6 +285,8 @@ func (s *BloodhoundDB) UpdateOpenGraphAssetGroupTagSelector(ctx context.Context,
 			UpdatedBy:    model.AssetGroupActorOpenGraphExtensionManagement,
 			Seeds:        input.Seeds,
 		}
+		sqlArgs  map[string]any
+		sqlQuery string
 	)
 
 	auditEntry := model.AuditEntry{
@@ -274,17 +296,30 @@ func (s *BloodhoundDB) UpdateOpenGraphAssetGroupTagSelector(ctx context.Context,
 
 	if err := s.AuditableTransaction(ctx, auditEntry, func(tx *gorm.DB) error {
 		bhdb := NewBloodhoundDB(tx, s.pool, s.idResolver, s.config)
-		if result := tx.Raw(fmt.Sprintf(`
+		sqlArgs = map[string]any{
+			"allow_disable": selector.AllowDisable,
+			"auto_certify":  selector.AutoCertify,
+			"description":   selector.Description,
+			"disabled_at":   selector.DisabledAt,
+			"disabled_by":   selector.DisabledBy,
+			"extension_id":  extensionId,
+			"is_default":    selector.IsDefault,
+			"name":          selector.Name,
+			"rule_key":      selector.RuleKey,
+			"updated_by":    selector.UpdatedBy,
+		}
+		sqlQuery = fmt.Sprintf(`
 			UPDATE %s
-			SET updated_at = NOW(), updated_by = ?, name = ?, description = ?, disabled_at = ?, disabled_by = ?,
-				auto_certify = ?, is_default = ?, allow_disable = ?
-			WHERE rule_key = ? AND extension_id = ?
+			SET updated_at = NOW(), updated_by = @updated_by, name = @name, description = @description,
+				disabled_at = @disabled_at, disabled_by = @disabled_by, auto_certify = @auto_certify,
+				is_default = @is_default, allow_disable = @allow_disable
+			WHERE rule_key = @rule_key AND extension_id = @extension_id
 			RETURNING id, asset_group_tag_id, created_at, created_by, updated_at, updated_by,
 				disabled_at, disabled_by, name, description, is_default, allow_disable,
 				auto_certify, rule_key, extension_id`,
-			selector.TableName()),
-			selector.UpdatedBy, selector.Name, selector.Description, selector.DisabledAt, selector.DisabledBy,
-			selector.AutoCertify, selector.IsDefault, selector.AllowDisable, selector.RuleKey, extensionId).Scan(&selector); result.Error != nil {
+			selector.TableName())
+
+		if result := tx.Raw(sqlQuery, sqlArgs).Scan(&selector); result.Error != nil {
 			return checkAssetGroupTagSelectorMutationError(result)
 		} else if result.RowsAffected == 0 {
 			return ErrNotFound
@@ -558,7 +593,7 @@ func (s *BloodhoundDB) UpdateAssetGroupTag(ctx context.Context, user model.User,
 		); result.Error != nil {
 			var pgErr *pgconn.PgError
 			if errors.As(result.Error, &pgErr) &&
-				pgErr.Code == "23505" && // unique_violation
+				pgErr.Code == PostgresUniqueViolationCode &&
 				pgErr.ConstraintName == "agl_name_unique_index" {
 				return fmt.Errorf("tag name must be unique: %w: %v", ErrDuplicateAGName, result.Error)
 			} else if strings.Contains(result.Error.Error(), "duplicate key value violates unique constraint \"asset_group_tags_glyph_key\"") {

--- a/cmd/api/src/database/assetgrouptags_integration_test.go
+++ b/cmd/api/src/database/assetgrouptags_integration_test.go
@@ -235,6 +235,28 @@ func TestDatabase_OpenGraphAssetGroupTagSelectorHelpers(t *testing.T) {
 	require.Equal(t, extension.ID, updatedSelector.ExtensionId.Int32)
 	require.Equal(t, 1, updatedSelector.AssetGroupTagId)
 
+	input.Name = "test opengraph selector updated without seeds"
+	input.Seeds = nil
+
+	updatedSelector, err = dbInst.UpdateOpenGraphAssetGroupTagSelector(testCtx, extension.ID, input)
+	require.NoError(t, err)
+	require.Nil(t, updatedSelector.Seeds)
+
+	readBackSelector, err := dbInst.GetAssetGroupTagSelectorBySelectorId(testCtx, updatedSelector.ID)
+	require.NoError(t, err)
+	require.Len(t, readBackSelector.Seeds, 1)
+	require.Equal(t, "ObjectID5678", readBackSelector.Seeds[0].Value)
+
+	input.Seeds = []model.SelectorSeed{}
+
+	updatedSelector, err = dbInst.UpdateOpenGraphAssetGroupTagSelector(testCtx, extension.ID, input)
+	require.NoError(t, err)
+	require.Empty(t, updatedSelector.Seeds)
+
+	readBackSelector, err = dbInst.GetAssetGroupTagSelectorBySelectorId(testCtx, updatedSelector.ID)
+	require.NoError(t, err)
+	require.Empty(t, readBackSelector.Seeds)
+
 	err = dbInst.DeleteAssetGroupTagSelector(testCtx, model.User{PrincipalName: model.AssetGroupActorOpenGraphExtensionManagement}, updatedSelector)
 	require.NoError(t, err)
 

--- a/cmd/api/src/database/assetgrouptags_integration_test.go
+++ b/cmd/api/src/database/assetgrouptags_integration_test.go
@@ -140,17 +140,17 @@ func TestDatabase_CreateAssetGroupTagSelectorRuleKey(t *testing.T) {
 
 	selector, err := createOpenGraphSelectorForTest(dbInst, testCtx, extension.ID, input)
 	require.NoError(t, err)
-	require.True(t, selector.RuleKey.Valid)
-	require.Equal(t, "test.rule", selector.RuleKey.String)
-	require.True(t, selector.ExtensionId.Valid)
-	require.Equal(t, extension.ID, selector.ExtensionId.Int32)
+	assert.True(t, selector.RuleKey.Valid)
+	assert.Equal(t, "test.rule", selector.RuleKey.String)
+	assert.True(t, selector.ExtensionId.Valid)
+	assert.Equal(t, extension.ID, selector.ExtensionId.Int32)
 
 	gotSelector, err := dbInst.GetAssetGroupTagSelectorBySelectorId(testCtx, selector.ID)
 	require.NoError(t, err)
-	require.True(t, gotSelector.RuleKey.Valid)
-	require.Equal(t, "test.rule", gotSelector.RuleKey.String)
-	require.True(t, gotSelector.ExtensionId.Valid)
-	require.Equal(t, extension.ID, gotSelector.ExtensionId.Int32)
+	assert.True(t, gotSelector.RuleKey.Valid)
+	assert.Equal(t, "test.rule", gotSelector.RuleKey.String)
+	assert.True(t, gotSelector.ExtensionId.Valid)
+	assert.Equal(t, extension.ID, gotSelector.ExtensionId.Int32)
 }
 
 func TestDatabase_CreateAssetGroupTagSelectorRequiresRuleKeyAndExtensionIDTogether(t *testing.T) {
@@ -209,11 +209,11 @@ func TestDatabase_CreateAssetGroupTagSelectorRuleKeyIsUniquePerExtension(t *test
 
 	input.Name = "test selector with same rule key in other extension"
 	_, err = createOpenGraphSelectorForTest(dbInst, testCtx, otherExtension.ID, input)
-	require.NoError(t, err)
+	assert.NoError(t, err)
 
 	input.Name = "test selector with duplicate rule key in same extension"
 	_, err = createOpenGraphSelectorForTest(dbInst, testCtx, extension.ID, input)
-	require.ErrorIs(t, err, database.ErrDuplicateAGTagSelectorRuleKey)
+	assert.ErrorIs(t, err, database.ErrDuplicateAGTagSelectorRuleKey)
 }
 
 func TestDatabase_UpdateAssetGroupTagSelectorPreservesExtensionManagedFields(t *testing.T) {
@@ -249,8 +249,8 @@ func TestDatabase_UpdateAssetGroupTagSelectorPreservesExtensionManagedFields(t *
 
 	gotSelector, err := dbInst.GetAssetGroupTagSelectorBySelectorId(testCtx, selector.ID)
 	require.NoError(t, err)
-	require.Equal(t, extension.ID, gotSelector.ExtensionId.Int32)
-	require.Equal(t, "test.rule", gotSelector.RuleKey.String)
+	assert.Equal(t, extension.ID, gotSelector.ExtensionId.Int32)
+	assert.Equal(t, "test.rule", gotSelector.RuleKey.String)
 }
 
 func TestDatabase_OpenGraphAssetGroupTagSelectorHelpers(t *testing.T) {
@@ -277,10 +277,10 @@ func TestDatabase_OpenGraphAssetGroupTagSelectorHelpers(t *testing.T) {
 
 	selector, err := createOpenGraphSelectorForTest(dbInst, testCtx, extension.ID, input)
 	require.NoError(t, err)
-	require.Equal(t, 1, selector.AssetGroupTagId)
-	require.Equal(t, extension.ID, selector.ExtensionId.Int32)
-	require.Equal(t, "test.rule", selector.RuleKey.String)
-	require.Len(t, selector.Seeds, 1)
+	assert.Equal(t, 1, selector.AssetGroupTagId)
+	assert.Equal(t, extension.ID, selector.ExtensionId.Int32)
+	assert.Equal(t, "test.rule", selector.RuleKey.String)
+	assert.Len(t, selector.Seeds, 1)
 
 	input.Name = "test opengraph selector updated"
 	input.Description = "test description updated"
@@ -295,13 +295,13 @@ func TestDatabase_OpenGraphAssetGroupTagSelectorHelpers(t *testing.T) {
 
 	updatedSelector, err := dbInst.UpdateOpenGraphAssetGroupTagSelector(testCtx, extension.ID, input)
 	require.NoError(t, err)
-	require.Equal(t, "test opengraph selector updated", updatedSelector.Name)
-	require.True(t, updatedSelector.DisabledAt.Valid)
-	require.Equal(t, input.DisabledBy, updatedSelector.DisabledBy)
-	require.Len(t, updatedSelector.Seeds, 1)
-	require.Equal(t, "ObjectID5678", updatedSelector.Seeds[0].Value)
-	require.Equal(t, extension.ID, updatedSelector.ExtensionId.Int32)
-	require.Equal(t, 1, updatedSelector.AssetGroupTagId)
+	assert.Equal(t, "test opengraph selector updated", updatedSelector.Name)
+	assert.True(t, updatedSelector.DisabledAt.Valid)
+	assert.Equal(t, input.DisabledBy, updatedSelector.DisabledBy)
+	assert.Len(t, updatedSelector.Seeds, 1)
+	assert.Equal(t, "ObjectID5678", updatedSelector.Seeds[0].Value)
+	assert.Equal(t, extension.ID, updatedSelector.ExtensionId.Int32)
+	assert.Equal(t, 1, updatedSelector.AssetGroupTagId)
 
 	input.Name = "test opengraph selector updated without seeds"
 	input.Seeds = nil

--- a/cmd/api/src/database/assetgrouptags_integration_test.go
+++ b/cmd/api/src/database/assetgrouptags_integration_test.go
@@ -38,6 +38,31 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type assetGroupTagSelectorCreator interface {
+	CreateAssetGroupTagSelector(context.Context, model.User, model.AssetGroupTagSelector) (model.AssetGroupTagSelector, error)
+}
+
+func createAssetGroupTagSelector(databaseInterface assetGroupTagSelectorCreator, ctx context.Context, assetGroupTagId int, user model.User, name string, description string, isDefault bool, allowDisable bool, autoCertify model.SelectorAutoCertifyMethod, seeds []model.SelectorSeed, ruleKey null.String) (model.AssetGroupTagSelector, error) {
+	return databaseInterface.CreateAssetGroupTagSelector(ctx, user, model.AssetGroupTagSelector{
+		AssetGroupTagId: assetGroupTagId,
+		Name:            name,
+		Description:     description,
+		IsDefault:       isDefault,
+		AllowDisable:    allowDisable,
+		AutoCertify:     autoCertify,
+		Seeds:           seeds,
+		RuleKey:         ruleKey,
+	})
+}
+
+func createOpenGraphSelectorForTest(databaseInterface assetGroupTagSelectorCreator, ctx context.Context, extensionId int32, input model.AssetGroupTagSelector) (model.AssetGroupTagSelector, error) {
+	input.AssetGroupTagId = model.AssetGroupTierZeroPosition
+	input.RuleKey = null.StringFrom(strings.TrimSpace(input.RuleKey.String))
+	input.ExtensionId = null.Int32From(extensionId)
+
+	return databaseInterface.CreateAssetGroupTagSelector(ctx, model.User{PrincipalName: model.AssetGroupActorOpenGraphExtensionManagement}, input)
+}
+
 func TestDatabase_CreateAssetGroupTagSelector(t *testing.T) {
 	t.Parallel()
 	var (
@@ -55,7 +80,7 @@ func TestDatabase_CreateAssetGroupTagSelector(t *testing.T) {
 		}
 	)
 
-	selector, err := dbInst.CreateAssetGroupTagSelector(testCtx, 1, testActor, testName, testDescription, isDefault, allowDisable, autoCertify, testSeeds)
+	selector, err := createAssetGroupTagSelector(dbInst, testCtx, 1, testActor, testName, testDescription, isDefault, allowDisable, autoCertify, testSeeds, null.String{})
 	require.NoError(t, err)
 	require.Equal(t, 1, selector.AssetGroupTagId)
 	require.False(t, selector.CreatedAt.IsZero())
@@ -80,6 +105,143 @@ func TestDatabase_CreateAssetGroupTagSelector(t *testing.T) {
 	require.Equal(t, model.AssetGroupHistoryActionCreateSelector, history[0].Action)
 }
 
+func TestDatabase_CreateAssetGroupTagSelectorRuleKey(t *testing.T) {
+	t.Parallel()
+	var (
+		dbInst    = integration.SetupDB(t).(*database.BloodhoundDB)
+		testCtx   = context.Background()
+		testActor = model.User{Unique: model.Unique{ID: uuid.FromStringOrNil("01234567-9012-4567-9012-456789012345")}}
+		testSeeds = []model.SelectorSeed{
+			{Type: model.SelectorTypeObjectId, Value: "ObjectID1234"},
+		}
+	)
+
+	selector, err := createAssetGroupTagSelector(dbInst, testCtx, 1, testActor, "test selector with rule key", "test description", false, true, model.SelectorAutoCertifyMethodDisabled, testSeeds, null.StringFrom("test.rule"))
+	require.NoError(t, err)
+	require.True(t, selector.RuleKey.Valid)
+	require.Equal(t, "test.rule", selector.RuleKey.String)
+
+	gotSelector, err := dbInst.GetAssetGroupTagSelectorBySelectorId(testCtx, selector.ID)
+	require.NoError(t, err)
+	require.True(t, gotSelector.RuleKey.Valid)
+	require.Equal(t, "test.rule", gotSelector.RuleKey.String)
+}
+
+func TestDatabase_CreateAssetGroupTagSelectorDuplicateRuleKey(t *testing.T) {
+	t.Parallel()
+	var (
+		dbInst    = integration.SetupDB(t).(*database.BloodhoundDB)
+		testCtx   = context.Background()
+		testActor = model.User{Unique: model.Unique{ID: uuid.FromStringOrNil("01234567-9012-4567-9012-456789012345")}}
+		testSeeds = []model.SelectorSeed{
+			{Type: model.SelectorTypeObjectId, Value: "ObjectID1234"},
+		}
+	)
+
+	label, err := dbInst.CreateAssetGroupTag(testCtx, model.AssetGroupTagTypeLabel, testActor, "test label", "test label description", null.Int32{}, null.Bool{}, null.String{})
+	require.NoError(t, err)
+
+	_, err = createAssetGroupTagSelector(dbInst, testCtx, 1, testActor, "test selector with rule key", "test description", false, true, model.SelectorAutoCertifyMethodDisabled, testSeeds, null.StringFrom("test.rule"))
+	require.NoError(t, err)
+
+	_, err = createAssetGroupTagSelector(dbInst, testCtx, label.ID, testActor, "test selector with duplicate rule key", "test description", false, true, model.SelectorAutoCertifyMethodDisabled, testSeeds, null.StringFrom("test.rule"))
+	require.ErrorIs(t, err, database.ErrDuplicateAGTagSelectorRuleKey)
+}
+
+func TestDatabase_UpdateAssetGroupTagSelectorPreservesExtensionManagedFields(t *testing.T) {
+	t.Parallel()
+	var (
+		dbInst    = integration.SetupDB(t).(*database.BloodhoundDB)
+		testCtx   = context.Background()
+		testActor = model.User{Unique: model.Unique{ID: uuid.FromStringOrNil("01234567-9012-4567-9012-456789012345")}}
+		testInput = model.AssetGroupTagSelector{
+			RuleKey:      null.StringFrom("test.rule"),
+			Name:         "test opengraph selector",
+			Description:  "test description",
+			AutoCertify:  model.SelectorAutoCertifyMethodDisabled,
+			AllowDisable: true,
+			Seeds: []model.SelectorSeed{
+				{Type: model.SelectorTypeObjectId, Value: "ObjectID1234"},
+			},
+		}
+	)
+
+	extension, err := dbInst.CreateGraphSchemaExtension(testCtx, "test_selector_extension", "Test Selector Extension", "v1.0.0", "test")
+	require.NoError(t, err)
+
+	selector, err := createOpenGraphSelectorForTest(dbInst, testCtx, extension.ID, testInput)
+	require.NoError(t, err)
+	require.Equal(t, extension.ID, selector.ExtensionId.Int32)
+
+	selector.ExtensionId = null.Int32From(extension.ID + 1)
+	selector.RuleKey = null.StringFrom("test.rule.updated")
+
+	_, err = dbInst.UpdateAssetGroupTagSelector(testCtx, testActor.ID.String(), "", selector)
+	require.NoError(t, err)
+
+	gotSelector, err := dbInst.GetAssetGroupTagSelectorBySelectorId(testCtx, selector.ID)
+	require.NoError(t, err)
+	require.Equal(t, extension.ID, gotSelector.ExtensionId.Int32)
+	require.Equal(t, "test.rule", gotSelector.RuleKey.String)
+}
+
+func TestDatabase_OpenGraphAssetGroupTagSelectorHelpers(t *testing.T) {
+	t.Parallel()
+	var (
+		dbInst  = integration.SetupDB(t).(*database.BloodhoundDB)
+		testCtx = context.Background()
+		input   = model.AssetGroupTagSelector{
+			RuleKey:      null.StringFrom("test.rule"),
+			Name:         "test opengraph selector",
+			Description:  "test description",
+			AutoCertify:  model.SelectorAutoCertifyMethodDisabled,
+			AllowDisable: true,
+			Seeds: []model.SelectorSeed{
+				{Type: model.SelectorTypeObjectId, Value: "ObjectID1234"},
+			},
+		}
+	)
+
+	extension, err := dbInst.CreateGraphSchemaExtension(testCtx, "test_selector_helper_extension", "Test Selector Helper Extension", "v1.0.0", "test")
+	require.NoError(t, err)
+	otherExtension, err := dbInst.CreateGraphSchemaExtension(testCtx, "test_selector_helper_other_extension", "Test Selector Helper Other Extension", "v1.0.0", "test_other")
+	require.NoError(t, err)
+
+	selector, err := createOpenGraphSelectorForTest(dbInst, testCtx, extension.ID, input)
+	require.NoError(t, err)
+	require.Equal(t, 1, selector.AssetGroupTagId)
+	require.Equal(t, extension.ID, selector.ExtensionId.Int32)
+	require.Equal(t, "test.rule", selector.RuleKey.String)
+	require.Len(t, selector.Seeds, 1)
+
+	input.Name = "test opengraph selector updated"
+	input.Description = "test description updated"
+	input.DisabledAt = null.TimeFrom(time.Now())
+	input.DisabledBy = null.StringFrom("test disabled actor")
+	input.Seeds = []model.SelectorSeed{
+		{Type: model.SelectorTypeObjectId, Value: "ObjectID5678"},
+	}
+
+	_, err = dbInst.UpdateOpenGraphAssetGroupTagSelector(testCtx, otherExtension.ID, input)
+	require.ErrorIs(t, err, database.ErrNotFound)
+
+	updatedSelector, err := dbInst.UpdateOpenGraphAssetGroupTagSelector(testCtx, extension.ID, input)
+	require.NoError(t, err)
+	require.Equal(t, "test opengraph selector updated", updatedSelector.Name)
+	require.True(t, updatedSelector.DisabledAt.Valid)
+	require.Equal(t, input.DisabledBy, updatedSelector.DisabledBy)
+	require.Len(t, updatedSelector.Seeds, 1)
+	require.Equal(t, "ObjectID5678", updatedSelector.Seeds[0].Value)
+	require.Equal(t, extension.ID, updatedSelector.ExtensionId.Int32)
+	require.Equal(t, 1, updatedSelector.AssetGroupTagId)
+
+	err = dbInst.DeleteAssetGroupTagSelector(testCtx, model.User{PrincipalName: model.AssetGroupActorOpenGraphExtensionManagement}, updatedSelector)
+	require.NoError(t, err)
+
+	_, err = dbInst.GetAssetGroupTagSelectorBySelectorId(testCtx, updatedSelector.ID)
+	require.ErrorIs(t, err, database.ErrNotFound)
+}
+
 func TestDatabase_GetAssetGroupTagSelectorBySelectorId(t *testing.T) {
 	var (
 		dbInst          = integration.SetupDB(t)
@@ -96,7 +258,7 @@ func TestDatabase_GetAssetGroupTagSelectorBySelectorId(t *testing.T) {
 		}
 	)
 
-	selector, err := dbInst.CreateAssetGroupTagSelector(testCtx, 1, testActor, testName, testDescription, isDefault, allowDisable, autoCertify, testSeeds)
+	selector, err := createAssetGroupTagSelector(dbInst, testCtx, 1, testActor, testName, testDescription, isDefault, allowDisable, autoCertify, testSeeds, null.String{})
 	require.NoError(t, err)
 
 	// test the read by ID function
@@ -144,7 +306,7 @@ func TestDatabase_UpdateAssetGroupTagSelector(t *testing.T) {
 		}
 	)
 
-	selector, err := dbInst.CreateAssetGroupTagSelector(testCtx, 1, testActor, testName, testDescription, isDefault, allowDisable, autoCertify, testSeeds)
+	selector, err := createAssetGroupTagSelector(dbInst, testCtx, 1, testActor, testName, testDescription, isDefault, allowDisable, autoCertify, testSeeds, null.String{})
 	require.NoError(t, err)
 
 	selector.Name = updateName
@@ -832,17 +994,17 @@ func TestDatabase_GetAssetGroupTagSelectorCounts(t *testing.T) {
 	require.NoError(t, err)
 
 	// label1 selectors
-	_, err = dbInst.CreateAssetGroupTagSelector(testCtx, label1.ID, model.User{}, "1", "", false, true, model.SelectorAutoCertifyMethodDisabled, []model.SelectorSeed{})
+	_, err = createAssetGroupTagSelector(dbInst, testCtx, label1.ID, model.User{}, "1", "", false, true, model.SelectorAutoCertifyMethodDisabled, []model.SelectorSeed{}, null.String{})
 	require.NoError(t, err)
-	_, err = dbInst.CreateAssetGroupTagSelector(testCtx, label1.ID, model.User{}, "2", "", false, true, model.SelectorAutoCertifyMethodAllMembers, []model.SelectorSeed{})
+	_, err = createAssetGroupTagSelector(dbInst, testCtx, label1.ID, model.User{}, "2", "", false, true, model.SelectorAutoCertifyMethodAllMembers, []model.SelectorSeed{}, null.String{})
 	require.NoError(t, err)
-	_, err = dbInst.CreateAssetGroupTagSelector(testCtx, label1.ID, model.User{}, "3", "", false, false, model.SelectorAutoCertifyMethodSeedsOnly, []model.SelectorSeed{})
+	_, err = createAssetGroupTagSelector(dbInst, testCtx, label1.ID, model.User{}, "3", "", false, false, model.SelectorAutoCertifyMethodSeedsOnly, []model.SelectorSeed{}, null.String{})
 	require.NoError(t, err)
-	_, err = dbInst.CreateAssetGroupTagSelector(testCtx, label1.ID, model.User{}, "4", "", true, false, model.SelectorAutoCertifyMethodSeedsOnly, []model.SelectorSeed{})
+	_, err = createAssetGroupTagSelector(dbInst, testCtx, label1.ID, model.User{}, "4", "", true, false, model.SelectorAutoCertifyMethodSeedsOnly, []model.SelectorSeed{}, null.String{})
 	require.NoError(t, err)
-	_, err = dbInst.CreateAssetGroupTagSelector(testCtx, label1.ID, model.User{}, "5", "", true, false, model.SelectorAutoCertifyMethodSeedsOnly, []model.SelectorSeed{})
+	_, err = createAssetGroupTagSelector(dbInst, testCtx, label1.ID, model.User{}, "5", "", true, false, model.SelectorAutoCertifyMethodSeedsOnly, []model.SelectorSeed{}, null.String{})
 	require.NoError(t, err)
-	selector6, err := dbInst.CreateAssetGroupTagSelector(testCtx, label1.ID, model.User{}, "6", "", true, true, model.SelectorAutoCertifyMethodSeedsOnly, []model.SelectorSeed{})
+	selector6, err := createAssetGroupTagSelector(dbInst, testCtx, label1.ID, model.User{}, "6", "", true, true, model.SelectorAutoCertifyMethodSeedsOnly, []model.SelectorSeed{}, null.String{})
 	require.NoError(t, err)
 	selector6.DisabledAt = disabledTime
 	selector6.DisabledBy = null.StringFrom(user.ID.String())
@@ -850,13 +1012,13 @@ func TestDatabase_GetAssetGroupTagSelectorCounts(t *testing.T) {
 	require.NoError(t, err)
 
 	// label2 selectors
-	_, err = dbInst.CreateAssetGroupTagSelector(testCtx, label2.ID, model.User{}, "7", "", false, true, model.SelectorAutoCertifyMethodDisabled, []model.SelectorSeed{})
+	_, err = createAssetGroupTagSelector(dbInst, testCtx, label2.ID, model.User{}, "7", "", false, true, model.SelectorAutoCertifyMethodDisabled, []model.SelectorSeed{}, null.String{})
 	require.NoError(t, err)
-	_, err = dbInst.CreateAssetGroupTagSelector(testCtx, label2.ID, model.User{}, "8", "", false, false, model.SelectorAutoCertifyMethodAllMembers, []model.SelectorSeed{})
+	_, err = createAssetGroupTagSelector(dbInst, testCtx, label2.ID, model.User{}, "8", "", false, false, model.SelectorAutoCertifyMethodAllMembers, []model.SelectorSeed{}, null.String{})
 	require.NoError(t, err)
-	_, err = dbInst.CreateAssetGroupTagSelector(testCtx, label2.ID, model.User{}, "9", "", true, false, model.SelectorAutoCertifyMethodDisabled, []model.SelectorSeed{})
+	_, err = createAssetGroupTagSelector(dbInst, testCtx, label2.ID, model.User{}, "9", "", true, false, model.SelectorAutoCertifyMethodDisabled, []model.SelectorSeed{}, null.String{})
 	require.NoError(t, err)
-	_, err = dbInst.CreateAssetGroupTagSelector(testCtx, label2.ID, model.User{}, "10", "", true, true, model.SelectorAutoCertifyMethodDisabled, []model.SelectorSeed{})
+	_, err = createAssetGroupTagSelector(dbInst, testCtx, label2.ID, model.User{}, "10", "", true, true, model.SelectorAutoCertifyMethodDisabled, []model.SelectorSeed{}, null.String{})
 	require.NoError(t, err)
 
 	t.Run("single asset group tag selector(s) count", func(t *testing.T) {
@@ -944,10 +1106,10 @@ func TestDatabase_GetAssetGroupTagSelectorsBySelectorIdFilteredAndPaginated(t *t
 	)
 
 	test_started_at := time.Now()
-	_, err := dbInst.CreateAssetGroupTagSelector(testCtx, 1, model.User{}, test1Selector.Name, test1Selector.Description, isDefault, allowDisable, autoCertify, test1Selector.Seeds)
+	_, err := createAssetGroupTagSelector(dbInst, testCtx, 1, model.User{}, test1Selector.Name, test1Selector.Description, isDefault, allowDisable, autoCertify, test1Selector.Seeds, null.String{})
 	require.NoError(t, err)
 	created_at := time.Now()
-	_, err = dbInst.CreateAssetGroupTagSelector(testCtx, 1, model.User{}, test2Selector.Name, test2Selector.Description, isDefault, allowDisable, autoCertify, test2Selector.Seeds)
+	_, err = createAssetGroupTagSelector(dbInst, testCtx, 1, model.User{}, test2Selector.Name, test2Selector.Description, isDefault, allowDisable, autoCertify, test2Selector.Seeds, null.String{})
 	require.NoError(t, err)
 
 	t.Run("successfully returns an array of selectors, no filters", func(t *testing.T) {
@@ -1067,7 +1229,7 @@ func TestDatabase_GetSelectorsByMemberId(t *testing.T) {
 			},
 		}
 	)
-	_, err := dbInst.CreateAssetGroupTagSelector(testCtx, 1, model.User{}, test1Selector.Name, test1Selector.Description, isDefault, allowDisable, autoCertify, test1Selector.Seeds)
+	_, err := createAssetGroupTagSelector(dbInst, testCtx, 1, model.User{}, test1Selector.Name, test1Selector.Description, isDefault, allowDisable, autoCertify, test1Selector.Seeds, null.String{})
 	require.NoError(t, err)
 	insertAssetGroupSelectorNodes(t, testCtx, dbInst, model.AssetGroupSelectorNode{
 		SelectorId:  testSelectorId,
@@ -1096,7 +1258,7 @@ func TestDatabase_DeleteAssetGroupTagSelector(t *testing.T) {
 		sortAscendingCreatedAt = model.Sort{{Column: "created_at", Direction: model.AscendingSortDirection}}
 	)
 
-	selector, err := dbInst.CreateAssetGroupTagSelector(testCtx, 1, model.User{}, testName, testDescription, isDefault, allowDisable, autoCertify, testSeeds)
+	selector, err := createAssetGroupTagSelector(dbInst, testCtx, 1, model.User{}, testName, testDescription, isDefault, allowDisable, autoCertify, testSeeds, null.String{})
 	require.NoError(t, err)
 
 	history, _, err := dbInst.GetAssetGroupHistoryRecords(testCtx, model.SQLFilter{}, sortAscendingCreatedAt, 0, 0)
@@ -1173,9 +1335,9 @@ func TestDatabase_GetAssetGroupTagSelectors(t *testing.T) {
 		}
 	)
 
-	_, err := dbInst.CreateAssetGroupTagSelector(testCtx, 1, model.User{}, test1Selector.Name, test1Selector.Description, isDefault, allowDisable, autoCertify, test1Selector.Seeds)
+	_, err := createAssetGroupTagSelector(dbInst, testCtx, 1, model.User{}, test1Selector.Name, test1Selector.Description, isDefault, allowDisable, autoCertify, test1Selector.Seeds, null.String{})
 	require.NoError(t, err)
-	_, err = dbInst.CreateAssetGroupTagSelector(testCtx, 1, model.User{}, test2Selector.Name, test2Selector.Description, isDefault, allowDisable, autoCertify, test2Selector.Seeds)
+	_, err = createAssetGroupTagSelector(dbInst, testCtx, 1, model.User{}, test2Selector.Name, test2Selector.Description, isDefault, allowDisable, autoCertify, test2Selector.Seeds, null.String{})
 	require.NoError(t, err)
 
 	t.Run("returns all selectors", func(t *testing.T) {
@@ -1183,6 +1345,136 @@ func TestDatabase_GetAssetGroupTagSelectors(t *testing.T) {
 		require.NoError(t, err)
 		require.GreaterOrEqual(t, len(items), 2)
 	})
+}
+
+func TestDatabase_GetAssetGroupTagSelectorsByExtensionId(t *testing.T) {
+
+	type testSetupData struct {
+		extensionId   int32
+		expectedCount int
+		expected      map[string]model.AssetGroupTagSelector
+	}
+
+	type testCase struct {
+		name   string
+		setup  func(t *testing.T, testSuite IntegrationTestSuite) testSetupData
+		assert func(t *testing.T, setupData testSetupData, selectors model.AssetGroupTagSelectors, err error)
+	}
+
+	assertSelectors := func(t *testing.T, setupData testSetupData, selectors model.AssetGroupTagSelectors, err error) {
+		t.Helper()
+		require.NoError(t, err)
+		require.Len(t, selectors, setupData.expectedCount)
+		for _, selector := range selectors {
+			expected, ok := setupData.expected[selector.RuleKey.String]
+			require.Truef(t, ok, "unexpected selector returned with rule key %q", selector.RuleKey.String)
+
+			assert.Equal(t, setupData.extensionId, selector.ExtensionId.Int32)
+			assert.True(t, selector.RuleKey.Valid)
+			assert.Equal(t, expected.Name, selector.Name)
+			assert.Equal(t, expected.Description, selector.Description)
+			assert.Equal(t, expected.AutoCertify, selector.AutoCertify)
+			assert.Equal(t, expected.AllowDisable, selector.AllowDisable)
+			assert.Equal(t, expected.IsDefault, selector.IsDefault)
+			assert.Equal(t, model.AssetGroupTierZeroPosition, selector.AssetGroupTagId)
+			assert.Equal(t, model.AssetGroupActorOpenGraphExtensionManagement, selector.CreatedBy)
+			assert.Equal(t, model.AssetGroupActorOpenGraphExtensionManagement, selector.UpdatedBy)
+			assert.NotZero(t, selector.ID)
+		}
+	}
+
+	tests := []testCase{
+		{
+			name: "success_-_returns_selectors_for_extension",
+			setup: func(t *testing.T, testSuite IntegrationTestSuite) testSetupData {
+				t.Helper()
+				extension, err := testSuite.BHDatabase.CreateGraphSchemaExtension(testSuite.Context, "test_ext_with_selectors", "Test Ext With Selectors", "v1.0.0", "test_ext_ws")
+				require.NoError(t, err)
+				expected := make(map[string]model.AssetGroupTagSelector)
+				for i := 0; i < 2; i++ {
+					input := model.AssetGroupTagSelector{
+						RuleKey:      null.StringFrom(fmt.Sprintf("test.rule.%d", i)),
+						Name:         fmt.Sprintf("test selector %d", i),
+						Description:  fmt.Sprintf("test description %d", i),
+						AutoCertify:  model.SelectorAutoCertifyMethodDisabled,
+						AllowDisable: true,
+						Seeds: []model.SelectorSeed{
+							{Type: model.SelectorTypeObjectId, Value: fmt.Sprintf("ObjectID%d", i)},
+						},
+					}
+					_, err := createOpenGraphSelectorForTest(testSuite.BHDatabase, testSuite.Context, extension.ID, input)
+					require.NoError(t, err)
+					expected[input.RuleKey.String] = input
+				}
+				return testSetupData{extensionId: extension.ID, expectedCount: 2, expected: expected}
+			},
+			assert: assertSelectors,
+		},
+		{
+			name: "success_-_returns_only_selectors_for_requested_extension",
+			setup: func(t *testing.T, testSuite IntegrationTestSuite) testSetupData {
+				t.Helper()
+				targetExtension, err := testSuite.BHDatabase.CreateGraphSchemaExtension(testSuite.Context, "test_ext_target", "Test Ext Target", "v1.0.0", "test_ext_tgt")
+				require.NoError(t, err)
+				otherExtension, err := testSuite.BHDatabase.CreateGraphSchemaExtension(testSuite.Context, "test_ext_other", "Test Ext Other", "v1.0.0", "test_ext_oth")
+				require.NoError(t, err)
+
+				targetInput := model.AssetGroupTagSelector{
+					RuleKey:      null.StringFrom("target.rule"),
+					Name:         "target selector",
+					Description:  "target description",
+					AutoCertify:  model.SelectorAutoCertifyMethodDisabled,
+					AllowDisable: true,
+					Seeds: []model.SelectorSeed{
+						{Type: model.SelectorTypeObjectId, Value: "ObjectIDTarget"},
+					},
+				}
+				_, err = createOpenGraphSelectorForTest(testSuite.BHDatabase, testSuite.Context, targetExtension.ID, targetInput)
+				require.NoError(t, err)
+
+				otherInput := model.AssetGroupTagSelector{
+					RuleKey:      null.StringFrom("other.rule"),
+					Name:         "other selector",
+					Description:  "other description",
+					AutoCertify:  model.SelectorAutoCertifyMethodDisabled,
+					AllowDisable: true,
+					Seeds: []model.SelectorSeed{
+						{Type: model.SelectorTypeObjectId, Value: "ObjectIDOther"},
+					},
+				}
+				_, err = createOpenGraphSelectorForTest(testSuite.BHDatabase, testSuite.Context, otherExtension.ID, otherInput)
+				require.NoError(t, err)
+
+				return testSetupData{
+					extensionId:   targetExtension.ID,
+					expectedCount: 1,
+					expected:      map[string]model.AssetGroupTagSelector{targetInput.RuleKey.String: targetInput},
+				}
+			},
+			assert: assertSelectors,
+		},
+		{
+			name: "success_-_returns_empty_for_extension_with_no_selectors",
+			setup: func(t *testing.T, testSuite IntegrationTestSuite) testSetupData {
+				t.Helper()
+				extension, err := testSuite.BHDatabase.CreateGraphSchemaExtension(testSuite.Context, "test_ext_no_selectors", "Test Ext No Selectors", "v1.0.0", "test_ext_ns")
+				require.NoError(t, err)
+				return testSetupData{extensionId: extension.ID, expectedCount: 0, expected: map[string]model.AssetGroupTagSelector{}}
+			},
+			assert: assertSelectors,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			testSuite := setupIntegrationTestSuite(t)
+			defer teardownIntegrationTestSuite(t, &testSuite)
+
+			setupData := testCase.setup(t, testSuite)
+			selectors, err := testSuite.BHDatabase.GetAssetGroupTagSelectorsByExtensionId(testSuite.Context, setupData.extensionId)
+			testCase.assert(t, setupData, selectors, err)
+		})
+	}
 }
 
 func TestDatabase_UpdateCertificationBySelectorNode(t *testing.T) {
@@ -1217,7 +1509,7 @@ func TestDatabase_UpdateCertificationBySelectorNode(t *testing.T) {
 		updateInputNode2   = database.UpdateCertificationBySelectorNodeInput{AssetGroupTagId: testAssetGroupTagId1, SelectorId: testSelectorId1, CertifiedBy: certifiedBy, CertificationStatus: model.AssetGroupCertificationManual, NodeId: testNodeId2, NodeName: test1Selector.Name, Note: testNote}
 		sort               = make(model.Sort, 0)
 	)
-	_, err := suite.BHDatabase.CreateAssetGroupTagSelector(testCtx, testAssetGroupTagId1, model.User{}, test1Selector.Name, test1Selector.Description, isDefault, allowDisable, autoCertify, test1Selector.Seeds)
+	_, err := createAssetGroupTagSelector(suite.BHDatabase, testCtx, testAssetGroupTagId1, model.User{}, test1Selector.Name, test1Selector.Description, isDefault, allowDisable, autoCertify, test1Selector.Seeds, null.String{})
 	require.NoError(t, err)
 
 	// insert selector nodes
@@ -1954,9 +2246,10 @@ func TestDatabase_DeleteSelectorNodes(t *testing.T) {
 func createUpdateSelectorNodesTestSelector(t *testing.T, ctx context.Context, bloodhoundDatabase *database.BloodhoundDB, testActor model.User, name string) model.AssetGroupTagSelector {
 	t.Helper()
 
-	selector, err := bloodhoundDatabase.CreateAssetGroupTagSelector(ctx, 1, testActor, name, "test description", false, true, model.SelectorAutoCertifyMethodDisabled, []model.SelectorSeed{
+	selector, err := createAssetGroupTagSelector(bloodhoundDatabase, ctx, 1, testActor, name, "test description", false, true, model.SelectorAutoCertifyMethodDisabled, []model.SelectorSeed{
 		{Type: model.SelectorTypeObjectId, Value: name + " object id"},
-	})
+	}, null.String{})
+
 	require.NoError(t, err)
 
 	return selector
@@ -2078,7 +2371,7 @@ func TestDatabase_GetAssetGroupSelectorNodeExpandedOrderedByIdAndPosition(t *tes
 	tierTag, err := suite.BHDatabase.CreateAssetGroupTag(testCtx, model.AssetGroupTagTypeTier, model.User{}, "tier 1", testDescription, null.Int32From(2), null.BoolFrom(false), null.String{})
 	require.NoError(t, err)
 
-	selector, err := suite.BHDatabase.CreateAssetGroupTagSelector(testCtx, tierTag.ID, testActor, testName, testDescription, isDefault, allowDisable, autoCertify, testSeeds)
+	selector, err := createAssetGroupTagSelector(suite.BHDatabase, testCtx, tierTag.ID, testActor, testName, testDescription, isDefault, allowDisable, autoCertify, testSeeds, null.String{})
 	require.NoError(t, err)
 
 	insertAssetGroupSelectorNodes(t, testCtx, suite.BHDatabase,
@@ -2156,22 +2449,22 @@ func TestDatabase_GetAggregatedSelectorNodesCertification(t *testing.T) {
 	require.NoError(t, err)
 
 	// Zone 0 is added by the migration and is ID 1
-	sel0, err := suite.BHDatabase.CreateAssetGroupTagSelector(testCtx, 1, model.User{}, "Test T0 selector", "description", false, true, model.SelectorAutoCertifyMethodDisabled, []model.SelectorSeed{})
+	sel0, err := createAssetGroupTagSelector(suite.BHDatabase, testCtx, 1, model.User{}, "Test T0 selector", "description", false, true, model.SelectorAutoCertifyMethodDisabled, []model.SelectorSeed{}, null.String{})
 	require.NoError(t, err)
 
-	sel0_1, err := suite.BHDatabase.CreateAssetGroupTagSelector(testCtx, 1, model.User{}, "Test T0 selector number 2", "description", false, true, model.SelectorAutoCertifyMethodDisabled, []model.SelectorSeed{})
+	sel0_1, err := createAssetGroupTagSelector(suite.BHDatabase, testCtx, 1, model.User{}, "Test T0 selector number 2", "description", false, true, model.SelectorAutoCertifyMethodDisabled, []model.SelectorSeed{}, null.String{})
 	require.NoError(t, err)
 
-	sel0_2, err := suite.BHDatabase.CreateAssetGroupTagSelector(testCtx, 1, model.User{}, "Test T0 selector number 3", "description", false, true, model.SelectorAutoCertifyMethodDisabled, []model.SelectorSeed{})
+	sel0_2, err := createAssetGroupTagSelector(suite.BHDatabase, testCtx, 1, model.User{}, "Test T0 selector number 3", "description", false, true, model.SelectorAutoCertifyMethodDisabled, []model.SelectorSeed{}, null.String{})
 	require.NoError(t, err)
 
-	sel0_3, err := suite.BHDatabase.CreateAssetGroupTagSelector(testCtx, 1, model.User{}, "Test T0 selector number 4", "description", false, true, model.SelectorAutoCertifyMethodDisabled, []model.SelectorSeed{})
+	sel0_3, err := createAssetGroupTagSelector(suite.BHDatabase, testCtx, 1, model.User{}, "Test T0 selector number 4", "description", false, true, model.SelectorAutoCertifyMethodDisabled, []model.SelectorSeed{}, null.String{})
 	require.NoError(t, err)
 
-	sel1, err := suite.BHDatabase.CreateAssetGroupTagSelector(testCtx, tier1.ID, model.User{}, "Test T1 selector", "description", false, true, model.SelectorAutoCertifyMethodDisabled, []model.SelectorSeed{})
+	sel1, err := createAssetGroupTagSelector(suite.BHDatabase, testCtx, tier1.ID, model.User{}, "Test T1 selector", "description", false, true, model.SelectorAutoCertifyMethodDisabled, []model.SelectorSeed{}, null.String{})
 	require.NoError(t, err)
 
-	sel2, err := suite.BHDatabase.CreateAssetGroupTagSelector(testCtx, tier2.ID, model.User{}, "Test T2 selector", "description", false, true, model.SelectorAutoCertifyMethodDisabled, []model.SelectorSeed{})
+	sel2, err := createAssetGroupTagSelector(suite.BHDatabase, testCtx, tier2.ID, model.User{}, "Test T2 selector", "description", false, true, model.SelectorAutoCertifyMethodDisabled, []model.SelectorSeed{}, null.String{})
 	require.NoError(t, err)
 
 	t.Run("Multiple nodes - verify highest tier wins", func(t *testing.T) {

--- a/cmd/api/src/database/assetgrouptags_integration_test.go
+++ b/cmd/api/src/database/assetgrouptags_integration_test.go
@@ -1348,17 +1348,21 @@ func TestDatabase_GetAssetGroupTagSelectors(t *testing.T) {
 }
 
 func TestDatabase_GetAssetGroupTagSelectorsByExtensionId(t *testing.T) {
+	t.Parallel()
 
 	type testSetupData struct {
 		extensionId   int32
+		extensionIds  []int32
 		expectedCount int
 		expected      map[string]model.AssetGroupTagSelector
+		db            *database.BloodhoundDB
 	}
 
 	type testCase struct {
-		name   string
-		setup  func(t *testing.T, testSuite IntegrationTestSuite) testSetupData
-		assert func(t *testing.T, setupData testSetupData, selectors model.AssetGroupTagSelectors, err error)
+		name     string
+		setup    func(t *testing.T, testSuite IntegrationTestSuite) testSetupData
+		assert   func(t *testing.T, setupData testSetupData, selectors model.AssetGroupTagSelectors, err error)
+		teardown func(t *testing.T, testSuite IntegrationTestSuite, setupData testSetupData)
 	}
 
 	assertSelectors := func(t *testing.T, setupData testSetupData, selectors model.AssetGroupTagSelectors, err error) {
@@ -1381,6 +1385,23 @@ func TestDatabase_GetAssetGroupTagSelectorsByExtensionId(t *testing.T) {
 			assert.Equal(t, model.AssetGroupActorOpenGraphExtensionManagement, selector.UpdatedBy)
 			assert.NotZero(t, selector.ID)
 		}
+	}
+
+	teardownExtensions := func(t *testing.T, testSuite IntegrationTestSuite, setupData testSetupData) {
+		t.Helper()
+		for _, extensionId := range setupData.extensionIds {
+			// ON DELETE CASCADE removes the extension's selectors
+			assert.NoError(t, testSuite.BHDatabase.DeleteGraphSchemaExtension(testSuite.Context, extensionId))
+			selectors, err := testSuite.BHDatabase.GetAssetGroupTagSelectorsByExtensionId(testSuite.Context, extensionId)
+			assert.NoError(t, err)
+			assert.Empty(t, selectors)
+		}
+	}
+
+	assertError := func(t *testing.T, setupData testSetupData, selectors model.AssetGroupTagSelectors, err error) {
+		t.Helper()
+		require.Error(t, err)
+		assert.Empty(t, selectors)
 	}
 
 	tests := []testCase{
@@ -1406,9 +1427,10 @@ func TestDatabase_GetAssetGroupTagSelectorsByExtensionId(t *testing.T) {
 					require.NoError(t, err)
 					expected[input.RuleKey.String] = input
 				}
-				return testSetupData{extensionId: extension.ID, expectedCount: 2, expected: expected}
+				return testSetupData{extensionId: extension.ID, extensionIds: []int32{extension.ID}, expectedCount: 2, expected: expected}
 			},
-			assert: assertSelectors,
+			assert:   assertSelectors,
+			teardown: teardownExtensions,
 		},
 		{
 			name: "success_-_returns_only_selectors_for_requested_extension",
@@ -1447,11 +1469,13 @@ func TestDatabase_GetAssetGroupTagSelectorsByExtensionId(t *testing.T) {
 
 				return testSetupData{
 					extensionId:   targetExtension.ID,
+					extensionIds:  []int32{targetExtension.ID, otherExtension.ID},
 					expectedCount: 1,
 					expected:      map[string]model.AssetGroupTagSelector{targetInput.RuleKey.String: targetInput},
 				}
 			},
-			assert: assertSelectors,
+			assert:   assertSelectors,
+			teardown: teardownExtensions,
 		},
 		{
 			name: "success_-_returns_empty_for_extension_with_no_selectors",
@@ -1459,19 +1483,37 @@ func TestDatabase_GetAssetGroupTagSelectorsByExtensionId(t *testing.T) {
 				t.Helper()
 				extension, err := testSuite.BHDatabase.CreateGraphSchemaExtension(testSuite.Context, "test_ext_no_selectors", "Test Ext No Selectors", "v1.0.0", "test_ext_ns")
 				require.NoError(t, err)
-				return testSetupData{extensionId: extension.ID, expectedCount: 0, expected: map[string]model.AssetGroupTagSelector{}}
+				return testSetupData{extensionId: extension.ID, extensionIds: []int32{extension.ID}, expectedCount: 0, expected: map[string]model.AssetGroupTagSelector{}}
 			},
-			assert: assertSelectors,
+			assert:   assertSelectors,
+			teardown: teardownExtensions,
+		},
+		{
+			name: "error_-_returns_error_on_closed_connection",
+			setup: func(t *testing.T, testSuite IntegrationTestSuite) testSetupData {
+				t.Helper()
+				closedSuite := setupIntegrationTestSuite(t)
+				teardownIntegrationTestSuite(t, &closedSuite)
+				return testSetupData{db: closedSuite.BHDatabase}
+			},
+			assert: assertError,
 		},
 	}
 
+	testSuite := setupIntegrationTestSuite(t)
+	defer teardownIntegrationTestSuite(t, &testSuite)
+
 	for _, testCase := range tests {
 		t.Run(testCase.name, func(t *testing.T) {
-			testSuite := setupIntegrationTestSuite(t)
-			defer teardownIntegrationTestSuite(t, &testSuite)
-
 			setupData := testCase.setup(t, testSuite)
-			selectors, err := testSuite.BHDatabase.GetAssetGroupTagSelectorsByExtensionId(testSuite.Context, setupData.extensionId)
+			if testCase.teardown != nil {
+				defer testCase.teardown(t, testSuite, setupData)
+			}
+			queryDB := testSuite.BHDatabase
+			if setupData.db != nil {
+				queryDB = setupData.db
+			}
+			selectors, err := queryDB.GetAssetGroupTagSelectorsByExtensionId(testSuite.Context, setupData.extensionId)
 			testCase.assert(t, setupData, selectors, err)
 		})
 	}

--- a/cmd/api/src/database/assetgrouptags_integration_test.go
+++ b/cmd/api/src/database/assetgrouptags_integration_test.go
@@ -20,6 +20,7 @@ package database_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"sort"
@@ -29,6 +30,7 @@ import (
 	"time"
 
 	"github.com/gofrs/uuid"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/specterops/bloodhound/cmd/api/src/database"
 	"github.com/specterops/bloodhound/cmd/api/src/database/types/null"
 	"github.com/specterops/bloodhound/cmd/api/src/model"
@@ -41,6 +43,8 @@ import (
 type assetGroupTagSelectorCreator interface {
 	CreateAssetGroupTagSelector(context.Context, model.User, model.AssetGroupTagSelector) (model.AssetGroupTagSelector, error)
 }
+
+const assetGroupTagSelectorsRuleKeyExtensionIDCheckConstraint = "asset_group_tag_selectors_rule_key_extension_id_check"
 
 func createAssetGroupTagSelector(databaseInterface assetGroupTagSelectorCreator, ctx context.Context, assetGroupTagId int, user model.User, name string, description string, isDefault bool, allowDisable bool, autoCertify model.SelectorAutoCertifyMethod, seeds []model.SelectorSeed, ruleKey null.String) (model.AssetGroupTagSelector, error) {
 	return databaseInterface.CreateAssetGroupTagSelector(ctx, user, model.AssetGroupTagSelector{
@@ -61,6 +65,15 @@ func createOpenGraphSelectorForTest(databaseInterface assetGroupTagSelectorCreat
 	input.ExtensionId = null.Int32From(extensionId)
 
 	return databaseInterface.CreateAssetGroupTagSelector(ctx, model.User{PrincipalName: model.AssetGroupActorOpenGraphExtensionManagement}, input)
+}
+
+func assertAssetGroupTagSelectorConstraintError(t *testing.T, err error, expectedConstraint string) {
+	t.Helper()
+
+	var pgErr *pgconn.PgError
+	require.Error(t, err)
+	require.True(t, errors.As(err, &pgErr), "expected wrapped *pgconn.PgError, got %T: %v", err, err)
+	assert.Equal(t, expectedConstraint, pgErr.ConstraintName)
 }
 
 func TestDatabase_CreateAssetGroupTagSelector(t *testing.T) {
@@ -108,26 +121,39 @@ func TestDatabase_CreateAssetGroupTagSelector(t *testing.T) {
 func TestDatabase_CreateAssetGroupTagSelectorRuleKey(t *testing.T) {
 	t.Parallel()
 	var (
-		dbInst    = integration.SetupDB(t).(*database.BloodhoundDB)
-		testCtx   = context.Background()
-		testActor = model.User{Unique: model.Unique{ID: uuid.FromStringOrNil("01234567-9012-4567-9012-456789012345")}}
-		testSeeds = []model.SelectorSeed{
-			{Type: model.SelectorTypeObjectId, Value: "ObjectID1234"},
+		dbInst  = integration.SetupDB(t).(*database.BloodhoundDB)
+		testCtx = context.Background()
+		input   = model.AssetGroupTagSelector{
+			RuleKey:      null.StringFrom("test.rule"),
+			Name:         "test selector with rule key",
+			Description:  "test description",
+			AutoCertify:  model.SelectorAutoCertifyMethodDisabled,
+			AllowDisable: true,
+			Seeds: []model.SelectorSeed{
+				{Type: model.SelectorTypeObjectId, Value: "ObjectID1234"},
+			},
 		}
 	)
 
-	selector, err := createAssetGroupTagSelector(dbInst, testCtx, 1, testActor, "test selector with rule key", "test description", false, true, model.SelectorAutoCertifyMethodDisabled, testSeeds, null.StringFrom("test.rule"))
+	extension, err := dbInst.CreateGraphSchemaExtension(testCtx, "test_selector_rule_key_extension", "Test Selector Rule Key Extension", "v1.0.0", "test_rk")
+	require.NoError(t, err)
+
+	selector, err := createOpenGraphSelectorForTest(dbInst, testCtx, extension.ID, input)
 	require.NoError(t, err)
 	require.True(t, selector.RuleKey.Valid)
 	require.Equal(t, "test.rule", selector.RuleKey.String)
+	require.True(t, selector.ExtensionId.Valid)
+	require.Equal(t, extension.ID, selector.ExtensionId.Int32)
 
 	gotSelector, err := dbInst.GetAssetGroupTagSelectorBySelectorId(testCtx, selector.ID)
 	require.NoError(t, err)
 	require.True(t, gotSelector.RuleKey.Valid)
 	require.Equal(t, "test.rule", gotSelector.RuleKey.String)
+	require.True(t, gotSelector.ExtensionId.Valid)
+	require.Equal(t, extension.ID, gotSelector.ExtensionId.Int32)
 }
 
-func TestDatabase_CreateAssetGroupTagSelectorDuplicateRuleKey(t *testing.T) {
+func TestDatabase_CreateAssetGroupTagSelectorRequiresRuleKeyAndExtensionIDTogether(t *testing.T) {
 	t.Parallel()
 	var (
 		dbInst    = integration.SetupDB(t).(*database.BloodhoundDB)
@@ -138,13 +164,55 @@ func TestDatabase_CreateAssetGroupTagSelectorDuplicateRuleKey(t *testing.T) {
 		}
 	)
 
-	label, err := dbInst.CreateAssetGroupTag(testCtx, model.AssetGroupTagTypeLabel, testActor, "test label", "test label description", null.Int32{}, null.Bool{}, null.String{})
+	extension, err := dbInst.CreateGraphSchemaExtension(testCtx, "test_selector_check_extension", "Test Selector Check Extension", "v1.0.0", "test_chk")
 	require.NoError(t, err)
 
-	_, err = createAssetGroupTagSelector(dbInst, testCtx, 1, testActor, "test selector with rule key", "test description", false, true, model.SelectorAutoCertifyMethodDisabled, testSeeds, null.StringFrom("test.rule"))
+	_, err = createAssetGroupTagSelector(dbInst, testCtx, 1, testActor, "test selector with rule key only", "test description", false, true, model.SelectorAutoCertifyMethodDisabled, testSeeds, null.StringFrom("test.rule.only"))
+	assertAssetGroupTagSelectorConstraintError(t, err, assetGroupTagSelectorsRuleKeyExtensionIDCheckConstraint)
+
+	_, err = dbInst.CreateAssetGroupTagSelector(testCtx, testActor, model.AssetGroupTagSelector{
+		AssetGroupTagId: 1,
+		ExtensionId:     null.Int32From(extension.ID),
+		Name:            "test selector with extension id only",
+		Description:     "test description",
+		AllowDisable:    true,
+		AutoCertify:     model.SelectorAutoCertifyMethodDisabled,
+		Seeds:           testSeeds,
+	})
+	assertAssetGroupTagSelectorConstraintError(t, err, assetGroupTagSelectorsRuleKeyExtensionIDCheckConstraint)
+}
+
+func TestDatabase_CreateAssetGroupTagSelectorRuleKeyIsUniquePerExtension(t *testing.T) {
+	t.Parallel()
+	var (
+		dbInst  = integration.SetupDB(t).(*database.BloodhoundDB)
+		testCtx = context.Background()
+		input   = model.AssetGroupTagSelector{
+			RuleKey:      null.StringFrom("test.rule"),
+			Name:         "test selector with rule key",
+			Description:  "test description",
+			AutoCertify:  model.SelectorAutoCertifyMethodDisabled,
+			AllowDisable: true,
+			Seeds: []model.SelectorSeed{
+				{Type: model.SelectorTypeObjectId, Value: "ObjectID1234"},
+			},
+		}
+	)
+
+	extension, err := dbInst.CreateGraphSchemaExtension(testCtx, "test_selector_unique_extension", "Test Selector Unique Extension", "v1.0.0", "test_unq")
+	require.NoError(t, err)
+	otherExtension, err := dbInst.CreateGraphSchemaExtension(testCtx, "test_selector_unique_other_extension", "Test Selector Unique Other Extension", "v1.0.0", "test_unq_oth")
 	require.NoError(t, err)
 
-	_, err = createAssetGroupTagSelector(dbInst, testCtx, label.ID, testActor, "test selector with duplicate rule key", "test description", false, true, model.SelectorAutoCertifyMethodDisabled, testSeeds, null.StringFrom("test.rule"))
+	_, err = createOpenGraphSelectorForTest(dbInst, testCtx, extension.ID, input)
+	require.NoError(t, err)
+
+	input.Name = "test selector with same rule key in other extension"
+	_, err = createOpenGraphSelectorForTest(dbInst, testCtx, otherExtension.ID, input)
+	require.NoError(t, err)
+
+	input.Name = "test selector with duplicate rule key in same extension"
+	_, err = createOpenGraphSelectorForTest(dbInst, testCtx, extension.ID, input)
 	require.ErrorIs(t, err, database.ErrDuplicateAGTagSelectorRuleKey)
 }
 

--- a/cmd/api/src/database/db.go
+++ b/cmd/api/src/database/db.go
@@ -46,16 +46,17 @@ var (
 )
 
 var (
-	ErrDuplicateAGName             = errors.New("duplicate asset group name")
-	ErrDuplicateAGTag              = errors.New("duplicate asset group tag")
-	ErrDuplicateAGTagSelectorName  = errors.New("duplicate asset group tag selector name")
-	ErrDuplicateSSOProviderName    = errors.New("duplicate sso provider name")
-	ErrDuplicateUserPrincipal      = errors.New("duplicate user principal name")
-	ErrDuplicateEmail              = errors.New("duplicate user email address")
-	ErrDuplicateCustomNodeKindName = errors.New("duplicate custom node kind name")
-	ErrDuplicateKindName           = errors.New("duplicate kind name")
-	ErrDuplicateGlyph              = errors.New("duplicate glyph")
-	ErrPositionOutOfRange          = errors.New("position out of range")
+	ErrDuplicateAGName               = errors.New("duplicate asset group name")
+	ErrDuplicateAGTag                = errors.New("duplicate asset group tag")
+	ErrDuplicateAGTagSelectorName    = errors.New("duplicate asset group tag selector name")
+	ErrDuplicateAGTagSelectorRuleKey = errors.New("duplicate asset group tag selector rule key")
+	ErrDuplicateSSOProviderName      = errors.New("duplicate sso provider name")
+	ErrDuplicateUserPrincipal        = errors.New("duplicate user principal name")
+	ErrDuplicateEmail                = errors.New("duplicate user email address")
+	ErrDuplicateCustomNodeKindName   = errors.New("duplicate custom node kind name")
+	ErrDuplicateKindName             = errors.New("duplicate kind name")
+	ErrDuplicateGlyph                = errors.New("duplicate glyph")
+	ErrPositionOutOfRange            = errors.New("position out of range")
 )
 
 func IsUnexpectedDatabaseError(err error) bool {

--- a/cmd/api/src/database/migration/migrations/20260814142955_v9_add_asset_group_tag_selector_extension_ownership.sql
+++ b/cmd/api/src/database/migration/migrations/20260814142955_v9_add_asset_group_tag_selector_extension_ownership.sql
@@ -37,9 +37,28 @@ BEGIN
 END $$;
 -- +goose StatementEnd
 
--- index for looking up selectors by rule_key and ensuring uniqueness of rule_key
+-- require rule_key and extension_id to be populated together
+-- +goose StatementBegin
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'asset_group_tag_selectors_rule_key_extension_id_check'
+    ) THEN
+        ALTER TABLE asset_group_tag_selectors
+            ADD CONSTRAINT asset_group_tag_selectors_rule_key_extension_id_check
+            CHECK (
+                (rule_key IS NULL AND extension_id IS NULL)
+                OR (rule_key IS NOT NULL AND extension_id IS NOT NULL)
+            );
+    END IF;
+END $$;
+-- +goose StatementEnd
+
+-- index for looking up selectors by rule_key and ensuring uniqueness of rule_key per extension
 CREATE UNIQUE INDEX IF NOT EXISTS idx_asset_group_tag_selectors_rule_key
-    ON asset_group_tag_selectors (rule_key)
+    ON asset_group_tag_selectors (rule_key, extension_id)
     WHERE rule_key IS NOT NULL;
 
 -- index for looking up selectors by extension_id
@@ -52,5 +71,6 @@ DROP INDEX IF EXISTS idx_asset_group_tag_selectors_rule_key;
 
 ALTER TABLE asset_group_tag_selectors
     DROP CONSTRAINT IF EXISTS asset_group_tag_selectors_extension_id_fkey,
+    DROP CONSTRAINT IF EXISTS asset_group_tag_selectors_rule_key_extension_id_check,
     DROP COLUMN IF EXISTS extension_id,
     DROP COLUMN IF EXISTS rule_key;

--- a/cmd/api/src/database/migration/migrations/20260814142955_v9_add_asset_group_tag_selector_extension_ownership.sql
+++ b/cmd/api/src/database/migration/migrations/20260814142955_v9_add_asset_group_tag_selector_extension_ownership.sql
@@ -1,0 +1,56 @@
+-- Copyright 2026 Specter Ops, Inc.
+--
+-- Licensed under the Apache License, Version 2.0
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- SPDX-License-Identifier: Apache-2.0
+
+-- +goose Up
+ALTER TABLE asset_group_tag_selectors
+    ADD COLUMN IF NOT EXISTS rule_key text,
+    ADD COLUMN IF NOT EXISTS extension_id integer;
+
+-- idempotent-ly add foreign key constraint to extension_id column
+-- +goose StatementBegin
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'asset_group_tag_selectors_extension_id_fkey'
+    ) THEN
+        ALTER TABLE asset_group_tag_selectors
+            ADD CONSTRAINT asset_group_tag_selectors_extension_id_fkey
+            FOREIGN KEY (extension_id)
+            REFERENCES schema_extensions(id)
+            ON DELETE CASCADE;
+    END IF;
+END $$;
+-- +goose StatementEnd
+
+-- index for looking up selectors by rule_key and ensuring uniqueness of rule_key
+CREATE UNIQUE INDEX IF NOT EXISTS idx_asset_group_tag_selectors_rule_key
+    ON asset_group_tag_selectors (rule_key)
+    WHERE rule_key IS NOT NULL;
+
+-- index for looking up selectors by extension_id
+CREATE INDEX IF NOT EXISTS idx_asset_group_tag_selectors_extension_id
+    ON asset_group_tag_selectors (extension_id);
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_asset_group_tag_selectors_extension_id;
+DROP INDEX IF EXISTS idx_asset_group_tag_selectors_rule_key;
+
+ALTER TABLE asset_group_tag_selectors
+    DROP CONSTRAINT IF EXISTS asset_group_tag_selectors_extension_id_fkey,
+    DROP COLUMN IF EXISTS extension_id,
+    DROP COLUMN IF EXISTS rule_key;

--- a/cmd/api/src/database/mocks/db.go
+++ b/cmd/api/src/database/mocks/db.go
@@ -208,18 +208,18 @@ func (mr *MockDatabaseMockRecorder) CreateAssetGroupTag(ctx, tagType, user, name
 }
 
 // CreateAssetGroupTagSelector mocks base method.
-func (m *MockDatabase) CreateAssetGroupTagSelector(ctx context.Context, assetGroupTagId int, user model.User, name, description string, isDefault, allowDisable bool, autoCertify model.SelectorAutoCertifyMethod, seeds []model.SelectorSeed) (model.AssetGroupTagSelector, error) {
+func (m *MockDatabase) CreateAssetGroupTagSelector(ctx context.Context, user model.User, selector model.AssetGroupTagSelector) (model.AssetGroupTagSelector, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateAssetGroupTagSelector", ctx, assetGroupTagId, user, name, description, isDefault, allowDisable, autoCertify, seeds)
+	ret := m.ctrl.Call(m, "CreateAssetGroupTagSelector", ctx, user, selector)
 	ret0, _ := ret[0].(model.AssetGroupTagSelector)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateAssetGroupTagSelector indicates an expected call of CreateAssetGroupTagSelector.
-func (mr *MockDatabaseMockRecorder) CreateAssetGroupTagSelector(ctx, assetGroupTagId, user, name, description, isDefault, allowDisable, autoCertify, seeds any) *gomock.Call {
+func (mr *MockDatabaseMockRecorder) CreateAssetGroupTagSelector(ctx, user, selector any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAssetGroupTagSelector", reflect.TypeOf((*MockDatabase)(nil).CreateAssetGroupTagSelector), ctx, assetGroupTagId, user, name, description, isDefault, allowDisable, autoCertify, seeds)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAssetGroupTagSelector", reflect.TypeOf((*MockDatabase)(nil).CreateAssetGroupTagSelector), ctx, user, selector)
 }
 
 // CreateAuditLog mocks base method.
@@ -1622,6 +1622,21 @@ func (m *MockDatabase) GetAssetGroupTagSelectors(ctx context.Context, sqlFilter 
 func (mr *MockDatabaseMockRecorder) GetAssetGroupTagSelectors(ctx, sqlFilter, limit any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAssetGroupTagSelectors", reflect.TypeOf((*MockDatabase)(nil).GetAssetGroupTagSelectors), ctx, sqlFilter, limit)
+}
+
+// GetAssetGroupTagSelectorsByExtensionId mocks base method.
+func (m *MockDatabase) GetAssetGroupTagSelectorsByExtensionId(ctx context.Context, extensionId int32) (model.AssetGroupTagSelectors, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAssetGroupTagSelectorsByExtensionId", ctx, extensionId)
+	ret0, _ := ret[0].(model.AssetGroupTagSelectors)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetAssetGroupTagSelectorsByExtensionId indicates an expected call of GetAssetGroupTagSelectorsByExtensionId.
+func (mr *MockDatabaseMockRecorder) GetAssetGroupTagSelectorsByExtensionId(ctx, extensionId any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAssetGroupTagSelectorsByExtensionId", reflect.TypeOf((*MockDatabase)(nil).GetAssetGroupTagSelectorsByExtensionId), ctx, extensionId)
 }
 
 // GetAssetGroupTagSelectorsByTagId mocks base method.

--- a/cmd/api/src/database/mocks/db.go
+++ b/cmd/api/src/database/mocks/db.go
@@ -3537,6 +3537,21 @@ func (mr *MockDatabaseMockRecorder) UpdateOIDCProvider(ctx, ssoProvider any) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateOIDCProvider", reflect.TypeOf((*MockDatabase)(nil).UpdateOIDCProvider), ctx, ssoProvider)
 }
 
+// UpdateOpenGraphAssetGroupTagSelector mocks base method.
+func (m *MockDatabase) UpdateOpenGraphAssetGroupTagSelector(ctx context.Context, extensionId int32, input model.AssetGroupTagSelector) (model.AssetGroupTagSelector, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateOpenGraphAssetGroupTagSelector", ctx, extensionId, input)
+	ret0, _ := ret[0].(model.AssetGroupTagSelector)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateOpenGraphAssetGroupTagSelector indicates an expected call of UpdateOpenGraphAssetGroupTagSelector.
+func (mr *MockDatabaseMockRecorder) UpdateOpenGraphAssetGroupTagSelector(ctx, extensionId, input any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateOpenGraphAssetGroupTagSelector", reflect.TypeOf((*MockDatabase)(nil).UpdateOpenGraphAssetGroupTagSelector), ctx, extensionId, input)
+}
+
 // UpdateRemediation mocks base method.
 func (m *MockDatabase) UpdateRemediation(ctx context.Context, findingId int32, shortDescription, longDescription, shortRemediation, longRemediation string) (model.Remediation, error) {
 	m.ctrl.T.Helper()

--- a/cmd/api/src/database/postgres_errors.go
+++ b/cmd/api/src/database/postgres_errors.go
@@ -1,0 +1,22 @@
+// Copyright 2026 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package database
+
+const (
+	// PostgresUniqueViolationCode is the SQLSTATE code for unique constraint violations.
+	PostgresUniqueViolationCode = "23505"
+)

--- a/cmd/api/src/model/assetgrouptags.go
+++ b/cmd/api/src/model/assetgrouptags.go
@@ -30,9 +30,10 @@ import (
 )
 
 const (
-	AssetGroupActorBloodHound          = "BloodHound"
-	AssetGroupTierZeroPosition         = 1
-	AssetGroupTierHygienePlaceholderId = 0
+	AssetGroupActorBloodHound                   = "BloodHound"
+	AssetGroupActorOpenGraphExtensionManagement = "OpenGraph Extension Management"
+	AssetGroupTierZeroPosition                  = 1
+	AssetGroupTierHygienePlaceholderId          = 0
 )
 
 type SelectorType int
@@ -236,6 +237,8 @@ type AssetGroupTagSelector struct {
 	AutoCertify     SelectorAutoCertifyMethod `json:"auto_certify"`
 	IsDefault       bool                      `json:"is_default"`
 	AllowDisable    bool                      `json:"allow_disable"`
+	RuleKey         null.String               `json:"rule_key"`
+	ExtensionId     null.Int32                `json:"extension_id"`
 
 	Seeds []SelectorSeed `json:"seeds,omitempty" validate:"required" gorm:"-"`
 }
@@ -252,6 +255,7 @@ func (s AssetGroupTagSelector) AuditData() AuditData {
 		"description":        s.Description,
 		"auto_certify":       s.AutoCertify,
 		"is_default":         s.IsDefault,
+		"rule_key":           s.RuleKey.String,
 	}
 }
 

--- a/packages/go/analysis/agt_test.go
+++ b/packages/go/analysis/agt_test.go
@@ -319,8 +319,15 @@ func TestTagAssetGroupNodesForTag(t *testing.T) {
 		tag, err := bhDB.CreateAssetGroupTag(testCtx, model.AssetGroupTagTypeLabel, testActor, "regression label all", "", null.Int32{}, null.Bool{}, null.String{})
 		require.NoError(t, err)
 
-		_, err = bhDB.CreateAssetGroupTagSelector(testCtx, tag.ID, testActor, "regression selector all", "", false, true, model.SelectorAutoCertifyMethodDisabled, []model.SelectorSeed{
-			{Type: model.SelectorTypeObjectId, Value: "REGRESSION-ALL-NO-MATCH"},
+		_, err = bhDB.CreateAssetGroupTagSelector(testCtx, testActor, model.AssetGroupTagSelector{
+			AssetGroupTagId: tag.ID,
+			Name:            "regression selector all",
+			IsDefault:       false,
+			AllowDisable:    true,
+			AutoCertify:     model.SelectorAutoCertifyMethodDisabled,
+			Seeds: []model.SelectorSeed{
+				{Type: model.SelectorTypeObjectId, Value: "REGRESSION-ALL-NO-MATCH"},
+			},
 		})
 		require.NoError(t, err)
 
@@ -368,8 +375,15 @@ func TestTagAssetGroupNodesForTag(t *testing.T) {
 		tag, err := bhDB.CreateAssetGroupTag(testCtx, model.AssetGroupTagTypeLabel, testActor, "regression label mixed", "", null.Int32{}, null.Bool{}, null.String{})
 		require.NoError(t, err)
 
-		selector, err := bhDB.CreateAssetGroupTagSelector(testCtx, tag.ID, testActor, "regression selector mixed", "", false, true, model.SelectorAutoCertifyMethodDisabled, []model.SelectorSeed{
-			{Type: model.SelectorTypeObjectId, Value: "REGRESSION-MIXED-OBJECT-ID-0"},
+		selector, err := bhDB.CreateAssetGroupTagSelector(testCtx, testActor, model.AssetGroupTagSelector{
+			AssetGroupTagId: tag.ID,
+			Name:            "regression selector mixed",
+			IsDefault:       false,
+			AllowDisable:    true,
+			AutoCertify:     model.SelectorAutoCertifyMethodDisabled,
+			Seeds: []model.SelectorSeed{
+				{Type: model.SelectorTypeObjectId, Value: "REGRESSION-MIXED-OBJECT-ID-0"},
+			},
 		})
 		require.NoError(t, err)
 
@@ -441,8 +455,15 @@ func TestTagAssetGroupNodesForTag(t *testing.T) {
 		tag, err := bhDB.CreateAssetGroupTag(testCtx, model.AssetGroupTagTypeTier, testActor, "regression tier", "", null.Int32From(tierPosition), null.Bool{}, null.String{})
 		require.NoError(t, err)
 
-		selector, err := bhDB.CreateAssetGroupTagSelector(testCtx, tag.ID, testActor, "regression tier selector", "", false, true, model.SelectorAutoCertifyMethodDisabled, []model.SelectorSeed{
-			{Type: model.SelectorTypeObjectId, Value: "REGRESSION-TIER-NO-MATCH"},
+		selector, err := bhDB.CreateAssetGroupTagSelector(testCtx, testActor, model.AssetGroupTagSelector{
+			AssetGroupTagId: tag.ID,
+			Name:            "regression tier selector",
+			IsDefault:       false,
+			AllowDisable:    true,
+			AutoCertify:     model.SelectorAutoCertifyMethodDisabled,
+			Seeds: []model.SelectorSeed{
+				{Type: model.SelectorTypeObjectId, Value: "REGRESSION-TIER-NO-MATCH"},
+			},
 		})
 		require.NoError(t, err)
 
@@ -803,14 +824,21 @@ func TestSelectNodes(t *testing.T) {
 
 func insertTagAndTagSelector(t *testing.T, ctx context.Context, bhDB interface {
 	CreateAssetGroupTag(ctx context.Context, assetGroupTagType model.AssetGroupTagType, user model.User, name, description string, position null.Int32, requireCertify null.Bool, glyph null.String) (model.AssetGroupTag, error)
-	CreateAssetGroupTagSelector(ctx context.Context, assetGroupTagId int, user model.User, name string, description string, isDefault bool, allowDisable bool, autoCertify model.SelectorAutoCertifyMethod, seeds []model.SelectorSeed) (model.AssetGroupTagSelector, error)
+	CreateAssetGroupTagSelector(ctx context.Context, user model.User, selector model.AssetGroupTagSelector) (model.AssetGroupTagSelector, error)
 }, testActor model.User, name string, autoCertify model.SelectorAutoCertifyMethod, seeds ...model.SelectorSeed) model.AssetGroupTagSelector {
 	t.Helper()
 
 	tag, err := bhDB.CreateAssetGroupTag(ctx, model.AssetGroupTagTypeLabel, testActor, name+" tag", "", null.Int32{}, null.Bool{}, null.String{})
 	require.NoError(t, err)
 
-	selector, err := bhDB.CreateAssetGroupTagSelector(ctx, tag.ID, testActor, name, "", false, true, autoCertify, seeds)
+	selector, err := bhDB.CreateAssetGroupTagSelector(ctx, testActor, model.AssetGroupTagSelector{
+		AssetGroupTagId: tag.ID,
+		Name:            name,
+		IsDefault:       false,
+		AllowDisable:    true,
+		AutoCertify:     autoCertify,
+		Seeds:           seeds,
+	})
 	require.NoError(t, err)
 
 	return selector

--- a/packages/go/openapi/doc/openapi.json
+++ b/packages/go/openapi/doc/openapi.json
@@ -6168,18 +6168,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/model.asset-group-tags-selector-request"
-                  },
-                  {
-                    "type": "object"
-                  }
-                ],
-                "required": [
-                  "name",
-                  "seeds"
-                ]
+                "$ref": "#/components/schemas/model.asset-group-tags-selector-create-request"
               }
             }
           }
@@ -23244,16 +23233,6 @@
           }
         }
       },
-      "null.time.response": {
-        "type": "string",
-        "nullable": true,
-        "format": "date-time",
-        "description": "An RFC-3339 formatted string"
-      },
-      "null.string.response": {
-        "type": "string",
-        "nullable": true
-      },
       "model.asset-group-tags-selector-seed": {
         "type": "object",
         "properties": {
@@ -23271,35 +23250,9 @@
           }
         }
       },
-      "model.asset-group-tags-selector-response": {
+      "model.asset-group-tags-selector-base": {
         "type": "object",
         "properties": {
-          "id": {
-            "type": "integer"
-          },
-          "asset_group_tag_id": {
-            "type": "integer"
-          },
-          "created_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "created_by": {
-            "type": "string"
-          },
-          "updated_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "updated_by": {
-            "type": "string"
-          },
-          "disabled_at": {
-            "$ref": "#/components/schemas/null.time.response"
-          },
-          "disabled_by": {
-            "$ref": "#/components/schemas/null.string.response"
-          },
           "name": {
             "type": "string"
           },
@@ -23315,12 +23268,6 @@
             ],
             "description": "auto_certify must be an input value of 0 (Disabled), 1 (AllMembers), or 2 (SeedsOnly)"
           },
-          "is_default": {
-            "type": "boolean"
-          },
-          "allow_disable": {
-            "type": "boolean"
-          },
           "seeds": {
             "type": "array",
             "items": {
@@ -23328,6 +23275,74 @@
             }
           }
         }
+      },
+      "null.time.response": {
+        "type": "string",
+        "nullable": true,
+        "format": "date-time",
+        "description": "An RFC-3339 formatted string"
+      },
+      "null.string.response": {
+        "type": "string",
+        "nullable": true
+      },
+      "model.asset-group-tags-selector-response": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/model.asset-group-tags-selector-base"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "integer"
+              },
+              "asset_group_tag_id": {
+                "type": "integer"
+              },
+              "created_at": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "created_by": {
+                "type": "string"
+              },
+              "updated_at": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "updated_by": {
+                "type": "string"
+              },
+              "disabled_at": {
+                "$ref": "#/components/schemas/null.time.response"
+              },
+              "disabled_by": {
+                "$ref": "#/components/schemas/null.string.response"
+              },
+              "is_default": {
+                "type": "boolean"
+              },
+              "allow_disable": {
+                "type": "boolean"
+              },
+              "rule_key": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/null.string.response"
+                  }
+                ],
+                "readOnly": true
+              },
+              "extension_id": {
+                "type": "integer",
+                "format": "int32",
+                "nullable": true,
+                "readOnly": true
+              }
+            }
+          }
+        ]
       },
       "api.params.predicate.filter.integer-strict": {
         "type": "string",
@@ -23392,26 +23407,25 @@
           "type": "string"
         }
       },
+      "model.asset-group-tags-selector-create-request": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/model.asset-group-tags-selector-base"
+          }
+        ],
+        "required": [
+          "name",
+          "seeds"
+        ]
+      },
       "model.asset-group-tags-selector-request": {
         "allOf": [
           {
-            "$ref": "#/components/schemas/model.asset-group-tags-selector-response"
+            "$ref": "#/components/schemas/model.asset-group-tags-selector-base"
           },
           {
             "type": "object",
             "properties": {
-              "auto_certify": {
-                "type": "integer",
-                "enum": [
-                  0,
-                  1,
-                  2
-                ],
-                "description": "auto_certify must be an input value of 0 (Disabled), 1 (AllMembers), or 2 (SeedsOnly)"
-              },
-              "description": {
-                "type": "string"
-              },
               "disabled": {
                 "type": "boolean"
               }

--- a/packages/go/openapi/src/paths/asset-isolation.asset-group-tags.id.selectors.yaml
+++ b/packages/go/openapi/src/paths/asset-isolation.asset-group-tags.id.selectors.yaml
@@ -156,12 +156,7 @@ post:
     content:
       application/json:
         schema:
-          allOf:
-            - $ref: './../schemas/model.asset-group-tags-selector-request.yaml'
-            - type: object
-          required: 
-            - name
-            - seeds
+          $ref: './../schemas/model.asset-group-tags-selector-create-request.yaml'
 
   responses:
     201:

--- a/packages/go/openapi/src/schemas/model.asset-group-tags-selector-base.yaml
+++ b/packages/go/openapi/src/schemas/model.asset-group-tags-selector-base.yaml
@@ -14,9 +14,17 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-allOf:
-  - $ref: './model.asset-group-tags-selector-base.yaml'
-  - type: object
-    properties:
-      disabled:
-        type: boolean
+type: object
+properties:
+  name:
+    type: string
+  description:
+    type: string
+  auto_certify:
+    type: integer
+    enum: [0,1,2]
+    description: auto_certify must be an input value of 0 (Disabled), 1 (AllMembers), or 2 (SeedsOnly)
+  seeds:
+    type: array
+    items:
+      $ref: './model.asset-group-tags-selector-seed.yaml'

--- a/packages/go/openapi/src/schemas/model.asset-group-tags-selector-create-request.yaml
+++ b/packages/go/openapi/src/schemas/model.asset-group-tags-selector-create-request.yaml
@@ -16,7 +16,6 @@
 
 allOf:
   - $ref: './model.asset-group-tags-selector-base.yaml'
-  - type: object
-    properties:
-      disabled:
-        type: boolean
+required:
+  - name
+  - seeds

--- a/packages/go/openapi/src/schemas/model.asset-group-tags-selector-response.yaml
+++ b/packages/go/openapi/src/schemas/model.asset-group-tags-selector-response.yaml
@@ -14,39 +14,38 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-type: object
-properties:
-  id:
-    type: integer
-  asset_group_tag_id:
-    type: integer
-  created_at:
-    type: string
-    format: date-time
-  created_by:
-    type: string
-  updated_at:
-    type: string
-    format: date-time
-  updated_by:
-    type: string
-  disabled_at:
-    $ref: './null.time.response.yaml'
-  disabled_by:
-    $ref: './null.string.response.yaml'
-  name:
-    type: string
-  description:
-    type: string
-  auto_certify:
-    type: integer
-    enum: [0,1,2]
-    description: auto_certify must be an input value of 0 (Disabled), 1 (AllMembers), or 2 (SeedsOnly)
-  is_default:
-    type: boolean
-  allow_disable:
-    type: boolean
-  seeds:
-    type: array
-    items:
-      $ref: './../schemas/model.asset-group-tags-selector-seed.yaml'
+allOf:
+  - $ref: './model.asset-group-tags-selector-base.yaml'
+  - type: object
+    properties:
+      id:
+        type: integer
+      asset_group_tag_id:
+        type: integer
+      created_at:
+        type: string
+        format: date-time
+      created_by:
+        type: string
+      updated_at:
+        type: string
+        format: date-time
+      updated_by:
+        type: string
+      disabled_at:
+        $ref: './null.time.response.yaml'
+      disabled_by:
+        $ref: './null.string.response.yaml'
+      is_default:
+        type: boolean
+      allow_disable:
+        type: boolean
+      rule_key:
+        allOf:
+          - $ref: './null.string.response.yaml'
+        readOnly: true
+      extension_id:
+        type: integer
+        format: int32
+        nullable: true
+        readOnly: true


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description
Adds DB helpers for creating, updating, and deleting rules from extension management. These changes add a rule_key and extension_id to the asset_group_tag_selector model. Those fields shouldnt be undateable from API routes for now so the create/update selector handlers identify those fields as read only.

This changeset also includes a fix to then OpenAPI spec create selector documentation.

Shoutout to @LawsonWillard for helping with GetByExtensionId and fixing tests!!

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-9331

Supporting OpenGraph Extension Management integration with Privilege Zone rules.

## How Has This Been Tested?

Unit test, integration tests, and manually regression testing the API endpoint handler changes.

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)
- New feature (non-breaking change which adds functionality)
- Database Migrations

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Asset-group tag selectors support extension ownership and rule keys.
  * Selector responses include read-only `extension_id` and `rule_key` fields.
  * OpenGraph-managed selectors support updates, retrieval, removal, and lifecycle tracking.
  * Selectors can be retrieved by extension ID.

* **Bug Fixes**
  * Improved handling for duplicate selector names and rule keys.
  * Prevented attempts to set read-only ownership fields during creation or updates.

* **Documentation**
  * Updated API schemas for selector creation requests, general requests, and responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->