### PR TITLE
chore(alerts): remove alerts constant from BHCE BED-9448

### DIFF
--- a/cmd/api/src/api/constant.go
+++ b/cmd/api/src/api/constant.go
@@ -53,7 +53,6 @@ const (
 
 	// URI path parameters
 	URIPathVariableApplicationConfigurationParameter = "parameter"
-	URIPathVariableAlertWebhookID                    = "alert_webhook_id"
 	URIPathVariableArtifactID                        = "artifact_id"
 	URIPathVariableAssetGroupID                      = "asset_group_id"
 	URIPathVariableAssetGroupSelectorID              = "asset_group_selector_id"


### PR DESCRIPTION
## Description

This const should live in BHE, where it is used, according to the new slice architecture. 

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-9448

## How Has This Been Tested?

No tests needed.

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)
## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed an unused alert webhook identifier path parameter from the API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->