### PR TITLE
feat: added keyboard navigation functionality BED-7220

### DIFF
--- a/cmd/ui/src/App.tsx
+++ b/cmd/ui/src/App.tsx
@@ -114,7 +114,18 @@ export const Inner: React.FC = () => {
             </Helmet>
             <div className={classes.applicationContainer} id='app-root'>
                 {showNavBar && <MainNav mainNavData={mainNavData} />}
-                <div id='content-wrapper' className='bg-neutral-1 grow overflow-y-auto overflow-x-hidden'>
+                <div
+                    id='main-content'
+                    role='main'
+                    tabIndex={-1}
+                    className='bg-neutral-1 grow overflow-y-auto overflow-x-hidden'>
+                    {showNavBar && (
+                        <a
+                            href='#global-navigation'
+                            className='sr-only focus:not-sr-only focus:fixed focus:left-3 focus:top-3 focus:z-[10000] focus:rounded focus:bg-neutral-1 focus:px-4 focus:py-2 focus:text-primary focus:shadow-lg focus:focus-ring'>
+                            Skip to navigation
+                        </a>
+                    )}
                     <Content />
                 </div>
                 <AppNotifications />

--- a/cmd/ui/src/App.tsx
+++ b/cmd/ui/src/App.tsx
@@ -115,7 +115,7 @@ export const Inner: React.FC = () => {
             <div className={classes.applicationContainer} id='app-root'>
                 {showNavBar && <MainNav mainNavData={mainNavData} />}
                 <div
-                    id='main-content'
+                    id='content-wrapper'
                     role='main'
                     tabIndex={-1}
                     className='bg-neutral-1 grow overflow-y-auto overflow-x-hidden'>

--- a/cmd/ui/src/views/Explore/ContextMenu/ContextMenu.test.tsx
+++ b/cmd/ui/src/views/Explore/ContextMenu/ContextMenu.test.tsx
@@ -28,7 +28,7 @@ import { rest } from 'msw';
 import { setupServer } from 'msw/node';
 import { act } from 'react-dom/test-utils';
 import { AppState } from 'src/store';
-import { render, screen, waitFor } from 'src/test-utils';
+import { render, screen } from 'src/test-utils';
 import ContextMenu from './ContextMenu';
 
 const mockUseExploreParams = vi.spyOn(bhSharedUi, 'useExploreParams');
@@ -194,33 +194,20 @@ describe('ContextMenu', async () => {
         });
     });
 
-    it('opens a submenu when user hovers over `Copy`', async () => {
+    it('opens a submenu when the user clicks `Copy`', async () => {
         await setup();
 
         const user = userEvent.setup();
 
         const copyOption = screen.getByRole('menuitem', { name: /copy/i });
-        await user.hover(copyOption);
+        await user.click(copyOption);
 
-        const tip = await screen.findByRole('tooltip');
-        expect(tip).toBeInTheDocument();
+        const nameOption = await screen.findByRole('menuitem', { name: 'Name' });
+        const objectIdOption = screen.getByRole('menuitem', { name: 'Object ID' });
+        const cypherOption = screen.getByRole('menuitem', { name: 'Cypher' });
 
-        const nameOption = screen.getByLabelText(/name/i);
         expect(nameOption).toBeInTheDocument();
-
-        const objectIdOption = screen.getByLabelText(/object id/i);
         expect(objectIdOption).toBeInTheDocument();
-
-        const cypherOption = screen.getByLabelText(/cypher/i);
         expect(cypherOption).toBeInTheDocument();
-
-        // hover off the `Copy` option in order to close the tooltip
-        await userEvent.unhover(copyOption);
-
-        await waitFor(() => {
-            expect(screen.queryByText(/name/i)).not.toBeInTheDocument();
-            expect(screen.queryByText(/object id/i)).not.toBeInTheDocument();
-            expect(screen.queryByText(/cypher/i)).not.toBeInTheDocument();
-        });
     });
 });

