### PR TITLE
fix: display kind handling in primary kind resolution BED-9486

### DIFF
--- a/packages/javascript/bh-shared-ui/src/hooks/usePrimaryKind.test.ts
+++ b/packages/javascript/bh-shared-ui/src/hooks/usePrimaryKind.test.ts
@@ -1,0 +1,107 @@
+// Copyright 2026 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { NodeKindRef } from 'js-client-library';
+import { rest } from 'msw';
+import { setupServer } from 'msw/node';
+import { renderHook, waitFor } from '../test-utils';
+import { usePrimaryKind } from './usePrimaryKind';
+
+// custom_node_kinds rows stand in for extension node kinds flagged is_display_kind, so a kind listed here
+// is treated as a display kind by the hook. The icon name must resolve to a real fas icon or
+// useCustomNodeKinds drops the entry.
+const displayKind = (kindName: string) => ({
+    id: 1,
+    kindName,
+    config: { icon: { type: 'font-awesome', name: 'user', color: '#fff' } },
+});
+
+const mockCustomNodeKinds = (kindNames: string[]) =>
+    rest.get('/api/v2/custom-nodes', (_req, res, ctx) => res(ctx.json({ data: kindNames.map(displayKind) })));
+
+const mockSourceKinds = (kindNames: string[]) =>
+    rest.get('/api/v2/graphs/source-kinds', (_req, res, ctx) =>
+        res(ctx.json({ data: { kinds: kindNames.map((name, id) => ({ id, name })) } }))
+    );
+
+const server = setupServer(mockCustomNodeKinds([]), mockSourceKinds([]));
+
+beforeAll(() => server.listen());
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+// Renders the hook and waits until the custom-nodes/source-kinds queries have resolved so that display-kind
+// prioritization has been applied before we assert on the result.
+const renderPrimaryKind = async (kinds: string[] | NodeKindRef[], expected: string) => {
+    const { result } = renderHook(() => usePrimaryKind(kinds));
+    await waitFor(() => expect(result.current).toBe(expected));
+    return result;
+};
+
+describe('usePrimaryKind', () => {
+    it('returns the display kind when it appears after a non-display kind', async () => {
+        server.use(mockCustomNodeKinds(['DisplayKind']));
+
+        await renderPrimaryKind(['NonDisplayKind', 'DisplayKind'], 'DisplayKind');
+    });
+
+    it('returns the display kind when it appears before a non-display kind', async () => {
+        server.use(mockCustomNodeKinds(['DisplayKind']));
+
+        await renderPrimaryKind(['DisplayKind', 'NonDisplayKind'], 'DisplayKind');
+    });
+
+    it('returns the first display kind when multiple display kinds are present', async () => {
+        server.use(mockCustomNodeKinds(['FirstDisplayKind', 'SecondDisplayKind']));
+
+        await renderPrimaryKind(['NonDisplayKind', 'FirstDisplayKind', 'SecondDisplayKind'], 'FirstDisplayKind');
+    });
+
+    it('falls back to the first non-source, non-tag kind when no display kind is present', async () => {
+        server.use(mockCustomNodeKinds([]));
+
+        await renderPrimaryKind(['FirstKind', 'SecondKind'], 'FirstKind');
+    });
+
+    it('prioritizes a display kind over source and tag kinds regardless of order', async () => {
+        server.use(mockCustomNodeKinds(['DisplayKind']), mockSourceKinds(['SourceKind']));
+
+        await renderPrimaryKind(['SourceKind', 'Tag_MyTag', 'DisplayKind'], 'DisplayKind');
+    });
+
+    it('filters out source and tag kinds before selecting a fallback primary kind', async () => {
+        server.use(mockSourceKinds(['SourceKind']));
+
+        await renderPrimaryKind(['SourceKind', 'Tag_MyTag', 'RemainingKind'], 'RemainingKind');
+    });
+
+    it('falls back to the first raw kind when every kind is filtered out', async () => {
+        server.use(mockSourceKinds(['SourceKind']));
+
+        await renderPrimaryKind(['SourceKind'], 'SourceKind');
+    });
+
+    it('accepts NodeKindRef objects and prioritizes the display kind', async () => {
+        server.use(mockCustomNodeKinds(['DisplayKind']));
+
+        const kinds: NodeKindRef[] = [
+            { node_kind_id: 1, name: 'NonDisplayKind' },
+            { node_kind_id: 2, name: 'DisplayKind' },
+        ];
+
+        await renderPrimaryKind(kinds, 'DisplayKind');
+    });
+});

--- a/packages/javascript/bh-shared-ui/src/hooks/usePrimaryKind.ts
+++ b/packages/javascript/bh-shared-ui/src/hooks/usePrimaryKind.ts
@@ -16,6 +16,7 @@
 
 import { NodeKindRef, RelationshipKindRef, SourceKind } from 'js-client-library';
 import { TagLabelPrefix } from '../constants';
+import { useCustomNodeKinds } from './useCustomNodeKinds';
 import { useSourceKindsQuery } from './useSourceKinds';
 
 type KindNames = string[];
@@ -47,13 +48,25 @@ const filterTagsAndSourceKinds = (kinds: KindNames, sourceKindNames: KindNames) 
 
 export const usePrimaryKind = (kinds: KindList) => {
     const { data: sourceKinds } = useSourceKindsQuery();
+    const { data: customNodeKinds } = useCustomNodeKinds();
+
     const sourceKindNames = getSourceKindNames(sourceKinds);
+
+    // The frontend has no endpoint that surfaces a node kind's is_display_kind flag directly. During schema
+    // reconciliation the backend creates a custom_node_kinds row for exactly those extension node kinds marked
+    // is_display_kind (see upsertCustomIcons), and useCustomNodeKinds keys its result by those kind names.
+    // The set of custom node kind names is therefore a faithful substitute for the set of is_display_kind kinds.
+    const displayKindNames = customNodeKinds ? Object.keys(customNodeKinds) : [];
 
     const kindNames = isKindNames(kinds) ? kinds : kindObjectsToKindNames(kinds);
 
     const sourceAndTagFilteredKinds = filterTagsAndSourceKinds(kindNames, sourceKindNames);
 
-    const primaryKind = sourceAndTagFilteredKinds[0];
+    // A display kind (extension node kind flagged with is_display_kind) takes priority over any
+    // non-display kind regardless of its position in the kinds array.
+    const displayKind = sourceAndTagFilteredKinds.find((kind) => displayKindNames.includes(kind));
+
+    const primaryKind = displayKind ?? sourceAndTagFilteredKinds[0];
 
     return primaryKind ? primaryKind : kindNames[0];
 };


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Handles display kind prioritization in client side primary kind resolution.

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-9486

Display kinds are not being prioritized as expected in client side primary kind resolution.

## How Has This Been Tested?

Kind prioritization tests added.

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed
