### PR TITLE
fix: Align managed-service-account DNS requirements in ADCS compositions BED-9336

### DIFF
--- a/cmd/api/src/test/integration/harnesses.go
+++ b/cmd/api/src/test/integration/harnesses.go
@@ -2240,6 +2240,115 @@ func (s *ESC3Harness3) Setup(c *GraphTestContext) {
 	addHostingComputer(c, "EnterpriseCA1 host", sid, s.EnterpriseCA1)
 }
 
+type ESC3ManagedServiceAccountDNSHarness struct {
+	GMSA                            *graph.Node
+	SMSA                            *graph.Node
+	RegularUser                     *graph.Node
+	SubjectAltRequireDNSTemplate    *graph.Node
+	DomainDNSTemplate               *graph.Node
+	DNSAuthenticationTemplate       *graph.Node
+	DomainDNSAuthenticationTemplate *graph.Node
+	DNSEnterpriseCA                 *graph.Node
+	DomainDNSEnterpriseCA           *graph.Node
+	DNSNTAuthStore                  *graph.Node
+	DomainDNSNTAuthStore            *graph.Node
+	DNSRootCA                       *graph.Node
+	DomainDNSRootCA                 *graph.Node
+	DNSDomain                       *graph.Node
+	DomainDNSDomain                 *graph.Node
+}
+
+func (s *ESC3ManagedServiceAccountDNSHarness) Setup(graphTestContext *GraphTestContext) {
+	var (
+		dnsDomainSID       = RandomDomainSID()
+		domainDNSDomainSID = RandomDomainSID()
+		emptyEKUs          = make([]string, 0)
+	)
+
+	s.GMSA = graphTestContext.NewActiveDirectoryUser("GMSA", dnsDomainSID)
+	s.GMSA.Properties.Set(ad.GMSA.String(), true)
+	graphTestContext.UpdateNode(s.GMSA)
+
+	s.SMSA = graphTestContext.NewActiveDirectoryUser("SMSA", dnsDomainSID)
+	s.SMSA.Properties.Set(ad.MSA.String(), true)
+	graphTestContext.UpdateNode(s.SMSA)
+
+	s.RegularUser = graphTestContext.NewActiveDirectoryUser("RegularUser", dnsDomainSID)
+	s.SubjectAltRequireDNSTemplate = graphTestContext.NewActiveDirectoryCertTemplate("SubjectAltRequireDNSTemplate", dnsDomainSID, CertTemplateData{
+		RequiresManagerApproval: false,
+		SubjectAltRequireDNS:    true,
+		SchemaVersion:           1,
+		AuthorizedSignatures:    0,
+		EffectiveEKUs:           emptyEKUs,
+		ApplicationPolicies:     emptyEKUs,
+	})
+	s.DNSAuthenticationTemplate = graphTestContext.NewActiveDirectoryCertTemplate("DNSAuthenticationTemplate", dnsDomainSID, CertTemplateData{
+		RequiresManagerApproval: false,
+		AuthenticationEnabled:   true,
+		SchemaVersion:           1,
+		AuthorizedSignatures:    0,
+		EffectiveEKUs:           emptyEKUs,
+		ApplicationPolicies:     emptyEKUs,
+	})
+	s.DomainDNSTemplate = graphTestContext.NewActiveDirectoryCertTemplate("SubjectAltRequireDomainDNSTemplate", domainDNSDomainSID, CertTemplateData{
+		RequiresManagerApproval:    false,
+		SubjectAltRequireDomainDNS: true,
+		SchemaVersion:              1,
+		AuthorizedSignatures:       0,
+		EffectiveEKUs:              emptyEKUs,
+		ApplicationPolicies:        emptyEKUs,
+	})
+	s.DomainDNSAuthenticationTemplate = graphTestContext.NewActiveDirectoryCertTemplate("DomainDNSAuthenticationTemplate", domainDNSDomainSID, CertTemplateData{
+		RequiresManagerApproval: false,
+		AuthenticationEnabled:   true,
+		SchemaVersion:           1,
+		AuthorizedSignatures:    0,
+		EffectiveEKUs:           emptyEKUs,
+		ApplicationPolicies:     emptyEKUs,
+	})
+	s.DNSEnterpriseCA = graphTestContext.NewActiveDirectoryEnterpriseCA("DNSEnterpriseCA", dnsDomainSID)
+	s.DomainDNSEnterpriseCA = graphTestContext.NewActiveDirectoryEnterpriseCA("DomainDNSEnterpriseCA", domainDNSDomainSID)
+	s.DNSNTAuthStore = graphTestContext.NewActiveDirectoryNTAuthStore("DNSNTAuthStore", dnsDomainSID)
+	s.DomainDNSNTAuthStore = graphTestContext.NewActiveDirectoryNTAuthStore("DomainDNSNTAuthStore", domainDNSDomainSID)
+	s.DNSRootCA = graphTestContext.NewActiveDirectoryRootCA("DNSRootCA", dnsDomainSID)
+	s.DomainDNSRootCA = graphTestContext.NewActiveDirectoryRootCA("DomainDNSRootCA", domainDNSDomainSID)
+	s.DNSDomain = graphTestContext.NewActiveDirectoryDomain("DNSDomain", dnsDomainSID, false, true)
+	s.DomainDNSDomain = graphTestContext.NewActiveDirectoryDomain("DomainDNSDomain", domainDNSDomainSID, false, true)
+
+	for _, principal := range []*graph.Node{s.GMSA, s.SMSA, s.RegularUser} {
+		graphTestContext.NewRelationship(principal, s.SubjectAltRequireDNSTemplate, ad.Enroll)
+		graphTestContext.NewRelationship(principal, s.DNSAuthenticationTemplate, ad.Enroll)
+		graphTestContext.NewRelationship(principal, s.DNSEnterpriseCA, ad.Enroll)
+		graphTestContext.NewRelationship(principal, s.DomainDNSTemplate, ad.Enroll)
+		graphTestContext.NewRelationship(principal, s.DomainDNSAuthenticationTemplate, ad.Enroll)
+		graphTestContext.NewRelationship(principal, s.DomainDNSEnterpriseCA, ad.Enroll)
+	}
+
+	graphTestContext.NewRelationship(s.SubjectAltRequireDNSTemplate, s.DNSAuthenticationTemplate, ad.EnrollOnBehalfOf)
+	graphTestContext.NewRelationship(s.SubjectAltRequireDNSTemplate, s.DNSEnterpriseCA, ad.PublishedTo)
+	graphTestContext.NewRelationship(s.DNSAuthenticationTemplate, s.DNSEnterpriseCA, ad.PublishedTo)
+	graphTestContext.NewRelationship(s.DNSEnterpriseCA, s.DNSNTAuthStore, ad.TrustedForNTAuth)
+	graphTestContext.NewRelationship(s.DNSEnterpriseCA, s.DNSRootCA, ad.IssuedSignedBy)
+	graphTestContext.NewRelationship(s.DNSNTAuthStore, s.DNSDomain, ad.NTAuthStoreFor)
+	graphTestContext.NewRelationship(s.DNSRootCA, s.DNSDomain, ad.RootCAFor)
+
+	graphTestContext.NewRelationship(s.DomainDNSTemplate, s.DomainDNSAuthenticationTemplate, ad.EnrollOnBehalfOf)
+	graphTestContext.NewRelationship(s.DomainDNSTemplate, s.DomainDNSEnterpriseCA, ad.PublishedTo)
+	graphTestContext.NewRelationship(s.DomainDNSAuthenticationTemplate, s.DomainDNSEnterpriseCA, ad.PublishedTo)
+	graphTestContext.NewRelationship(s.DomainDNSEnterpriseCA, s.DomainDNSNTAuthStore, ad.TrustedForNTAuth)
+	graphTestContext.NewRelationship(s.DomainDNSEnterpriseCA, s.DomainDNSRootCA, ad.IssuedSignedBy)
+	graphTestContext.NewRelationship(s.DomainDNSNTAuthStore, s.DomainDNSDomain, ad.NTAuthStoreFor)
+	graphTestContext.NewRelationship(s.DomainDNSRootCA, s.DomainDNSDomain, ad.RootCAFor)
+
+	s.DNSEnterpriseCA.Properties.Set(ad.EnrollmentAgentRestrictionsCollected.String(), false)
+	graphTestContext.UpdateNode(s.DNSEnterpriseCA)
+	s.DomainDNSEnterpriseCA.Properties.Set(ad.EnrollmentAgentRestrictionsCollected.String(), false)
+	graphTestContext.UpdateNode(s.DomainDNSEnterpriseCA)
+
+	addHostingComputer(graphTestContext, "DNSEnterpriseCA host", dnsDomainSID, s.DNSEnterpriseCA)
+	addHostingComputer(graphTestContext, "DomainDNSEnterpriseCA host", domainDNSDomainSID, s.DomainDNSEnterpriseCA)
+}
+
 type ESC9aPrincipalHarness struct {
 	CertTemplate *graph.Node
 	DC           *graph.Node
@@ -10409,6 +10518,7 @@ type HarnessDetails struct {
 	ESC3Harness1                                    ESC3Harness1
 	ESC3Harness2                                    ESC3Harness2
 	ESC3Harness3                                    ESC3Harness3
+	ESC3ManagedServiceAccountDNSHarness             ESC3ManagedServiceAccountDNSHarness
 	ESC6aHarnessPrincipalEdges                      ESC6aHarnessPrincipalEdges
 	ESC6aHarnessECA                                 ESC6aHarnessECA
 	ESC6aHarnessTemplate1                           ESC6aHarnessTemplate1

--- a/packages/go/analysis/ad/ad.go
+++ b/packages/go/analysis/ad/ad.go
@@ -18,6 +18,7 @@ package ad
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"sort"
@@ -40,6 +41,18 @@ import (
 const (
 	AdminSDHolderDNPrefix = "CN=ADMINSDHOLDER,CN=SYSTEM,"
 )
+
+func isManagedServiceAccount(node *graph.Node) (bool, error) {
+	if gmsa, err := node.Properties.Get(ad.GMSA.String()).Bool(); err != nil && !errors.Is(err, graph.ErrPropertyNotFound) {
+		return false, err
+	} else if gmsa {
+		return true, nil
+	} else if msa, err := node.Properties.Get(ad.MSA.String()).Bool(); err != nil && !errors.Is(err, graph.ErrPropertyNotFound) {
+		return false, err
+	} else {
+		return msa, nil
+	}
+}
 
 func TierZeroWellKnownSIDSuffixes() []string {
 	return []string{

--- a/packages/go/analysis/ad/ad_internal_test.go
+++ b/packages/go/analysis/ad/ad_internal_test.go
@@ -19,7 +19,7 @@ package ad
 import (
 	"testing"
 
-	adSchema "github.com/specterops/bloodhound/packages/go/graphschema/ad"
+	adschema "github.com/specterops/bloodhound/packages/go/graphschema/ad"
 	"github.com/specterops/dawgs/graph"
 	"github.com/stretchr/testify/require"
 )
@@ -33,18 +33,18 @@ func TestIsManagedServiceAccount(t *testing.T) {
 	}{
 		{
 			name:       "gMSA",
-			properties: graph.NewProperties().Set(adSchema.GMSA.String(), true),
+			properties: graph.NewProperties().Set(adschema.GMSA.String(), true),
 			expected:   true,
 		},
 		{
 			name:       "sMSA",
-			properties: graph.NewProperties().Set(adSchema.MSA.String(), true),
+			properties: graph.NewProperties().Set(adschema.MSA.String(), true),
 			expected:   true,
 		},
 		{
 			name: "both properties false",
-			properties: graph.NewProperties().Set(adSchema.GMSA.String(), false).
-				Set(adSchema.MSA.String(), false),
+			properties: graph.NewProperties().Set(adschema.GMSA.String(), false).
+				Set(adschema.MSA.String(), false),
 		},
 		{
 			name:       "properties absent",
@@ -52,19 +52,19 @@ func TestIsManagedServiceAccount(t *testing.T) {
 		},
 		{
 			name:                  "invalid gMSA property",
-			properties:            graph.NewProperties().Set(adSchema.GMSA.String(), "true"),
+			properties:            graph.NewProperties().Set(adschema.GMSA.String(), "true"),
 			expectedPropertyError: true,
 		},
 		{
 			name:                  "invalid sMSA property",
-			properties:            graph.NewProperties().Set(adSchema.MSA.String(), "true"),
+			properties:            graph.NewProperties().Set(adschema.MSA.String(), "true"),
 			expectedPropertyError: true,
 		},
 	}
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			node := graph.NewNode(1, testCase.properties, adSchema.User)
+			node := graph.NewNode(1, testCase.properties, adschema.User)
 
 			actual, err := isManagedServiceAccount(node)
 			if testCase.expectedPropertyError {

--- a/packages/go/analysis/ad/ad_parallel_integration_test.go
+++ b/packages/go/analysis/ad/ad_parallel_integration_test.go
@@ -33,11 +33,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestPostADCSESC6a_ManagedServiceAccounts verifies that gMSA and sMSA enrollees
-// (both ingested as User-kind nodes) are preserved as ADCSESC6a edge starts when
-// the cert template requires DNS in the SubjectAltName, while regular User
-// enrollees are filtered out by filterUserDNSResults.
-func TestPostADCSESC6a_ManagedServiceAccounts(t *testing.T) {
+// TestManagedServiceAccountDNSCompositions verifies that gMSA and sMSA enrollees
+// are preserved in ADCS compositions when the cert template requires DNS.
+func TestManagedServiceAccountDNSCompositions(t *testing.T) {
 	t.Parallel()
 
 	suite := setupIntegrationTestSuite(t)
@@ -52,19 +50,31 @@ func TestPostADCSESC6a_ManagedServiceAccounts(t *testing.T) {
 			SchemaVersion:         1,
 			SubjectAltRequireDNS:  true,
 		})
-		enterpriseCA = NewActiveDirectoryEnterpriseCA(t, &suite, "EnterpriseCA", domainSID)
-		ntAuthStore  = NewActiveDirectoryNTAuthStore(t, &suite, "NTAuthStore", domainSID)
-		rootCA       = NewActiveDirectoryRootCA(t, &suite, "RootCA", domainSID)
-		regularUser  = NewActiveDirectoryUser(t, &suite, "RegularUser", domainSID)
-		gmsaUser     = NewActiveDirectoryUser(t, &suite, "GMSAUser", domainSID)
-		smsaUser     = NewActiveDirectoryUser(t, &suite, "SMSAUser", domainSID)
-		computer     = NewActiveDirectoryComputer(t, &suite, "Computer", domainSID)
-		ecaHost      = NewActiveDirectoryComputer(t, &suite, "ECA Host", domainSID)
+		enterpriseCA     = NewActiveDirectoryEnterpriseCA(t, &suite, "EnterpriseCA", domainSID)
+		ntAuthStore      = NewActiveDirectoryNTAuthStore(t, &suite, "NTAuthStore", domainSID)
+		rootCA           = NewActiveDirectoryRootCA(t, &suite, "RootCA", domainSID)
+		regularUser      = NewActiveDirectoryUser(t, &suite, "RegularUser", domainSID)
+		gmsaUser         = NewActiveDirectoryUser(t, &suite, "GMSAUser", domainSID)
+		smsaUser         = NewActiveDirectoryUser(t, &suite, "SMSAUser", domainSID)
+		computer         = NewActiveDirectoryComputer(t, &suite, "Computer", domainSID)
+		ecaHost          = NewActiveDirectoryComputer(t, &suite, "ECA Host", domainSID)
+		domainController = NewActiveDirectoryComputer(t, &suite, "Domain Controller", domainSID)
+		attacker         = NewActiveDirectoryUser(t, &suite, "Attacker", domainSID)
+
+		managedServiceAccountEdges []*graph.Relationship
+		attackerEdges              = map[graph.Kind]*graph.Relationship{}
 	)
 
 	ecaHost.Properties.Set(common.Enabled.String(), true)
 	UpdateNode(t, &suite, ecaHost)
+	domainController.Properties.Set(ad.CertificateMappingMethodsRaw.String(), "4")
+	domainController.Properties.Set(ad.StrongCertificateBindingEnforcementRaw.String(), "1")
+	UpdateNode(t, &suite, domainController)
+	certTemplate.Properties.Set(ad.SubjectAltRequireUPN.String(), true)
+	certTemplate.Properties.Set(ad.EffectiveEKUs.String(), []string{})
+	UpdateNode(t, &suite, certTemplate)
 	NewRelationship(t, &suite, ecaHost, enterpriseCA, ad.HostsCAService)
+	NewRelationship(t, &suite, domainController, domain, ad.DCFor)
 
 	gmsaUser.Properties.Set(ad.GMSA.String(), true)
 	UpdateNode(t, &suite, gmsaUser)
@@ -87,8 +97,10 @@ func TestPostADCSESC6a_ManagedServiceAccounts(t *testing.T) {
 	NewRelationship(t, &suite, enterpriseCA, rootCA, ad.IssuedSignedBy)
 	NewRelationship(t, &suite, ntAuthStore, domain, ad.NTAuthStoreFor)
 	NewRelationship(t, &suite, rootCA, domain, ad.RootCAFor)
+	NewRelationship(t, &suite, attacker, gmsaUser, ad.GenericAll)
+	NewRelationship(t, &suite, attacker, smsaUser, ad.GenericAll)
 
-	operation := post.NewPostRelationshipOperation(suite.Context, suite.GraphDB, "ADCS Post Process Test - ESC6a MSA")
+	operation := post.NewPostRelationshipOperation(suite.Context, suite.GraphDB, "ADCS managed service account composition test")
 
 	localGroupData, cache, err := FetchADCSPrereqs(suite.GraphDB)
 	require.NoError(t, err)
@@ -96,10 +108,12 @@ func TestPostADCSESC6a_ManagedServiceAccounts(t *testing.T) {
 	for _, certChains := range cache.GetECAHostedChainedDomains() {
 		operation.Operation.SubmitReader(func(ctx context.Context, tx graph.Transaction, outC chan<- post.EnsureRelationshipJob) error {
 			if err := adAnalysis.PostADCSESC6a(ctx, tx, outC, localGroupData, certChains, cache); err != nil {
-				t.Logf("failed post processing for %s: %v", ad.ADCSESC6a.String(), err)
 				return err
+			} else if err := adAnalysis.PostADCSESC9a(ctx, tx, outC, localGroupData, certChains, cache); err != nil {
+				return err
+			} else {
+				return adAnalysis.PostADCSESC10a(ctx, tx, outC, localGroupData, certChains, cache)
 			}
-			return nil
 		})
 	}
 
@@ -123,7 +137,175 @@ func TestPostADCSESC6a_ManagedServiceAccounts(t *testing.T) {
 			"Computer enroller should retain its ESC6a edge when SubjectAltRequireDNS is true")
 		assert.False(t, results.Contains(regularUser),
 			"plain User enroller should be filtered out when SubjectAltRequireDNS is true")
+
+		managedServiceAccountEdges, err = ops.FetchRelationships(tx.Relationships().Filterf(func() graph.Criteria {
+			return query.And(
+				query.Kind(query.Relationship(), ad.ADCSESC6a),
+				query.InIDs(query.StartID(), gmsaUser.ID, smsaUser.ID),
+			)
+		}))
+		require.NoError(t, err)
+
+		for _, edgeKind := range []graph.Kind{ad.ADCSESC9a, ad.ADCSESC10a} {
+			attackerEdge, err := tx.Relationships().Filterf(func() graph.Criteria {
+				return query.And(
+					query.Kind(query.Relationship(), edgeKind),
+					query.Equals(query.StartID(), attacker.ID),
+					query.Equals(query.EndID(), domain.ID),
+				)
+			}).First()
+			require.NoError(t, err)
+			attackerEdges[edgeKind] = attackerEdge
+		}
+
 		return nil
 	})
 	require.NoError(t, err)
+	require.Len(t, managedServiceAccountEdges, 2)
+
+	for _, edge := range managedServiceAccountEdges {
+		composition, err := adAnalysis.GetADCSESC6EdgeComposition(suite.Context, suite.GraphDB, edge)
+		require.NoError(t, err)
+		require.NotEmpty(t, composition)
+		require.True(t, composition.AllNodes().ContainsID(edge.StartID))
+	}
+
+	for edgeKind, edge := range attackerEdges {
+		composition, err := adAnalysis.GetEdgeCompositionPath(suite.Context, suite.GraphDB, edge)
+		require.NoError(t, err, edgeKind.String())
+		require.NotEmpty(t, composition, edgeKind.String())
+		require.True(t, composition.AllNodes().Contains(gmsaUser), edgeKind.String())
+		require.True(t, composition.AllNodes().Contains(smsaUser), edgeKind.String())
+	}
+
+}
+
+func TestPostADCSESC13_ManagedServiceAccountDNSRequirements(t *testing.T) {
+	t.Parallel()
+
+	suite := setupIntegrationTestSuite(t)
+	defer teardownIntegrationTestSuite(t, &suite)
+
+	var (
+		domainSID           = RandomDomainSID()
+		domain              = NewActiveDirectoryDomain(t, &suite, "ESC13 managed service accounts", domainSID, false, true)
+		dnsFreeCertTemplate = NewActiveDirectoryCertTemplate(t, &suite, "DNS-free cert template", domainSID, CertTemplateProperties{
+			AuthenticationEnabled: true,
+			SchemaVersion:         1,
+			EffectiveEKUs:         []string{},
+			ApplicationPolicies:   []string{},
+		})
+		dnsCertTemplate = NewActiveDirectoryCertTemplate(t, &suite, "DNS cert template", domainSID, CertTemplateProperties{
+			AuthenticationEnabled: true,
+			SchemaVersion:         1,
+			SubjectAltRequireDNS:  true,
+			EffectiveEKUs:         []string{},
+			ApplicationPolicies:   []string{},
+		})
+		enterpriseCA = NewActiveDirectoryEnterpriseCA(t, &suite, "EnterpriseCA", domainSID)
+		ntAuthStore  = NewActiveDirectoryNTAuthStore(t, &suite, "NTAuthStore", domainSID)
+		rootCA       = NewActiveDirectoryRootCA(t, &suite, "RootCA", domainSID)
+		regularUser  = NewActiveDirectoryUser(t, &suite, "RegularUser", domainSID)
+		dnsOnlyUser  = NewActiveDirectoryUser(t, &suite, "DNSOnlyUser", domainSID)
+		gmsaUser     = NewActiveDirectoryUser(t, &suite, "GMSAUser", domainSID)
+		smsaUser     = NewActiveDirectoryUser(t, &suite, "SMSAUser", domainSID)
+		ecaHost      = NewActiveDirectoryComputer(t, &suite, "ECA Host", domainSID)
+		targetGroup  = NewNode(t, &suite, graph.AsProperties(graph.PropertyMap{
+			common.Name:     "TargetGroup",
+			common.ObjectID: newRandomObjectID(t),
+			ad.DomainSID:    domainSID,
+		}), ad.Entity, ad.Group)
+		issuancePolicy = NewNode(t, &suite, graph.AsProperties(graph.PropertyMap{
+			common.Name:     "IssuancePolicy",
+			common.ObjectID: newRandomObjectID(t),
+			ad.DomainSID:    domainSID,
+		}), ad.Entity, ad.IssuancePolicy)
+
+		esc13EdgesByStartID = map[graph.ID]*graph.Relationship{}
+	)
+
+	ecaHost.Properties.Set(common.Enabled.String(), true)
+	UpdateNode(t, &suite, ecaHost)
+	gmsaUser.Properties.Set(ad.GMSA.String(), true)
+	UpdateNode(t, &suite, gmsaUser)
+	smsaUser.Properties.Set(ad.MSA.String(), true)
+	UpdateNode(t, &suite, smsaUser)
+	for _, certTemplate := range []*graph.Node{dnsFreeCertTemplate, dnsCertTemplate} {
+		certTemplate.Properties.Set(ad.SubjectAltRequireDomainDNS.String(), false)
+		UpdateNode(t, &suite, certTemplate)
+	}
+
+	NewRelationship(t, &suite, ecaHost, enterpriseCA, ad.HostsCAService)
+	NewRelationship(t, &suite, enterpriseCA, ntAuthStore, ad.TrustedForNTAuth)
+	NewRelationship(t, &suite, enterpriseCA, rootCA, ad.IssuedSignedBy)
+	NewRelationship(t, &suite, ntAuthStore, domain, ad.NTAuthStoreFor)
+	NewRelationship(t, &suite, rootCA, domain, ad.RootCAFor)
+	NewRelationship(t, &suite, domain, targetGroup, ad.Contains)
+	NewRelationship(t, &suite, issuancePolicy, targetGroup, ad.OIDGroupLink)
+
+	for _, certTemplate := range []*graph.Node{dnsFreeCertTemplate, dnsCertTemplate} {
+		NewRelationship(t, &suite, certTemplate, enterpriseCA, ad.PublishedTo)
+		NewRelationship(t, &suite, certTemplate, issuancePolicy, ad.ExtendedByPolicy)
+	}
+
+	for _, principal := range []*graph.Node{regularUser, dnsOnlyUser, gmsaUser, smsaUser} {
+		NewRelationship(t, &suite, principal, enterpriseCA, ad.Enroll)
+	}
+	NewRelationship(t, &suite, regularUser, dnsFreeCertTemplate, ad.Enroll)
+	for _, principal := range []*graph.Node{regularUser, dnsOnlyUser, gmsaUser, smsaUser} {
+		NewRelationship(t, &suite, principal, dnsCertTemplate, ad.Enroll)
+	}
+
+	operation := post.NewPostRelationshipOperation(suite.Context, suite.GraphDB, "ADCS Post Process Test - ESC13 managed service account DNS requirements")
+
+	localGroupData, cache, err := FetchADCSPrereqs(suite.GraphDB)
+	require.NoError(t, err)
+
+	for _, certChains := range cache.GetECAHostedChainedDomains() {
+		operation.Operation.SubmitReader(func(ctx context.Context, tx graph.Transaction, outC chan<- post.EnsureRelationshipJob) error {
+			return adAnalysis.PostADCSESC13(ctx, tx, outC, localGroupData, certChains, cache)
+		})
+	}
+
+	require.NoError(t, operation.Done())
+
+	err = suite.GraphDB.ReadTransaction(suite.Context, func(tx graph.Transaction) error {
+		edges, err := ops.FetchRelationships(tx.Relationships().Filterf(func() graph.Criteria {
+			return query.Kind(query.Relationship(), ad.ADCSESC13)
+		}))
+		if err != nil {
+			return err
+		}
+
+		for _, edge := range edges {
+			esc13EdgesByStartID[edge.StartID] = edge
+		}
+
+		return nil
+	})
+	require.NoError(t, err)
+	require.Len(t, esc13EdgesByStartID, 3)
+	require.Contains(t, esc13EdgesByStartID, regularUser.ID)
+	require.Contains(t, esc13EdgesByStartID, gmsaUser.ID)
+	require.Contains(t, esc13EdgesByStartID, smsaUser.ID)
+	require.NotContains(t, esc13EdgesByStartID, dnsOnlyUser.ID)
+
+	regularUserComposition, err := adAnalysis.GetADCSESC13EdgeComposition(suite.Context, suite.GraphDB, esc13EdgesByStartID[regularUser.ID])
+	require.NoError(t, err)
+	require.NotEmpty(t, regularUserComposition)
+	assert.True(t, regularUserComposition.AllNodes().Contains(dnsFreeCertTemplate))
+	assert.False(t, regularUserComposition.AllNodes().Contains(dnsCertTemplate))
+
+	for _, managedServiceAccount := range []*graph.Node{gmsaUser, smsaUser} {
+		composition, err := adAnalysis.GetADCSESC13EdgeComposition(suite.Context, suite.GraphDB, esc13EdgesByStartID[managedServiceAccount.ID])
+		require.NoError(t, err)
+		require.NotEmpty(t, composition)
+		assert.True(t, composition.AllNodes().Contains(dnsCertTemplate))
+		assert.True(t, composition.AllNodes().Contains(managedServiceAccount))
+	}
+
+	legacyDNSOnlyEdge := NewRelationship(t, &suite, dnsOnlyUser, targetGroup, ad.ADCSESC13)
+	legacyComposition, err := adAnalysis.GetADCSESC13EdgeComposition(suite.Context, suite.GraphDB, legacyDNSOnlyEdge)
+	require.NoError(t, err)
+	assert.Empty(t, legacyComposition)
 }

--- a/packages/go/analysis/ad/adcs_integration_test.go
+++ b/packages/go/analysis/ad/adcs_integration_test.go
@@ -784,6 +784,82 @@ func TestADCSESC3(t *testing.T) {
 			})
 		})
 	})
+
+	t.Run("ADCSESC3ManagedServiceAccountDNSRequirements", func(t *testing.T) {
+		testContext := integration.NewGraphTestContext(t, graphschema.DefaultGraphSchema())
+		testContext.DatabaseTestWithSetup(func(harness *integration.HarnessDetails) error {
+			harness.ESC3ManagedServiceAccountDNSHarness.Setup(testContext)
+			return nil
+		}, func(harness integration.HarnessDetails, db graph.Database) {
+			var (
+				ctx       = context.Background()
+				operation = post.NewPostRelationshipOperation(ctx, db, "ADCS Post Process Test - ESC3 managed service account DNS requirements")
+			)
+
+			localGroupData, cache, err := FetchADCSPrereqs(db)
+			require.NoError(t, err)
+
+			for _, certChains := range cache.GetECAHostedChainedDomains() {
+				operation.Operation.SubmitReader(func(ctx context.Context, tx graph.Transaction, outC chan<- post.EnsureRelationshipJob) error {
+					return adAnalysis.PostADCSESC3(ctx, tx, outC, localGroupData, certChains, cache)
+				})
+			}
+
+			require.NoError(t, operation.Done())
+
+			err = db.ReadTransaction(ctx, func(tx graph.Transaction) error {
+				edges, err := ops.FetchRelationships(tx.Relationships().Filterf(func() graph.Criteria {
+					return query.Kind(query.Relationship(), ad.ADCSESC3)
+				}))
+				require.NoError(t, err)
+				require.Len(t, edges, 4)
+
+				testCases := []struct {
+					name      string
+					principal *graph.Node
+					domain    *graph.Node
+				}{
+					{name: "gMSA with SubjectAltRequireDNS", principal: harness.ESC3ManagedServiceAccountDNSHarness.GMSA, domain: harness.ESC3ManagedServiceAccountDNSHarness.DNSDomain},
+					{name: "sMSA with SubjectAltRequireDNS", principal: harness.ESC3ManagedServiceAccountDNSHarness.SMSA, domain: harness.ESC3ManagedServiceAccountDNSHarness.DNSDomain},
+					{name: "gMSA with SubjectAltRequireDomainDNS", principal: harness.ESC3ManagedServiceAccountDNSHarness.GMSA, domain: harness.ESC3ManagedServiceAccountDNSHarness.DomainDNSDomain},
+					{name: "sMSA with SubjectAltRequireDomainDNS", principal: harness.ESC3ManagedServiceAccountDNSHarness.SMSA, domain: harness.ESC3ManagedServiceAccountDNSHarness.DomainDNSDomain},
+				}
+
+				for _, testCase := range testCases {
+					edge, err := tx.Relationships().Filterf(func() graph.Criteria {
+						return query.And(
+							query.Kind(query.Relationship(), ad.ADCSESC3),
+							query.Equals(query.StartID(), testCase.principal.ID),
+							query.Equals(query.EndID(), testCase.domain.ID),
+						)
+					}).First()
+					require.NoError(t, err, testCase.name)
+
+					composition, err := adAnalysis.GetADCSESC3EdgeComposition(ctx, db, edge)
+					require.NoError(t, err, testCase.name)
+					require.NotEmpty(t, composition, testCase.name)
+					require.True(t, composition.AllNodes().Contains(testCase.principal), testCase.name)
+				}
+
+				for _, domain := range []*graph.Node{
+					harness.ESC3ManagedServiceAccountDNSHarness.DNSDomain,
+					harness.ESC3ManagedServiceAccountDNSHarness.DomainDNSDomain,
+				} {
+					_, err := tx.Relationships().Filterf(func() graph.Criteria {
+						return query.And(
+							query.Kind(query.Relationship(), ad.ADCSESC3),
+							query.Equals(query.StartID(), harness.ESC3ManagedServiceAccountDNSHarness.RegularUser.ID),
+							query.Equals(query.EndID(), domain.ID),
+						)
+					}).First()
+					require.True(t, graph.IsErrNotFound(err))
+				}
+
+				return nil
+			})
+			require.NoError(t, err)
+		})
+	})
 }
 
 func TestADCSESC4(t *testing.T) {

--- a/packages/go/analysis/ad/esc10.go
+++ b/packages/go/analysis/ad/esc10.go
@@ -350,7 +350,11 @@ func GetADCSESC10EdgeComposition(ctx context.Context, db graph.Database, edge *g
 				})
 
 				if !certTemplateValidForUserVictim(certTemplate) {
-					return nil
+					if managedServiceAccount, err := isManagedServiceAccount(victimNode); err != nil {
+						return err
+					} else if !managedServiceAccount {
+						return nil
+					}
 				}
 			}
 