--- a/cmd/ui/src/views/Explore/ContextMenu/ContextMenu.tsx
+++ b/cmd/ui/src/views/Explore/ContextMenu/ContextMenu.tsx
@@ -72,6 +72,7 @@ const ContextMenu: FC<{
             open={contextMenu !== null}
             anchorPosition={{ left: contextMenu?.mouseX || 0 + 10, top: contextMenu?.mouseY || 0 }}
             anchorReference='anchorPosition'
+            onClose={handleClose}
             onClick={handleClose}>
             <MenuItem onClick={handleSetStartingNode}>Set as starting node</MenuItem>
             <MenuItem onClick={handleSetEndingNode}>Set as ending node</MenuItem>

--- a/packages/javascript/bh-shared-ui/src/components/ColumnHeaders/ColumnHeaders.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/ColumnHeaders/ColumnHeaders.test.tsx
@@ -83,17 +83,19 @@ describe('ColumnHeaders', () => {
         it('renders the tooltip icon when tooltipText prop is passed', () => {
             render(<SortableHeader title={'test'} tooltipText='test tooltip text' sortOrder='asc' onSort={vi.fn} />);
 
-            const tooltipIcon = screen.getByRole('img', { name: /more information in tooltip/i });
+            const sortButton = screen.getByRole('button', { name: /sort by test/i });
+            const tooltipIcon = screen.getByTestId('column-header_tooltip-trigger-icon');
 
-            expect(tooltipIcon).toHaveAttribute('tabindex', '0');
-            expect(screen.queryByRole('button', { name: /more information in tooltip/i })).not.toBeInTheDocument();
+            expect(sortButton).toHaveAccessibleDescription('test tooltip text');
+            expect(tooltipIcon).toHaveAttribute('aria-hidden', 'true');
+            expect(tooltipIcon).not.toHaveAttribute('tabindex');
         });
 
         // Not hovered
         it('does not show tooltip text by default', async () => {
             render(<SortableHeader title={'test'} tooltipText='test tooltip text' onSort={vi.fn} />);
 
-            expect(screen.queryByText('test tooltip text')).not.toBeInTheDocument();
+            expect(screen.queryByTestId('column-header_tooltip-content-text')).not.toBeInTheDocument();
         });
 
         // Hovered
@@ -102,7 +104,7 @@ describe('ColumnHeaders', () => {
 
             render(<SortableHeader title={'test'} tooltipText='test tooltip text' onSort={vi.fn} />);
 
-            expect(screen.queryByText('test tooltip text')).not.toBeInTheDocument();
+            expect(screen.queryByTestId('column-header_tooltip-content-text')).not.toBeInTheDocument();
 
             await user.hover(screen.getByTestId('column-header_tooltip-trigger-icon'));
 

--- a/packages/javascript/bh-shared-ui/src/components/ColumnHeaders/ColumnHeaders.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/ColumnHeaders/ColumnHeaders.tsx
@@ -17,6 +17,7 @@
 import { faInfoCircle } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { TextButton, TooltipContent, TooltipPortal, TooltipProvider, TooltipRoot, TooltipTrigger } from 'doodle-ui';
+import { useId } from 'react';
 import { SortOrder } from '../../types';
 import { adaptClickHandlerToKeyDown, cn } from '../../utils';
 import { AppIcon } from '../AppIcon';
@@ -52,6 +53,7 @@ interface SortableHeaderProps extends React.HTMLAttributes<HTMLDivElement> {
 
 export const SortableHeader: React.FC<SortableHeaderProps> = (props) => {
     const { title, tooltipText, sortOrder, disable, classes, onSort, ...rest } = props;
+    const tooltipDescriptionId = useId();
 
     const containerClass = classes && classes.container ? classes.container : '';
     const buttonClass = classes && classes.button ? classes.button : '';
@@ -68,6 +70,7 @@ export const SortableHeader: React.FC<SortableHeaderProps> = (props) => {
                         <TextButton
                             disabled={disable}
                             aria-label={`Sort by ${title}`}
+                            aria-describedby={tooltipText ? tooltipDescriptionId : undefined}
                             className={cn(
                                 'p-0 font-semibold rounded-sm text-base text-text-main hover:no-underline relative',
                                 buttonClass
@@ -80,17 +83,12 @@ export const SortableHeader: React.FC<SortableHeaderProps> = (props) => {
                             {!tooltipText && <IconComponent size={12} className='absolute -right-5 m-1' />}
                             {tooltipText && (
                                 <>
-                                    {/* The informational tooltip must be keyboard-focusable without presenting as a button. */}
-                                    {/* eslint-disable jsx-a11y/no-noninteractive-tabindex */}
                                     <span
                                         className='flex items-center'
-                                        role='img'
-                                        aria-label='More information in tooltip'
-                                        tabIndex={0}
+                                        aria-hidden='true'
                                         data-testid='column-header_tooltip-trigger-icon'>
                                         <FontAwesomeIcon size='sm' icon={faInfoCircle} />
                                     </span>
-                                    {/* eslint-enable jsx-a11y/no-noninteractive-tabindex */}
                                     <span className='flex items-center'>
                                         <IconComponent size={12} />
                                     </span>
@@ -104,6 +102,11 @@ export const SortableHeader: React.FC<SortableHeaderProps> = (props) => {
                                 </>
                             )}
                         </TextButton>
+                        {tooltipText && (
+                            <span id={tooltipDescriptionId} className='sr-only'>
+                                {tooltipText}
+                            </span>
+                        )}
                     </div>
                 </TooltipTrigger>
             </TooltipRoot>

--- a/packages/javascript/bh-shared-ui/src/components/FileDrop/FileDrop.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/FileDrop/FileDrop.tsx
@@ -17,7 +17,7 @@
 import { faArrowDown, faInbox, IconDefinition } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { DragEvent, useRef, useState } from 'react';
-import { adaptClickHandlerToKeyDown, cn } from '../../utils';
+import { cn } from '../../utils';
 
 const FileDrop: React.FC<{
     onDrop: (files: any) => void;
@@ -59,6 +59,9 @@ const FileDrop: React.FC<{
     const handleMouseLeave = () => setHoverActive(false);
 
     const formatAcceptList = () => (accept && accept.length ? accept.join(',') : undefined);
+    const uploadLabel = multiple
+        ? 'Choose JSON or zip/compressed JSON files to upload'
+        : 'Choose a JSON file to upload';
 
     return (
         <div
@@ -86,18 +89,18 @@ const FileDrop: React.FC<{
                     ? 'Click here or drag and drop to upload JSON or zip/compressed JSON files'
                     : 'Click here or drag and drop to upload a JSON file'}
             </p>
-            <div
-                role='button'
-                tabIndex={0}
-                className='absolute size-full'
+            <button
+                type='button'
+                aria-label={uploadLabel}
+                disabled={disabled}
+                className='absolute inset-0 size-full rounded focus-visible:focus-ring'
                 onClick={handleClick}
                 onDragEnter={handleDragEnter}
                 onDragLeave={handleDragLeave}
                 onDragOver={handleDragOver}
                 onMouseEnter={handleMouseEnter}
                 onMouseLeave={handleMouseLeave}
-                onKeyDown={adaptClickHandlerToKeyDown(handleClick)}
-                onDrop={handleDrop}></div>
+                onDrop={handleDrop}></button>
         </div>
     );
 };

--- a/packages/javascript/bh-shared-ui/src/components/Navigation/MainNav.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/Navigation/MainNav.tsx
@@ -26,6 +26,7 @@ import { cn, useAppNavigate } from '../../utils';
 import { adaptClickHandlerToKeyDown } from '../../utils/adaptClickHandlerToKeyDown';
 import { ConditionalTooltip } from '../ConditionalTooltip';
 import { AppLink } from './AppLink';
+import { SkipLink } from './SkipLink';
 import SubNav from './SubNav';
 import type { MainNavData, MainNavDataListItem, MainNavLogoDataObject, NavActionItem, NavLinkItem } from './types';
 
@@ -185,6 +186,7 @@ const MainNav: FC<{ mainNavData: MainNavData }> = ({ mainNavData }) => {
 
     return (
         <>
+            <SkipLink href='#main-content'>Skip to main content</SkipLink>
             {/* Nav expand/collapse button */}
             <IconButton
                 aria-expanded={isExpanded}
@@ -209,6 +211,9 @@ const MainNav: FC<{ mainNavData: MainNavData }> = ({ mainNavData }) => {
             </IconButton>
 
             <nav
+                id='global-navigation'
+                aria-label='Global navigation'
+                tabIndex={-1}
                 className={cn(
                     'flex flex-col flex-none font-medium shadow-md z-nav print:hidden overflow-hidden',
                     'transition-all duration-300 ease-in',

--- a/packages/javascript/bh-shared-ui/src/components/Navigation/MainNav.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/Navigation/MainNav.tsx
@@ -186,7 +186,7 @@ const MainNav: FC<{ mainNavData: MainNavData }> = ({ mainNavData }) => {
 
     return (
         <>
-            <SkipLink href='#main-content'>Skip to main content</SkipLink>
+            <SkipLink href='#content-wrapper'>Skip to main content</SkipLink>
             {/* Nav expand/collapse button */}
             <IconButton
                 aria-expanded={isExpanded}

--- a/packages/javascript/bh-shared-ui/src/components/Navigation/SkipLink.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/Navigation/SkipLink.tsx
@@ -1,4 +1,4 @@
-// Copyright 2025 Specter Ops, Inc.
+// Copyright 2026 Specter Ops, Inc.
 //
 // Licensed under the Apache License, Version 2.0
 // you may not use this file except in compliance with the License.
@@ -14,12 +14,17 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-export * from './BasicObjectInfoFields';
-export * from './ContextMenu/AssetGroupMenuItemPrivilegeZonesEnabled';
-export { default as ContextMenuPrivilegeZonesEnabled } from './ContextMenu/ContextMenuPrivilegeZonesEnabled';
-export { default as CopyMenuItem } from './ContextMenu/CopyMenuItem';
-export * from './ExploreSearch';
-export * from './fragments';
-export { default as GraphItemInformationPanel } from './GraphItemInformationPanel';
-export * from './InfoStyles';
-export * from './providers';
+import { AnchorHTMLAttributes, FC } from 'react';
+import { cn } from '../../utils';
+
+export const SkipLink: FC<AnchorHTMLAttributes<HTMLAnchorElement>> = ({ children, className, ...props }) => (
+    <a
+        className={cn(
+            'sr-only focus:not-sr-only focus:fixed focus:left-3 focus:top-3 focus:z-[10000]',
+            'focus:rounded focus:bg-neutral-1 focus:px-4 focus:py-2 focus:text-primary focus:shadow-lg focus:focus-ring',
+            className
+        )}
+        {...props}>
+        {children}
+    </a>
+);

--- a/packages/javascript/bh-shared-ui/src/components/Navigation/index.ts
+++ b/packages/javascript/bh-shared-ui/src/components/Navigation/index.ts
@@ -20,5 +20,6 @@ import { MainNavData } from './types';
 
 export * from './AppLink';
 export * from './AppNavigate';
+export * from './SkipLink';
 export * from './utils';
 export { MainNav, SubNav, type MainNavData };

--- a/packages/javascript/bh-shared-ui/src/views/Explore/ContextMenu/ContextMenuPrivilegeZonesEnabled.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/Explore/ContextMenu/ContextMenuPrivilegeZonesEnabled.test.tsx
@@ -18,7 +18,7 @@ import userEvent from '@testing-library/user-event';
 import { rest } from 'msw';
 import { setupServer } from 'msw/node';
 import { createAuthStateWithPermissions, mockSourceKindsHandler } from '../../../mocks';
-import { render, screen, waitFor } from '../../../test-utils';
+import { render, screen } from '../../../test-utils';
 import { Permission } from '../../../utils';
 import ContextMenu from './ContextMenuPrivilegeZonesEnabled';
 
@@ -188,7 +188,7 @@ describe('ContextMenu', () => {
         expect(window.location.search).toContain('exploreSearchTab=pathfinding');
     });
 
-    it('opens a submenu when user hovers over `Copy`', async () => {
+    it('opens a submenu when the user clicks `Copy`', async () => {
         render(<ContextMenu contextMenu={{ mouseX: 0, mouseY: 0 }} onClose={vi.fn()} />, {
             route: '/test?selectedItem=abc',
         });
@@ -196,27 +196,14 @@ describe('ContextMenu', () => {
         const user = userEvent.setup();
 
         const copyOption = await screen.findByRole('menuitem', { name: /copy/i });
-        await user.hover(copyOption);
+        await user.click(copyOption);
 
-        const tip = await screen.findByRole('tooltip');
-        expect(tip).toBeInTheDocument();
+        const nameOption = await screen.findByRole('menuitem', { name: 'Name' });
+        const objectIdOption = screen.getByRole('menuitem', { name: 'Object ID' });
+        const cypherOption = screen.getByRole('menuitem', { name: 'Cypher' });
 
-        const nameOption = screen.getByLabelText(/name/i);
         expect(nameOption).toBeInTheDocument();
-
-        const objectIdOption = screen.getByLabelText(/object id/i);
         expect(objectIdOption).toBeInTheDocument();
-
-        const cypherOption = screen.getByLabelText(/cypher/i);
         expect(cypherOption).toBeInTheDocument();
-
-        // hover off the `Copy` option in order to close the tooltip
-        await userEvent.unhover(copyOption);
-
-        await waitFor(() => {
-            expect(screen.queryByText(/name/i)).not.toBeInTheDocument();
-            expect(screen.queryByText(/object id/i)).not.toBeInTheDocument();
-            expect(screen.queryByText(/cypher/i)).not.toBeInTheDocument();
-        });
     });
 });

--- a/packages/javascript/bh-shared-ui/src/views/Explore/ContextMenu/ContextMenuPrivilegeZonesEnabled.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/Explore/ContextMenu/ContextMenuPrivilegeZonesEnabled.tsx
@@ -88,6 +88,7 @@ const ContextMenu: FC<{
             open={contextMenu !== null}
             anchorPosition={{ left: contextMenu?.mouseX || 0, top: contextMenu?.mouseY || 0 }}
             anchorReference='anchorPosition'
+            onClose={onClose}
             onClick={onClose}
             keepMounted>
             <MenuItem onClick={handleSetStartingNode}>Set as starting node</MenuItem>

--- a/packages/javascript/bh-shared-ui/src/views/Explore/ContextMenu/CopyMenuItem.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/Explore/ContextMenu/CopyMenuItem.test.tsx
@@ -49,8 +49,7 @@ describe('CopyMenuItem', () => {
         const user = userEvent.setup();
 
         const copyOption = screen.getByRole('menuitem', { name: /copy/i });
-        copyOption.focus();
-        await user.keyboard('{ArrowRight}');
+        await user.click(copyOption);
 
         const nameOption = await screen.findByRole('menuitem', { name: 'Name' });
         const objectIdOption = screen.getByRole('menuitem', { name: 'Object ID' });

--- a/packages/javascript/bh-shared-ui/src/views/Explore/ContextMenu/CopyMenuItem.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/Explore/ContextMenu/CopyMenuItem.test.tsx
@@ -49,13 +49,17 @@ describe('CopyMenuItem', () => {
         const user = userEvent.setup();
 
         const copyOption = screen.getByRole('menuitem', { name: /copy/i });
-        await user.hover(copyOption);
+        copyOption.focus();
+        await user.keyboard('{ArrowRight}');
 
-        const tooltip = await screen.findByRole('tooltip');
-        expect(tooltip).toBeInTheDocument();
+        const nameOption = await screen.findByRole('menuitem', { name: 'Name' });
+        const objectIdOption = screen.getByRole('menuitem', { name: 'Object ID' });
+        const cypherOption = screen.getByRole('menuitem', { name: 'Cypher' });
 
-        // the tooltip container and the menu item for `name` have the same accessible name, so return the second element here (which is the menu item)
-        const nameOption = screen.getAllByRole('menuitem', { name: /name/i })[1];
+        expect(nameOption).toBeInTheDocument();
+        expect(objectIdOption).toBeInTheDocument();
+        expect(cypherOption).toBeInTheDocument();
+
         await user.click(nameOption);
 
         const clipboardText = await navigator.clipboard.readText();

--- a/packages/javascript/bh-shared-ui/src/views/Explore/ContextMenu/CopyMenuItem.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/Explore/ContextMenu/CopyMenuItem.tsx
@@ -16,40 +16,45 @@
 
 import { faCaretRight } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { MenuItem, Tooltip, TooltipProps, styled, tooltipClasses } from '@mui/material';
+import { Menu, MenuItem } from '@mui/material';
 import { NodeDetails } from 'js-client-library';
+import { KeyboardEvent, MouseEvent, useRef, useState } from 'react';
 import { useExploreSelectedItem } from '../../../hooks';
 import { usePrimaryKind } from '../../../hooks/usePrimaryKind';
 import { useNotifications } from '../../../providers';
 import { escapeCypherString } from '../../../utils/cypher';
 
-export const StyledTooltip = styled(({ className, ...props }: TooltipProps) => (
-    <Tooltip {...props} classes={{ popper: className }} />
-))(({ theme }) => ({
-    [`& .${tooltipClasses.tooltip}`]: {
-        color: theme.palette.text.primary,
-        backgroundColor: theme.palette.background.paper,
-        padding: 0,
-        paddingTop: '0.5rem',
-        paddingBottom: '0.5rem',
-        boxShadow: theme.shadows[8],
-        marginLeft: '2px !important',
-    },
-}));
-
 const CopyMenuItem = () => {
     const { addNotification } = useNotifications();
+    const triggerRef = useRef<HTMLLIElement>(null);
+    const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
 
     const { selectedItemQuery } = useExploreSelectedItem();
     const nodeInfo = selectedItemQuery.data as NodeDetails | undefined;
 
     const primaryKind = usePrimaryKind(nodeInfo?.kinds || []);
 
+    const closeMenu = () => {
+        setAnchorEl(null);
+        requestAnimationFrame(() => triggerRef.current?.focus());
+    };
+
+    const handleOpen = (event: MouseEvent<HTMLElement> | KeyboardEvent<HTMLElement>) => {
+        event.preventDefault();
+        event.stopPropagation();
+        setAnchorEl(event.currentTarget);
+    };
+
+    const handleTriggerKeyDown = (event: KeyboardEvent<HTMLElement>) => {
+        if (event.key === 'ArrowRight' || event.key === 'Enter' || event.key === ' ') handleOpen(event);
+    };
+
     const handleCopyName = () => {
         if (nodeInfo) {
             navigator.clipboard.writeText(nodeInfo.properties.name || nodeInfo.properties.objectid || '');
             addNotification(`Name copied to clipboard`, 'copyToClipboard');
         }
+        closeMenu();
     };
 
     const handleCopyObjectId = () => {
@@ -57,6 +62,7 @@ const CopyMenuItem = () => {
             navigator.clipboard.writeText(nodeInfo.properties.objectid || '');
             addNotification(`Object ID copied to clipboard`, 'copyToClipboard');
         }
+        closeMenu();
     };
 
     const handleCopyCypher = () => {
@@ -65,24 +71,32 @@ const CopyMenuItem = () => {
             navigator.clipboard.writeText(cypher);
             addNotification(`Cypher copied to clipboard`, 'copyToClipboard');
         }
+        closeMenu();
     };
 
     return (
-        <div>
-            <StyledTooltip
-                placement='right'
-                title={
-                    <>
-                        <MenuItem onClick={handleCopyName}>Name</MenuItem>
-                        <MenuItem onClick={handleCopyObjectId}>Object ID</MenuItem>
-                        <MenuItem onClick={handleCopyCypher}>Cypher</MenuItem>
-                    </>
-                }>
-                <MenuItem className='justify-between' onClick={(e) => e.stopPropagation()}>
-                    Copy <FontAwesomeIcon icon={faCaretRight} />
-                </MenuItem>
-            </StyledTooltip>
-        </div>
+        <>
+            <MenuItem
+                ref={triggerRef}
+                className='justify-between'
+                aria-haspopup='menu'
+                aria-expanded={Boolean(anchorEl)}
+                onClick={handleOpen}
+                onKeyDown={handleTriggerKeyDown}>
+                Copy <FontAwesomeIcon icon={faCaretRight} />
+            </MenuItem>
+            <Menu
+                anchorEl={anchorEl}
+                open={Boolean(anchorEl)}
+                onClose={closeMenu}
+                anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
+                transformOrigin={{ vertical: 'top', horizontal: 'left' }}
+                MenuListProps={{ 'aria-label': 'Copy options' }}>
+                <MenuItem onClick={handleCopyName}>Name</MenuItem>
+                <MenuItem onClick={handleCopyObjectId}>Object ID</MenuItem>
+                <MenuItem onClick={handleCopyCypher}>Cypher</MenuItem>
+            </Menu>
+        </>
     );
 };
 

--- a/packages/javascript/bh-shared-ui/src/views/Explore/ContextMenu/CopyMenuItem.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/Explore/ContextMenu/CopyMenuItem.tsx
@@ -91,7 +91,10 @@ const CopyMenuItem = () => {
                 onClose={closeMenu}
                 anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
                 transformOrigin={{ vertical: 'top', horizontal: 'left' }}
-                MenuListProps={{ 'aria-label': 'Copy options' }}>
+                MenuListProps={{
+                    'aria-label': 'Copy options',
+                    onKeyDown: (event) => event.stopPropagation(),
+                }}>
                 <MenuItem onClick={handleCopyName}>Name</MenuItem>
                 <MenuItem onClick={handleCopyObjectId}>Object ID</MenuItem>
                 <MenuItem onClick={handleCopyCypher}>Cypher</MenuItem>

--- a/packages/javascript/bh-shared-ui/src/views/Explore/ContextMenu/CopyMenuItem.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/Explore/ContextMenu/CopyMenuItem.tsx
@@ -93,7 +93,10 @@ const CopyMenuItem = () => {
                 transformOrigin={{ vertical: 'top', horizontal: 'left' }}
                 MenuListProps={{
                     'aria-label': 'Copy options',
-                    onKeyDown: (event) => event.stopPropagation(),
+                    onKeyDown: (event) => {
+                        if (event.key === 'Tab' || event.key === 'Escape') return;
+                        event.stopPropagation();
+                    },
                 }}>
                 <MenuItem onClick={handleCopyName}>Name</MenuItem>
                 <MenuItem onClick={handleCopyObjectId}>Object ID</MenuItem>

--- a/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/fragments.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/fragments.tsx
@@ -72,6 +72,7 @@ export const EditTagButtonLink: FC = () => {
     return (
         <AppLink
             data-testid='privilege-zones_edit-tag-link'
+            aria-label={`Edit ${tagTypeDisplay}`}
             to={tagEditLink(tagId, tagType)}
             className={ButtonVariants({
                 variant: 'secondary',
@@ -94,6 +95,7 @@ export const CreateRuleButtonLink: FC = () => {
     return (
         <AppLink
             data-testid='privilege-zones_create-rule-link'
+            aria-label='Create Rule'
             to={ruleCreateLink(tagId)}
             className={ButtonVariants({
                 variant: 'secondary',
@@ -116,6 +118,7 @@ export const EditRuleButtonLink: FC = () => {
     return (
         <AppLink
             data-testid='privilege-zones_edit-rule-link'
+            aria-label='Edit Rule'
             to={ruleEditLink(tagId, ruleId)}
             className={ButtonVariants({
                 variant: 'secondary',


### PR DESCRIPTION
## Description

This adds keyboard navigation functionality to previously non-functional components.
A skip link component was also added for keyboard users to be able to skip repetitive content. 

## Motivation and Context
Resolves [BED-7220](https://specterops.atlassian.net/browse/BED-7220)

## How Has This Been Tested?

Unit tests were updated and tested manually.

## Screenshots (optional):

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


[BED-7220]: https://specterops.atlassian.net/browse/BED-7220?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility Improvements**
  * Added keyboard-friendly skip links and semantic main-content navigation.
  * Improved accessible labels, focus behavior, and disabled-state handling for file uploads.
  * Enhanced screen-reader descriptions for sortable columns, privilege-zone actions, and decorative tooltip icons.

* **Usability Improvements**
  * Replaced the copy submenu tooltip with a keyboard-accessible menu that restores focus after closing.
  * Added native keyboard activation and clearer upload labels for file controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->