### PR TITLE
test(A11y): add stubs for BHE coverage - BED-9441

### DIFF
--- a/packages/javascript/bh-playwright-testing/src/stubs/attack-paths/finding-trends.ts
+++ b/packages/javascript/bh-playwright-testing/src/stubs/attack-paths/finding-trends.ts
@@ -1,0 +1,303 @@
+// Copyright 2026 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Page } from '@playwright/test';
+
+// Deterministic environment the "With graph data" graph spec navigates to and asserts on. The id
+// matches the owner_objectid baked into the meta-node/meta-tree fixtures below so the graph resolves
+// a root node, and `name` is the label RootMetaNodeAnnotation renders once the graph settles.
+export const environment = {
+    type: 'active-directory',
+    name: 'SEVENKINGDOMS.LOCAL',
+    id: 'S-1-5-21-2768881856-185705006-2548489946',
+    collected: true,
+    impactValue: 74,
+    hygiene_attack_paths: 0,
+    exposures: [
+        {
+            exposure_percent: 74,
+            asset_group_tag: { id: 1, type: 1, name: 'Tier Zero', position: 1 },
+        },
+    ],
+};
+
+// Tier Zero asset group tag. useSelectedTag / useHighestPrivilegeTagId / useContextSeverity read this
+// (matched by exposures[].asset_group_tag.id) to label and scope the root meta-node annotation.
+const tierZeroTag = {
+    id: 1,
+    type: 1,
+    kind_id: 173,
+    name: 'Tier Zero',
+    description: 'Tier Zero',
+    created_at: '2025-04-15T21:02:26.504736Z',
+    created_by: 'BloodHound',
+    updated_at: '2026-06-09T17:01:52.688496Z',
+    updated_by: 'playwright',
+    deleted_at: null,
+    deleted_by: null,
+    position: 1,
+    require_certify: true,
+    analysis_enabled: true,
+    glyph: 'gem',
+};
+
+// Root Meta node (Tier Zero) keyed by node id; getLatestMetaNode returns this and its first key
+// becomes the graph's rootMetaNodeId.
+const metaNodes = {
+    '1564342163': {
+        color: '#000',
+        data: {
+            isTierZero: true,
+            kinds: ['Meta', 'Tag_Tier_Zero'],
+            level: 0,
+            nodetype: 'Meta',
+            owner_objectid: environment.id,
+            zone: 'Tag_Tier_Zero',
+        },
+        border: { color: 'black' },
+        image: '/ui/meta.png',
+        label: { backgroundColor: 'rgba(255,255,255,0.9)', center: true, fontSize: 14, text: 'NO NAME' },
+        size: 1,
+    },
+};
+
+// The full meta tree: the root node plus child meta-nodes and the relationships linking them to the
+// root. getAttackPathsGraph returns this; merged with metaNodes it forms the rendered graph.
+const metaTrees = {
+    ...metaNodes,
+    '1564342165': {
+        color: '#000',
+        data: {
+            isTierZero: false,
+            kinds: ['Meta'],
+            nodetype: 'Meta',
+            owner_objectid: environment.id,
+            zone: 'Tag_Tier_Zero',
+        },
+        border: { color: 'black' },
+        image: '/ui/meta.png',
+        label: { backgroundColor: 'rgba(255,255,255,0.9)', center: true, fontSize: 14, text: 'NO NAME' },
+        size: 1,
+    },
+    '1564342167': {
+        color: '#000',
+        data: {
+            isTierZero: false,
+            kinds: ['Meta'],
+            nodetype: 'Meta',
+            owner_objectid: environment.id,
+            zone: 'Tag_Tier_Zero',
+        },
+        border: { color: 'black' },
+        image: '/ui/meta.png',
+        label: { backgroundColor: 'rgba(255,255,255,0.9)', center: true, fontSize: 14, text: 'NO NAME' },
+        size: 1,
+    },
+    rel_19954328980: {
+        color: '3a5464',
+        data: { composite_risk_impact_count: 9, composite_risk_impact_percent: 60 },
+        id: 19954328980,
+        end2: { arrow: true },
+        id1: '1564342165',
+        id2: '1564342163',
+        label: { text: 'GenericAll' },
+    },
+    rel_19954328982: {
+        color: '3a5464',
+        data: { composite_risk_impact_count: 4, composite_risk_impact_percent: 26.67 },
+        id: 19954328982,
+        end2: { arrow: true },
+        id1: '1564342167',
+        id2: '1564342163',
+        label: { text: 'MemberOf' },
+    },
+};
+
+// The two findings surfaced in the right information panel. They line up with the GenericAll /
+// MemberOf edges in metaTrees so the graph and findings list tell a consistent story.
+const findingNames = ['T0GenericAll', 'T0MemberOf'];
+
+// getPostureFindingTrends (finding-trends) data, keyed later by finding name. Header renders
+// display_title and composite_risk from these entries.
+const findingTrends = [
+    {
+        environment_ids: [environment.id],
+        composite_risk: 60,
+        finding: 'T0GenericAll',
+        impact_count: 246,
+        exposure_count: 24,
+        finding_count_start: 14,
+        finding_count_end: 17,
+        finding_count_increase: 12,
+        finding_count_decrease: 9,
+        archived_count: 22,
+        display_title: 'GenericAll Privileges on Objects in Privilege Zone',
+        display_type: 'Tier Zero Attack Paths',
+    },
+    {
+        environment_ids: [environment.id],
+        composite_risk: 26.666666666666668,
+        finding: 'T0MemberOf',
+        impact_count: 84,
+        exposure_count: 6,
+        finding_count_start: 10,
+        finding_count_end: 4,
+        finding_count_increase: 20,
+        finding_count_decrease: 26,
+        archived_count: 45,
+        display_title: 'Non-Certified Principal with Privileges in Privilege Zone',
+        display_type: 'Tier Zero Attack Paths',
+    },
+];
+
+// One sparkline point per finding. mapAvailableFindingSparklines keys these by data[0].Finding and
+// FindingsInformationPanel treats a finding with no points as "unavailable", so each needs >=1 point.
+const findingSparkline = (finding: string, compositeRisk: number) => [
+    {
+        id: 1,
+        DomainSID: environment.id,
+        Finding: finding,
+        CompositeRisk: compositeRisk,
+        FindingCount: 1,
+        ImpactedAssetCount: 1,
+        created_at: '2026-08-24T21:42:00Z',
+        updated_at: '2026-08-24T21:42:00Z',
+    },
+];
+
+// One relationship-detail row per finding. mapAvailableFindingDetails reads Finding /
+// ComboGraphRelationID to build findingNameCounts and findingNameToEdgeMap (rel_<id>).
+const findingDetail = (finding: string, comboGraphRelationId: number) => ({
+    data: [{ Finding: finding, ComboGraphRelationID: comboGraphRelationId }],
+    count: 1,
+});
+
+// getFindings (findings/{name}) content, keyed by finding name. Header renders `title` and
+// FindingInformation renders the description / remediation markdown. Trimmed from the full API
+// payload to the fields the components read while keeping enough prose to exercise MarkdownContent.
+const findingContent: Record<string, Record<string, string>> = {
+    T0GenericAll: {
+        title: 'GenericAll Privileges on Objects in Privilege Zone',
+        type: 'Privilege Zone Attack Paths',
+        short_description:
+            'The "GenericAll" privilege grants principals the ability to perform nearly any action against the object, including abusable actions such as resetting user passwords and adding new users to security groups. "GenericAll" is also known as "Full Control".',
+        long_description:
+            'The "GenericAll" privilege grants principals the ability to perform nearly any action against the object, including abusable actions such as resetting user passwords and adding new users to security groups.\n\nOnly those users belonging to Tier Zero domain groups should have control over Tier Zero users, groups, computers, and special objects.',
+        short_remediation:
+            'Remove the "GenericAll" privilege that the Principal outside the Privilege Zone holds against the object in the Privilege Zone.',
+        long_remediation:
+            'Deny all principals in the domain the ability to control a Tier Zero asset except where that principal is itself also a Tier Zero asset.',
+        references:
+            '### MITRE ATT&CK\n* [ATT&CK T1098: Account Manipulation](https://attack.mitre.org/techniques/T1098/)',
+    },
+    T0MemberOf: {
+        title: 'Non-Certified Principal with Privileges in Privilege Zone',
+        type: 'Privilege Zone Attack Paths',
+        short_description:
+            'Group members in Active Directory retain all privileges held by the group, therefore, if a group is in a Privilege Zone, then the members of that group must also be part of that Privilege Zone.',
+        long_description:
+            'Group members in Active Directory retain all privileges held by the group, therefore, if a group is in a Privilege Zone, then the members of that group must also be part of that Privilege Zone.',
+        short_remediation:
+            'Either certify the group member from the Certification page, or remove the group member from the Privilege Zone group.',
+        long_remediation:
+            'If the object is an expected member, certify the object in the certifications page. Otherwise, remove the object from the group it belongs to.',
+        references:
+            '### How Attackers Abuse This Attack Path\n* [BloodHound Docs: MemberOf](https://bloodhound.specterops.io/resources/edges/member-of)',
+    },
+};
+
+/**
+ * Stubs the Attack Paths graph endpoints so the "With graph data" spec renders a deterministic,
+ * hermetic Tier Zero graph for `environment`:
+ *   - `available-domains` returns the single environment (also keeps the "No Data" dialog closed).
+ *   - `asset-group-tags` returns the Tier Zero tag used to label/scope the root node annotation.
+ *   - `meta-nodes` / `meta-trees` return the fixture graph so regraph settles and the environment
+ *     name label appears.
+ *   - `available-types` / `sparkline` / `details` / `finding-trends` return the two fixture findings
+ *     so the right information panel lists findings instead of "No risks identified".
+ *   - `findings/{name}` returns each finding's title / description / remediation content so the
+ *     finding header renders its title and the expanded panel renders its markdown.
+ *   - `custom-nodes` returns an empty array so the global saga resolves without escaping to the
+ *     real backend.
+ * Only GET traffic is handled; anything else falls through to lower-priority handlers.
+ */
+export async function installAttackPathsStubs(page: Page): Promise<void> {
+    await page.route('**/api/v2/available-domains', async (route) => {
+        if (route.request().method() !== 'GET') return route.fallback();
+        return route.fulfill({ json: { data: [environment] } });
+    });
+
+    await page.route('**/api/v2/asset-group-tags?*', async (route) => {
+        if (route.request().method() !== 'GET') return route.fallback();
+        return route.fulfill({ json: { data: { tags: [tierZeroTag] } } });
+    });
+
+    await page.route(`**/api/v2/meta-nodes/${environment.id}*`, async (route) => {
+        if (route.request().method() !== 'GET') return route.fallback();
+        return route.fulfill({ json: { data: metaNodes } });
+    });
+
+    await page.route(`**/api/v2/meta-trees/${environment.id}*`, async (route) => {
+        if (route.request().method() !== 'GET') return route.fallback();
+        return route.fulfill({ json: { data: metaTrees } });
+    });
+
+    await page.route('**/api/v2/custom-nodes', async (route) => {
+        if (route.request().method() !== 'GET') return route.fallback();
+        return route.fulfill({ json: { data: [] } });
+    });
+
+    await page.route(`**/api/v2/domains/${environment.id}/available-types*`, async (route) => {
+        if (route.request().method() !== 'GET') return route.fallback();
+        return route.fulfill({ json: { data: findingNames } });
+    });
+
+    await page.route(`**/api/v2/domains/${environment.id}/sparkline*`, async (route) => {
+        if (route.request().method() !== 'GET') return route.fallback();
+        const finding = new URL(route.request().url()).searchParams.get('finding') ?? '';
+        const compositeRisk = findingTrends.find((trend) => trend.finding === finding)?.composite_risk ?? 0;
+        return route.fulfill({ json: { data: findingSparkline(finding, compositeRisk), count: 1 } });
+    });
+
+    await page.route(`**/api/v2/domains/${environment.id}/details*`, async (route) => {
+        if (route.request().method() !== 'GET') return route.fallback();
+        const finding = new URL(route.request().url()).searchParams.get('finding') ?? '';
+        const comboGraphRelationId = finding === 'T0GenericAll' ? 19954328980 : 19954328982;
+        return route.fulfill({ json: findingDetail(finding, comboGraphRelationId) });
+    });
+
+    await page.route('**/api/v2/findings/*', async (route) => {
+        if (route.request().method() !== 'GET') return route.fallback();
+        const finding = new URL(route.request().url()).pathname.split('/').pop() ?? '';
+        return route.fulfill({ json: { data: findingContent[finding] ?? {} } });
+    });
+
+    await page.route('**/api/v2/attack-paths/finding-trends*', async (route) => {
+        if (route.request().method() !== 'GET') return route.fallback();
+        return route.fulfill({
+            json: {
+                data: {
+                    findings: findingTrends,
+                    total_finding_count_start: 24,
+                    total_finding_count_end: 21,
+                },
+                start: null,
+                end: null,
+                environments: [environment.id],
+            },
+        });
+    });
+}

