### PR TITLE
fix: Color token changes for correct contrast - BED-9563

### DIFF
--- a/packages/javascript/bh-shared-ui/src/views/Explore/ExploreSearch/PathfindingSearch.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/Explore/ExploreSearch/PathfindingSearch.tsx
@@ -164,7 +164,7 @@ const PathfindingSearch = ({
                                         handleReorderNodes(index, index + 1);
                                     }
                                 }}
-                                className='cursor-grab text-neutral-400 hover:text-neutral-600 dark:text-common-white dark:hover:text-neutral-light-5 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition-opacity'>
+                                className='cursor-grab text-light hover:text-main dark:text-common-white dark:hover:text-neutral-light-5 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition-opacity'>
                                 <FontAwesomeIcon icon={faGripVertical} size='sm' />
                             </div>
                             <div
@@ -187,7 +187,7 @@ const PathfindingSearch = ({
                             {node.removable && (
                                 <button
                                     onClick={() => handleRemoveNode(index)}
-                                    className='absolute right-1 top-1/2 -translate-y-1/2 p-1 text-neutral-500 hover:text-neutral-700 dark:text-common-white dark:hover:text-neutral-light-5 z-10'
+                                    className='absolute right-1 top-1/2 -translate-y-1/2 p-1 text-light hover:text-main dark:text-common-white dark:hover:text-neutral-light-5 z-10'
                                     aria-label={`Remove ${node.ariaLabel}`}
                                     title={`Remove ${node.ariaLabel}`}>
                                     <FontAwesomeIcon icon={faTimes} size='sm' />
@@ -199,7 +199,7 @@ const PathfindingSearch = ({
                 {totalNodeCount < maxNodes && (
                     <button
                         onClick={handleAddNode}
-                        className='flex items-center gap-1.5 ml-4 text-xs text-neutral-500 hover:text-neutral-700 dark:text-common-white dark:hover:text-neutral-light-5 py-0.5 cursor-pointer'
+                        className='flex items-center gap-1.5 ml-4 text-xs text-light hover:text-main dark:text-common-white dark:hover:text-neutral-light-5 py-0.5 cursor-pointer'
                         aria-label='Add destination'>
                         <FontAwesomeIcon icon={faPlus} size='xs' />
                         <span>Add Destination</span>


### PR DESCRIPTION
## Description

Current light-theme contrast does not meet WCAG AA 4.5:1 for the "X", "Add Destination", and drag and drop icons introduced by multi-destination pathfinding. This addresses that by swapping text-neutral to text-light / text-main.

Small change from text-neutral to text-light / text-main on the previously mentioned elements to enhance contrast and meet WCAG AA requirements.

## Motivation and Context

Resolves [BED-9546](https://specterops.atlassian.net/browse/BED-9546)

*Why is this change required? What problem does it solve?*

## How Has This Been Tested?

Tested locally in CE

## Screenshots (optional):

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


[BED-9546]: https://specterops.atlassian.net/browse/BED-9546?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