### PR TITLE
feat(UI): Update JSClient to support Zone protected asset score endpoint

### DIFF
--- a/packages/javascript/js-client-library/src/client.ts
+++ b/packages/javascript/js-client-library/src/client.ts
@@ -123,6 +123,7 @@ import {
     UpdateConfigurationResponse,
     UploadFileToIngestResponse,
     WebhookTestResponse,
+    ZoneProtectedAssetScoreResponse,
 } from './responses';
 import * as types from './types';
 
@@ -747,6 +748,13 @@ class BHEAPIClient {
     getPostureHistory = (dataType: string, options?: RequestOptions) =>
         this.baseClient.get<PostureHistoryResponse>(`/api/v2/posture-history/${dataType}`, {
             ...options,
+            paramsSerializer: { indexes: null },
+        });
+
+    getZoneProtectedAssetScore = (environments: string[], assetGroupTagId: number, options?: RequestOptions) =>
+        this.baseClient.get<ZoneProtectedAssetScoreResponse>('/api/v2/asset-scores/zone-protected-asset-score', {
+            ...options,
+            params: { ...options?.params, environments, asset_group_tag_id: assetGroupTagId },
             paramsSerializer: { indexes: null },
         });
 

--- a/packages/javascript/js-client-library/src/responses.ts
+++ b/packages/javascript/js-client-library/src/responses.ts
@@ -193,6 +193,20 @@ export type PostureHistoryResponse = TimeWindowedResponse<PostureHistoryData[]> 
     data_type: string;
 };
 
+export type ZoneProtectedAssetScoreData = {
+    date: string;
+    exposed_count: number;
+    protected_count: number;
+    total_count: number;
+    // The protected share of the zone, expressed as a fraction between 0 and 1.
+    value: number;
+};
+
+export type ZoneProtectedAssetScoreResponse = TimeWindowedResponse<ZoneProtectedAssetScoreData[]> & {
+    environments: string[];
+    asset_group_tag_id: number;
+};
+
 type DatapipeStatus = {
     status: 'idle' | 'ingesting' | 'analyzing' | 'purging';
     last_complete_analysis_at: string;


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Update JSClient to support zone protected asset score endpoint.

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-8760

To support changes in Posture page

## How Has This Been Tested?

*Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc.*

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)
- Database Migrations

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added API support for retrieving zone-protected asset scores.
  * Responses now include exposed, protected, total, and fractional score metrics over time.
  * Results can be filtered by environment and asset group.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->