### PR TITLE
chore: add migration to default support bundle and artifact cleanup - BED-9554

### DIFF
--- a/cmd/api/src/database/migration/migrations/20260901134902_v9_enable_support_bundle_and_artifact_expiration_cleanup.sql
+++ b/cmd/api/src/database/migration/migrations/20260901134902_v9_enable_support_bundle_and_artifact_expiration_cleanup.sql
@@ -1,3 +1,18 @@
+-- Copyright 2026 Specter Ops, Inc.
+--
+-- Licensed under the Apache License, Version 2.0
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- SPDX-License-Identifier: Apache-2.0
 -- +goose Up
 UPDATE feature_flags
 SET enabled = TRUE

--- a/cmd/api/src/database/migration/migrations/20260901134902_v9_enable_support_bundle_and_artifact_expiration_cleanup.sql
+++ b/cmd/api/src/database/migration/migrations/20260901134902_v9_enable_support_bundle_and_artifact_expiration_cleanup.sql
@@ -1,0 +1,13 @@
+-- +goose Up
+UPDATE feature_flags
+SET enabled = TRUE
+WHERE
+  key = 'collector_support_bundle'
+  OR key = 'artifact_expiration_cleanup';
+
+-- +goose Down
+UPDATE feature_flags
+SET enabled = FALSE
+WHERE
+  key = 'collector_support_bundle'
+  OR key = 'artifact_expiration_cleanup';


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

This PR defaults the feature flags `collector_support_bundle` and `artifact_expiration_cleanup` to enabled. This done for the support bundle functionality release. 

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-9554

## How Has This Been Tested?

This has been tested by running the application and ensuring the migration runs, and the expected outcome takes place. 

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)
- Database Migrations

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled support bundle collection.
  * Enabled automatic cleanup of expired artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->