### PR TITLE
chore(alerts): update openAPI docs for `retry` endpoint

### DIFF
--- a/packages/go/openapi/doc/openapi.json
+++ b/packages/go/openapi/doc/openapi.json
@@ -22510,7 +22510,7 @@
       "post": {
         "operationId": "RetryAlertAttempt",
         "summary": "Retry Alert Attempt",
-        "description": "Manually re-queues an existing alert delivery attempt. The composite key\nin the request body identifies the specific attempt (alert, event, channel/webhook) to retry. The attempt is ignored\nwhen the attempt has already succeeded, or when the alert, event, or channel/webhook is disabled.\n",
+        "description": "Manually re-queues an existing alert delivery attempt. The composite key\nin the request body identifies the specific attempt (alert, event, channel/webhook) to retry. The attempt is ignored\nwhen the attempt has already succeeded, or when the alert, subscription, or channel/webhook is disabled.\n",
         "tags": [
           "Alerts",
           "Enterprise"
@@ -22521,7 +22521,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "description": "Request body for manually re-queueing an alert delivery attempt. The supplied\ncomposite key identifies the row to retry; the handler is a no-op when the\nattempt has already succeeded (`succeeded_at IS NOT NULL`) or when the alert, event, or channel/webhook is disabled.\n",
+                "description": "Request body for manually re-queueing an alert delivery attempt. The supplied\ncomposite key identifies the row to retry; the handler is a no-op when the\nattempt has already succeeded (`succeeded_at IS NOT NULL`) or when the alert, subscription, or channel/webhook is disabled.\n",
                 "required": [
                   "alert_id",
                   "channel_id",

--- a/packages/go/openapi/doc/openapi.json
+++ b/packages/go/openapi/doc/openapi.json
@@ -22510,7 +22510,7 @@
       "post": {
         "operationId": "RetryAlertAttempt",
         "summary": "Retry Alert Attempt",
-        "description": "Manually re-queues an existing alert delivery attempt. The composite key\nin the request body identifies the specific attempt (alert, event, channel/webhook) to retry. The attempt is ignored\nwhen the attempt has already succeeded.\n",
+        "description": "Manually re-queues an existing alert delivery attempt. The composite key\nin the request body identifies the specific attempt (alert, event, channel/webhook) to retry. The attempt is ignored\nwhen the attempt has already succeeded, or when the alert, event, or channel/webhook are disabled.\n",
         "tags": [
           "Alerts",
           "Enterprise"

--- a/packages/go/openapi/doc/openapi.json
+++ b/packages/go/openapi/doc/openapi.json
@@ -22510,7 +22510,7 @@
       "post": {
         "operationId": "RetryAlertAttempt",
         "summary": "Retry Alert Attempt",
-        "description": "Manually re-queues an existing alert delivery attempt. The composite key\nin the request body identifies the specific attempt (alert, event, channel/webhook) to retry. The attempt is ignored\nwhen the attempt has already succeeded, or when the alert, event, or channel/webhook are disabled.\n",
+        "description": "Manually re-queues an existing alert delivery attempt. The composite key\nin the request body identifies the specific attempt (alert, event, channel/webhook) to retry. The attempt is ignored\nwhen the attempt has already succeeded, or when the alert, event, or channel/webhook is disabled.\n",
         "tags": [
           "Alerts",
           "Enterprise"
@@ -22521,7 +22521,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "description": "Request body for manually re-queueing an alert delivery attempt. The supplied\ncomposite key identifies the row to retry; the handler is a no-op when the\nattempt has already succeeded (`succeeded_at IS NOT NULL`).\n",
+                "description": "Request body for manually re-queueing an alert delivery attempt. The supplied\ncomposite key identifies the row to retry; the handler is a no-op when the\nattempt has already succeeded (`succeeded_at IS NOT NULL`) or when the alert, event, or channel/webhook is disabled.\n",
                 "required": [
                   "alert_id",
                   "channel_id",

--- a/packages/go/openapi/src/paths/alerts.alert-attempts.retry.yaml
+++ b/packages/go/openapi/src/paths/alerts.alert-attempts.retry.yaml
@@ -23,7 +23,7 @@ post:
   description: |
     Manually re-queues an existing alert delivery attempt. The composite key
     in the request body identifies the specific attempt (alert, event, channel/webhook) to retry. The attempt is ignored
-    when the attempt has already succeeded, or when the alert, event, or channel/webhook are disabled.
+    when the attempt has already succeeded, or when the alert, event, or channel/webhook is disabled.
   tags:
     - Alerts
     - Enterprise
@@ -36,7 +36,7 @@ post:
           description: |
             Request body for manually re-queueing an alert delivery attempt. The supplied
             composite key identifies the row to retry; the handler is a no-op when the
-            attempt has already succeeded (`succeeded_at IS NOT NULL`).
+            attempt has already succeeded (`succeeded_at IS NOT NULL`) or when the alert, event, or channel/webhook is disabled.
           required:
             - alert_id
             - channel_id

--- a/packages/go/openapi/src/paths/alerts.alert-attempts.retry.yaml
+++ b/packages/go/openapi/src/paths/alerts.alert-attempts.retry.yaml
@@ -23,7 +23,7 @@ post:
   description: |
     Manually re-queues an existing alert delivery attempt. The composite key
     in the request body identifies the specific attempt (alert, event, channel/webhook) to retry. The attempt is ignored
-    when the attempt has already succeeded.
+    when the attempt has already succeeded, or when the alert, event, or channel/webhook are disabled.
   tags:
     - Alerts
     - Enterprise

--- a/packages/go/openapi/src/paths/alerts.alert-attempts.retry.yaml
+++ b/packages/go/openapi/src/paths/alerts.alert-attempts.retry.yaml
@@ -23,7 +23,7 @@ post:
   description: |
     Manually re-queues an existing alert delivery attempt. The composite key
     in the request body identifies the specific attempt (alert, event, channel/webhook) to retry. The attempt is ignored
-    when the attempt has already succeeded, or when the alert, event, or channel/webhook is disabled.
+    when the attempt has already succeeded, or when the alert, subscription, or channel/webhook is disabled.
   tags:
     - Alerts
     - Enterprise
@@ -36,7 +36,7 @@ post:
           description: |
             Request body for manually re-queueing an alert delivery attempt. The supplied
             composite key identifies the row to retry; the handler is a no-op when the
-            attempt has already succeeded (`succeeded_at IS NOT NULL`) or when the alert, event, or channel/webhook is disabled.
+            attempt has already succeeded (`succeeded_at IS NOT NULL`) or when the alert, subscription, or channel/webhook is disabled.
           required:
             - alert_id
             - channel_id


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Adding a note in the OpenAPI docs for this endpoint. The retry attempt is ignored if any piece of its identifier is disabled.

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-9449

Further clarifies the functionality of this endpoint.

## How Has This Been Tested?

No code changes, just docs

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that retry requests are ignored or treated as no-ops when the associated alert, subscription, or channel/webhook is disabled, or when the attempt has already succeeded.
  * Updated retry endpoint descriptions for greater accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->