### PR TITLE
fix: Scope ADCS host validation to exact Enterprise CAs BED-9336

### DIFF
--- a/packages/go/analysis/ad/adcs_forest_integration_test.go
+++ b/packages/go/analysis/ad/adcs_forest_integration_test.go
@@ -19,14 +19,17 @@
 package ad_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/specterops/bloodhound/cmd/api/src/test/integration"
 	adAnalysis "github.com/specterops/bloodhound/packages/go/analysis/ad"
+	"github.com/specterops/bloodhound/packages/go/analysis/post"
 	"github.com/specterops/bloodhound/packages/go/graphschema"
 	"github.com/specterops/bloodhound/packages/go/graphschema/ad"
 	"github.com/specterops/bloodhound/packages/go/graphschema/common"
 	"github.com/specterops/dawgs/graph"
+	"github.com/specterops/dawgs/query"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -196,6 +199,221 @@ func TestADCSNTAuthStoreChainRequiresExactPattern(t *testing.T) {
 				}
 				return nil
 			}))
+		},
+	)
+}
+
+func TestADCSESC1CompositionScopesHostsToExactEnterpriseCA(t *testing.T) {
+	testContext := integration.NewGraphTestContext(t, graphschema.DefaultGraphSchema())
+
+	var (
+		domainSID                = integration.RandomDomainSID()
+		foreignDomainSID         = integration.RandomDomainSID()
+		unknownDomainSID         = integration.RandomDomainSID()
+		principal                *graph.Node
+		domain                   *graph.Node
+		validEnterpriseCA        *graph.Node
+		unhostedCA               *graph.Node
+		disabledHostedCA         *graph.Node
+		crossForestCA            *graph.Node
+		unknownHostDomainCA      *graph.Node
+		validHost                *graph.Node
+		disabledValidCAHost      *graph.Node
+		crossForestValidCAHost   *graph.Node
+		unknownDomainValidCAHost *graph.Node
+		disabledHost             *graph.Node
+		crossForestHost          *graph.Node
+		unknownDomainHost        *graph.Node
+	)
+
+	testContext.DatabaseTestWithSetup(
+		func(harness *integration.HarnessDetails) error {
+			domain = testContext.NewActiveDirectoryDomain("Domain", domainSID, false, true)
+			testContext.NewActiveDirectoryDomain("ForeignDomain", foreignDomainSID, false, true)
+			rootCA := testContext.NewActiveDirectoryRootCA("RootCA", domainSID)
+			ntAuthStore := testContext.NewActiveDirectoryNTAuthStore("NTAuthStore", domainSID)
+			certificateTemplate := testContext.NewActiveDirectoryCertTemplate("CertificateTemplate", domainSID, integration.CertTemplateData{
+				AuthenticationEnabled:   true,
+				AuthorizedSignatures:    0,
+				EnrolleeSuppliesSubject: true,
+				RequiresManagerApproval: false,
+				SchemaVersion:           1,
+			})
+			principal = testContext.NewActiveDirectoryGroup("Principal", domainSID)
+
+			validEnterpriseCA = testContext.NewActiveDirectoryEnterpriseCA("ValidEnterpriseCA", domainSID)
+			unhostedCA = testContext.NewActiveDirectoryEnterpriseCA("UnhostedCA", domainSID)
+			disabledHostedCA = testContext.NewActiveDirectoryEnterpriseCA("DisabledHostedCA", domainSID)
+			crossForestCA = testContext.NewActiveDirectoryEnterpriseCA("CrossForestCA", domainSID)
+			unknownHostDomainCA = testContext.NewActiveDirectoryEnterpriseCA("UnknownHostDomainCA", domainSID)
+
+			testContext.NewRelationship(rootCA, domain, ad.RootCAFor)
+			testContext.NewRelationship(ntAuthStore, domain, ad.NTAuthStoreFor)
+			testContext.NewRelationship(principal, certificateTemplate, ad.Enroll)
+
+			for _, enterpriseCA := range []*graph.Node{
+				validEnterpriseCA,
+				unhostedCA,
+				disabledHostedCA,
+				crossForestCA,
+				unknownHostDomainCA,
+			} {
+				testContext.NewRelationship(enterpriseCA, rootCA, ad.IssuedSignedBy)
+				testContext.NewRelationship(enterpriseCA, ntAuthStore, ad.TrustedForNTAuth)
+				testContext.NewRelationship(certificateTemplate, enterpriseCA, ad.PublishedTo)
+				testContext.NewRelationship(principal, enterpriseCA, ad.Enroll)
+			}
+
+			validHost = addEnabledHostingComputer(testContext, "ValidHost", domainSID, validEnterpriseCA)
+			disabledValidCAHost = testContext.NewActiveDirectoryComputer("DisabledValidCAHost", domainSID)
+			disabledValidCAHost.Properties.Set(common.Enabled.String(), false)
+			testContext.UpdateNode(disabledValidCAHost)
+			testContext.NewRelationship(disabledValidCAHost, validEnterpriseCA, ad.HostsCAService)
+			crossForestValidCAHost = addEnabledHostingComputer(testContext, "CrossForestValidCAHost", foreignDomainSID, validEnterpriseCA)
+			unknownDomainValidCAHost = addEnabledHostingComputer(testContext, "UnknownDomainValidCAHost", unknownDomainSID, validEnterpriseCA)
+
+			disabledHost = testContext.NewActiveDirectoryComputer("DisabledHost", domainSID)
+			disabledHost.Properties.Set(common.Enabled.String(), false)
+			testContext.UpdateNode(disabledHost)
+			testContext.NewRelationship(disabledHost, disabledHostedCA, ad.HostsCAService)
+			crossForestHost = addEnabledHostingComputer(testContext, "CrossForestHost", foreignDomainSID, crossForestCA)
+			unknownDomainHost = addEnabledHostingComputer(testContext, "UnknownDomainHost", unknownDomainSID, unknownHostDomainCA)
+			return nil
+		},
+		func(harness integration.HarnessDetails, db graph.Database) {
+			localGroupData, cache, err := FetchADCSPrereqs(db)
+			require.NoError(t, err)
+
+			chainedDomains := cache.GetECAHostedChainedDomains()
+			require.Contains(t, chainedDomains, validEnterpriseCA.ID.Uint64())
+			assert.NotContains(t, chainedDomains, unhostedCA.ID.Uint64())
+			assert.NotContains(t, chainedDomains, disabledHostedCA.ID.Uint64())
+			assert.NotContains(t, chainedDomains, crossForestCA.ID.Uint64())
+			assert.NotContains(t, chainedDomains, unknownHostDomainCA.ID.Uint64())
+
+			edgeOperation := post.NewPostRelationshipOperation(t.Context(), db, "ADCS ESC1 exact host CA scoping")
+			for _, certificateChains := range chainedDomains {
+				certificateChains := certificateChains
+				require.NoError(t, edgeOperation.Operation.SubmitReader(func(ctx context.Context, tx graph.Transaction, outC chan<- post.EnsureRelationshipJob) error {
+					return adAnalysis.PostADCSESC1(ctx, tx, outC, localGroupData, certificateChains, cache)
+				}))
+			}
+			require.NoError(t, edgeOperation.Done())
+
+			var edge *graph.Relationship
+			require.NoError(t, db.ReadTransaction(t.Context(), func(tx graph.Transaction) error {
+				edge, err = tx.Relationships().Filterf(func() graph.Criteria {
+					return query.And(
+						query.Kind(query.Relationship(), ad.ADCSESC1),
+						query.Equals(query.StartID(), principal.ID),
+						query.Equals(query.EndID(), domain.ID),
+					)
+				}).First()
+				return err
+			}))
+
+			composition, err := adAnalysis.GetADCSESC1EdgeComposition(t.Context(), db, edge)
+			require.NoError(t, err)
+			require.NotEmpty(t, composition)
+			require.True(t, composition.AllNodes().Contains(validEnterpriseCA))
+			for _, invalidNode := range []*graph.Node{
+				unhostedCA,
+				disabledHostedCA,
+				crossForestCA,
+				unknownHostDomainCA,
+				disabledValidCAHost,
+				crossForestValidCAHost,
+				unknownDomainValidCAHost,
+				disabledHost,
+				crossForestHost,
+				unknownDomainHost,
+			} {
+				require.False(t, composition.AllNodes().Contains(invalidNode))
+			}
+
+			var validHostPathFound bool
+			for _, path := range composition.Paths() {
+				path.Walk(func(start, end *graph.Node, relationship *graph.Relationship) bool {
+					if relationship.Kind.Is(ad.HostsCAService) {
+						require.Equal(t, validHost.ID, start.ID)
+						require.Equal(t, validEnterpriseCA.ID, end.ID)
+						validHostPathFound = true
+					}
+					return true
+				})
+			}
+			require.True(t, validHostPathFound)
+		},
+	)
+}
+
+func TestADCSHostEligibilityFallsBackWhenEnterpriseCAForestIsUnresolved(t *testing.T) {
+	testContext := integration.NewGraphTestContext(t, graphschema.DefaultGraphSchema())
+
+	var (
+		domainSID             = integration.RandomDomainSID()
+		unresolvedCADomainSID = integration.RandomDomainSID()
+		principal             *graph.Node
+		domain                *graph.Node
+		enterpriseCA          *graph.Node
+		host                  *graph.Node
+	)
+
+	testContext.DatabaseTestWithSetup(
+		func(harness *integration.HarnessDetails) error {
+			domain = testContext.NewActiveDirectoryDomain("Domain", domainSID, false, true)
+			rootCA := testContext.NewActiveDirectoryRootCA("RootCA", domainSID)
+			ntAuthStore := testContext.NewActiveDirectoryNTAuthStore("NTAuthStore", domainSID)
+			certificateTemplate := testContext.NewActiveDirectoryCertTemplate("CertificateTemplate", domainSID, integration.CertTemplateData{
+				AuthenticationEnabled:   true,
+				AuthorizedSignatures:    0,
+				EnrolleeSuppliesSubject: true,
+				RequiresManagerApproval: false,
+				SchemaVersion:           1,
+			})
+			principal = testContext.NewActiveDirectoryGroup("Principal", domainSID)
+			enterpriseCA = testContext.NewActiveDirectoryEnterpriseCA("EnterpriseCA", unresolvedCADomainSID)
+
+			testContext.NewRelationship(rootCA, domain, ad.RootCAFor)
+			testContext.NewRelationship(ntAuthStore, domain, ad.NTAuthStoreFor)
+			testContext.NewRelationship(enterpriseCA, rootCA, ad.IssuedSignedBy)
+			testContext.NewRelationship(enterpriseCA, ntAuthStore, ad.TrustedForNTAuth)
+			testContext.NewRelationship(certificateTemplate, enterpriseCA, ad.PublishedTo)
+			testContext.NewRelationship(principal, certificateTemplate, ad.Enroll)
+			testContext.NewRelationship(principal, enterpriseCA, ad.Enroll)
+			host = addEnabledHostingComputer(testContext, "Host", domainSID, enterpriseCA)
+			return nil
+		},
+		func(harness integration.HarnessDetails, db graph.Database) {
+			localGroupData, cache, err := FetchADCSPrereqs(db)
+			require.NoError(t, err)
+
+			chainedDomains := cache.GetECAHostedChainedDomains()
+			require.Contains(t, chainedDomains, enterpriseCA.ID.Uint64())
+
+			edgeOperation := post.NewPostRelationshipOperation(t.Context(), db, "ADCS unresolved CA forest fallback")
+			require.NoError(t, edgeOperation.Operation.SubmitReader(func(ctx context.Context, tx graph.Transaction, outC chan<- post.EnsureRelationshipJob) error {
+				return adAnalysis.PostADCSESC1(ctx, tx, outC, localGroupData, chainedDomains[enterpriseCA.ID.Uint64()], cache)
+			}))
+			require.NoError(t, edgeOperation.Done())
+
+			var edge *graph.Relationship
+			require.NoError(t, db.ReadTransaction(t.Context(), func(tx graph.Transaction) error {
+				edge, err = tx.Relationships().Filterf(func() graph.Criteria {
+					return query.And(
+						query.Kind(query.Relationship(), ad.ADCSESC1),
+						query.Equals(query.StartID(), principal.ID),
+						query.Equals(query.EndID(), domain.ID),
+					)
+				}).First()
+				return err
+			}))
+
+			composition, err := adAnalysis.GetADCSESC1EdgeComposition(t.Context(), db, edge)
+			require.NoError(t, err)
+			require.NotEmpty(t, composition)
+			require.True(t, composition.AllNodes().Contains(enterpriseCA))
+			require.True(t, composition.AllNodes().Contains(host))
 		},
 	)
 }

--- a/packages/go/analysis/ad/adcs_forest_integration_test.go
+++ b/packages/go/analysis/ad/adcs_forest_integration_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/specterops/bloodhound/packages/go/graphschema/ad"
 	"github.com/specterops/bloodhound/packages/go/graphschema/common"
 	"github.com/specterops/dawgs/graph"
+	"github.com/specterops/dawgs/ops"
 	"github.com/specterops/dawgs/query"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -343,6 +344,94 @@ func TestADCSESC1CompositionScopesHostsToExactEnterpriseCA(t *testing.T) {
 				})
 			}
 			require.True(t, validHostPathFound)
+		},
+	)
+}
+
+func TestGoldenCertCreationAndCompositionUseOnlyQualifyingHosts(t *testing.T) {
+	testContext := integration.NewGraphTestContext(t, graphschema.DefaultGraphSchema())
+
+	var (
+		domainSID         = integration.RandomDomainSID()
+		foreignDomainSID  = integration.RandomDomainSID()
+		unknownDomainSID  = integration.RandomDomainSID()
+		domain            *graph.Node
+		enterpriseCA      *graph.Node
+		validHost         *graph.Node
+		disabledHost      *graph.Node
+		crossForestHost   *graph.Node
+		unknownDomainHost *graph.Node
+	)
+
+	testContext.DatabaseTestWithSetup(
+		func(harness *integration.HarnessDetails) error {
+			domain = testContext.NewActiveDirectoryDomain("Domain", domainSID, false, true)
+			testContext.NewActiveDirectoryDomain("ForeignDomain", foreignDomainSID, false, true)
+			rootCA := testContext.NewActiveDirectoryRootCA("RootCA", domainSID)
+			enterpriseCA = testContext.NewActiveDirectoryEnterpriseCA("EnterpriseCA", domainSID)
+
+			testContext.NewRelationship(enterpriseCA, rootCA, ad.IssuedSignedBy)
+			linkEnterpriseCAToDomain(testContext, enterpriseCA, rootCA, domain, domainSID)
+
+			validHost = addEnabledHostingComputer(testContext, "ValidHost", domainSID, enterpriseCA)
+			disabledHost = testContext.NewActiveDirectoryComputer("DisabledHost", domainSID)
+			disabledHost.Properties.Set(common.Enabled.String(), false)
+			testContext.UpdateNode(disabledHost)
+			testContext.NewRelationship(disabledHost, enterpriseCA, ad.HostsCAService)
+			crossForestHost = addEnabledHostingComputer(testContext, "CrossForestHost", foreignDomainSID, enterpriseCA)
+			unknownDomainHost = addEnabledHostingComputer(testContext, "UnknownDomainHost", unknownDomainSID, enterpriseCA)
+
+			return nil
+		},
+		func(harness integration.HarnessDetails, db graph.Database) {
+			_, cache, err := FetchADCSPrereqs(db)
+			require.NoError(t, err)
+
+			chainedDomains := cache.GetECAHostedChainedDomains()
+			require.Contains(t, chainedDomains, enterpriseCA.ID.Uint64())
+
+			edgeOperation := post.NewPostRelationshipOperation(t.Context(), db, "GoldenCert exact host scoping")
+			require.NoError(t, edgeOperation.Operation.SubmitReader(func(ctx context.Context, tx graph.Transaction, outC chan<- post.EnsureRelationshipJob) error {
+				return adAnalysis.PostGoldenCert(ctx, tx, outC, chainedDomains[enterpriseCA.ID.Uint64()])
+			}))
+			require.NoError(t, edgeOperation.Done())
+
+			var goldenCertEdge *graph.Relationship
+			require.NoError(t, db.ReadTransaction(t.Context(), func(tx graph.Transaction) error {
+				edges, err := ops.FetchRelationships(tx.Relationships().Filter(query.And(
+					query.Kind(query.Relationship(), ad.GoldenCert),
+					query.Equals(query.EndID(), domain.ID),
+				)))
+				if err != nil {
+					return err
+				}
+
+				require.Len(t, edges, 1)
+				goldenCertEdge = edges[0]
+				assert.Equal(t, validHost.ID, goldenCertEdge.StartID)
+				return nil
+			}))
+
+			composition, err := adAnalysis.GetEdgeCompositionPath(t.Context(), db, goldenCertEdge)
+			require.NoError(t, err)
+			require.NotEmpty(t, composition)
+			require.True(t, composition.AllNodes().Contains(validHost))
+			for _, invalidHost := range []*graph.Node{disabledHost, crossForestHost, unknownDomainHost} {
+				require.False(t, composition.AllNodes().Contains(invalidHost))
+			}
+
+			var qualifyingHostPathFound bool
+			for _, path := range composition.Paths() {
+				path.Walk(func(start, end *graph.Node, relationship *graph.Relationship) bool {
+					if relationship.Kind.Is(ad.HostsCAService) {
+						require.Equal(t, validHost.ID, start.ID)
+						require.Equal(t, enterpriseCA.ID, end.ID)
+						qualifyingHostPathFound = true
+					}
+					return true
+				})
+			}
+			require.True(t, qualifyingHostPathFound)
 		},
 	)
 }

--- a/packages/go/analysis/ad/adcs_integration_test.go
+++ b/packages/go/analysis/ad/adcs_integration_test.go
@@ -52,6 +52,26 @@ func FetchADCSPrereqs(db graph.Database) (*adAnalysis.LocalGroupData, *adAnalysi
 	}
 }
 
