### PR TITLE
test(a11y): quick upload dialog & date range coverage - BED-8641

### DIFF
--- a/cmd/ui/tests/a11y/Shared/date-range.a11y.spec.ts
+++ b/cmd/ui/tests/a11y/Shared/date-range.a11y.spec.ts
@@ -1,0 +1,166 @@
+// Copyright 2026 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { hideBySelector } from 'bh-playwright-testing/axe';
+import { expectNoAccessibilityViolations, test } from '../../fixtures';
+
+test.describe('Date Range', () => {
+    test.beforeEach(async ({ page }) => {
+        await page.route('**/api/v2/features', async (route) => {
+            if (route.request().method() !== 'GET') {
+                return route.fallback();
+            }
+
+            await route.fulfill({
+                json: {
+                    data: [{ key: 'open_graph_phase_2', enabled: true }],
+                },
+            });
+        });
+        await page.route('**/api/v2/file-upload**', async (route) => {
+            if (
+                route.request().method() !== 'GET' ||
+                new URL(route.request().url()).pathname !== '/api/v2/file-upload'
+            ) {
+                return route.fallback();
+            }
+
+            await route.fulfill({
+                json: {
+                    count: 0,
+                    data: [],
+                    limit: 10,
+                    skip: 0,
+                },
+            });
+        });
+        await page.route('**/api/v2/bloodhound-users-minimal', async (route) => {
+            if (route.request().method() !== 'GET') {
+                return route.fallback();
+            }
+
+            await route.fulfill({
+                json: {
+                    data: {
+                        users: [],
+                    },
+                },
+            });
+        });
+
+        await page.goto('/ui/administration/file-ingest');
+
+        await page
+            .getByRole('columnheader', {
+                name: 'ID / User / Status',
+                exact: true,
+            })
+            .waitFor({ state: 'visible' });
+        await page.getByText('0\u20130 of 0', { exact: true }).waitFor({ state: 'visible' });
+
+        const filterButton = page.getByRole('button', {
+            name: 'Open file ingest filters',
+            exact: true,
+        });
+
+        await filterButton.waitFor({ state: 'visible' });
+        await filterButton.click();
+
+        await hideBySelector(page, '#content-wrapper');
+
+        const filterDialog = page.getByRole('dialog');
+
+        await filterDialog.waitFor({ state: 'visible' });
+        await filterDialog
+            .getByRole('heading', {
+                name: 'Filter Clear All',
+                exact: true,
+            })
+            .waitFor({ state: 'visible' });
+    });
+
+    test('default state', async ({ page, makeAxeBuilder }, testInfo) => {
+        const filterDialog = page.getByRole('dialog');
+        const startDate = filterDialog.getByRole('textbox', {
+            name: 'Start Date',
+            exact: true,
+        });
+        const endDate = filterDialog.getByRole('textbox', {
+            name: 'End Date',
+            exact: true,
+        });
+
+        await filterDialog.getByText('Date Range', { exact: true }).waitFor({ state: 'visible' });
+        await startDate.waitFor({ state: 'visible' });
+        await endDate.waitFor({ state: 'visible' });
+
+        const results = await makeAxeBuilder().include('[role="dialog"]').analyze();
+
+        await expectNoAccessibilityViolations(testInfo, results, { page });
+    });
+
+    test('with focus', async ({ page, makeAxeBuilder }, testInfo) => {
+        const filterDialog = page.getByRole('dialog');
+        const statusSelect = filterDialog.getByRole('combobox', {
+            name: 'Status Select',
+            exact: true,
+        });
+        const startDate = filterDialog.getByRole('textbox', {
+            name: 'Start Date',
+            exact: true,
+        });
+
+        await statusSelect.focus();
+        await page.keyboard.press('Tab');
+
+        await startDate.and(page.locator(':focus')).waitFor({ state: 'visible' });
+        await filterDialog.getByPlaceholder('yyyy-mm-dd', { exact: true }).waitFor({ state: 'visible' });
+
+        const results = await makeAxeBuilder().include('[role="dialog"]').analyze();
+
+        await expectNoAccessibilityViolations(testInfo, results, { page });
+    });
+
+    test('calendar visible', async ({ page, makeAxeBuilder }, testInfo) => {
+        const filterDialog = page.getByRole('dialog');
+        const startDateCalendarButton = filterDialog
+            .getByRole('button', {
+                name: 'Choose Date',
+                exact: true,
+            })
+            .first();
+
+        await startDateCalendarButton.click();
+
+        const calendarGrid = page.getByRole('grid');
+        const calendarDialog = page.getByRole('dialog').filter({
+            has: calendarGrid,
+        });
+        const visibleMonth = new Intl.DateTimeFormat('en-US', {
+            month: 'long',
+            year: 'numeric',
+        }).format(new Date());
+
+        await calendarDialog.waitFor({ state: 'visible' });
+        await calendarGrid.waitFor({ state: 'visible' });
+        await calendarGrid.getByRole('gridcell').first().waitFor({ state: 'visible' });
+        await calendarDialog.getByText(visibleMonth, { exact: true }).waitFor({ state: 'visible' });
+
+        const results = await makeAxeBuilder().include('[role="dialog"]').analyze();
+
+        await expectNoAccessibilityViolations(testInfo, results, { page });
+    });
+});

--- a/cmd/ui/tests/a11y/Shared/fixtures/playwright-upload.json
+++ b/cmd/ui/tests/a11y/Shared/fixtures/playwright-upload.json
@@ -1,0 +1,1 @@
+{"value":"playwright"}

--- a/cmd/ui/tests/a11y/Shared/quick-upload.a11y.spec.ts
+++ b/cmd/ui/tests/a11y/Shared/quick-upload.a11y.spec.ts
@@ -17,196 +17,198 @@
 import { hideBySelector } from 'bh-playwright-testing/axe';
 import { expectNoAccessibilityViolations, test } from '../../fixtures';
 
-const UPLOAD_FILE = 'tests/a11y/Shared/fixtures/playwright-upload.json';
+test.describe('Quick Upload dialog', () => {
+    const UPLOAD_FILE = 'tests/a11y/Shared/fixtures/playwright-upload.json';
 
-test.beforeEach(async ({ page }) => {
-    await page.route('**/api/v2/file-upload/accepted-types', async (route) => {
-        if (route.request().method() !== 'GET') {
-            return route.fallback();
-        }
+    test.beforeEach(async ({ page }) => {
+        await page.route('**/api/v2/file-upload/accepted-types', async (route) => {
+            if (route.request().method() !== 'GET') {
+                return route.fallback();
+            }
 
-        await route.fulfill({
-            json: {
-                data: ['application/json'],
-            },
+            await route.fulfill({
+                json: {
+                    data: ['application/json'],
+                },
+            });
         });
-    });
 
-    await page.goto('/ui/administration/data-quality');
+        await page.goto('/ui/administration/data-quality');
 
-    await page.getByRole('heading', { name: 'Data Quality', exact: true }).waitFor({ state: 'visible' });
+        await page.getByRole('heading', { name: 'Data Quality', exact: true }).waitFor({ state: 'visible' });
 
-    const quickUploadButton = page.getByRole('button', {
-        name: 'Quick Upload',
-        exact: true,
-    });
-
-    await quickUploadButton.waitFor({ state: 'visible' });
-    await quickUploadButton.click();
-
-    await page.getByRole('dialog').waitFor({ state: 'visible' });
-    await hideBySelector(page, '#content-wrapper');
-});
-
-test('Quick Upload dialog', async ({ page, makeAxeBuilder }, testInfo) => {
-    const dialog = page.getByRole('dialog');
-
-    await dialog
-        .getByText('Click here or drag and drop to upload JSON or zip/compressed JSON files', {
+        const quickUploadButton = page.getByRole('button', {
+            name: 'Quick Upload',
             exact: true,
-        })
-        .waitFor({ state: 'visible' });
-    await dialog.getByText('View File Ingest History', { exact: true }).waitFor({ state: 'visible' });
-
-    const results = await makeAxeBuilder().include('[role="dialog"]').analyze();
-
-    await expectNoAccessibilityViolations(testInfo, results, { page });
-});
-
-test('Quick Upload dialog with files added', async ({ page, makeAxeBuilder }, testInfo) => {
-    const dialog = page.getByRole('dialog');
-
-    const fileChooserPromise = page.waitForEvent('filechooser');
-
-    await dialog.locator('div[role="button"].size-full').click();
-
-    const fileChooser = await fileChooserPromise;
-    await fileChooser.setFiles(UPLOAD_FILE);
-    await dialog.getByText('playwright-upload.json', { exact: true }).waitFor({ state: 'visible' });
-    await dialog.getByRole('button', { name: 'Remove item', exact: true }).waitFor({ state: 'visible' });
-
-    const results = await makeAxeBuilder().include('[role="dialog"]').analyze();
-
-    await expectNoAccessibilityViolations(testInfo, results, { page });
-});
-
-test('Quick Upload dialog with completed uploads', async ({ page, makeAxeBuilder }, testInfo) => {
-    await page.route('**/api/v2/file-upload/start', async (route) => {
-        if (route.request().method() !== 'POST') {
-            return route.fallback();
-        }
-
-        await route.fulfill({
-            status: 201,
-            json: {
-                data: {
-                    id: 1,
-                },
-            },
         });
-    });
-    await page.route('**/api/v2/file-upload/1', async (route) => {
-        if (route.request().method() !== 'POST') {
-            return route.fallback();
-        }
 
-        await route.fulfill({
-            status: 202,
-            json: {
-                data: '',
-            },
-        });
-    });
-    await page.route('**/api/v2/file-upload/1/end', async (route) => {
-        if (route.request().method() !== 'POST') {
-            return route.fallback();
-        }
+        await quickUploadButton.waitFor({ state: 'visible' });
+        await quickUploadButton.click();
 
-        await route.fulfill({
-            status: 200,
-            json: {
-                data: '',
-            },
-        });
+        await page.getByRole('dialog').waitFor({ state: 'visible' });
+        await hideBySelector(page, '#content-wrapper');
     });
 
-    const dialog = page.getByRole('dialog');
+    test('default state', async ({ page, makeAxeBuilder }, testInfo) => {
+        const dialog = page.getByRole('dialog');
 
-    const fileChooserPromise = page.waitForEvent('filechooser');
+        await dialog
+            .getByText('Click here or drag and drop to upload JSON or zip/compressed JSON files', {
+                exact: true,
+            })
+            .waitFor({ state: 'visible' });
+        await dialog.getByText('View File Ingest History', { exact: true }).waitFor({ state: 'visible' });
 
-    await dialog.locator('div[role="button"].size-full').click();
+        const results = await makeAxeBuilder().include('[role="dialog"]').analyze();
 
-    const fileChooser = await fileChooserPromise;
-    await fileChooser.setFiles(UPLOAD_FILE);
-    await dialog.getByText('playwright-upload.json', { exact: true }).waitFor({ state: 'visible' });
-    await dialog.getByRole('button', { name: 'Upload', exact: true }).click();
-
-    await dialog
-        .getByText('All files have successfully been uploaded for ingest.', { exact: true })
-        .waitFor({ state: 'visible' });
-    await dialog.getByText('100%', { exact: true }).waitFor({ state: 'visible' });
-    await dialog.getByText('Upload in progress.', { exact: true }).waitFor({ state: 'hidden' });
-
-    const results = await makeAxeBuilder().include('[role="dialog"]').analyze();
-
-    await expectNoAccessibilityViolations(testInfo, results, { page });
-});
-
-test('Quick Upload dialog with failed uploads', async ({ page, makeAxeBuilder }, testInfo) => {
-    await page.route('**/api/v2/file-upload/start', async (route) => {
-        if (route.request().method() !== 'POST') {
-            return route.fallback();
-        }
-
-        await route.fulfill({
-            status: 201,
-            json: {
-                data: {
-                    id: 1,
-                },
-            },
-        });
+        await expectNoAccessibilityViolations(testInfo, results, { page });
     });
-    await page.route('**/api/v2/file-upload/1', async (route) => {
-        if (route.request().method() !== 'POST') {
-            return route.fallback();
-        }
 
-        await route.fulfill({
-            status: 400,
-            json: {
-                errors: [
-                    {
-                        message: 'Playwright upload failure',
+    test('with files added', async ({ page, makeAxeBuilder }, testInfo) => {
+        const dialog = page.getByRole('dialog');
+
+        const fileChooserPromise = page.waitForEvent('filechooser');
+
+        await dialog.locator('div[role="button"].size-full').click();
+
+        const fileChooser = await fileChooserPromise;
+        await fileChooser.setFiles(UPLOAD_FILE);
+        await dialog.getByText('playwright-upload.json', { exact: true }).waitFor({ state: 'visible' });
+        await dialog.getByRole('button', { name: 'Remove item', exact: true }).waitFor({ state: 'visible' });
+
+        const results = await makeAxeBuilder().include('[role="dialog"]').analyze();
+
+        await expectNoAccessibilityViolations(testInfo, results, { page });
+    });
+
+    test('with completed uploads', async ({ page, makeAxeBuilder }, testInfo) => {
+        await page.route('**/api/v2/file-upload/start', async (route) => {
+            if (route.request().method() !== 'POST') {
+                return route.fallback();
+            }
+
+            await route.fulfill({
+                status: 201,
+                json: {
+                    data: {
+                        id: 1,
                     },
-                ],
-            },
+                },
+            });
         });
-    });
-    await page.route('**/api/v2/file-upload/1/end', async (route) => {
-        if (route.request().method() !== 'POST') {
-            return route.fallback();
-        }
+        await page.route('**/api/v2/file-upload/1', async (route) => {
+            if (route.request().method() !== 'POST') {
+                return route.fallback();
+            }
 
-        await route.fulfill({
-            status: 200,
-            json: {
-                data: '',
-            },
+            await route.fulfill({
+                status: 202,
+                json: {
+                    data: '',
+                },
+            });
         });
+        await page.route('**/api/v2/file-upload/1/end', async (route) => {
+            if (route.request().method() !== 'POST') {
+                return route.fallback();
+            }
+
+            await route.fulfill({
+                status: 200,
+                json: {
+                    data: '',
+                },
+            });
+        });
+
+        const dialog = page.getByRole('dialog');
+
+        const fileChooserPromise = page.waitForEvent('filechooser');
+
+        await dialog.locator('div[role="button"].size-full').click();
+
+        const fileChooser = await fileChooserPromise;
+        await fileChooser.setFiles(UPLOAD_FILE);
+        await dialog.getByText('playwright-upload.json', { exact: true }).waitFor({ state: 'visible' });
+        await dialog.getByRole('button', { name: 'Upload', exact: true }).click();
+
+        await dialog
+            .getByText('All files have successfully been uploaded for ingest.', { exact: true })
+            .waitFor({ state: 'visible' });
+        await dialog.getByText('100%', { exact: true }).waitFor({ state: 'visible' });
+        await dialog.getByText('Upload in progress.', { exact: true }).waitFor({ state: 'hidden' });
+
+        const results = await makeAxeBuilder().include('[role="dialog"]').analyze();
+
+        await expectNoAccessibilityViolations(testInfo, results, { page });
     });
 
-    const dialog = page.getByRole('dialog');
+    test('with failed uploads', async ({ page, makeAxeBuilder }, testInfo) => {
+        await page.route('**/api/v2/file-upload/start', async (route) => {
+            if (route.request().method() !== 'POST') {
+                return route.fallback();
+            }
 
-    const fileChooserPromise = page.waitForEvent('filechooser');
+            await route.fulfill({
+                status: 201,
+                json: {
+                    data: {
+                        id: 1,
+                    },
+                },
+            });
+        });
+        await page.route('**/api/v2/file-upload/1', async (route) => {
+            if (route.request().method() !== 'POST') {
+                return route.fallback();
+            }
 
-    await dialog.locator('div[role="button"].size-full').click();
+            await route.fulfill({
+                status: 400,
+                json: {
+                    errors: [
+                        {
+                            message: 'Playwright upload failure',
+                        },
+                    ],
+                },
+            });
+        });
+        await page.route('**/api/v2/file-upload/1/end', async (route) => {
+            if (route.request().method() !== 'POST') {
+                return route.fallback();
+            }
 
-    const fileChooser = await fileChooserPromise;
-    await fileChooser.setFiles(UPLOAD_FILE);
-    await dialog.getByText('playwright-upload.json', { exact: true }).waitFor({ state: 'visible' });
-    await dialog.getByRole('button', { name: 'Upload', exact: true }).click();
+            await route.fulfill({
+                status: 200,
+                json: {
+                    data: '',
+                },
+            });
+        });
 
-    await dialog
-        .getByText('Some files have failed to upload and have not been included for ingest.', {
-            exact: true,
-        })
-        .waitFor({ state: 'visible' });
-    await dialog.getByText('Failed to Upload', { exact: true }).waitFor({ state: 'visible' });
-    await dialog.getByRole('button', { name: 'Retry upload', exact: true }).waitFor({ state: 'visible' });
-    await dialog.getByText('Upload in progress.', { exact: true }).waitFor({ state: 'hidden' });
+        const dialog = page.getByRole('dialog');
 
-    const results = await makeAxeBuilder().include('[role="dialog"]').analyze();
+        const fileChooserPromise = page.waitForEvent('filechooser');
 
-    await expectNoAccessibilityViolations(testInfo, results, { page });
+        await dialog.locator('div[role="button"].size-full').click();
+
+        const fileChooser = await fileChooserPromise;
+        await fileChooser.setFiles(UPLOAD_FILE);
+        await dialog.getByText('playwright-upload.json', { exact: true }).waitFor({ state: 'visible' });
+        await dialog.getByRole('button', { name: 'Upload', exact: true }).click();
+
+        await dialog
+            .getByText('Some files have failed to upload and have not been included for ingest.', {
+                exact: true,
+            })
+            .waitFor({ state: 'visible' });
+        await dialog.getByText('Failed to Upload', { exact: true }).waitFor({ state: 'visible' });
+        await dialog.getByRole('button', { name: 'Retry upload', exact: true }).waitFor({ state: 'visible' });
+        await dialog.getByText('Upload in progress.', { exact: true }).waitFor({ state: 'hidden' });
+
+        const results = await makeAxeBuilder().include('[role="dialog"]').analyze();
+
+        await expectNoAccessibilityViolations(testInfo, results, { page });
+    });
 });

--- a/cmd/ui/tests/a11y/Shared/quick-upload.a11y.spec.ts
+++ b/cmd/ui/tests/a11y/Shared/quick-upload.a11y.spec.ts
@@ -1,0 +1,212 @@
+// Copyright 2026 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { hideBySelector } from 'bh-playwright-testing/axe';
+import { expectNoAccessibilityViolations, test } from '../../fixtures';
+
+const UPLOAD_FILE = 'tests/a11y/Shared/fixtures/playwright-upload.json';
+
+test.beforeEach(async ({ page }) => {
+    await page.route('**/api/v2/file-upload/accepted-types', async (route) => {
+        if (route.request().method() !== 'GET') {
+            return route.fallback();
+        }
+
+        await route.fulfill({
+            json: {
+                data: ['application/json'],
+            },
+        });
+    });
+
+    await page.goto('/ui/administration/data-quality');
+
+    await page.getByRole('heading', { name: 'Data Quality', exact: true }).waitFor({ state: 'visible' });
+
+    const quickUploadButton = page.getByRole('button', {
+        name: 'Quick Upload',
+        exact: true,
+    });
+
+    await quickUploadButton.waitFor({ state: 'visible' });
+    await quickUploadButton.click();
+
+    await page.getByRole('dialog').waitFor({ state: 'visible' });
+    await hideBySelector(page, '#content-wrapper');
+});
+
+test('Quick Upload dialog', async ({ page, makeAxeBuilder }, testInfo) => {
+    const dialog = page.getByRole('dialog');
+
+    await dialog
+        .getByText('Click here or drag and drop to upload JSON or zip/compressed JSON files', {
+            exact: true,
+        })
+        .waitFor({ state: 'visible' });
+    await dialog.getByText('View File Ingest History', { exact: true }).waitFor({ state: 'visible' });
+
+    const results = await makeAxeBuilder().include('[role="dialog"]').analyze();
+
+    await expectNoAccessibilityViolations(testInfo, results, { page });
+});
+
+test('Quick Upload dialog with files added', async ({ page, makeAxeBuilder }, testInfo) => {
+    const dialog = page.getByRole('dialog');
+
+    const fileChooserPromise = page.waitForEvent('filechooser');
+
+    await dialog.locator('div[role="button"].size-full').click();
+
+    const fileChooser = await fileChooserPromise;
+    await fileChooser.setFiles(UPLOAD_FILE);
+    await dialog.getByText('playwright-upload.json', { exact: true }).waitFor({ state: 'visible' });
+    await dialog.getByRole('button', { name: 'Remove item', exact: true }).waitFor({ state: 'visible' });
+
+    const results = await makeAxeBuilder().include('[role="dialog"]').analyze();
+
+    await expectNoAccessibilityViolations(testInfo, results, { page });
+});
+
+test('Quick Upload dialog with completed uploads', async ({ page, makeAxeBuilder }, testInfo) => {
+    await page.route('**/api/v2/file-upload/start', async (route) => {
+        if (route.request().method() !== 'POST') {
+            return route.fallback();
+        }
+
+        await route.fulfill({
+            status: 201,
+            json: {
+                data: {
+                    id: 1,
+                },
+            },
+        });
+    });
+    await page.route('**/api/v2/file-upload/1', async (route) => {
+        if (route.request().method() !== 'POST') {
+            return route.fallback();
+        }
+
+        await route.fulfill({
+            status: 202,
+            json: {
+                data: '',
+            },
+        });
+    });
+    await page.route('**/api/v2/file-upload/1/end', async (route) => {
+        if (route.request().method() !== 'POST') {
+            return route.fallback();
+        }
+
+        await route.fulfill({
+            status: 200,
+            json: {
+                data: '',
+            },
+        });
+    });
+
+    const dialog = page.getByRole('dialog');
+
+    const fileChooserPromise = page.waitForEvent('filechooser');
+
+    await dialog.locator('div[role="button"].size-full').click();
+
+    const fileChooser = await fileChooserPromise;
+    await fileChooser.setFiles(UPLOAD_FILE);
+    await dialog.getByText('playwright-upload.json', { exact: true }).waitFor({ state: 'visible' });
+    await dialog.getByRole('button', { name: 'Upload', exact: true }).click();
+
+    await dialog
+        .getByText('All files have successfully been uploaded for ingest.', { exact: true })
+        .waitFor({ state: 'visible' });
+    await dialog.getByText('100%', { exact: true }).waitFor({ state: 'visible' });
+    await dialog.getByText('Upload in progress.', { exact: true }).waitFor({ state: 'hidden' });
+
+    const results = await makeAxeBuilder().include('[role="dialog"]').analyze();
+
+    await expectNoAccessibilityViolations(testInfo, results, { page });
+});
+
+test('Quick Upload dialog with failed uploads', async ({ page, makeAxeBuilder }, testInfo) => {
+    await page.route('**/api/v2/file-upload/start', async (route) => {
+        if (route.request().method() !== 'POST') {
+            return route.fallback();
+        }
+
+        await route.fulfill({
+            status: 201,
+            json: {
+                data: {
+                    id: 1,
+                },
+            },
+        });
+    });
+    await page.route('**/api/v2/file-upload/1', async (route) => {
+        if (route.request().method() !== 'POST') {
+            return route.fallback();
+        }
+
+        await route.fulfill({
+            status: 400,
+            json: {
+                errors: [
+                    {
+                        message: 'Playwright upload failure',
+                    },
+                ],
+            },
+        });
+    });
+    await page.route('**/api/v2/file-upload/1/end', async (route) => {
+        if (route.request().method() !== 'POST') {
+            return route.fallback();
+        }
+
+        await route.fulfill({
+            status: 200,
+            json: {
+                data: '',
+            },
+        });
+    });
+
+    const dialog = page.getByRole('dialog');
+
+    const fileChooserPromise = page.waitForEvent('filechooser');
+
+    await dialog.locator('div[role="button"].size-full').click();
+
+    const fileChooser = await fileChooserPromise;
+    await fileChooser.setFiles(UPLOAD_FILE);
+    await dialog.getByText('playwright-upload.json', { exact: true }).waitFor({ state: 'visible' });
+    await dialog.getByRole('button', { name: 'Upload', exact: true }).click();
+
+    await dialog
+        .getByText('Some files have failed to upload and have not been included for ingest.', {
+            exact: true,
+        })
+        .waitFor({ state: 'visible' });
+    await dialog.getByText('Failed to Upload', { exact: true }).waitFor({ state: 'visible' });
+    await dialog.getByRole('button', { name: 'Retry upload', exact: true }).waitFor({ state: 'visible' });
+    await dialog.getByText('Upload in progress.', { exact: true }).waitFor({ state: 'hidden' });
+
+    const results = await makeAxeBuilder().include('[role="dialog"]').analyze();
+
+    await expectNoAccessibilityViolations(testInfo, results, { page });
+});


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Adds accessibility tests for the share components - quick upload dialog and date range component, to verify compliance with accessibility standards.

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-8641

*Why is this change required? What problem does it solve?*

This change was needed to ensure the share components - quick upload dialog and date range component, adhere to accessibility standards.


## How Has This Been Tested?

The tests were run locally.

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- New feature (non-breaking change which adds functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [X] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [X] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [X] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Tests**
  * Added accessibility coverage for the Date Range filter in default, focused-input, and calendar-visible states.
  * Expanded accessibility coverage for the Quick Upload dialog across empty, file-selected, successful-upload, and failed-upload states.
  * Added supporting upload test data to validate Quick Upload behavior consistently across scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->