--- a/packages/go/analysis/ad/esc13.go
+++ b/packages/go/analysis/ad/esc13.go
@@ -254,6 +254,14 @@ func GetADCSESC13EdgeComposition(ctx context.Context, db graph.Database, edge *g
 					return nextSegment.Node.Kinds.ContainsOneOf(ad.CertTemplate)
 				})
 
+				if startNode.Kinds.ContainsOneOf(ad.User) && !certTemplateValidForUserVictim(certTemplate) {
+					if managedServiceAccount, err := isManagedServiceAccount(startNode); err != nil {
+						return err
+					} else if !managedServiceAccount {
+						return nil
+					}
+				}
+
 				lock.Lock()
 				path1CandidateSegments[enterpriseCANode.ID] = append(path1CandidateSegments[enterpriseCANode.ID], terminal)
 				path1EnterpriseCAs.Add(enterpriseCANode.ID.Uint64())
@@ -265,6 +273,10 @@ func GetADCSESC13EdgeComposition(ctx context.Context, db graph.Database, edge *g
 		}); err != nil {
 			return nil, err
 		}
+	}
+
+	if path1EnterpriseCAs.Cardinality() == 0 {
+		return paths, nil
 	}
 
 	//Manifest P2 and key it to the enterprise CA nodes to cross product

--- a/packages/go/analysis/ad/esc3.go
+++ b/packages/go/analysis/ad/esc3.go
@@ -580,16 +580,23 @@ func GetADCSESC3EdgeComposition(ctx context.Context, db graph.Database, edge *gr
 		if err := traversalInst.BreadthFirst(ctx, traversal.Plan{
 			Root: n,
 			Driver: ADCSESC3Path1Pattern(edge.EndID, enterpriseCANodes).Do(func(terminal *graph.PathSegment) error {
-				certTemplateNode := terminal.Search(func(nextSegment *graph.PathSegment) bool {
-					return nextSegment.Node.Kinds.ContainsOneOf(ad.CertTemplate)
-				})
+				var (
+					certTemplateNode = terminal.Search(func(nextSegment *graph.PathSegment) bool {
+						return nextSegment.Node.Kinds.ContainsOneOf(ad.CertTemplate)
+					})
+					userStartNode = startNode.Kinds.ContainsOneOf(ad.User)
+				)
+
+				managedServiceAccount, err := isManagedServiceAccount(startNode)
+				if err != nil {
+					return err
+				}
 
 				lock.Lock()
 				path1CandidateSegments[certTemplateNode.ID] = append(path1CandidateSegments[certTemplateNode.ID], terminal)
 
-				// Check that CT is valid for user start nodes
-				userStartNode := startNode.Kinds.ContainsOneOf(ad.User)
-				if !userStartNode || certTemplateValidForUserVictim(certTemplateNode) {
+				// gMSAs and sMSAs are User nodes with DNS names, so DNS requirements are valid for them.
+				if !userStartNode || managedServiceAccount || certTemplateValidForUserVictim(certTemplateNode) {
 					path1CertTemplates.Add(certTemplateNode.ID.Uint64())
 				}
 				lock.Unlock()

--- a/packages/go/analysis/ad/esc6.go
+++ b/packages/go/analysis/ad/esc6.go
@@ -291,18 +291,24 @@ func GetADCSESC6EdgeComposition(ctx context.Context, db graph.Database, edge *gr
 						return nextSegment.Node.Kinds.ContainsOneOf(ad.CertTemplate)
 					})
 
-					if !startNode.Kinds.ContainsOneOf(ad.User) || certTemplateValidForUserVictim(certTemplate) {
-						paths.AddPath(terminal.Path())
-
-						// add the ECA where the template is published (first ECA in the path in case of multi-tier hierarchy) to final list of ECAs
-						terminal.Path().Walk(func(start, end *graph.Node, relationship *graph.Relationship) bool {
-							if end.Kinds.ContainsOneOf(ad.EnterpriseCA) {
-								finalEnterpriseCAs.Add(end.ID.Uint64())
-								return false
-							}
-							return true
-						})
+					if startNode.Kinds.ContainsOneOf(ad.User) && !certTemplateValidForUserVictim(certTemplate) {
+						if managedServiceAccount, err := isManagedServiceAccount(startNode); err != nil {
+							return err
+						} else if !managedServiceAccount {
+							return nil
+						}
 					}
+
+					paths.AddPath(terminal.Path())
+
+					// add the ECA where the template is published (first ECA in the path in case of multi-tier hierarchy) to final list of ECAs
+					terminal.Path().Walk(func(start, end *graph.Node, relationship *graph.Relationship) bool {
+						if end.Kinds.ContainsOneOf(ad.EnterpriseCA) {
+							finalEnterpriseCAs.Add(end.ID.Uint64())
+							return false
+						}
+						return true
+					})
 					return nil
 				})}); err != nil {
 			return nil, err

--- a/packages/go/analysis/ad/esc9.go
+++ b/packages/go/analysis/ad/esc9.go
@@ -253,7 +253,11 @@ func GetADCSESC9aEdgeComposition(ctx context.Context, db graph.Database, edge *g
 				})
 
 				if !certTemplateValidForUserVictim(certTemplate) {
-					return nil
+					if managedServiceAccount, err := isManagedServiceAccount(victimNode); err != nil {
+						return err
+					} else if !managedServiceAccount {
+						return nil
+					}
 				}
 			}
 

--- a/packages/go/analysis/ad/esc_shared.go
+++ b/packages/go/analysis/ad/esc_shared.go
@@ -386,28 +386,30 @@ func certTemplateValidForUserVictim(certTemplate *graph.Node) bool {
 }
 
 func filterUserDNSResults(tx graph.Transaction, bitmap cardinality.Duplex[uint64], certTemplate *graph.Node) (cardinality.Duplex[uint64], error) {
+	if certTemplateValidForUserVictim(certTemplate) {
+		return bitmap, nil
+	}
+
 	// gMSAs and sMSAs are ingested as User nodes but behave like Computer objects in AD
 	// and possess DNS names, so they should not be filtered out of attack paths that
 	// require DNS in the SubjectAltName
 	if userNodes, err := ops.FetchNodeSet(tx.Nodes().Filterf(func() graph.Criteria {
 		return query.And(
 			query.KindIn(query.Node(), ad.User),
-			query.Not(query.And(
-				query.Exists(query.NodeProperty(ad.GMSA.String())),
-				query.Equals(query.NodeProperty(ad.GMSA.String()), true),
-			)),
-			query.Not(query.And(
-				query.Exists(query.NodeProperty(ad.MSA.String())),
-				query.Equals(query.NodeProperty(ad.MSA.String()), true),
-			)),
 			query.InIDs(query.NodeID(), graph.DuplexToGraphIDs(bitmap)...),
 		)
 	})); err != nil {
 		if !graph.IsErrNotFound(err) {
 			return nil, err
 		}
-	} else if len(userNodes) > 0 && !certTemplateValidForUserVictim(certTemplate) {
-		bitmap.Xor(graph.NodeSetToDuplex(userNodes))
+	} else {
+		for _, userNode := range userNodes {
+			if managedServiceAccount, err := isManagedServiceAccount(userNode); err != nil {
+				return nil, err
+			} else if !managedServiceAccount {
+				bitmap.Remove(userNode.ID.Uint64())
+			}
+		}
 	}
 
 	return bitmap, nil

--- a/packages/go/analysis/ad/managed_service_accounts_test.go
+++ b/packages/go/analysis/ad/managed_service_accounts_test.go
@@ -1,0 +1,78 @@
+// Copyright 2026 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package ad
+
+import (
+	"testing"
+
+	adSchema "github.com/specterops/bloodhound/packages/go/graphschema/ad"
+	"github.com/specterops/dawgs/graph"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsManagedServiceAccount(t *testing.T) {
+	testCases := []struct {
+		name                  string
+		properties            *graph.Properties
+		expected              bool
+		expectedPropertyError bool
+	}{
+		{
+			name:       "gMSA",
+			properties: graph.NewProperties().Set(adSchema.GMSA.String(), true),
+			expected:   true,
+		},
+		{
+			name:       "sMSA",
+			properties: graph.NewProperties().Set(adSchema.MSA.String(), true),
+			expected:   true,
+		},
+		{
+			name: "both properties false",
+			properties: graph.NewProperties().Set(adSchema.GMSA.String(), false).
+				Set(adSchema.MSA.String(), false),
+		},
+		{
+			name:       "properties absent",
+			properties: graph.NewProperties(),
+		},
+		{
+			name:                  "invalid gMSA property",
+			properties:            graph.NewProperties().Set(adSchema.GMSA.String(), "true"),
+			expectedPropertyError: true,
+		},
+		{
+			name:                  "invalid sMSA property",
+			properties:            graph.NewProperties().Set(adSchema.MSA.String(), "true"),
+			expectedPropertyError: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			node := graph.NewNode(1, testCase.properties, adSchema.User)
+
+			actual, err := isManagedServiceAccount(node)
+			if testCase.expectedPropertyError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, testCase.expected, actual)
+		})
+	}
+}

--- a/packages/go/analysis/ad/owns.go
+++ b/packages/go/analysis/ad/owns.go
@@ -18,7 +18,6 @@ package ad
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
 
@@ -294,14 +293,8 @@ func createPostRelFromRaw(rel *graph.Relationship, kind graph.Kind) post.EnsureR
 func isTargetNodeComputerDerived(node *graph.Node) (bool, error) {
 	if node.Kinds.ContainsOneOf(ad.Computer) {
 		return true, nil
-	} else if isGmsa, err := node.Properties.Get(ad.GMSA.String()).Bool(); err != nil && !errors.Is(err, graph.ErrPropertyNotFound) {
-		return false, err
-	} else if isGmsa {
-		return true, nil
-	} else if isMsa, err := node.Properties.Get(ad.MSA.String()).Bool(); err != nil && !errors.Is(err, graph.ErrPropertyNotFound) {
-		return false, err
 	} else {
-		return isMsa, nil
+		return isManagedServiceAccount(node)
 	}
 }
 

--- a/packages/go/analysis/ad/owns.go
+++ b/packages/go/analysis/ad/owns.go
@@ -293,9 +293,9 @@ func createPostRelFromRaw(rel *graph.Relationship, kind graph.Kind) post.EnsureR
 func isTargetNodeComputerDerived(node *graph.Node) (bool, error) {
 	if node.Kinds.ContainsOneOf(ad.Computer) {
 		return true, nil
-	} else {
-		return isManagedServiceAccount(node)
 	}
+
+	return isManagedServiceAccount(node)
 }
 
 func FetchAdminGroupIds(ctx context.Context, db graph.Database, groupExpansions *algo.ReachabilityCache) (cardinality.Duplex[uint64], error) {


### PR DESCRIPTION
## Description

This PR aligns ADCS edge creation and composition when a certificate template requires a DNS or domain-DNS subject alternative name.

gMSAs and sMSAs are represented as `User` nodes, but they possess the DNS identity required by these templates. Creation already preserved these accounts in some paths, while several composition implementations treated them as ordinary users and discarded the supporting template path.

This change:

- Adds a shared `isManagedServiceAccount` helper for the `gmsa` and `msa` properties.
- Reuses the helper in DNS filtering and computer-derived target classification.
- Preserves computers, gMSAs, and sMSAs for DNS-required certificate templates.
- Continues rejecting ordinary users when the template requires DNS.
- Treats absent managed-account properties as false and propagates malformed-property errors.
- Applies equivalent composition handling to ESC3, ESC6, existing ESC9a edges, ESC10a, and ESC13.
- Adds creation and composition coverage for ordinary users, computers, gMSAs, and sMSAs.

### Stack

- Base: `main`
- Head: `BED-9336-adcs-managed-account-dns`
- This is PR 1 of 4.
- Merge the stack in order.
- After this PR merges, retarget `BED-9336-adcs-trust-paths` to `main`.

### Commit review order

1. `refactor: centralize managed service account detection BED-9336`
   - Introduces and unit-tests `isManagedServiceAccount`.
   - Removes duplicate gMSA/sMSA property handling.

2. `fix: align ESC3 managed-account DNS requirements BED-9336`
   - Applies the shared decision to ESC3 composition.
   - Adds an ESC3 harness covering both DNS template flags and ordinary-user rejection.

3. `fix: align managed-account DNS in ADCS compositions BED-9336`
   - Applies the same rule to ESC6, existing ESC9a, ESC10a, and ESC13.
   - Adds end-to-end creation and composition assertions.

## Motivation and Context

Resolves BED-9336

Creation and composition must evaluate certificate-template requirements consistently. Previously, a managed service account could receive a valid post-processed edge because it has a DNS identity, but composition could reject the same path because the account is ingested as a `User`.

That produced edges with empty or incomplete composition graphs. Centralizing the account classification removes the inconsistency without relaxing DNS requirements for ordinary users.

## How Has This Been Tested?

Validated with:

- `go test ./packages/go/analysis/ad -count=1`
- `just prepare-for-codereview`

Coverage includes:

- gMSA and sMSA detection.
- Missing, false, and malformed managed-account properties.
- ESC3 templates using `SubjectAltRequireDNS` and `SubjectAltRequireDomainDNS`.
- ESC6, existing ESC9a, ESC10a, and ESC13 composition.
- Ordinary-user negative cases and computer positive cases.

## Screenshots (optional):

N/A — backend graph analysis only.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved certificate enrollment path analysis for managed service accounts, including gMSA and sMSA scenarios.
  * Added support for DNS and domain-DNS certificate requirements in relevant security analyses.
* **Bug Fixes**
  * Regular users are now excluded from paths requiring managed service account capabilities.
  * Improved handling of invalid certificate templates and property errors.
* **Tests**
  * Added comprehensive integration coverage for ESC3, ESC6, ESC9, ESC10, and ESC13 managed service account scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->