--- a/packages/javascript/bh-playwright-testing/src/stubs/attack-paths/findings.ts
+++ b/packages/javascript/bh-playwright-testing/src/stubs/attack-paths/findings.ts
@@ -1,0 +1,151 @@
+// Copyright 2026 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Page } from '@playwright/test';
+
+// Deterministic environment the table findings belong to. Its id/name match the environment_id and
+// environment_name baked into the findings below so the Environment column and Environment filter tell
+// a consistent story, and a single collected environment keeps the "No Data" upload dialog closed.
+const environment = {
+    type: 'active-directory',
+    name: 'SEVENKINGDOMS.LOCAL',
+    id: 'S-1-5-21-2768881856-185705006-2548489946',
+    collected: true,
+    impactValue: 74,
+    hygiene_attack_paths: 0,
+    exposures: [
+        {
+            exposure_percent: 74,
+            asset_group_tag: { id: 1, type: 1, name: 'Tier Zero', position: 1 },
+        },
+    ],
+};
+
+// Tier Zero asset group tag. The Zone column / Zone filter read this (matched by asset_group_tag_id)
+// to label the findings' zone.
+const tierZeroTag = {
+    id: 1,
+    type: 1,
+    kind_id: 173,
+    name: 'Tier Zero',
+    description: 'Tier Zero',
+    created_at: '2025-04-15T21:02:26.504736Z',
+    created_by: 'BloodHound',
+    updated_at: '2026-06-09T17:01:52.688496Z',
+    updated_by: 'playwright',
+    deleted_at: null,
+    deleted_by: null,
+    position: 1,
+    require_certify: true,
+    analysis_enabled: true,
+    glyph: 'gem',
+};
+
+// One template per distinct attack-path finding captured in table.json, paired with how many rows of
+// that finding the HAR returned. Expanded below into the 26-row page the findings table renders.
+const findingTemplates: { template: Record<string, unknown>; rows: number }[] = [
+    {
+        rows: 17,
+        template: {
+            severity: 'moderate',
+            finding: 'T0GenericAll',
+            title: 'GenericAll Privileges on Objects in Privilege Zone',
+            finding_type: 'relationship',
+            status: 'active',
+        },
+    },
+    {
+        rows: 4,
+        template: {
+            severity: 'high',
+            finding: 'T0MarkSensitive',
+            title: 'Tier Zero Objects Lack Kerberos Delegation Protection',
+            finding_type: 'list',
+            status: 'active',
+        },
+    },
+    {
+        rows: 4,
+        template: {
+            severity: 'low',
+            finding: 'T0MemberOf',
+            title: 'Non-Certified Principal with Privileges in Privilege Zone',
+            finding_type: 'relationship',
+            status: 'accepted',
+        },
+    },
+    {
+        rows: 1,
+        template: {
+            severity: 'low',
+            finding: 'T0GPLink',
+            title: 'Non-Certified GPO Linked to Privilege Zone OU',
+            finding_type: 'relationship',
+            status: 'active',
+        },
+    },
+];
+
+// Expand the templates into the flat 26-row page. Each row gets a deterministic target principal so the
+// Target Principal column renders distinct, stable values without embedding every captured row verbatim.
+const findings = findingTemplates.flatMap(({ template, rows }, groupIndex) =>
+    Array.from({ length: rows }, (_unused, rowIndex) => ({
+        ...template,
+        platform: 'Active Directory',
+        environment_id: environment.id,
+        environment_name: environment.name,
+        asset_group_tag_id: tierZeroTag.id,
+        zone_name: tierZeroTag.name,
+        source_principal_id: '',
+        source_principal_kind: '',
+        source_principal_name: '',
+        target_principal_id: `${environment.id}-${1000 + groupIndex * 100 + rowIndex}`,
+        target_principal_kind: 'User',
+        target_principal_name: `PRINCIPAL-${groupIndex}-${rowIndex}@${environment.name}`,
+        first_seen: '2026-06-05T05:09:50.085107Z',
+        last_seen: '2026-08-25T03:42:11.149145Z',
+    }))
+);
+
+/**
+ * Stubs the Attack Paths table endpoints so the "With attack paths" spec renders a deterministic,
+ * hermetic findings table:
+ *   - `available-domains` returns the single environment the findings belong to (also keeps the
+ *     "No Data" dialog closed) and populates the Environment filter.
+ *   - `asset-group-tags` returns the Tier Zero tag so the Zone column / filter resolve.
+ *   - `attack-paths/findings` returns the 26-row findings page (skip/limit/count) that
+ *     `useUnifiedFindings` reads, so the table body and the "26 Findings" count render instead of the
+ *     loading or empty state.
+ * Only GET traffic is handled; anything else falls through to lower-priority handlers.
+ */
+export async function installAttackPathsTableStubs(page: Page): Promise<void> {
+    await page.route('**/api/v2/available-domains', async (route) => {
+        if (route.request().method() !== 'GET') return route.fallback();
+        return route.fulfill({ json: { data: [environment] } });
+    });
+
+    await page.route('**/api/v2/asset-group-tags?*', async (route) => {
+        if (route.request().method() !== 'GET') return route.fallback();
+        return route.fulfill({ json: { data: { tags: [tierZeroTag] } } });
+    });
+
+    await page.route('**/api/v2/attack-paths/findings?*', async (route) => {
+        if (route.request().method() !== 'GET') return route.fallback();
+        return route.fulfill({
+            json: { data: findings, skip: 0, limit: 100, count: findings.length },
+        });
+    });
+}

