### PR TITLE
feat: a11y - Hidden UI headings of Explore and PZ - BED-9537

### DIFF
--- a/cmd/ui/src/views/Explore/ExploreSearch/ExploreSearch.test.tsx
+++ b/cmd/ui/src/views/Explore/ExploreSearch/ExploreSearch.test.tsx
@@ -142,6 +142,12 @@ const setup = async (exploreSearchTab?: string) => {
 // Example
 
 describe('ExploreSearch rendering per tab', async () => {
+    it('renders hidden h2 with current tab name for screen readers', async () => {
+        await setup();
+        const hiddenHeading = screen.getByRole('heading', { level: 2, name: /search/i });
+        expect(hiddenHeading).toBeInTheDocument();
+        expect(hiddenHeading).toHaveClass('sr-only');
+    });
     it('should render', async () => {
         await setup();
         expect(screen.getByLabelText('Search Nodes')).toBeInTheDocument();
@@ -150,7 +156,6 @@ describe('ExploreSearch rendering per tab', async () => {
         expect(screen.getByRole('tab', { name: /pathfinding/i })).toBeInTheDocument();
         expect(screen.getByRole('tab', { name: /cypher/i })).toBeInTheDocument();
     });
-
     it('should render the pathfinding search controls when searchType is pathfinding', async () => {
         await setup('pathfinding');
 

--- a/cmd/ui/src/views/Explore/ExploreSearch/ExploreSearch.tsx
+++ b/cmd/ui/src/views/Explore/ExploreSearch/ExploreSearch.tsx
@@ -62,7 +62,7 @@ const tabs = [
 ];
 
 const getTab = (exploreSearchTab: ExploreQueryParams['exploreSearchTab']) => {
-    if (exploreSearchTab && exploreSearchTab in tabMap) return exploreSearchTab as keyof typeof tabMap;
+    if (exploreSearchTab && Object.hasOwn(tabMap, exploreSearchTab)) return exploreSearchTab as keyof typeof tabMap;
     return 'node';
 };
 

--- a/cmd/ui/src/views/Explore/ExploreSearch/ExploreSearch.tsx
+++ b/cmd/ui/src/views/Explore/ExploreSearch/ExploreSearch.tsx
@@ -79,6 +79,8 @@ const ExploreSearch: React.FC = () => {
     const pathfindingFilterState = usePathfindingFilters();
 
     const activeTab = getTab(exploreSearchTab);
+    const activeTabValue = tabMap[activeTab];
+    const activeTabLabel = tabs[activeTabValue].label;
 
     const [showSearchWidget, setShowSearchWidget] = useState(true);
 
@@ -188,6 +190,8 @@ const ExploreSearch: React.FC = () => {
 
     return (
         <div data-testid='explore_search-container' className='h-full min-h-0 w-[600px] flex gap-4 flex-col rounded'>
+            {/* Added for Screen Reader */}
+            <h2 className='sr-only'>{`${activeTabLabel} tab`}</h2>
             <div
                 className='h-10 pl-1 w-full flex gap-1 items-center rounded-lg shadow-outer-1 pointer-events-auto bg-[#f4f4f4] dark:bg-[#222222]'
                 data-testid='explore_search-container_header'>
@@ -202,7 +206,7 @@ const ExploreSearch: React.FC = () => {
                 </IconButton>
                 <Tabs
                     variant='fullWidth'
-                    value={tabMap[activeTab]}
+                    value={activeTabValue}
                     onChange={(e, newTabIdx) => handleTabChange(newTabIdx)}
                     onClick={() => setShowSearchWidget(true)}
                     className='h-10 min-h-10 w-full'

--- a/cmd/ui/src/views/Explore/GraphView.test.tsx
+++ b/cmd/ui/src/views/Explore/GraphView.test.tsx
@@ -185,6 +185,12 @@ afterEach(() => server.resetHandlers());
 afterAll(() => server.close());
 
 describe('GraphView', () => {
+    it('renders a hidden h1 with the text Explore for screen readers', async () => {
+        render(<GraphView />, { route: `/explore?searchType=cypher&cypherSearch=encodedquery` });
+        const hiddenHeading = screen.getByRole('heading', { level: 1, name: /explore/i });
+        expect(hiddenHeading).toBeInTheDocument();
+        expect(hiddenHeading).toHaveClass('sr-only');
+    });
     it('renders a graph view', () => {
         render(<GraphView />, { route: `/explore?searchType=cypher&cypherSearch=encodedquery` });
         const container = screen.getByTestId('explore');

--- a/cmd/ui/src/views/Explore/GraphView.tsx
+++ b/cmd/ui/src/views/Explore/GraphView.tsx
@@ -77,6 +77,8 @@ const GraphView: FC = () => {
             <title>Explore | {appName}</title>
         </Helmet>
     );
+    // For Screen Readers
+    const hiddenHeading = <h1 className='sr-only'>Explore</h1>;
 
     const { selectedItem, setSelectedItem, selectedItemQuery, previousSelectedItem, clearSelectedItem } =
         useExploreSelectedItem();
@@ -239,14 +241,27 @@ const GraphView: FC = () => {
     if (graphHasDataQuery.isLoading) {
         return (
             <div className='relative h-full w-full overflow-hidden' data-testid='explore'>
+                {hiddenHeading}
                 <GraphProgress loading={graphHasDataQuery.isLoading} />
             </div>
         );
     }
 
-    if (graphHasDataQuery.isError) return <GraphViewErrorAlert />;
+    if (graphHasDataQuery.isError)
+        return (
+            <>
+                {hiddenHeading}
+                <GraphViewErrorAlert />
+            </>
+        );
 
-    if (!isWebGLEnabledMemo) return <WebGLDisabledAlert />;
+    if (!isWebGLEnabledMemo)
+        return (
+            <>
+                {hiddenHeading}
+                <WebGLDisabledAlert />
+            </>
+        );
 
     /* Event Handlers */
     const handleCloseContextMenu = () => {
@@ -272,8 +287,7 @@ const GraphView: FC = () => {
             data-testid='explore'
             onContextMenu={(e) => e.preventDefault()}>
             {title}
-            {/* Added for Screen Readers */}
-            <h1 className='sr-only'>Explore</h1>
+            {hiddenHeading}
             <SigmaChart
                 graph={graphologyGraph}
                 highlightedItem={selectedItem}

--- a/cmd/ui/src/views/Explore/GraphView.tsx
+++ b/cmd/ui/src/views/Explore/GraphView.tsx
@@ -18,6 +18,7 @@ import {
     BaseExploreLayoutOptions,
     ContextMenuPrivilegeZonesEnabled,
     DEFAULT_PINNED_COLUMN_KEYS,
+    ExploreSearchTab,
     ExploreTable,
     FeatureFlag,
     GraphControls,
@@ -48,6 +49,7 @@ import {
 } from 'bh-shared-ui';
 import { MultiDirectedGraph } from 'graphology';
 import { Attributes } from 'graphology-types';
+import { capitalize } from 'lodash';
 import { FC, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { SigmaNodeEventPayload } from 'sigma/sigma';
@@ -110,6 +112,12 @@ const GraphView: FC = () => {
     const [autoDisplayTable, setAutoDisplayTable] = useExploreTableAutoDisplay(autoDisplayTableEnabled);
     // TODO: incorporate into larger hook with auto display table logic
     const displayTable = searchType === 'cypher' && (isExploreTableSelected || autoDisplayTable);
+
+    const formattedHiddenHeadingTabDisplay = (currentTab: ExploreSearchTab | null) => {
+        if (!currentTab || currentTab === 'node') return 'Search';
+        return capitalize(currentTab);
+    };
+    const hiddenHeading = `Explore - ${formattedHiddenHeadingTabDisplay(exploreSearchTab)} tab`;
 
     const [showNodeLabels, toggleShowNodeLabels] = useToggle(true);
     const [showEdgeLabels, toggleShowEdgeLabels] = useToggle(true);
@@ -272,6 +280,8 @@ const GraphView: FC = () => {
             data-testid='explore'
             onContextMenu={(e) => e.preventDefault()}>
             {title}
+            {/* Added for Screen Readers */}
+            <h1 className='sr-only'>{hiddenHeading}</h1>
             <SigmaChart
                 graph={graphologyGraph}
                 highlightedItem={selectedItem}

--- a/cmd/ui/src/views/Explore/GraphView.tsx
+++ b/cmd/ui/src/views/Explore/GraphView.tsx
@@ -18,7 +18,6 @@ import {
     BaseExploreLayoutOptions,
     ContextMenuPrivilegeZonesEnabled,
     DEFAULT_PINNED_COLUMN_KEYS,
-    ExploreSearchTab,
     ExploreTable,
     FeatureFlag,
     GraphControls,
@@ -49,7 +48,6 @@ import {
 } from 'bh-shared-ui';
 import { MultiDirectedGraph } from 'graphology';
 import { Attributes } from 'graphology-types';
-import { capitalize } from 'lodash';
 import { FC, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { SigmaNodeEventPayload } from 'sigma/sigma';
@@ -112,12 +110,6 @@ const GraphView: FC = () => {
     const [autoDisplayTable, setAutoDisplayTable] = useExploreTableAutoDisplay(autoDisplayTableEnabled);
     // TODO: incorporate into larger hook with auto display table logic
     const displayTable = searchType === 'cypher' && (isExploreTableSelected || autoDisplayTable);
-
-    const formattedHiddenHeadingTabDisplay = (currentTab: ExploreSearchTab | null) => {
-        if (!currentTab || currentTab === 'node') return 'Search';
-        return capitalize(currentTab);
-    };
-    const hiddenHeading = `Explore - ${formattedHiddenHeadingTabDisplay(exploreSearchTab)} tab`;
 
     const [showNodeLabels, toggleShowNodeLabels] = useToggle(true);
     const [showEdgeLabels, toggleShowEdgeLabels] = useToggle(true);
@@ -281,7 +273,7 @@ const GraphView: FC = () => {
             onContextMenu={(e) => e.preventDefault()}>
             {title}
             {/* Added for Screen Readers */}
-            <h1 className='sr-only'>{hiddenHeading}</h1>
+            <h1 className='sr-only'>Explore</h1>
             <SigmaChart
                 graph={graphologyGraph}
                 highlightedItem={selectedItem}

--- a/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/History/HistoryContent.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/History/HistoryContent.tsx
@@ -14,7 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { Card, CardHeader, CardTitle, DataTable } from 'doodle-ui';
+import { Card, CardHeader, DataTable, Typography } from 'doodle-ui';
 import { useState } from 'react';
 import { SearchInput } from '../../../components/SearchInput';
 import { useInfiniteScroll } from '../../../hooks';
@@ -81,7 +81,7 @@ const HistoryContent = () => {
             <div data-testid='history-wrapper' className='flex gap-6 mt-4 h-[calc(100%-5rem)]'>
                 <Card className='flex flex-col'>
                     <CardHeader className='flex-row ml-3 justify-between items-center'>
-                        <CardTitle>History Log</CardTitle>
+                        <Typography variant='h2'>History Log</Typography>
                         <div className='flex items-center'>
                             <SearchInput id='search-pz-history' value={search} onInputChange={setSearch} />
                             <FilterDialog setFilters={setFilters} filters={filters} />


### PR DESCRIPTION
## Description

Added hidden h1 Heading in Explore and h2 in in Explore Tabs. Also changed title in PZ History table to h2.  

## Motivation and Context

Resolves: [BED-9537](https://specterops.atlassian.net/browse/BED-9537)

## How Has This Been Tested?

Manually Tested

## Screenshots (optional):

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


[BED-9537]: https://specterops.atlassian.net/browse/BED-9537?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility**
  * Improved screen-reader navigation in Explore by identifying the current tab and adding clear page headings across loading, error, and graph views.
  * Added a screen-reader-only “Search” heading to the Explore search experience.
  * Updated the Explore history heading to use more appropriate semantic heading markup.
  * Improved tab state handling for more consistent navigation feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->