### PR TITLE
feat: Add Saved Queries to Extension Upsert - BED-9320

### DIFF
--- a/cmd/api/src/api/v2/opengraphschema.go
+++ b/cmd/api/src/api/v2/opengraphschema.go
@@ -115,10 +115,29 @@ func (s Resources) OpenGraphSchemaIngest(response http.ResponseWriter, request *
 
 // Recognized component file names within an extension bundle.
 const (
-	bundleFileNameSchema       = "schema.json"
-	bundleFileNamePzRules      = "pz_rules.json"
-	bundleFileNameSavedQueries = "saved_queries.json"
+	bundleFileNameSchema                      = "schema.json"
+	bundleFileNamePzRules                     = "pz_rules.json"
+	bundleFileNameSavedQueries                = "saved_queries.json"
+	bundleComponentDecompressedReadLimitBytes = api.DefaultAPIPayloadReadLimitBytes
 )
+
+type bundleComponentReadCloser struct {
+	io.Reader
+	io.Closer
+}
+
+func openBundleComponent(file *zip.File) (io.ReadCloser, error) {
+	if file.UncompressedSize64 > uint64(bundleComponentDecompressedReadLimitBytes) {
+		return nil, fmt.Errorf("component %q exceeds decompressed size limit of %d bytes", file.Name, bundleComponentDecompressedReadLimitBytes)
+	} else if componentReader, err := file.Open(); err != nil {
+		return nil, err
+	} else {
+		return bundleComponentReadCloser{
+			Reader: io.LimitReader(componentReader, bundleComponentDecompressedReadLimitBytes),
+			Closer: componentReader,
+		}, nil
+	}
+}
 
 func validateZipBundle(payload model.GraphExtensionPayload) error {
 	if len(payload.GraphRelationshipFindings) > 0 && payload.PZRules == nil {
@@ -240,7 +259,7 @@ func decodeFileIntoPayload(extension *model.GraphExtensionPayload, schemaFound *
 	case bundleFileNameSchema:
 		if *schemaFound {
 			return fmt.Errorf("duplicate component %q in zip archive", bundleFileNameSchema)
-		} else if reader, err := file.Open(); err != nil {
+		} else if reader, err := openBundleComponent(file); err != nil {
 			return fmt.Errorf("unable to open %s in zip archive: %w", bundleFileNameSchema, err)
 		} else {
 			defer reader.Close()
@@ -259,7 +278,7 @@ func decodeFileIntoPayload(extension *model.GraphExtensionPayload, schemaFound *
 	case bundleFileNamePzRules:
 		if extension.PZRules != nil {
 			return fmt.Errorf("duplicate component %q in zip archive", bundleFileNamePzRules)
-		} else if reader, err := file.Open(); err != nil {
+		} else if reader, err := openBundleComponent(file); err != nil {
 			return fmt.Errorf("unable to open %s in zip archive: %w", bundleFileNamePzRules, err)
 		} else {
 			defer reader.Close()
@@ -272,7 +291,7 @@ func decodeFileIntoPayload(extension *model.GraphExtensionPayload, schemaFound *
 	case bundleFileNameSavedQueries:
 		if extension.SavedQueries != nil {
 			return fmt.Errorf("duplicate component %q in zip archive", bundleFileNameSavedQueries)
-		} else if reader, err := file.Open(); err != nil {
+		} else if reader, err := openBundleComponent(file); err != nil {
 			return fmt.Errorf("unable to open %s in zip archive: %w", bundleFileNameSavedQueries, err)
 		} else {
 			defer reader.Close()

--- a/cmd/api/src/api/v2/opengraphschema.go
+++ b/cmd/api/src/api/v2/opengraphschema.go
@@ -157,18 +157,27 @@ func extractPZRulesFromJSON(payload io.Reader) (model.PZRulesPayload, error) {
 	return pzRules, nil
 }
 
-// extractSavedQueriesFromJSON - extracts a model.SavedQueriesPayload from the incoming payload. Will return an error
-// if the decoder fails to decode the payload.
-func extractSavedQueriesFromJSON(payload io.Reader) (model.SavedQueriesPayload, error) {
-	var savedQueries model.SavedQueriesPayload
+// extractSavedQueriesFromJSON - extracts saved queries from the incoming payload. Will return an error if the decoder
+// fails to decode the payload.
+func extractSavedQueriesFromJSON(payload io.Reader) (*model.SavedQueriesPayload, error) {
+	var (
+		// contains the json tag for unmarshall
+		graphExtension model.GraphExtensionPayload
+		// saves a nil slice to the extension payload which determines if the file has been seen
+		nilSavedQueries model.SavedQueriesPayload
+	)
 
 	if normFile, err := bomenc.NormalizeToUTF8(payload); err != nil {
-		return savedQueries, fmt.Errorf("failed to normalize %s: %w", bundleFileNameSavedQueries, err)
-	} else if err = json.NewDecoder(normFile).Decode(&savedQueries); err != nil {
-		return savedQueries, fmt.Errorf("unable to decode %s: %w", bundleFileNameSavedQueries, err)
+		return nil, fmt.Errorf("failed to normalize %s: %w", bundleFileNameSavedQueries, err)
+	} else if err = json.NewDecoder(normFile).Decode(&graphExtension); err != nil {
+		return nil, fmt.Errorf("unable to decode %s: %w", bundleFileNameSavedQueries, err)
 	}
 
-	return savedQueries, nil
+	if graphExtension.SavedQueries == nil {
+		graphExtension.SavedQueries = &nilSavedQueries
+	}
+
+	return graphExtension.SavedQueries, nil
 }
 
 func validateSchemaComponent(payload model.GraphExtensionPayload) error {
@@ -270,7 +279,7 @@ func decodeFileIntoPayload(extension *model.GraphExtensionPayload, schemaFound *
 			if queries, err := extractSavedQueriesFromJSON(reader); err != nil {
 				return err
 			} else {
-				extension.SavedQueries = &queries
+				extension.SavedQueries = queries
 			}
 		}
 	default:

--- a/cmd/api/src/api/v2/opengraphschema_internal_test.go
+++ b/cmd/api/src/api/v2/opengraphschema_internal_test.go
@@ -55,7 +55,8 @@ const validSavedQueryJSON = `{
 	"query_key": "all-domain-admins",
 	"name": "All Domain Admins",
 	"query": "MATCH (n) RETURN n LIMIT 1",
-	"description": "example"
+	"description": "example",
+	"category": "administration"
 }`
 
 // validSavedQueriesJSON is a minimal saved queries component.
@@ -128,14 +129,15 @@ func newExtensionZipWithDuplicate(t *testing.T, name, content string) []byte {
 
 func TestExtractBundleFromZip(t *testing.T) {
 	var tests = []struct {
-		name             string
-		archive          []byte
-		wantErrText      string
-		wantSchemaName   string
-		wantHasSchema    bool
-		wantHasPZRules   bool
-		wantHasSavedQrys bool
-		wantQueryKey     string
+		name                string
+		archive             []byte
+		wantErrText         string
+		wantSchemaName      string
+		wantHasSchema       bool
+		wantHasPZRules      bool
+		wantHasSavedQrys    bool
+		wantSavedQueriesNil bool
+		wantSavedQuery      *model.SavedQueryPayload
 	}{
 		{
 			name:           "valid zip with only schema.json yields a schema-only bundle",
@@ -178,7 +180,13 @@ func TestExtractBundleFromZip(t *testing.T) {
 			wantHasSchema:    true,
 			wantHasPZRules:   true,
 			wantHasSavedQrys: true,
-			wantQueryKey:     "all-domain-admins",
+			wantSavedQuery: &model.SavedQueryPayload{
+				QueryKey:    "all-domain-admins",
+				Name:        "All Domain Admins",
+				Query:       "MATCH (n) RETURN n LIMIT 1",
+				Description: "example",
+				Category:    "administration",
+			},
 		},
 		{
 			name:           "missing schema.json is an extractor error",
@@ -212,6 +220,26 @@ func TestExtractBundleFromZip(t *testing.T) {
 			wantErrText: "duplicate component \"schema.json\" in zip archive",
 		},
 		{
+			name:                "duplicate null saved query components are rejected",
+			archive:             newExtensionZipWithDuplicate(t, "saved_queries.json", `{"queries": null}`),
+			wantErrText:         "duplicate component \"saved_queries.json\" in zip archive",
+			wantHasSavedQrys:    true,
+			wantSavedQueriesNil: true,
+		},
+		{
+			name:             "duplicate empty saved query components are rejected",
+			archive:          newExtensionZipWithDuplicate(t, "saved_queries.json", `{"queries": []}`),
+			wantErrText:      "duplicate component \"saved_queries.json\" in zip archive",
+			wantHasSavedQrys: true,
+		},
+		{
+			name:                "duplicate saved query components with missing queries are rejected",
+			archive:             newExtensionZipWithDuplicate(t, "saved_queries.json", `{}`),
+			wantErrText:         "duplicate component \"saved_queries.json\" in zip archive",
+			wantHasSavedQrys:    true,
+			wantSavedQueriesNil: true,
+		},
+		{
 			name:        "schema.json embedding pz_rules is rejected in a bundle",
 			archive:     newExtensionZip(t, map[string]string{"schema.json": validSchemaWithEmbeddedPZRulesJSON}),
 			wantErrText: "schema.json must not embed optional components: pz_rules.json",
@@ -243,9 +271,14 @@ func TestExtractBundleFromZip(t *testing.T) {
 			}
 			assert.Equal(t, tt.wantHasPZRules, extension.PZRules != nil)
 			assert.Equal(t, tt.wantHasSavedQrys, extension.SavedQueries != nil)
-			if tt.wantQueryKey != "" {
-				require.NotEmpty(t, *extension.SavedQueries)
-				assert.Equal(t, tt.wantQueryKey, (*extension.SavedQueries)[0].QueryKey)
+			if tt.wantHasSavedQrys {
+				require.NotNil(t, extension.SavedQueries)
+				assert.Equal(t, tt.wantSavedQueriesNil, *extension.SavedQueries == nil)
+			}
+			if tt.wantSavedQuery != nil {
+				require.NotNil(t, extension.SavedQueries)
+				require.Len(t, *extension.SavedQueries, 1)
+				assert.Equal(t, *tt.wantSavedQuery, (*extension.SavedQueries)[0])
 			}
 		})
 	}
@@ -258,6 +291,20 @@ func TestExtractExtensionDataFromJSON(t *testing.T) {
 		assert.Equal(t, "TestExtension", extension.GraphSchemaExtension.Name)
 		assert.Nil(t, extension.PZRules)
 		assert.Nil(t, extension.SavedQueries)
+	})
+
+	t.Run("schema with saved queries preserves every query field", func(t *testing.T) {
+		extension, err := extractExtensionDataFromJSON(bytes.NewReader([]byte(validSchemaWithEmbeddedSavedQueriesJSON)))
+		require.NoError(t, err)
+		require.NotNil(t, extension.SavedQueries)
+		require.Len(t, *extension.SavedQueries, 1)
+		assert.Equal(t, model.SavedQueryPayload{
+			QueryKey:    "all-domain-admins",
+			Name:        "All Domain Admins",
+			Query:       "MATCH (n) RETURN n LIMIT 1",
+			Description: "example",
+			Category:    "administration",
+		}, (*extension.SavedQueries)[0])
 	})
 
 	t.Run("schema with findings is valid without pz_rules", func(t *testing.T) {

--- a/cmd/api/src/api/v2/opengraphschema_internal_test.go
+++ b/cmd/api/src/api/v2/opengraphschema_internal_test.go
@@ -19,8 +19,10 @@ package v2
 import (
 	"archive/zip"
 	"bytes"
+	"fmt"
 	"testing"
 
+	"github.com/specterops/bloodhound/cmd/api/src/api"
 	"github.com/specterops/bloodhound/cmd/api/src/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -127,28 +129,71 @@ func newExtensionZipWithDuplicate(t *testing.T, name, content string) []byte {
 	return buf.Bytes()
 }
 
+func newOversizedExtensionZip(t *testing.T, name, baseContent string) []byte {
+	t.Helper()
+
+	var (
+		buf              bytes.Buffer
+		whitespaceChunk  = bytes.Repeat([]byte(" "), 4*1024)
+		uncompressedSize int
+	)
+
+	zipWriter := zip.NewWriter(&buf)
+	entryWriter, err := zipWriter.Create(name)
+	require.NoError(t, err)
+
+	bytesWritten, err := entryWriter.Write([]byte(baseContent))
+	require.NoError(t, err)
+	uncompressedSize += bytesWritten
+
+	for uncompressedSize <= bundleComponentDecompressedReadLimitBytes {
+		bytesWritten, err = entryWriter.Write(whitespaceChunk)
+		require.NoError(t, err)
+		uncompressedSize += bytesWritten
+	}
+
+	require.NoError(t, zipWriter.Close())
+
+	archive := buf.Bytes()
+	require.Less(t, len(archive), api.DefaultAPIPayloadReadLimitBytes)
+
+	return archive
+}
+
 func TestExtractBundleFromZip(t *testing.T) {
+	type expectedResults struct {
+		errorText    string
+		schemaName   string
+		hasPZRules   bool
+		savedQueries *model.SavedQueriesPayload
+	}
+
 	var tests = []struct {
-		name                string
-		archive             []byte
-		wantErrText         string
-		wantSchemaName      string
-		wantHasSchema       bool
-		wantHasPZRules      bool
-		wantHasSavedQrys    bool
-		wantSavedQueriesNil bool
-		wantSavedQuery      *model.SavedQueryPayload
+		name     string
+		archive  []byte
+		expected expectedResults
 	}{
 		{
-			name:           "valid zip with only schema.json yields a schema-only bundle",
-			archive:        newExtensionZip(t, map[string]string{"schema.json": validSchemaJSON}),
-			wantSchemaName: "TestExtension",
-			wantHasSchema:  true,
+			name:    "valid zip with only schema.json yields a schema-only bundle",
+			archive: newExtensionZip(t, map[string]string{"schema.json": validSchemaJSON}),
+			expected: expectedResults{
+				schemaName: "TestExtension",
+			},
 		},
 		{
-			name:        "zip schema with findings requires pz_rules.json",
-			archive:     newExtensionZip(t, map[string]string{"schema.json": validSchemaWithFindingsJSON}),
-			wantErrText: "requires a \"pz_rules.json\" component",
+			name:    "schema.json exceeding decompressed component limit is rejected",
+			archive: newOversizedExtensionZip(t, bundleFileNameSchema, validSchemaJSON),
+			expected: expectedResults{
+				errorText: fmt.Sprintf("component %q exceeds decompressed size limit of %d bytes", bundleFileNameSchema, bundleComponentDecompressedReadLimitBytes),
+			},
+		},
+		{
+			name:    "zip schema with findings requires pz_rules.json",
+			archive: newExtensionZip(t, map[string]string{"schema.json": validSchemaWithFindingsJSON}),
+			expected: expectedResults{
+				errorText:  "requires a \"pz_rules.json\" component",
+				schemaName: "TestExtension",
+			},
 		},
 		{
 			name: "zip schema with findings requires at least one pz rule",
@@ -156,8 +201,11 @@ func TestExtractBundleFromZip(t *testing.T) {
 				"schema.json":   validSchemaWithFindingsJSON,
 				"pz_rules.json": `{"rules": []}`,
 			}),
-			wantErrText:    "\"pz_rules.json\" must contain at least one rule",
-			wantHasPZRules: true,
+			expected: expectedResults{
+				errorText:  "\"pz_rules.json\" must contain at least one rule",
+				schemaName: "TestExtension",
+				hasPZRules: true,
+			},
 		},
 		{
 			name: "zip schema with findings and pz_rules.json is valid",
@@ -165,9 +213,10 @@ func TestExtractBundleFromZip(t *testing.T) {
 				"schema.json":   validSchemaWithFindingsJSON,
 				"pz_rules.json": validPZRulesJSON,
 			}),
-			wantSchemaName: "TestExtension",
-			wantHasSchema:  true,
-			wantHasPZRules: true,
+			expected: expectedResults{
+				schemaName: "TestExtension",
+				hasPZRules: true,
+			},
 		},
 		{
 			name: "valid zip with all three components populates the full bundle",
@@ -176,33 +225,41 @@ func TestExtractBundleFromZip(t *testing.T) {
 				"pz_rules.json":      validPZRulesJSON,
 				"saved_queries.json": validSavedQueriesJSON,
 			}),
-			wantSchemaName:   "TestExtension",
-			wantHasSchema:    true,
-			wantHasPZRules:   true,
-			wantHasSavedQrys: true,
-			wantSavedQuery: &model.SavedQueryPayload{
-				QueryKey:    "all-domain-admins",
-				Name:        "All Domain Admins",
-				Query:       "MATCH (n) RETURN n LIMIT 1",
-				Description: "example",
-				Category:    "administration",
+			expected: expectedResults{
+				schemaName: "TestExtension",
+				hasPZRules: true,
+				savedQueries: &model.SavedQueriesPayload{
+					{
+						QueryKey:    "all-domain-admins",
+						Name:        "All Domain Admins",
+						Query:       "MATCH (n) RETURN n LIMIT 1",
+						Description: "example",
+						Category:    "administration",
+					},
+				},
 			},
 		},
 		{
-			name:           "missing schema.json is an extractor error",
-			archive:        newExtensionZip(t, map[string]string{"pz_rules.json": validPZRulesJSON}),
-			wantErrText:    "required component \"schema.json\" not found in extension bundle",
-			wantHasPZRules: true,
+			name:    "missing schema.json is an extractor error",
+			archive: newExtensionZip(t, map[string]string{"pz_rules.json": validPZRulesJSON}),
+			expected: expectedResults{
+				errorText:  "required component \"schema.json\" not found in extension bundle",
+				hasPZRules: true,
+			},
 		},
 		{
-			name:        "malformed archive returns an open error",
-			archive:     []byte("this is not a zip archive"),
-			wantErrText: "unable to open zip archive",
+			name:    "malformed archive returns an open error",
+			archive: []byte("this is not a zip archive"),
+			expected: expectedResults{
+				errorText: "unable to open zip archive",
+			},
 		},
 		{
-			name:        "invalid json in schema.json returns a decode error",
-			archive:     newExtensionZip(t, map[string]string{"schema.json": "{ not valid json"}),
-			wantErrText: "unable to decode graph extension payload",
+			name:    "invalid json in schema.json returns a decode error",
+			archive: newExtensionZip(t, map[string]string{"schema.json": "{ not valid json"}),
+			expected: expectedResults{
+				errorText: "unable to decode graph extension payload",
+			},
 		},
 		{
 			name: "unexpected file returns an error but recognized components still populate",
@@ -210,76 +267,80 @@ func TestExtractBundleFromZip(t *testing.T) {
 				"schema.json": validSchemaJSON,
 				"README.md":   "not a component",
 			}),
-			wantErrText:    "unexpected file \"README.md\" in zip archive",
-			wantSchemaName: "TestExtension",
-			wantHasSchema:  true,
+			expected: expectedResults{
+				errorText:  "unexpected file \"README.md\" in zip archive",
+				schemaName: "TestExtension",
+			},
 		},
 		{
-			name:        "duplicate component (same file name twice) returns an error",
-			archive:     newExtensionZipWithDuplicate(t, "schema.json", validSchemaJSON),
-			wantErrText: "duplicate component \"schema.json\" in zip archive",
+			name:    "duplicate component (same file name twice) returns an error",
+			archive: newExtensionZipWithDuplicate(t, "schema.json", validSchemaJSON),
+			expected: expectedResults{
+				errorText:  "duplicate component \"schema.json\" in zip archive",
+				schemaName: "TestExtension",
+			},
 		},
 		{
-			name:                "duplicate null saved query components are rejected",
-			archive:             newExtensionZipWithDuplicate(t, "saved_queries.json", `{"queries": null}`),
-			wantErrText:         "duplicate component \"saved_queries.json\" in zip archive",
-			wantHasSavedQrys:    true,
-			wantSavedQueriesNil: true,
+			name:    "duplicate null saved query components are rejected",
+			archive: newExtensionZipWithDuplicate(t, "saved_queries.json", `{"queries": null}`),
+			expected: expectedResults{
+				errorText:    "duplicate component \"saved_queries.json\" in zip archive",
+				savedQueries: new(model.SavedQueriesPayload),
+			},
 		},
 		{
-			name:             "duplicate empty saved query components are rejected",
-			archive:          newExtensionZipWithDuplicate(t, "saved_queries.json", `{"queries": []}`),
-			wantErrText:      "duplicate component \"saved_queries.json\" in zip archive",
-			wantHasSavedQrys: true,
+			name:    "duplicate empty saved query components are rejected",
+			archive: newExtensionZipWithDuplicate(t, "saved_queries.json", `{"queries": []}`),
+			expected: expectedResults{
+				errorText:    "duplicate component \"saved_queries.json\" in zip archive",
+				savedQueries: &model.SavedQueriesPayload{},
+			},
 		},
 		{
-			name:                "duplicate saved query components with missing queries are rejected",
-			archive:             newExtensionZipWithDuplicate(t, "saved_queries.json", `{}`),
-			wantErrText:         "duplicate component \"saved_queries.json\" in zip archive",
-			wantHasSavedQrys:    true,
-			wantSavedQueriesNil: true,
+			name:    "duplicate saved query components with missing queries are rejected",
+			archive: newExtensionZipWithDuplicate(t, "saved_queries.json", `{}`),
+			expected: expectedResults{
+				errorText:    "duplicate component \"saved_queries.json\" in zip archive",
+				savedQueries: new(model.SavedQueriesPayload),
+			},
 		},
 		{
-			name:        "schema.json embedding pz_rules is rejected in a bundle",
-			archive:     newExtensionZip(t, map[string]string{"schema.json": validSchemaWithEmbeddedPZRulesJSON}),
-			wantErrText: "schema.json must not embed optional components: pz_rules.json",
+			name:    "schema.json embedding pz_rules is rejected in a bundle",
+			archive: newExtensionZip(t, map[string]string{"schema.json": validSchemaWithEmbeddedPZRulesJSON}),
+			expected: expectedResults{
+				errorText: "schema.json must not embed optional components: pz_rules.json",
+			},
 		},
 		{
-			name:        "schema.json embedding saved_queries is rejected in a bundle",
-			archive:     newExtensionZip(t, map[string]string{"schema.json": validSchemaWithEmbeddedSavedQueriesJSON}),
-			wantErrText: "schema.json must not embed optional components: saved_queries.json",
+			name:    "schema.json embedding saved_queries is rejected in a bundle",
+			archive: newExtensionZip(t, map[string]string{"schema.json": validSchemaWithEmbeddedSavedQueriesJSON}),
+			expected: expectedResults{
+				errorText: "schema.json must not embed optional components: saved_queries.json",
+			},
 		},
 		{
-			name:        "schema.json embedding both optional components is rejected in a bundle",
-			archive:     newExtensionZip(t, map[string]string{"schema.json": validSchemaWithEmbeddedOptionalComponentsJSON}),
-			wantErrText: "schema.json must not embed optional components: pz_rules.json, saved_queries.json",
+			name:    "schema.json embedding both optional components is rejected in a bundle",
+			archive: newExtensionZip(t, map[string]string{"schema.json": validSchemaWithEmbeddedOptionalComponentsJSON}),
+			expected: expectedResults{
+				errorText: "schema.json must not embed optional components: pz_rules.json, saved_queries.json",
+			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			extension, err := extractBundleFromZip(bytes.NewReader(tt.archive))
-			if tt.wantErrText != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.wantErrText)
+			if tt.expected.errorText != "" {
+				if assert.Error(t, err) {
+					assert.Contains(t, err.Error(), tt.expected.errorText)
+				}
 			} else {
-				require.NoError(t, err)
+				assert.NoError(t, err)
 			}
 
-			if tt.wantHasSchema {
-				assert.Equal(t, tt.wantSchemaName, extension.GraphSchemaExtension.Name)
-			}
-			assert.Equal(t, tt.wantHasPZRules, extension.PZRules != nil)
-			assert.Equal(t, tt.wantHasSavedQrys, extension.SavedQueries != nil)
-			if tt.wantHasSavedQrys {
-				require.NotNil(t, extension.SavedQueries)
-				assert.Equal(t, tt.wantSavedQueriesNil, *extension.SavedQueries == nil)
-			}
-			if tt.wantSavedQuery != nil {
-				require.NotNil(t, extension.SavedQueries)
-				require.Len(t, *extension.SavedQueries, 1)
-				assert.Equal(t, *tt.wantSavedQuery, (*extension.SavedQueries)[0])
-			}
+			assert.Equal(t, tt.expected.schemaName, extension.GraphSchemaExtension.Name)
+			assert.Equal(t, tt.expected.hasPZRules, extension.PZRules != nil)
+			assert.Equal(t, tt.expected.savedQueries, extension.SavedQueries)
 		})
 	}
 }

--- a/cmd/api/src/api/v2/opengraphschema_internal_test.go
+++ b/cmd/api/src/api/v2/opengraphschema_internal_test.go
@@ -50,16 +50,17 @@ const validPZRulesJSON = `{
 	]
 }`
 
+// validSavedQueryJSON is a minimal saved query definition.
+const validSavedQueryJSON = `{
+	"query_key": "all-domain-admins",
+	"name": "All Domain Admins",
+	"query": "MATCH (n) RETURN n LIMIT 1",
+	"description": "example"
+}`
+
 // validSavedQueriesJSON is a minimal saved queries component.
 const validSavedQueriesJSON = `{
-	"queries": [
-		{
-			"query_key": "all-domain-admins",
-			"name": "All Domain Admins",
-			"query": "MATCH (n) RETURN n LIMIT 1",
-			"description": "example"
-		}
-	]
+	"queries": [` + validSavedQueryJSON + `]
 }`
 
 // validSchemaJSON is a minimal extension definition schema used to exercise the ZIP ingest path.
@@ -80,13 +81,13 @@ const validSchemaWithEmbeddedPZRulesJSON = validSchemaBaseJSON + `,
 
 const validSchemaWithEmbeddedSavedQueriesJSON = validSchemaBaseJSON + `,
 	"relationship_findings": [],
-	"saved_queries": ` + validSavedQueriesJSON + `
+	"queries": [` + validSavedQueryJSON + `]
 }`
 
 const validSchemaWithEmbeddedOptionalComponentsJSON = validSchemaBaseJSON + `,
 	"relationship_findings": [],
 	"pz_rules": ` + validPZRulesJSON + `,
-	"saved_queries": ` + validSavedQueriesJSON + `
+	"queries": [` + validSavedQueryJSON + `]
 }`
 
 // newExtensionZip builds an in-memory ZIP archive from the given file name -> content map.
@@ -243,8 +244,8 @@ func TestExtractBundleFromZip(t *testing.T) {
 			assert.Equal(t, tt.wantHasPZRules, extension.PZRules != nil)
 			assert.Equal(t, tt.wantHasSavedQrys, extension.SavedQueries != nil)
 			if tt.wantQueryKey != "" {
-				require.NotEmpty(t, extension.SavedQueries.Queries)
-				assert.Equal(t, tt.wantQueryKey, extension.SavedQueries.Queries[0].QueryKey)
+				require.NotEmpty(t, *extension.SavedQueries)
+				assert.Equal(t, tt.wantQueryKey, (*extension.SavedQueries)[0].QueryKey)
 			}
 		})
 	}

--- a/cmd/api/src/api/v2/opengraphschema_test.go
+++ b/cmd/api/src/api/v2/opengraphschema_test.go
@@ -97,6 +97,15 @@ func TestResources_OpenGraphSchemaIngest(t *testing.T) {
 					},
 				},
 			},
+			SavedQueries: &model.SavedQueriesPayload{
+				{
+					QueryKey:    "test-query",
+					Name:        "Test Query",
+					Query:       "MATCH (n) RETURN n",
+					Description: "Test saved query",
+					Category:    "Test Category",
+				},
+			},
 		}
 		serviceGraphExtension = model.GraphExtensionInput{
 			ExtensionInput: model.ExtensionInput{
@@ -143,6 +152,15 @@ func TestResources_OpenGraphSchemaIngest(t *testing.T) {
 						ShortRemediation: "do x",
 						LongRemediation:  "do x but better",
 					},
+				},
+			},
+			SavedQueriesInput: model.SavedQueriesInput{
+				{
+					QueryKey:    "test-query",
+					Name:        "Test Query",
+					Query:       "MATCH (n) RETURN n",
+					Description: "Test saved query",
+					Category:    "Test Category",
 				},
 			},
 		}
@@ -387,16 +405,26 @@ func TestResources_OpenGraphSchemaIngest(t *testing.T) {
 			args: args{
 				func() *http.Request {
 					var (
-						zipBuffer     bytes.Buffer
-						jsonPayload   []byte
-						zipWriter     *zip.Writer
-						schemaWriter  io.Writer
-						pzRulesWriter io.Writer
-						request       *http.Request
-						err           error
+						schemaExtension       = graphExtension
+						savedQueriesComponent = struct {
+							SavedQueries *model.SavedQueriesPayload `json:"queries"`
+						}{SavedQueries: graphExtension.SavedQueries}
+						zipBuffer           bytes.Buffer
+						jsonPayload         []byte
+						savedQueriesPayload []byte
+						zipWriter           *zip.Writer
+						schemaWriter        io.Writer
+						pzRulesWriter       io.Writer
+						savedQueriesWriter  io.Writer
+						request             *http.Request
+						err                 error
 					)
 
-					jsonPayload, err = json.Marshal(graphExtension)
+					schemaExtension.SavedQueries = nil
+					schemaExtension.PZRules = nil
+					jsonPayload, err = json.Marshal(schemaExtension)
+					require.NoError(t, err)
+					savedQueriesPayload, err = json.Marshal(savedQueriesComponent)
 					require.NoError(t, err)
 
 					zipWriter = zip.NewWriter(&zipBuffer)
@@ -417,6 +445,10 @@ func TestResources_OpenGraphSchemaIngest(t *testing.T) {
 							}]
 						}]
 					}`))
+					require.NoError(t, err)
+					savedQueriesWriter, err = zipWriter.Create("saved_queries.json")
+					require.NoError(t, err)
+					_, err = savedQueriesWriter.Write(savedQueriesPayload)
 					require.NoError(t, err)
 					require.NoError(t, zipWriter.Close())
 

--- a/cmd/api/src/database/mocks/db.go
+++ b/cmd/api/src/database/mocks/db.go
@@ -2514,6 +2514,21 @@ func (mr *MockDatabaseMockRecorder) GetSSOProviderUsers(ctx, id any) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSSOProviderUsers", reflect.TypeOf((*MockDatabase)(nil).GetSSOProviderUsers), ctx, id)
 }
 
+// GetSavedQueriesByExtensionID mocks base method.
+func (m *MockDatabase) GetSavedQueriesByExtensionID(ctx context.Context, schemaExtensionID int32) (model.SavedQueries, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSavedQueriesByExtensionID", ctx, schemaExtensionID)
+	ret0, _ := ret[0].(model.SavedQueries)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetSavedQueriesByExtensionID indicates an expected call of GetSavedQueriesByExtensionID.
+func (mr *MockDatabaseMockRecorder) GetSavedQueriesByExtensionID(ctx, schemaExtensionID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSavedQueriesByExtensionID", reflect.TypeOf((*MockDatabase)(nil).GetSavedQueriesByExtensionID), ctx, schemaExtensionID)
+}
+
 // GetSavedQueriesOwnedBy mocks base method.
 func (m *MockDatabase) GetSavedQueriesOwnedBy(ctx context.Context, userID uuid.UUID) (model.SavedQueries, error) {
 	m.ctrl.T.Helper()

--- a/cmd/api/src/database/saved_queries.go
+++ b/cmd/api/src/database/saved_queries.go
@@ -29,6 +29,7 @@ import (
 
 type SavedQueriesData interface {
 	GetSavedQuery(ctx context.Context, savedQueryID int64) (model.SavedQuery, error)
+	GetSavedQueriesByExtensionID(ctx context.Context, schemaExtensionID int32) (model.SavedQueries, error)
 	ListSavedQueries(ctx context.Context, scope string, userID uuid.UUID, order string, filter model.SQLFilter, skip, limit int) ([]model.ScopedSavedQuery, int, error)
 	CreateSavedQuery(ctx context.Context, userID uuid.UUID, name string, query string, description string, schemaExtensionID *int32, queryKey *string, category string) (model.SavedQuery, error)
 	UpdateSavedQuery(ctx context.Context, savedQuery model.SavedQuery) (model.SavedQuery, error)
@@ -45,6 +46,15 @@ func (s *BloodhoundDB) GetSavedQuery(ctx context.Context, savedQueryID int64) (m
 	savedQuery := model.SavedQuery{}
 	result := s.db.WithContext(ctx).First(&savedQuery, savedQueryID)
 	return savedQuery, CheckError(result)
+}
+
+func (s *BloodhoundDB) GetSavedQueriesByExtensionID(ctx context.Context, schemaExtensionID int32) (model.SavedQueries, error) {
+	var (
+		savedQueries = model.SavedQueries{}
+		queryResult  = s.db.WithContext(ctx).Where("schema_extension_id = ?", schemaExtensionID).Find(&savedQueries)
+	)
+
+	return savedQueries, CheckError(queryResult)
 }
 
 func (s *BloodhoundDB) ListSavedQueries(ctx context.Context, scope string, userID uuid.UUID, order string, filter model.SQLFilter, skip, limit int) ([]model.ScopedSavedQuery, int, error) {

--- a/cmd/api/src/database/upsert_schema_extension.go
+++ b/cmd/api/src/database/upsert_schema_extension.go
@@ -20,6 +20,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
+
+	"github.com/gofrs/uuid"
 
 	"github.com/specterops/bloodhound/cmd/api/src/model"
 	"github.com/specterops/bloodhound/packages/go/graphschema"
@@ -72,6 +75,10 @@ func (s *BloodhoundDB) UpsertOpenGraphExtension(ctx context.Context, graphExtens
 		return schemaExists, fmt.Errorf("failed to fetch existing findings: %w", err)
 	} else if _, err := reconcile(ctx, graphExtensionInput.RelationshipFindingsInput, existingFindings, bloodhoundDBTransaction.findingReconcileConfig(extension.ID)); err != nil {
 		return schemaExists, fmt.Errorf("failed to reconcile findings: %w", err)
+	} else if existingSavedQueries, err := bloodhoundDBTransaction.GetSavedQueriesByExtensionID(ctx, extension.ID); err != nil {
+		return schemaExists, fmt.Errorf("failed to fetch existing saved queries: %w", err)
+	} else if _, err := reconcile(ctx, graphExtensionInput.SavedQueriesInput, existingSavedQueries, bloodhoundDBTransaction.savedQueryReconcileConfig(extension.ID)); err != nil {
+		return schemaExists, fmt.Errorf("failed to reconcile saved queries: %w", err)
 	} else if err = tx.Commit().Error; err != nil {
 		return schemaExists, err
 	} else {
@@ -121,6 +128,36 @@ func (s *BloodhoundDB) createNewExtension(ctx context.Context, extensionInput mo
 		return model.GraphSchemaExtension{}, false, fmt.Errorf("error creating extension: %w", err)
 	} else {
 		return created, false, nil
+	}
+}
+
+func (s *BloodhoundDB) createExtensionSavedQuery(ctx context.Context, extensionID int32, input model.SavedQueryInput) (model.SavedQuery, error) {
+	queryKey := input.QueryKey
+	if created, err := s.CreateSavedQuery(ctx, uuid.Nil, input.Name, input.Query, input.Description, &extensionID, &queryKey, ""); err != nil {
+		return model.SavedQuery{}, fmt.Errorf("failed to create extension saved query %q: %w", input.QueryKey, err)
+	} else if _, err := s.CreateSavedQueryPermissionToPublic(ctx, created.ID); err != nil {
+		return model.SavedQuery{}, fmt.Errorf("failed to make extension saved query %q public: %w", input.QueryKey, err)
+	} else {
+		return created, nil
+	}
+}
+
+func (s *BloodhoundDB) savedQueryReconcileConfig(extensionID int32) reconcileConfig[model.SavedQueryInput, model.SavedQuery, string] {
+	return reconcileConfig[model.SavedQueryInput, model.SavedQuery, string]{
+		getInputKey:    func(input model.SavedQueryInput) string { return strings.ToLower(input.QueryKey) },
+		getExistingKey: func(existing model.SavedQuery) string { return strings.ToLower(*existing.QueryKey) },
+		create: func(ctx context.Context, input model.SavedQueryInput) (model.SavedQuery, error) {
+			return s.createExtensionSavedQuery(ctx, extensionID, input)
+		},
+		update: func(ctx context.Context, existing model.SavedQuery, input model.SavedQueryInput) (model.SavedQuery, error) {
+			existing.Name = input.Name
+			existing.Query = input.Query
+			existing.Description = input.Description
+			return s.UpdateSavedQuery(ctx, existing)
+		},
+		delete: func(ctx context.Context, existing model.SavedQuery) error {
+			return s.DeleteSavedQuery(ctx, existing.ID)
+		},
 	}
 }
 

--- a/cmd/api/src/database/upsert_schema_extension.go
+++ b/cmd/api/src/database/upsert_schema_extension.go
@@ -143,8 +143,14 @@ func (s *BloodhoundDB) createExtensionSavedQuery(ctx context.Context, extensionI
 
 func (s *BloodhoundDB) savedQueryReconcileConfig(extensionID int32) reconcileConfig[model.SavedQueryInput, model.SavedQuery, string] {
 	return reconcileConfig[model.SavedQueryInput, model.SavedQuery, string]{
-		getInputKey:    func(input model.SavedQueryInput) string { return input.QueryKey },
-		getExistingKey: func(existing model.SavedQuery) string { return *existing.QueryKey },
+		getInputKey: func(input model.SavedQueryInput) string { return input.QueryKey },
+		getExistingKey: func(existing model.SavedQuery) string {
+			if existing.QueryKey == nil {
+				return ""
+			}
+
+			return *existing.QueryKey
+		},
 		create: func(ctx context.Context, input model.SavedQueryInput) (model.SavedQuery, error) {
 			return s.createExtensionSavedQuery(ctx, extensionID, input)
 		},

--- a/cmd/api/src/database/upsert_schema_extension.go
+++ b/cmd/api/src/database/upsert_schema_extension.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/gofrs/uuid"
 
@@ -133,7 +132,7 @@ func (s *BloodhoundDB) createNewExtension(ctx context.Context, extensionInput mo
 
 func (s *BloodhoundDB) createExtensionSavedQuery(ctx context.Context, extensionID int32, input model.SavedQueryInput) (model.SavedQuery, error) {
 	queryKey := input.QueryKey
-	if created, err := s.CreateSavedQuery(ctx, uuid.Nil, input.Name, input.Query, input.Description, &extensionID, &queryKey, ""); err != nil {
+	if created, err := s.CreateSavedQuery(ctx, uuid.Nil, input.Name, input.Query, input.Description, &extensionID, &queryKey, input.Category); err != nil {
 		return model.SavedQuery{}, fmt.Errorf("failed to create extension saved query %q: %w", input.QueryKey, err)
 	} else if _, err := s.CreateSavedQueryPermissionToPublic(ctx, created.ID); err != nil {
 		return model.SavedQuery{}, fmt.Errorf("failed to make extension saved query %q public: %w", input.QueryKey, err)
@@ -144,12 +143,13 @@ func (s *BloodhoundDB) createExtensionSavedQuery(ctx context.Context, extensionI
 
 func (s *BloodhoundDB) savedQueryReconcileConfig(extensionID int32) reconcileConfig[model.SavedQueryInput, model.SavedQuery, string] {
 	return reconcileConfig[model.SavedQueryInput, model.SavedQuery, string]{
-		getInputKey:    func(input model.SavedQueryInput) string { return strings.ToLower(input.QueryKey) },
-		getExistingKey: func(existing model.SavedQuery) string { return strings.ToLower(*existing.QueryKey) },
+		getInputKey:    func(input model.SavedQueryInput) string { return input.QueryKey },
+		getExistingKey: func(existing model.SavedQuery) string { return *existing.QueryKey },
 		create: func(ctx context.Context, input model.SavedQueryInput) (model.SavedQuery, error) {
 			return s.createExtensionSavedQuery(ctx, extensionID, input)
 		},
 		update: func(ctx context.Context, existing model.SavedQuery, input model.SavedQueryInput) (model.SavedQuery, error) {
+			existing.Category = input.Category
 			existing.Name = input.Name
 			existing.Query = input.Query
 			existing.Description = input.Description

--- a/cmd/api/src/database/upsert_schema_saved_query_integration_test.go
+++ b/cmd/api/src/database/upsert_schema_saved_query_integration_test.go
@@ -18,7 +18,6 @@
 package database_test
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/gofrs/uuid"
@@ -28,12 +27,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func savedQuery(queryKey string, name string, query string, description string) model.SavedQueryInput {
+func savedQuery(queryKey string, name string, query string, description string, category string) model.SavedQueryInput {
 	return model.SavedQueryInput{
 		QueryKey:    queryKey,
 		Name:        name,
 		Query:       query,
 		Description: description,
+		Category:    category,
 	}
 }
 
@@ -52,43 +52,44 @@ func upsertExtensionSavedQueries(t *testing.T, testSuite IntegrationTestSuite, e
 	return extensions[0].ID
 }
 
-func requireExtensionSavedQueries(t *testing.T, testSuite IntegrationTestSuite, extensionID int32, expectedSavedQueries ...model.SavedQueryInput) map[string]model.SavedQuery {
+func assertExtensionSavedQueries(t *testing.T, testSuite IntegrationTestSuite, extensionID int32, expectedSavedQueries ...model.SavedQueryInput) map[string]model.SavedQuery {
 	t.Helper()
 	var (
 		expectedSavedQueriesByKey = map[string]model.SavedQueryInput{}
 		savedQueriesByKey         = map[string]model.SavedQuery{}
 	)
 	for _, expectedSavedQuery := range expectedSavedQueries {
-		expectedSavedQueriesByKey[strings.ToLower(expectedSavedQuery.QueryKey)] = expectedSavedQuery
+		expectedSavedQueriesByKey[expectedSavedQuery.QueryKey] = expectedSavedQuery
 	}
 	savedQueries, err := testSuite.BHDatabase.GetSavedQueriesByExtensionID(testSuite.Context, extensionID)
 	require.NoError(t, err)
-	require.Len(t, savedQueries, len(expectedSavedQueries))
+	assert.Len(t, savedQueries, len(expectedSavedQueries))
 	for _, savedQuery := range savedQueries {
 		require.NotNil(t, savedQuery.QueryKey)
-		normalizedQueryKey := strings.ToLower(*savedQuery.QueryKey)
-		expectedSavedQuery, found := expectedSavedQueriesByKey[normalizedQueryKey]
-		require.True(t, found)
-		require.Equal(t, expectedSavedQuery.QueryKey, *savedQuery.QueryKey)
-		require.Equal(t, uuid.Nil.String(), savedQuery.UserID)
+		queryKey := *savedQuery.QueryKey
+		expectedSavedQuery, found := expectedSavedQueriesByKey[queryKey]
+		assert.True(t, found)
+		assert.Equal(t, expectedSavedQuery.QueryKey, *savedQuery.QueryKey)
+		assert.Equal(t, uuid.Nil.String(), savedQuery.UserID)
 		require.NotNil(t, savedQuery.SchemaExtensionID)
-		require.Equal(t, extensionID, *savedQuery.SchemaExtensionID)
-		require.Equal(t, expectedSavedQuery.Name, savedQuery.Name)
-		require.Equal(t, expectedSavedQuery.Query, savedQuery.Query)
-		require.Equal(t, expectedSavedQuery.Description, savedQuery.Description)
+		assert.Equal(t, extensionID, *savedQuery.SchemaExtensionID)
+		assert.Equal(t, expectedSavedQuery.Category, savedQuery.Category)
+		assert.Equal(t, expectedSavedQuery.Name, savedQuery.Name)
+		assert.Equal(t, expectedSavedQuery.Query, savedQuery.Query)
+		assert.Equal(t, expectedSavedQuery.Description, savedQuery.Description)
 		isPublic, err := testSuite.BHDatabase.IsSavedQueryPublic(testSuite.Context, savedQuery.ID)
 		require.NoError(t, err)
-		require.True(t, isPublic)
-		savedQueriesByKey[normalizedQueryKey] = savedQuery
+		assert.True(t, isPublic)
+		savedQueriesByKey[queryKey] = savedQuery
 	}
 	return savedQueriesByKey
 }
 
-func requireSavedQueriesDeleted(t *testing.T, testSuite IntegrationTestSuite, savedQueryIDs ...int64) {
+func assertSavedQueriesDeleted(t *testing.T, testSuite IntegrationTestSuite, savedQueryIDs ...int64) {
 	t.Helper()
 	for _, savedQueryID := range savedQueryIDs {
 		_, err := testSuite.BHDatabase.GetSavedQuery(testSuite.Context, savedQueryID)
-		require.ErrorIs(t, err, database.ErrNotFound)
+		assert.ErrorIs(t, err, database.ErrNotFound)
 	}
 }
 
@@ -100,39 +101,49 @@ func TestBloodhoundDB_UpsertOpenGraphExtensionSavedQueries(t *testing.T) {
 		existingSavedQueriesByKey map[string]model.SavedQuery
 		deletedSavedQueryIDs      []int64
 	}
+
+	var (
+		baseGraphExtensionInput = model.GraphExtensionInput{
+			ExtensionInput: model.ExtensionInput{
+				DisplayName: "Saved Query Extension",
+				Version:     "1.0.0",
+				Namespace:   "SQ",
+			},
+			NodeKindsInput: model.NodesInput{{Name: "SQ_Node"}},
+		}
+		teardownExtension = func(t *testing.T, testSuite IntegrationTestSuite, setupData testSetupData) {
+			t.Helper()
+			if setupData.extensionID != 0 {
+				assert.NoError(t, testSuite.BHDatabase.DeleteGraphSchemaExtension(testSuite.Context, setupData.extensionID))
+			}
+		}
+	)
+	t.Parallel()
+	testSuite := setupIntegrationTestSuite(t)
+	defer teardownIntegrationTestSuite(t, &testSuite)
+
 	type testCase struct {
 		name     string
 		setup    func(t *testing.T, testSuite IntegrationTestSuite) testSetupData
 		assert   func(t *testing.T, testSuite IntegrationTestSuite, setupData *testSetupData, updated bool, err error)
 		teardown func(t *testing.T, testSuite IntegrationTestSuite, setupData testSetupData)
 	}
-	graphExtensionWithSavedQueries := func(extensionName string, savedQueries model.SavedQueriesInput) model.GraphExtensionInput {
-		return model.GraphExtensionInput{
-			ExtensionInput:    model.ExtensionInput{Name: extensionName, DisplayName: "Saved Query Extension", Version: "1.0.0", Namespace: "SQ"},
-			NodeKindsInput:    model.NodesInput{{Name: "SQ_Node"}},
-			SavedQueriesInput: savedQueries,
-		}
-	}
-	teardownExtension := func(t *testing.T, testSuite IntegrationTestSuite, setupData testSetupData) {
-		t.Helper()
-		if setupData.extensionID != 0 {
-			assert.NoError(t, testSuite.BHDatabase.DeleteGraphSchemaExtension(testSuite.Context, setupData.extensionID))
-		}
-	}
-	t.Parallel()
-	testSuite := setupIntegrationTestSuite(t)
-	defer teardownIntegrationTestSuite(t, &testSuite)
 	tests := []testCase{
 		{
 			name: "Create",
 			setup: func(t *testing.T, testSuite IntegrationTestSuite) testSetupData {
 				t.Helper()
-				expectedSavedQueries := model.SavedQueriesInput{
-					savedQuery("one", "One", "RETURN 1", "first"),
-					savedQuery("two", "Two", "RETURN 2", "second"),
-				}
+				var (
+					expectedSavedQueries = model.SavedQueriesInput{
+						savedQuery("one", "One", "RETURN 1", "first", "First Category"),
+						savedQuery("two", "Two", "RETURN 2", "second", "Second Category"),
+					}
+					graphExtensionInput = baseGraphExtensionInput
+				)
+				graphExtensionInput.ExtensionInput.Name = "SavedQueryReconcileCreate"
+				graphExtensionInput.SavedQueriesInput = expectedSavedQueries
 				return testSetupData{
-					graphExtensionInput:  graphExtensionWithSavedQueries("SavedQueryReconcileCreate", expectedSavedQueries),
+					graphExtensionInput:  graphExtensionInput,
 					expectedSavedQueries: expectedSavedQueries,
 				}
 			},
@@ -150,7 +161,7 @@ func TestBloodhoundDB_UpsertOpenGraphExtensionSavedQueries(t *testing.T) {
 				require.NoError(t, lookupErr)
 				require.Len(t, graphSchemaExtensions, 1)
 				setupData.extensionID = graphSchemaExtensions[0].ID
-				requireExtensionSavedQueries(t, testSuite, setupData.extensionID, setupData.expectedSavedQueries...)
+				assertExtensionSavedQueries(t, testSuite, setupData.extensionID, setupData.expectedSavedQueries...)
 			},
 			teardown: teardownExtension,
 		},
@@ -160,14 +171,17 @@ func TestBloodhoundDB_UpsertOpenGraphExtensionSavedQueries(t *testing.T) {
 				t.Helper()
 				var (
 					extensionName             = "SavedQueryReconcileUpdate"
-					initialSavedQueries       = model.SavedQueriesInput{savedQuery("keep", "Keep", "RETURN 1", "old")}
-					expectedSavedQueries      = model.SavedQueriesInput{savedQuery("keep", "Updated", "RETURN 2", "new")}
-					updatedSavedQueries       = model.SavedQueriesInput{savedQuery("KEEP", "Updated", "RETURN 2", "new")}
+					initialSavedQueries       = model.SavedQueriesInput{savedQuery("keep", "Keep", "RETURN 1", "old", "Old Category")}
+					expectedSavedQueries      = model.SavedQueriesInput{savedQuery("keep", "Updated", "RETURN 2", "new", "New Category")}
+					updatedSavedQueries       = model.SavedQueriesInput{savedQuery("keep", "Updated", "RETURN 2", "new", "New Category")}
+					graphExtensionInput       = baseGraphExtensionInput
 					extensionID               = upsertExtensionSavedQueries(t, testSuite, extensionName, initialSavedQueries...)
-					existingSavedQueriesByKey = requireExtensionSavedQueries(t, testSuite, extensionID, initialSavedQueries...)
+					existingSavedQueriesByKey = assertExtensionSavedQueries(t, testSuite, extensionID, initialSavedQueries...)
 				)
+				graphExtensionInput.ExtensionInput.Name = extensionName
+				graphExtensionInput.SavedQueriesInput = updatedSavedQueries
 				return testSetupData{
-					graphExtensionInput:       graphExtensionWithSavedQueries(extensionName, updatedSavedQueries),
+					graphExtensionInput:       graphExtensionInput,
 					extensionID:               extensionID,
 					expectedSavedQueries:      expectedSavedQueries,
 					existingSavedQueriesByKey: existingSavedQueriesByKey,
@@ -177,7 +191,7 @@ func TestBloodhoundDB_UpsertOpenGraphExtensionSavedQueries(t *testing.T) {
 				t.Helper()
 				require.NoError(t, err)
 				assert.True(t, updated)
-				currentSavedQueriesByKey := requireExtensionSavedQueries(t, testSuite, setupData.extensionID, setupData.expectedSavedQueries...)
+				currentSavedQueriesByKey := assertExtensionSavedQueries(t, testSuite, setupData.extensionID, setupData.expectedSavedQueries...)
 				require.Equal(t, setupData.existingSavedQueriesByKey["keep"].ID, currentSavedQueriesByKey["keep"].ID)
 			},
 			teardown: teardownExtension,
@@ -188,13 +202,16 @@ func TestBloodhoundDB_UpsertOpenGraphExtensionSavedQueries(t *testing.T) {
 				t.Helper()
 				var (
 					extensionName        = "SavedQueryReconcileDelete"
-					initialSavedQueries  = model.SavedQueriesInput{savedQuery("keep", "Keep", "RETURN 1", "keep"), savedQuery("drop", "Drop", "RETURN 2", "drop")}
-					expectedSavedQueries = model.SavedQueriesInput{savedQuery("keep", "Keep", "RETURN 1", "keep")}
+					initialSavedQueries  = model.SavedQueriesInput{savedQuery("keep", "Keep", "RETURN 1", "keep", "Keep Category"), savedQuery("drop", "Drop", "RETURN 2", "drop", "Drop Category")}
+					expectedSavedQueries = model.SavedQueriesInput{savedQuery("keep", "Keep", "RETURN 1", "keep", "Keep Category")}
+					graphExtensionInput  = baseGraphExtensionInput
 					extensionID          = upsertExtensionSavedQueries(t, testSuite, extensionName, initialSavedQueries...)
-					savedQueriesByKey    = requireExtensionSavedQueries(t, testSuite, extensionID, initialSavedQueries...)
+					savedQueriesByKey    = assertExtensionSavedQueries(t, testSuite, extensionID, initialSavedQueries...)
 				)
+				graphExtensionInput.ExtensionInput.Name = extensionName
+				graphExtensionInput.SavedQueriesInput = expectedSavedQueries
 				return testSetupData{
-					graphExtensionInput:  graphExtensionWithSavedQueries(extensionName, expectedSavedQueries),
+					graphExtensionInput:  graphExtensionInput,
 					extensionID:          extensionID,
 					expectedSavedQueries: expectedSavedQueries,
 					deletedSavedQueryIDs: []int64{savedQueriesByKey["drop"].ID},
@@ -204,8 +221,8 @@ func TestBloodhoundDB_UpsertOpenGraphExtensionSavedQueries(t *testing.T) {
 				t.Helper()
 				require.NoError(t, err)
 				assert.True(t, updated)
-				requireExtensionSavedQueries(t, testSuite, setupData.extensionID, setupData.expectedSavedQueries...)
-				requireSavedQueriesDeleted(t, testSuite, setupData.deletedSavedQueryIDs...)
+				assertExtensionSavedQueries(t, testSuite, setupData.extensionID, setupData.expectedSavedQueries...)
+				assertSavedQueriesDeleted(t, testSuite, setupData.deletedSavedQueryIDs...)
 			},
 			teardown: teardownExtension,
 		},

--- a/cmd/api/src/database/upsert_schema_saved_query_integration_test.go
+++ b/cmd/api/src/database/upsert_schema_saved_query_integration_test.go
@@ -1,0 +1,226 @@
+// Copyright 2026 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//go:build integration
+
+package database_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gofrs/uuid"
+	"github.com/specterops/bloodhound/cmd/api/src/database"
+	"github.com/specterops/bloodhound/cmd/api/src/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func savedQuery(queryKey string, name string, query string, description string) model.SavedQueryInput {
+	return model.SavedQueryInput{
+		QueryKey:    queryKey,
+		Name:        name,
+		Query:       query,
+		Description: description,
+	}
+}
+
+func upsertExtensionSavedQueries(t *testing.T, testSuite IntegrationTestSuite, extensionName string, savedQueries ...model.SavedQueryInput) int32 {
+	t.Helper()
+	input := model.GraphExtensionInput{
+		ExtensionInput:    model.ExtensionInput{Name: extensionName, DisplayName: "Saved Query Extension", Version: "1.0.0", Namespace: "SQ"},
+		NodeKindsInput:    model.NodesInput{{Name: "SQ_Node"}},
+		SavedQueriesInput: savedQueries,
+	}
+	_, err := testSuite.BHDatabase.UpsertOpenGraphExtension(testSuite.Context, input)
+	require.NoError(t, err)
+	extensions, _, err := testSuite.BHDatabase.GetGraphSchemaExtensions(testSuite.Context, model.Filters{"name": []model.Filter{{Operator: model.Equals, Value: extensionName, SetOperator: model.FilterAnd}}}, model.Sort{}, 0, 1)
+	require.NoError(t, err)
+	require.Len(t, extensions, 1)
+	return extensions[0].ID
+}
+
+func requireExtensionSavedQueries(t *testing.T, testSuite IntegrationTestSuite, extensionID int32, expectedSavedQueries ...model.SavedQueryInput) map[string]model.SavedQuery {
+	t.Helper()
+	var (
+		expectedSavedQueriesByKey = map[string]model.SavedQueryInput{}
+		savedQueriesByKey         = map[string]model.SavedQuery{}
+	)
+	for _, expectedSavedQuery := range expectedSavedQueries {
+		expectedSavedQueriesByKey[strings.ToLower(expectedSavedQuery.QueryKey)] = expectedSavedQuery
+	}
+	savedQueries, err := testSuite.BHDatabase.GetSavedQueriesByExtensionID(testSuite.Context, extensionID)
+	require.NoError(t, err)
+	require.Len(t, savedQueries, len(expectedSavedQueries))
+	for _, savedQuery := range savedQueries {
+		require.NotNil(t, savedQuery.QueryKey)
+		normalizedQueryKey := strings.ToLower(*savedQuery.QueryKey)
+		expectedSavedQuery, found := expectedSavedQueriesByKey[normalizedQueryKey]
+		require.True(t, found)
+		require.Equal(t, expectedSavedQuery.QueryKey, *savedQuery.QueryKey)
+		require.Equal(t, uuid.Nil.String(), savedQuery.UserID)
+		require.NotNil(t, savedQuery.SchemaExtensionID)
+		require.Equal(t, extensionID, *savedQuery.SchemaExtensionID)
+		require.Equal(t, expectedSavedQuery.Name, savedQuery.Name)
+		require.Equal(t, expectedSavedQuery.Query, savedQuery.Query)
+		require.Equal(t, expectedSavedQuery.Description, savedQuery.Description)
+		isPublic, err := testSuite.BHDatabase.IsSavedQueryPublic(testSuite.Context, savedQuery.ID)
+		require.NoError(t, err)
+		require.True(t, isPublic)
+		savedQueriesByKey[normalizedQueryKey] = savedQuery
+	}
+	return savedQueriesByKey
+}
+
+func requireSavedQueriesDeleted(t *testing.T, testSuite IntegrationTestSuite, savedQueryIDs ...int64) {
+	t.Helper()
+	for _, savedQueryID := range savedQueryIDs {
+		_, err := testSuite.BHDatabase.GetSavedQuery(testSuite.Context, savedQueryID)
+		require.ErrorIs(t, err, database.ErrNotFound)
+	}
+}
+
+func TestBloodhoundDB_UpsertOpenGraphExtensionSavedQueries(t *testing.T) {
+	type testSetupData struct {
+		graphExtensionInput       model.GraphExtensionInput
+		extensionID               int32
+		expectedSavedQueries      model.SavedQueriesInput
+		existingSavedQueriesByKey map[string]model.SavedQuery
+		deletedSavedQueryIDs      []int64
+	}
+	type testCase struct {
+		name     string
+		setup    func(t *testing.T, testSuite IntegrationTestSuite) testSetupData
+		assert   func(t *testing.T, testSuite IntegrationTestSuite, setupData *testSetupData, updated bool, err error)
+		teardown func(t *testing.T, testSuite IntegrationTestSuite, setupData testSetupData)
+	}
+	graphExtensionWithSavedQueries := func(extensionName string, savedQueries model.SavedQueriesInput) model.GraphExtensionInput {
+		return model.GraphExtensionInput{
+			ExtensionInput:    model.ExtensionInput{Name: extensionName, DisplayName: "Saved Query Extension", Version: "1.0.0", Namespace: "SQ"},
+			NodeKindsInput:    model.NodesInput{{Name: "SQ_Node"}},
+			SavedQueriesInput: savedQueries,
+		}
+	}
+	teardownExtension := func(t *testing.T, testSuite IntegrationTestSuite, setupData testSetupData) {
+		t.Helper()
+		if setupData.extensionID != 0 {
+			assert.NoError(t, testSuite.BHDatabase.DeleteGraphSchemaExtension(testSuite.Context, setupData.extensionID))
+		}
+	}
+	t.Parallel()
+	testSuite := setupIntegrationTestSuite(t)
+	defer teardownIntegrationTestSuite(t, &testSuite)
+	tests := []testCase{
+		{
+			name: "Create",
+			setup: func(t *testing.T, testSuite IntegrationTestSuite) testSetupData {
+				t.Helper()
+				expectedSavedQueries := model.SavedQueriesInput{
+					savedQuery("one", "One", "RETURN 1", "first"),
+					savedQuery("two", "Two", "RETURN 2", "second"),
+				}
+				return testSetupData{
+					graphExtensionInput:  graphExtensionWithSavedQueries("SavedQueryReconcileCreate", expectedSavedQueries),
+					expectedSavedQueries: expectedSavedQueries,
+				}
+			},
+			assert: func(t *testing.T, testSuite IntegrationTestSuite, setupData *testSetupData, updated bool, err error) {
+				t.Helper()
+				require.NoError(t, err)
+				assert.False(t, updated)
+				graphSchemaExtensions, _, lookupErr := testSuite.BHDatabase.GetGraphSchemaExtensions(
+					testSuite.Context,
+					model.Filters{"name": []model.Filter{{Operator: model.Equals, Value: setupData.graphExtensionInput.ExtensionInput.Name, SetOperator: model.FilterAnd}}},
+					model.Sort{},
+					0,
+					1,
+				)
+				require.NoError(t, lookupErr)
+				require.Len(t, graphSchemaExtensions, 1)
+				setupData.extensionID = graphSchemaExtensions[0].ID
+				requireExtensionSavedQueries(t, testSuite, setupData.extensionID, setupData.expectedSavedQueries...)
+			},
+			teardown: teardownExtension,
+		},
+		{
+			name: "Update",
+			setup: func(t *testing.T, testSuite IntegrationTestSuite) testSetupData {
+				t.Helper()
+				var (
+					extensionName             = "SavedQueryReconcileUpdate"
+					initialSavedQueries       = model.SavedQueriesInput{savedQuery("keep", "Keep", "RETURN 1", "old")}
+					expectedSavedQueries      = model.SavedQueriesInput{savedQuery("keep", "Updated", "RETURN 2", "new")}
+					updatedSavedQueries       = model.SavedQueriesInput{savedQuery("KEEP", "Updated", "RETURN 2", "new")}
+					extensionID               = upsertExtensionSavedQueries(t, testSuite, extensionName, initialSavedQueries...)
+					existingSavedQueriesByKey = requireExtensionSavedQueries(t, testSuite, extensionID, initialSavedQueries...)
+				)
+				return testSetupData{
+					graphExtensionInput:       graphExtensionWithSavedQueries(extensionName, updatedSavedQueries),
+					extensionID:               extensionID,
+					expectedSavedQueries:      expectedSavedQueries,
+					existingSavedQueriesByKey: existingSavedQueriesByKey,
+				}
+			},
+			assert: func(t *testing.T, testSuite IntegrationTestSuite, setupData *testSetupData, updated bool, err error) {
+				t.Helper()
+				require.NoError(t, err)
+				assert.True(t, updated)
+				currentSavedQueriesByKey := requireExtensionSavedQueries(t, testSuite, setupData.extensionID, setupData.expectedSavedQueries...)
+				require.Equal(t, setupData.existingSavedQueriesByKey["keep"].ID, currentSavedQueriesByKey["keep"].ID)
+			},
+			teardown: teardownExtension,
+		},
+		{
+			name: "Delete",
+			setup: func(t *testing.T, testSuite IntegrationTestSuite) testSetupData {
+				t.Helper()
+				var (
+					extensionName        = "SavedQueryReconcileDelete"
+					initialSavedQueries  = model.SavedQueriesInput{savedQuery("keep", "Keep", "RETURN 1", "keep"), savedQuery("drop", "Drop", "RETURN 2", "drop")}
+					expectedSavedQueries = model.SavedQueriesInput{savedQuery("keep", "Keep", "RETURN 1", "keep")}
+					extensionID          = upsertExtensionSavedQueries(t, testSuite, extensionName, initialSavedQueries...)
+					savedQueriesByKey    = requireExtensionSavedQueries(t, testSuite, extensionID, initialSavedQueries...)
+				)
+				return testSetupData{
+					graphExtensionInput:  graphExtensionWithSavedQueries(extensionName, expectedSavedQueries),
+					extensionID:          extensionID,
+					expectedSavedQueries: expectedSavedQueries,
+					deletedSavedQueryIDs: []int64{savedQueriesByKey["drop"].ID},
+				}
+			},
+			assert: func(t *testing.T, testSuite IntegrationTestSuite, setupData *testSetupData, updated bool, err error) {
+				t.Helper()
+				require.NoError(t, err)
+				assert.True(t, updated)
+				requireExtensionSavedQueries(t, testSuite, setupData.extensionID, setupData.expectedSavedQueries...)
+				requireSavedQueriesDeleted(t, testSuite, setupData.deletedSavedQueryIDs...)
+			},
+			teardown: teardownExtension,
+		},
+	}
+	for _, currentTestCase := range tests {
+		t.Run(currentTestCase.name, func(t *testing.T) {
+			setupData := currentTestCase.setup(t, testSuite)
+			if currentTestCase.teardown != nil {
+				t.Cleanup(func() {
+					currentTestCase.teardown(t, testSuite, setupData)
+				})
+			}
+
+			updated, err := testSuite.BHDatabase.UpsertOpenGraphExtension(testSuite.Context, setupData.graphExtensionInput)
+			currentTestCase.assert(t, testSuite, &setupData, updated, err)
+		})
+	}
+}

--- a/cmd/api/src/model/graphschema.go
+++ b/cmd/api/src/model/graphschema.go
@@ -474,6 +474,15 @@ type GraphSchemaRelationshipKindsWithNamedSchema []GraphSchemaRelationshipKindWi
 
 // Graph Extension Upsert Input
 
+type SavedQueriesInput []SavedQueryInput
+
+type SavedQueryInput struct {
+	QueryKey    string
+	Name        string
+	Query       string
+	Description string
+}
+
 type GraphExtensionInput struct {
 	ExtensionInput            ExtensionInput
 	RelationshipKindsInput    RelationshipsInput
@@ -497,14 +506,6 @@ type SelectorSeedInput struct {
 	Value string
 }
 
-type SavedQueriesInput []SavedQueryInput
-type SavedQueryInput struct {
-	Name        string
-	Query       string
-	QueryKey    string
-	Description string
-}
-
 // Validate performs comprehensive validation on a GraphExtensionInput
 func (s GraphExtensionInput) Validate() error {
 	var (
@@ -512,7 +513,11 @@ func (s GraphExtensionInput) Validate() error {
 		relationshipKinds = make(map[string]any, 0)
 		environments      = make(map[string]any, 0)
 		findings          = make(map[string]any, 0)
+		savedQueryKeys    = map[string]struct{}{}
+		savedQueryNames   = map[string]struct{}{}
 	)
+
+	// Schema Validation
 	if strings.TrimSpace(s.ExtensionInput.Name) == "" {
 		return errors.New("graph schema extension name is required")
 	} else if strings.TrimSpace(s.ExtensionInput.Version) == "" {
@@ -527,6 +532,7 @@ func (s GraphExtensionInput) Validate() error {
 		return errors.New("graph schema node kinds are required")
 	}
 
+	// Node kind validation
 	for _, kind := range s.NodeKindsInput {
 		if kindName, found := strings.CutPrefix(kind.Name, fmt.Sprintf("%s_", s.ExtensionInput.Namespace)); !found {
 			return fmt.Errorf("graph schema node kind %s is missing extension namespace prefix", kind.Name)
@@ -545,6 +551,7 @@ func (s GraphExtensionInput) Validate() error {
 		nodeKinds[kind.Name] = struct{}{}
 	}
 
+	// Relationship Kinds Validation
 	for _, kind := range s.RelationshipKindsInput {
 		if kindName, found := strings.CutPrefix(kind.Name, fmt.Sprintf("%s_", s.ExtensionInput.Namespace)); !found {
 			return fmt.Errorf("graph schema edge kind %s is missing extension namespace prefix", kind.Name)
@@ -563,6 +570,7 @@ func (s GraphExtensionInput) Validate() error {
 		relationshipKinds[kind.Name] = struct{}{}
 	}
 
+	// Environments Validation
 	for _, environment := range s.EnvironmentsInput {
 		if environmentKindName, found := strings.CutPrefix(environment.EnvironmentKindName, fmt.Sprintf("%s_", s.ExtensionInput.Namespace)); !found {
 			return fmt.Errorf("graph schema environment kind %s is missing extension namespace prefix", environment.EnvironmentKindName)
@@ -597,6 +605,7 @@ func (s GraphExtensionInput) Validate() error {
 		environments[environment.EnvironmentKindName] = struct{}{}
 	}
 
+	// Findings Validation
 	for _, relationshipFindingInput := range s.RelationshipFindingsInput {
 		if findingName, found := strings.CutPrefix(relationshipFindingInput.Name, fmt.Sprintf("%s_", s.ExtensionInput.Namespace)); !found {
 			return fmt.Errorf("graph schema relationship finding %s is missing extension namespace prefix", relationshipFindingInput.Name)
@@ -615,11 +624,28 @@ func (s GraphExtensionInput) Validate() error {
 		findings[relationshipFindingInput.Name] = struct{}{}
 	}
 
+	// Saved queries validation
+	for _, savedQueryInput := range s.SavedQueriesInput {
+		if strings.TrimSpace(savedQueryInput.QueryKey) == "" {
+			return errors.New("graph schema saved query key is required")
+		} else if strings.TrimSpace(savedQueryInput.Name) == "" {
+			return errors.New("graph schema saved query name is required")
+		} else if strings.TrimSpace(savedQueryInput.Query) == "" {
+			return errors.New("graph schema saved query text is required")
+		}
+		if _, found := savedQueryKeys[savedQueryInput.QueryKey]; found {
+			return fmt.Errorf("duplicate graph schema saved query key: %s", savedQueryInput.QueryKey)
+		} else if _, found := savedQueryNames[savedQueryInput.Name]; found {
+			return fmt.Errorf("duplicate graph schema saved query name: %s", savedQueryInput.Name)
+		}
+		savedQueryKeys[savedQueryInput.QueryKey] = struct{}{}
+		savedQueryNames[savedQueryInput.Name] = struct{}{}
+	}
+
 	if err := s.PZRulesInput.Validate(); err != nil {
 		return err
-	} else if err := s.SavedQueriesInput.Validate(); err != nil {
-		return err
 	}
+
 	return nil
 }
 
@@ -643,25 +669,6 @@ func (s PZRulesInput) Validate() error {
 			}
 		}
 		ruleNames[rule.Name] = struct{}{}
-	}
-	return nil
-}
-
-// Placeholder, may be more to consider here
-func (s SavedQueriesInput) Validate() error {
-	var queryNames = make(map[string]any, len(s))
-
-	for _, query := range s {
-		if strings.TrimSpace(query.Name) == "" {
-			return errors.New("saved query name is required")
-		}
-		if _, ok := queryNames[query.Name]; ok {
-			return fmt.Errorf("duplicate saved query: %s", query.Name)
-		}
-		if strings.TrimSpace(query.Query) == "" {
-			return fmt.Errorf("saved query %s requires a query body", query.Name)
-		}
-		queryNames[query.Name] = struct{}{}
 	}
 	return nil
 }
@@ -757,10 +764,8 @@ type GraphExtensionPayload struct {
 	GraphSchemaNodeKinds         []GraphSchemaNodeKindsPayload         `json:"node_kinds"`
 	GraphEnvironments            []EnvironmentPayload                  `json:"environments"`
 	GraphRelationshipFindings    []RelationshipFindingsPayload         `json:"relationship_findings"`
-
-	// PZRules and SavedQueries are optional components
-	PZRules      *PZRulesPayload      `json:"pz_rules,omitempty"`
-	SavedQueries *SavedQueriesPayload `json:"saved_queries,omitempty"`
+	SavedQueries                 *SavedQueriesPayload                  `json:"queries,omitempty"`
+	PZRules                      *PZRulesPayload                       `json:"pz_rules,omitempty"`
 }
 
 // SelectorSeedPayload is the JSON shape of a single privilege-zone selector seed within pz_rules.
@@ -780,19 +785,6 @@ type PZRulePayload struct {
 // PZRulesPayload is the "rules" envelope for the pz_rules.json component.
 type PZRulesPayload struct {
 	Rules []PZRulePayload `json:"rules"`
-}
-
-// SavedQueryPayload is the JSON shape of a single saved query within saved_queries.
-type SavedQueryPayload struct {
-	Name        string `json:"name"`
-	Query       string `json:"query"`
-	QueryKey    string `json:"query_key"`
-	Description string `json:"description"`
-}
-
-// SavedQueriesPayload is the "queries" envelope for the saved_queries.json component.
-type SavedQueriesPayload struct {
-	Queries []SavedQueryPayload `json:"queries"`
 }
 
 type GraphSchemaExtensionPayload struct {
@@ -845,6 +837,15 @@ type RemediationPayload struct {
 	ShortRemediation string `json:"short_remediation"`
 	LongRemediation  string `json:"long_remediation"`
 }
+
+type SavedQueryPayload struct {
+	QueryKey    string `json:"query_key"`
+	Name        string `json:"name"`
+	Query       string `json:"query"`
+	Description string `json:"description"`
+}
+
+type SavedQueriesPayload []SavedQueryPayload
 
 // parseInfoPayload converts the typed KindInfoPayload map to a KindInfoInputs slice
 func parseInfoPayload(infoPayload map[string]KindInfoPayload) (KindInfoInputs, error) {
@@ -908,8 +909,10 @@ func (s GraphExtensionPayload) ToGraphExtensionInput() (GraphExtensionInput, err
 			RelationshipKindsInput: make(RelationshipsInput, 0),
 			EnvironmentsInput:      make(EnvironmentsInput, 0),
 		}
-		infoInputs KindInfoInputs
-		err        error
+		infoInputs    KindInfoInputs
+		autoCertify   SelectorAutoCertifyMethod
+		selectorSeeds []SelectorSeedInput
+		err           error
 	)
 
 	for _, nodeKindPayload := range s.GraphSchemaNodeKinds {
@@ -968,29 +971,32 @@ func (s GraphExtensionPayload) ToGraphExtensionInput() (GraphExtensionInput, err
 	if s.PZRules != nil {
 		graphExtension.PZRulesInput = make(PZRulesInput, 0, len(s.PZRules.Rules))
 		for _, rulePayload := range s.PZRules.Rules {
-			var autoCertify = SelectorAutoCertifyMethodDisabled
+			autoCertify = SelectorAutoCertifyMethodDisabled
 			if rulePayload.AutoCertify != nil && *rulePayload.AutoCertify {
 				autoCertify = SelectorAutoCertifyMethodAllMembers
 			}
 
-			var seeds = make([]SelectorSeedInput, 0, len(rulePayload.Seeds))
+			selectorSeeds = make([]SelectorSeedInput, 0, len(rulePayload.Seeds))
 			for _, seedPayload := range rulePayload.Seeds {
-				seeds = append(seeds, SelectorSeedInput(seedPayload))
+				selectorSeeds = append(selectorSeeds, SelectorSeedInput{
+					Type:  seedPayload.Type,
+					Value: seedPayload.Value,
+				})
 			}
 
 			graphExtension.PZRulesInput = append(graphExtension.PZRulesInput, PZRuleInput{
 				Name:        rulePayload.Name,
 				Description: rulePayload.Description,
 				AutoCertify: autoCertify,
-				Seeds:       seeds,
+				Seeds:       selectorSeeds,
 			})
 		}
 	}
 
 	if s.SavedQueries != nil {
-		graphExtension.SavedQueriesInput = make(SavedQueriesInput, 0, len(s.SavedQueries.Queries))
-		for _, queryPayload := range s.SavedQueries.Queries {
-			graphExtension.SavedQueriesInput = append(graphExtension.SavedQueriesInput, SavedQueryInput(queryPayload))
+		graphExtension.SavedQueriesInput = make(SavedQueriesInput, 0, len(*s.SavedQueries))
+		for _, savedQueryPayload := range *s.SavedQueries {
+			graphExtension.SavedQueriesInput = append(graphExtension.SavedQueriesInput, SavedQueryInput(savedQueryPayload))
 		}
 	}
 	return graphExtension, nil

--- a/cmd/api/src/model/graphschema.go
+++ b/cmd/api/src/model/graphschema.go
@@ -481,6 +481,7 @@ type SavedQueryInput struct {
 	Name        string
 	Query       string
 	Description string
+	Category    string
 }
 
 type GraphExtensionInput struct {
@@ -843,6 +844,7 @@ type SavedQueryPayload struct {
 	Name        string `json:"name"`
 	Query       string `json:"query"`
 	Description string `json:"description"`
+	Category    string `json:"category"`
 }
 
 type SavedQueriesPayload []SavedQueryPayload
@@ -908,6 +910,7 @@ func (s GraphExtensionPayload) ToGraphExtensionInput() (GraphExtensionInput, err
 			NodeKindsInput:         make(NodesInput, 0),
 			RelationshipKindsInput: make(RelationshipsInput, 0),
 			EnvironmentsInput:      make(EnvironmentsInput, 0),
+			SavedQueriesInput:      make(SavedQueriesInput, 0),
 		}
 		infoInputs    KindInfoInputs
 		autoCertify   SelectorAutoCertifyMethod

--- a/cmd/api/src/model/graphschema.go
+++ b/cmd/api/src/model/graphschema.go
@@ -31,6 +31,7 @@ import (
 	"github.com/specterops/bloodhound/cmd/api/src/database/types/null"
 	"github.com/specterops/bloodhound/cmd/api/src/version"
 	"github.com/specterops/bloodhound/packages/go/safetemplate"
+	"github.com/specterops/dawgs/cypher/frontend"
 	"github.com/specterops/dawgs/graph"
 )
 
@@ -638,6 +639,9 @@ func (s GraphExtensionInput) Validate() error {
 			return fmt.Errorf("duplicate graph schema saved query key: %s", savedQueryInput.QueryKey)
 		} else if _, found := savedQueryNames[savedQueryInput.Name]; found {
 			return fmt.Errorf("duplicate graph schema saved query name: %s", savedQueryInput.Name)
+		}
+		if _, err := frontend.ParseCypher(frontend.NewContext(), savedQueryInput.Query); err != nil {
+			return fmt.Errorf("graph schema saved query %s contains invalid Cypher: %w", savedQueryInput.Name, err)
 		}
 		savedQueryKeys[savedQueryInput.QueryKey] = struct{}{}
 		savedQueryNames[savedQueryInput.Name] = struct{}{}

--- a/cmd/api/src/model/graphschema.go
+++ b/cmd/api/src/model/graphschema.go
@@ -515,8 +515,6 @@ func (s GraphExtensionInput) Validate() error {
 		relationshipKinds = make(map[string]any, 0)
 		environments      = make(map[string]any, 0)
 		findings          = make(map[string]any, 0)
-		savedQueryKeys    = map[string]struct{}{}
-		savedQueryNames   = map[string]struct{}{}
 	)
 
 	// Schema Validation
@@ -626,28 +624,9 @@ func (s GraphExtensionInput) Validate() error {
 		findings[relationshipFindingInput.Name] = struct{}{}
 	}
 
-	// Saved queries validation
-	for _, savedQueryInput := range s.SavedQueriesInput {
-		if strings.TrimSpace(savedQueryInput.QueryKey) == "" {
-			return errors.New("graph schema saved query key is required")
-		} else if strings.TrimSpace(savedQueryInput.Name) == "" {
-			return errors.New("graph schema saved query name is required")
-		} else if strings.TrimSpace(savedQueryInput.Query) == "" {
-			return errors.New("graph schema saved query text is required")
-		}
-		if _, found := savedQueryKeys[savedQueryInput.QueryKey]; found {
-			return fmt.Errorf("duplicate graph schema saved query key: %s", savedQueryInput.QueryKey)
-		} else if _, found := savedQueryNames[savedQueryInput.Name]; found {
-			return fmt.Errorf("duplicate graph schema saved query name: %s", savedQueryInput.Name)
-		}
-		if _, err := frontend.ParseCypher(frontend.NewContext(), savedQueryInput.Query); err != nil {
-			return fmt.Errorf("graph schema saved query %s contains invalid Cypher: %w", savedQueryInput.Name, err)
-		}
-		savedQueryKeys[savedQueryInput.QueryKey] = struct{}{}
-		savedQueryNames[savedQueryInput.Name] = struct{}{}
-	}
-
 	if err := s.PZRulesInput.Validate(); err != nil {
+		return err
+	} else if err := s.SavedQueriesInput.Validate(); err != nil {
 		return err
 	}
 
@@ -675,6 +654,35 @@ func (s PZRulesInput) Validate() error {
 		}
 		ruleNames[rule.Name] = struct{}{}
 	}
+	return nil
+}
+
+func (s SavedQueriesInput) Validate() error {
+	var (
+		savedQueryKeys  = make(map[string]any, len(s))
+		savedQueryNames = make(map[string]any, len(s))
+	)
+
+	for _, savedQueryInput := range s {
+		if strings.TrimSpace(savedQueryInput.QueryKey) == "" {
+			return errors.New("graph schema saved query key is required")
+		} else if strings.TrimSpace(savedQueryInput.Name) == "" {
+			return errors.New("graph schema saved query name is required")
+		} else if strings.TrimSpace(savedQueryInput.Query) == "" {
+			return errors.New("graph schema saved query text is required")
+		}
+		if _, found := savedQueryKeys[savedQueryInput.QueryKey]; found {
+			return fmt.Errorf("duplicate graph schema saved query key: %s", savedQueryInput.QueryKey)
+		} else if _, found := savedQueryNames[savedQueryInput.Name]; found {
+			return fmt.Errorf("duplicate graph schema saved query name: %s", savedQueryInput.Name)
+		}
+		if _, err := frontend.ParseCypher(frontend.DefaultCypherContext(), savedQueryInput.Query); err != nil {
+			return fmt.Errorf("graph schema saved query %s contains invalid Cypher: %w", savedQueryInput.Name, err)
+		}
+		savedQueryKeys[savedQueryInput.QueryKey] = struct{}{}
+		savedQueryNames[savedQueryInput.Name] = struct{}{}
+	}
+
 	return nil
 }
 

--- a/cmd/api/src/model/graphschema.go
+++ b/cmd/api/src/model/graphschema.go
@@ -985,10 +985,7 @@ func (s GraphExtensionPayload) ToGraphExtensionInput() (GraphExtensionInput, err
 
 			selectorSeeds = make([]SelectorSeedInput, 0, len(rulePayload.Seeds))
 			for _, seedPayload := range rulePayload.Seeds {
-				selectorSeeds = append(selectorSeeds, SelectorSeedInput{
-					Type:  seedPayload.Type,
-					Value: seedPayload.Value,
-				})
+				selectorSeeds = append(selectorSeeds, SelectorSeedInput(seedPayload))
 			}
 
 			graphExtension.PZRulesInput = append(graphExtension.PZRulesInput, PZRuleInput{

--- a/cmd/api/src/model/graphschema_test.go
+++ b/cmd/api/src/model/graphschema_test.go
@@ -865,6 +865,36 @@ func Test_validateGraphExtension(t *testing.T) {
 		{name: "fail - duplicate saved query key", args: args{graphExtension: GraphExtensionInput{ExtensionInput: baseExtensionInput(), NodeKindsInput: NodesInput{{Name: "AD_node_kind"}}, SavedQueriesInput: SavedQueriesInput{{QueryKey: "query-key", Name: "Query One", Query: "RETURN 1"}, {QueryKey: "query-key", Name: "Query Two", Query: "RETURN 2"}}}}, wantErr: fmt.Errorf("duplicate graph schema saved query key: query-key")},
 		{name: "fail - duplicate saved query name", args: args{graphExtension: GraphExtensionInput{ExtensionInput: baseExtensionInput(), NodeKindsInput: NodesInput{{Name: "AD_node_kind"}}, SavedQueriesInput: SavedQueriesInput{{QueryKey: "query-one", Name: "Query", Query: "RETURN 1"}, {QueryKey: "query-two", Name: "Query", Query: "RETURN 2"}}}}, wantErr: fmt.Errorf("duplicate graph schema saved query name: Query")},
 		{
+			name: "success - parsable saved query",
+			args: args{
+				graphExtension: GraphExtensionInput{
+					ExtensionInput: baseExtensionInput(),
+					NodeKindsInput: NodesInput{{Name: "AD_node_kind_1"}},
+					SavedQueriesInput: SavedQueriesInput{{
+						QueryKey: "valid-query",
+						Name:     "Valid query",
+						Query:    "MATCH (n) RETURN n",
+					}},
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "fail - unparseable saved query",
+			args: args{
+				graphExtension: GraphExtensionInput{
+					ExtensionInput: baseExtensionInput(),
+					NodeKindsInput: NodesInput{{Name: "AD_node_kind_1"}},
+					SavedQueriesInput: SavedQueriesInput{{
+						QueryKey: "invalid-query",
+						Name:     "Invalid query",
+						Query:    "MATCH (",
+					}},
+				},
+			},
+			wantErr: fmt.Errorf("graph schema saved query Invalid query contains invalid Cypher"),
+		},
+		{
 			name: "success - valid ExtensionInput",
 			args: args{
 				graphExtension: GraphExtensionInput{

--- a/cmd/api/src/model/graphschema_test.go
+++ b/cmd/api/src/model/graphschema_test.go
@@ -880,6 +880,36 @@ func Test_validateGraphExtension(t *testing.T) {
 			wantErr: nil,
 		},
 		{
+			name: "fail - saved query contains updating clause",
+			args: args{
+				graphExtension: GraphExtensionInput{
+					ExtensionInput: baseExtensionInput(),
+					NodeKindsInput: NodesInput{{Name: "AD_node_kind_1"}},
+					SavedQueriesInput: SavedQueriesInput{{
+						QueryKey: "updating-query",
+						Name:     "Updating query",
+						Query:    "MATCH (n) DELETE n",
+					}},
+				},
+			},
+			wantErr: fmt.Errorf("graph schema saved query Updating query contains invalid Cypher: updating clauses are not supported"),
+		},
+		{
+			name: "fail - saved query contains procedure invocation",
+			args: args{
+				graphExtension: GraphExtensionInput{
+					ExtensionInput: baseExtensionInput(),
+					NodeKindsInput: NodesInput{{Name: "AD_node_kind_1"}},
+					SavedQueriesInput: SavedQueriesInput{{
+						QueryKey: "procedure-query",
+						Name:     "Procedure query",
+						Query:    "CALL db.labels()",
+					}},
+				},
+			},
+			wantErr: fmt.Errorf("graph schema saved query Procedure query contains invalid Cypher: procedure invocation is not supported"),
+		},
+		{
 			name: "fail - unparseable saved query",
 			args: args{
 				graphExtension: GraphExtensionInput{

--- a/cmd/api/src/model/graphschema_test.go
+++ b/cmd/api/src/model/graphschema_test.go
@@ -1307,6 +1307,9 @@ func Test_GraphExtensionPayload_ToGraphExtensionInput(t *testing.T) {
 							},
 						},
 					},
+					SavedQueries: &SavedQueriesPayload{{
+						QueryKey: "query-key", Name: "Query Name", Query: "MATCH (n) RETURN n", Description: "Description", Category: "Category",
+					}},
 				},
 			},
 			want: GraphExtensionInput{
@@ -1356,20 +1359,21 @@ func Test_GraphExtensionPayload_ToGraphExtensionInput(t *testing.T) {
 						},
 					},
 				},
+				SavedQueriesInput: SavedQueriesInput{{
+					QueryKey: "query-key", Name: "Query Name", Query: "MATCH (n) RETURN n", Description: "Description", Category: "Category",
+				}},
 			},
 		},
 		{
-			name: "success_-_saved_query",
-			args: args{payload: GraphExtensionPayload{SavedQueries: &SavedQueriesPayload{{
-				QueryKey: "query-key", Name: "Query Name", Query: "MATCH (n) RETURN n", Description: "Description",
-			}}}},
+			name: "success_without_saved_queries",
+			args: args{
+				payload: GraphExtensionPayload{},
+			},
 			want: GraphExtensionInput{
-				RelationshipKindsInput: RelationshipsInput{},
-				NodeKindsInput:         NodesInput{},
-				EnvironmentsInput:      EnvironmentsInput{},
-				SavedQueriesInput: SavedQueriesInput{{
-					QueryKey: "query-key", Name: "Query Name", Query: "MATCH (n) RETURN n", Description: "Description",
-				}},
+				NodeKindsInput:         make(NodesInput, 0),
+				RelationshipKindsInput: make(RelationshipsInput, 0),
+				EnvironmentsInput:      make(EnvironmentsInput, 0),
+				SavedQueriesInput:      make(SavedQueriesInput, 0),
 			},
 		},
 		{

--- a/cmd/api/src/model/graphschema_test.go
+++ b/cmd/api/src/model/graphschema_test.go
@@ -856,6 +856,14 @@ func Test_validateGraphExtension(t *testing.T) {
 			},
 			wantErr: fmt.Errorf("duplicate graph schema relationship finding: AD_finding_1"),
 		},
+		{name: "fail - saved query empty key", args: args{graphExtension: GraphExtensionInput{ExtensionInput: baseExtensionInput(), NodeKindsInput: NodesInput{{Name: "AD_node_kind"}}, SavedQueriesInput: SavedQueriesInput{{Name: "Query", Query: "MATCH (n) RETURN n"}}}}, wantErr: fmt.Errorf("graph schema saved query key is required")},
+		{name: "fail - saved query whitespace key", args: args{graphExtension: GraphExtensionInput{ExtensionInput: baseExtensionInput(), NodeKindsInput: NodesInput{{Name: "AD_node_kind"}}, SavedQueriesInput: SavedQueriesInput{{QueryKey: " ", Name: "Query", Query: "MATCH (n) RETURN n"}}}}, wantErr: fmt.Errorf("graph schema saved query key is required")},
+		{name: "fail - saved query empty name", args: args{graphExtension: GraphExtensionInput{ExtensionInput: baseExtensionInput(), NodeKindsInput: NodesInput{{Name: "AD_node_kind"}}, SavedQueriesInput: SavedQueriesInput{{QueryKey: "query-key", Query: "MATCH (n) RETURN n"}}}}, wantErr: fmt.Errorf("graph schema saved query name is required")},
+		{name: "fail - saved query whitespace name", args: args{graphExtension: GraphExtensionInput{ExtensionInput: baseExtensionInput(), NodeKindsInput: NodesInput{{Name: "AD_node_kind"}}, SavedQueriesInput: SavedQueriesInput{{QueryKey: "query-key", Name: " ", Query: "MATCH (n) RETURN n"}}}}, wantErr: fmt.Errorf("graph schema saved query name is required")},
+		{name: "fail - saved query empty query", args: args{graphExtension: GraphExtensionInput{ExtensionInput: baseExtensionInput(), NodeKindsInput: NodesInput{{Name: "AD_node_kind"}}, SavedQueriesInput: SavedQueriesInput{{QueryKey: "query-key", Name: "Query"}}}}, wantErr: fmt.Errorf("graph schema saved query text is required")},
+		{name: "fail - saved query whitespace query", args: args{graphExtension: GraphExtensionInput{ExtensionInput: baseExtensionInput(), NodeKindsInput: NodesInput{{Name: "AD_node_kind"}}, SavedQueriesInput: SavedQueriesInput{{QueryKey: "query-key", Name: "Query", Query: " "}}}}, wantErr: fmt.Errorf("graph schema saved query text is required")},
+		{name: "fail - duplicate saved query key", args: args{graphExtension: GraphExtensionInput{ExtensionInput: baseExtensionInput(), NodeKindsInput: NodesInput{{Name: "AD_node_kind"}}, SavedQueriesInput: SavedQueriesInput{{QueryKey: "query-key", Name: "Query One", Query: "RETURN 1"}, {QueryKey: "query-key", Name: "Query Two", Query: "RETURN 2"}}}}, wantErr: fmt.Errorf("duplicate graph schema saved query key: query-key")},
+		{name: "fail - duplicate saved query name", args: args{graphExtension: GraphExtensionInput{ExtensionInput: baseExtensionInput(), NodeKindsInput: NodesInput{{Name: "AD_node_kind"}}, SavedQueriesInput: SavedQueriesInput{{QueryKey: "query-one", Name: "Query", Query: "RETURN 1"}, {QueryKey: "query-two", Name: "Query", Query: "RETURN 2"}}}}, wantErr: fmt.Errorf("duplicate graph schema saved query name: Query")},
 		{
 			name: "success - valid ExtensionInput",
 			args: args{
@@ -1348,6 +1356,20 @@ func Test_GraphExtensionPayload_ToGraphExtensionInput(t *testing.T) {
 						},
 					},
 				},
+			},
+		},
+		{
+			name: "success_-_saved_query",
+			args: args{payload: GraphExtensionPayload{SavedQueries: &SavedQueriesPayload{{
+				QueryKey: "query-key", Name: "Query Name", Query: "MATCH (n) RETURN n", Description: "Description",
+			}}}},
+			want: GraphExtensionInput{
+				RelationshipKindsInput: RelationshipsInput{},
+				NodeKindsInput:         NodesInput{},
+				EnvironmentsInput:      EnvironmentsInput{},
+				SavedQueriesInput: SavedQueriesInput{{
+					QueryKey: "query-key", Name: "Query Name", Query: "MATCH (n) RETURN n", Description: "Description",
+				}},
 			},
 		},
 		{

--- a/packages/go/openapi/doc/openapi.json
+++ b/packages/go/openapi/doc/openapi.json
@@ -7939,7 +7939,8 @@
                         "query_key": "all-node-kind-1",
                         "name": "All Node Kind 1",
                         "query": "MATCH (n:OGE_Node_Kind_1) RETURN n",
-                        "description": "Lists all OGE_Node_Kind_1 nodes."
+                        "description": "Lists all OGE_Node_Kind_1 nodes.",
+                        "category": "Asset Management"
                       }
                     ]
                   }
@@ -25842,6 +25843,11 @@
                   "type": "string",
                   "description": "An optional description of the saved query.",
                   "example": "Lists all critical assets."
+                },
+                "category": {
+                  "type": "string",
+                  "description": "An optional category for grouping the saved query.",
+                  "example": "Asset Management"
                 }
               }
             }

--- a/packages/go/openapi/doc/openapi.json
+++ b/packages/go/openapi/doc/openapi.json
@@ -7827,7 +7827,7 @@
     },
     "/api/v2/extensions": {
       "put": {
-        "description": "**Experimental** - Upserts the OpenGraph extension.\n\nThe request body may be a JSON extension payload or a ZIP bundle. ZIP bundles must contain `schema.json` and may include `pz_rules.json` and `saved_queries.json`.\n",
+        "description": "**Experimental** - Upserts the OpenGraph extension.\n\nThe request body may be a JSON extension payload or a ZIP bundle. A ZIP root must contain `schema.json` without optional components and may contain `pz_rules.json` (`{\"rules\":[...]}`) and `saved_queries.json` (`{\"queries\":[...]}`). Duplicate or unexpected files are rejected; findings require `pz_rules.json` with at least one rule.\n",
         "tags": [
           "OpenGraph (Experimental)",
           "Community",

--- a/packages/go/openapi/doc/openapi.json
+++ b/packages/go/openapi/doc/openapi.json
@@ -7827,7 +7827,7 @@
     },
     "/api/v2/extensions": {
       "put": {
-        "description": "**Experimental** - Upserts the OpenGraph extension.\n\nThe request body may be a JSON extension payload or a ZIP bundle. A ZIP root must contain `schema.json` without optional components and may contain `pz_rules.json` (`{\"rules\":[...]}`) and `saved_queries.json` (`{\"queries\":[...]}`). Duplicate or unexpected files are rejected; findings require `pz_rules.json` with at least one rule.\n",
+        "description": "**Experimental** - Upserts the OpenGraph extension.\n\nThe request body may be a JSON extension payload or a ZIP bundle. A ZIP root must contain `schema.json` without optional components and may contain `pz_rules.json` (`{\"rules\":[...]}`) and `saved_queries.json` (`{\"queries\":[...]}`). Duplicate or unexpected files are rejected; findings require `pz_rules.json` with at least one rule.\n\nEach recognized ZIP component is limited to 10 MiB after decompression; an oversized component is rejected as a bad request.\n",
         "tags": [
           "OpenGraph (Experimental)",
           "Community",
@@ -25836,7 +25836,7 @@
                 },
                 "query": {
                   "type": "string",
-                  "description": "The Cypher query to run.",
+                  "description": "Extension-provided saved queries must be read-only; updating clauses are not supported.",
                   "example": "MATCH (n) RETURN n"
                 },
                 "description": {

--- a/packages/go/openapi/doc/openapi.json
+++ b/packages/go/openapi/doc/openapi.json
@@ -7933,6 +7933,14 @@
                           "long_remediation": "Do X to fix Finding 1"
                         }
                       }
+                    ],
+                    "queries": [
+                      {
+                        "query_key": "all-node-kind-1",
+                        "name": "All Node Kind 1",
+                        "query": "MATCH (n:OGE_Node_Kind_1) RETURN n",
+                        "description": "Lists all OGE_Node_Kind_1 nodes."
+                      }
                     ]
                   }
                 },
@@ -25767,6 +25775,9 @@
           "pz_rules": {
             "type": "object",
             "description": "Optional privilege-zone rules component.",
+            "required": [
+              "rules"
+            ],
             "properties": {
               "rules": {
                 "type": "array",
@@ -25801,32 +25812,36 @@
               }
             }
           },
-          "saved_queries": {
-            "type": "object",
-            "description": "Optional saved queries component.",
-            "properties": {
-              "queries": {
-                "type": "array",
-                "items": {
-                  "type": "object",
-                  "properties": {
-                    "query_key": {
-                      "type": "string",
-                      "example": "all-domain-admins"
-                    },
-                    "name": {
-                      "type": "string",
-                      "example": "All Domain Admins"
-                    },
-                    "query": {
-                      "type": "string",
-                      "example": "MATCH (n) RETURN n LIMIT 1"
-                    },
-                    "description": {
-                      "type": "string",
-                      "example": "Returns all domain admin nodes."
-                    }
-                  }
+          "queries": {
+            "type": "array",
+            "description": "Declares the extension's desired saved queries. Omitting this property or\nproviding an empty array removes existing saved queries associated with the extension.\n",
+            "items": {
+              "type": "object",
+              "required": [
+                "query_key",
+                "name",
+                "query"
+              ],
+              "properties": {
+                "query_key": {
+                  "type": "string",
+                  "description": "A stable identifier for reconciling the saved query.",
+                  "example": "critical-assets"
+                },
+                "name": {
+                  "type": "string",
+                  "description": "The saved query's display name.",
+                  "example": "Critical Assets"
+                },
+                "query": {
+                  "type": "string",
+                  "description": "The Cypher query to run.",
+                  "example": "MATCH (n) RETURN n"
+                },
+                "description": {
+                  "type": "string",
+                  "description": "An optional description of the saved query.",
+                  "example": "Lists all critical assets."
                 }
               }
             }

--- a/packages/go/openapi/src/paths/opengraph.extensions.yaml
+++ b/packages/go/openapi/src/paths/opengraph.extensions.yaml
@@ -101,6 +101,7 @@ put:
                   name: All Node Kind 1
                   query: MATCH (n:OGE_Node_Kind_1) RETURN n
                   description: Lists all OGE_Node_Kind_1 nodes.
+                  category: Asset Management
           Active Directory:
             summary: Active Directory Example
             description: An example Active Directory OpenGraph Extension. As a note, the Active Directory objects in the DB do not currently conform to the expected validation rules. This will change in the future. The example provided is how an Active Directory extension would look in the OpenGraph framework.

--- a/packages/go/openapi/src/paths/opengraph.extensions.yaml
+++ b/packages/go/openapi/src/paths/opengraph.extensions.yaml
@@ -18,7 +18,7 @@ put:
   description: |
     **Experimental** - Upserts the OpenGraph extension.
 
-    The request body may be a JSON extension payload or a ZIP bundle. ZIP bundles must contain `schema.json` and may include `pz_rules.json` and `saved_queries.json`.
+    The request body may be a JSON extension payload or a ZIP bundle. A ZIP root must contain `schema.json` without optional components and may contain `pz_rules.json` (`{"rules":[...]}`) and `saved_queries.json` (`{"queries":[...]}`). Duplicate or unexpected files are rejected; findings require `pz_rules.json` with at least one rule.
   tags:
     - OpenGraph (Experimental)
     - Community

--- a/packages/go/openapi/src/paths/opengraph.extensions.yaml
+++ b/packages/go/openapi/src/paths/opengraph.extensions.yaml
@@ -96,6 +96,11 @@ put:
                     long_description: a remediation to fix Finding 1
                     short_remediation: Do X
                     long_remediation: Do X to fix Finding 1
+              queries:
+                - query_key: all-node-kind-1
+                  name: All Node Kind 1
+                  query: MATCH (n:OGE_Node_Kind_1) RETURN n
+                  description: Lists all OGE_Node_Kind_1 nodes.
           Active Directory:
             summary: Active Directory Example
             description: An example Active Directory OpenGraph Extension. As a note, the Active Directory objects in the DB do not currently conform to the expected validation rules. This will change in the future. The example provided is how an Active Directory extension would look in the OpenGraph framework.

--- a/packages/go/openapi/src/paths/opengraph.extensions.yaml
+++ b/packages/go/openapi/src/paths/opengraph.extensions.yaml
@@ -19,6 +19,8 @@ put:
     **Experimental** - Upserts the OpenGraph extension.
 
     The request body may be a JSON extension payload or a ZIP bundle. A ZIP root must contain `schema.json` without optional components and may contain `pz_rules.json` (`{"rules":[...]}`) and `saved_queries.json` (`{"queries":[...]}`). Duplicate or unexpected files are rejected; findings require `pz_rules.json` with at least one rule.
+
+    Each recognized ZIP component is limited to 10 MiB after decompression; an oversized component is rejected as a bad request.
   tags:
     - OpenGraph (Experimental)
     - Community

--- a/packages/go/openapi/src/schemas/model.graph-extension.payload.yaml
+++ b/packages/go/openapi/src/schemas/model.graph-extension.payload.yaml
@@ -70,23 +70,6 @@ properties:
           type: boolean
         info:
           $ref: './model.graph-extension.kind-info-definition.yaml'
-  #properties:
-  #  type: array
-  #  items:
-  #    type: object
-  #    properties:
-  #      name:
-  #        type: string
-  #        example: UserPrincipalName
-  #      display_name:
-  #        type: string
-  #        example: User Principal Name
-  #      data_type:
-  #        type: string
-  #        example: string
-  #      description:
-  #        type: string
-  #        example: An Active Directory User Principal Name
   environments:
     type: array
     items:
@@ -136,6 +119,8 @@ properties:
   pz_rules:
     type: object
     description: Optional privilege-zone rules component.
+    required:
+      - rules
     properties:
       rules:
         type: array
@@ -157,24 +142,31 @@ properties:
                     type: integer
                   value:
                     type: string
-  saved_queries:
-    type: object
-    description: Optional saved queries component.
-    properties:
-      queries:
-        type: array
-        items:
-          type: object
-          properties:
-            query_key:
-              type: string
-              example: all-domain-admins
-            name:
-              type: string
-              example: All Domain Admins
-            query:
-              type: string
-              example: MATCH (n) RETURN n LIMIT 1
-            description:
-              type: string
-              example: Returns all domain admin nodes.
+  queries:
+    type: array
+    description: |
+      Declares the extension's desired saved queries. Omitting this property or
+      providing an empty array removes existing saved queries associated with the extension.
+    items:
+      type: object
+      required:
+        - query_key
+        - name
+        - query
+      properties:
+        query_key:
+          type: string
+          description: A stable identifier for reconciling the saved query.
+          example: critical-assets
+        name:
+          type: string
+          description: The saved query's display name.
+          example: Critical Assets
+        query:
+          type: string
+          description: The Cypher query to run.
+          example: MATCH (n) RETURN n
+        description:
+          type: string
+          description: An optional description of the saved query.
+          example: Lists all critical assets.

--- a/packages/go/openapi/src/schemas/model.graph-extension.payload.yaml
+++ b/packages/go/openapi/src/schemas/model.graph-extension.payload.yaml
@@ -170,3 +170,7 @@ properties:
           type: string
           description: An optional description of the saved query.
           example: Lists all critical assets.
+        category:
+          type: string
+          description: An optional category for grouping the saved query.
+          example: Asset Management

--- a/packages/go/openapi/src/schemas/model.graph-extension.payload.yaml
+++ b/packages/go/openapi/src/schemas/model.graph-extension.payload.yaml
@@ -164,7 +164,7 @@ properties:
           example: Critical Assets
         query:
           type: string
-          description: The Cypher query to run.
+          description: Extension-provided saved queries must be read-only; updating clauses are not supported.
           example: MATCH (n) RETURN n
         description:
           type: string

--- a/schemas/open_graph/dog-park-schema.json
+++ b/schemas/open_graph/dog-park-schema.json
@@ -122,5 +122,14 @@
         "long_remediation": "Query the registration system to confirm this patron has a valid membership and authorized access to this area."
       }
     }
+  ],
+  "saved_queries": [
+    {
+      "query_key": "dogs-and-owners",
+      "name": "Dogs and Their Owners",
+      "query": "MATCH p=(:dogpark_Dog)-[:dogpark_OwnedBy]->(:dogpark_Patron) RETURN p",
+      "description": "Lists dogs and their registered owners.",
+      "category": "Dog Park"
+    }
   ]
 }

--- a/schemas/open_graph/dog-park-schema.json
+++ b/schemas/open_graph/dog-park-schema.json
@@ -123,7 +123,7 @@
       }
     }
   ],
-  "saved_queries": [
+  "queries": [
     {
       "query_key": "dogs-and-owners",
       "name": "Dogs and Their Owners",


### PR DESCRIPTION
## Description

- Adds Saved Queries to OpenGraph Bundle upsert
- Adds unit and integration tests covering the changeset

## Motivation and Context
Resolves: BED-9320

Enables extension authors to add and link saved queries to an extension bundle. 

## How Has This Been Tested?

- Adds new unit and integration tests for the changeset
- Manually tested locally to ensure saved queries are added as expected

## Types of changes
- New feature (non-breaking change which adds functionality)

## Checklist:
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OpenGraph extensions can now be uploaded as JSON or ZIP bundles.
  * ZIP bundles support schemas, privilege-zone rules, and saved queries.
  * Saved queries can be created, updated, removed, and associated with extensions.
  * Added validation for query fields, duplicate identifiers, Cypher syntax, and privilege-zone rules.
* **Documentation**
  * Updated API documentation with ZIP requirements, supported components, examples, and validation responses.
* **Bug Fixes**
  * Extension updates now keep saved queries synchronized with the submitted configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->