### PR TITLE
fix(ci): BHCE Tagging Parity To BHE For Tagging Images BED-9375 

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -45,8 +45,18 @@ jobs:
       image_cache_to: type=gha,mode=max
       image_flavor: latest=${{ (github.ref_name == 'main' || contains(github.ref_name, '-rc')) == false }}
       image_tags: |
+        # Edge builds from main
         type=edge,branch=main
+        type=sha,format=short,prefix=edge-,enable=${{ github.ref_name == 'main' }}
+
+        # Release candidates
+        type=sha,format=short,prefix=candidate-,enable=${{ contains(github.ref_name, '-rc') }}
+        type=raw,value=candidate,enable=${{ contains(github.ref_name, '-rc') }}
         type=semver,pattern={{version}}
+
+        # Production releases
+        type=sha,format=short,prefix=production-,enable=${{ github.ref_type == 'tag' && !contains(github.ref_name, '-rc') }}
+        type=raw,value=production,enable=${{ github.ref_type == 'tag' && !contains(github.ref_name, '-rc') }}
         type=semver,pattern={{major}}.{{minor}},enable=${{ ! contains(github.ref_name, '-rc') }}
         type=semver,pattern={{major}},enable=${{ ! contains(github.ref_name, '-rc') }}
       build_args: |

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -46,15 +46,18 @@ jobs:
       image_flavor: latest=${{ (github.ref_name == 'main' || contains(github.ref_name, '-rc')) == false }}
       image_tags: |
         # Edge builds from main
+        ## edge-<git_sha>
         type=edge,branch=main
         type=sha,format=short,prefix=edge-,enable=${{ github.ref_name == 'main' }}
 
         # Release candidates
+        ## candidate-<git_sha>
         type=sha,format=short,prefix=candidate-,enable=${{ contains(github.ref_name, '-rc') }}
         type=raw,value=candidate,enable=${{ contains(github.ref_name, '-rc') }}
         type=semver,pattern={{version}}
 
         # Production releases
+        ## production-<git_sha>
         type=sha,format=short,prefix=production-,enable=${{ github.ref_type == 'tag' && !contains(github.ref_name, '-rc') }}
         type=raw,value=production,enable=${{ github.ref_type == 'tag' && !contains(github.ref_name, '-rc') }}
         type=semver,pattern={{major}}.{{minor}},enable=${{ ! contains(github.ref_name, '-rc') }}


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

`testbhce` was not receiving release candidate builds, this was due to our github action not following the expected image tagging policy that `commute` uses. This PR fixes the BHCE tagging to match BHE in order for `commute` to properly deploy to `testbhce`

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-9375


## How Has This Been Tested?


## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved container image tagging for development, release candidate, and production builds.
  * Added conditional tags based on the Git reference, including edge, candidate, version, and production tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->