### PR TITLE
fix(a11y): update stale locators - BED-9545

### DIFF
--- a/cmd/ui/tests/a11y/Administration/manage-users.a11y.spec.ts
+++ b/cmd/ui/tests/a11y/Administration/manage-users.a11y.spec.ts
@@ -207,7 +207,7 @@ test.describe('Administration - Manage Users - has no detectable WCAG A/AA viola
 
         await page.getByRole('dialog', { name: 'Change Password' }).waitFor({ state: 'visible' });
 
-        await page.getByLabel('New Password', { exact: true }).waitFor({ state: 'visible' });
+        await page.getByRole('textbox', { name: 'New Password', exact: true }).waitFor({ state: 'visible' });
 
         const results = await makeAxeBuilder().include('[data-testid="password-dialog"]').analyze();
 

--- a/cmd/ui/tests/a11y/Shared/quick-upload.a11y.spec.ts
+++ b/cmd/ui/tests/a11y/Shared/quick-upload.a11y.spec.ts
@@ -69,7 +69,9 @@ test.describe('Quick Upload dialog', () => {
 
         const fileChooserPromise = page.waitForEvent('filechooser');
 
-        await dialog.locator('div[role="button"].size-full').click();
+        await dialog
+            .getByRole('button', { name: 'Choose JSON or zip/compressed JSON files to upload', exact: true })
+            .click();
 
         const fileChooser = await fileChooserPromise;
         await fileChooser.setFiles(UPLOAD_FILE);
@@ -125,7 +127,9 @@ test.describe('Quick Upload dialog', () => {
 
         const fileChooserPromise = page.waitForEvent('filechooser');
 
-        await dialog.locator('div[role="button"].size-full').click();
+        await dialog
+            .getByRole('button', { name: 'Choose JSON or zip/compressed JSON files to upload', exact: true })
+            .click();
 
         const fileChooser = await fileChooserPromise;
         await fileChooser.setFiles(UPLOAD_FILE);
@@ -191,7 +195,9 @@ test.describe('Quick Upload dialog', () => {
 
         const fileChooserPromise = page.waitForEvent('filechooser');
 
-        await dialog.locator('div[role="button"].size-full').click();
+        await dialog
+            .getByRole('button', { name: 'Choose JSON or zip/compressed JSON files to upload', exact: true })
+            .click();
 
         const fileChooser = await fileChooserPromise;
         await fileChooser.setFiles(UPLOAD_FILE);


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Updates stale playwright locators in bhce accessibility tests that were timing out.

The changes update:
- The Ccange password dialog password field locator in manage users.
- The file upload button locator used by the quick upload accessibility tests.

## Motivation and Context

Resolves BED-9545

The affected tests were timing out because their locators no longer matched the current UI markup. These updates use the current accessible roles and names instead.


## How Has This Been Tested?

I ran the tests locally. 

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [X] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [X] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [X] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved accessibility test interactions for changing passwords by using the field’s accessible name.
  * Updated Quick Upload accessibility tests to use the dialog’s accessible upload button.
  * Preserved existing test coverage and upload behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->