### PR TITLE
fix(auth): store identifiers - BED-9064

### DIFF
--- a/cmd/api/src/api/v2/auth/saml.go
+++ b/cmd/api/src/api/v2/auth/saml.go
@@ -488,7 +488,7 @@ func (s ManagementResource) SAMLCallbackHandler(response http.ResponseWriter, re
 		)
 		// Technical issues or invalid form data
 		api.RedirectToLoginURL(response, request, fmt.Sprintf("Invalid SSO response %s", err.Error()))
-	} else if assertion, err := s.SAML.ParseResponse(serviceProvider, request, nil); err != nil {
+	} else if validatedResponse, err := s.SAML.ParseResponse(serviceProvider, request, nil); err != nil {
 		var typedErr *saml.InvalidResponseError
 		switch {
 		case errors.As(err, &typedErr):
@@ -509,7 +509,7 @@ func (s ManagementResource) SAMLCallbackHandler(response http.ResponseWriter, re
 		}
 		// SAML credentials issue scenario (authentication failed)
 		api.RedirectToLoginURL(response, request, fmt.Sprintf("Invalid SSO response: Failed to parse ACS response %s", err.Error()))
-	} else if principalName, err := ssoProvider.SAMLProvider.GetSAMLUserPrincipalNameFromAssertion(assertion); err != nil {
+	} else if principalName, err := ssoProvider.SAMLProvider.GetSAMLUserPrincipalNameFromAssertion(validatedResponse.Assertion); err != nil {
 		slog.WarnContext(
 			request.Context(),
 			"[SAML] Failed to lookup user for SAML provider",
@@ -520,7 +520,7 @@ func (s ManagementResource) SAMLCallbackHandler(response http.ResponseWriter, re
 		api.RedirectToLoginURL(response, request, "Invalid assertion: no valid email address found")
 	} else {
 		if ssoProvider.Config.AutoProvision.Enabled {
-			if err := jitSAMLUserUpsert(request.Context(), ssoProvider, principalName, assertion, s.db, s.DogTags); err != nil {
+			if err := jitSAMLUserUpsert(request.Context(), ssoProvider, principalName, validatedResponse.Assertion, s.db, s.DogTags); err != nil {
 				// It is safe to let this request drop into the CreateSSOSession function below to ensure proper audit logging
 				slog.WarnContext(
 					request.Context(),

--- a/cmd/api/src/api/v2/auth/saml.go
+++ b/cmd/api/src/api/v2/auth/saml.go
@@ -39,6 +39,7 @@ import (
 	"github.com/specterops/bloodhound/cmd/api/src/database/types/null"
 	"github.com/specterops/bloodhound/cmd/api/src/model"
 	"github.com/specterops/bloodhound/cmd/api/src/services/dogtags"
+	bhceSAML "github.com/specterops/bloodhound/cmd/api/src/services/saml"
 	"github.com/specterops/bloodhound/packages/go/bhlog/attr"
 	"github.com/specterops/bloodhound/packages/go/crypto"
 	"github.com/specterops/bloodhound/packages/go/headers"
@@ -509,6 +510,36 @@ func (s ManagementResource) SAMLCallbackHandler(response http.ResponseWriter, re
 		}
 		// SAML credentials issue scenario (authentication failed)
 		api.RedirectToLoginURL(response, request, fmt.Sprintf("Invalid SSO response: Failed to parse ACS response %s", err.Error()))
+	} else if err := s.db.CreateSAMLConsumedIdentifiers(request.Context(),
+		ssoProvider.ID,
+		validatedResponse.Assertion.Issuer.Value,
+		validatedResponse.ResponseID,
+		validatedResponse.Assertion.ID,
+		bhceSAML.CalculateSAMLTimeExpiry(validatedResponse.ResponseIssueInstant, validatedResponse.Assertion.IssueInstant)); err != nil {
+		switch {
+		case errors.Is(err, database.ErrSAMLIdentifierAlreadyConsumed):
+			slog.WarnContext(
+				request.Context(),
+				"[SAML] Replayed SAML response rejected",
+				slog.String("provider_name", ssoProvider.Name),
+				slog.String("issuer_uri", ssoProvider.SAMLProvider.IssuerURI),
+				slog.String("response_id", validatedResponse.ResponseID),
+				slog.String("assertion_id", validatedResponse.Assertion.ID),
+				attr.Error(err),
+			)
+			// Replay detected, cannot safely create a session
+			api.RedirectToLoginURL(response, request, "Invalid SSO response")
+		default:
+			slog.ErrorContext(
+				request.Context(),
+				"[SAML] Failed to add SAMLResponse and/or assertion IDs to DB",
+				slog.String("provider_name", ssoProvider.Name),
+				slog.String("issuer_uri", ssoProvider.SAMLProvider.IssuerURI),
+				attr.Error(err),
+			)
+			// Technical issues scenario: DB write failed
+			api.RedirectToLoginURL(response, request, "Your SSO connection failed, please try again")
+		}
 	} else if principalName, err := ssoProvider.SAMLProvider.GetSAMLUserPrincipalNameFromAssertion(validatedResponse.Assertion); err != nil {
 		slog.WarnContext(
 			request.Context(),

--- a/cmd/api/src/api/v2/auth/saml_test.go
+++ b/cmd/api/src/api/v2/auth/saml_test.go
@@ -1348,10 +1348,10 @@ func TestManagementResource_UpdateSAMLProviderRequest(t *testing.T) {
 					SAMLProvider: &model.SAMLProvider{},
 				}, nil)
 			}, expected: expected{
-				responseCode:   http.StatusBadRequest,
-				responseHeader: http.Header{"Content-Type": []string{"application/json"}},
-				responseBody:   `{"http_status":400,"timestamp":"0001-01-01T00:00:00Z","request_id":"","errors":[{"context":"","message":"request Content-Type isn't multipart/form-data"}]}`,
-			},
+			responseCode:   http.StatusBadRequest,
+			responseHeader: http.Header{"Content-Type": []string{"application/json"}},
+			responseBody:   `{"http_status":400,"timestamp":"0001-01-01T00:00:00Z","request_id":"","errors":[{"context":"","message":"request Content-Type isn't multipart/form-data"}]}`,
+		},
 		},
 		{
 			name: "Error: Empty multiform, ParseMultipartForm - Bad Request",
@@ -3286,6 +3286,90 @@ func TestManagementResource_SAMLCallbackHandler(t *testing.T) {
 			expected: expected{
 				responseCode:   http.StatusFound,
 				responseHeader: http.Header{"Location": []string{"/api/v2/sso/slug/callback/ui"}, "Set-Cookie": []string{"token=token; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT"}},
+			},
+		},
+		{
+			name: "Error: CreateSAMLConsumedIdentifiers replay detected - Redirect to Login with Error Message",
+			buildRequest: func() *http.Request {
+				request := &http.Request{
+					URL: &url.URL{
+						Path: "/api/v2/sso/slug/callback",
+					},
+					Method: http.MethodGet,
+				}
+
+				bhContext := &bhctx.Context{
+					Host: request.URL,
+				}
+				return request.WithContext(context.WithValue(context.Background(), bhctx.ValueKey, bhContext))
+			},
+			setupMocks: func(t *testing.T, mock *mock) {
+				mock.mockDatabase.EXPECT().GetSSOProviderBySlug(gomock.Any(), "slug").Return(model.SSOProvider{
+					Name: "POST Provider",
+					Slug: "post-provider",
+					Type: model.SessionAuthProviderSAML,
+					SAMLProvider: &model.SAMLProvider{
+						Name:            "POST SAML Provider",
+						DisplayName:     "POST SAML SSO",
+						IssuerURI:       "https://post-provider.com/saml",
+						SingleSignOnURI: "https://post-provider.com/sso",
+						MetadataXML: []byte(`<EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" entityID="https://post-provider.com/saml">
+						<IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+							<SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://post-provider.com/sso"/>
+						</IDPSSODescriptor>
+					</EntityDescriptor>`),
+					},
+				}, nil)
+				mock.mockSAML.EXPECT().ParseResponse(gomock.Any(), gomock.Any(), nil).Return(&bhceSAML.ValidatedResponse{
+					Assertion: &saml.Assertion{}}, nil)
+				mock.mockDatabase.EXPECT().CreateSAMLConsumedIdentifiers(gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any(), gomock.Any(), gomock.Any()).Return(database.ErrSAMLIdentifierAlreadyConsumed)
+			},
+			expected: expected{
+				responseCode:   http.StatusFound,
+				responseHeader: http.Header{"Location": []string{"/api/v2/sso/slug/callback/ui/login?error=Invalid+SSO+response"}},
+			},
+		},
+		{
+			name: "Error: CreateSAMLConsumedIdentifiers DB failure - Redirect to Login with Error Message",
+			buildRequest: func() *http.Request {
+				request := &http.Request{
+					URL: &url.URL{
+						Path: "/api/v2/sso/slug/callback",
+					},
+					Method: http.MethodGet,
+				}
+
+				bhContext := &bhctx.Context{
+					Host: request.URL,
+				}
+				return request.WithContext(context.WithValue(context.Background(), bhctx.ValueKey, bhContext))
+			},
+			setupMocks: func(t *testing.T, mock *mock) {
+				mock.mockDatabase.EXPECT().GetSSOProviderBySlug(gomock.Any(), "slug").Return(model.SSOProvider{
+					Name: "POST Provider",
+					Slug: "post-provider",
+					Type: model.SessionAuthProviderSAML,
+					SAMLProvider: &model.SAMLProvider{
+						Name:            "POST SAML Provider",
+						DisplayName:     "POST SAML SSO",
+						IssuerURI:       "https://post-provider.com/saml",
+						SingleSignOnURI: "https://post-provider.com/sso",
+						MetadataXML: []byte(`<EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" entityID="https://post-provider.com/saml">
+						<IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+							<SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://post-provider.com/sso"/>
+						</IDPSSODescriptor>
+					</EntityDescriptor>`),
+					},
+				}, nil)
+				mock.mockSAML.EXPECT().ParseResponse(gomock.Any(), gomock.Any(), nil).Return(&bhceSAML.ValidatedResponse{
+					Assertion: &saml.Assertion{}}, nil)
+				mock.mockDatabase.EXPECT().CreateSAMLConsumedIdentifiers(gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("error"))
+			},
+			expected: expected{
+				responseCode:   http.StatusFound,
+				responseHeader: http.Header{"Location": []string{"/api/v2/sso/slug/callback/ui/login?error=Your+SSO+connection+failed%2C+please+try+again"}},
 			},
 		},
 	}

--- a/cmd/api/src/api/v2/auth/saml_test.go
+++ b/cmd/api/src/api/v2/auth/saml_test.go
@@ -1348,10 +1348,10 @@ func TestManagementResource_UpdateSAMLProviderRequest(t *testing.T) {
 					SAMLProvider: &model.SAMLProvider{},
 				}, nil)
 			}, expected: expected{
-			responseCode:   http.StatusBadRequest,
-			responseHeader: http.Header{"Content-Type": []string{"application/json"}},
-			responseBody:   `{"http_status":400,"timestamp":"0001-01-01T00:00:00Z","request_id":"","errors":[{"context":"","message":"request Content-Type isn't multipart/form-data"}]}`,
-		},
+				responseCode:   http.StatusBadRequest,
+				responseHeader: http.Header{"Content-Type": []string{"application/json"}},
+				responseBody:   `{"http_status":400,"timestamp":"0001-01-01T00:00:00Z","request_id":"","errors":[{"context":"","message":"request Content-Type isn't multipart/form-data"}]}`,
+			},
 		},
 		{
 			name: "Error: Empty multiform, ParseMultipartForm - Bad Request",

--- a/cmd/api/src/api/v2/auth/saml_test.go
+++ b/cmd/api/src/api/v2/auth/saml_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/specterops/bloodhound/cmd/api/src/model/appcfg"
 	"github.com/specterops/bloodhound/cmd/api/src/serde"
 	"github.com/specterops/bloodhound/cmd/api/src/services/dogtags"
+	bhceSAML "github.com/specterops/bloodhound/cmd/api/src/services/saml"
 	samlmocks "github.com/specterops/bloodhound/cmd/api/src/services/saml/mocks"
 	"github.com/specterops/bloodhound/cmd/api/src/utils/test"
 	"github.com/stretchr/testify/assert"
@@ -2594,7 +2595,7 @@ func TestManagementResource_SAMLCallbackHandler(t *testing.T) {
 					</EntityDescriptor>`),
 					},
 				}, nil)
-				mock.mockSAML.EXPECT().ParseResponse(gomock.Any(), gomock.Any(), nil).Return(&saml.Assertion{}, &saml.InvalidResponseError{
+				mock.mockSAML.EXPECT().ParseResponse(gomock.Any(), gomock.Any(), nil).Return(&bhceSAML.ValidatedResponse{}, &saml.InvalidResponseError{
 					PrivateErr: errors.New("error"),
 				})
 			},
@@ -2635,7 +2636,7 @@ func TestManagementResource_SAMLCallbackHandler(t *testing.T) {
 					</EntityDescriptor>`),
 					},
 				}, nil)
