### PR TITLE
feat: use trigram index on objectid for improved search - BED-9103

### DIFF
--- a/cmd/api/src/queries/graph.go
+++ b/cmd/api/src/queries/graph.go
@@ -324,8 +324,8 @@ func createFuzzyNodeSearchGraphCriteria(kinds graph.Kinds, nameTerm string, obje
 	var nameAndObjectIDCriteria graph.Criteria
 	if useRawObjectID {
 		nameAndObjectIDCriteria = query.Or(
-			query.CaseInsensitiveStringContains(query.NodeProperty(common.Name.String()), nameTerm),
-			query.CaseInsensitiveStringContains(query.NodeProperty(common.ObjectID.String()), objectIDTerm),
+			query.IndexableCaseInsensitiveStringContains(query.NodeProperty(common.Name.String()), nameTerm),
+			query.IndexableCaseInsensitiveStringContains(query.NodeProperty(common.ObjectID.String()), objectIDTerm),
 		)
 	} else {
 		nameAndObjectIDCriteria = query.Or(
@@ -354,8 +354,8 @@ func createNodeStartsWithSearchGraphCriteria(kinds graph.Kinds, nameTerm string,
 	var nameAndObjectIDCriteria graph.Criteria
 	if useRawObjectID {
 		nameAndObjectIDCriteria = query.Or(
-			query.CaseInsensitiveStringStartsWith(query.NodeProperty(common.Name.String()), nameTerm),
-			query.CaseInsensitiveStringStartsWith(query.NodeProperty(common.ObjectID.String()), objectIDTerm),
+			query.IndexableCaseInsensitiveStringStartsWith(query.NodeProperty(common.Name.String()), nameTerm),
+			query.IndexableCaseInsensitiveStringStartsWith(query.NodeProperty(common.ObjectID.String()), objectIDTerm),
 		)
 	} else {
 		nameAndObjectIDCriteria = query.Or(

--- a/cmd/api/src/queries/graph_internal_test.go
+++ b/cmd/api/src/queries/graph_internal_test.go
@@ -264,14 +264,14 @@ func requireCaseSensitiveComparison(t *testing.T, comparison *cypher.Comparison,
 	require.Equal(t, term, parameter.Value)
 }
 
-// requireCaseInsensitiveComparison asserts that comparison is a case-insensitive comparison of
-// the form `toLower(n.<propertyName>) <operator> toLower(<term>)`.
-func requireCaseInsensitiveComparison(t *testing.T, comparison *cypher.Comparison, propertyName string, operator cypher.Operator, term string) {
+// requireIndexableCaseInsensitiveComparison asserts that comparison uses Dawgs' explicit
+// indexable case-insensitive predicate wrapper.
+func requireIndexableCaseInsensitiveComparison(t *testing.T, comparison *cypher.Comparison, propertyName string, operator cypher.Operator, term string) {
 	t.Helper()
 
 	functionInvocation, ok := comparison.Left.(*cypher.FunctionInvocation)
 	require.True(t, ok, "expected *cypher.FunctionInvocation, got %T", comparison.Left)
-	require.Equal(t, "toLower", functionInvocation.Name)
+	require.Equal(t, cypher.IndexableCaseInsensitiveFunction, functionInvocation.Name)
 	require.Len(t, functionInvocation.Arguments, 1)
 
 	propertyLookup, ok := functionInvocation.Arguments[0].(*cypher.PropertyLookup)
@@ -321,13 +321,13 @@ func TestCreateFuzzyNodeSearchGraphCriteria_Search(t *testing.T) {
 		requireNotEqualsExclusion(t, filters[2], common.ObjectID.String(), objectIDTerm)
 	})
 
-	t.Run("flag on: contains criteria becomes case-insensitive", func(t *testing.T) {
+	t.Run("flag on: contains criteria uses the indexable case-insensitive predicate", func(t *testing.T) {
 		filters := createFuzzyNodeSearchGraphCriteria(nil, nameTerm, objectIDTerm, false, true)
 		require.Len(t, filters, 3)
 
 		nameComparison, objectIDComparison := extractOrComparisons(t, filters[0])
-		requireCaseInsensitiveComparison(t, nameComparison, common.Name.String(), cypher.OperatorContains, nameTerm)
-		requireCaseInsensitiveComparison(t, objectIDComparison, common.ObjectID.String(), cypher.OperatorContains, objectIDTerm)
+		requireIndexableCaseInsensitiveComparison(t, nameComparison, common.Name.String(), cypher.OperatorContains, nameTerm)
+		requireIndexableCaseInsensitiveComparison(t, objectIDComparison, common.ObjectID.String(), cypher.OperatorContains, objectIDTerm)
 
 		// Exact-match exclusion clauses remain case-sensitive even when the flag is on.
 		requireNotEqualsExclusion(t, filters[1], common.Name.String(), nameTerm)
@@ -367,13 +367,13 @@ func TestCreateNodeStartsWithSearchGraphCriteria_Search(t *testing.T) {
 		requireNotEqualsExclusion(t, filters[2], common.ObjectID.String(), objectIDTerm)
 	})
 
-	t.Run("flag on: starts-with criteria becomes case-insensitive", func(t *testing.T) {
+	t.Run("flag on: starts-with criteria uses the indexable case-insensitive predicate", func(t *testing.T) {
 		filters := createNodeStartsWithSearchGraphCriteria(nil, nameTerm, objectIDTerm, true)
 		require.Len(t, filters, 3)
 
 		nameComparison, objectIDComparison := extractOrComparisons(t, filters[0])
-		requireCaseInsensitiveComparison(t, nameComparison, common.Name.String(), cypher.OperatorStartsWith, nameTerm)
-		requireCaseInsensitiveComparison(t, objectIDComparison, common.ObjectID.String(), cypher.OperatorStartsWith, objectIDTerm)
+		requireIndexableCaseInsensitiveComparison(t, nameComparison, common.Name.String(), cypher.OperatorStartsWith, nameTerm)
+		requireIndexableCaseInsensitiveComparison(t, objectIDComparison, common.ObjectID.String(), cypher.OperatorStartsWith, objectIDTerm)
 
 		// Exact-match exclusion clauses remain case-sensitive even when the flag is on.
 		requireNotEqualsExclusion(t, filters[1], common.Name.String(), nameTerm)

--- a/cmd/api/src/queries/graph_internal_test.go
+++ b/cmd/api/src/queries/graph_internal_test.go
@@ -225,10 +225,10 @@ func Test_sortAndSliceResults_limit(t *testing.T) {
 	require.Equal(t, actual, expected)
 }
 
-// extractOrComparisons unwraps a `query.Or(...)` criteria (the first entry returned by
-// createFuzzyNodeSearchGraphCriteria/createNodeStartsWithSearchGraphCriteria) into its two
-// underlying comparisons: the Name comparison and the ObjectID comparison, respectively.
-func extractOrComparisons(t *testing.T, criteria graph.Criteria) (*cypher.Comparison, *cypher.Comparison) {
+// extractOrCriteria unwraps a `query.Or(...)` criteria (the first entry returned by
+// createFuzzyNodeSearchGraphCriteria/createNodeStartsWithSearchGraphCriteria) into its Name
+// and ObjectID criteria, respectively.
+func extractOrCriteria(t *testing.T, criteria graph.Criteria) (graph.Criteria, graph.Criteria) {
 	t.Helper()
 
 	parenthetical, ok := criteria.(*cypher.Parenthetical)
@@ -238,11 +238,19 @@ func extractOrComparisons(t *testing.T, criteria graph.Criteria) (*cypher.Compar
 	require.True(t, ok, "expected *cypher.Disjunction, got %T", parenthetical.Expression)
 	require.Len(t, disjunction.Expressions, 2)
 
-	nameComparison, ok := disjunction.Expressions[0].(*cypher.Comparison)
-	require.True(t, ok, "expected *cypher.Comparison, got %T", disjunction.Expressions[0])
+	return disjunction.Expressions[0], disjunction.Expressions[1]
+}
 
-	objectIDComparison, ok := disjunction.Expressions[1].(*cypher.Comparison)
-	require.True(t, ok, "expected *cypher.Comparison, got %T", disjunction.Expressions[1])
+func extractOrComparisons(t *testing.T, criteria graph.Criteria) (*cypher.Comparison, *cypher.Comparison) {
+	t.Helper()
+
+	nameCriteria, objectIDCriteria := extractOrCriteria(t, criteria)
+
+	nameComparison, ok := nameCriteria.(*cypher.Comparison)
+	require.True(t, ok, "expected *cypher.Comparison, got %T", nameCriteria)
+
+	objectIDComparison, ok := objectIDCriteria.(*cypher.Comparison)
+	require.True(t, ok, "expected *cypher.Comparison, got %T", objectIDCriteria)
 
 	return nameComparison, objectIDComparison
 }
@@ -264,26 +272,18 @@ func requireCaseSensitiveComparison(t *testing.T, comparison *cypher.Comparison,
 	require.Equal(t, term, parameter.Value)
 }
 
-// requireIndexableCaseInsensitiveComparison asserts that comparison uses Dawgs' explicit
-// indexable case-insensitive predicate wrapper.
-func requireIndexableCaseInsensitiveComparison(t *testing.T, comparison *cypher.Comparison, propertyName string, operator cypher.Operator, term string) {
+func requireIndexableCaseInsensitivePredicate(t *testing.T, criteria graph.Criteria, propertyName string, operator cypher.Operator, term string) {
 	t.Helper()
 
-	functionInvocation, ok := comparison.Left.(*cypher.FunctionInvocation)
-	require.True(t, ok, "expected *cypher.FunctionInvocation, got %T", comparison.Left)
-	require.Equal(t, cypher.IndexableCaseInsensitiveFunction, functionInvocation.Name)
-	require.Len(t, functionInvocation.Arguments, 1)
+	predicate, ok := criteria.(*cypher.IndexableCaseInsensitiveStringPredicate)
+	require.True(t, ok, "expected *cypher.IndexableCaseInsensitiveStringPredicate, got %T", criteria)
+	require.Equal(t, operator, predicate.Operator)
 
-	propertyLookup, ok := functionInvocation.Arguments[0].(*cypher.PropertyLookup)
-	require.True(t, ok, "expected *cypher.PropertyLookup, got %T", functionInvocation.Arguments[0])
+	propertyLookup, ok := predicate.Reference.(*cypher.PropertyLookup)
+	require.True(t, ok, "expected *cypher.PropertyLookup, got %T", predicate.Reference)
 	require.Equal(t, propertyName, propertyLookup.Symbol)
 
-	require.Len(t, comparison.Partials, 1)
-	require.Equal(t, operator, comparison.Partials[0].Operator)
-
-	parameter, ok := comparison.Partials[0].Right.(*cypher.Parameter)
-	require.True(t, ok, "expected *cypher.Parameter, got %T", comparison.Partials[0].Right)
-	require.Equal(t, strings.ToLower(term), parameter.Value)
+	require.Equal(t, strings.ToLower(term), predicate.Value.Value)
 }
 
 // requireNotEqualsExclusion asserts that criteria is a `query.Not(query.Equals(n.<propertyName>, <term>))`
@@ -325,9 +325,9 @@ func TestCreateFuzzyNodeSearchGraphCriteria_Search(t *testing.T) {
 		filters := createFuzzyNodeSearchGraphCriteria(nil, nameTerm, objectIDTerm, false, true)
 		require.Len(t, filters, 3)
 
-		nameComparison, objectIDComparison := extractOrComparisons(t, filters[0])
-		requireIndexableCaseInsensitiveComparison(t, nameComparison, common.Name.String(), cypher.OperatorContains, nameTerm)
-		requireIndexableCaseInsensitiveComparison(t, objectIDComparison, common.ObjectID.String(), cypher.OperatorContains, objectIDTerm)
+		nameCriteria, objectIDCriteria := extractOrCriteria(t, filters[0])
+		requireIndexableCaseInsensitivePredicate(t, nameCriteria, common.Name.String(), cypher.OperatorContains, nameTerm)
+		requireIndexableCaseInsensitivePredicate(t, objectIDCriteria, common.ObjectID.String(), cypher.OperatorContains, objectIDTerm)
 
 		// Exact-match exclusion clauses remain case-sensitive even when the flag is on.
 		requireNotEqualsExclusion(t, filters[1], common.Name.String(), nameTerm)
@@ -371,9 +371,9 @@ func TestCreateNodeStartsWithSearchGraphCriteria_Search(t *testing.T) {
 		filters := createNodeStartsWithSearchGraphCriteria(nil, nameTerm, objectIDTerm, true)
 		require.Len(t, filters, 3)
 
-		nameComparison, objectIDComparison := extractOrComparisons(t, filters[0])
-		requireIndexableCaseInsensitiveComparison(t, nameComparison, common.Name.String(), cypher.OperatorStartsWith, nameTerm)
-		requireIndexableCaseInsensitiveComparison(t, objectIDComparison, common.ObjectID.String(), cypher.OperatorStartsWith, objectIDTerm)
+		nameCriteria, objectIDCriteria := extractOrCriteria(t, filters[0])
+		requireIndexableCaseInsensitivePredicate(t, nameCriteria, common.Name.String(), cypher.OperatorStartsWith, nameTerm)
+		requireIndexableCaseInsensitivePredicate(t, objectIDCriteria, common.ObjectID.String(), cypher.OperatorStartsWith, objectIDTerm)
 
 		// Exact-match exclusion clauses remain case-sensitive even when the flag is on.
 		requireNotEqualsExclusion(t, filters[1], common.Name.String(), nameTerm)

--- a/packages/go/graphschema/primarykind_test.go
+++ b/packages/go/graphschema/primarykind_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/specterops/bloodhound/packages/go/graphschema/ad"
+	"github.com/specterops/bloodhound/packages/go/graphschema/common"
 	"github.com/specterops/dawgs/graph"
 	"github.com/stretchr/testify/require"
 )
@@ -146,5 +147,12 @@ func Test_PrimaryDisplayKinds_Add(t *testing.T) {
 			},
 			IsSourceKind: true,
 		}, primaryDisplayKinds[graph.StringKind("dogpark_Entity")])
+	})
+}
+
+func TestDefaultGraphIncludesObjectIDTextSearchIndex(t *testing.T) {
+	require.Contains(t, DefaultGraph().NodeIndexes, graph.Index{
+		Field: common.ObjectID.String(),
+		Type:  graph.TextSearchIndex,
 	})
 }

--- a/packages/go/graphschema/schema.go
+++ b/packages/go/graphschema/schema.go
@@ -59,6 +59,10 @@ func CombinedGraphSchema(name string) graph.Graph {
 		}},
 		NodeIndexes: []graph.Index{
 			{
+				Field: common.ObjectID.String(),
+				Type:  graph.TextSearchIndex,
+			},
+			{
 				Field: common.Name.String(),
 				Type:  graph.TextSearchIndex,
 			},


### PR DESCRIPTION
## Description

Updates raw ObjectID fuzzy and prefix search to use DAWGS' upcoming indexable case-insensitive predicates when the `use_raw_object_id` feature flag is enabled.

Adds an ObjectID text-search index to the graph schema so PostgreSQL can efficiently search both `Name` and `ObjectID` from the shared Search/Explore input.

Exact ObjectID matching remains case-sensitive. Flag-off search behavior is unchanged.

This PR depends on a related [DAWGS PR](https://github.com/SpecterOps/DAWGS/pull/127)

> [!CAUTION]
> The Dawgs version must be updated after the related PR is merged.


## Motivation and Context

Resolves [BED-9103](https://specterops.atlassian.net/browse/BED-9103)

The raw objectIDs feature flag preserves source casing. Fuzzy and prefix search must therefore be case-insensitive while still searching both `Name` and `ObjectID`.

The existing raw-ObjectID fuzzy and prefix query shape scans graph nodes because its PostgreSQL helpers use `strpos` and `left` rather than `ILIKE`, preventing PostgreSQL from using trigram indexes. ObjectID has an exact-match B-tree index but no text-search index for fuzzy or prefix matching.

This change enables an indexable query shape for the feature-flagged raw ObjectID search path and adds the missing ObjectID text-search index.

No Goose migration is needed. The ObjectID text-search index is declared in the Dawgs graph schema and is created when graph schema assertion runs.

> [!CAUTION]
> Production rollout must ensure the updated graph schema is asserted so the index is created. Dawgs currently uses ordinary index creation, not `CREATE INDEX CONCURRENTLY`.


## How Has This Been Tested?

Focused BHE query and graph-schema tests were run using a temporary workspace with the local Dawgs checkout.

Manual `PostgreSQL EXPLAIN (ANALYZE, BUFFERS)` benchmarks were run against a local GitHub graph containing 38,655 nodes:

- Current raw-ObjectID fuzzy query shape: sequential scan, ~74 ms.
- Proposed fuzzy query shape: Name/ObjectID `BitmapOr` trigram-index plan, ~5.7 ms.
- Current raw-ObjectID prefix query shape: sequential scan, ~81 ms.
- Proposed prefix query shape: Name/ObjectID `BitmapOr` trigram-index plan, ~6.5 ms.

The authenticated `/api/v2/search` endpoint was also exercised with `use_raw_object_id` enabled. Warm requests completed in approximately 6-7 ms.


## Types of Changes

- [x] New feature (non-breaking change which adds functionality)


## Checklist

I have met the contributing prerequisites

- [x] Assigned myself to this PR
- [x] Added the appropriate labels
- [x] Associated an issue: BED-9103
- [x] Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing

I have ensured that related documentation is up-to-date

- [x] OpenAPI docs: not applicable
- [x] Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
- [x] Added/updated tests to cover my changes
- [ ] Full test suite run


[BED-9103]: https://specterops.atlassian.net/browse/BED-9103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