--- a/packages/javascript/bh-playwright-testing/src/stubs/index.ts
+++ b/packages/javascript/bh-playwright-testing/src/stubs/index.ts
@@ -14,15 +14,18 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-export * from './asset-group-tags/members';
 export * from './asset-group-tags/history';
 export * from './asset-group-tags/labels';
+export * from './asset-group-tags/members';
 export * from './asset-group-tags/search';
 export * from './asset-group-tags/selectors';
 export * from './asset-group-tags/tag';
 export * from './asset-group-tags/zone-details';
+export * from './attack-paths/finding-trends';
+export * from './attack-paths/findings';
 export * from './bloodhound-users/mfa';
 export * from './bloodhound-users/secret';
 export * from './features/flags';
 export * from './graphs/cypher';
+export * from './kennel/collectors';
 export * from './tokens/index';

--- a/packages/javascript/bh-playwright-testing/src/stubs/kennel/collectors.ts
+++ b/packages/javascript/bh-playwright-testing/src/stubs/kennel/collectors.ts
@@ -1,0 +1,163 @@
+// Copyright 2026 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Page } from '@playwright/test';
+
+type CollectorAsset = {
+    name: string;
+    download_url: string;
+    checksum_download_url: string;
+    os: string;
+    arch: string;
+};
+
+type CollectorManifest = {
+    version: string;
+    version_meta: { major: number; minor: number; patch: number; prerelease: string };
+    release_date: string;
+    release_assets: CollectorAsset[];
+};
+
+type CommunityCollectorType = 'sharphound' | 'azurehound';
+type EnterpriseCollectorType = 'sharphound_enterprise' | 'azurehound_enterprise' | 'openhound';
+
+type CommunityManifest = Record<CommunityCollectorType, CollectorManifest[]>;
+type EnterpriseManifest = Record<EnterpriseCollectorType, CollectorManifest[]>;
+
+const GITHUB = 'https://github.com/SpecterOps';
+const KENNEL_DOWNLOAD = 'https://test.bloodhoundenterprise.io/api/v2/kennel/download';
+
+const asset = (name: string, base: string, os: string, arch: string): CollectorAsset => ({
+    name,
+    download_url: `${base}/${name}`,
+    checksum_download_url: `${base}/${name}.sha256`,
+    os,
+    arch,
+});
+
+const release = (
+    version: string,
+    prerelease: string,
+    release_date: string,
+    release_assets: CollectorAsset[]
+): CollectorManifest => {
+    const [major, minor, patch] = version.replace(/^v/, '').split('-')[0].split('.').map(Number);
+    return { version, version_meta: { major, minor, patch, prerelease }, release_date, release_assets };
+};
+
+const COMMUNITY_MANIFEST: CommunityManifest = {
+    sharphound: [
+        release('v2.14.0', '', '2026-07-24T15:24:43Z', [
+            asset(
+                'SharpHound_v2.14.0_windows_x86.zip',
+                `${GITHUB}/SharpHound/releases/download/v2.14.0`,
+                'windows',
+                'x86'
+            ),
+        ]),
+        release('v2.14.0-rc1', 'rc1', '2026-07-21T14:11:43Z', [
+            asset(
+                'SharpHound_v2.14.0-rc1_windows_x86.zip',
+                `${GITHUB}/SharpHound/releases/download/v2.14.0-rc1`,
+                'windows',
+                'x86'
+            ),
+        ]),
+    ],
+    azurehound: [
+        release('v3.1.0', '', '2026-08-17T18:25:34Z', [
+            asset(
+                'AzureHound_v3.1.0_windows_amd64.zip',
+                `${GITHUB}/AzureHound/releases/download/v3.1.0`,
+                'windows',
+                'amd64'
+            ),
+            asset(
+                'AzureHound_v3.1.0_darwin_arm64.zip',
+                `${GITHUB}/AzureHound/releases/download/v3.1.0`,
+                'darwin',
+                'arm64'
+            ),
+            asset(
+                'AzureHound_v3.1.0_linux_amd64.zip',
+                `${GITHUB}/AzureHound/releases/download/v3.1.0`,
+                'linux',
+                'amd64'
+            ),
+        ]),
+    ],
+};
+
+const ENTERPRISE_MANIFEST: EnterpriseManifest = {
+    sharphound_enterprise: [
+        release('v2.15.0', '', '2026-08-17T18:33:34Z', [
+            asset('SharpHoundEnterpriseService_v2.15.0_windows_x86.zip', KENNEL_DOWNLOAD, 'windows', 'x86'),
+        ]),
+        release('v2.15.0-rc1', 'rc1', '2026-08-11T15:13:29Z', [
+            asset('SharpHoundEnterpriseService_v2.15.0-rc1_windows_x86.zip', KENNEL_DOWNLOAD, 'windows', 'x86'),
+        ]),
+    ],
+    azurehound_enterprise: [
+        release('v3.1.0', '', '2026-08-17T18:34:51Z', [
+            asset('AzureHoundEnterprise_v3.1.0_windows_amd64.zip', KENNEL_DOWNLOAD, 'windows', 'amd64'),
+            asset('AzureHoundEnterprise_v3.1.0_windows_arm64.zip', KENNEL_DOWNLOAD, 'windows', 'arm64'),
+        ]),
+    ],
+    openhound: [],
+};
+
+/**
+ * Stubs the community collector manifest endpoint (`GET /api/v2/kennel/manifest`) so the
+ * Download Collectors page renders SharpHound and AzureHound cards without depending on the
+ * live GitHub-backed manifest. Install before navigation. Non-GET traffic falls through to
+ * any lower-priority route handlers.
+ */
+export async function installCommunityCollectorsStub(
+    page: Page,
+    manifest: CommunityManifest = COMMUNITY_MANIFEST
+): Promise<void> {
+    await page.route('**/api/v2/kennel/manifest', async (route) => {
+        if (route.request().method() !== 'GET') return route.fallback();
+
+        return route.fulfill({ json: { data: manifest } });
+    });
+}
+
+/**
+ * Stubs the enterprise collector manifest endpoint (`GET /api/v2/kennel/enterprise-manifest`) so
+ * the Download Collectors page renders SharpHound/AzureHound Enterprise cards without depending on
+ * the live S3-backed manifest. Install before navigation. Non-GET traffic falls through to any
+ * lower-priority route handlers.
+ */
+export async function installEnterpriseCollectorsStub(
+    page: Page,
+    manifest: EnterpriseManifest = ENTERPRISE_MANIFEST
+): Promise<void> {
+    await page.route('**/api/v2/kennel/enterprise-manifest', async (route) => {
+        if (route.request().method() !== 'GET') return route.fallback();
+
+        return route.fulfill({ json: { data: manifest } });
+    });
+}
+
+/**
+ * Convenience helper that installs both the community and enterprise collector manifest stubs so
+ * the Download Collectors page fully renders with data. Install before navigation.
+ */
+export async function installCollectorsStub(page: Page): Promise<void> {
+    await installCommunityCollectorsStub(page);
+    await installEnterpriseCollectorsStub(page);
+}


### PR DESCRIPTION
## Description

Add stubs needed for BHE coverage

## Motivation and Context

Resolves BED-9441

## How Has This Been Tested?

Manually ran related BHE Playwright a11y tests

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added deterministic test coverage for Attack Paths findings, trends, graphs, and related details.
  * Added test data for community and enterprise collector releases, including SharpHound and AzureHound.
  * Expanded Playwright testing utilities with reusable API stubs for Attack Paths and collector experiences.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->