-				mock.mockSAML.EXPECT().ParseResponse(gomock.Any(), gomock.Any(), nil).Return(&saml.Assertion{}, errors.New("error"))
+				mock.mockSAML.EXPECT().ParseResponse(gomock.Any(), gomock.Any(), nil).Return(&bhceSAML.ValidatedResponse{}, errors.New("error"))
 			},
 			expected: expected{
 				responseCode:   http.StatusFound,
@@ -2674,7 +2675,10 @@ func TestManagementResource_SAMLCallbackHandler(t *testing.T) {
 					</EntityDescriptor>`),
 					},
 				}, nil)
-				mock.mockSAML.EXPECT().ParseResponse(gomock.Any(), gomock.Any(), nil).Return(&saml.Assertion{}, nil)
+				mock.mockSAML.EXPECT().ParseResponse(gomock.Any(), gomock.Any(), nil).Return(&bhceSAML.ValidatedResponse{
+					Assertion: &saml.Assertion{}}, nil)
+				mock.mockDatabase.EXPECT().CreateSAMLConsumedIdentifiers(gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			},
 			expected: expected{
 				responseCode:   http.StatusFound,
@@ -2713,19 +2717,22 @@ func TestManagementResource_SAMLCallbackHandler(t *testing.T) {
 					</EntityDescriptor>`),
 					},
 				}, nil)
