### PR TITLE
feat: Add Catagory to Saved Queries - BED-9496

### DIFF
--- a/cmd/api/src/api/v2/saved_queries.go
+++ b/cmd/api/src/api/v2/saved_queries.go
@@ -477,7 +477,7 @@ func (s Resources) CreateSavedQuery(response http.ResponseWriter, request *http.
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, err.Error(), request), response)
 	} else if createRequest.Name == "" || createRequest.Query == "" {
 		api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, "the name and/or query field is empty", request), response)
-	} else if savedQuery, err := s.DB.CreateSavedQuery(request.Context(), user.ID, createRequest.Name, createRequest.Query, createRequest.Description, nil, nil); err != nil {
+	} else if savedQuery, err := s.DB.CreateSavedQuery(request.Context(), user.ID, createRequest.Name, createRequest.Query, createRequest.Description, nil, nil, ""); err != nil {
 		if strings.Contains(err.Error(), "duplicate key value violates unique constraint") {
 			api.WriteErrorResponse(request.Context(), api.BuildErrorResponse(http.StatusBadRequest, "duplicate name for saved query: please choose a different name", request), response)
 		} else {

--- a/cmd/api/src/api/v2/saved_queries_test.go
+++ b/cmd/api/src/api/v2/saved_queries_test.go
@@ -189,7 +189,7 @@ func TestResources_CreateSavedQuery_DuplicateName(t *testing.T) {
 
 	req.Header.Set(headers.ContentType.String(), mediatypes.ApplicationJson.String())
 
-	mockDB.EXPECT().CreateSavedQuery(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(model.SavedQuery{}, fmt.Errorf("duplicate key value violates unique constraint \"idx_saved_queries_composite_index\""))
+	mockDB.EXPECT().CreateSavedQuery(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(model.SavedQuery{}, fmt.Errorf("duplicate key value violates unique constraint \"idx_saved_queries_composite_index\""))
 
 	router := mux.NewRouter()
 	router.HandleFunc(endpoint, resources.CreateSavedQuery).Methods("POST")
@@ -232,7 +232,7 @@ func TestResources_CreateSavedQuery_CreateFailure(t *testing.T) {
 
 	req.Header.Set(headers.ContentType.String(), mediatypes.ApplicationJson.String())
 
-	mockDB.EXPECT().CreateSavedQuery(gomock.Any(), userId, payload["name"], payload["query"], payload["description"], gomock.Any(), gomock.Any()).Return(model.SavedQuery{}, fmt.Errorf("foo"))
+	mockDB.EXPECT().CreateSavedQuery(gomock.Any(), userId, payload["name"], payload["query"], payload["description"], gomock.Any(), gomock.Any(), gomock.Any()).Return(model.SavedQuery{}, fmt.Errorf("foo"))
 
 	router := mux.NewRouter()
 	router.HandleFunc(endpoint, resources.CreateSavedQuery).Methods("POST")
@@ -275,11 +275,12 @@ func TestResources_CreateSavedQuery(t *testing.T) {
 
 	req.Header.Set(headers.ContentType.String(), mediatypes.ApplicationJson.String())
 
-	mockDB.EXPECT().CreateSavedQuery(gomock.Any(), userId, payload["name"], payload["query"], payload["description"], gomock.Any(), gomock.Any()).Return(model.SavedQuery{
+	mockDB.EXPECT().CreateSavedQuery(gomock.Any(), userId, payload["name"], payload["query"], payload["description"], gomock.Any(), gomock.Any(), "").Return(model.SavedQuery{
 		UserID:      userId.String(),
 		Name:        fmt.Sprintf("%v", payload["name"]),
 		Query:       fmt.Sprintf("%v", payload["query"]),
 		Description: fmt.Sprintf("%v", payload["description"]),
+		Category:    "extension",
 	}, nil)
 
 	router := mux.NewRouter()

--- a/cmd/api/src/api/v2/saved_queries_test.go
+++ b/cmd/api/src/api/v2/saved_queries_test.go
@@ -189,7 +189,7 @@ func TestResources_CreateSavedQuery_DuplicateName(t *testing.T) {
 
 	req.Header.Set(headers.ContentType.String(), mediatypes.ApplicationJson.String())
 
-	mockDB.EXPECT().CreateSavedQuery(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(model.SavedQuery{}, fmt.Errorf("duplicate key value violates unique constraint \"idx_saved_queries_composite_index\""))
+	mockDB.EXPECT().CreateSavedQuery(gomock.Any(), userId, "myQuery", "Match(n) return n", "", nil, nil, "").Return(model.SavedQuery{}, fmt.Errorf("duplicate key value violates unique constraint \"idx_saved_queries_composite_index\""))
 
 	router := mux.NewRouter()
 	router.HandleFunc(endpoint, resources.CreateSavedQuery).Methods("POST")
@@ -232,7 +232,7 @@ func TestResources_CreateSavedQuery_CreateFailure(t *testing.T) {
 
 	req.Header.Set(headers.ContentType.String(), mediatypes.ApplicationJson.String())
 
-	mockDB.EXPECT().CreateSavedQuery(gomock.Any(), userId, payload["name"], payload["query"], payload["description"], gomock.Any(), gomock.Any(), gomock.Any()).Return(model.SavedQuery{}, fmt.Errorf("foo"))
+	mockDB.EXPECT().CreateSavedQuery(gomock.Any(), userId, "myCustomQuery1", "Match(n) return n", "An example description", nil, nil, "").Return(model.SavedQuery{}, fmt.Errorf("foo"))
 
 	router := mux.NewRouter()
 	router.HandleFunc(endpoint, resources.CreateSavedQuery).Methods("POST")
@@ -275,7 +275,7 @@ func TestResources_CreateSavedQuery(t *testing.T) {
 
 	req.Header.Set(headers.ContentType.String(), mediatypes.ApplicationJson.String())
 
-	mockDB.EXPECT().CreateSavedQuery(gomock.Any(), userId, payload["name"], payload["query"], payload["description"], gomock.Any(), gomock.Any(), "").Return(model.SavedQuery{
+	mockDB.EXPECT().CreateSavedQuery(gomock.Any(), userId, "myCustomQuery1", "Match(n) return n", "An example description", nil, nil, "").Return(model.SavedQuery{
 		UserID:      userId.String(),
 		Name:        fmt.Sprintf("%v", payload["name"]),
 		Query:       fmt.Sprintf("%v", payload["query"]),

--- a/cmd/api/src/database/migration/migrations/20260901110807_v9_add_schema_extension_id_to_saved_queries.sql
+++ b/cmd/api/src/database/migration/migrations/20260901110807_v9_add_schema_extension_id_to_saved_queries.sql
@@ -22,7 +22,8 @@ ALTER TABLE saved_queries
             (schema_extension_id IS NULL AND query_key IS NULL AND user_id <> '00000000-0000-0000-0000-000000000000')
             OR
             (schema_extension_id IS NOT NULL AND query_key IS NOT NULL AND user_id = '00000000-0000-0000-0000-000000000000')
-        );
+        ),
+    ADD COLUMN IF NOT EXISTS category TEXT NOT NULL DEFAULT '';
 
 CREATE INDEX IF NOT EXISTS idx_saved_queries_schema_extension_id
     ON saved_queries (schema_extension_id) WHERE schema_extension_id IS NOT NULL;
@@ -53,5 +54,6 @@ DROP INDEX IF EXISTS idx_saved_queries_schema_extension_id;
 DROP INDEX IF EXISTS idx_saved_queries_extension_query_key;
 
 ALTER TABLE saved_queries
+    DROP COLUMN IF EXISTS category,
     DROP COLUMN IF EXISTS query_key,
     DROP COLUMN IF EXISTS schema_extension_id;

--- a/cmd/api/src/database/mocks/db.go
+++ b/cmd/api/src/database/mocks/db.go
@@ -611,18 +611,18 @@ func (mr *MockDatabaseMockRecorder) CreateSavedQueries(ctx, savedQueries any) *g
 }
 
 // CreateSavedQuery mocks base method.
-func (m *MockDatabase) CreateSavedQuery(ctx context.Context, userID uuid.UUID, name, query, description string, schemaExtensionID *int32, queryKey *string) (model.SavedQuery, error) {
+func (m *MockDatabase) CreateSavedQuery(ctx context.Context, userID uuid.UUID, name, query, description string, schemaExtensionID *int32, queryKey *string, category string) (model.SavedQuery, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateSavedQuery", ctx, userID, name, query, description, schemaExtensionID, queryKey)
+	ret := m.ctrl.Call(m, "CreateSavedQuery", ctx, userID, name, query, description, schemaExtensionID, queryKey, category)
 	ret0, _ := ret[0].(model.SavedQuery)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateSavedQuery indicates an expected call of CreateSavedQuery.
-func (mr *MockDatabaseMockRecorder) CreateSavedQuery(ctx, userID, name, query, description, schemaExtensionID, queryKey any) *gomock.Call {
+func (mr *MockDatabaseMockRecorder) CreateSavedQuery(ctx, userID, name, query, description, schemaExtensionID, queryKey, category any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSavedQuery", reflect.TypeOf((*MockDatabase)(nil).CreateSavedQuery), ctx, userID, name, query, description, schemaExtensionID, queryKey)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSavedQuery", reflect.TypeOf((*MockDatabase)(nil).CreateSavedQuery), ctx, userID, name, query, description, schemaExtensionID, queryKey, category)
 }
 
 // CreateSavedQueryPermissionToPublic mocks base method.

--- a/cmd/api/src/database/saved_queries.go
+++ b/cmd/api/src/database/saved_queries.go
@@ -30,7 +30,7 @@ import (
 type SavedQueriesData interface {
 	GetSavedQuery(ctx context.Context, savedQueryID int64) (model.SavedQuery, error)
 	ListSavedQueries(ctx context.Context, scope string, userID uuid.UUID, order string, filter model.SQLFilter, skip, limit int) ([]model.ScopedSavedQuery, int, error)
-	CreateSavedQuery(ctx context.Context, userID uuid.UUID, name string, query string, description string, schemaExtensionID *int32, queryKey *string) (model.SavedQuery, error)
+	CreateSavedQuery(ctx context.Context, userID uuid.UUID, name string, query string, description string, schemaExtensionID *int32, queryKey *string, category string) (model.SavedQuery, error)
 	UpdateSavedQuery(ctx context.Context, savedQuery model.SavedQuery) (model.SavedQuery, error)
 	DeleteSavedQuery(ctx context.Context, savedQueryID int64) error
 	SavedQueryBelongsToUser(ctx context.Context, userID uuid.UUID, savedQueryID int64) (bool, error)
@@ -97,12 +97,13 @@ func (s *BloodhoundDB) ListSavedQueries(ctx context.Context, scope string, userI
 	return queries, int(count), CheckError(result)
 }
 
-func (s *BloodhoundDB) CreateSavedQuery(ctx context.Context, userID uuid.UUID, name string, query string, description string, schemaExtensionID *int32, queryKey *string) (model.SavedQuery, error) {
+func (s *BloodhoundDB) CreateSavedQuery(ctx context.Context, userID uuid.UUID, name string, query string, description string, schemaExtensionID *int32, queryKey *string, category string) (model.SavedQuery, error) {
 	savedQuery := model.SavedQuery{
 		UserID:            userID.String(),
 		Name:              name,
 		Query:             query,
 		Description:       description,
+		Category:          category,
 		SchemaExtensionID: schemaExtensionID,
 		QueryKey:          queryKey,
 	}

--- a/cmd/api/src/database/saved_queries_integration_test.go
+++ b/cmd/api/src/database/saved_queries_integration_test.go
@@ -52,7 +52,7 @@ func TestSavedQueries_ListSavedQueries(t *testing.T) {
 	require.Nil(t, err)
 
 	for i := 0; i < 7; i++ {
-		if _, err := dbInst.CreateSavedQuery(testCtx, userUUID, fmt.Sprintf("saved_query_%d", i), "", "", nil, nil); err != nil {
+		if _, err := dbInst.CreateSavedQuery(testCtx, userUUID, fmt.Sprintf("saved_query_%d", i), "", "", nil, nil, ""); err != nil {
 			t.Fatalf("Error creating audit log: %v", err)
 		}
 	}
@@ -100,6 +100,7 @@ func TestSavedQueries_CreateSavedQuery(t *testing.T) {
 		description       string
 		schemaExtensionID *int32
 		queryKey          *string
+		category          string
 	}
 	type testCase struct {
 		name     string
@@ -114,7 +115,7 @@ func TestSavedQueries_CreateSavedQuery(t *testing.T) {
 
 	tests := []testCase{
 		{
-			name: "success_-_extension_and_query_key_persist",
+			name: "success_-_create_extension_query",
 			setup: func(t *testing.T, suite IntegrationTestSuite) testSetupData {
 				t.Helper()
 				ext, err := suite.BHDatabase.CreateGraphSchemaExtension(suite.Context, "CreateSQPersistExt", "Create SQ Persist Ext", "v1.0.0", "create_sq_persist_ns")
@@ -125,19 +126,22 @@ func TestSavedQueries_CreateSavedQuery(t *testing.T) {
 					description:       "desc",
 					schemaExtensionID: &ext.ID,
 					queryKey:          stringPtr("ext_query_key"),
+					category:          "extension",
 				}
 			},
 			assert: func(t *testing.T, suite IntegrationTestSuite, setupData testSetupData) model.SavedQuery {
 				t.Helper()
-				created, err := suite.BHDatabase.CreateSavedQuery(suite.Context, uuid.Nil, setupData.name, setupData.query, setupData.description, setupData.schemaExtensionID, setupData.queryKey)
+				created, err := suite.BHDatabase.CreateSavedQuery(suite.Context, uuid.Nil, setupData.name, setupData.query, setupData.description, setupData.schemaExtensionID, setupData.queryKey, setupData.category)
 				require.NoError(t, err)
 				assert.Equal(t, setupData.schemaExtensionID, created.SchemaExtensionID)
 				assert.Equal(t, setupData.queryKey, created.QueryKey)
+				assert.Equal(t, setupData.category, created.Category)
 
 				fetched, err := suite.BHDatabase.GetSavedQuery(suite.Context, created.ID)
 				require.NoError(t, err)
 				assert.Equal(t, setupData.schemaExtensionID, fetched.SchemaExtensionID)
 				assert.Equal(t, setupData.queryKey, fetched.QueryKey)
+				assert.Equal(t, setupData.category, fetched.Category)
 				return created
 			},
 			teardown: func(t *testing.T, suite IntegrationTestSuite, setupData testSetupData, created model.SavedQuery) {
@@ -146,26 +150,29 @@ func TestSavedQueries_CreateSavedQuery(t *testing.T) {
 			},
 		},
 		{
-			name: "success_-_no_extension_or_query_key_persists_as_null",
+			name: "success_-_create_user_query",
 			setup: func(t *testing.T, suite IntegrationTestSuite) testSetupData {
 				t.Helper()
 				return testSetupData{
 					name:        "user_query",
 					query:       "MATCH (n) RETURN n",
 					description: "desc",
+					category:    "",
 				}
 			},
 			assert: func(t *testing.T, suite IntegrationTestSuite, setupData testSetupData) model.SavedQuery {
 				t.Helper()
-				created, err := suite.BHDatabase.CreateSavedQuery(suite.Context, userUUID, setupData.name, setupData.query, setupData.description, setupData.schemaExtensionID, setupData.queryKey)
+				created, err := suite.BHDatabase.CreateSavedQuery(suite.Context, userUUID, setupData.name, setupData.query, setupData.description, setupData.schemaExtensionID, setupData.queryKey, setupData.category)
 				require.NoError(t, err)
 				assert.Nil(t, created.SchemaExtensionID)
 				assert.Nil(t, created.QueryKey)
+				assert.Equal(t, setupData.category, created.Category)
 
 				fetched, err := suite.BHDatabase.GetSavedQuery(suite.Context, created.ID)
 				require.NoError(t, err)
 				assert.Nil(t, fetched.SchemaExtensionID)
 				assert.Nil(t, fetched.QueryKey)
+				assert.Equal(t, setupData.category, fetched.Category)
 				return created
 			},
 			teardown: func(t *testing.T, suite IntegrationTestSuite, setupData testSetupData, created model.SavedQuery) {
@@ -189,7 +196,7 @@ func TestSavedQueries_CreateSavedQuery(t *testing.T) {
 			},
 			assert: func(t *testing.T, suite IntegrationTestSuite, setupData testSetupData) model.SavedQuery {
 				t.Helper()
-				created, err := suite.BHDatabase.CreateSavedQuery(suite.Context, uuid.Nil, setupData.name, setupData.query, setupData.description, setupData.schemaExtensionID, setupData.queryKey)
+				created, err := suite.BHDatabase.CreateSavedQuery(suite.Context, uuid.Nil, setupData.name, setupData.query, setupData.description, setupData.schemaExtensionID, setupData.queryKey, setupData.category)
 				require.NoError(t, err)
 				require.NoError(t, suite.BHDatabase.DeleteGraphSchemaExtension(suite.Context, *setupData.schemaExtensionID))
 
@@ -217,7 +224,7 @@ func TestSavedQueries_CreateSavedQuery(t *testing.T) {
 			},
 			assert: func(t *testing.T, suite IntegrationTestSuite, setupData testSetupData) model.SavedQuery {
 				t.Helper()
-				created, err := suite.BHDatabase.CreateSavedQuery(suite.Context, uuid.Nil, setupData.name, setupData.query, setupData.description, setupData.schemaExtensionID, setupData.queryKey)
+				created, err := suite.BHDatabase.CreateSavedQuery(suite.Context, uuid.Nil, setupData.name, setupData.query, setupData.description, setupData.schemaExtensionID, setupData.queryKey, setupData.category)
 				assertSavedQueryConstraintError(t, err, "chk_saved_queries_extension_shape")
 				return created
 			},
@@ -239,7 +246,7 @@ func TestSavedQueries_CreateSavedQuery(t *testing.T) {
 			},
 			assert: func(t *testing.T, suite IntegrationTestSuite, setupData testSetupData) model.SavedQuery {
 				t.Helper()
-				created, err := suite.BHDatabase.CreateSavedQuery(suite.Context, userUUID, setupData.name, setupData.query, setupData.description, setupData.schemaExtensionID, setupData.queryKey)
+				created, err := suite.BHDatabase.CreateSavedQuery(suite.Context, userUUID, setupData.name, setupData.query, setupData.description, setupData.schemaExtensionID, setupData.queryKey, setupData.category)
 				assertSavedQueryConstraintError(t, err, "chk_saved_queries_extension_shape")
 				return created
 			},
@@ -253,7 +260,7 @@ func TestSavedQueries_CreateSavedQuery(t *testing.T) {
 			setup: func(t *testing.T, suite IntegrationTestSuite) testSetupData {
 				t.Helper()
 				name := "duplicate_user_name"
-				savedQuery, err := suite.BHDatabase.CreateSavedQuery(suite.Context, userUUID, name, "MATCH (n) RETURN n", "desc", nil, nil)
+				savedQuery, err := suite.BHDatabase.CreateSavedQuery(suite.Context, userUUID, name, "MATCH (n) RETURN n", "desc", nil, nil, "")
 				require.NoError(t, err)
 				return testSetupData{
 					name:         name,
@@ -264,7 +271,7 @@ func TestSavedQueries_CreateSavedQuery(t *testing.T) {
 			},
 			assert: func(t *testing.T, suite IntegrationTestSuite, setupData testSetupData) model.SavedQuery {
 				t.Helper()
-				created, err := suite.BHDatabase.CreateSavedQuery(suite.Context, userUUID, setupData.name, setupData.query, setupData.description, nil, nil)
+				created, err := suite.BHDatabase.CreateSavedQuery(suite.Context, userUUID, setupData.name, setupData.query, setupData.description, nil, nil, setupData.category)
 				assertSavedQueryConstraintError(t, err, "idx_saved_queries_user_id_name")
 				return created
 			},
@@ -281,7 +288,7 @@ func TestSavedQueries_CreateSavedQuery(t *testing.T) {
 				require.NoError(t, err)
 
 				name := "duplicate_extension_name"
-				_, err = suite.BHDatabase.CreateSavedQuery(suite.Context, uuid.Nil, name, "MATCH (n) RETURN n", "desc", &ext.ID, stringPtr("first"))
+				_, err = suite.BHDatabase.CreateSavedQuery(suite.Context, uuid.Nil, name, "MATCH (n) RETURN n", "desc", &ext.ID, stringPtr("first"), "")
 				require.NoError(t, err)
 
 				return testSetupData{
@@ -294,7 +301,7 @@ func TestSavedQueries_CreateSavedQuery(t *testing.T) {
 			},
 			assert: func(t *testing.T, suite IntegrationTestSuite, setupData testSetupData) model.SavedQuery {
 				t.Helper()
-				created, err := suite.BHDatabase.CreateSavedQuery(suite.Context, uuid.Nil, setupData.name, setupData.query, setupData.description, setupData.schemaExtensionID, setupData.queryKey)
+				created, err := suite.BHDatabase.CreateSavedQuery(suite.Context, uuid.Nil, setupData.name, setupData.query, setupData.description, setupData.schemaExtensionID, setupData.queryKey, setupData.category)
 				assertSavedQueryConstraintError(t, err, "idx_saved_queries_schema_extension_id_name")
 				return created
 			},
@@ -310,7 +317,7 @@ func TestSavedQueries_CreateSavedQuery(t *testing.T) {
 				ext, err := suite.BHDatabase.CreateGraphSchemaExtension(suite.Context, "DupKeyExt", "Dup Key Ext", "v1.0.0", "dup_key_ns")
 				require.NoError(t, err)
 
-				_, err = suite.BHDatabase.CreateSavedQuery(suite.Context, uuid.Nil, "dup_first", "MATCH (n) RETURN n", "desc", &ext.ID, stringPtr("dup"))
+				_, err = suite.BHDatabase.CreateSavedQuery(suite.Context, uuid.Nil, "dup_first", "MATCH (n) RETURN n", "desc", &ext.ID, stringPtr("dup"), "")
 				require.NoError(t, err)
 
 				return testSetupData{
@@ -323,7 +330,7 @@ func TestSavedQueries_CreateSavedQuery(t *testing.T) {
 			},
 			assert: func(t *testing.T, suite IntegrationTestSuite, setupData testSetupData) model.SavedQuery {
 				t.Helper()
-				created, err := suite.BHDatabase.CreateSavedQuery(suite.Context, uuid.Nil, setupData.name, setupData.query, setupData.description, setupData.schemaExtensionID, setupData.queryKey)
+				created, err := suite.BHDatabase.CreateSavedQuery(suite.Context, uuid.Nil, setupData.name, setupData.query, setupData.description, setupData.schemaExtensionID, setupData.queryKey, setupData.category)
 				assertSavedQueryConstraintError(t, err, "idx_saved_queries_extension_query_key")
 				return created
 			},
@@ -348,7 +355,7 @@ func TestSavedQueries_CreateSavedQuery(t *testing.T) {
 			},
 			assert: func(t *testing.T, suite IntegrationTestSuite, setupData testSetupData) model.SavedQuery {
 				t.Helper()
-				created, err := suite.BHDatabase.CreateSavedQuery(suite.Context, userUUID, setupData.name, setupData.query, setupData.description, setupData.schemaExtensionID, setupData.queryKey)
+				created, err := suite.BHDatabase.CreateSavedQuery(suite.Context, userUUID, setupData.name, setupData.query, setupData.description, setupData.schemaExtensionID, setupData.queryKey, setupData.category)
 				assertSavedQueryConstraintError(t, err, "chk_saved_queries_extension_shape")
 				return created
 			},
@@ -369,7 +376,7 @@ func TestSavedQueries_CreateSavedQuery(t *testing.T) {
 			},
 			assert: func(t *testing.T, suite IntegrationTestSuite, setupData testSetupData) model.SavedQuery {
 				t.Helper()
-				created, err := suite.BHDatabase.CreateSavedQuery(suite.Context, uuid.Nil, setupData.name, setupData.query, setupData.description, setupData.schemaExtensionID, setupData.queryKey)
+				created, err := suite.BHDatabase.CreateSavedQuery(suite.Context, uuid.Nil, setupData.name, setupData.query, setupData.description, setupData.schemaExtensionID, setupData.queryKey, setupData.category)
 				assertSavedQueryConstraintError(t, err, "chk_saved_queries_extension_shape")
 				return created
 			},

--- a/cmd/api/src/database/saved_queries_permissions_integration_test.go
+++ b/cmd/api/src/database/saved_queries_permissions_integration_test.go
@@ -40,7 +40,7 @@ func TestSavedQueriesPermissions_CreateSavedQueryPermissionToPublic(t *testing.T
 	)
 
 	t.Run("Creates saved query permission to public", func(t *testing.T) {
-		query, err := dbInst.CreateSavedQuery(testCtx, user.ID, "Test Query", "TESTING", "Example", nil, nil)
+		query, err := dbInst.CreateSavedQuery(testCtx, user.ID, "Test Query", "TESTING", "Example", nil, nil, "")
 		require.NoError(t, err)
 
 		_, err = dbInst.CreateSavedQueryPermissionToPublic(testCtx, query.ID)
@@ -56,7 +56,7 @@ func TestSavedQueriesPermissions_CreateSavedQueryPermissionToPublic(t *testing.T
 	})
 
 	t.Run("Creates saved query permission to public while deleting previous user's shared query permission", func(t *testing.T) {
-		query, err := dbInst.CreateSavedQuery(testCtx, user.ID, "Test Query2", "TESTING2", "Example2", nil, nil)
+		query, err := dbInst.CreateSavedQuery(testCtx, user.ID, "Test Query2", "TESTING2", "Example2", nil, nil, "")
 		require.NoError(t, err)
 
 		_, err = dbInst.CreateSavedQueryPermissionsToUsers(testCtx, query.ID, user2.ID)
@@ -93,7 +93,7 @@ func TestSavedQueriesPermissions_CreateSavedQueryPermissionsToUsers(t *testing.T
 		user4   = createUser(t, dbInst, user4Principal)
 	)
 
-	query, err := dbInst.CreateSavedQuery(testCtx, user1.ID, "Test Query", "TESTING", "Example", nil, nil)
+	query, err := dbInst.CreateSavedQuery(testCtx, user1.ID, "Test Query", "TESTING", "Example", nil, nil, "")
 	require.NoError(t, err)
 
 	// Share with Users 2 and 3 and ensure its not shared with user 4
@@ -163,7 +163,7 @@ func TestSavedQueriesPermissions_CreateSavedQueryPermissionsBatchBadDataError(t 
 
 	unknownUUID, _ := uuid.NewV4()
 
-	query, err := dbInst.CreateSavedQuery(testCtx, user1.ID, "Test Query", "TESTING", "Example", nil, nil)
+	query, err := dbInst.CreateSavedQuery(testCtx, user1.ID, "Test Query", "TESTING", "Example", nil, nil, "")
 	require.NoError(t, err)
 
 	_, err = dbInst.CreateSavedQueryPermissionsToUsers(testCtx, query.ID, user2.ID, unknownUUID)
@@ -195,7 +195,7 @@ func TestSavedQueriesPermissions_GetScopeForSavedQueryPublic(t *testing.T) {
 		user2   = createUser(t, dbInst, user2Principal)
 	)
 
-	query, err := dbInst.CreateSavedQuery(testCtx, user2.ID, "Test Query", "TESTING", "Example", nil, nil)
+	query, err := dbInst.CreateSavedQuery(testCtx, user2.ID, "Test Query", "TESTING", "Example", nil, nil, "")
 	require.NoError(t, err)
 
 	_, err = dbInst.CreateSavedQueryPermissionToPublic(testCtx, query.ID)
@@ -219,7 +219,7 @@ func TestSavedQueriesPermissions_GetScopeForSavedQueryShared(t *testing.T) {
 		user2   = createUser(t, dbInst, user2Principal)
 	)
 
-	query, err := dbInst.CreateSavedQuery(testCtx, user2.ID, "Test Query", "TESTING", "Example", nil, nil)
+	query, err := dbInst.CreateSavedQuery(testCtx, user2.ID, "Test Query", "TESTING", "Example", nil, nil, "")
 	require.NoError(t, err)
 
 	_, err = dbInst.CreateSavedQueryPermissionsToUsers(testCtx, query.ID, user1.ID)
@@ -243,7 +243,7 @@ func TestSavedQueriesPermissions_GetScopeForSavedQueryOwned(t *testing.T) {
 		user2   = createUser(t, dbInst, user2Principal)
 	)
 
-	query, err := dbInst.CreateSavedQuery(testCtx, user1.ID, "Test Query", "TESTING", "Example", nil, nil)
+	query, err := dbInst.CreateSavedQuery(testCtx, user1.ID, "Test Query", "TESTING", "Example", nil, nil, "")
 	require.NoError(t, err)
 
 	_, err = dbInst.CreateSavedQueryPermissionsToUsers(testCtx, query.ID, user2.ID)
@@ -269,7 +269,7 @@ func TestSavedQueriesPermissions_DeleteSavedQueryPermissionsForUsers(t *testing.
 	)
 
 	t.Run("Deletes saved query permissions for user(s)", func(t *testing.T) {
-		query, err := dbInst.CreateSavedQuery(testCtx, user1.ID, "Test Query", "TESTING", "Example", nil, nil)
+		query, err := dbInst.CreateSavedQuery(testCtx, user1.ID, "Test Query", "TESTING", "Example", nil, nil, "")
 		require.NoError(t, err)
 
 		_, err = dbInst.CreateSavedQueryPermissionsToUsers(testCtx, query.ID, user2.ID, user3.ID)
@@ -312,7 +312,7 @@ func TestSavedQueriesPermissions_DeleteSavedQueryPermissionsForUsers(t *testing.
 	})
 
 	t.Run("Deletes saved query permissions given no provided users", func(t *testing.T) {
-		query, err := dbInst.CreateSavedQuery(testCtx, user1.ID, "Test Query2", "TESTING2", "Example2", nil, nil)
+		query, err := dbInst.CreateSavedQuery(testCtx, user1.ID, "Test Query2", "TESTING2", "Example2", nil, nil, "")
 		require.NoError(t, err)
 
 		_, err = dbInst.CreateSavedQueryPermissionsToUsers(testCtx, query.ID, user2.ID)
@@ -345,7 +345,7 @@ func TestSavedQueriesPermissions_IsSavedQueryPublic(t *testing.T) {
 		dbInst, user1 = initAndCreateUser(t)
 	)
 
-	query, err := dbInst.CreateSavedQuery(testCtx, user1.ID, "Test Query", "TESTING", "Example", nil, nil)
+	query, err := dbInst.CreateSavedQuery(testCtx, user1.ID, "Test Query", "TESTING", "Example", nil, nil, "")
 	require.NoError(t, err)
 
 	_, err = dbInst.CreateSavedQueryPermissionToPublic(testCtx, query.ID)
@@ -362,7 +362,7 @@ func TestSavedQueriesPermissions_IsSavedQuerySharedToUser(t *testing.T) {
 		dbInst, user1 = initAndCreateUser(t)
 	)
 
-	query, err := dbInst.CreateSavedQuery(testCtx, user1.ID, "Test Query", "TESTING", "Example", nil, nil)
+	query, err := dbInst.CreateSavedQuery(testCtx, user1.ID, "Test Query", "TESTING", "Example", nil, nil, "")
 	require.NoError(t, err)
 
 	_, err = dbInst.CreateSavedQueryPermissionsToUsers(testCtx, query.ID, user1.ID)
@@ -391,7 +391,7 @@ func TestSavedQueriesPermissions_GetSavedQueryPermissions(t *testing.T) {
 		}}
 	)
 
-	query, err := dbInst.CreateSavedQuery(testCtx, user1.ID, "Test Query", "TESTING", "Test Description", nil, nil)
+	query, err := dbInst.CreateSavedQuery(testCtx, user1.ID, "Test Query", "TESTING", "Test Description", nil, nil, "")
 	require.NoError(t, err)
 	_, err = dbInst.CreateSavedQueryPermissionsToUsers(testCtx, query.ID, user2.ID)
 	require.NoError(t, err)

--- a/cmd/api/src/model/saved_queries.go
+++ b/cmd/api/src/model/saved_queries.go
@@ -25,6 +25,7 @@ type SavedQuery struct {
 	Name              string  `json:"name" gorm:"index:,unique,composite:compositeIndex"`
 	Query             string  `json:"query"`
 	Description       string  `json:"description"`
+	Category          string  `json:"-" gorm:"column:category"`
 	SchemaExtensionID *int32  `json:"-" gorm:"column:schema_extension_id;index:,unique,composite:compositeIndex;index:,unique,composite:extensionQueryKey"`
 	QueryKey          *string `json:"-" gorm:"column:query_key;index:,unique,composite:extensionQueryKey"`
 	BigSerial


### PR DESCRIPTION
## Description

- Adds category to saved queries model and tables. 
- Updates integration tests to fill and test for category

## Motivation and Context
Resolves: BED-9496

A category field/column is needed to allow for easy organization of saved queries. 

## How Has This Been Tested?

Tested locally to ensure migration works as expected. 
Adds new integration tests to ensure column gets populated as expected. 

## Types of changes
- New feature (non-breaking change which adds functionality)
- Database Migrations

## Checklist:
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Saved queries now support category metadata.
  * Categories are retained when creating and retrieving saved queries.
* **Bug Fixes**
  * Updated saved-query creation and permission handling to consistently preserve category information.
* **Tests**
  * Expanded coverage to verify category persistence alongside existing validation, ownership, duplication, and cascade behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->