### PR TITLE
chore(alerts): uncomment `test` endpoint BED-8020

### DIFF
--- a/packages/go/openapi/doc/openapi.json
+++ b/packages/go/openapi/doc/openapi.json
@@ -21285,6 +21285,92 @@
           }
         }
       }
+    },
+    "/api/v2/alert-attempts/retry": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/header.prefer"
+        }
+      ],
+      "post": {
+        "operationId": "RetryAlertAttempt",
+        "summary": "Retry Alert Attempt",
+        "description": "Manually re-queues an existing alert delivery attempt. The composite key\nin the request body identifies the specific attempt (alert, event, channel/webhook) to retry. The attempt is ignored\nwhen the attempt has already succeeded.\n",
+        "tags": [
+          "Alerts",
+          "Enterprise"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "description": "Request body for manually re-queueing an alert delivery attempt. The supplied\ncomposite key identifies the row to retry; the handler is a no-op when the\nattempt has already succeeded (`succeeded_at IS NOT NULL`).\n",
+                "required": [
+                  "alert_id",
+                  "channel_id",
+                  "event_id"
+                ],
+                "properties": {
+                  "alert_id": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "channel_id": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "event_id": {
+                    "type": "string",
+                    "format": "uuid"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "alert_attempt": {
+                          "$ref": "#/components/schemas/model.alert-attempt"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/bad-request"
+          },
+          "401": {
+            "$ref": "#/components/responses/unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/not-found"
+          },
+          "429": {
+            "$ref": "#/components/responses/too-many-requests"
+          },
+          "500": {
+            "$ref": "#/components/responses/internal-server-error"
+          }
+        }
+      }
     }
   },
   "components": {

--- a/packages/go/openapi/doc/openapi.json
+++ b/packages/go/openapi/doc/openapi.json
@@ -20474,6 +20474,96 @@
         }
       }
     },
+    "/api/v2/alert-webhooks/{alert_webhook_id}/test": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/header.prefer"
+        },
+        {
+          "$ref": "#/components/parameters/path.alert-webhook-id"
+        }
+      ],
+      "post": {
+        "operationId": "TestAlertWebhook",
+        "summary": "Test Alert Webhook",
+        "description": "Synchronously dispatches a mock payload for the given `event_type` to the\nwebhook's target URL using the current HMAC secret. No `alert_attempts`\nrow is persisted. The handler returns `200` for both successful and failed\nupstream deliveries; the `status_code` and `error` fields in the response\nbody surface the upstream outcome.\n",
+        "tags": [
+          "Alerts",
+          "Enterprise"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "description": "Request body for dispatching a mock payload to an alert webhook.",
+                "required": [
+                  "event_type",
+                  "version"
+                ],
+                "properties": {
+                  "event_type": {
+                    "type": "string",
+                    "description": "The alert event type to mock in the dispatched payload. The server builds\na representative payload for the given type using the webhook's current\nHMAC secret.\n"
+                  },
+                  "version": {
+                    "type": "integer",
+                    "description": "Payload data version for the supplied `event_type`. Must be one of\nthe data versions advertised for that type by\n`GET /api/v2/alert-event-types`.\n"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "description": "Result of dispatching a mock payload to an alert webhook. The handler returns\nthis body with a `200` status code on both successful and failed upstream\ndeliveries; the `status_code` and `error` fields surface the upstream outcome.\n",
+                      "properties": {
+                        "status_code": {
+                          "type": "integer",
+                          "description": "HTTP status code returned by the webhook target.",
+                          "nullable": true
+                        },
+                        "error": {
+                          "$ref": "#/components/schemas/null.string.response"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/bad-request"
+          },
+          "401": {
+            "$ref": "#/components/responses/unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/not-found"
+          },
+          "429": {
+            "$ref": "#/components/responses/too-many-requests"
+          },
+          "500": {
+            "$ref": "#/components/responses/internal-server-error"
+          }
+        }
+      }
+    },
     "/api/v2/alert-events": {
       "parameters": [
         {

--- a/packages/go/openapi/src/openapi.yaml
+++ b/packages/go/openapi/src/openapi.yaml
@@ -809,8 +809,8 @@ paths:
     $ref: './paths/alerts.alerts.id.yaml'
   /api/v2/alert-attempts:
     $ref: './paths/alerts.alert-attempts.yaml'
-#  /api/v2/alert-attempts/retry:
-#    $ref: './paths/alerts.alert-attempts.retry.yaml'
+  /api/v2/alert-attempts/retry:
+    $ref: './paths/alerts.alert-attempts.retry.yaml'
 
   # graph schema findings
   #/api/v2/extensions-findings:

--- a/packages/go/openapi/src/openapi.yaml
+++ b/packages/go/openapi/src/openapi.yaml
@@ -795,8 +795,8 @@ paths:
     $ref: './paths/alerts.alert-webhooks.id.yaml'
   /api/v2/alert-webhooks/{alert_webhook_id}/rotate-secret:
     $ref: './paths/alerts.alert-webhooks.id.rotate-secret.yaml'
-#  /api/v2/alert-webhooks/{alert_webhook_id}/test:
-#    $ref: './paths/alerts.alert-webhooks.id.test.yaml'
+  /api/v2/alert-webhooks/{alert_webhook_id}/test:
+    $ref: './paths/alerts.alert-webhooks.id.test.yaml'
   /api/v2/alert-events:
     $ref: './paths/alerts.alert-events.yaml'
   /api/v2/alert-events/{alert_event_id}:

--- a/packages/go/openapi/src/paths/alerts.alert-webhooks.id.test.yaml
+++ b/packages/go/openapi/src/paths/alerts.alert-webhooks.id.test.yaml
@@ -74,7 +74,7 @@ post:
                     description: HTTP status code returned by the webhook target.
                     nullable: true
                   error:
-                    $ref: './../schemas/null.string.yaml'
+                    $ref: './../schemas/null.string.response.yaml'
     400:
       $ref: './../responses/bad-request.yaml'
     401:


### PR DESCRIPTION
## Description

Uncommenting the `test` endpoint. Also updating the error response definition to `null.string.response` to match other endpoints.

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-8020

## How Has This Been Tested?

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an endpoint to test alert webhooks using a mock payload and the current security secret.
  * Test results report upstream delivery status and error details.
  * Added an endpoint to retry failed alert delivery attempts using alert, channel, and event identifiers.
  * Successful delivery attempts are not re-queued.
  * Documented request schemas and standard validation, authorization, rate-limit, and server error responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->