-				mock.mockSAML.EXPECT().ParseResponse(gomock.Any(), gomock.Any(), nil).Return(&saml.Assertion{
-					AttributeStatements: []saml.AttributeStatement{{
-						Attributes: []saml.Attribute{{
-							FriendlyName: "uid",
-							Name:         model.XMLSOAPClaimsEmailAddress,
-							NameFormat:   model.ObjectIDAttributeNameFormat,
-							Values: []saml.AttributeValue{{
-								Type:  model.XMLTypeString,
-								Value: "username",
+				mock.mockSAML.EXPECT().ParseResponse(gomock.Any(), gomock.Any(), nil).Return(&bhceSAML.ValidatedResponse{
+					Assertion: &saml.Assertion{
+						AttributeStatements: []saml.AttributeStatement{{
+							Attributes: []saml.Attribute{{
+								FriendlyName: "uid",
+								Name:         model.XMLSOAPClaimsEmailAddress,
+								NameFormat:   model.ObjectIDAttributeNameFormat,
+								Values: []saml.AttributeValue{{
+									Type:  model.XMLTypeString,
+									Value: "username",
+								}},
 							}},
 						}},
-					}},
-				}, nil)
+					}}, nil)
+				mock.mockDatabase.EXPECT().CreateSAMLConsumedIdentifiers(gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 				mock.mockDatabase.EXPECT().CreateAuditLog(gomock.Any(), gomock.Any()).Times(2)
 				mock.mockDatabase.EXPECT().LookupUser(gomock.Any(), "username").Return(model.User{}, nil)
 			},
@@ -2770,19 +2777,22 @@ func TestManagementResource_SAMLCallbackHandler(t *testing.T) {
 						ID: int32(1),
 					},
 				}, nil)
-				mock.mockSAML.EXPECT().ParseResponse(gomock.Any(), gomock.Any(), nil).Return(&saml.Assertion{
-					AttributeStatements: []saml.AttributeStatement{{
-						Attributes: []saml.Attribute{{
-							FriendlyName: "uid",
-							Name:         model.XMLSOAPClaimsEmailAddress,
-							NameFormat:   model.ObjectIDAttributeNameFormat,
-							Values: []saml.AttributeValue{{
-								Type:  model.XMLTypeString,
-								Value: "username",
+				mock.mockSAML.EXPECT().ParseResponse(gomock.Any(), gomock.Any(), nil).Return(&bhceSAML.ValidatedResponse{
+					Assertion: &saml.Assertion{
+						AttributeStatements: []saml.AttributeStatement{{
+							Attributes: []saml.Attribute{{
+								FriendlyName: "uid",
+								Name:         model.XMLSOAPClaimsEmailAddress,
+								NameFormat:   model.ObjectIDAttributeNameFormat,
+								Values: []saml.AttributeValue{{
+									Type:  model.XMLTypeString,
+									Value: "username",
+								}},
 							}},
 						}},
-					}},
-				}, nil)
+					}}, nil)
+				mock.mockDatabase.EXPECT().CreateSAMLConsumedIdentifiers(gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 				mock.mockDatabase.EXPECT().CreateAuditLog(gomock.Any(), gomock.Any()).Times(2)
 				mock.mockDatabase.EXPECT().LookupUser(gomock.Any(), "username").Return(model.User{
 					SSOProviderID: null.Int32{
@@ -2851,19 +2861,23 @@ func TestManagementResource_SAMLCallbackHandler(t *testing.T) {
 						},
 					},
 				}, nil)
-				mock.mockSAML.EXPECT().ParseResponse(gomock.Any(), gomock.Any(), nil).Return(&saml.Assertion{
-					AttributeStatements: []saml.AttributeStatement{{
-						Attributes: []saml.Attribute{{
-							FriendlyName: "uid",
-							Name:         model.XMLSOAPClaimsEmailAddress,
-							NameFormat:   model.ObjectIDAttributeNameFormat,
-							Values: []saml.AttributeValue{{
-								Type:  model.XMLTypeString,
-								Value: "username",
+				mock.mockSAML.EXPECT().ParseResponse(gomock.Any(), gomock.Any(), nil).Return(&bhceSAML.ValidatedResponse{
+					Assertion: &saml.Assertion{
+						AttributeStatements: []saml.AttributeStatement{{
+							Attributes: []saml.Attribute{{
+								FriendlyName: "uid",
+								Name:         model.XMLSOAPClaimsEmailAddress,
+								NameFormat:   model.ObjectIDAttributeNameFormat,
+								Values: []saml.AttributeValue{{
+									Type:  model.XMLTypeString,
+									Value: "username",
+								}},
 							}},
 						}},
-					}},
-				}, nil)
+					}}, nil)
+				mock.mockDatabase.EXPECT().CreateSAMLConsumedIdentifiers(
+					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+				).Return(nil)
 				mock.mockDatabase.EXPECT().GetAllRoles(gomock.Any(), gomock.Any(), gomock.Any()).Return(model.Roles{
 					{
 						Permissions: model.Permissions{model.NewPermission("auth", "ManageUsers")},
@@ -2939,19 +2953,22 @@ func TestManagementResource_SAMLCallbackHandler(t *testing.T) {
 						},
 					},
 				}, nil)
-				mock.mockSAML.EXPECT().ParseResponse(gomock.Any(), gomock.Any(), nil).Return(&saml.Assertion{
-					AttributeStatements: []saml.AttributeStatement{{
-						Attributes: []saml.Attribute{{
-							FriendlyName: "uid",
-							Name:         model.XMLSOAPClaimsEmailAddress,
-							NameFormat:   model.ObjectIDAttributeNameFormat,
-							Values: []saml.AttributeValue{{
-								Type:  model.XMLTypeString,
-								Value: "username",
+				mock.mockSAML.EXPECT().ParseResponse(gomock.Any(), gomock.Any(), nil).Return(&bhceSAML.ValidatedResponse{
+					Assertion: &saml.Assertion{
+						AttributeStatements: []saml.AttributeStatement{{
+							Attributes: []saml.Attribute{{
+								FriendlyName: "uid",
+								Name:         model.XMLSOAPClaimsEmailAddress,
+								NameFormat:   model.ObjectIDAttributeNameFormat,
+								Values: []saml.AttributeValue{{
+									Type:  model.XMLTypeString,
+									Value: "username",
+								}},
 							}},
 						}},
-					}},
-				}, nil)
+					}}, nil)
+				mock.mockDatabase.EXPECT().CreateSAMLConsumedIdentifiers(gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 				mock.mockDatabase.EXPECT().GetAllRoles(gomock.Any(), gomock.Any(), gomock.Any()).Return(model.Roles{
 					{
 						Permissions: model.Permissions{model.NewPermission("auth", "ManageUsers")},
@@ -3020,19 +3037,22 @@ func TestManagementResource_SAMLCallbackHandler(t *testing.T) {
 						ID: int32(1),
 					},
 				}, nil)
-				mock.mockSAML.EXPECT().ParseResponse(gomock.Any(), gomock.Any(), nil).Return(&saml.Assertion{
-					AttributeStatements: []saml.AttributeStatement{{
-						Attributes: []saml.Attribute{{
-							FriendlyName: "uid",
-							Name:         model.XMLSOAPClaimsEmailAddress,
-							NameFormat:   model.ObjectIDAttributeNameFormat,
-							Values: []saml.AttributeValue{{
-								Type:  model.XMLTypeString,
-								Value: "username",
+				mock.mockSAML.EXPECT().ParseResponse(gomock.Any(), gomock.Any(), nil).Return(&bhceSAML.ValidatedResponse{
+					Assertion: &saml.Assertion{
+						AttributeStatements: []saml.AttributeStatement{{
+							Attributes: []saml.Attribute{{
+								FriendlyName: "uid",
+								Name:         model.XMLSOAPClaimsEmailAddress,
+								NameFormat:   model.ObjectIDAttributeNameFormat,
+								Values: []saml.AttributeValue{{
+									Type:  model.XMLTypeString,
+									Value: "username",
+								}},
 							}},
 						}},
-					}},
-				}, nil)
+					}}, nil)
+				mock.mockDatabase.EXPECT().CreateSAMLConsumedIdentifiers(gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 				mock.mockDatabase.EXPECT().CreateAuditLog(gomock.Any(), gomock.Any()).Times(2)
 				mock.mockDatabase.EXPECT().LookupUser(gomock.Any(), "username").Return(model.User{
 					SSOProviderID: null.Int32{
@@ -3129,29 +3149,32 @@ func TestManagementResource_SAMLCallbackHandler(t *testing.T) {
 					SSOProviderID: null.Int32From(1),
 					Roles:         model.Roles{model.Role{Name: auth.RoleAdministrator}},
 				}, nil)
-				mock.mockSAML.EXPECT().ParseResponse(gomock.Any(), gomock.Any(), nil).Return(&saml.Assertion{
-					AttributeStatements: []saml.AttributeStatement{{
-						Attributes: []saml.Attribute{{
-							FriendlyName: "uid",
-							Name:         model.XMLSOAPClaimsEmailAddress,
-							NameFormat:   model.ObjectIDAttributeNameFormat,
-							Values: []saml.AttributeValue{{
-								Type:  model.XMLTypeString,
-								Value: "username",
-							}},
-						},
-							{
-								FriendlyName: "role",
-								Name:         model.MicrosoftClaimsRole,
+				mock.mockSAML.EXPECT().ParseResponse(gomock.Any(), gomock.Any(), nil).Return(&bhceSAML.ValidatedResponse{
+					Assertion: &saml.Assertion{
+						AttributeStatements: []saml.AttributeStatement{{
+							Attributes: []saml.Attribute{{
+								FriendlyName: "uid",
+								Name:         model.XMLSOAPClaimsEmailAddress,
 								NameFormat:   model.ObjectIDAttributeNameFormat,
 								Values: []saml.AttributeValue{{
 									Type:  model.XMLTypeString,
-									Value: auth.RoleAdministrator,
+									Value: "username",
 								}},
 							},
-						},
-					}},
-				}, nil)
+								{
+									FriendlyName: "role",
+									Name:         model.MicrosoftClaimsRole,
+									NameFormat:   model.ObjectIDAttributeNameFormat,
+									Values: []saml.AttributeValue{{
+										Type:  model.XMLTypeString,
+										Value: auth.RoleAdministrator,
+									}},
+								},
+							},
+						}},
+					}}, nil)
+				mock.mockDatabase.EXPECT().CreateSAMLConsumedIdentifiers(gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 				mock.mockDatabase.EXPECT().CreateAuditLog(gomock.Any(), gomock.Any()).Times(2)
 				mock.mockDatabase.EXPECT().CreateUserSession(gomock.Any(), gomock.Any()).Return(model.UserSession{}, nil)
 			},
@@ -3231,29 +3254,32 @@ func TestManagementResource_SAMLCallbackHandler(t *testing.T) {
 					SSOProviderID: null.Int32From(1),
 					Roles:         model.Roles{model.Role{Name: auth.RoleUser}},
 				}, nil)
-				mock.mockSAML.EXPECT().ParseResponse(gomock.Any(), gomock.Any(), nil).Return(&saml.Assertion{
-					AttributeStatements: []saml.AttributeStatement{{
-						Attributes: []saml.Attribute{{
-							FriendlyName: "uid",
-							Name:         model.XMLSOAPClaimsEmailAddress,
-							NameFormat:   model.ObjectIDAttributeNameFormat,
-							Values: []saml.AttributeValue{{
-								Type:  model.XMLTypeString,
-								Value: "username",
-							}},
-						},
-							{
-								FriendlyName: "role",
-								Name:         model.MicrosoftClaimsRole,
+				mock.mockSAML.EXPECT().ParseResponse(gomock.Any(), gomock.Any(), nil).Return(&bhceSAML.ValidatedResponse{
+					Assertion: &saml.Assertion{
+						AttributeStatements: []saml.AttributeStatement{{
+							Attributes: []saml.Attribute{{
+								FriendlyName: "uid",
+								Name:         model.XMLSOAPClaimsEmailAddress,
 								NameFormat:   model.ObjectIDAttributeNameFormat,
 								Values: []saml.AttributeValue{{
 									Type:  model.XMLTypeString,
-									Value: auth.RoleUser,
+									Value: "username",
 								}},
 							},
-						},
-					}},
-				}, nil)
+								{
+									FriendlyName: "role",
+									Name:         model.MicrosoftClaimsRole,
+									NameFormat:   model.ObjectIDAttributeNameFormat,
+									Values: []saml.AttributeValue{{
+										Type:  model.XMLTypeString,
+										Value: auth.RoleUser,
+									}},
+								},
+							},
+						}},
+					}}, nil)
+				mock.mockDatabase.EXPECT().CreateSAMLConsumedIdentifiers(gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 				mock.mockDatabase.EXPECT().CreateAuditLog(gomock.Any(), gomock.Any()).Times(2)
 				mock.mockDatabase.EXPECT().CreateUserSession(gomock.Any(), gomock.Any()).Return(model.UserSession{}, nil)
 			},

--- a/cmd/api/src/daemons/gc/data_pruning.go
+++ b/cmd/api/src/daemons/gc/data_pruning.go
@@ -18,9 +18,11 @@ package gc
 
 import (
 	"context"
+	"log/slog"
 	"time"
 
 	"github.com/specterops/bloodhound/cmd/api/src/database"
+	"github.com/specterops/bloodhound/packages/go/bhlog/attr"
 )
 
 // Daemon holds data relevant to the data daemon
@@ -52,6 +54,7 @@ func (s *Daemon) Start(ctx context.Context) {
 	// prune sessions and collections once when the daemon starts up
 	s.db.SweepSessions(ctx)
 	s.db.SweepAssetGroupCollections(ctx)
+	runSAMLConsumedIdentifiersSweep(ctx, s.db)
 
 	// thereafter, prune conditionally once a day
 	for {
@@ -59,6 +62,7 @@ func (s *Daemon) Start(ctx context.Context) {
 		case <-ticker.C:
 			s.db.SweepSessions(ctx)
 			s.db.SweepAssetGroupCollections(ctx)
+			runSAMLConsumedIdentifiersSweep(ctx, s.db)
 
 		case <-s.exitC:
 			return
@@ -77,4 +81,11 @@ func (s *Daemon) Stop(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+func runSAMLConsumedIdentifiersSweep(ctx context.Context, db database.Database) {
+	err := db.SweepSAMLConsumedIdentifiers(ctx)
+	if err != nil {
+		slog.ErrorContext(ctx, "Failed to remove expired SAML consumed identifiers", attr.Error(err))
+	}
 }

--- a/cmd/api/src/daemons/gc/data_pruning_test.go
+++ b/cmd/api/src/daemons/gc/data_pruning_test.go
@@ -58,6 +58,9 @@ func TestGC_Start(t *testing.T) {
 	mockDB.EXPECT().SweepAssetGroupCollections(gomock.Any()).Do(func(ctx context.Context) {
 		time.Sleep(1 * time.Millisecond)
 	})
+	mockDB.EXPECT().SweepSAMLConsumedIdentifiers(gomock.Any()).Do(func(ctx context.Context) {
+		time.Sleep(1 * time.Millisecond)
+	}).Return(nil)
 
 	daemon := NewDataPruningDaemon(mockDB)
 	require.NotNil(t, daemon)

--- a/cmd/api/src/database/db.go
+++ b/cmd/api/src/database/db.go
@@ -57,6 +57,7 @@ var (
 	ErrDuplicateKindName             = errors.New("duplicate kind name")
 	ErrDuplicateGlyph                = errors.New("duplicate glyph")
 	ErrPositionOutOfRange            = errors.New("position out of range")
+	ErrSAMLIdentifierAlreadyConsumed = errors.New("SAMLResponse or assertion has already been consumed")
 )
 
 func IsUnexpectedDatabaseError(err error) bool {

--- a/cmd/api/src/database/db.go
+++ b/cmd/api/src/database/db.go
@@ -134,6 +134,7 @@ type Database interface {
 	SSOProviderData
 	OIDCProviderData
 	SAMLProviderData
+	SAMLConsumedData
 
 	// Sessions
 	CreateUserSession(ctx context.Context, userSession model.UserSession) (model.UserSession, error)

--- a/cmd/api/src/database/migration/migrations/20260812000031_v9_add_saml_consumed_identifiers_bed_9064.sql
+++ b/cmd/api/src/database/migration/migrations/20260812000031_v9_add_saml_consumed_identifiers_bed_9064.sql
@@ -1,0 +1,18 @@
+-- +goose Up
+CREATE TABLE IF NOT EXISTS saml_consumed_identifiers
+(
+  sso_provider_id INTEGER                  NOT NULL REFERENCES sso_providers (id) ON DELETE CASCADE,
+  idp_issuer      VARCHAR(1024)            NOT NULL,
+  identifier_type TEXT                     NOT NULL CHECK (identifier_type IN ('response', 'assertion')),
+  identifier      VARCHAR(255)             NOT NULL,
+  expires_at      TIMESTAMP WITH TIME ZONE NOT NULL,
+  consumed_at     TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+
+  PRIMARY KEY (sso_provider_id, idp_issuer, identifier_type, identifier)
+);
+
+CREATE INDEX IF NOT EXISTS idx_saml_consumed_identifiers_expires_at
+  ON saml_consumed_identifiers (expires_at);
+
+-- +goose Down
+DROP TABLE IF EXISTS saml_consumed_identifiers;

--- a/cmd/api/src/database/migration/migrations/20260812000031_v9_add_saml_consumed_identifiers_bed_9064.sql
+++ b/cmd/api/src/database/migration/migrations/20260812000031_v9_add_saml_consumed_identifiers_bed_9064.sql
@@ -15,20 +15,31 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 -- +goose Up
+-- +goose StatementBegin
+DO $$ BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_type t
+                   JOIN pg_namespace n ON n.oid = t.typnamespace
+                   WHERE t.typname = 'saml_identifier_type' AND n.nspname = 'public') THEN
+        CREATE TYPE saml_identifier_type AS ENUM ('response', 'assertion');
+    END IF;
+END $$;
+-- +goose StatementEnd
+
 CREATE TABLE IF NOT EXISTS saml_consumed_identifiers
 (
-  sso_provider_id INTEGER                  NOT NULL REFERENCES sso_providers (id) ON DELETE CASCADE,
-  idp_issuer      VARCHAR(1024)            NOT NULL,
-  identifier_type TEXT                     NOT NULL CHECK (identifier_type IN ('response', 'assertion')),
-  identifier      VARCHAR(255)             NOT NULL,
-  expires_at      TIMESTAMP WITH TIME ZONE NOT NULL,
-  consumed_at     TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    sso_provider_id INTEGER                  NOT NULL REFERENCES sso_providers (id) ON DELETE CASCADE,
+    idp_issuer      TEXT                     NOT NULL,
+    identifier_type saml_identifier_type     NOT NULL,
+    identifier      TEXT                     NOT NULL,
+    expires_at      TIMESTAMP WITH TIME ZONE NOT NULL,
+    consumed_at     TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
 
-  PRIMARY KEY (sso_provider_id, idp_issuer, identifier_type, identifier)
+    PRIMARY KEY (sso_provider_id, identifier_type, identifier)
 );
 
 CREATE INDEX IF NOT EXISTS idx_saml_consumed_identifiers_expires_at
-  ON saml_consumed_identifiers (expires_at);
+    ON saml_consumed_identifiers (expires_at);
 
 -- +goose Down
 DROP TABLE IF EXISTS saml_consumed_identifiers;
+DROP TYPE IF EXISTS saml_identifier_type;

--- a/cmd/api/src/database/migration/migrations/20260812000031_v9_add_saml_consumed_identifiers_bed_9064.sql
+++ b/cmd/api/src/database/migration/migrations/20260812000031_v9_add_saml_consumed_identifiers_bed_9064.sql
@@ -1,3 +1,19 @@
+-- Copyright 2026 Specter Ops, Inc.
+--
+-- Licensed under the Apache License, Version 2.0
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- SPDX-License-Identifier: Apache-2.0
+
 -- +goose Up
 CREATE TABLE IF NOT EXISTS saml_consumed_identifiers
 (

--- a/cmd/api/src/database/mocks/db.go
+++ b/cmd/api/src/database/mocks/db.go
@@ -552,6 +552,20 @@ func (mr *MockDatabaseMockRecorder) CreateRemediation(ctx, findingId, shortDescr
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateRemediation", reflect.TypeOf((*MockDatabase)(nil).CreateRemediation), ctx, findingId, shortDescription, longDescription, shortRemediation, longRemediation)
 }
 
+// CreateSAMLConsumedIdentifiers mocks base method.
+func (m *MockDatabase) CreateSAMLConsumedIdentifiers(ctx context.Context, ssoProviderID int32, idpIssuer, responseID, assertionID string, expiresAt time.Time) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateSAMLConsumedIdentifiers", ctx, ssoProviderID, idpIssuer, responseID, assertionID, expiresAt)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CreateSAMLConsumedIdentifiers indicates an expected call of CreateSAMLConsumedIdentifiers.
+func (mr *MockDatabaseMockRecorder) CreateSAMLConsumedIdentifiers(ctx, ssoProviderID, idpIssuer, responseID, assertionID, expiresAt any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSAMLConsumedIdentifiers", reflect.TypeOf((*MockDatabase)(nil).CreateSAMLConsumedIdentifiers), ctx, ssoProviderID, idpIssuer, responseID, assertionID, expiresAt)
+}
+
 // CreateSAMLIdentityProvider mocks base method.
 func (m *MockDatabase) CreateSAMLIdentityProvider(ctx context.Context, samlProvider model.SAMLProvider, config model.SSOProviderConfig) (model.SAMLProvider, error) {
 	m.ctrl.T.Helper()

--- a/cmd/api/src/database/mocks/db.go
+++ b/cmd/api/src/database/mocks/db.go
@@ -3262,6 +3262,20 @@ func (mr *MockDatabaseMockRecorder) SweepAssetGroupCollections(ctx any) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SweepAssetGroupCollections", reflect.TypeOf((*MockDatabase)(nil).SweepAssetGroupCollections), ctx)
 }
 
+// SweepSAMLConsumedIdentifiers mocks base method.
+func (m *MockDatabase) SweepSAMLConsumedIdentifiers(ctx context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SweepSAMLConsumedIdentifiers", ctx)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SweepSAMLConsumedIdentifiers indicates an expected call of SweepSAMLConsumedIdentifiers.
+func (mr *MockDatabaseMockRecorder) SweepSAMLConsumedIdentifiers(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SweepSAMLConsumedIdentifiers", reflect.TypeOf((*MockDatabase)(nil).SweepSAMLConsumedIdentifiers), ctx)
+}
+
 // SweepSessions mocks base method.
 func (m *MockDatabase) SweepSessions(ctx context.Context) {
 	m.ctrl.T.Helper()

--- a/cmd/api/src/database/samlconsumedidentifiers.go
+++ b/cmd/api/src/database/samlconsumedidentifiers.go
@@ -1,3 +1,18 @@
+// Copyright 2026 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 package database
 
 import (

--- a/cmd/api/src/database/samlconsumedidentifiers.go
+++ b/cmd/api/src/database/samlconsumedidentifiers.go
@@ -13,6 +13,7 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
+
 package database
 
 import (
@@ -35,7 +36,6 @@ const (
 // stored in the saml_consumed_identifiers table.
 type SAMLConsumedData interface {
 	CreateSAMLConsumedIdentifiers(ctx context.Context, ssoProviderID int32, idpIssuer, responseID, assertionID string, expiresAt time.Time) error
-	//SweepSAMLConsumedIdentifiers(ctx context.Context) error
 }
 
 // CreateSAMLConsumedIdentifiers inserts the SAMLResponse and assertion from a single SAML login so they cannot be replayed.
@@ -69,8 +69,3 @@ func (s *BloodhoundDB) CreateSAMLConsumedIdentifiers(ctx context.Context, ssoPro
 		return nil
 	})
 }
-
-// SweepSAMLConsumedIdentifiers deletes all SAMLResponse and Assertion identifiers that have already expired
-//func (s *BloodhoundDB) SweepSAMLConsumedIdentifiers(ctx context.Context) error {
-//	return s.db.WithContext(ctx).Where("expires_at < NOW()").Delete(xyz).Error
-//}

--- a/cmd/api/src/database/samlconsumedidentifiers.go
+++ b/cmd/api/src/database/samlconsumedidentifiers.go
@@ -36,6 +36,7 @@ const (
 // stored in the saml_consumed_identifiers table.
 type SAMLConsumedData interface {
 	CreateSAMLConsumedIdentifiers(ctx context.Context, ssoProviderID int32, idpIssuer, responseID, assertionID string, expiresAt time.Time) error
+	SweepSAMLConsumedIdentifiers(ctx context.Context) error
 }
 
 // CreateSAMLConsumedIdentifiers inserts the SAMLResponse and assertion from a single SAML login so they cannot be replayed.
@@ -68,4 +69,18 @@ func (s *BloodhoundDB) CreateSAMLConsumedIdentifiers(ctx context.Context, ssoPro
 		}
 		return nil
 	})
+}
+
+// SweepSAMLConsumedIdentifiers deletes all SAMLResponse and assertion identifiers that have expired
+func (s *BloodhoundDB) SweepSAMLConsumedIdentifiers(ctx context.Context) error {
+	result := s.db.WithContext(ctx).Exec(fmt.Sprintf(`DELETE FROM %s WHERE expires_at < NOW()`,
+		samlConsumedIdentifiersTableName))
+
+	if result.Error != nil {
+		return result.Error
+	}
+	if result.RowsAffected > 0 {
+		slog.DebugContext(ctx, "SAML identifiers cleanup", slog.Int64("rows_affected", result.RowsAffected))
+	}
+	return nil
 }

--- a/cmd/api/src/database/samlconsumedidentifiers.go
+++ b/cmd/api/src/database/samlconsumedidentifiers.go
@@ -1,0 +1,58 @@
+package database
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+const (
+	samlConsumedIdentifiersTableName = "saml_consumed_identifiers"
+)
+
+// SAMLConsumedData defines the methods for persisting and deleting SAML identifiers consumed during login,
+// stored in the saml_consumed_identifiers table
+type SAMLConsumedData interface {
+	CreateSAMLConsumedIdentifiers(ctx context.Context, ssoProviderID int32, idpIssuer, responseID, assertionID string, expiresAt time.Time) error
+	//SweepSAMLConsumedIdentifiers(ctx context.Context) error
+}
+
+// CreateSAMLConsumedIdentifiers inserts the SAMLResponse and assertion from a single SAML login so they cannot be replayed.
+// Both identifiers are inserted together or not at all. If either identifier has already been consumed, it returns
+// ErrSAMLIdentifierAlreadyConsumed and no records are written.
+func (s *BloodhoundDB) CreateSAMLConsumedIdentifiers(ctx context.Context, ssoProviderID int32, idpIssuer, responseID, assertionID string,
+	expiresAt time.Time) error {
+	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		result := tx.Exec(fmt.Sprintf(`INSERT INTO %s
+			(sso_provider_id, idp_issuer, identifier_type, identifier, expires_at)
+			VALUES
+				(?, ?, 'response', ?, ?),
+				(?, ?, 'assertion', ?, ?)
+			ON CONFLICT DO NOTHING`, samlConsumedIdentifiersTableName),
+			ssoProviderID, idpIssuer, responseID, expiresAt,
+			ssoProviderID, idpIssuer, assertionID, expiresAt,
+		)
+
+		if result.Error != nil {
+			return result.Error
+		}
+		if result.RowsAffected != 2 {
+			slog.WarnContext(
+				ctx,
+				"SAMLResponse or assertion already consumed (possible replay)",
+				slog.Int("sso_provider_id", int(ssoProviderID)),
+				slog.String("idp_issuer", idpIssuer),
+			)
+			return ErrSAMLIdentifierAlreadyConsumed
+		}
+		return nil
+	})
+}
+
+// SweepSAMLConsumedIdentifiers deletes all SAMLResponse and Assertion identifiers that have already expired
+//func (s *BloodhoundDB) SweepSAMLConsumedIdentifiers(ctx context.Context) error {
+//	return s.db.WithContext(ctx).Where("expires_at < NOW()").Delete(xyz).Error
+//}

--- a/cmd/api/src/database/samlconsumedidentifiers.go
+++ b/cmd/api/src/database/samlconsumedidentifiers.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -26,10 +26,13 @@ import (
 
 const (
 	samlConsumedIdentifiersTableName = "saml_consumed_identifiers"
+	// these must match the saml_identifier_type enum in the saml_consumed_identifiers migration.
+	samlIdentifierTypeResponse  = "response"
+	samlIdentifierTypeAssertion = "assertion"
 )
 
 // SAMLConsumedData defines the methods for persisting and deleting SAML identifiers consumed during login,
-// stored in the saml_consumed_identifiers table
+// stored in the saml_consumed_identifiers table.
 type SAMLConsumedData interface {
 	CreateSAMLConsumedIdentifiers(ctx context.Context, ssoProviderID int32, idpIssuer, responseID, assertionID string, expiresAt time.Time) error
 	//SweepSAMLConsumedIdentifiers(ctx context.Context) error
@@ -44,11 +47,11 @@ func (s *BloodhoundDB) CreateSAMLConsumedIdentifiers(ctx context.Context, ssoPro
 		result := tx.Exec(fmt.Sprintf(`INSERT INTO %s
 			(sso_provider_id, idp_issuer, identifier_type, identifier, expires_at)
 			VALUES
-				(?, ?, 'response', ?, ?),
-				(?, ?, 'assertion', ?, ?)
+				(?, ?, ?, ?, ?),
+				(?, ?, ?, ?, ?)
 			ON CONFLICT DO NOTHING`, samlConsumedIdentifiersTableName),
-			ssoProviderID, idpIssuer, responseID, expiresAt,
-			ssoProviderID, idpIssuer, assertionID, expiresAt,
+			ssoProviderID, idpIssuer, samlIdentifierTypeResponse, responseID, expiresAt,
+			ssoProviderID, idpIssuer, samlIdentifierTypeAssertion, assertionID, expiresAt,
 		)
 
 		if result.Error != nil {

--- a/cmd/api/src/database/samlconsumedidentifiers_integration_test.go
+++ b/cmd/api/src/database/samlconsumedidentifiers_integration_test.go
@@ -1,0 +1,127 @@
+// Copyright 2026 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build integration
+
+package database_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/specterops/bloodhound/cmd/api/src/database"
+	"github.com/specterops/bloodhound/cmd/api/src/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// registerAndGetSSOProvider creates an SSO provider that saml_consumed_identifiers can reference and returns its int32 ID.
+func registerAndGetSSOProvider(t *testing.T, testSuite IntegrationTestSuite, name string) int32 {
+	t.Helper()
+
+	provider, err := testSuite.BHDatabase.CreateSSOProvider(testSuite.Context, name, model.SessionAuthProviderSAML, model.SSOProviderConfig{})
+	require.NoError(t, err)
+
+	return provider.ID
+}
+
+func TestDatabase_CreateSAMLConsumedIdentifiers(t *testing.T) {
+	const idpIssuer = "https://idp.example.com/12345678-90ab-cdef-1234-567890abcdef"
+
+	tests := []struct {
+		name string
+		test func(t *testing.T, testSuite IntegrationTestSuite)
+	}{
+		{
+			name: "Success: consumes both identifiers (SAMLResponse and assertion) on first login",
+			test: func(t *testing.T, testSuite IntegrationTestSuite) {
+				ssoProviderID := registerAndGetSSOProvider(t, testSuite, "provider-first-login")
+
+				err := testSuite.BHDatabase.CreateSAMLConsumedIdentifiers(testSuite.Context, ssoProviderID, idpIssuer, "response-1", "assertion-1", time.Now().Add(time.Hour))
+				require.NoError(t, err)
+			},
+		},
+		{
+			name: "Error: rejects a full replay of both identifiers",
+			test: func(t *testing.T, testSuite IntegrationTestSuite) {
+				ssoProviderID := registerAndGetSSOProvider(t, testSuite, "provider-full-replay")
+				expiresAt := time.Now().Add(time.Hour)
+
+				err := testSuite.BHDatabase.CreateSAMLConsumedIdentifiers(testSuite.Context, ssoProviderID, idpIssuer, "response-2", "assertion-2", expiresAt)
+				require.NoError(t, err)
+
+				// replaying the exact same response/assertion pair is rejected
+				err = testSuite.BHDatabase.CreateSAMLConsumedIdentifiers(testSuite.Context, ssoProviderID, idpIssuer, "response-2", "assertion-2", expiresAt)
+				assert.ErrorIs(t, err, database.ErrSAMLIdentifierAlreadyConsumed)
+			},
+		},
+		{
+			name: "Error: rejects and rolls back when only one identifier is a replay",
+			test: func(t *testing.T, testSuite IntegrationTestSuite) {
+				ssoProviderID := registerAndGetSSOProvider(t, testSuite, "provider-partial-replay")
+				expiresAt := time.Now().Add(time.Hour)
+
+				err := testSuite.BHDatabase.CreateSAMLConsumedIdentifiers(testSuite.Context, ssoProviderID, idpIssuer, "response-3", "assertion-3", expiresAt)
+				require.NoError(t, err)
+
+				// reuse the SAMLResponse ID with a new assertion ID: only one row is new
+				err = testSuite.BHDatabase.CreateSAMLConsumedIdentifiers(testSuite.Context, ssoProviderID, idpIssuer, "response-3", "assertion-3-new", expiresAt)
+				assert.ErrorIs(t, err, database.ErrSAMLIdentifierAlreadyConsumed)
+
+				// "assertion-3-new" was never persisted and can now be consumed alongside a new SAMLResponse ID
+				err = testSuite.BHDatabase.CreateSAMLConsumedIdentifiers(testSuite.Context, ssoProviderID, idpIssuer, "response-3-new", "assertion-3-new", expiresAt)
+				require.NoError(t, err)
+			},
+		},
+		{
+			name: "Success: identical identifiers are allowed for a different sso provider",
+			test: func(t *testing.T, testSuite IntegrationTestSuite) {
+				firstProviderID := registerAndGetSSOProvider(t, testSuite, "provider-scope-first")
+				secondProviderID := registerAndGetSSOProvider(t, testSuite, "provider-scope-second")
+				expiresAt := time.Now().Add(time.Hour)
+
+				err := testSuite.BHDatabase.CreateSAMLConsumedIdentifiers(testSuite.Context, firstProviderID, idpIssuer, "shared-response", "shared-assertion", expiresAt)
+				require.NoError(t, err)
+
+				// the composite primary key includes sso_provider_id, so the same SAMLResponse/assertion values under a
+				// different provider are not a replay
+				err = testSuite.BHDatabase.CreateSAMLConsumedIdentifiers(testSuite.Context, secondProviderID, idpIssuer, "shared-response", "shared-assertion", expiresAt)
+				require.NoError(t, err)
+			},
+		},
+		{
+			name: "Error: rejects identifiers for a non-existent sso provider",
+			test: func(t *testing.T, testSuite IntegrationTestSuite) {
+				// intentionally skip creating a provider (foreign key) so the insert fails before any replay check
+				const nonExistentSSOProviderID = int32(999999)
+
+				err := testSuite.BHDatabase.CreateSAMLConsumedIdentifiers(testSuite.Context, nonExistentSSOProviderID, idpIssuer, "response-4", "assertion-4", time.Now().Add(time.Hour))
+				require.Error(t, err)
+				// assert this failed on the foreign key, not as a replay rejection
+				assert.NotErrorIs(t, err, database.ErrSAMLIdentifierAlreadyConsumed)
+			},
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			testSuite := setupIntegrationTestSuite(t)
+			defer teardownIntegrationTestSuite(t, &testSuite)
+
+			testCase.test(t, testSuite)
+		})
+	}
+}

--- a/cmd/api/src/database/samlconsumedidentifiers_integration_test.go
+++ b/cmd/api/src/database/samlconsumedidentifiers_integration_test.go
@@ -28,16 +28,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// registerAndGetSSOProvider creates an SSO provider that saml_consumed_identifiers can reference and returns its int32 ID.
-func registerAndGetSSOProvider(t *testing.T, testSuite IntegrationTestSuite, name string) int32 {
-	t.Helper()
-
-	provider, err := testSuite.BHDatabase.CreateSSOProvider(testSuite.Context, name, model.SessionAuthProviderSAML, model.SSOProviderConfig{})
-	require.NoError(t, err)
-
-	return provider.ID
-}
-
 func TestDatabase_CreateSAMLConsumedIdentifiers(t *testing.T) {
 	const idpIssuer = "https://idp.example.com/12345678-90ab-cdef-1234-567890abcdef"
 
@@ -124,4 +114,71 @@ func TestDatabase_CreateSAMLConsumedIdentifiers(t *testing.T) {
 			testCase.test(t, testSuite)
 		})
 	}
+}
+
+func TestDatabase_SweepSAMLConsumedIdentifiers(t *testing.T) {
+	const idpIssuer = "https://idp.example.com/12345678-90ab-cdef-1234-567890abcdef"
+
+	tests := []struct {
+		name string
+		test func(t *testing.T, testSuite IntegrationTestSuite)
+	}{
+		{
+			name: "Success: no-op when the table is empty",
+			test: func(t *testing.T, testSuite IntegrationTestSuite) {
+				err := testSuite.BHDatabase.SweepSAMLConsumedIdentifiers(testSuite.Context)
+				require.NoError(t, err)
+
+				assert.Empty(t, remainingSAMLConsumedIdentifiers(t, testSuite))
+			},
+		},
+		{
+			name: "Success: deletes expired records and keeps unexpired ones",
+			test: func(t *testing.T, testSuite IntegrationTestSuite) {
+				ssoProviderID := registerAndGetSSOProvider(t, testSuite, "1234")
+
+				err := testSuite.BHDatabase.CreateSAMLConsumedIdentifiers(testSuite.Context, ssoProviderID, idpIssuer, "response-expired", "assertion-expired", time.Now().Add(-time.Hour))
+				require.NoError(t, err)
+
+				err = testSuite.BHDatabase.CreateSAMLConsumedIdentifiers(testSuite.Context, ssoProviderID, idpIssuer, "response-live", "assertion-live", time.Now().Add(time.Hour))
+				require.NoError(t, err)
+
+				err = testSuite.BHDatabase.SweepSAMLConsumedIdentifiers(testSuite.Context)
+				require.NoError(t, err)
+
+				assert.ElementsMatch(t, []string{"response-live", "assertion-live"}, remainingSAMLConsumedIdentifiers(t, testSuite))
+			},
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			testSuite := setupIntegrationTestSuite(t)
+			defer teardownIntegrationTestSuite(t, &testSuite)
+
+			testCase.test(t, testSuite)
+		})
+	}
+}
+
+// registerAndGetSSOProvider creates an SSO provider that saml_consumed_identifiers can reference and returns its int32 ID.
+func registerAndGetSSOProvider(t *testing.T, testSuite IntegrationTestSuite, name string) int32 {
+	t.Helper()
+
+	provider, err := testSuite.BHDatabase.CreateSSOProvider(testSuite.Context, name, model.SessionAuthProviderSAML, model.SSOProviderConfig{})
+	require.NoError(t, err)
+
+	return provider.ID
+}
+
+// remainingSAMLConsumedIdentifiers returns the identifier values currently stored in saml_consumed_identifiers.
+func remainingSAMLConsumedIdentifiers(t *testing.T, testSuite IntegrationTestSuite) []string {
+	t.Helper()
+
+	var identifiers []string
+
+	result := testSuite.DB.WithContext(testSuite.Context).Raw(`SELECT identifier FROM saml_consumed_identifiers`).Scan(&identifiers)
+	require.NoError(t, result.Error)
+
+	return identifiers
 }

--- a/cmd/api/src/services/saml/mocks/saml.go
+++ b/cmd/api/src/services/saml/mocks/saml.go
@@ -30,6 +30,7 @@ import (
 	reflect "reflect"
 
 	saml "github.com/crewjam/saml"
+	saml0 "github.com/specterops/bloodhound/cmd/api/src/services/saml"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -73,10 +74,10 @@ func (mr *MockServiceMockRecorder) MakeAuthenticationRequest(serviceProvider, id
 }
 
 // ParseResponse mocks base method.
-func (m *MockService) ParseResponse(serviceProvider saml.ServiceProvider, req *http.Request, possibleRequestIDs []string) (*saml.Assertion, error) {
+func (m *MockService) ParseResponse(serviceProvider saml.ServiceProvider, req *http.Request, possibleRequestIDs []string) (*saml0.ValidatedResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ParseResponse", serviceProvider, req, possibleRequestIDs)
-	ret0, _ := ret[0].(*saml.Assertion)
+	ret0, _ := ret[0].(*saml0.ValidatedResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/cmd/api/src/services/saml/saml.go
+++ b/cmd/api/src/services/saml/saml.go
@@ -36,10 +36,18 @@ type Service interface {
 
 type Client struct{}
 
+// ValidatedResponse represents a successfully parsed and validated SAML login: the verified assertion
+// and the SAMLResponse's own ID and IssueInstant
 type ValidatedResponse struct {
 	Assertion            *saml.Assertion
 	ResponseID           string
 	ResponseIssueInstant time.Time
+}
+
+type assertionCounter struct {
+	XMLName             xml.Name
+	Assertions          []struct{} `xml:"urn:oasis:names:tc:SAML:2.0:assertion Assertion"`
+	EncryptedAssertions []struct{} `xml:"urn:oasis:names:tc:SAML:2.0:assertion EncryptedAssertion"`
 }
 
 // MakeAuthenticationRequest abstracts creating an SAML authentication request using
@@ -48,13 +56,13 @@ func (c *Client) MakeAuthenticationRequest(serviceProvider saml.ServiceProvider,
 	return serviceProvider.MakeAuthenticationRequest(idpURL, binding, resultBinding)
 }
 
-// ParseResponse abstracts the handling/validation of the IdP response. // TODO
-// The purpose is to extract the SAML IdP response received in req, resolves
-// artifacts when necessary, validates it, and returns the verified assertion and response.
+// ParseResponse wraps the parsing and validation of the IdP's SAMLResponse in req and returns the verified assertion
+// together with the SAMLResponse's own details in a ValidatedResponse.
 func (c *Client) ParseResponse(serviceProvider saml.ServiceProvider, req *http.Request, possibleRequestIDs []string) (*ValidatedResponse, error) {
 	var (
 		fullResponse ValidatedResponse
 		samlResponse saml.Response
+		issuer       string
 	)
 
 	assertion, err := serviceProvider.ParseResponse(req, possibleRequestIDs)
@@ -66,7 +74,29 @@ func (c *Client) ParseResponse(serviceProvider saml.ServiceProvider, req *http.R
 		return nil, fmt.Errorf("saml: failed to decode SAMLResponse: %w", err)
 	}
 	if err := xml.Unmarshal(rawXMLSAMLResponse, &samlResponse); err != nil {
-		return nil, fmt.Errorf("saml: failed to unmarshal SAML response: %w", err)
+		return nil, fmt.Errorf("saml: failed to unmarshal SAMLResponse: %w", err)
+	}
+	if samlResponse.Issuer != nil {
+		issuer = samlResponse.Issuer.Value
+	}
+
+	// It is rare but possible for a SAMLResponse to have more than one signed assertion (with an unsigned SAMLResponse);
+	// crewjam validates them all, but returns only the first. Since discarded assertions are replayable,
+	// reject a SAMLResponse with multiple assertions
+	if assertionCount, err := countAssertions(rawXMLSAMLResponse); err != nil {
+		return nil, fmt.Errorf("saml: failed to count assertions: %w", err)
+	} else if assertionCount > 1 {
+		return nil, fmt.Errorf("saml: SAMLResponse contains multiple assertions (issuer: %q)", issuer)
+	}
+
+	if samlResponse.ID == "" {
+		return nil, fmt.Errorf("saml: SAMLResponse ID is empty (issuer: %q)", issuer)
+	}
+	if assertion == nil {
+		return nil, fmt.Errorf("saml: assertion is nil (issuer: %q)", issuer)
+	}
+	if assertion.ID == "" {
+		return nil, fmt.Errorf("saml: assertion ID is empty (issuer: %q)", issuer)
 	}
 
 	fullResponse = ValidatedResponse{
@@ -76,4 +106,31 @@ func (c *Client) ParseResponse(serviceProvider saml.ServiceProvider, req *http.R
 	}
 
 	return &fullResponse, nil
+}
+
+// countAssertions returns how many SAML assertions (plaintext plus encrypted, in the SAML assertion namespace)
+// appear in the raw response XML.
+func countAssertions(rawResponseXML []byte) (int, error) {
+	var counter assertionCounter
+	if err := xml.Unmarshal(rawResponseXML, &counter); err != nil {
+		return 0, err
+	}
+
+	return len(counter.Assertions) + len(counter.EncryptedAssertions), nil
+}
+
+// CalculateSAMLTimeExpiry returns the time when a consumed SAML identifier (SAMLResponse or assertion) can be safely deleted,
+// since by then any replay attempt would be rejected as expired. It uses whichever identifier's IssueInstant is most recent
+// plus the allowed delay (crewjam's MaxIssueDelay).
+func CalculateSAMLTimeExpiry(responseIssueInstant, assertionIssueInstant time.Time) time.Time {
+	var (
+		responseExpiration  = responseIssueInstant.Add(saml.MaxIssueDelay)
+		assertionExpiration = assertionIssueInstant.Add(saml.MaxIssueDelay)
+		latest              = responseExpiration
+	)
+
+	if assertionExpiration.After(latest) {
+		latest = assertionExpiration
+	}
+	return latest
 }

--- a/cmd/api/src/services/saml/saml.go
+++ b/cmd/api/src/services/saml/saml.go
@@ -17,7 +17,11 @@
 package saml
 
 import (
+	"encoding/base64"
+	"encoding/xml"
+	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/crewjam/saml"
 )
@@ -27,10 +31,16 @@ import (
 // Service serves as a lightweight wrapper around the SAML package.
 type Service interface {
 	MakeAuthenticationRequest(serviceProvider saml.ServiceProvider, idpURL string, binding string, resultBinding string) (*saml.AuthnRequest, error)
-	ParseResponse(serviceProvider saml.ServiceProvider, req *http.Request, possibleRequestIDs []string) (*saml.Assertion, error)
+	ParseResponse(serviceProvider saml.ServiceProvider, req *http.Request, possibleRequestIDs []string) (*ValidatedResponse, error)
 }
 
 type Client struct{}
+
+type ValidatedResponse struct {
+	Assertion            *saml.Assertion
+	ResponseID           string
+	ResponseIssueInstant time.Time
+}
 
 // MakeAuthenticationRequest abstracts creating an SAML authentication request using
 // the HTTP-Redirect binding. It returns a URL that we will redirect the user to in order to start the auth process.
@@ -38,9 +48,32 @@ func (c *Client) MakeAuthenticationRequest(serviceProvider saml.ServiceProvider,
 	return serviceProvider.MakeAuthenticationRequest(idpURL, binding, resultBinding)
 }
 
-// ParseResponse abstracts the handling/validation of the IDP response.
-// The purpose is to extract the SAML IDP response received in req, resolves
-// artifacts when necessary, validates it, and returns the verified assertion.
-func (c *Client) ParseResponse(serviceProvider saml.ServiceProvider, req *http.Request, possibleRequestIDs []string) (*saml.Assertion, error) {
-	return serviceProvider.ParseResponse(req, possibleRequestIDs)
+// ParseResponse abstracts the handling/validation of the IdP response. // TODO
+// The purpose is to extract the SAML IdP response received in req, resolves
+// artifacts when necessary, validates it, and returns the verified assertion and response.
+func (c *Client) ParseResponse(serviceProvider saml.ServiceProvider, req *http.Request, possibleRequestIDs []string) (*ValidatedResponse, error) {
+	var (
+		fullResponse ValidatedResponse
+		samlResponse saml.Response
+	)
+
+	assertion, err := serviceProvider.ParseResponse(req, possibleRequestIDs)
+	if err != nil {
+		return nil, err
+	}
+	rawXMLSAMLResponse, err := base64.StdEncoding.DecodeString(req.PostForm.Get("SAMLResponse"))
+	if err != nil {
+		return nil, fmt.Errorf("saml: failed to decode SAMLResponse: %w", err)
+	}
+	if err := xml.Unmarshal(rawXMLSAMLResponse, &samlResponse); err != nil {
+		return nil, fmt.Errorf("saml: failed to unmarshal SAML response: %w", err)
+	}
+
+	fullResponse = ValidatedResponse{
+		Assertion:            assertion,
+		ResponseID:           samlResponse.ID,
+		ResponseIssueInstant: samlResponse.IssueInstant,
+	}
+
+	return &fullResponse, nil
 }

--- a/cmd/api/src/services/saml/saml.go
+++ b/cmd/api/src/services/saml/saml.go
@@ -19,6 +19,7 @@ package saml
 import (
 	"encoding/base64"
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -52,18 +53,23 @@ type assertionCounter struct {
 
 // MakeAuthenticationRequest abstracts creating an SAML authentication request using
 // the HTTP-Redirect binding. It returns a URL that we will redirect the user to in order to start the auth process.
-func (c *Client) MakeAuthenticationRequest(serviceProvider saml.ServiceProvider, idpURL string, binding string, resultBinding string) (*saml.AuthnRequest, error) {
+func (s *Client) MakeAuthenticationRequest(serviceProvider saml.ServiceProvider, idpURL string, binding string, resultBinding string) (*saml.AuthnRequest, error) {
 	return serviceProvider.MakeAuthenticationRequest(idpURL, binding, resultBinding)
 }
 
 // ParseResponse wraps the parsing and validation of the IdP's SAMLResponse in req and returns the verified assertion
 // together with the SAMLResponse's own details in a ValidatedResponse.
-func (c *Client) ParseResponse(serviceProvider saml.ServiceProvider, req *http.Request, possibleRequestIDs []string) (*ValidatedResponse, error) {
+func (s *Client) ParseResponse(serviceProvider saml.ServiceProvider, req *http.Request, possibleRequestIDs []string) (*ValidatedResponse, error) {
 	var (
 		fullResponse ValidatedResponse
 		samlResponse saml.Response
 		issuer       string
 	)
+
+	// Rejecting explicitly since BloodHound doesn't support HTTP-Artifact binding
+	if req.Form.Get("SAMLart") != "" {
+		return nil, errors.New("saml: HTTP-Artifact binding is not supported")
+	}
 
 	assertion, err := serviceProvider.ParseResponse(req, possibleRequestIDs)
 	if err != nil {

--- a/cmd/api/src/services/saml/saml_integration_test.go
+++ b/cmd/api/src/services/saml/saml_integration_test.go
@@ -1,0 +1,394 @@
+// Copyright 2026 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build integration
+
+package saml_test
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"math/big"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/beevik/etree"
+	"github.com/crewjam/saml"
+	bhceSAML "github.com/specterops/bloodhound/cmd/api/src/services/saml"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestParseResponse verifies how a real crewjam ServiceProvider validates all SAMLResponse/assertion signing
+// combinations before ParseResponse's validations take over
+func TestParseResponse(t *testing.T) {
+	tests := []struct {
+		name         string
+		buildRequest func(t *testing.T, idp testIdP) *http.Request
+		wantAccepted bool
+		errContains  string
+	}{
+		{
+			name: "unsigned Response, unsigned assertion is rejected",
+			buildRequest: func(t *testing.T, idp testIdP) *http.Request {
+				encoded, _ := idp.buildUnsignedSAMLResponse(t, defaultResponseID,
+					assertionSpec{id: "_assertion_id_a", signed: false})
+				return newSAMLRequest(t, encoded)
+			},
+			// crewjam returns an 'Authentication failed' error, so verify only that it is rejected
+			wantAccepted: false,
+		},
+		{
+			name: "unsigned Response, signed assertion is accepted",
+			buildRequest: func(t *testing.T, idp testIdP) *http.Request {
+				encoded, _ := idp.buildUnsignedSAMLResponse(t, defaultResponseID)
+				return newSAMLRequest(t, encoded)
+			},
+			wantAccepted: true,
+		},
+		{
+			name: "signed Response, unsigned assertion is accepted",
+			buildRequest: func(t *testing.T, idp testIdP) *http.Request {
+				return newSAMLRequest(t, idp.buildSignedSAMLResponse(t, "_assertion_id_a", false))
+			},
+			wantAccepted: true,
+		},
+		{
+			name: "signed Response, signed assertion is accepted",
+			buildRequest: func(t *testing.T, idp testIdP) *http.Request {
+				return newSAMLRequest(t, idp.buildSignedSAMLResponse(t, "_assertion_id_a", true))
+			},
+			wantAccepted: true,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			var (
+				idp            = newTestIdP(t)
+				req            = testCase.buildRequest(t, idp)
+				validated, err = (&bhceSAML.Client{}).ParseResponse(idp.newServiceProvider(), req, nil)
+			)
+
+			if testCase.wantAccepted {
+				require.NoError(t, err)
+				require.NotNil(t, validated)
+			} else {
+				require.Error(t, err)
+				assert.Nil(t, validated)
+				if testCase.errContains != "" {
+					assert.Contains(t, err.Error(), testCase.errContains)
+				}
+			}
+		})
+	}
+}
+
+// TestParseResponse_MultipleAssertions verifies the multiple-assertion rejection: the assertions pass crewjam's own validation,
+// but a SAMLResponse carrying more than one is still rejected (regardless of signing).
+func TestParseResponse_MultipleAssertions(t *testing.T) {
+	tests := []struct {
+		name       string
+		assertions []assertionSpec
+	}{
+		{
+			name: "two signed assertions are rejected",
+			assertions: []assertionSpec{
+				{id: "_assertion_id_a", signed: true},
+				{id: "_assertion_id_b", signed: true},
+			},
+		},
+		{
+			name: "one signed and one unsigned assertion are rejected",
+			assertions: []assertionSpec{
+				{id: "_assertion_id_a", signed: true},
+				{id: "_assertion_id_b", signed: false},
+			},
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			var (
+				idp        = newTestIdP(t)
+				encoded, _ = idp.buildUnsignedSAMLResponse(t, defaultResponseID, testCase.assertions...)
+				req        = newSAMLRequest(t, encoded)
+			)
+
+			validated, err := (&bhceSAML.Client{}).ParseResponse(idp.newServiceProvider(), req, nil)
+
+			require.Error(t, err)
+			assert.Nil(t, validated)
+			assert.Contains(t, err.Error(), "multiple assertions")
+		})
+	}
+}
+
+// TestParseResponse_EmptyIdentifiers verifies ParseResponse's checks for an empty Response ID and empty assertion ID"
+func TestParseResponse_EmptyIdentifiers(t *testing.T) {
+	t.Run("empty Response ID is rejected", func(t *testing.T) {
+		var (
+			idp = newTestIdP(t)
+			// setting up an unsigned SAMLResponse (thus its Response ID is never checked by crewjam),
+			// so it reaches ParseResponse's empty Response ID guard
+			encoded, _ = idp.buildUnsignedSAMLResponse(t, "",
+				assertionSpec{id: "_assertion_id_a", signed: true})
+			req = newSAMLRequest(t, encoded)
+		)
+
+		validated, err := (&bhceSAML.Client{}).ParseResponse(idp.newServiceProvider(), req, nil)
+
+		require.Error(t, err)
+		assert.Nil(t, validated)
+		assert.Contains(t, err.Error(), "SAMLResponse ID is empty")
+	})
+
+	t.Run("empty assertion ID is rejected", func(t *testing.T) {
+		var (
+			idp = newTestIdP(t)
+			// setting up a signed SAMLResponse containing an unsigned assertion whose ID is empty
+			// (assertion ID not checked by crewjam), so it reaches ParseResponse's empty assertion ID guard
+			req = newSAMLRequest(t, idp.buildSignedSAMLResponse(t, "", false))
+		)
+
+		validated, err := (&bhceSAML.Client{}).ParseResponse(idp.newServiceProvider(), req, nil)
+
+		require.Error(t, err)
+		assert.Nil(t, validated)
+		assert.Contains(t, err.Error(), "assertion ID is empty")
+	})
+}
+
+// TestParseResponse_ResponseFields verifies the SAMLResponse fields ParseResponse extracts again from the request/raw XML, which
+// crewjam validates but discards.
+func TestParseResponse_ResponseFields(t *testing.T) {
+	var (
+		idp                   = newTestIdP(t)
+		encoded, issueInstant = idp.buildUnsignedSAMLResponse(t, defaultResponseID)
+		req                   = newSAMLRequest(t, encoded)
+	)
+
+	validated, err := (&bhceSAML.Client{}).ParseResponse(idp.newServiceProvider(), req, nil)
+
+	require.NoError(t, err)
+	require.NotNil(t, validated)
+	// check that og Response ID matches extracted
+	assert.Equal(t, defaultResponseID, validated.ResponseID)
+	// rounded to the millisecond so IssueInstant matches exactly after crewjam's round trip
+	assert.True(t, issueInstant.Equal(validated.ResponseIssueInstant),
+		"expected ResponseIssueInstant %s to equal %s", validated.ResponseIssueInstant, issueInstant)
+}
+
+// --- TEST SETUP ---
+
+const defaultResponseID = "_response_id"
+
+// newServiceProvider builds a SP that trusts the IdP's signing certificate and accepts IdP-initiated
+// responses, so it will validate the signed assertions.
+func (s testIdP) newServiceProvider() saml.ServiceProvider {
+	var acsURL, _ = url.Parse(s.acsURL)
+
+	return saml.ServiceProvider{
+		EntityID:          s.spEntityID,
+		AcsURL:            *acsURL,
+		IDPMetadata:       s.idp.Metadata(),
+		AllowIDPInitiated: true,
+	}
+}
+
+// newSAMLRequest wraps a base64 SAMLResponse in an *http.Request (via PostForm), the way ParseResponse expects it
+func newSAMLRequest(t *testing.T, samlResponse string) *http.Request {
+	t.Helper()
+
+	req, reqErr := http.NewRequest(http.MethodPost, "https://sp.test/callback", strings.NewReader(""))
+	require.NoError(t, reqErr)
+
+	req.PostForm = url.Values{"SAMLResponse": []string{samlResponse}}
+	return req
+}
+
+type assertionSpec struct {
+	id     string
+	signed bool
+}
+
+// buildUnsignedSAMLResponse creates an unsigned samlp:Response with the given SAMLResponse ID and assertions
+// then base64-encodes it as an IdP would over the HTTP-POST binding.
+func (s testIdP) buildUnsignedSAMLResponse(t *testing.T, responseID string, assertions ...assertionSpec) (string, time.Time) {
+	t.Helper()
+
+	var issueInstant = time.Now().Round(time.Millisecond).UTC()
+
+	if len(assertions) == 0 {
+		// default base case is to have one SAMLResponse with one single assertion
+		assertions = []assertionSpec{{id: "_assertion_id_a", signed: true}}
+	}
+
+	response := saml.Response{
+		ID:           responseID,
+		Version:      "2.0",
+		IssueInstant: issueInstant,
+		Issuer:       &saml.Issuer{Value: s.entityID},
+		Status: saml.Status{
+			StatusCode: saml.StatusCode{Value: saml.StatusSuccess},
+		},
+	}
+
+	responseEl := response.Element()
+	for _, spec := range assertions {
+		responseEl.AddChild(s.buildAssertionEl(t, spec))
+	}
+
+	doc := etree.NewDocument()
+	doc.SetRoot(responseEl)
+
+	rawXML, writeErr := doc.WriteToBytes()
+	require.NoError(t, writeErr)
+
+	return base64.StdEncoding.EncodeToString(rawXML), issueInstant
+}
+
+// buildSignedSAMLResponse creates a signed samlp:Response containing a single assertion via crewjam's MakeResponse.
+// signedAssertion controls whether the inner assertion is individually signed too. A random Response ID is assigned.
+func (s testIdP) buildSignedSAMLResponse(t *testing.T, assertionID string, signedAssertion bool) string {
+	t.Helper()
+
+	var (
+		acsURL, _    = url.Parse(s.acsURL)
+		authnRequest = saml.IdpAuthnRequest{
+			IDP:             s.idp,
+			Now:             time.Now().Round(time.Millisecond).UTC(),
+			SPSSODescriptor: &saml.SPSSODescriptor{},
+			ACSEndpoint:     &saml.IndexedEndpoint{Location: acsURL.String()},
+			Assertion:       s.buildAssertion(assertionID, time.Now()),
+		}
+	)
+
+	// initialize the XML assertion child so that crewjam's MakeResponse doesn't sign the assertion
+	// (so we can test the unsigned assertion case)
+	if !signedAssertion {
+		authnRequest.AssertionEl = authnRequest.Assertion.Element()
+	}
+
+	require.NoError(t, authnRequest.MakeResponse())
+
+	doc := etree.NewDocument()
+	doc.SetRoot(authnRequest.ResponseEl)
+
+	rawXML, writeErr := doc.WriteToBytes()
+	require.NoError(t, writeErr)
+
+	return base64.StdEncoding.EncodeToString(rawXML)
+}
+
+// buildAssertionEl builds a single assertion xml element
+func (s testIdP) buildAssertionEl(t *testing.T, spec assertionSpec) *etree.Element {
+	t.Helper()
+
+	var authnRequest = saml.IdpAuthnRequest{
+		IDP:             s.idp,
+		Now:             time.Now(),
+		SPSSODescriptor: &saml.SPSSODescriptor{}, // no encryption cert -- signed assertions stay plaintext
+		Assertion:       s.buildAssertion(spec.id, time.Now()),
+	}
+
+	if !spec.signed {
+		return authnRequest.Assertion.Element()
+	}
+	require.NoError(t, authnRequest.MakeAssertionEl())
+
+	return authnRequest.AssertionEl
+}
+
+// buildAssertion builds a minimal SAML assertion the SP will accept: fresh timestamps/windows and matching
+// issuer/recipient/audience.
+func (s testIdP) buildAssertion(id string, now time.Time) *saml.Assertion {
+	return &saml.Assertion{
+		ID:           id,
+		IssueInstant: now,
+		Version:      "2.0",
+		Issuer:       saml.Issuer{Value: s.entityID},
+		Subject: &saml.Subject{
+			NameID: &saml.NameID{Value: "user@sp.test"},
+			SubjectConfirmations: []saml.SubjectConfirmation{{
+				Method: "urn:oasis:names:tc:SAML:2.0:cm:bearer",
+				SubjectConfirmationData: &saml.SubjectConfirmationData{
+					Recipient:    s.acsURL,
+					NotOnOrAfter: now.Add(time.Hour),
+				},
+			}},
+		},
+		Conditions: &saml.Conditions{
+			NotBefore:    now.Add(-time.Minute),
+			NotOnOrAfter: now.Add(time.Hour),
+			AudienceRestrictions: []saml.AudienceRestriction{{
+				Audience: saml.Audience{Value: s.spEntityID},
+			}},
+		},
+	}
+}
+
+// testIdP wraps a crewjam IdP so we can create assertions signed by crewjam itself.
+type testIdP struct {
+	idp        *saml.IdentityProvider
+	entityID   string
+	acsURL     string
+	spEntityID string
+}
+
+// newTestIdP generates a fresh RSA key and self-signed certificate and builds a crewjam IdP whose
+// Metadata() includes that certificate, so the real ServiceProvider.ParseResponse can validate the assertions we sign.
+func newTestIdP(t *testing.T) testIdP {
+	t.Helper()
+
+	var (
+		key, keyErr = rsa.GenerateKey(rand.Reader, 2048)
+		metadataURL = url.URL{Scheme: "https", Host: "idp.test", Path: "/metadata"}
+		ssoURL      = url.URL{Scheme: "https", Host: "idp.test", Path: "/sso"}
+	)
+	require.NoError(t, keyErr)
+
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "idp.test"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+	}
+	certDER, certErr := x509.CreateCertificate(rand.Reader, &template, &template, &key.PublicKey, key)
+	require.NoError(t, certErr)
+
+	cert, parseErr := x509.ParseCertificate(certDER)
+	require.NoError(t, parseErr)
+
+	return testIdP{
+		idp: &saml.IdentityProvider{
+			Key:             key,
+			Certificate:     cert,
+			MetadataURL:     metadataURL,
+			SSOURL:          ssoURL,
+			SignatureMethod: "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256",
+		},
+		entityID:   metadataURL.String(),
+		acsURL:     "https://sp.test/callback",
+		spEntityID: "https://sp.test/metadata",
+	}
+}

--- a/cmd/api/src/services/saml/saml_test.go
+++ b/cmd/api/src/services/saml/saml_test.go
@@ -1,0 +1,132 @@
+// Copyright 2026 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package saml
+
+import (
+	"testing"
+	"time"
+
+	"github.com/crewjam/saml"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCountAssertions verifies that countAssertions counts every <Assertion> and <EncryptedAssertion>
+// in the SAML assertion namespace, counting from the raw XML because crewjam's saml.Response only keeps one assertion.
+func TestCountAssertions(t *testing.T) {
+	const assertionNS = `xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"`
+
+	testCases := []struct {
+		name      string
+		xml       string
+		wantCount int
+	}{
+		{
+			name: "single plaintext assertion",
+			xml: `<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" ` + assertionNS + `>
+				<saml:Assertion ID="a1"/>
+			</samlp:Response>`,
+			wantCount: 1,
+		},
+		{
+			name: "two plaintext assertions",
+			xml: `<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" ` + assertionNS + `>
+				<saml:Assertion ID="a1"/>
+				<saml:Assertion ID="a2"/>
+			</samlp:Response>`,
+			wantCount: 2,
+		},
+		{
+			name: "one plaintext and one encrypted assertion",
+			xml: `<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" ` + assertionNS + `>
+				<saml:Assertion ID="a1"/>
+				<saml:EncryptedAssertion/>
+			</samlp:Response>`,
+			wantCount: 2,
+		},
+		{
+			name: "two encrypted assertions",
+			xml: `<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" ` + assertionNS + `>
+				<saml:EncryptedAssertion/>
+				<saml:EncryptedAssertion/>
+			</samlp:Response>`,
+			wantCount: 2,
+		},
+		{
+			name: "no assertions",
+			xml: `<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" ` + assertionNS + `>
+			</samlp:Response>`,
+			wantCount: 0,
+		},
+		{
+			name: "assertion in wrong namespace is not counted",
+			xml: `<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" ` + assertionNS + ` xmlns:evil="urn:example:evil">
+				<saml:Assertion ID="a1"/>
+				<evil:Assertion ID="spoofed"/>
+			</samlp:Response>`,
+			wantCount: 1,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			count, err := countAssertions([]byte(testCase.xml))
+
+			require.NoError(t, err)
+			assert.Equal(t, testCase.wantCount, count, "total assertion count")
+		})
+	}
+}
+
+// TestCalculateSAMLTimeExpiry verifies that CalculateSAMLTimeExpiry returns whichever IssueInstant + MaxIssueDelay is later.
+func TestCalculateSAMLTimeExpiry(t *testing.T) {
+	base := time.Date(2026, 8, 18, 23, 3, 0, 0, time.UTC)
+
+	testCases := []struct {
+		name                  string
+		responseIssueInstant  time.Time
+		assertionIssueInstant time.Time
+		want                  time.Time
+	}{
+		{
+			name:                  "response later than assertion uses response deadline",
+			responseIssueInstant:  base.Add(40 * time.Second),
+			assertionIssueInstant: base,
+			want:                  base.Add(40 * time.Second).Add(saml.MaxIssueDelay),
+		},
+		{
+			name:                  "assertion later than response uses assertion deadline",
+			responseIssueInstant:  base,
+			assertionIssueInstant: base.Add(40 * time.Second),
+			want:                  base.Add(40 * time.Second).Add(saml.MaxIssueDelay),
+		},
+		{
+			name:                  "equal instants use that instant plus delay",
+			responseIssueInstant:  base,
+			assertionIssueInstant: base,
+			want:                  base.Add(saml.MaxIssueDelay),
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			got := CalculateSAMLTimeExpiry(testCase.responseIssueInstant, testCase.assertionIssueInstant)
+
+			assert.True(t, testCase.want.Equal(got), "expected %s, got %s", testCase.want, got)
+		})
+	}
+}

--- a/cmd/api/src/services/saml/saml_test.go
+++ b/cmd/api/src/services/saml/saml_test.go
@@ -17,6 +17,10 @@
 package saml
 
 import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
 	"testing"
 	"time"
 
@@ -127,6 +131,46 @@ func TestCalculateSAMLTimeExpiry(t *testing.T) {
 			got := CalculateSAMLTimeExpiry(testCase.responseIssueInstant, testCase.assertionIssueInstant)
 
 			assert.True(t, testCase.want.Equal(got), "expected %s, got %s", testCase.want, got)
+		})
+	}
+}
+
+// TestParseResponse_RejectsArtifactBinding verifies that ParseResponse rejects HTTP-Artifact
+// requests (SAMLart in either the POST form or as a query parameter), since we don't support HTTP-Artifact binding.
+func TestParseResponse_RejectsArtifactBinding(t *testing.T) {
+	testCases := []struct {
+		name    string
+		request func() *http.Request
+	}{
+		{
+			name: "SAMLart in POST form",
+			request: func() *http.Request {
+				form := url.Values{"SAMLart": {"artifact-id"}}
+				req := httptest.NewRequest(http.MethodPost, "/api/v2/sso/slug/callback", strings.NewReader(form.Encode()))
+				req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+				return req
+			},
+		},
+		{
+			name: "SAMLart as a query parameter",
+			request: func() *http.Request {
+				return httptest.NewRequest(http.MethodGet, "/api/v2/sso/slug/callback?SAMLart=artifact-id", nil)
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			var (
+				client Client
+				req    = testCase.request()
+			)
+			require.NoError(t, req.ParseForm())
+
+			validatedResponse, err := client.ParseResponse(saml.ServiceProvider{}, req, nil)
+
+			require.ErrorContains(t, err, "HTTP-Artifact binding is not supported")
+			assert.Nil(t, validatedResponse)
 		})
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -151,7 +151,7 @@ require (
 	github.com/aws/smithy-go v1.26.0
 	github.com/axiomhq/hyperloglog v0.2.6 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
-	github.com/beevik/etree v1.6.0 // indirect
+	github.com/beevik/etree v1.6.0
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bits-and-blooms/bitset v1.24.5 // indirect
 	github.com/bkielbasa/cyclop v1.2.3 // indirect


### PR DESCRIPTION
## Description

See BHE PR for internal details: [link](https://github.com/SpecterOps/bloodhound-enterprise/pull/1803)

## Motivation and Context

See BHE PR for internal details: [link](https://github.com/SpecterOps/bloodhound-enterprise/pull/1803)
Fixes: [BED-9064](https://specterops.atlassian.net/browse/BED-9064)

## How Has This Been Tested?

See [BHE PR](https://github.com/SpecterOps/bloodhound-enterprise/pull/1803)

## Screenshots (optional):

See [BHE PR](https://github.com/SpecterOps/bloodhound-enterprise/pull/1803) 

## Types of changes

<!-- Please remove any items that do not apply. -->
- Bug fix (non-breaking change which fixes an issue)
- Database Migrations
## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


[BED-9064]: https://specterops.atlassian.net/browse/BED-9064?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Added SAML replay protection to prevent previously used responses or assertions from being accepted again.
  * Improved validation for malformed, incomplete, or unsupported SAML responses.
* **Bug Fixes**
  * SAML authentication now handles persistence failures with retryable errors.
  * User lookup and just-in-time provisioning use only successfully validated SAML responses.
* **Maintenance**
  * Expired SAML authentication records are automatically removed during routine data cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->