### PR TITLE
fix: merge properties for node info enriched by API at runtime BED-9345

### DIFF
--- a/packages/javascript/bh-shared-ui/src/hooks/useGraphItem/useGraphItem.test.ts
+++ b/packages/javascript/bh-shared-ui/src/hooks/useGraphItem/useGraphItem.test.ts
@@ -27,12 +27,38 @@ import {
 } from './useGraphItem';
 
 const MOCK_NODE_ID = 42;
+const MOCK_CUSTOM_NODE_ID = 43;
+const MOCK_USER_NODE_ID = 44;
 const MOCK_REL_ID = 99;
+const MOCK_OBJECT_ID = 'S-1-5-21-000';
 
+// AZApp is one of the enrichable kinds whose entity endpoint returns a runtime-derived related-node id.
 const MOCK_NODE_RESPONSE = {
     node_id: MOCK_NODE_ID,
-    kinds: [{ name: 'User', node_kind_id: 1 }],
-    properties: { objectid: 'S-1-5-21-000' },
+    kinds: [{ name: 'AZApp', node_kind_id: 1 }],
+    properties: { objectid: MOCK_OBJECT_ID },
+};
+
+// A node whose kinds are not built in AD/Azure kinds should not be enriched via kind-specific endpoints.
+const MOCK_CUSTOM_NODE_RESPONSE = {
+    node_id: MOCK_CUSTOM_NODE_ID,
+    kinds: [{ name: 'CustomKind', node_kind_id: 2 }],
+    properties: { objectid: 'custom-object-id' },
+};
+
+// A built in AD kind that is not in the enrichable allow-list should not trigger a kind-specific fetch.
+const MOCK_USER_NODE_RESPONSE = {
+    node_id: MOCK_USER_NODE_ID,
+    kinds: [{ name: 'User', node_kind_id: 4 }],
+    properties: { objectid: 'user-object-id' },
+};
+
+// Runtime-derived properties that only the kind-specific entity endpoint returns.
+const MOCK_ENRICHED_PROPS = { objectid: MOCK_OBJECT_ID, serviceprincipalid: 'SP-123' };
+
+const MOCK_ENRICHED_NODE_RESPONSE = {
+    ...MOCK_NODE_RESPONSE,
+    properties: { ...MOCK_NODE_RESPONSE.properties, ...MOCK_ENRICHED_PROPS },
 };
 
 const MOCK_RELATIONSHIP_RESPONSE = {
@@ -46,6 +72,15 @@ const MOCK_RELATIONSHIP_RESPONSE = {
 const server = setupServer(
     rest.get(`/api/v2/nodes/${MOCK_NODE_ID}`, (_req, res, ctx) => {
         return res(ctx.json({ data: MOCK_NODE_RESPONSE }));
+    }),
+    rest.get(`/api/v2/nodes/${MOCK_CUSTOM_NODE_ID}`, (_req, res, ctx) => {
+        return res(ctx.json({ data: MOCK_CUSTOM_NODE_RESPONSE }));
+    }),
+    rest.get(`/api/v2/nodes/${MOCK_USER_NODE_ID}`, (_req, res, ctx) => {
+        return res(ctx.json({ data: MOCK_USER_NODE_RESPONSE }));
+    }),
+    rest.get('/api/v2/azure/applications', (_req, res, ctx) => {
+        return res(ctx.json({ data: { props: MOCK_ENRICHED_PROPS, kinds: ['AZApp', 'AZBase'] } }));
     }),
     rest.get(`/api/v2/relationships/${MOCK_REL_ID}`, (_req, res, ctx) => {
         return res(ctx.json({ data: MOCK_RELATIONSHIP_RESPONSE }));
@@ -103,7 +138,62 @@ describe('useGetNodeById', () => {
             MOCK_NODE_ID,
             expect.objectContaining({ params: { 'include-info': true } })
         );
+        await waitFor(() => expect(result.current.data).toEqual(MOCK_ENRICHED_NODE_RESPONSE));
+    });
+
+    it('merges kind-specific runtime properties for enrichable node kinds', async () => {
+        const getAZEntityInfoV2Spy = vi.spyOn(apiClient, 'getAZEntityInfoV2');
+        const { result } = renderHook(() => useGetNodeById(MOCK_NODE_ID));
+
+        await waitFor(() => expect(result.current.data).toEqual(MOCK_ENRICHED_NODE_RESPONSE));
+
+        expect(getAZEntityInfoV2Spy).toHaveBeenCalledWith(
+            'applications',
+            MOCK_OBJECT_ID,
+            undefined,
+            false,
+            undefined,
+            undefined,
+            undefined,
+            expect.anything()
+        );
+        expect(result.current.data?.properties.serviceprincipalid).toBe('SP-123');
+    });
+
+    it('falls back to the base node when the kind-specific request fails', async () => {
+        server.use(
+            rest.get('/api/v2/azure/applications', (_req, res, ctx) => {
+                return res(ctx.status(500));
+            })
+        );
+
+        const { result } = renderHook(() => useGetNodeById(MOCK_NODE_ID));
+
+        await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
         expect(result.current.data).toEqual(MOCK_NODE_RESPONSE);
+    });
+
+    it('does not enrich non built in node kinds', async () => {
+        const getAZEntityInfoV2Spy = vi.spyOn(apiClient, 'getAZEntityInfoV2');
+        const { result } = renderHook(() => useGetNodeById(MOCK_CUSTOM_NODE_ID));
+
+        await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+        expect(getAZEntityInfoV2Spy).not.toHaveBeenCalled();
+        expect(result.current.data).toEqual(MOCK_CUSTOM_NODE_RESPONSE);
+    });
+
+    it('does not enrich built in node kinds outside the enrichable allow-list', async () => {
+        const getAZEntityInfoV2Spy = vi.spyOn(apiClient, 'getAZEntityInfoV2');
+        const getUserV2Spy = vi.spyOn(apiClient, 'getUserV2');
+        const { result } = renderHook(() => useGetNodeById(MOCK_USER_NODE_ID));
+
+        await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+        expect(getAZEntityInfoV2Spy).not.toHaveBeenCalled();
+        expect(getUserV2Spy).not.toHaveBeenCalled();
+        expect(result.current.data).toEqual(MOCK_USER_NODE_RESPONSE);
     });
 });
 
@@ -153,7 +243,7 @@ describe('useGraphItem', () => {
         await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
         expect(getNodeByIDSpy).toHaveBeenCalledWith(MOCK_NODE_ID, expect.anything());
-        expect(result.current.data).toEqual(MOCK_NODE_RESPONSE);
+        await waitFor(() => expect(result.current.data).toEqual(MOCK_ENRICHED_NODE_RESPONSE));
     });
 
     it('fetches relationship data when itemId has the rel_ prefix', async () => {

--- a/packages/javascript/bh-shared-ui/src/hooks/useGraphItem/useGraphItem.ts
+++ b/packages/javascript/bh-shared-ui/src/hooks/useGraphItem/useGraphItem.ts
@@ -23,7 +23,15 @@ import {
     RelationshipDetailsWithInfo,
 } from 'js-client-library';
 import { useQuery } from 'react-query';
-import { apiClient, ParsedQueryItem, parseItemId, REL_ID_PREFIX } from '../../utils';
+import { AzureNodeKind } from '../../graphSchema';
+import {
+    apiClient,
+    entityInformationEndpoints,
+    EntityKinds,
+    ParsedQueryItem,
+    parseItemId,
+    REL_ID_PREFIX,
+} from '../../utils';
 import { escapeCypherString } from '../../utils/cypher';
 import { useExploreParams } from '../useExploreParams';
 
@@ -55,11 +63,57 @@ export const useGetRelationshipById = (id?: number) => {
     });
 };
 
+// The only built in node kinds whose entity endpoints return runtime-derived properties that the generic
+// node-by-id endpoint omits. Each adds a related-node id computed via a relationship traversal at request time:
+// AZApp -> service_principal_id, AZServicePrincipal -> appid, AZFederatedIdentityCredential ->
+// federatedidentitycredentialappid. All other properties (e.g. isTierZero) are derivable from the base node.
+const ENRICHABLE_NODE_KINDS = new Set<EntityKinds>([
+    AzureNodeKind.App,
+    AzureNodeKind.ServicePrincipal,
+    AzureNodeKind.FederatedIdentityCredential,
+]);
+
+const getEnrichableNodeKind = (kinds: NodeDetails['kinds']): EntityKinds | undefined => {
+    for (const kind of kinds) {
+        if (ENRICHABLE_NODE_KINDS.has(kind.name as EntityKinds)) return kind.name as EntityKinds;
+    }
+
+    return undefined;
+};
+
+// The generic node-by-id endpoint does not include the runtime-derived properties (e.g. an AZApp's service
+// principal id) that the kind-specific entity endpoints add. For the enrichable node kinds we fetch those
+// properties from the same endpoints the entity panel relied on previously and merge them into the node
+// properties.
+const enrichBuiltInNodeProperties = async (
+    node: NodeDetails | NodeDetailsWithInfo,
+    signal?: AbortSignal
+): Promise<NodeDetails | NodeDetailsWithInfo> => {
+    const enrichableKind = getEnrichableNodeKind(node.kinds);
+    const objectId = node.properties.objectid;
+
+    if (!enrichableKind || !objectId) return node;
+
+    try {
+        const properties = await entityInformationEndpoints[enrichableKind](objectId, { signal }).then(
+            (res) => res.data.data.props
+        );
+
+        return { ...node, properties: { ...node.properties, ...properties } };
+    } catch {
+        return node;
+    }
+};
+
 export const useGetNodeById = (id?: number) => {
     return useQuery({
         queryKey: ['getNodeById', id],
-        queryFn: async () => {
-            return apiClient.getNodeByID(id!, { params: { 'include-info': true } }).then((res) => res.data.data);
+        queryFn: async ({ signal }) => {
+            const node = await apiClient
+                .getNodeByID(id!, { params: { 'include-info': true } })
+                .then((res) => res.data.data);
+
+            return enrichBuiltInNodeProperties(node, signal);
         },
         enabled: !!id,
         retryOnMount: false,

--- a/packages/javascript/bh-shared-ui/src/hooks/useGraphItem/useGraphItem.ts
+++ b/packages/javascript/bh-shared-ui/src/hooks/useGraphItem/useGraphItem.ts
@@ -100,7 +100,8 @@ const enrichBuiltInNodeProperties = async (
         );
 
         return { ...node, properties: { ...node.properties, ...properties } };
-    } catch {
+    } catch (error) {
+        if (signal?.aborted) throw error;
         return node;
     }
 };
@@ -110,7 +111,7 @@ export const useGetNodeById = (id?: number) => {
         queryKey: ['getNodeById', id],
         queryFn: async ({ signal }) => {
             const node = await apiClient
-                .getNodeByID(id!, { params: { 'include-info': true } })
+                .getNodeByID(id!, { params: { 'include-info': true }, signal })
                 .then((res) => res.data.data);
 
             return enrichBuiltInNodeProperties(node, signal);

--- a/packages/javascript/bh-shared-ui/src/views/Explore/BasicObjectInfoFields.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/Explore/BasicObjectInfoFields.test.tsx
@@ -1,0 +1,130 @@
+// Copyright 2026 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import userEvent from '@testing-library/user-event';
+import { ActiveDirectoryNodeKind, AzureNodeKind } from '../../graphSchema';
+import { render, screen } from '../../test-utils';
+import { BasicObjectInfoFields } from './BasicObjectInfoFields';
+
+const nodeName = 'test-node-name';
+
+const relatedKindCases = [
+    {
+        description: 'Service Principal ID',
+        property: 'service_principal_id',
+        id: 'service-principal-id-value',
+        label: 'Service Principal ID:',
+        kind: AzureNodeKind.ServicePrincipal,
+    },
+    {
+        description: 'Federated Identity Credential Application ID',
+        property: 'federatedidentitycredentialappid',
+        id: 'federated-identity-credential-app-id-value',
+        label: 'Federated Identity Credential Application ID:',
+        kind: AzureNodeKind.App,
+    },
+    {
+        description: 'Node Resource Group ID',
+        property: 'noderesourcegroupid',
+        id: 'node-resource-group-id-value',
+        label: 'Node Resource Group ID:',
+        kind: AzureNodeKind.ResourceGroup,
+    },
+    {
+        description: 'Linked Group ID',
+        property: 'grouplinkid',
+        id: 'group-link-id-value',
+        label: 'Linked Group ID:',
+        kind: ActiveDirectoryNodeKind.Group,
+    },
+] as const;
+
+describe('BasicObjectInfoFields related kind fields', () => {
+    describe.each(relatedKindCases)('$description', ({ property, id, label, kind }) => {
+        it('renders the label and clickable id when handleSourceNodeSelected is provided', () => {
+            render(
+                <BasicObjectInfoFields
+                    properties={{ name: nodeName, [property]: id }}
+                    handleSourceNodeSelected={vi.fn()}
+                />
+            );
+
+            expect(screen.getByText(label)).toBeInTheDocument();
+            expect(screen.getByText(id)).toBeInTheDocument();
+        });
+
+        it('calls handleSourceNodeSelected with the related node when the id is clicked', async () => {
+            const user = userEvent.setup();
+            const handleSourceNodeSelected = vi.fn();
+
+            render(
+                <BasicObjectInfoFields
+                    properties={{ name: nodeName, [property]: id }}
+                    handleSourceNodeSelected={handleSourceNodeSelected}
+                />
+            );
+
+            await user.click(screen.getByText(id));
+
+            expect(handleSourceNodeSelected).toHaveBeenCalledTimes(1);
+            expect(handleSourceNodeSelected).toHaveBeenCalledWith({
+                objectid: id,
+                type: kind,
+                name: nodeName,
+            });
+        });
+
+        it('passes an empty name to handleSourceNodeSelected when the node has no name', async () => {
+            const user = userEvent.setup();
+            const handleSourceNodeSelected = vi.fn();
+
+            render(
+                <BasicObjectInfoFields
+                    properties={{ [property]: id }}
+                    handleSourceNodeSelected={handleSourceNodeSelected}
+                />
+            );
+
+            await user.click(screen.getByText(id));
+
+            expect(handleSourceNodeSelected).toHaveBeenCalledWith({
+                objectid: id,
+                type: kind,
+                name: '',
+            });
+        });
+
+        it('does not render the field when handleSourceNodeSelected is not provided', () => {
+            render(<BasicObjectInfoFields properties={{ name: nodeName, [property]: id }} />);
+
+            expect(screen.queryByText(label)).not.toBeInTheDocument();
+            expect(screen.queryByText(id)).not.toBeInTheDocument();
+        });
+    });
+
+    it('renders every related kind field when all special properties are present', () => {
+        const properties = relatedKindCases.reduce((acc, { property, id }) => ({ ...acc, [property]: id }), {
+            name: nodeName,
+        });
+
+        render(<BasicObjectInfoFields properties={properties} handleSourceNodeSelected={vi.fn()} />);
+
+        relatedKindCases.forEach(({ label, id }) => {
+            expect(screen.getByText(label)).toBeInTheDocument();
+            expect(screen.getByText(id)).toBeInTheDocument();
+        });
+    });
+});


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Restores runtime enriched node properties for certain node kinds.

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-9345

AZApps, AZServicePrincipals, and AZFederatedIdentityCredential have additional information in the response under node properties that the API tacks on at runtime. These properties are not literally part of the node entity properties. 

After refactors to pull this information from the new GET node by id endpoint the runtime enriched data was absent and thus the extra related info did not display as before. 

For these three specific node kinds that have backend enriched info an extra call is made to the original azure entity endpoints in order to get this data.

## How Has This Been Tested?

Unit tests added. Local verification

## Screenshots (optional):

<img width="1386" height="550" alt="Screenshot 2026-08-25 at 1 22 19 PM" src="https://github.com/user-attachments/assets/b146e2c7-6ec8-4c9c-85e7-578f52a0f313" />


## Types of changes

<!-- Please remove any items that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Azure App, Service Principal, and Federated Identity Credential nodes now display enriched details when available.
  - Enriched node information is combined with runtime-derived properties.
  - Related Azure and Active Directory properties are displayed with clickable identifiers where supported.

- **Bug Fixes**
  - Nodes retain their original details if enrichment fails or is unavailable.
  - Unsupported enrichment requests are no longer made.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->