+func requireCompositionContainsEdge(t *testing.T, composition graph.PathSet, kind graph.Kind) {
+	t.Helper()
+
+	var found bool
+	for _, path := range composition.Paths() {
+		path.Walk(func(start, end *graph.Node, relationship *graph.Relationship) bool {
+			if relationship.Kind.Is(kind) {
+				found = true
+				return false
+			}
+			return true
+		})
+		if found {
+			break
+		}
+	}
+
+	require.True(t, found, "composition does not contain a %s edge", kind.String())
+}
+
 func TestTrustedForNTAuth(t *testing.T) {
 	testContext := integration.NewGraphTestContext(t, graphschema.DefaultGraphSchema())
 
@@ -560,9 +580,10 @@ func TestADCSESC1(t *testing.T) {
 				} else {
 					comp, err := adAnalysis.GetADCSESC1EdgeComposition(context.Background(), db, edge)
 					assert.Nil(t, err)
+					requireCompositionContainsEdge(t, comp, ad.HostsCAService)
 
 					domain2Nodes := comp.AllNodes()
-					assert.Len(t, domain2Nodes, 9)
+					assert.Len(t, domain2Nodes, 10)
 					require.True(t, domain2Nodes.Contains(harness.ADCSESC1Harness.Group22))
 					require.True(t, domain2Nodes.Contains(harness.ADCSESC1Harness.CertTemplate2))
 					require.True(t, domain2Nodes.Contains(harness.ADCSESC1Harness.EnterpriseCA21))
@@ -585,9 +606,10 @@ func TestADCSESC1(t *testing.T) {
 				} else {
 					comp, err := adAnalysis.GetADCSESC1EdgeComposition(context.Background(), db, edge)
 					assert.Nil(t, err)
+					requireCompositionContainsEdge(t, comp, ad.HostsCAService)
 
 					domain3Nodes := comp.AllNodes()
-					assert.Len(t, domain3Nodes, 6)
+					assert.Len(t, domain3Nodes, 7)
 					require.True(t, domain3Nodes.Contains(harness.ADCSESC1Harness.Group32))
 					require.True(t, domain3Nodes.Contains(harness.ADCSESC1Harness.CertTemplate3))
 					require.True(t, domain3Nodes.Contains(harness.ADCSESC1Harness.EnterpriseCA31))
@@ -726,7 +748,8 @@ func TestADCSESC3(t *testing.T) {
 				} else {
 					comp, err := adAnalysis.GetADCSESC3EdgeComposition(context.Background(), db, edge)
 					assert.Nil(t, err)
-					assert.Equal(t, 8, len(comp.AllNodes()))
+					requireCompositionContainsEdge(t, comp, ad.HostsCAService)
+					assert.Equal(t, 9, len(comp.AllNodes()))
 					assert.False(t, comp.AllNodes().Contains(harness.ESC3Harness2.User2))
 					// CT3 requires DNS name meaning user3 -> domain is not a valid ESC3
 					assert.False(t, comp.AllNodes().Contains(harness.ESC3Harness2.User3))
@@ -779,7 +802,8 @@ func TestADCSESC3(t *testing.T) {
 				} else {
 					comp, err := adAnalysis.GetADCSESC3EdgeComposition(context.Background(), db, edge)
 					assert.Nil(t, err)
-					assert.Equal(t, 7, len(comp.AllNodes()))
+					requireCompositionContainsEdge(t, comp, ad.HostsCAService)
+					assert.Equal(t, 8, len(comp.AllNodes()))
 					assert.False(t, comp.AllNodes().Contains(harness.ESC3Harness3.User2))
 				}
 				return nil
@@ -840,6 +864,7 @@ func TestADCSESC3(t *testing.T) {
 					composition, err := adAnalysis.GetADCSESC3EdgeComposition(ctx, db, edge)
 					require.NoError(t, err, testCase.name)
 					require.NotEmpty(t, composition, testCase.name)
+					requireCompositionContainsEdge(t, composition, ad.HostsCAService)
 					require.True(t, composition.AllNodes().Contains(testCase.principal), testCase.name)
 				}
 
@@ -1107,10 +1132,11 @@ func TestADCSESC4Composition(t *testing.T) {
 			} else {
 				composition, err := adAnalysis.GetADCSESC4EdgeComposition(context.Background(), db, edge)
 				require.Nil(t, err)
+				requireCompositionContainsEdge(t, composition, ad.HostsCAService)
 
 				nodes := composition.AllNodes()
 
-				require.Equal(t, 7, len(nodes))
+				require.Equal(t, 8, len(nodes))
 				require.True(t, nodes.Contains(harness.ESC4Template1.Group11))
 				require.True(t, nodes.Contains(harness.ESC4Template1.Group0))
 				require.True(t, nodes.Contains(harness.ESC4Template1.CertTemplate1))
@@ -1137,10 +1163,11 @@ func TestADCSESC4Composition(t *testing.T) {
 				} else {
 					composition, err := adAnalysis.GetADCSESC4EdgeComposition(context.Background(), db, edge)
 					require.Nil(t, err)
+					requireCompositionContainsEdge(t, composition, ad.HostsCAService)
 
 					nodes := composition.AllNodes()
 
-					require.Equal(t, 7, len(nodes))
+					require.Equal(t, 8, len(nodes))
 					require.True(t, nodes.Contains(harness.ESC4Template1.Group12))
 					require.True(t, nodes.Contains(harness.ESC4Template1.Group0))
 					require.True(t, nodes.Contains(harness.ESC4Template1.CertTemplate1))
@@ -1177,10 +1204,11 @@ func TestADCSESC4Composition(t *testing.T) {
 			} else {
 				composition, err := adAnalysis.GetADCSESC4EdgeComposition(context.Background(), db, edge)
 				require.Nil(t, err)
+				requireCompositionContainsEdge(t, composition, ad.HostsCAService)
 
 				nodes := composition.AllNodes()
 
-				require.Equal(t, 7, len(nodes))
+				require.Equal(t, 8, len(nodes))
 				require.True(t, nodes.Contains(harness.ESC4Template1.Group13))
 				require.True(t, nodes.Contains(harness.ESC4Template1.Group0))
 				require.True(t, nodes.Contains(harness.ESC4Template1.CertTemplate1))
@@ -1217,10 +1245,11 @@ func TestADCSESC4Composition(t *testing.T) {
 			} else {
 				composition, err := adAnalysis.GetADCSESC4EdgeComposition(context.Background(), db, edge)
 				require.Nil(t, err)
+				requireCompositionContainsEdge(t, composition, ad.HostsCAService)
 
 				nodes := composition.AllNodes()
 
-				require.Equal(t, 7, len(nodes))
+				require.Equal(t, 8, len(nodes))
 				require.True(t, nodes.Contains(harness.ESC4Template1.Group14))
 				require.True(t, nodes.Contains(harness.ESC4Template1.Group0))
 				require.True(t, nodes.Contains(harness.ESC4Template1.CertTemplate1))
@@ -1257,10 +1286,11 @@ func TestADCSESC4Composition(t *testing.T) {
 			} else {
 				composition, err := adAnalysis.GetADCSESC4EdgeComposition(context.Background(), db, edge)
 				require.Nil(t, err)
+				requireCompositionContainsEdge(t, composition, ad.HostsCAService)
 
 				nodes := composition.AllNodes()
 
-				require.Equal(t, 7, len(nodes))
+				require.Equal(t, 8, len(nodes))
 				require.True(t, nodes.Contains(harness.ESC4Template1.Group15))
 				require.True(t, nodes.Contains(harness.ESC4Template1.Group0))
 				require.True(t, nodes.Contains(harness.ESC4Template1.CertTemplate1))
@@ -1413,12 +1443,13 @@ func TestADCSESC6a(t *testing.T) {
 				} else {
 					composition, err := adAnalysis.GetADCSESC6EdgeComposition(context.Background(), db, edge)
 					require.Nil(t, err)
+					requireCompositionContainsEdge(t, composition, ad.HostsCAService)
 					names := []string{}
 					for _, node := range composition.AllNodes() {
 						name, _ := node.Properties.Get(common.Name.String()).String()
 						names = append(names, name)
 					}
-					require.Equal(t, 7, len(composition.AllNodes()))
+					require.Equal(t, 8, len(composition.AllNodes()))
 					require.Contains(t, names, "Group1")
 					require.Contains(t, names, "Group0")
 					require.Contains(t, names, "CertTemplate1")
@@ -1438,12 +1469,13 @@ func TestADCSESC6a(t *testing.T) {
 				} else {
 					composition, err := adAnalysis.GetADCSESC6EdgeComposition(context.Background(), db, edge)
 					require.Nil(t, err)
+					requireCompositionContainsEdge(t, composition, ad.HostsCAService)
 					names := []string{}
 					for _, node := range composition.AllNodes() {
 						name, _ := node.Properties.Get(common.Name.String()).String()
 						names = append(names, name)
 					}
-					require.Equal(t, 7, len(composition.AllNodes()))
+					require.Equal(t, 8, len(composition.AllNodes()))
 					require.Contains(t, names, "Group2")
 					require.Contains(t, names, "Group0")
 					require.Contains(t, names, "CertTemplate2")
@@ -1555,8 +1587,9 @@ func TestADCSESC6b(t *testing.T) {
 				} else {
 					composition, err := adAnalysis.GetADCSESC6EdgeComposition(context.Background(), db, edge)
 					require.Nil(t, err)
+					requireCompositionContainsEdge(t, composition, ad.HostsCAService)
 
-					require.Equal(t, 8, len(composition.AllNodes()))
+					require.Equal(t, 9, len(composition.AllNodes()))
 					require.True(t, composition.AllNodes().Contains(harness.ESC6bTemplate1Harness.Group0))
 					require.True(t, composition.AllNodes().Contains(harness.ESC6bTemplate1Harness.Group1))
 					require.True(t, composition.AllNodes().Contains(harness.ESC6bTemplate1Harness.CertTemplate1))
@@ -1580,8 +1613,9 @@ func TestADCSESC6b(t *testing.T) {
 				} else {
 					composition, err := adAnalysis.GetADCSESC6EdgeComposition(context.Background(), db, edge)
 					require.Nil(t, err)
+					requireCompositionContainsEdge(t, composition, ad.HostsCAService)
 
-					require.Equal(t, 8, len(composition.AllNodes()))
+					require.Equal(t, 9, len(composition.AllNodes()))
 					require.True(t, composition.AllNodes().Contains(harness.ESC6bTemplate1Harness.Group0))
 					require.True(t, composition.AllNodes().Contains(harness.ESC6bTemplate1Harness.Group2))
 					require.True(t, composition.AllNodes().Contains(harness.ESC6bTemplate1Harness.CertTemplate2))
@@ -1981,12 +2015,13 @@ func TestADCSESC10a(t *testing.T) {
 					if composition, err := adAnalysis.GetEdgeCompositionPath(context.Background(), db, edge); err != nil {
 						t.Fatalf("error getting edge composition for esc10a: %v", err)
 					} else {
+						requireCompositionContainsEdge(t, composition, ad.HostsCAService)
 						names := []string{}
 						for _, node := range composition.AllNodes() {
 							name, _ := node.Properties.Get(common.Name.String()).String()
 							names = append(names, name)
 						}
-						require.Equal(t, 8, len(composition.AllNodes()))
+						require.Equal(t, 9, len(composition.AllNodes()))
 						require.Contains(t, names, "Group1")
 						require.Contains(t, names, "Domain1")
 						require.Contains(t, names, "DC1")
@@ -2295,12 +2330,13 @@ func TestADCSESC10b(t *testing.T) {
 					if composition, err := adAnalysis.GetEdgeCompositionPath(context.Background(), db, edge); err != nil {
 						t.Fatalf("error getting edge composition for esc10b: %v", err)
 					} else {
+						requireCompositionContainsEdge(t, composition, ad.HostsCAService)
 						names := []string{}
 						for _, node := range composition.AllNodes() {
 							name, _ := node.Properties.Get(common.Name.String()).String()
 							names = append(names, name)
 						}
-						require.Equal(t, 8, len(composition.AllNodes()))
+						require.Equal(t, 9, len(composition.AllNodes()))
 						require.Contains(t, names, "Group1")
 						require.Contains(t, names, "Domain1")
 						require.Contains(t, names, "ComputerDC1")
@@ -2616,6 +2652,7 @@ func TestADCSESC13(t *testing.T) {
 					if edgeComp, err := adAnalysis.GetEdgeCompositionPath(context.Background(), db, edge); err != nil {
 						t.Fatalf("error getting edge composition for esc13: %v", err)
 					} else {
+						requireCompositionContainsEdge(t, edgeComp, ad.HostsCAService)
 						nodes := edgeComp.AllNodes().Slice()
 						assert.Contains(t, nodes, harness.ESC13HarnessECA.Group1)
 						assert.Contains(t, nodes, harness.ESC13HarnessECA.Domain1)

--- a/packages/go/analysis/ad/adcs_integration_test.go
+++ b/packages/go/analysis/ad/adcs_integration_test.go
@@ -45,8 +45,9 @@ func FetchADCSPrereqs(db graph.Database) (*adAnalysis.LocalGroupData, *adAnalysi
 			return nil, nil, err
 		} else if certTemplates, err := adAnalysis.FetchNodesByKind(context.Background(), db, ad.CertTemplate); err != nil {
 			return nil, nil, err
+		} else if err := cache.BuildCache(context.Background(), db, enterpriseCertAuthorities, certTemplates); err != nil {
+			return nil, nil, err
 		} else {
-			cache.BuildCache(context.Background(), db, enterpriseCertAuthorities, certTemplates)
 			return localGroupData, cache, nil
 		}
 	}
@@ -1837,7 +1838,86 @@ func TestADCSESC6b(t *testing.T) {
 	})
 }
 
+type esc10CompositionHarness struct {
+	attacker        *graph.Node
+	domain          *graph.Node
+	enterpriseCA    *graph.Node
+	hostingComputer *graph.Node
+}
+
+func setupESC10CompositionHarness(graphTestContext *integration.GraphTestContext) esc10CompositionHarness {
+	var (
+		domainSID    = integration.RandomDomainSID()
+		domain       = graphTestContext.NewActiveDirectoryDomain("Domain", domainSID, false, true)
+		rootCA       = graphTestContext.NewActiveDirectoryRootCA("RootCA", domainSID)
+		authStore    = graphTestContext.NewActiveDirectoryNTAuthStore("NTAuthStore", domainSID)
+		enterpriseCA = graphTestContext.NewActiveDirectoryEnterpriseCA("EnterpriseCA", domainSID)
+		certTemplate = graphTestContext.NewActiveDirectoryCertTemplate("CertTemplate", domainSID, integration.CertTemplateData{
+			ApplicationPolicies:           []string{},
+			AuthorizedSignatures:          0,
+			EffectiveEKUs:                 []string{},
+			EnrolleeSuppliesSubject:       false,
+			RequiresManagerApproval:       false,
+			SchemaVersion:                 1,
+			SchannelAuthenticationEnabled: true,
+			SubjectAltRequireUPN:          true,
+		})
+		domainController = graphTestContext.NewActiveDirectoryComputer("Domain Controller", domainSID)
+		hostingComputer  = graphTestContext.NewActiveDirectoryComputer("EnterpriseCA host", domainSID)
+		attacker         = graphTestContext.NewActiveDirectoryGroup("Attacker", domainSID)
+		victim           = graphTestContext.NewActiveDirectoryUser("Victim", domainSID)
+	)
+
+	domainController.Properties.Set(ad.CertificateMappingMethodsRaw.String(), "31")
+	hostingComputer.Properties.Set(common.Enabled.String(), true)
+	graphTestContext.UpdateNode(domainController)
+	graphTestContext.UpdateNode(hostingComputer)
+
+	graphTestContext.NewRelationship(rootCA, domain, ad.RootCAFor)
+	graphTestContext.NewRelationship(enterpriseCA, rootCA, ad.IssuedSignedBy)
+	graphTestContext.NewRelationship(authStore, domain, ad.NTAuthStoreFor)
+	graphTestContext.NewRelationship(enterpriseCA, authStore, ad.TrustedForNTAuth)
+	graphTestContext.NewRelationship(domainController, domain, ad.DCFor)
+	graphTestContext.NewRelationship(hostingComputer, enterpriseCA, ad.HostsCAService)
+	graphTestContext.NewRelationship(certTemplate, enterpriseCA, ad.PublishedTo)
+	graphTestContext.NewRelationship(attacker, victim, ad.GenericAll)
+	graphTestContext.NewRelationship(victim, certTemplate, ad.Enroll)
+	graphTestContext.NewRelationship(victim, enterpriseCA, ad.Enroll)
+
+	return esc10CompositionHarness{
+		attacker:        attacker,
+		domain:          domain,
+		enterpriseCA:    enterpriseCA,
+		hostingComputer: hostingComputer,
+	}
+}
+
 func TestADCSESC10a(t *testing.T) {
+	t.Run("composition excludes shared paths when the exact CA host is disabled", func(t *testing.T) {
+		testContext := integration.NewGraphTestContext(t, graphschema.DefaultGraphSchema())
+		var testHarness esc10CompositionHarness
+
+		testContext.DatabaseTestWithSetup(
+			func(harness *integration.HarnessDetails) error {
+				testHarness = setupESC10CompositionHarness(testContext)
+				testHarness.hostingComputer.Properties.Set(common.Enabled.String(), false)
+				testContext.UpdateNode(testHarness.hostingComputer)
+				return nil
+			},
+			func(harness integration.HarnessDetails, db graph.Database) {
+				composition, err := adAnalysis.GetADCSESC10EdgeComposition(t.Context(), db, graph.NewRelationship(
+					0,
+					testHarness.attacker.ID,
+					testHarness.domain.ID,
+					graph.NewProperties(),
+					ad.ADCSESC10a,
+				))
+				require.NoError(t, err)
+				require.Empty(t, composition)
+				require.False(t, composition.AllNodes().Contains(testHarness.enterpriseCA))
+			},
+		)
+	})
 	t.Run("ADCSESC10aPrincipalHarness", func(t *testing.T) {
 		testContext := integration.NewGraphTestContext(t, graphschema.DefaultGraphSchema())
 		testContext.DatabaseTestWithSetup(func(harness *integration.HarnessDetails) error {

--- a/packages/go/analysis/ad/adcscache.go
+++ b/packages/go/analysis/ad/adcscache.go
@@ -127,19 +127,17 @@ type ADCSCache struct {
 	domains                   []*graph.Node
 
 	// To discourage direct access without getting a read lock, these are private
-	chainedDomainsByEnterpriseCA    map[uint64]*EnterpriseCAChainedDomains  // chainedDomainsByEnterpriseCA maps each Enterprise CA node ID to the domains reachable from it through a valid certificate chain (RootCAFor ∩ TrustedForNTAuth).
-	certTemplateHasSpecialEnrollers map[graph.ID]bool                       // whether Auth. Users or Everyone has enrollment rights on templates
-	enterpriseCAHasSpecialEnrollers map[graph.ID]bool                       // whether Auth. Users or Everyone has enrollment rights on enterprise CAs
-	certTemplateEnrollers           map[graph.ID]CachedPrincipalSet         // principals that have enrollment on a cert template via `enroll`, `generic all`, `all extended rights` edges
-	certTemplateControllers         map[graph.ID]CachedPrincipalSet         // principals that have privileges on a cert template via `owner`, `generic all`, `write dacl`, `write owner` edges
-	enterpriseCAEnrollers           map[graph.ID]CachedPrincipalSet         // principals that have enrollment rights on an enterprise ca via `enroll` edge
-	publishedTemplateCache          map[graph.ID][]*graph.Node              // cert templates that are published to an enterprise ca (needs property access)
-	authUsersByDomain               map[graph.ID]graph.ID                   // domain node ID → Authenticated Users group node ID
-	ecasWithHostingComputers        cardinality.Duplex[uint64]              // enterprise CAs with at least one hosting computer where the computer is enabled
-	authStoreForChainValid          map[graph.ID]cardinality.Duplex[uint64] //Auth stores with a valid chain to the domain, key is domain ID
-	rootCAForChainValid             map[graph.ID]cardinality.Duplex[uint64] //Root CA with a valid chain to the domain, key is domain ID
-	hasHostingComputer              map[graph.ID]bool
-	hasInForestHostingComputer      map[graph.ID]bool // enterprise CA ID -> whether the CA has an enabled hosting computer inside its own forest
+	chainedDomainsByEnterpriseCA     map[uint64]*EnterpriseCAChainedDomains  // chainedDomainsByEnterpriseCA maps each Enterprise CA node ID to the domains reachable from it through a valid certificate chain (RootCAFor ∩ TrustedForNTAuth).
+	certTemplateHasSpecialEnrollers  map[graph.ID]bool                       // whether Auth. Users or Everyone has enrollment rights on templates
+	enterpriseCAHasSpecialEnrollers  map[graph.ID]bool                       // whether Auth. Users or Everyone has enrollment rights on enterprise CAs
+	certTemplateEnrollers            map[graph.ID]CachedPrincipalSet         // principals that have enrollment on a cert template via `enroll`, `generic all`, `all extended rights` edges
+	certTemplateControllers          map[graph.ID]CachedPrincipalSet         // principals that have privileges on a cert template via `owner`, `generic all`, `write dacl`, `write owner` edges
+	enterpriseCAEnrollers            map[graph.ID]CachedPrincipalSet         // principals that have enrollment rights on an enterprise ca via `enroll` edge
+	publishedTemplateCache           map[graph.ID][]*graph.Node              // cert templates that are published to an enterprise ca (needs property access)
+	authUsersByDomain                map[graph.ID]graph.ID                   // domain node ID → Authenticated Users group node ID
+	enterpriseCAsWithQualifyingHosts cardinality.Duplex[uint64]              // enterprise CAs with at least one enabled and, when resolvable, in-forest hosting computer
+	authStoreForChainValid           map[graph.ID]cardinality.Duplex[uint64] //Auth stores with a valid chain to the domain, key is domain ID
+	rootCAForChainValid              map[graph.ID]cardinality.Duplex[uint64] //Root CA with a valid chain to the domain, key is domain ID
 
 	// ESC4-specific caches: principals with specific rights on cert templates, pre-computed to avoid per-ECA DB queries
 	certTemplateGenericWriters              map[graph.ID]CachedPrincipalSet         // principals with GenericWrite on a cert template
@@ -159,14 +157,12 @@ func NewADCSCache() *ADCSCache {
 		enterpriseCAHasSpecialEnrollers:         make(map[graph.ID]bool),
 		authStoreForChainValid:                  make(map[graph.ID]cardinality.Duplex[uint64]),
 		rootCAForChainValid:                     make(map[graph.ID]cardinality.Duplex[uint64]),
-		hasHostingComputer:                      make(map[graph.ID]bool),
-		hasInForestHostingComputer:              make(map[graph.ID]bool),
 		certTemplateEnrollers:                   make(map[graph.ID]CachedPrincipalSet),
 		certTemplateControllers:                 make(map[graph.ID]CachedPrincipalSet),
 		enterpriseCAEnrollers:                   make(map[graph.ID]CachedPrincipalSet),
 		publishedTemplateCache:                  make(map[graph.ID][]*graph.Node),
 		authUsersByDomain:                       make(map[graph.ID]graph.ID),
-		ecasWithHostingComputers:                cardinality.NewBitmap64(),
+		enterpriseCAsWithQualifyingHosts:        cardinality.NewBitmap64(),
 		hasUPNCertMappingInForest:               cardinality.NewBitmap64(),
 		certTemplateGenericWriters:              make(map[graph.ID]CachedPrincipalSet),
 		certTemplateEnrollOrAllExtendedRighters: make(map[graph.ID]CachedPrincipalSet),
@@ -289,6 +285,20 @@ func (s *ADCSCache) BuildCache(ctx context.Context, db graph.Database, enterpris
 			attr.Scope("routine"),
 		)
 
+		enterpriseCAIDs := cardinality.NewBitmap64()
+		for _, enterpriseCA := range s.enterpriseCertAuthorities {
+			enterpriseCAIDs.Add(enterpriseCA.ID.Uint64())
+		}
+
+		s.enterpriseCAsWithQualifyingHosts = cardinality.NewBitmap64()
+		if qualifyingHostPaths, err := fetchQualifyingEnterpriseCAHostPathsForTransaction(tx, enterpriseCAIDs, domainsBySID); err != nil {
+			return fmt.Errorf("failed fetching qualifying hosting computers for enterprise CAs: %w", err)
+		} else {
+			for enterpriseCAID := range qualifyingHostPaths {
+				s.enterpriseCAsWithQualifyingHosts.Add(enterpriseCAID.Uint64())
+			}
+		}
+
 		for _, eca := range s.enterpriseCertAuthorities {
 			if enterpriseCAEnrollers, err := fetchFirstDegreeNodes(tx, eca, ad.Enroll); err != nil {
 				slog.ErrorContext(
@@ -322,63 +332,6 @@ func (s *ADCSCache) BuildCache(ctx context.Context, db graph.Database, enterpris
 				)
 			} else {
 				s.publishedTemplateCache[eca.ID] = publishedTemplates.Slice()
-			}
-
-			if hostingComputers, err := fetchFirstDegreeNodes(tx, eca, ad.HostsCAService); err != nil {
-				slog.ErrorContext(
-					ctx,
-					"Error fetching hosting computers for enterprise ca",
-					slog.Uint64("enterprise_ca", uint64(eca.ID)),
-					attr.Error(err),
-				)
-			} else {
-				// Resolve the CA's own forest; fall back to forest-agnostic behavior
-				// when it can't be determined.
-				forestDomains, err := resolveEnterpriseCAForest(tx, eca, domainsBySID)
-				if err != nil {
-					slog.WarnContext(
-						ctx,
-						"Error resolving forest for enterprise ca",
-						slog.Uint64("enterprise_ca", uint64(eca.ID)),
-						attr.Error(err),
-					)
-				}
-
-				var (
-					hasHostingComputer = false
-					hostInForest       = false
-				)
-
-				for _, computer := range hostingComputers.Slice() {
-					if !enterpriseCAHostIsEligible(computer, nil, domainsBySID) {
-						continue
-					}
-
-					hasHostingComputer = true
-
-					// Only count a host that lives in the CA's forest; a shared CA can
-					// be linked to a computer in another forest.
-					if forestDomains != nil {
-						if computerSID, err := computer.Properties.Get(ad.DomainSID.String()).String(); err != nil || computerSID == "" {
-							// Without a domainsid we can't place the host in a forest, so it
-							// won't count as in-forest. Log it: if this is the CA's only host
-							// the CA is dropped, and the silent skip would be hard to diagnose.
-							slog.WarnContext(
-								ctx,
-								"Hosting computer is missing a domainsid; cannot determine whether it is in the CA's forest",
-								slog.Uint64("computer", uint64(computer.ID)),
-								slog.Uint64("enterprise_ca", uint64(eca.ID)),
-							)
-						} else if enterpriseCAHostIsEligible(computer, forestDomains, domainsBySID) {
-							hostInForest = true
-						}
-					}
-				}
-
-				s.hasHostingComputer[eca.ID] = hasHostingComputer
-				if forestDomains != nil {
-					s.hasInForestHostingComputer[eca.ID] = hostInForest
-				}
 			}
 		}
 
@@ -527,8 +480,9 @@ func enterpriseCAHostIsEligible(computer *graph.Node, forestDomains cardinality.
 
 // resolveEnterpriseCAForest returns the domain IDs in the CA's forest (the
 // SameForestTrust closure of the CA's domain, resolved from its domainsid). It
-// returns a nil set when the forest can't be resolved, so callers fall back to
-// forest-agnostic behavior rather than dropping the CA.
+// returns a nil set only when collected metadata can't identify the forest, so
+// callers fall back to forest-agnostic behavior rather than dropping the CA.
+// Database and traversal failures are returned to the caller.
 func resolveEnterpriseCAForest(tx graph.Transaction, eca *graph.Node, domainsBySID map[string]*graph.Node) (cardinality.Duplex[uint64], error) {
 	domainSID, err := eca.Properties.Get(ad.DomainSID.String()).String()
 	if err != nil || domainSID == "" {
@@ -553,21 +507,82 @@ func resolveEnterpriseCAForest(tx graph.Transaction, eca *graph.Node, domainsByS
 	return forestDomains, nil
 }
 
-func (s *ADCSCache) enterpriseCAHasQualifyingHost(enterpriseCAID graph.ID) bool {
-	if hasInForestHostingComputer, forestKnown := s.hasInForestHostingComputer[enterpriseCAID]; forestKnown {
-		return hasInForestHostingComputer
+// fetchQualifyingEnterpriseCAHostPathsForTransaction returns only the
+// HostsCAService paths whose computer is enabled and, when the Enterprise CA's
+// forest can be resolved, belongs to that forest. Results are keyed by the
+// exact Enterprise CA so one CA's host cannot qualify another CA.
+func fetchQualifyingEnterpriseCAHostPathsForTransaction(tx graph.Transaction, enterpriseCAs cardinality.Duplex[uint64], domainsBySID map[string]*graph.Node) (map[graph.ID]graph.PathSet, error) {
+	var hostPathsByEnterpriseCA = make(map[graph.ID]graph.PathSet)
+
+	if enterpriseCAs.Cardinality() == 0 {
+		return hostPathsByEnterpriseCA, nil
 	}
 
-	return s.hasHostingComputer[enterpriseCAID]
+	hostingPaths, err := ops.FetchPathSet(tx.Relationships().Filter(query.And(
+		query.Kind(query.Start(), ad.Computer),
+		query.Kind(query.Relationship(), ad.HostsCAService),
+		query.Kind(query.End(), ad.EnterpriseCA),
+		query.InIDs(query.EndID(), graph.DuplexToGraphIDs(enterpriseCAs)...),
+	)))
+	if graph.IsErrNotFound(err) {
+		return hostPathsByEnterpriseCA, nil
+	} else if err != nil {
+		return hostPathsByEnterpriseCA, err
+	}
+
+	return qualifyEnterpriseCAHostPaths(hostingPaths, domainsBySID, func(enterpriseCA *graph.Node) (cardinality.Duplex[uint64], error) {
+		return resolveEnterpriseCAForest(tx, enterpriseCA, domainsBySID)
+	})
 }
 
-// EnterpriseCAHasQualifyingHost returns whether an Enterprise CA has an enabled
+// qualifyEnterpriseCAHostPaths filters materialized HostsCAService paths using
+// a forest resolver. Forest resolution is cached per CA and errors are returned
+// so an operational failure cannot activate the unresolved-forest fallback.
+func qualifyEnterpriseCAHostPaths(hostingPaths graph.PathSet, domainsBySID map[string]*graph.Node, resolveForest func(*graph.Node) (cardinality.Duplex[uint64], error)) (map[graph.ID]graph.PathSet, error) {
+	var (
+		hostPathsByEnterpriseCA     = make(map[graph.ID]graph.PathSet)
+		resolvedEnterpriseCAs       = make(map[graph.ID]bool)
+		forestDomainsByEnterpriseCA = make(map[graph.ID]cardinality.Duplex[uint64])
+	)
+
+	for _, hostingPath := range hostingPaths {
+		var forestDomains cardinality.Duplex[uint64]
+		enterpriseCA := hostingPath.Terminal()
+
+		if resolvedEnterpriseCAs[enterpriseCA.ID] {
+			forestDomains = forestDomainsByEnterpriseCA[enterpriseCA.ID]
+		} else {
+			var err error
+			forestDomains, err = resolveForest(enterpriseCA)
+			if err != nil {
+				return nil, fmt.Errorf("failed resolving forest for enterprise CA %d: %w", enterpriseCA.ID, err)
+			}
+
+			resolvedEnterpriseCAs[enterpriseCA.ID] = true
+			forestDomainsByEnterpriseCA[enterpriseCA.ID] = forestDomains
+		}
+
+		if enterpriseCAHostIsEligible(hostingPath.Root(), forestDomains, domainsBySID) {
+			paths := hostPathsByEnterpriseCA[enterpriseCA.ID]
+			paths.AddPath(hostingPath)
+			hostPathsByEnterpriseCA[enterpriseCA.ID] = paths
+		}
+	}
+
+	return hostPathsByEnterpriseCA, nil
+}
+
+func (s *ADCSCache) enterpriseCAHasQualifyingHostLocked(enterpriseCAID graph.ID) bool {
+	return s.enterpriseCAsWithQualifyingHosts.Contains(enterpriseCAID.Uint64())
+}
+
+// enterpriseCAHasQualifyingHost returns whether an Enterprise CA has an enabled
 // hosting computer and, when the CA's forest is known, that host is in-forest.
-func (s *ADCSCache) EnterpriseCAHasQualifyingHost(enterpriseCAID graph.ID) bool {
+func (s *ADCSCache) enterpriseCAHasQualifyingHost(enterpriseCAID graph.ID) bool {
 	s.mutex.RLock()
 	defer s.mutex.RUnlock()
 
-	return s.enterpriseCAHasQualifyingHost(enterpriseCAID)
+	return s.enterpriseCAHasQualifyingHostLocked(enterpriseCAID)
 }
 
 func (s *ADCSCache) GetECAHostedChainedDomains() map[uint64]*EnterpriseCAChainedDomains {
@@ -581,7 +596,7 @@ func (s *ADCSCache) GetECAHostedChainedDomains() map[uint64]*EnterpriseCAChained
 
 		// Require an enabled hosting computer; when the forest is known, require it
 		// in-forest. Drops CAs whose only host was matched across a forest boundary.
-		if !s.enterpriseCAHasQualifyingHost(innerEnterpriseCA.ID) {
+		if !s.enterpriseCAHasQualifyingHostLocked(innerEnterpriseCA.ID) {
 			continue
 		}
 

--- a/packages/go/analysis/ad/adcscache.go
+++ b/packages/go/analysis/ad/adcscache.go
@@ -278,14 +278,7 @@ func (s *ADCSCache) BuildCache(ctx context.Context, db graph.Database, enterpris
 
 		certTemplateMeasure()
 
-		// Index domains by SID so a CA or computer can be mapped to its forest via
-		// its domainsid. SIDs are upper-cased to match collected node identifiers.
-		domainsBySID := make(map[string]*graph.Node, len(s.domains))
-		for _, domain := range s.domains {
-			if sid, err := domain.Properties.Get(common.ObjectID.String()).String(); err == nil && sid != "" {
-				domainsBySID[strings.ToUpper(sid)] = domain
-			}
-		}
+		domainsBySID := indexDomainsBySID(s.domains)
 
 		ecaMeasure := measure.ContextMeasure(
 			ctx,
@@ -357,9 +350,7 @@ func (s *ADCSCache) BuildCache(ctx context.Context, db graph.Database, enterpris
 				)
 
 				for _, computer := range hostingComputers.Slice() {
-					if enabled, err := computer.Properties.Get(common.Enabled.String()).Bool(); err != nil {
-						continue
-					} else if !enabled {
+					if !enterpriseCAHostIsEligible(computer, nil, domainsBySID) {
 						continue
 					}
 
@@ -378,7 +369,7 @@ func (s *ADCSCache) BuildCache(ctx context.Context, db graph.Database, enterpris
 								slog.Uint64("computer", uint64(computer.ID)),
 								slog.Uint64("enterprise_ca", uint64(eca.ID)),
 							)
-						} else if computerDomain, ok := domainsBySID[strings.ToUpper(computerSID)]; ok && forestDomains.Contains(computerDomain.ID.Uint64()) {
+						} else if enterpriseCAHostIsEligible(computer, forestDomains, domainsBySID) {
 							hostInForest = true
 						}
 					}
@@ -504,6 +495,36 @@ func (s *ADCSCache) BuildCache(ctx context.Context, db graph.Database, enterpris
 	return err
 }
 
+func indexDomainsBySID(domains []*graph.Node) map[string]*graph.Node {
+	domainsBySID := make(map[string]*graph.Node, len(domains))
+
+	for _, domain := range domains {
+		if sid, err := domain.Properties.Get(common.ObjectID.String()).String(); err == nil && sid != "" {
+			domainsBySID[strings.ToUpper(sid)] = domain
+		}
+	}
+
+	return domainsBySID
+}
+
+// enterpriseCAHostIsEligible returns whether a host is enabled and, when the
+// Enterprise CA's forest is known, belongs to that forest.
+func enterpriseCAHostIsEligible(computer *graph.Node, forestDomains cardinality.Duplex[uint64], domainsBySID map[string]*graph.Node) bool {
+	if !computer.Kinds.ContainsOneOf(ad.Computer) {
+		return false
+	} else if enabled, err := computer.Properties.Get(common.Enabled.String()).Bool(); err != nil || !enabled {
+		return false
+	} else if forestDomains == nil {
+		return true
+	} else if computerSID, err := computer.Properties.Get(ad.DomainSID.String()).String(); err != nil || computerSID == "" {
+		return false
+	} else if computerDomain, ok := domainsBySID[strings.ToUpper(computerSID)]; !ok {
+		return false
+	} else {
+		return forestDomains.Contains(computerDomain.ID.Uint64())
+	}
+}
+
 // resolveEnterpriseCAForest returns the domain IDs in the CA's forest (the
 // SameForestTrust closure of the CA's domain, resolved from its domainsid). It
 // returns a nil set when the forest can't be resolved, so callers fall back to
@@ -532,6 +553,23 @@ func resolveEnterpriseCAForest(tx graph.Transaction, eca *graph.Node, domainsByS
 	return forestDomains, nil
 }
 
+func (s *ADCSCache) enterpriseCAHasQualifyingHost(enterpriseCAID graph.ID) bool {
+	if hasInForestHostingComputer, forestKnown := s.hasInForestHostingComputer[enterpriseCAID]; forestKnown {
+		return hasInForestHostingComputer
+	}
+
+	return s.hasHostingComputer[enterpriseCAID]
+}
+
+// EnterpriseCAHasQualifyingHost returns whether an Enterprise CA has an enabled
+// hosting computer and, when the CA's forest is known, that host is in-forest.
+func (s *ADCSCache) EnterpriseCAHasQualifyingHost(enterpriseCAID graph.ID) bool {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
+	return s.enterpriseCAHasQualifyingHost(enterpriseCAID)
+}
+
 func (s *ADCSCache) GetECAHostedChainedDomains() map[uint64]*EnterpriseCAChainedDomains {
 	s.mutex.RLock()
 	defer s.mutex.RUnlock()
@@ -543,11 +581,7 @@ func (s *ADCSCache) GetECAHostedChainedDomains() map[uint64]*EnterpriseCAChained
 
 		// Require an enabled hosting computer; when the forest is known, require it
 		// in-forest. Drops CAs whose only host was matched across a forest boundary.
-		if hasInForestHostingComputer, forestKnown := s.hasInForestHostingComputer[innerEnterpriseCA.ID]; forestKnown {
-			if !hasInForestHostingComputer {
-				continue
-			}
-		} else if !s.hasHostingComputer[innerEnterpriseCA.ID] {
+		if !s.enterpriseCAHasQualifyingHost(innerEnterpriseCA.ID) {
 			continue
 		}
 

--- a/packages/go/analysis/ad/adcscache_test.go
+++ b/packages/go/analysis/ad/adcscache_test.go
@@ -17,9 +17,11 @@
 package ad
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/specterops/bloodhound/packages/go/graphschema/ad"
+	"github.com/specterops/bloodhound/packages/go/graphschema/common"
 	"github.com/specterops/dawgs/cardinality"
 	"github.com/specterops/dawgs/graph"
 	"github.com/stretchr/testify/assert"
@@ -63,8 +65,7 @@ func TestGetECAHostedChainedDomains_ForestHosting(t *testing.T) {
 		eca, inForestDomain, foreignDomain := adcsForestHostingNodes()
 		cache := newForestHostingCache(eca, inForestDomain, foreignDomain)
 
-		cache.hasHostingComputer[eca.ID] = true
-		cache.hasInForestHostingComputer[eca.ID] = true
+		cache.enterpriseCAsWithQualifyingHosts.Add(eca.ID.Uint64())
 
 		result := cache.GetECAHostedChainedDomains()
 
@@ -79,9 +80,8 @@ func TestGetECAHostedChainedDomains_ForestHosting(t *testing.T) {
 		eca, inForestDomain, foreignDomain := adcsForestHostingNodes()
 		cache := newForestHostingCache(eca, inForestDomain, foreignDomain)
 
-		// A hosting computer exists, but it lives outside the CA's forest.
-		cache.hasHostingComputer[eca.ID] = true
-		cache.hasInForestHostingComputer[eca.ID] = false
+		// The CA is absent from the qualifying-host bitmap because its only host
+		// lives outside the CA's forest.
 
 		result := cache.GetECAHostedChainedDomains()
 
@@ -92,8 +92,7 @@ func TestGetECAHostedChainedDomains_ForestHosting(t *testing.T) {
 		eca, inForestDomain, foreignDomain := adcsForestHostingNodes()
 		cache := newForestHostingCache(eca, inForestDomain, foreignDomain)
 
-		// No hasInForestHostingComputer entry => forest unknown.
-		cache.hasHostingComputer[eca.ID] = true
+		cache.enterpriseCAsWithQualifyingHosts.Add(eca.ID.Uint64())
 
 		result := cache.GetECAHostedChainedDomains()
 
@@ -108,7 +107,7 @@ func TestGetECAHostedChainedDomains_ForestHosting(t *testing.T) {
 		eca, inForestDomain, foreignDomain := adcsForestHostingNodes()
 		cache := newForestHostingCache(eca, inForestDomain, foreignDomain)
 
-		// hasHostingComputer absent/false and forest unknown.
+		// The CA has no entry in the qualifying-host bitmap.
 
 		result := cache.GetECAHostedChainedDomains()
 
@@ -120,7 +119,6 @@ func TestGetChainedDomains_IgnoresForestHosting(t *testing.T) {
 	t.Run("does not apply the hosting-computer guard", func(t *testing.T) {
 		eca, inForestDomain, foreignDomain := adcsForestHostingNodes()
 		cache := newForestHostingCache(eca, inForestDomain, foreignDomain)
-		cache.hasInForestHostingComputer[eca.ID] = false
 
 		result := cache.GetChainedDomains()
 
@@ -140,4 +138,203 @@ func TestGetChainedDomains_IgnoresForestHosting(t *testing.T) {
 		chains := result[eca.ID.Uint64()]
 		assert.Equal(t, uint64(2), chains.Domains.Cardinality())
 	})
+}
+
+func TestEnterpriseCAHostIsEligible(t *testing.T) {
+	var (
+		inForestDomainSID = "S-1-5-21-100-200-300"
+		foreignDomainSID  = "S-1-5-21-400-500-600"
+		inForestDomain    = graph.NewNode(1, graph.NewProperties(), ad.Domain)
+		foreignDomain     = graph.NewNode(2, graph.NewProperties(), ad.Domain)
+		domainsBySID      = map[string]*graph.Node{
+			inForestDomainSID: inForestDomain,
+			foreignDomainSID:  foreignDomain,
+		}
+		knownForest = duplexOf(inForestDomain.ID)
+		testCases   = []struct {
+			name             string
+			kind             graph.Kind
+			setEnabled       bool
+			enabled          any
+			setDomainSID     bool
+			domainSID        string
+			forestDomains    cardinality.Duplex[uint64]
+			expectedEligible bool
+		}{
+			{
+				name:             "enabled host qualifies when CA forest is unresolved",
+				kind:             ad.Computer,
+				setEnabled:       true,
+				enabled:          true,
+				forestDomains:    nil,
+				expectedEligible: true,
+			},
+			{
+				name:             "disabled host does not qualify",
+				kind:             ad.Computer,
+				setEnabled:       true,
+				enabled:          false,
+				forestDomains:    nil,
+				expectedEligible: false,
+			},
+			{
+				name:             "missing enabled property does not qualify",
+				kind:             ad.Computer,
+				forestDomains:    nil,
+				expectedEligible: false,
+			},
+			{
+				name:             "malformed enabled property does not qualify",
+				kind:             ad.Computer,
+				setEnabled:       true,
+				enabled:          "true",
+				forestDomains:    nil,
+				expectedEligible: false,
+			},
+			{
+				name:             "enabled in-forest host qualifies",
+				kind:             ad.Computer,
+				setEnabled:       true,
+				enabled:          true,
+				setDomainSID:     true,
+				domainSID:        inForestDomainSID,
+				forestDomains:    knownForest,
+				expectedEligible: true,
+			},
+			{
+				name:             "enabled cross-forest host does not qualify",
+				kind:             ad.Computer,
+				setEnabled:       true,
+				enabled:          true,
+				setDomainSID:     true,
+				domainSID:        foreignDomainSID,
+				forestDomains:    knownForest,
+				expectedEligible: false,
+			},
+			{
+				name:             "host missing domain SID does not qualify for known forest",
+				kind:             ad.Computer,
+				setEnabled:       true,
+				enabled:          true,
+				forestDomains:    knownForest,
+				expectedEligible: false,
+			},
+			{
+				name:             "host with unknown domain SID does not qualify for known forest",
+				kind:             ad.Computer,
+				setEnabled:       true,
+				enabled:          true,
+				setDomainSID:     true,
+				domainSID:        "S-1-5-21-700-800-900",
+				forestDomains:    knownForest,
+				expectedEligible: false,
+			},
+			{
+				name:             "enabled non-computer does not qualify",
+				kind:             ad.User,
+				setEnabled:       true,
+				enabled:          true,
+				setDomainSID:     true,
+				domainSID:        inForestDomainSID,
+				forestDomains:    knownForest,
+				expectedEligible: false,
+			},
+		}
+	)
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			properties := graph.NewProperties()
+			if testCase.setEnabled {
+				properties.Set(common.Enabled.String(), testCase.enabled)
+			}
+			if testCase.setDomainSID {
+				properties.Set(ad.DomainSID.String(), testCase.domainSID)
+			}
+
+			host := graph.NewNode(10, properties, testCase.kind)
+
+			assert.Equal(t, testCase.expectedEligible, enterpriseCAHostIsEligible(host, testCase.forestDomains, domainsBySID))
+		})
+	}
+}
+
+func TestQualifyEnterpriseCAHostPathsPropagatesForestResolutionErrors(t *testing.T) {
+	var (
+		expectedErr  = errors.New("failed forest traversal")
+		host         = graph.NewNode(1, graph.NewProperties(), ad.Computer)
+		enterpriseCA = graph.NewNode(2, graph.NewProperties(), ad.EnterpriseCA)
+		hostingPath  = graph.Path{
+			Nodes: []*graph.Node{host, enterpriseCA},
+			Edges: []*graph.Relationship{{
+				ID:      3,
+				Kind:    ad.HostsCAService,
+				StartID: host.ID,
+				EndID:   enterpriseCA.ID,
+			}},
+		}
+	)
+
+	qualifyingPaths, err := qualifyEnterpriseCAHostPaths(graph.NewPathSet(hostingPath), nil, func(*graph.Node) (cardinality.Duplex[uint64], error) {
+		return nil, expectedErr
+	})
+
+	require.ErrorIs(t, err, expectedErr)
+	assert.Nil(t, qualifyingPaths)
+}
+
+func TestQualifyEnterpriseCAHostPathsKeepsOnlyEligibleHostsForExactCA(t *testing.T) {
+	const (
+		inForestDomainSID = "S-1-5-21-100-200-300"
+		foreignDomainSID  = "S-1-5-21-400-500-600"
+	)
+
+	var (
+		inForestDomain = graph.NewNode(1, graph.NewProperties(), ad.Domain)
+		foreignDomain  = graph.NewNode(2, graph.NewProperties(), ad.Domain)
+		enterpriseCA   = graph.NewNode(3, graph.NewProperties(), ad.EnterpriseCA)
+		validHost      = graph.NewNode(4, graph.NewProperties(), ad.Computer)
+		disabledHost   = graph.NewNode(5, graph.NewProperties(), ad.Computer)
+		foreignHost    = graph.NewNode(6, graph.NewProperties(), ad.Computer)
+		forestDomains  = duplexOf(inForestDomain.ID)
+		domainsBySID   = map[string]*graph.Node{
+			inForestDomainSID: inForestDomain,
+			foreignDomainSID:  foreignDomain,
+		}
+		forestResolutionCount int
+	)
+
+	validHost.Properties.Set(common.Enabled.String(), true)
+	validHost.Properties.Set(ad.DomainSID.String(), inForestDomainSID)
+	disabledHost.Properties.Set(common.Enabled.String(), false)
+	disabledHost.Properties.Set(ad.DomainSID.String(), inForestDomainSID)
+	foreignHost.Properties.Set(common.Enabled.String(), true)
+	foreignHost.Properties.Set(ad.DomainSID.String(), foreignDomainSID)
+
+	hostingPath := func(id graph.ID, host *graph.Node) graph.Path {
+		return graph.Path{
+			Nodes: []*graph.Node{host, enterpriseCA},
+			Edges: []*graph.Relationship{{
+				ID:      id,
+				Kind:    ad.HostsCAService,
+				StartID: host.ID,
+				EndID:   enterpriseCA.ID,
+			}},
+		}
+	}
+
+	qualifyingPaths, err := qualifyEnterpriseCAHostPaths(graph.NewPathSet(
+		hostingPath(10, validHost),
+		hostingPath(11, disabledHost),
+		hostingPath(12, foreignHost),
+	), domainsBySID, func(*graph.Node) (cardinality.Duplex[uint64], error) {
+		forestResolutionCount++
+		return forestDomains, nil
+	})
+
+	require.NoError(t, err)
+	require.Contains(t, qualifyingPaths, enterpriseCA.ID)
+	require.Len(t, qualifyingPaths[enterpriseCA.ID], 1)
+	assert.Equal(t, validHost.ID, qualifyingPaths[enterpriseCA.ID][0].Root().ID)
+	assert.Equal(t, 1, forestResolutionCount)
 }

--- a/packages/go/analysis/ad/esc1.go
+++ b/packages/go/analysis/ad/esc1.go
@@ -259,45 +259,66 @@ func GetADCSESC1EdgeComposition(ctx context.Context, db graph.Database, edge *gr
 }
 
 func getGoldenCertEdgeComposition(tx graph.Transaction, edge *graph.Relationship) (graph.PathSet, error) {
-	finalPaths := graph.NewPathSet()
+	var (
+		finalPaths             = graph.NewPathSet()
+		candidateEnterpriseCAs = cardinality.NewBitmap64()
+		domains                []*graph.Node
+	)
+
 	//Grab the start node (computer) as well as the target domain node
 	if startNode, targetDomainNode, err := ops.FetchRelationshipNodes(tx, edge); err != nil {
 		return finalPaths, err
+	} else if ecaPaths, err := ops.FetchPathSet(tx.Relationships().Filter(query.And(
+		query.Equals(query.StartID(), startNode.ID),
+		query.Kind(query.End(), ad.EnterpriseCA),
+		query.Kind(query.Relationship(), ad.HostsCAService),
+	))); graph.IsErrNotFound(err) {
+		return finalPaths, nil
+	} else if err != nil {
+		return finalPaths, err
 	} else {
-		//Find hosted enterprise CA
-		if ecaPaths, err := ops.FetchPathSet(tx.Relationships().Filter(query.And(
-			query.Equals(query.StartID(), startNode.ID),
-			query.KindIn(query.End(), ad.EnterpriseCA),
-			query.KindIn(query.Relationship(), ad.HostsCAService),
-		))); err != nil {
-			slog.Error(
-				"Error getting hostscaservice edge to enterprise ca for computer",
-				slog.Uint64("start_node_id", uint64(startNode.ID)),
-				attr.Error(err),
-			)
+		for _, ecaPath := range ecaPaths {
+			candidateEnterpriseCAs.Add(ecaPath.Terminal().ID.Uint64())
+		}
+
+		if fetchedDomains, err := ops.FetchNodes(tx.Nodes().Filter(query.Kind(query.Node(), ad.Domain))); err != nil && !graph.IsErrNotFound(err) {
+			return finalPaths, err
 		} else {
-			for _, ecaPath := range ecaPaths {
-				eca := ecaPath.Terminal()
-				if chainToRootCAPaths, err := FetchEnterpriseCAsCertChainPathToDomain(tx, eca, targetDomainNode); err != nil {
+			domains = fetchedDomains
+		}
+
+		qualifyingHostPaths, err := fetchQualifyingEnterpriseCAHostPathsForTransaction(tx, candidateEnterpriseCAs, indexDomainsBySID(domains))
+		if err != nil {
+			return finalPaths, err
+		}
+
+		for _, enterpriseCAHostPaths := range qualifyingHostPaths {
+			for _, qualifyingHostPath := range enterpriseCAHostPaths {
+				if qualifyingHostPath.Root().ID != startNode.ID {
+					continue
+				}
+				enterpriseCA := qualifyingHostPath.Terminal()
+
+				if chainToRootCAPaths, err := FetchEnterpriseCAsCertChainPathToDomain(tx, enterpriseCA, targetDomainNode); err != nil {
 					slog.Error(
 						"Error getting enterprise ca path to domain",
-						slog.Uint64("enterprise_ca", uint64(eca.ID)),
+						slog.Uint64("enterprise_ca", uint64(enterpriseCA.ID)),
 						slog.Uint64("target_domain_id", uint64(targetDomainNode.ID)),
 						attr.Error(err),
 					)
 				} else if chainToRootCAPaths.Len() == 0 {
 					continue
-				} else if trustedForAuthPaths, err := FetchEnterpriseCAsTrustedForAuthPathToDomain(tx, eca, targetDomainNode); err != nil {
+				} else if trustedForAuthPaths, err := FetchEnterpriseCAsTrustedForAuthPathToDomain(tx, enterpriseCA, targetDomainNode); err != nil {
 					slog.Error(
 						"Error getting enterprise ca path to domain via trusted for auth",
-						slog.Uint64("enterprise_ca", uint64(eca.ID)),
+						slog.Uint64("enterprise_ca", uint64(enterpriseCA.ID)),
 						slog.Uint64("target_domain_id", uint64(targetDomainNode.ID)),
 						attr.Error(err),
 					)
 				} else if trustedForAuthPaths.Len() == 0 {
 					continue
 				} else {
-					finalPaths.AddPath(ecaPath)
+					finalPaths.AddPath(qualifyingHostPath)
 					finalPaths.AddPathSet(chainToRootCAPaths)
 					finalPaths.AddPathSet(trustedForAuthPaths)
 				}

--- a/packages/go/analysis/ad/esc1.go
+++ b/packages/go/analysis/ad/esc1.go
@@ -159,12 +159,13 @@ func GetADCSESC1EdgeComposition(ctx context.Context, db graph.Database, edge *gr
 		startNode  *graph.Node
 		startNodes = graph.NodeSet{}
 
-		traversalInst      = traversal.New(db, post.MaximumDatabaseParallelWorkers)
-		paths              = graph.PathSet{}
-		candidateSegments  = map[graph.ID][]*graph.PathSegment{}
-		path1EnterpriseCAs = cardinality.NewBitmap64()
-		path2EnterpriseCAs = cardinality.NewBitmap64()
-		lock               = &sync.Mutex{}
+		traversalInst           = traversal.New(db, post.MaximumDatabaseParallelWorkers)
+		paths                   = graph.PathSet{}
+		candidateSegments       = map[graph.ID][]*graph.PathSegment{}
+		path1EnterpriseCAs      = cardinality.NewBitmap64()
+		path2EnterpriseCAs      = cardinality.NewBitmap64()
+		hostPathsByEnterpriseCA map[graph.ID]graph.PathSet
+		lock                    = &sync.Mutex{}
 	)
 
 	if err := db.ReadTransaction(ctx, func(tx graph.Transaction) error {
@@ -241,18 +242,26 @@ func GetADCSESC1EdgeComposition(ctx context.Context, db graph.Database, edge *gr
 
 	// Intersect the CAs and take only those seen in both paths
 	path1EnterpriseCAs.And(path2EnterpriseCAs)
+	if qualifyingHostPaths, err := fetchQualifyingEnterpriseCAHostPaths(ctx, db, path1EnterpriseCAs); err != nil {
+		return nil, err
+	} else {
+		hostPathsByEnterpriseCA = qualifyingHostPaths
+	}
 
-	// Render paths from the segments
+	// Render paths only for CAs with an exact qualifying host.
 	path1EnterpriseCAs.Each(func(value uint64) bool {
+		hostPaths, hasQualifyingHost := hostPathsByEnterpriseCA[graph.ID(value)]
+		if !hasQualifyingHost {
+			return true
+		}
+
 		for _, segment := range candidateSegments[graph.ID(value)] {
 			paths.AddPath(segment.Path())
 		}
+		paths.AddPathSet(hostPaths)
 
 		return true
 	})
-	if err := addHostsCAServicePathsToComposition(ctx, db, &paths, path1EnterpriseCAs); err != nil {
-		return nil, err
-	}
 
 	return paths, nil
 }

--- a/packages/go/analysis/ad/esc1.go
+++ b/packages/go/analysis/ad/esc1.go
@@ -120,15 +120,7 @@ func ADCSESC1Path1Pattern(domainID graph.ID) traversal.PatternContinuation {
 }
 
 func ADCSESC1Path2Pattern(domainID graph.ID, enterpriseCAs cardinality.Duplex[uint64]) traversal.PatternContinuation {
-	return enterpriseCATrustedForNTAuthToDomainPattern(traversal.NewPattern().OutboundWithDepth(0, 0, query.And(
-		query.Kind(query.Relationship(), ad.MemberOf),
-		query.Kind(query.End(), ad.Group),
-	)).
-		Outbound(query.And(
-			query.KindIn(query.Relationship(), ad.Enroll),
-			query.Kind(query.End(), ad.EnterpriseCA),
-			query.InIDs(query.EndID(), graph.DuplexToGraphIDs(enterpriseCAs)...),
-		)), domainID)
+	return adcsCAEnrollmentPathPattern(graph.DuplexToGraphIDs(enterpriseCAs), domainID)
 }
 
 func GetADCSESC1EdgeComposition(ctx context.Context, db graph.Database, edge *graph.Relationship) (graph.PathSet, error) {

--- a/packages/go/analysis/ad/esc1.go
+++ b/packages/go/analysis/ad/esc1.go
@@ -250,6 +250,9 @@ func GetADCSESC1EdgeComposition(ctx context.Context, db graph.Database, edge *gr
 
 		return true
 	})
+	if err := addHostsCAServicePathsToComposition(ctx, db, &paths, path1EnterpriseCAs); err != nil {
+		return nil, err
+	}
 
 	return paths, nil
 }

--- a/packages/go/analysis/ad/esc10.go
+++ b/packages/go/analysis/ad/esc10.go
@@ -300,16 +300,18 @@ func GetADCSESC10EdgeComposition(ctx context.Context, db graph.Database, edge *g
 		startNode *graph.Node
 		endNode   *graph.Node
 
-		traversalInst          = traversal.New(db, post.MaximumDatabaseParallelWorkers)
-		paths                  = graph.PathSet{}
-		path1CandidateSegments = map[graph.ID][]*graph.PathSegment{}
-		victimCANodes          = map[graph.ID][]graph.ID{}
-		path2CandidateSegments = map[graph.ID][]*graph.PathSegment{}
-		path3CandidateSegments = []*graph.PathSegment{}
-		p2canodes              = make([]graph.ID, 0)
-		nodeMap                = map[graph.ID]*graph.Node{}
-		finalEnterpriseCAs     = cardinality.NewBitmap64()
-		lock                   = &sync.Mutex{}
+		traversalInst           = traversal.New(db, post.MaximumDatabaseParallelWorkers)
+		paths                   = graph.PathSet{}
+		path1CandidateSegments  = map[graph.ID][]*graph.PathSegment{}
+		victimCANodes           = map[graph.ID][]graph.ID{}
+		path2CandidateSegments  = map[graph.ID][]*graph.PathSegment{}
+		path3CandidateSegments  = []*graph.PathSegment{}
+		p2canodes               = make([]graph.ID, 0)
+		nodeMap                 = map[graph.ID]*graph.Node{}
+		path1EnterpriseCAs      = cardinality.NewBitmap64()
+		hostPathsByEnterpriseCA map[graph.ID]graph.PathSet
+		finalEnterpriseCAs      = cardinality.NewBitmap64()
+		lock                    = &sync.Mutex{}
 	)
 
 	if err := db.ReadTransaction(ctx, func(tx graph.Transaction) error {
@@ -361,6 +363,7 @@ func GetADCSESC10EdgeComposition(ctx context.Context, db graph.Database, edge *g
 			path1CandidateSegments[victimNode.ID] = append(path1CandidateSegments[victimNode.ID], terminal)
 			nodeMap[victimNode.ID] = victimNode
 			victimCANodes[victimNode.ID] = append(victimCANodes[victimNode.ID], caNode.ID)
+			path1EnterpriseCAs.Add(caNode.ID.Uint64())
 			lock.Unlock()
 
 			return nil
@@ -369,11 +372,27 @@ func GetADCSESC10EdgeComposition(ctx context.Context, db graph.Database, edge *g
 		return nil, err
 	}
 
+	if qualifyingHostPaths, err := fetchQualifyingEnterpriseCAHostPaths(ctx, db, path1EnterpriseCAs); err != nil {
+		return nil, err
+	} else {
+		hostPathsByEnterpriseCA = qualifyingHostPaths
+	}
+
 	//We can re-use p2 from ESC9a, since they're the same
 	for victim, p1CANodes := range victimCANodes {
+		qualifyingP1CANodes := make([]graph.ID, 0, len(p1CANodes))
+		for _, enterpriseCAID := range p1CANodes {
+			if _, hasQualifyingHost := hostPathsByEnterpriseCA[enterpriseCAID]; hasQualifyingHost {
+				qualifyingP1CANodes = append(qualifyingP1CANodes, enterpriseCAID)
+			}
+		}
+		if len(qualifyingP1CANodes) == 0 {
+			continue
+		}
+
 		if err := traversalInst.BreadthFirst(ctx, traversal.Plan{
 			Root: nodeMap[victim],
-			Driver: adcsESC9APath2Pattern(p1CANodes, edge.EndID).Do(func(terminal *graph.PathSegment) error {
+			Driver: adcsESC9APath2Pattern(qualifyingP1CANodes, edge.EndID).Do(func(terminal *graph.PathSegment) error {
 				caNode := terminal.Search(func(nextSegment *graph.PathSegment) bool {
 					return nextSegment.Node.Kinds.ContainsOneOf(ad.EnterpriseCA)
 				})
@@ -409,7 +428,6 @@ func GetADCSESC10EdgeComposition(ctx context.Context, db graph.Database, edge *g
 			return nil, err
 		}
 	}
-
 	for _, p1paths := range path1CandidateSegments {
 		for _, p1path := range p1paths {
 			// First ECA in the path
@@ -422,7 +440,9 @@ func GetADCSESC10EdgeComposition(ctx context.Context, db graph.Database, edge *g
 				return true
 			})
 
-			if p2segments, ok := path2CandidateSegments[caNode.ID]; !ok {
+			if _, hasQualifyingHost := hostPathsByEnterpriseCA[caNode.ID]; !hasQualifyingHost {
+				continue
+			} else if p2segments, ok := path2CandidateSegments[caNode.ID]; !ok {
 				continue
 			} else {
 				paths.AddPath(p1path.Path())
@@ -439,9 +459,10 @@ func GetADCSESC10EdgeComposition(ctx context.Context, db graph.Database, edge *g
 			paths.AddPath(p3.Path())
 		}
 	}
-	if err := addHostsCAServicePathsToComposition(ctx, db, &paths, finalEnterpriseCAs); err != nil {
-		return nil, err
-	}
+	finalEnterpriseCAs.Each(func(enterpriseCAID uint64) bool {
+		paths.AddPathSet(hostPathsByEnterpriseCA[graph.ID(enterpriseCAID)])
+		return true
+	})
 
 	return paths, nil
 }

--- a/packages/go/analysis/ad/esc10.go
+++ b/packages/go/analysis/ad/esc10.go
@@ -392,7 +392,7 @@ func GetADCSESC10EdgeComposition(ctx context.Context, db graph.Database, edge *g
 
 		if err := traversalInst.BreadthFirst(ctx, traversal.Plan{
 			Root: nodeMap[victim],
-			Driver: adcsESC9APath2Pattern(qualifyingP1CANodes, edge.EndID).Do(func(terminal *graph.PathSegment) error {
+			Driver: adcsCAEnrollmentPathPattern(qualifyingP1CANodes, edge.EndID).Do(func(terminal *graph.PathSegment) error {
 				caNode := terminal.Search(func(nextSegment *graph.PathSegment) bool {
 					return nextSegment.Node.Kinds.ContainsOneOf(ad.EnterpriseCA)
 				})

--- a/packages/go/analysis/ad/esc10.go
+++ b/packages/go/analysis/ad/esc10.go
@@ -308,6 +308,7 @@ func GetADCSESC10EdgeComposition(ctx context.Context, db graph.Database, edge *g
 		path3CandidateSegments = []*graph.PathSegment{}
 		p2canodes              = make([]graph.ID, 0)
 		nodeMap                = map[graph.ID]*graph.Node{}
+		finalEnterpriseCAs     = cardinality.NewBitmap64()
 		lock                   = &sync.Mutex{}
 	)
 
@@ -425,6 +426,7 @@ func GetADCSESC10EdgeComposition(ctx context.Context, db graph.Database, edge *g
 				continue
 			} else {
 				paths.AddPath(p1path.Path())
+				finalEnterpriseCAs.Add(caNode.ID.Uint64())
 				for _, p2 := range p2segments {
 					paths.AddPath(p2.Path())
 				}
@@ -436,6 +438,9 @@ func GetADCSESC10EdgeComposition(ctx context.Context, db graph.Database, edge *g
 		for _, p3 := range path3CandidateSegments {
 			paths.AddPath(p3.Path())
 		}
+	}
+	if err := addHostsCAServicePathsToComposition(ctx, db, &paths, finalEnterpriseCAs); err != nil {
+		return nil, err
 	}
 
 	return paths, nil

--- a/packages/go/analysis/ad/esc13.go
+++ b/packages/go/analysis/ad/esc13.go
@@ -197,18 +197,19 @@ func GetADCSESC13EdgeComposition(ctx context.Context, db graph.Database, edge *g
 		endNode    *graph.Node
 		startNodes = graph.NodeSet{}
 
-		traversalInst          = traversal.New(db, post.MaximumDatabaseParallelWorkers)
-		paths                  = graph.PathSet{}
-		path1CandidateSegments = map[graph.ID][]*graph.PathSegment{}
-		path1EnterpriseCAs     = cardinality.NewBitmap64()
-		path1DomainNodes       = cardinality.NewBitmap64()
-		path1CertTemplates     = cardinality.NewBitmap64()
-		path2CandidateSegments = map[graph.ID][]*graph.PathSegment{}
-		path3CandidateSegments = map[graph.ID][]*graph.PathSegment{}
-		path4CandidateSegments = map[graph.ID][]*graph.PathSegment{}
-		path2EnterpriseCAs     = cardinality.NewBitmap64()
-		finalEnterpriseCAs     = cardinality.NewBitmap64()
-		lock                   = &sync.Mutex{}
+		traversalInst           = traversal.New(db, post.MaximumDatabaseParallelWorkers)
+		paths                   = graph.PathSet{}
+		path1CandidateSegments  = map[graph.ID][]*graph.PathSegment{}
+		path1EnterpriseCAs      = cardinality.NewBitmap64()
+		path1DomainNodes        = cardinality.NewBitmap64()
+		path1CertTemplates      = cardinality.NewBitmap64()
+		path2CandidateSegments  = map[graph.ID][]*graph.PathSegment{}
+		path3CandidateSegments  = map[graph.ID][]*graph.PathSegment{}
+		path4CandidateSegments  = map[graph.ID][]*graph.PathSegment{}
+		path2EnterpriseCAs      = cardinality.NewBitmap64()
+		hostPathsByEnterpriseCA map[graph.ID]graph.PathSet
+		finalEnterpriseCAs      = cardinality.NewBitmap64()
+		lock                    = &sync.Mutex{}
 	)
 
 	if err := db.ReadTransaction(ctx, func(tx graph.Transaction) error {
@@ -280,6 +281,22 @@ func GetADCSESC13EdgeComposition(ctx context.Context, db graph.Database, edge *g
 		return paths, nil
 	}
 
+	if qualifyingHostPaths, err := fetchQualifyingEnterpriseCAHostPaths(ctx, db, path1EnterpriseCAs); err != nil {
+		return nil, err
+	} else {
+		qualifyingEnterpriseCAs := cardinality.NewBitmap64()
+		for enterpriseCAID := range qualifyingHostPaths {
+			qualifyingEnterpriseCAs.Add(enterpriseCAID.Uint64())
+		}
+
+		path1EnterpriseCAs.And(qualifyingEnterpriseCAs)
+		hostPathsByEnterpriseCA = qualifyingHostPaths
+	}
+
+	if path1EnterpriseCAs.Cardinality() == 0 {
+		return paths, nil
+	}
+
 	//Manifest P2 and key it to the enterprise CA nodes to cross product
 	for _, n := range startNodes.Slice() {
 		if err := traversalInst.BreadthFirst(ctx, traversal.Plan{
@@ -342,6 +359,12 @@ func GetADCSESC13EdgeComposition(ctx context.Context, db graph.Database, edge *g
 	path1EnterpriseCAs.And(path2EnterpriseCAs)
 
 	for path1NodeIndex, path1Segments := range path1CandidateSegments {
+		if !path1EnterpriseCAs.Contains(path1NodeIndex.Uint64()) {
+			continue
+		} else if _, hasQualifyingHost := hostPathsByEnterpriseCA[path1NodeIndex]; !hasQualifyingHost {
+			continue
+		}
+
 		path2segments := path2CandidateSegments[path1NodeIndex]
 		for _, p1 := range path1Segments {
 			//If we don't have a domain contain relationship, then this is not a valid path and we can kick out early
@@ -377,9 +400,10 @@ func GetADCSESC13EdgeComposition(ctx context.Context, db graph.Database, edge *g
 			}
 		}
 	}
-	if err := addHostsCAServicePathsToComposition(ctx, db, &paths, finalEnterpriseCAs); err != nil {
-		return nil, err
-	}
+	finalEnterpriseCAs.Each(func(enterpriseCAID uint64) bool {
+		paths.AddPathSet(hostPathsByEnterpriseCA[graph.ID(enterpriseCAID)])
+		return true
+	})
 
 	return paths, nil
 }

--- a/packages/go/analysis/ad/esc13.go
+++ b/packages/go/analysis/ad/esc13.go
@@ -207,6 +207,7 @@ func GetADCSESC13EdgeComposition(ctx context.Context, db graph.Database, edge *g
 		path3CandidateSegments = map[graph.ID][]*graph.PathSegment{}
 		path4CandidateSegments = map[graph.ID][]*graph.PathSegment{}
 		path2EnterpriseCAs     = cardinality.NewBitmap64()
+		finalEnterpriseCAs     = cardinality.NewBitmap64()
 		lock                   = &sync.Mutex{}
 	)
 
@@ -365,6 +366,7 @@ func GetADCSESC13EdgeComposition(ctx context.Context, db graph.Database, edge *g
 					//Merge all our paths together
 					paths.AddPath(p1.Path())
 					paths.AddPath(p2.Path())
+					finalEnterpriseCAs.Add(path1NodeIndex.Uint64())
 					for _, p3 := range p3segments {
 						paths.AddPath(p3.Path())
 					}
@@ -374,6 +376,9 @@ func GetADCSESC13EdgeComposition(ctx context.Context, db graph.Database, edge *g
 				}
 			}
 		}
+	}
+	if err := addHostsCAServicePathsToComposition(ctx, db, &paths, finalEnterpriseCAs); err != nil {
+		return nil, err
 	}
 
 	return paths, nil

--- a/packages/go/analysis/ad/esc3.go
+++ b/packages/go/analysis/ad/esc3.go
@@ -107,6 +107,10 @@ func PostADCSESC3(ctx context.Context, tx graph.Transaction, outC chan<- post.En
 							)
 						} else {
 							for _, eca1 := range publishedECAs {
+								if !cache.EnterpriseCAHasQualifyingHost(eca1.ID) {
+									continue
+								}
+
 								tempResults := CalculateCrossProductNodeSets(
 									localGroupData,
 									certTemplateEnrollersOne,
@@ -129,6 +133,10 @@ func PostADCSESC3(ctx context.Context, tx graph.Transaction, outC chan<- post.En
 						}
 					} else {
 						for _, eca1 := range publishedECAs {
+							if !cache.EnterpriseCAHasQualifyingHost(eca1.ID) {
+								continue
+							}
+
 							tempResults := CalculateCrossProductNodeSets(
 								localGroupData,
 								certTemplateEnrollersOne,
@@ -524,9 +532,10 @@ func GetADCSESC3EdgeComposition(ctx context.Context, db graph.Database, edge *gr
 		lock                     = &sync.Mutex{}
 		path1CertTemplates       = cardinality.NewBitmap64()
 		path2CertTemplates       = cardinality.NewBitmap64()
-		finalEnterpriseCAs       = cardinality.NewBitmap64()
 		enterpriseCANodes        = cardinality.NewBitmap64()
 		enterpriseCASegments     = map[graph.ID][]*graph.PathSegment{}
+		finalEnterpriseCAs       = cardinality.NewBitmap64()
+		hostPathsByEnterpriseCA  map[graph.ID]graph.PathSet
 		path2CandidateTemplates  = cardinality.NewBitmap64()
 		enrollOnBehalfOfPaths    graph.PathSet
 	)
@@ -574,6 +583,22 @@ func GetADCSESC3EdgeComposition(ctx context.Context, db graph.Database, edge *gr
 		}); err != nil {
 			return nil, err
 		}
+	}
+
+	if qualifyingHostPaths, err := fetchQualifyingEnterpriseCAHostPaths(ctx, db, enterpriseCANodes); err != nil {
+		return nil, err
+	} else {
+		qualifyingEnterpriseCAs := cardinality.NewBitmap64()
+		for enterpriseCAID := range qualifyingHostPaths {
+			qualifyingEnterpriseCAs.Add(enterpriseCAID.Uint64())
+		}
+
+		enterpriseCANodes.And(qualifyingEnterpriseCAs)
+		hostPathsByEnterpriseCA = qualifyingHostPaths
+	}
+
+	if enterpriseCANodes.Cardinality() == 0 {
+		return paths, nil
 	}
 
 	//Use the enterprise CA nodes we gathered to filter the first set of paths for P1
@@ -651,6 +676,10 @@ func GetADCSESC3EdgeComposition(ctx context.Context, db graph.Database, edge *gr
 
 	//Manifest P6/P7 keyed to enterprise ca nodes
 	for ecaID := range enterpriseCASegments {
+		if !enterpriseCANodes.Contains(ecaID.Uint64()) {
+			continue
+		}
+
 		if err := db.ReadTransaction(ctx, func(tx graph.Transaction) error {
 			if ecaNode, err := ops.FetchNode(tx, ecaID); err != nil {
 				return err
@@ -721,6 +750,11 @@ func GetADCSESC3EdgeComposition(ctx context.Context, db graph.Database, edge *gr
 				eca2 := p2.Search(func(nextSegment *graph.PathSegment) bool {
 					return nextSegment.Node.Kinds.ContainsOneOf(ad.EnterpriseCA) && enterpriseCANodes.Contains(nextSegment.Node.ID.Uint64())
 				})
+				_, eca1HasQualifyingHost := hostPathsByEnterpriseCA[eca1.ID]
+				_, eca2HasQualifyingHost := hostPathsByEnterpriseCA[eca2.ID]
+				if !eca1HasQualifyingHost || !eca2HasQualifyingHost {
+					continue
+				}
 
 				// Verify P6 and P7 paths exists
 				p6segments, ok := path6_7CandidateSegments[eca1.ID]
@@ -780,13 +814,16 @@ func GetADCSESC3EdgeComposition(ctx context.Context, db graph.Database, edge *gr
 				paths.AddPath(p3)
 				paths.AddPath(p1.Path())
 				paths.AddPath(p2.Path())
+				finalEnterpriseCAs.Add(eca1.ID.Uint64())
 				finalEnterpriseCAs.Add(eca2.ID.Uint64())
 			}
 		}
 	}
-	if err := addHostsCAServicePathsToComposition(ctx, db, &paths, finalEnterpriseCAs); err != nil {
-		return nil, err
-	}
+
+	finalEnterpriseCAs.Each(func(enterpriseCAID uint64) bool {
+		paths.AddPathSet(hostPathsByEnterpriseCA[graph.ID(enterpriseCAID)])
+		return true
+	})
 
 	return paths, nil
 }

--- a/packages/go/analysis/ad/esc3.go
+++ b/packages/go/analysis/ad/esc3.go
@@ -524,6 +524,7 @@ func GetADCSESC3EdgeComposition(ctx context.Context, db graph.Database, edge *gr
 		lock                     = &sync.Mutex{}
 		path1CertTemplates       = cardinality.NewBitmap64()
 		path2CertTemplates       = cardinality.NewBitmap64()
+		finalEnterpriseCAs       = cardinality.NewBitmap64()
 		enterpriseCANodes        = cardinality.NewBitmap64()
 		enterpriseCASegments     = map[graph.ID][]*graph.PathSegment{}
 		path2CandidateTemplates  = cardinality.NewBitmap64()
@@ -779,8 +780,12 @@ func GetADCSESC3EdgeComposition(ctx context.Context, db graph.Database, edge *gr
 				paths.AddPath(p3)
 				paths.AddPath(p1.Path())
 				paths.AddPath(p2.Path())
+				finalEnterpriseCAs.Add(eca2.ID.Uint64())
 			}
 		}
+	}
+	if err := addHostsCAServicePathsToComposition(ctx, db, &paths, finalEnterpriseCAs); err != nil {
+		return nil, err
 	}
 
 	return paths, nil

--- a/packages/go/analysis/ad/esc3.go
+++ b/packages/go/analysis/ad/esc3.go
@@ -107,7 +107,7 @@ func PostADCSESC3(ctx context.Context, tx graph.Transaction, outC chan<- post.En
 							)
 						} else {
 							for _, eca1 := range publishedECAs {
-								if !cache.EnterpriseCAHasQualifyingHost(eca1.ID) {
+								if !cache.enterpriseCAHasQualifyingHost(eca1.ID) {
 									continue
 								}
 
@@ -133,7 +133,7 @@ func PostADCSESC3(ctx context.Context, tx graph.Transaction, outC chan<- post.En
 						}
 					} else {
 						for _, eca1 := range publishedECAs {
-							if !cache.EnterpriseCAHasQualifyingHost(eca1.ID) {
+							if !cache.enterpriseCAHasQualifyingHost(eca1.ID) {
 								continue
 							}
 

--- a/packages/go/analysis/ad/esc4.go
+++ b/packages/go/analysis/ad/esc4.go
@@ -709,6 +709,9 @@ func GetADCSESC4EdgeComposition(ctx context.Context, db graph.Database, edge *gr
 				return true
 			})
 	}
+	if err := addHostsCAServicePathsToComposition(ctx, db, &paths, finalECAs); err != nil {
+		return nil, err
+	}
 
 	return paths, nil
 }

--- a/packages/go/analysis/ad/esc4.go
+++ b/packages/go/analysis/ad/esc4.go
@@ -534,9 +534,10 @@ func GetADCSESC4EdgeComposition(ctx context.Context, db graph.Database, edge *gr
 		startNode  *graph.Node
 		startNodes = graph.NodeSet{}
 
-		enrollAndNTAuthECAs cardinality.Duplex[uint64]
-		domainID            = edge.EndID
-		paths               = graph.PathSet{}
+		enrollAndNTAuthECAs     cardinality.Duplex[uint64]
+		domainID                = edge.EndID
+		paths                   = graph.PathSet{}
+		hostPathsByEnterpriseCA map[graph.ID]graph.PathSet
 
 		enrollAndNTAuthECASegments = map[graph.ID][]*graph.PathSegment{}
 		finalECAs                  = cardinality.NewBitmap64()
@@ -572,6 +573,20 @@ func GetADCSESC4EdgeComposition(ctx context.Context, db graph.Database, edge *gr
 	} else {
 		enrollAndNTAuthECASegments = paths
 		enrollAndNTAuthECAs = ecaIDs
+	}
+	if qualifyingHostPaths, err := fetchQualifyingEnterpriseCAHostPaths(ctx, db, enrollAndNTAuthECAs); err != nil {
+		return nil, err
+	} else {
+		qualifyingEnterpriseCAs := cardinality.NewBitmap64()
+		for enterpriseCAID := range qualifyingHostPaths {
+			qualifyingEnterpriseCAs.Add(enterpriseCAID.Uint64())
+		}
+
+		enrollAndNTAuthECAs.And(qualifyingEnterpriseCAs)
+		hostPathsByEnterpriseCA = qualifyingHostPaths
+	}
+	if enrollAndNTAuthECAs.Cardinality() == 0 {
+		return paths, nil
 	}
 
 	// p1, p2
@@ -706,11 +721,9 @@ func GetADCSESC4EdgeComposition(ctx context.Context, db graph.Database, edge *gr
 				for _, segment := range enrollAndNTAuthECASegments[graph.ID(value)] {
 					paths.AddPath(segment.Path())
 				}
+				paths.AddPathSet(hostPathsByEnterpriseCA[graph.ID(value)])
 				return true
 			})
-	}
-	if err := addHostsCAServicePathsToComposition(ctx, db, &paths, finalECAs); err != nil {
-		return nil, err
 	}
 
 	return paths, nil

--- a/packages/go/analysis/ad/esc6.go
+++ b/packages/go/analysis/ad/esc6.go
@@ -201,13 +201,14 @@ func GetADCSESC6EdgeComposition(ctx context.Context, db graph.Database, edge *gr
 		endNode    *graph.Node
 		startNodes = graph.NodeSet{}
 
-		traversalInst      = traversal.New(db, post.MaximumDatabaseParallelWorkers)
-		lock               = &sync.Mutex{}
-		paths              = graph.PathSet{}
-		path1Segments      = map[graph.ID][]*graph.PathSegment{}
-		path2Segments      = []*graph.PathSegment{}
-		path1EnterpriseCAs = cardinality.NewBitmap64()
-		finalEnterpriseCAs = cardinality.NewBitmap64()
+		traversalInst           = traversal.New(db, post.MaximumDatabaseParallelWorkers)
+		lock                    = &sync.Mutex{}
+		paths                   = graph.PathSet{}
+		path1Segments           = map[graph.ID][]*graph.PathSegment{}
+		path2Segments           = []*graph.PathSegment{}
+		path1EnterpriseCAs      = cardinality.NewBitmap64()
+		finalEnterpriseCAs      = cardinality.NewBitmap64()
+		hostPathsByEnterpriseCA map[graph.ID]graph.PathSet
 	)
 
 	if err := db.ReadTransaction(ctx, func(tx graph.Transaction) error {
@@ -258,6 +259,20 @@ func GetADCSESC6EdgeComposition(ctx context.Context, db graph.Database, edge *gr
 			}); err != nil {
 			return nil, err
 		}
+	}
+	if qualifyingHostPaths, err := fetchQualifyingEnterpriseCAHostPaths(ctx, db, path1EnterpriseCAs); err != nil {
+		return nil, err
+	} else {
+		qualifyingEnterpriseCAs := cardinality.NewBitmap64()
+		for enterpriseCAID := range qualifyingHostPaths {
+			qualifyingEnterpriseCAs.Add(enterpriseCAID.Uint64())
+		}
+
+		path1EnterpriseCAs.And(qualifyingEnterpriseCAs)
+		hostPathsByEnterpriseCA = qualifyingHostPaths
+	}
+	if path1EnterpriseCAs.Cardinality() == 0 {
+		return paths, nil
 	}
 
 	// P2
@@ -320,15 +335,13 @@ func GetADCSESC6EdgeComposition(ctx context.Context, db graph.Database, edge *gr
 			for _, segment := range path1Segments[graph.ID(value)] {
 				paths.AddPath(segment.Path())
 			}
+			paths.AddPathSet(hostPathsByEnterpriseCA[graph.ID(value)])
 			return true
 		})
 
 		for _, segment := range path2Segments {
 			paths.AddPath(segment.Path())
 		}
-	}
-	if err := addHostsCAServicePathsToComposition(ctx, db, &paths, finalEnterpriseCAs); err != nil {
-		return nil, err
 	}
 
 	return paths, nil

--- a/packages/go/analysis/ad/esc6.go
+++ b/packages/go/analysis/ad/esc6.go
@@ -327,6 +327,9 @@ func GetADCSESC6EdgeComposition(ctx context.Context, db graph.Database, edge *gr
 			paths.AddPath(segment.Path())
 		}
 	}
+	if err := addHostsCAServicePathsToComposition(ctx, db, &paths, finalEnterpriseCAs); err != nil {
+		return nil, err
+	}
 
 	return paths, nil
 }

--- a/packages/go/analysis/ad/esc9.go
+++ b/packages/go/analysis/ad/esc9.go
@@ -223,6 +223,7 @@ func GetADCSESC9aEdgeComposition(ctx context.Context, db graph.Database, edge *g
 		path3CandidateSegments = []*graph.PathSegment{}
 		p2canodes              = make([]graph.ID, 0)
 		nodeMap                = map[graph.ID]*graph.Node{}
+		finalEnterpriseCAs     = cardinality.NewBitmap64()
 		lock                   = &sync.Mutex{}
 	)
 
@@ -339,6 +340,7 @@ func GetADCSESC9aEdgeComposition(ctx context.Context, db graph.Database, edge *g
 				continue
 			} else {
 				paths.AddPath(p1path.Path())
+				finalEnterpriseCAs.Add(caNode.ID.Uint64())
 				for _, p2 := range p2segments {
 					paths.AddPath(p2.Path())
 				}
@@ -350,6 +352,9 @@ func GetADCSESC9aEdgeComposition(ctx context.Context, db graph.Database, edge *g
 		for _, p3 := range path3CandidateSegments {
 			paths.AddPath(p3.Path())
 		}
+	}
+	if err := addHostsCAServicePathsToComposition(ctx, db, &paths, finalEnterpriseCAs); err != nil {
+		return nil, err
 	}
 
 	return paths, nil
@@ -525,6 +530,7 @@ func GetADCSESC9bEdgeComposition(ctx context.Context, db graph.Database, edge *g
 		path3CandidateSegments = []*graph.PathSegment{}
 		p2canodes              = make([]graph.ID, 0)
 		nodeMap                = map[graph.ID]*graph.Node{}
+		finalEnterpriseCAs     = cardinality.NewBitmap64()
 		lock                   = &sync.Mutex{}
 	)
 
@@ -626,6 +632,7 @@ func GetADCSESC9bEdgeComposition(ctx context.Context, db graph.Database, edge *g
 				continue
 			} else {
 				paths.AddPath(p1path.Path())
+				finalEnterpriseCAs.Add(caNode.ID.Uint64())
 				for _, p2 := range p2segments {
 					paths.AddPath(p2.Path())
 				}
@@ -637,6 +644,9 @@ func GetADCSESC9bEdgeComposition(ctx context.Context, db graph.Database, edge *g
 		for _, p3 := range path3CandidateSegments {
 			paths.AddPath(p3.Path())
 		}
+	}
+	if err := addHostsCAServicePathsToComposition(ctx, db, &paths, finalEnterpriseCAs); err != nil {
+		return nil, err
 	}
 
 	return paths, nil

--- a/packages/go/analysis/ad/esc9.go
+++ b/packages/go/analysis/ad/esc9.go
@@ -215,16 +215,18 @@ func GetADCSESC9aEdgeComposition(ctx context.Context, db graph.Database, edge *g
 		startNode *graph.Node
 		endNode   *graph.Node
 
-		traversalInst          = traversal.New(db, post.MaximumDatabaseParallelWorkers)
-		paths                  = graph.PathSet{}
-		path1CandidateSegments = map[graph.ID][]*graph.PathSegment{}
-		victimCANodes          = map[graph.ID][]graph.ID{}
-		path2CandidateSegments = map[graph.ID][]*graph.PathSegment{}
-		path3CandidateSegments = []*graph.PathSegment{}
-		p2canodes              = make([]graph.ID, 0)
-		nodeMap                = map[graph.ID]*graph.Node{}
-		finalEnterpriseCAs     = cardinality.NewBitmap64()
-		lock                   = &sync.Mutex{}
+		traversalInst           = traversal.New(db, post.MaximumDatabaseParallelWorkers)
+		paths                   = graph.PathSet{}
+		path1CandidateSegments  = map[graph.ID][]*graph.PathSegment{}
+		victimCANodes           = map[graph.ID][]graph.ID{}
+		path2CandidateSegments  = map[graph.ID][]*graph.PathSegment{}
+		path3CandidateSegments  = []*graph.PathSegment{}
+		p2canodes               = make([]graph.ID, 0)
+		nodeMap                 = map[graph.ID]*graph.Node{}
+		path1EnterpriseCAs      = cardinality.NewBitmap64()
+		hostPathsByEnterpriseCA map[graph.ID]graph.PathSet
+		finalEnterpriseCAs      = cardinality.NewBitmap64()
+		lock                    = &sync.Mutex{}
 	)
 
 	if err := db.ReadTransaction(ctx, func(tx graph.Transaction) error {
@@ -276,6 +278,7 @@ func GetADCSESC9aEdgeComposition(ctx context.Context, db graph.Database, edge *g
 			path1CandidateSegments[victimNode.ID] = append(path1CandidateSegments[victimNode.ID], terminal)
 			nodeMap[victimNode.ID] = victimNode
 			victimCANodes[victimNode.ID] = append(victimCANodes[victimNode.ID], caNode.ID)
+			path1EnterpriseCAs.Add(caNode.ID.Uint64())
 			lock.Unlock()
 
 			return nil
@@ -284,10 +287,26 @@ func GetADCSESC9aEdgeComposition(ctx context.Context, db graph.Database, edge *g
 		return nil, err
 	}
 
+	if qualifyingHostPaths, err := fetchQualifyingEnterpriseCAHostPaths(ctx, db, path1EnterpriseCAs); err != nil {
+		return nil, err
+	} else {
+		hostPathsByEnterpriseCA = qualifyingHostPaths
+	}
+
 	for victim, p1CANodes := range victimCANodes {
+		qualifyingP1CANodes := make([]graph.ID, 0, len(p1CANodes))
+		for _, enterpriseCAID := range p1CANodes {
+			if _, hasQualifyingHost := hostPathsByEnterpriseCA[enterpriseCAID]; hasQualifyingHost {
+				qualifyingP1CANodes = append(qualifyingP1CANodes, enterpriseCAID)
+			}
+		}
+		if len(qualifyingP1CANodes) == 0 {
+			continue
+		}
+
 		if err := traversalInst.BreadthFirst(ctx, traversal.Plan{
 			Root: nodeMap[victim],
-			Driver: adcsESC9APath2Pattern(p1CANodes, edge.EndID).Do(func(terminal *graph.PathSegment) error {
+			Driver: adcsESC9APath2Pattern(qualifyingP1CANodes, edge.EndID).Do(func(terminal *graph.PathSegment) error {
 				caNode := terminal.Search(func(nextSegment *graph.PathSegment) bool {
 					return nextSegment.Node.Kinds.ContainsOneOf(ad.EnterpriseCA)
 				})
@@ -323,7 +342,6 @@ func GetADCSESC9aEdgeComposition(ctx context.Context, db graph.Database, edge *g
 			return nil, err
 		}
 	}
-
 	for _, p1paths := range path1CandidateSegments {
 		for _, p1path := range p1paths {
 			// First ECA in the path
@@ -336,7 +354,9 @@ func GetADCSESC9aEdgeComposition(ctx context.Context, db graph.Database, edge *g
 				return true
 			})
 
-			if p2segments, ok := path2CandidateSegments[caNode.ID]; !ok {
+			if _, hasQualifyingHost := hostPathsByEnterpriseCA[caNode.ID]; !hasQualifyingHost {
+				continue
+			} else if p2segments, ok := path2CandidateSegments[caNode.ID]; !ok {
 				continue
 			} else {
 				paths.AddPath(p1path.Path())
@@ -353,9 +373,10 @@ func GetADCSESC9aEdgeComposition(ctx context.Context, db graph.Database, edge *g
 			paths.AddPath(p3.Path())
 		}
 	}
-	if err := addHostsCAServicePathsToComposition(ctx, db, &paths, finalEnterpriseCAs); err != nil {
-		return nil, err
-	}
+	finalEnterpriseCAs.Each(func(enterpriseCAID uint64) bool {
+		paths.AddPathSet(hostPathsByEnterpriseCA[graph.ID(enterpriseCAID)])
+		return true
+	})
 
 	return paths, nil
 }
@@ -522,16 +543,18 @@ func GetADCSESC9bEdgeComposition(ctx context.Context, db graph.Database, edge *g
 		startNode *graph.Node
 		endNode   *graph.Node
 
-		traversalInst          = traversal.New(db, post.MaximumDatabaseParallelWorkers)
-		paths                  = graph.PathSet{}
-		path1CandidateSegments = map[graph.ID][]*graph.PathSegment{}
-		victimCANodes          = map[graph.ID][]graph.ID{}
-		path2CandidateSegments = map[graph.ID][]*graph.PathSegment{}
-		path3CandidateSegments = []*graph.PathSegment{}
-		p2canodes              = make([]graph.ID, 0)
-		nodeMap                = map[graph.ID]*graph.Node{}
-		finalEnterpriseCAs     = cardinality.NewBitmap64()
-		lock                   = &sync.Mutex{}
+		traversalInst           = traversal.New(db, post.MaximumDatabaseParallelWorkers)
+		paths                   = graph.PathSet{}
+		path1CandidateSegments  = map[graph.ID][]*graph.PathSegment{}
+		victimCANodes           = map[graph.ID][]graph.ID{}
+		path2CandidateSegments  = map[graph.ID][]*graph.PathSegment{}
+		path3CandidateSegments  = []*graph.PathSegment{}
+		p2canodes               = make([]graph.ID, 0)
+		nodeMap                 = map[graph.ID]*graph.Node{}
+		path1EnterpriseCAs      = cardinality.NewBitmap64()
+		hostPathsByEnterpriseCA map[graph.ID]graph.PathSet
+		finalEnterpriseCAs      = cardinality.NewBitmap64()
+		lock                    = &sync.Mutex{}
 	)
 
 	if err := db.ReadTransaction(ctx, func(tx graph.Transaction) error {
@@ -568,6 +591,7 @@ func GetADCSESC9bEdgeComposition(ctx context.Context, db graph.Database, edge *g
 			path1CandidateSegments[victimNode.ID] = append(path1CandidateSegments[victimNode.ID], terminal)
 			nodeMap[victimNode.ID] = victimNode
 			victimCANodes[victimNode.ID] = append(victimCANodes[victimNode.ID], caNode.ID)
+			path1EnterpriseCAs.Add(caNode.ID.Uint64())
 			lock.Unlock()
 
 			return nil
@@ -576,10 +600,26 @@ func GetADCSESC9bEdgeComposition(ctx context.Context, db graph.Database, edge *g
 		return nil, err
 	}
 
+	if qualifyingHostPaths, err := fetchQualifyingEnterpriseCAHostPaths(ctx, db, path1EnterpriseCAs); err != nil {
+		return nil, err
+	} else {
+		hostPathsByEnterpriseCA = qualifyingHostPaths
+	}
+
 	for victim, p1CANodes := range victimCANodes {
+		qualifyingP1CANodes := make([]graph.ID, 0, len(p1CANodes))
+		for _, enterpriseCAID := range p1CANodes {
+			if _, hasQualifyingHost := hostPathsByEnterpriseCA[enterpriseCAID]; hasQualifyingHost {
+				qualifyingP1CANodes = append(qualifyingP1CANodes, enterpriseCAID)
+			}
+		}
+		if len(qualifyingP1CANodes) == 0 {
+			continue
+		}
+
 		if err := traversalInst.BreadthFirst(ctx, traversal.Plan{
 			Root: nodeMap[victim],
-			Driver: adcsESC9bPath2Pattern(p1CANodes, edge.EndID).Do(func(terminal *graph.PathSegment) error {
+			Driver: adcsESC9bPath2Pattern(qualifyingP1CANodes, edge.EndID).Do(func(terminal *graph.PathSegment) error {
 				caNode := terminal.Search(func(nextSegment *graph.PathSegment) bool {
 					return nextSegment.Node.Kinds.ContainsOneOf(ad.EnterpriseCA)
 				})
@@ -615,7 +655,6 @@ func GetADCSESC9bEdgeComposition(ctx context.Context, db graph.Database, edge *g
 			return nil, err
 		}
 	}
-
 	for _, p1paths := range path1CandidateSegments {
 		for _, p1path := range p1paths {
 			// First ECA in the path
@@ -628,7 +667,9 @@ func GetADCSESC9bEdgeComposition(ctx context.Context, db graph.Database, edge *g
 				return true
 			})
 
-			if p2segments, ok := path2CandidateSegments[caNode.ID]; !ok {
+			if _, hasQualifyingHost := hostPathsByEnterpriseCA[caNode.ID]; !hasQualifyingHost {
+				continue
+			} else if p2segments, ok := path2CandidateSegments[caNode.ID]; !ok {
 				continue
 			} else {
 				paths.AddPath(p1path.Path())
@@ -645,9 +686,10 @@ func GetADCSESC9bEdgeComposition(ctx context.Context, db graph.Database, edge *g
 			paths.AddPath(p3.Path())
 		}
 	}
-	if err := addHostsCAServicePathsToComposition(ctx, db, &paths, finalEnterpriseCAs); err != nil {
-		return nil, err
-	}
+	finalEnterpriseCAs.Each(func(enterpriseCAID uint64) bool {
+		paths.AddPathSet(hostPathsByEnterpriseCA[graph.ID(enterpriseCAID)])
+		return true
+	})
 
 	return paths, nil
 }

--- a/packages/go/analysis/ad/esc9.go
+++ b/packages/go/analysis/ad/esc9.go
@@ -306,7 +306,7 @@ func GetADCSESC9aEdgeComposition(ctx context.Context, db graph.Database, edge *g
 
 		if err := traversalInst.BreadthFirst(ctx, traversal.Plan{
 			Root: nodeMap[victim],
-			Driver: adcsESC9APath2Pattern(qualifyingP1CANodes, edge.EndID).Do(func(terminal *graph.PathSegment) error {
+			Driver: adcsCAEnrollmentPathPattern(qualifyingP1CANodes, edge.EndID).Do(func(terminal *graph.PathSegment) error {
 				caNode := terminal.Search(func(nextSegment *graph.PathSegment) bool {
 					return nextSegment.Node.Kinds.ContainsOneOf(ad.EnterpriseCA)
 				})
@@ -424,19 +424,6 @@ func adcsESC9aPath1Pattern(domainID graph.ID) traversal.PatternContinuation {
 		)), domainID)
 }
 
-func adcsESC9APath2Pattern(caNodes []graph.ID, domainId graph.ID) traversal.PatternContinuation {
-	return enterpriseCATrustedForNTAuthToDomainPattern(traversal.NewPattern().
-		OutboundWithDepth(0, 0, query.And(
-			query.Kind(query.Relationship(), ad.MemberOf),
-			query.Kind(query.End(), ad.Group),
-		)).
-		Outbound(query.And(
-			query.Kind(query.Relationship(), ad.Enroll),
-			query.Kind(query.End(), ad.EnterpriseCA),
-			query.InIDs(query.End(), caNodes...),
-		)), domainId)
-}
-
 func adcsESC9APath3Pattern() traversal.PatternContinuation {
 	return traversal.NewPattern().
 		InboundWithDepth(0, 0,
@@ -488,19 +475,6 @@ func adcsESC9bPath1Pattern(domainID graph.ID) traversal.PatternContinuation {
 			query.KindIn(query.Relationship(), ad.PublishedTo),
 			query.Kind(query.End(), ad.EnterpriseCA),
 		)), domainID)
-}
-
-func adcsESC9bPath2Pattern(caNodes []graph.ID, domainId graph.ID) traversal.PatternContinuation {
-	return enterpriseCATrustedForNTAuthToDomainPattern(traversal.NewPattern().
-		OutboundWithDepth(0, 0, query.And(
-			query.Kind(query.Relationship(), ad.MemberOf),
-			query.Kind(query.End(), ad.Group),
-		)).
-		Outbound(query.And(
-			query.Kind(query.Relationship(), ad.Enroll),
-			query.Kind(query.End(), ad.EnterpriseCA),
-			query.InIDs(query.End(), caNodes...),
-		)), domainId)
 }
 
 func adcsESC9bPath3Pattern() traversal.PatternContinuation {
@@ -619,7 +593,7 @@ func GetADCSESC9bEdgeComposition(ctx context.Context, db graph.Database, edge *g
 
 		if err := traversalInst.BreadthFirst(ctx, traversal.Plan{
 			Root: nodeMap[victim],
-			Driver: adcsESC9bPath2Pattern(qualifyingP1CANodes, edge.EndID).Do(func(terminal *graph.PathSegment) error {
+			Driver: adcsCAEnrollmentPathPattern(qualifyingP1CANodes, edge.EndID).Do(func(terminal *graph.PathSegment) error {
 				caNode := terminal.Search(func(nextSegment *graph.PathSegment) bool {
 					return nextSegment.Node.Kinds.ContainsOneOf(ad.EnterpriseCA)
 				})

--- a/packages/go/analysis/ad/esc_shared.go
+++ b/packages/go/analysis/ad/esc_shared.go
@@ -204,44 +204,12 @@ func PostGoldenCert(ctx context.Context, tx graph.Transaction, outC chan<- post.
 	return nil
 }
 
-func addHostsCAServicePathsToComposition(ctx context.Context, db graph.Database, composition *graph.PathSet, enterpriseCAs cardinality.Duplex[uint64]) error {
-	if composition.Len() == 0 {
-		return nil
-	} else if enterpriseCAs.Cardinality() == 0 {
-		*composition = graph.PathSet{}
-		return nil
-	}
-
-	return db.ReadTransaction(ctx, func(tx graph.Transaction) error {
-		if hostingPaths, err := ops.FetchPathSet(tx.Relationships().Filter(query.And(
-			query.Kind(query.Start(), ad.Computer),
-			query.Kind(query.Relationship(), ad.HostsCAService),
-			query.InIDs(query.EndID(), graph.DuplexToGraphIDs(enterpriseCAs)...),
-		))); graph.IsErrNotFound(err) {
-			*composition = graph.PathSet{}
-			return nil
-		} else if err != nil {
-			return err
-		} else if hostingPaths.Len() == 0 {
-			*composition = graph.PathSet{}
-			return nil
-		} else {
-			composition.AddPathSet(hostingPaths)
-			return nil
-		}
-	})
-}
-
 // fetchQualifyingEnterpriseCAHostPaths returns only HostsCAService paths whose
 // computer satisfies the same enabled and forest-scoping rules used by ADCS
 // edge creation. Results are keyed by the exact Enterprise CA they host so a
 // qualifying host for one CA cannot validate a different CA candidate.
 func fetchQualifyingEnterpriseCAHostPaths(ctx context.Context, db graph.Database, enterpriseCAs cardinality.Duplex[uint64]) (map[graph.ID]graph.PathSet, error) {
-	var (
-		hostPathsByEnterpriseCA     = make(map[graph.ID]graph.PathSet)
-		resolvedEnterpriseCAs       = make(map[graph.ID]bool)
-		forestDomainsByEnterpriseCA = make(map[graph.ID]cardinality.Duplex[uint64])
-	)
+	var hostPathsByEnterpriseCA = make(map[graph.ID]graph.PathSet)
 
 	if enterpriseCAs.Cardinality() == 0 {
 		return hostPathsByEnterpriseCA, nil
@@ -249,53 +217,12 @@ func fetchQualifyingEnterpriseCAHostPaths(ctx context.Context, db graph.Database
 
 	err := db.ReadTransaction(ctx, func(tx graph.Transaction) error {
 		domains, err := ops.FetchNodes(tx.Nodes().Filter(query.Kind(query.Node(), ad.Domain)))
-		if err != nil {
-			return err
-		}
-		domainsBySID := indexDomainsBySID(domains)
-
-		hostingPaths, err := ops.FetchPathSet(tx.Relationships().Filter(query.And(
-			query.Kind(query.Start(), ad.Computer),
-			query.Kind(query.Relationship(), ad.HostsCAService),
-			query.Kind(query.End(), ad.EnterpriseCA),
-			query.InIDs(query.EndID(), graph.DuplexToGraphIDs(enterpriseCAs)...),
-		)))
-		if graph.IsErrNotFound(err) {
-			return nil
-		} else if err != nil {
+		if err != nil && !graph.IsErrNotFound(err) {
 			return err
 		}
 
-		for _, hostingPath := range hostingPaths {
-			var forestDomains cardinality.Duplex[uint64]
-			enterpriseCA := hostingPath.Terminal()
-
-			if resolvedEnterpriseCAs[enterpriseCA.ID] {
-				forestDomains = forestDomainsByEnterpriseCA[enterpriseCA.ID]
-			} else {
-				forestDomains, err = resolveEnterpriseCAForest(tx, enterpriseCA, domainsBySID)
-				if err != nil {
-					slog.WarnContext(
-						ctx,
-						"Error resolving forest for enterprise ca while composing ADCS edge",
-						slog.Uint64("enterprise_ca", uint64(enterpriseCA.ID)),
-						attr.Error(err),
-					)
-					forestDomains = nil
-				}
-
-				resolvedEnterpriseCAs[enterpriseCA.ID] = true
-				forestDomainsByEnterpriseCA[enterpriseCA.ID] = forestDomains
-			}
-
-			if enterpriseCAHostIsEligible(hostingPath.Root(), forestDomains, domainsBySID) {
-				paths := hostPathsByEnterpriseCA[enterpriseCA.ID]
-				paths.AddPath(hostingPath)
-				hostPathsByEnterpriseCA[enterpriseCA.ID] = paths
-			}
-		}
-
-		return nil
+		hostPathsByEnterpriseCA, err = fetchQualifyingEnterpriseCAHostPathsForTransaction(tx, enterpriseCAs, indexDomainsBySID(domains))
+		return err
 	})
 
 	return hostPathsByEnterpriseCA, err

--- a/packages/go/analysis/ad/esc_shared.go
+++ b/packages/go/analysis/ad/esc_shared.go
@@ -246,6 +246,27 @@ func enterpriseCATrustedForNTAuthToDomainPattern(pattern traversal.PatternContin
 	return enterpriseCATrustedForNTAuthPattern(pattern, query.Equals(query.EndID(), domainID))
 }
 
+func addHostsCAServicePathsToComposition(ctx context.Context, db graph.Database, composition *graph.PathSet, enterpriseCAs cardinality.Duplex[uint64]) error {
+	if composition.Len() == 0 || enterpriseCAs.Cardinality() == 0 {
+		return nil
+	}
+
+	return db.ReadTransaction(ctx, func(tx graph.Transaction) error {
+		if hostingPaths, err := ops.FetchPathSet(tx.Relationships().Filter(query.And(
+			query.Kind(query.Start(), ad.Computer),
+			query.Kind(query.Relationship(), ad.HostsCAService),
+			query.InIDs(query.EndID(), graph.DuplexToGraphIDs(enterpriseCAs)...),
+		))); graph.IsErrNotFound(err) {
+			return nil
+		} else if err != nil {
+			return err
+		} else {
+			composition.AddPathSet(hostingPaths)
+			return nil
+		}
+	})
+}
+
 func PostExtendedByPolicyBinding(operation post.StatTrackedOperation[post.EnsureRelationshipJob], certTemplates []*graph.Node) error {
 	operation.Operation.SubmitReader(func(ctx context.Context, tx graph.Transaction, outC chan<- post.EnsureRelationshipJob) error {
 		if allIssuancePolicies, err := fetchAllIssuancePolicies(tx); err != nil {

--- a/packages/go/analysis/ad/esc_shared.go
+++ b/packages/go/analysis/ad/esc_shared.go
@@ -270,6 +270,19 @@ func enterpriseCATrustedForNTAuthToDomainPattern(pattern traversal.PatternContin
 	return enterpriseCATrustedForNTAuthPattern(pattern, query.Equals(query.EndID(), domainID))
 }
 
+func adcsCAEnrollmentPathPattern(enterpriseCAs []graph.ID, domainID graph.ID) traversal.PatternContinuation {
+	return enterpriseCATrustedForNTAuthToDomainPattern(traversal.NewPattern().
+		OutboundWithDepth(0, 0, query.And(
+			query.Kind(query.Relationship(), ad.MemberOf),
+			query.Kind(query.End(), ad.Group),
+		)).
+		Outbound(query.And(
+			query.Kind(query.Relationship(), ad.Enroll),
+			query.Kind(query.End(), ad.EnterpriseCA),
+			query.InIDs(query.End(), enterpriseCAs...),
+		)), domainID)
+}
+
 func PostExtendedByPolicyBinding(operation post.StatTrackedOperation[post.EnsureRelationshipJob], certTemplates []*graph.Node) error {
 	operation.Operation.SubmitReader(func(ctx context.Context, tx graph.Transaction, outC chan<- post.EnsureRelationshipJob) error {
 		if allIssuancePolicies, err := fetchAllIssuancePolicies(tx); err != nil {

--- a/packages/go/analysis/ad/esc_shared.go
+++ b/packages/go/analysis/ad/esc_shared.go
@@ -204,6 +204,103 @@ func PostGoldenCert(ctx context.Context, tx graph.Transaction, outC chan<- post.
 	return nil
 }
 
+func addHostsCAServicePathsToComposition(ctx context.Context, db graph.Database, composition *graph.PathSet, enterpriseCAs cardinality.Duplex[uint64]) error {
+	if composition.Len() == 0 {
+		return nil
+	} else if enterpriseCAs.Cardinality() == 0 {
+		*composition = graph.PathSet{}
+		return nil
+	}
+
+	return db.ReadTransaction(ctx, func(tx graph.Transaction) error {
+		if hostingPaths, err := ops.FetchPathSet(tx.Relationships().Filter(query.And(
+			query.Kind(query.Start(), ad.Computer),
+			query.Kind(query.Relationship(), ad.HostsCAService),
+			query.InIDs(query.EndID(), graph.DuplexToGraphIDs(enterpriseCAs)...),
+		))); graph.IsErrNotFound(err) {
+			*composition = graph.PathSet{}
+			return nil
+		} else if err != nil {
+			return err
+		} else if hostingPaths.Len() == 0 {
+			*composition = graph.PathSet{}
+			return nil
+		} else {
+			composition.AddPathSet(hostingPaths)
+			return nil
+		}
+	})
+}
+
+// fetchQualifyingEnterpriseCAHostPaths returns only HostsCAService paths whose
+// computer satisfies the same enabled and forest-scoping rules used by ADCS
+// edge creation. Results are keyed by the exact Enterprise CA they host so a
+// qualifying host for one CA cannot validate a different CA candidate.
+func fetchQualifyingEnterpriseCAHostPaths(ctx context.Context, db graph.Database, enterpriseCAs cardinality.Duplex[uint64]) (map[graph.ID]graph.PathSet, error) {
+	var (
+		hostPathsByEnterpriseCA     = make(map[graph.ID]graph.PathSet)
+		resolvedEnterpriseCAs       = make(map[graph.ID]bool)
+		forestDomainsByEnterpriseCA = make(map[graph.ID]cardinality.Duplex[uint64])
+	)
+
+	if enterpriseCAs.Cardinality() == 0 {
+		return hostPathsByEnterpriseCA, nil
+	}
+
+	err := db.ReadTransaction(ctx, func(tx graph.Transaction) error {
+		domains, err := ops.FetchNodes(tx.Nodes().Filter(query.Kind(query.Node(), ad.Domain)))
+		if err != nil {
+			return err
+		}
+		domainsBySID := indexDomainsBySID(domains)
+
+		hostingPaths, err := ops.FetchPathSet(tx.Relationships().Filter(query.And(
+			query.Kind(query.Start(), ad.Computer),
+			query.Kind(query.Relationship(), ad.HostsCAService),
+			query.Kind(query.End(), ad.EnterpriseCA),
+			query.InIDs(query.EndID(), graph.DuplexToGraphIDs(enterpriseCAs)...),
+		)))
+		if graph.IsErrNotFound(err) {
+			return nil
+		} else if err != nil {
+			return err
+		}
+
+		for _, hostingPath := range hostingPaths {
+			var forestDomains cardinality.Duplex[uint64]
+			enterpriseCA := hostingPath.Terminal()
+
+			if resolvedEnterpriseCAs[enterpriseCA.ID] {
+				forestDomains = forestDomainsByEnterpriseCA[enterpriseCA.ID]
+			} else {
+				forestDomains, err = resolveEnterpriseCAForest(tx, enterpriseCA, domainsBySID)
+				if err != nil {
+					slog.WarnContext(
+						ctx,
+						"Error resolving forest for enterprise ca while composing ADCS edge",
+						slog.Uint64("enterprise_ca", uint64(enterpriseCA.ID)),
+						attr.Error(err),
+					)
+					forestDomains = nil
+				}
+
+				resolvedEnterpriseCAs[enterpriseCA.ID] = true
+				forestDomainsByEnterpriseCA[enterpriseCA.ID] = forestDomains
+			}
+
+			if enterpriseCAHostIsEligible(hostingPath.Root(), forestDomains, domainsBySID) {
+				paths := hostPathsByEnterpriseCA[enterpriseCA.ID]
+				paths.AddPath(hostingPath)
+				hostPathsByEnterpriseCA[enterpriseCA.ID] = paths
+			}
+		}
+
+		return nil
+	})
+
+	return hostPathsByEnterpriseCA, err
+}
+
 func enterpriseCAChainPattern(pattern traversal.PatternContinuation, rootCAForCriteria ...graph.Criteria) traversal.PatternContinuation {
 	var criteria = []graph.Criteria{
 		query.Kind(query.Relationship(), ad.RootCAFor),
@@ -244,27 +341,6 @@ func enterpriseCATrustedForNTAuthPattern(pattern traversal.PatternContinuation, 
 
 func enterpriseCATrustedForNTAuthToDomainPattern(pattern traversal.PatternContinuation, domainID graph.ID) traversal.PatternContinuation {
 	return enterpriseCATrustedForNTAuthPattern(pattern, query.Equals(query.EndID(), domainID))
-}
-
-func addHostsCAServicePathsToComposition(ctx context.Context, db graph.Database, composition *graph.PathSet, enterpriseCAs cardinality.Duplex[uint64]) error {
-	if composition.Len() == 0 || enterpriseCAs.Cardinality() == 0 {
-		return nil
-	}
-
-	return db.ReadTransaction(ctx, func(tx graph.Transaction) error {
-		if hostingPaths, err := ops.FetchPathSet(tx.Relationships().Filter(query.And(
-			query.Kind(query.Start(), ad.Computer),
-			query.Kind(query.Relationship(), ad.HostsCAService),
-			query.InIDs(query.EndID(), graph.DuplexToGraphIDs(enterpriseCAs)...),
-		))); graph.IsErrNotFound(err) {
-			return nil
-		} else if err != nil {
-			return err
-		} else {
-			composition.AddPathSet(hostingPaths)
-			return nil
-		}
-	})
 }
 
 func PostExtendedByPolicyBinding(operation post.StatTrackedOperation[post.EnsureRelationshipJob], certTemplates []*graph.Node) error {

--- a/packages/go/analysis/ad/esc_shared.go
+++ b/packages/go/analysis/ad/esc_shared.go
@@ -183,24 +183,35 @@ func PostEnterpriseCAFor(operation post.StatTrackedOperation[post.EnsureRelation
 }
 
 func PostGoldenCert(ctx context.Context, tx graph.Transaction, outC chan<- post.EnsureRelationshipJob, certChains *EnterpriseCAChainedDomains) error {
-	if hostCAServiceComputers, err := FetchHostsCAServiceComputers(tx, certChains.EnterpriseCA); err != nil {
-		slog.ErrorContext(
-			ctx,
-			"Error fetching host ca computer for enterprise ca",
-			slog.Uint64("enterprise_ca_id", uint64(certChains.EnterpriseCA.ID)),
-			attr.Error(err),
-		)
+	var (
+		enterpriseCAIDs = cardinality.NewBitmap64()
+		domains         []*graph.Node
+	)
+
+	if fetchedDomains, err := ops.FetchNodes(tx.Nodes().Filter(query.Kind(query.Node(), ad.Domain))); err != nil && !graph.IsErrNotFound(err) {
+		return fmt.Errorf("failed fetching domains for GoldenCert host validation: %w", err)
 	} else {
-		for _, computer := range hostCAServiceComputers {
-			for _, domain := range certChains.Domains.Slice() {
-				channels.Submit(ctx, outC, post.EnsureRelationshipJob{
-					FromID: computer.ID,
-					ToID:   graph.ID(domain),
-					Kind:   ad.GoldenCert,
-				})
+		domains = fetchedDomains
+	}
+
+	enterpriseCAIDs.Add(certChains.EnterpriseCA.ID.Uint64())
+	qualifyingHostPaths, err := fetchQualifyingEnterpriseCAHostPathsForTransaction(tx, enterpriseCAIDs, indexDomainsBySID(domains))
+	if err != nil {
+		return fmt.Errorf("failed fetching qualifying hosts for GoldenCert: %w", err)
+	}
+
+	for _, hostPath := range qualifyingHostPaths[certChains.EnterpriseCA.ID] {
+		for _, domain := range certChains.Domains.Slice() {
+			if !channels.Submit(ctx, outC, post.EnsureRelationshipJob{
+				FromID: hostPath.Root().ID,
+				ToID:   graph.ID(domain),
+				Kind:   ad.GoldenCert,
+			}) {
+				return fmt.Errorf("context timed out while creating GoldenCert edge")
 			}
 		}
 	}
+
 	return nil
 }
 

--- a/packages/go/analysis/ad/ntlm.go
+++ b/packages/go/analysis/ad/ntlm.go
@@ -215,12 +215,13 @@ func GetCoerceAndRelayNTLMtoADCSEdgeComposition(ctx context.Context, db graph.Da
 		domainNode *graph.Node
 		startNodes = graph.NodeSet{}
 
-		traversalInst      = traversal.New(db, post.MaximumDatabaseParallelWorkers)
-		paths              = graph.PathSet{}
-		candidateSegments  = map[graph.ID][]*graph.PathSegment{}
-		path1EnterpriseCAs = cardinality.NewBitmap64()
-		path2EnterpriseCAs = cardinality.NewBitmap64()
-		lock               = &sync.Mutex{}
+		traversalInst           = traversal.New(db, post.MaximumDatabaseParallelWorkers)
+		paths                   = graph.PathSet{}
+		candidateSegments       = map[graph.ID][]*graph.PathSegment{}
+		path1EnterpriseCAs      = cardinality.NewBitmap64()
+		path2EnterpriseCAs      = cardinality.NewBitmap64()
+		hostPathsByEnterpriseCA map[graph.ID]graph.PathSet
+		lock                    = &sync.Mutex{}
 	)
 
 	if err := db.ReadTransaction(ctx, func(tx graph.Transaction) error {
@@ -315,17 +316,26 @@ func GetCoerceAndRelayNTLMtoADCSEdgeComposition(ctx context.Context, db graph.Da
 
 	// Intersect the CAs and take only those seen in both paths
 	path1EnterpriseCAs.And(path2EnterpriseCAs)
-	// Render paths from the segments
+	if qualifyingHostPaths, err := fetchQualifyingEnterpriseCAHostPaths(ctx, db, path1EnterpriseCAs); err != nil {
+		return nil, err
+	} else {
+		hostPathsByEnterpriseCA = qualifyingHostPaths
+	}
+
+	// Render paths only for CAs with an exact qualifying host.
 	path1EnterpriseCAs.Each(func(value uint64) bool {
+		hostPaths, hasQualifyingHost := hostPathsByEnterpriseCA[graph.ID(value)]
+		if !hasQualifyingHost {
+			return true
+		}
+
 		for _, segment := range candidateSegments[graph.ID(value)] {
 			paths.AddPath(segment.Path())
 		}
+		paths.AddPathSet(hostPaths)
 
 		return true
 	})
-	if err := addHostsCAServicePathsToComposition(ctx, db, &paths, path1EnterpriseCAs); err != nil {
-		return nil, err
-	}
 
 	return paths, nil
 }

--- a/packages/go/analysis/ad/ntlm.go
+++ b/packages/go/analysis/ad/ntlm.go
@@ -323,6 +323,9 @@ func GetCoerceAndRelayNTLMtoADCSEdgeComposition(ctx context.Context, db graph.Da
 
 		return true
 	})
+	if err := addHostsCAServicePathsToComposition(ctx, db, &paths, path1EnterpriseCAs); err != nil {
+		return nil, err
+	}
 
 	return paths, nil
 }

--- a/packages/go/analysis/ad/ntlm.go
+++ b/packages/go/analysis/ad/ntlm.go
@@ -357,15 +357,7 @@ func coerceAndRelayNTLMtoADCSPath1Pattern(domainID graph.ID) traversal.PatternCo
 }
 
 func coerceAndRelayNTLMtoADCSPath2Pattern(domainID graph.ID, enterpriseCAs cardinality.Duplex[uint64]) traversal.PatternContinuation {
-	return enterpriseCATrustedForNTAuthToDomainPattern(traversal.NewPattern().OutboundWithDepth(0, 0, query.And(
-		query.Kind(query.Relationship(), ad.MemberOf),
-		query.Kind(query.End(), ad.Group),
-	)).
-		Outbound(query.And(
-			query.KindIn(query.Relationship(), ad.Enroll),
-			query.Kind(query.End(), ad.EnterpriseCA),
-			query.InIDs(query.EndID(), graph.DuplexToGraphIDs(enterpriseCAs)...),
-		)), domainID)
+	return adcsCAEnrollmentPathPattern(graph.DuplexToGraphIDs(enterpriseCAs), domainID)
 }
 
 func PostCoerceAndRelayNTLMToADCS(ctx context.Context, operation post.StatTrackedOperation[post.EnsureRelationshipJob], adcsCache *ADCSCache, ntlmCache NTLMCache) error {

--- a/packages/go/analysis/ad/ntlm_integration_test.go
+++ b/packages/go/analysis/ad/ntlm_integration_test.go
@@ -111,10 +111,11 @@ func TestNTLMRelayToADCSComposition(t *testing.T) {
 			} else {
 				composition, err := adAnalysis.GetCoerceAndRelayNTLMtoADCSEdgeComposition(t.Context(), db, edge)
 				require.Nil(t, err)
+				requireCompositionContainsEdge(t, composition, ad.HostsCAService)
 
 				nodes := composition.AllNodes()
 
-				require.Equal(t, 7, len(nodes))
+				require.Equal(t, 8, len(nodes))
 				require.True(t, nodes.Contains(harness.NTLMCoerceAndRelayNTLMToADCS.Computer))
 				require.True(t, nodes.Contains(harness.NTLMCoerceAndRelayNTLMToADCS.CertTemplate1))
 				require.True(t, nodes.Contains(harness.NTLMCoerceAndRelayNTLMToADCS.EnterpriseCA1))
@@ -186,6 +187,7 @@ func TestCoerceAndRelayNTLMToADCSTrust(t *testing.T) {
 				composition, err := adAnalysis.GetCoerceAndRelayNTLMtoADCSEdgeComposition(ctx, graphDB, edge)
 				require.NoError(t, err)
 				require.Greater(t, composition.AllNodes().Len(), 0)
+				requireCompositionContainsEdge(t, composition, ad.HostsCAService)
 
 				compositionEdgeCount := 0
 				for _, path := range composition.Paths() {


### PR DESCRIPTION
## Description

This PR makes Enterprise CA host validation equivalent in ADCS edge creation and composition, and correlates every host with the exact Enterprise CA selected by a candidate path.

A qualifying host must:

- Be a `Computer` connected to the selected `EnterpriseCA` by `HostsCAService`.
- Have `enabled = true`.
- Belong to the Enterprise CA’s forest when that forest can be resolved from the CA’s `domainsid`.
- Have a resolvable host domain within that forest.
- Fall back to forest-agnostic handling only when collected metadata cannot identify the CA’s forest.
- Propagate database and traversal failures instead of treating operational errors as an unresolved-forest fallback.

Composition candidates are staged by Enterprise CA. A candidate is added only when that exact CA has a qualifying host, and only qualifying `HostsCAService` paths for that CA are returned.

This prevents a valid host for CA A from preserving composition paths belonging to an unhosted, disabled-hosted, or cross-forest-hosted CA B.

The behavior applies to ESC1, ESC3, ESC4, ESC6, existing ESC9 composition, ESC10, ESC13, ADCS NTLM relay, and GoldenCert creation and composition. ESC3 requires qualifying hosts for both its CT1 publisher CA and target CA.

### Stack

- Base: `BED-9336-adcs-trust-paths`
- Head: `BED-9336-adcs-host-validation`
- This is PR 3 of 4.
- After PR 2 merges, retarget this PR to `main`.

### Commit review order

1. `fix: include HostsCAService paths in ADCS compositions BED-9336`
   - Makes the required host relationship visible in affected composition graphs.
   - Updates existing composition expectations.

2. `fix: require qualifying hosts for ESC3 CAs BED-9336`
   - Introduces shared enabled/in-forest host eligibility.
   - Requires qualifying hosts for both ESC3 Enterprise CAs.

3. `fix: scope ADCS host validation to exact CAs BED-9336`
   - Reuses one host qualification operation in cache construction and composition.
   - Filters composition candidates by exact CA.
   - Adds eligibility, fallback, error-propagation, and multi-CA tests.

4. `refactor: share ADCS CA enrollment traversal BED-9336`
   - Consolidates the repeated CA enrollment and NTAuth traversal used by several compositions.
   - This commit is mechanical and does not change intended requirements.

5. `fix: validate GoldenCert hosts consistently BED-9336`
   - Applies the same host predicate to GoldenCert creation.
   - Returns only qualifying host paths from GoldenCert composition.
   - Adds mixed valid/invalid host coverage.

## Motivation and Context

Resolves BED-9336

Creation required an enabled and, when resolvable, in-forest CA host. Composition previously accepted any `Computer-[:HostsCAService]->EnterpriseCA` relationship and validated all materialized CA alternatives collectively.

One valid hosted CA could therefore keep the composition nonempty while it still contained alternatives through invalid CAs. Composition also omitted a relationship required by creation.

This PR establishes the invariant that every returned CA candidate is justified by a qualifying host path for that same CA.

## How Has This Been Tested?

The final stack passed:

- `just prepare-for-codereview`

Focused coverage includes enabled, disabled, cross-forest, unresolved-domain, and mixed-host scenarios; the unresolved-CA-forest fallback; error propagation; multi-CA composition isolation; GoldenCert host filtering; and affected ADCS compositions requiring `HostsCAService`.

## Screenshots (optional):

N/A — backend graph analysis only.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed