### PR TITLE
refactor(a11y): update explore and shared a11y tests - BED-9440

### DIFF
--- a/cmd/ui/tests/a11y/Explore/cypher.a11y.spec.ts
+++ b/cmd/ui/tests/a11y/Explore/cypher.a11y.spec.ts
@@ -14,56 +14,118 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { expect, expectNoAccessibilityViolations, test } from '../../fixtures';
+import { Page, TestInfo } from '@playwright/test';
+import { hideBySelector, test } from 'bh-playwright-testing';
 
-test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
-    test.beforeEach(async ({ page }) => {
-        await page.goto('/ui/explore');
+const installSaveQueryStub = async (page: Page, testInfo: TestInfo) => {
+    const queryName = `a11y-export-${testInfo.project.name}-${Date.now()}`;
 
-        const cypherTab = page.getByRole('tab', { name: 'Cypher' });
-        await cypherTab.click();
-        await page.getByRole('textbox', { name: 'Cypher Editor' }).waitFor({ state: 'visible' });
+    const savedQuery = {
+        id: 1,
+        name: queryName,
+        description: '',
+        query: 'MATCH (n) RETURN n LIMIT 10',
+        user_id: '0e712979-d6e9-4496-9f31-f96f5565873e',
+        scope: 'owned',
+    };
+
+    const self = {
+        data: {
+            sso_provider_id: null,
+            AuthSecret: {
+                digest_method: 'argon2',
+                expires_at: '2026-11-15T14:32:05.868773Z',
+                id: 1,
+            },
+            first_name: 'BloodHound',
+            last_name: 'Dev',
+            email_address: 'spam@example.com',
+            principal_name: 'admin',
+            last_login: '2026-08-24T17:12:33.222043Z',
+            is_disabled: false,
+            all_environments: true,
+            environment_targeted_access_control: [],
+            eula_accepted: true,
+            id: '0e712979-d6e9-4496-9f31-f96f5565873e',
+        },
+    };
+
+    // Fetch the real /api/v2/self response and override the id so the logged-in
+    // user (self) owns the stubbed saved query and can edit it. The rest of the
+    // self payload is preserved so the page keeps loading normally.
+    await page.route('**/api/v2/self', async (route) => {
+        const request = route.request();
+        const pathname = new URL(request.url()).pathname;
+
+        if (request.method() === 'GET' && pathname === '/api/v2/self') {
+            return route.fulfill({ json: self });
+        }
+
+        return route.fallback();
     });
 
-    test('Empty query', async ({ page, makeAxeBuilder }, testInfo) => {
+    // Stub the saved queries list so a single owned query already exists, and the
+    // per-query permissions lookup opened by the Edit/Share dialog. Any other
+    // saved-query requests fall through to the real API.
+    await page.route('**/api/v2/saved-queries**', async (route) => {
+        const request = route.request();
+        const pathname = new URL(request.url()).pathname;
+
+        if (request.method() === 'GET' && pathname === '/api/v2/saved-queries') {
+            return route.fulfill({
+                json: { data: [savedQuery], count: 1, limit: 10, skip: 0 },
+            });
+        }
+
+        if (request.method() === 'GET' && pathname === `/api/v2/saved-queries/${savedQuery.id}/permissions`) {
+            return route.fulfill({
+                json: { data: { query_id: savedQuery.id, public: false, shared_to_user_ids: [] } },
+            });
+        }
+
+        return route.fallback();
+    });
+};
+
+test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
+    test.beforeEach(async ({ goAndWaitFor, page }, testInfo) => {
+        await goAndWaitFor('/ui/explore?exploreSearchTab=cypher', page.getByRole('textbox', { name: 'Cypher Editor' }));
+    });
+
+    test('Empty query', async ({ page, checkA11y }) => {
         const cypherEditor = page.getByRole('textbox', {
             name: 'Cypher Editor',
         });
 
-        await cypherEditor.waitFor({ state: 'visible' });
+        await cypherEditor.waitFor();
 
-        const results = await makeAxeBuilder().include('#content-wrapper').analyze();
-
-        await expectNoAccessibilityViolations(testInfo, results, { page });
+        await checkA11y();
     });
 
-    test('With full query', async ({ page, makeAxeBuilder }, testInfo) => {
+    test('With full query', async ({ page, checkA11y }) => {
         const query = 'MATCH (n) RETURN n LIMIT 10';
         const cypherEditor = page.getByRole('textbox', {
             name: 'Cypher Editor',
         });
 
-        await cypherEditor.waitFor({ state: 'visible' });
+        await cypherEditor.waitFor();
 
         await cypherEditor.fill(query);
 
-        const results = await makeAxeBuilder().include('#content-wrapper').analyze();
-
-        await expectNoAccessibilityViolations(testInfo, results, { page });
+        await checkA11y();
     });
 
-    test('Tag Results to Zone dialog', async ({ page, makeAxeBuilder }, testInfo) => {
+    test('Tag Results to Zone dialog', async ({ page, checkA11y }) => {
         const query = 'MATCH (n) RETURN n LIMIT 10';
         const cypherEditor = page.getByRole('textbox', {
             name: 'Cypher Editor',
         });
 
-        await cypherEditor.waitFor({ state: 'visible' });
-
+        await cypherEditor.waitFor();
         await cypherEditor.fill(query);
 
         const tagButton = page.getByRole('button', { name: 'Tag' });
-        await tagButton.waitFor({ state: 'visible' });
+        await tagButton.waitFor();
         await tagButton.click();
 
         await page.getByRole('button', { name: 'Zone' }).click();
@@ -71,7 +133,10 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
         const dialog = page.getByRole('dialog', {
             name: 'Tag Results to Zone',
         });
-        await dialog.waitFor({ state: 'visible' });
+        await dialog.waitFor();
+
+        await hideBySelector(page, '[data-radix-popper-content-wrapper]');
+        await hideBySelector(page, '#content-wrapper');
 
         const selectZoneControl = dialog.getByRole('combobox');
         const cancelButton = dialog.getByRole('button', { name: 'Cancel' });
@@ -79,26 +144,25 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
             name: 'Continue',
         });
 
-        await selectZoneControl.waitFor({ state: 'visible' });
-        await cancelButton.waitFor({ state: 'visible' });
-        await continueButton.waitFor({ state: 'visible' });
+        await selectZoneControl.waitFor();
+        await cancelButton.waitFor();
+        await continueButton.waitFor();
 
-        const results = await makeAxeBuilder().include('#content-wrapper').include('[role="dialog"]').analyze();
-        await expectNoAccessibilityViolations(testInfo, results, { page });
+        await checkA11y({ include: '[role="dialog"]' });
     });
 
-    test('Tag Results to Label dialog', async ({ page, makeAxeBuilder }, testInfo) => {
+    test('Tag Results to Label dialog', async ({ page, checkA11y }) => {
         const query = 'MATCH (n) RETURN n LIMIT 10';
         const cypherEditor = page.getByRole('textbox', {
             name: 'Cypher Editor',
         });
 
-        await cypherEditor.waitFor({ state: 'visible' });
+        await cypherEditor.waitFor();
 
         await cypherEditor.fill(query);
 
         const tagButton = page.getByRole('button', { name: 'Tag' });
-        await tagButton.waitFor({ state: 'visible' });
+        await tagButton.waitFor();
         await tagButton.click();
 
         await page
@@ -110,7 +174,10 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
         const dialog = page.getByRole('dialog', {
             name: 'Tag Results to Label',
         });
-        await dialog.waitFor({ state: 'visible' });
+        await dialog.waitFor();
+
+        await hideBySelector(page, '[data-radix-popper-content-wrapper]');
+        await hideBySelector(page, '#content-wrapper');
 
         const selectLabelControl = dialog.getByRole('combobox');
         const cancelButton = dialog.getByRole('button', { name: 'Cancel' });
@@ -118,21 +185,20 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
             name: 'Continue',
         });
 
-        await selectLabelControl.waitFor({ state: 'visible' });
-        await cancelButton.waitFor({ state: 'visible' });
-        await continueButton.waitFor({ state: 'visible' });
+        await selectLabelControl.waitFor();
+        await cancelButton.waitFor();
+        await continueButton.waitFor();
 
-        const results = await makeAxeBuilder().include('#content-wrapper').include('[role="dialog"]').analyze();
-        await expectNoAccessibilityViolations(testInfo, results, { page });
+        await checkA11y({ include: '[role="dialog"]' });
     });
 
-    test('Save Query dialog', async ({ page, makeAxeBuilder }, testInfo) => {
+    test('Save Query dialog', async ({ page, checkA11y }) => {
         const query = 'MATCH (n) RETURN n LIMIT 10';
         const cypherEditor = page.getByRole('textbox', {
             name: 'Cypher Editor',
         });
 
-        await cypherEditor.waitFor({ state: 'visible' });
+        await cypherEditor.waitFor();
 
         await cypherEditor.fill(query);
 
@@ -141,24 +207,24 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
             exact: true,
         });
 
-        await saveQueryButton.waitFor({ state: 'visible' });
+        await saveQueryButton.waitFor();
         await saveQueryButton.click();
 
-        const dialog = page.getByTestId('save-query-dialog');
+        await page.getByTestId('save-query-dialog').waitFor();
 
-        await dialog.waitFor({ state: 'visible' });
+        await hideBySelector(page, 'nav');
+        await hideBySelector(page, '#content-wrapper');
 
-        const results = await makeAxeBuilder().include('#content-wrapper').include('[role="dialog"]').analyze();
-        await expectNoAccessibilityViolations(testInfo, results, { page });
+        await checkA11y({ include: '[role="dialog"]' });
     });
 
-    test('Save As New Query dialog', async ({ page, makeAxeBuilder }, testInfo) => {
+    test('Save As New Query dialog', async ({ page, checkA11y }) => {
         const query = 'MATCH (n) RETURN n LIMIT 10';
         const cypherEditor = page.getByRole('textbox', {
             name: 'Cypher Editor',
         });
 
-        await cypherEditor.waitFor({ state: 'visible' });
+        await cypherEditor.waitFor();
 
         await cypherEditor.fill(query);
 
@@ -171,8 +237,8 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
             exact: true,
         });
 
-        await saveQueryButton.waitFor({ state: 'visible' });
-        await saveQueryOptionsButton.waitFor({ state: 'visible' });
+        await saveQueryButton.waitFor();
+        await saveQueryOptionsButton.waitFor();
         await saveQueryOptionsButton.click();
 
         const saveAsButton = page.getByRole('button', {
@@ -180,27 +246,28 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
             exact: true,
         });
 
-        await saveAsButton.waitFor({ state: 'visible' });
+        await saveAsButton.waitFor();
         await saveAsButton.click();
 
-        const dialog = page.getByRole('dialog', {
-            name: 'Save As New Query',
-        });
+        await page
+            .getByRole('dialog', {
+                name: 'Save As New Query',
+            })
+            .waitFor();
 
-        await dialog.waitFor({ state: 'visible' });
+        await hideBySelector(page, 'nav');
+        await hideBySelector(page, '#content-wrapper');
 
-        const results = await makeAxeBuilder().include('#content-wrapper').include('[role="dialog"]').analyze();
-
-        await expectNoAccessibilityViolations(testInfo, results, { page });
+        await checkA11y({ include: '[role="dialog"]' });
     });
 
-    test('Saved Queries - Search with no results', async ({ page, makeAxeBuilder }, testInfo) => {
+    test('Saved Queries - Search with no results', async ({ page, checkA11y }) => {
         const savedQueriesButton = page.getByRole('button', {
             name: 'Saved Queries',
             exact: true,
         });
 
-        await savedQueriesButton.waitFor({ state: 'visible' });
+        await savedQueriesButton.waitFor();
         await savedQueriesButton.click();
 
         const searchTextbox = page.getByRole('textbox', {
@@ -209,26 +276,25 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
         });
         const searchTerm = 'a11y-no-results-9f7c2e1b';
 
-        await searchTextbox.waitFor({ state: 'visible' });
+        await searchTextbox.waitFor();
         await searchTextbox.fill(searchTerm);
 
         const noResultsHeading = page.getByRole('heading', {
             name: 'No Results',
             exact: true,
         });
-        await noResultsHeading.waitFor({ state: 'visible' });
+        await noResultsHeading.waitFor();
 
-        const results = await makeAxeBuilder().include('#content-wrapper').analyze();
-        await expectNoAccessibilityViolations(testInfo, results, { page });
+        await checkA11y();
     });
 
-    test('Saved Queries - Import dialog', async ({ page, makeAxeBuilder }, testInfo) => {
+    test('Saved Queries - Import dialog', async ({ page, checkA11y }) => {
         const savedQueriesButton = page.getByRole('button', {
             name: 'Saved Queries',
             exact: true,
         });
 
-        await savedQueriesButton.waitFor({ state: 'visible' });
+        await savedQueriesButton.waitFor();
         await savedQueriesButton.click();
 
         const importButton = page.getByRole('button', {
@@ -236,208 +302,22 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
             exact: true,
         });
 
-        await importButton.waitFor({ state: 'visible' });
+        await importButton.waitFor();
         await importButton.click();
 
-        const dialog = page.getByRole('dialog');
+        await page.getByRole('dialog').waitFor();
+        await hideBySelector(page, '#content-wrapper');
 
-        await dialog.waitFor({ state: 'visible' });
-
-        const results = await makeAxeBuilder().include('#content-wrapper').include('[role="dialog"]').analyze();
-
-        await expectNoAccessibilityViolations(testInfo, results, { page });
+        await checkA11y({ include: '[role="dialog"]' });
     });
 
-    test('Saved Queries - Export saved query', async ({ page, makeAxeBuilder }, testInfo) => {
-        const query = 'MATCH (n) RETURN n LIMIT 1';
-        const queryName = `a11y-export-${testInfo.project.name}-${Date.now()}`;
-        const savedQueryAccessibleName = `Run pre-built search query: ${queryName}`;
-        let testError: unknown;
-        let cleanupError: unknown;
-
-        try {
-            const cypherEditor = page.getByRole('textbox', {
-                name: 'Cypher Editor',
-            });
-
-            await cypherEditor.waitFor({ state: 'visible' });
-
-            await cypherEditor.fill(query);
-
-            const saveQueryButton = page.getByRole('button', {
-                name: 'Save query',
-                exact: true,
-            });
-
-            await saveQueryButton.waitFor({ state: 'visible' });
-            await saveQueryButton.click();
-
-            const saveQueryDialog = page.getByTestId('save-query-dialog');
-            const queryNameTextbox = saveQueryDialog.getByRole('textbox', {
-                name: 'Query Name',
-                exact: true,
-            });
-            const saveButton = saveQueryDialog.getByRole('button', {
-                name: 'Save',
-                exact: true,
-            });
-
-            await saveQueryDialog.waitFor({ state: 'visible' });
-            await queryNameTextbox.fill(queryName);
-            await saveButton.click();
-            await saveQueryDialog.waitFor({ state: 'hidden' });
-            await page.goto('/ui/explore');
-
-            const cypherTab = page.getByRole('tab', {
-                name: 'Cypher',
-            });
-
-            await cypherTab.click();
-            await page.getByRole('textbox', { name: 'Cypher Editor' }).waitFor({ state: 'visible' });
-
-            const savedQueriesButton = page.getByRole('button', {
-                name: 'Saved Queries',
-                exact: true,
-            });
-
-            await savedQueriesButton.waitFor({ state: 'visible' });
-            await savedQueriesButton.click();
-
-            const searchTextbox = page.getByRole('textbox', {
-                name: 'Search',
-                exact: true,
-            });
-
-            await searchTextbox.waitFor({ state: 'visible' });
-            await searchTextbox.fill(queryName);
-
-            const savedQueryButton = page.getByRole('button', {
-                name: savedQueryAccessibleName,
-                exact: true,
-            });
-
-            await savedQueryButton.waitFor({ state: 'visible' });
-
-            const autoRunCheckbox = page.getByRole('checkbox', {
-                name: 'Auto-run selected query',
-                exact: true,
-            });
-
-            await autoRunCheckbox.waitFor({ state: 'visible' });
-
-            if (await autoRunCheckbox.isChecked()) {
-                await autoRunCheckbox.uncheck();
-            }
-
-            await savedQueryButton.click();
-
-            const results = await makeAxeBuilder().include('#content-wrapper').analyze();
-
-            await expectNoAccessibilityViolations(testInfo, results, { page });
-            const exportButtons = page.getByRole('button', {
-                name: 'Export',
-                exact: true,
-            });
-
-            const exportButton = exportButtons.first();
-
-            await exportButton.waitFor({ state: 'visible' });
-
-            const [download] = await Promise.all([page.waitForEvent('download'), exportButton.click()]);
-            expect(download.suggestedFilename()).toMatch(/\.json$/i);
-        } catch (error) {
-            testError = error;
-        } finally {
-            try {
-                await page.goto('/ui/explore');
-
-                const cypherTab = page.getByRole('tab', {
-                    name: 'Cypher',
-                });
-
-                await cypherTab.click();
-                await page.getByRole('textbox', { name: 'Cypher Editor' }).waitFor({ state: 'visible' });
-
-                const savedQueriesButton = page.getByRole('button', {
-                    name: 'Saved Queries',
-                    exact: true,
-                });
-
-                await savedQueriesButton.waitFor({ state: 'visible' });
-                await savedQueriesButton.click();
-
-                const searchTextbox = page.getByRole('textbox', {
-                    name: 'Search',
-                    exact: true,
-                });
-
-                await searchTextbox.waitFor({ state: 'visible' });
-                await searchTextbox.fill(queryName);
-
-                const savedQueryButton = page.getByRole('button', {
-                    name: savedQueryAccessibleName,
-                    exact: true,
-                });
-                const noResultsHeading = page.getByRole('heading', {
-                    name: 'No Results',
-                    exact: true,
-                });
-
-                await savedQueryButton.or(noResultsHeading).waitFor({ state: 'visible' });
-
-                if (await savedQueryButton.isVisible()) {
-                    const actionMenuButton = page.getByRole('button', {
-                        name: 'Show saved query actions',
-                        exact: true,
-                    });
-
-                    await actionMenuButton.waitFor({ state: 'visible' });
-                    await actionMenuButton.click();
-
-                    const deleteButton = page.getByRole('button', {
-                        name: 'Delete',
-                        exact: true,
-                    });
-
-                    await deleteButton.waitFor({ state: 'visible' });
-                    await deleteButton.click();
-
-                    const deleteDialog = page.getByRole('dialog', {
-                        name: 'Delete Query',
-                        exact: true,
-                    });
-                    const confirmButton = deleteDialog.getByRole('button', {
-                        name: 'Confirm',
-                        exact: true,
-                    });
-
-                    await deleteDialog.waitFor({ state: 'visible' });
-                    await confirmButton.click();
-
-                    await deleteDialog.waitFor({ state: 'hidden' });
-                    await savedQueryButton.waitFor({ state: 'detached' });
-                }
-            } catch (error) {
-                cleanupError = error;
-            }
-        }
-
-        if (testError !== undefined) {
-            throw testError;
-        }
-
-        if (cleanupError !== undefined) {
-            throw cleanupError;
-        }
-    });
-
-    test('Saved Queries - Filter by Platforms', async ({ page, makeAxeBuilder }, testInfo) => {
+    test('Saved Queries - With filter', async ({ page, checkA11y }) => {
         const savedQueriesButton = page.getByRole('button', {
             name: 'Saved Queries',
             exact: true,
         });
 
-        await savedQueriesButton.waitFor({ state: 'visible' });
+        await savedQueriesButton.waitFor();
         await savedQueriesButton.click();
 
         const platformsFilter = page.getByRole('combobox', {
@@ -445,7 +325,7 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
             exact: true,
         });
 
-        await platformsFilter.waitFor({ state: 'visible' });
+        await platformsFilter.waitFor();
         await platformsFilter.click();
 
         const activeDirectoryOption = page.getByRole('option', {
@@ -453,724 +333,69 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab', () => {
             exact: true,
         });
 
-        await activeDirectoryOption.waitFor({ state: 'visible' });
+        await activeDirectoryOption.waitFor();
         await activeDirectoryOption.click();
         const selectedPlatformsFilter = page.getByRole('combobox', {
             name: /Active Directory/,
         });
 
-        await selectedPlatformsFilter.waitFor({ state: 'visible' });
-        const results = await makeAxeBuilder().include('#content-wrapper').analyze();
+        await selectedPlatformsFilter.waitFor();
+        await checkA11y();
+    });
+});
 
-        await expectNoAccessibilityViolations(testInfo, results, { page });
+test.describe('WCAG A/AA Violations - Explore - Cypher Tab - Saved Queries', () => {
+    test.beforeEach(async ({ goAndWaitFor, page }, testInfo) => {
+        await installSaveQueryStub(page, testInfo);
+        await goAndWaitFor('/ui/explore?exploreSearchTab=cypher', page.getByRole('textbox', { name: 'Cypher Editor' }));
     });
 
-    test('Saved Queries - Filter by Categories', async ({ page, makeAxeBuilder }, testInfo) => {
-        const savedQueriesButton = page.getByRole('button', {
-            name: 'Saved Queries',
-            exact: true,
-        });
+    test('Saved Queries - Query dots menu', async ({ page, checkA11y }) => {
+        // Expand queries panel and filter down to saved queries
+        await page.getByRole('button', { name: 'Saved Queries', exact: true }).click();
+        await page.getByRole('combobox', { name: 'Platforms', exact: true }).click();
+        await page.getByRole('option', { name: 'Saved Queries', exact: true }).click();
 
-        await savedQueriesButton.waitFor({ state: 'visible' });
-        await savedQueriesButton.click();
+        // Select the dots action from the saved query
+        await page.getByTestId('saved-query-action-menu-trigger').click();
 
-        const categoriesFilter = page.getByRole('combobox', {
-            name: 'Categories',
-            exact: true,
-        });
+        await hideBySelector(page, '#root');
 
-        await categoriesFilter.waitFor({ state: 'visible' });
-        await categoriesFilter.click();
-
-        const domainInformationOption = page.getByRole('option', {
-            name: 'Domain Information',
-            exact: true,
-        });
-
-        await domainInformationOption.waitFor({ state: 'visible' });
-        const selectedCategoriesFilter = page.getByRole('combobox', {
-            name: /Domain Information/,
-        });
-
-        await selectedCategoriesFilter.waitFor({ state: 'visible' });
-
-        const results = await makeAxeBuilder().include('#content-wrapper').analyze();
-
-        await expectNoAccessibilityViolations(testInfo, results, { page });
+        await checkA11y({ include: '[data-radix-popper-content-wrapper]' });
     });
 
-    test('Saved Queries - Filter by Source', async ({ page, makeAxeBuilder }, testInfo) => {
-        const savedQueriesButton = page.getByRole('button', {
-            name: 'Saved Queries',
-            exact: true,
-        });
+    // NOTE: Even with the hidden sections, this test still has incompletes in the axe-results.json
+    test('Edit Saved Query dialog', async ({ page, checkA11y }) => {
+        // Expand queries panel and filter down to saved queries
+        await page.getByRole('button', { name: 'Saved Queries', exact: true }).click();
+        await page.getByRole('combobox', { name: 'Platforms', exact: true }).click();
+        await page.getByRole('option', { name: 'Saved Queries', exact: true }).click();
 
-        await savedQueriesButton.waitFor({ state: 'visible' });
-        await savedQueriesButton.click();
+        // Select the dots action from the saved query
+        await page.getByTestId('saved-query-action-menu-trigger').click();
+        await page.getByRole('button', { name: 'Edit/Share' }).click();
 
-        const sourceFilter = page.getByRole('combobox', {
-            name: 'Source',
-            exact: true,
-        });
+        await hideBySelector(page, 'nav');
+        await hideBySelector(page, '#content-wrapper');
 
-        await sourceFilter.waitFor({ state: 'visible' });
-        await sourceFilter.click();
-
-        const prebuiltOption = page.getByRole('option', {
-            name: 'Prebuilt',
-            exact: true,
-        });
-
-        await prebuiltOption.waitFor({ state: 'visible' });
-        const selectedSourceFilter = page.getByRole('combobox', {
-            name: /Prebuilt/,
-        });
-
-        await selectedSourceFilter.waitFor({ state: 'visible' });
-
-        const results = await makeAxeBuilder().include('#content-wrapper').analyze();
-
-        await expectNoAccessibilityViolations(testInfo, results, { page });
+        await checkA11y({ include: '[role="dialog"]' });
     });
 
-    test('Saved Queries - Query dots menu', async ({ page, makeAxeBuilder }, testInfo) => {
-        const query = 'MATCH (n) RETURN n LIMIT 1';
-        const queryName = `a11y-dots-menu-${testInfo.project.name}-${Date.now()}`;
-        const savedQueryAccessibleName = `Run pre-built search query: ${queryName}`;
-        let testError: unknown;
-        let cleanupError: unknown;
+    test('Delete Query dialog', async ({ page, checkA11y }) => {
+        // Expand queries panel and filter down to saved queries
+        await page.getByRole('button', { name: 'Saved Queries', exact: true }).click();
+        await page.getByRole('combobox', { name: 'Platforms', exact: true }).click();
+        await page.getByRole('option', { name: 'Saved Queries', exact: true }).click();
 
-        try {
-            const cypherEditor = page.getByRole('textbox', {
-                name: 'Cypher Editor',
-            });
+        // Select the dots action from the saved query
+        await page.getByTestId('saved-query-action-menu-trigger').click();
 
-            await cypherEditor.waitFor({ state: 'visible' });
+        // Additional specifier as there are multiple Delete buttons in scope
+        await page.getByTestId('saved-query-action-menu').getByRole('button', { name: 'Delete' }).click();
 
-            await cypherEditor.fill(query);
+        await hideBySelector(page, 'nav');
+        await hideBySelector(page, '#content-wrapper');
 
-            const saveQueryButton = page.getByRole('button', {
-                name: 'Save query',
-                exact: true,
-            });
-
-            await saveQueryButton.waitFor({ state: 'visible' });
-            await saveQueryButton.click();
-
-            const saveQueryDialog = page.getByTestId('save-query-dialog');
-            const queryNameTextbox = saveQueryDialog.getByRole('textbox', {
-                name: 'Query Name',
-                exact: true,
-            });
-            const saveButton = saveQueryDialog.getByRole('button', {
-                name: 'Save',
-                exact: true,
-            });
-
-            await saveQueryDialog.waitFor({ state: 'visible' });
-            await queryNameTextbox.fill(queryName);
-            await saveButton.click();
-            await saveQueryDialog.waitFor({ state: 'hidden' });
-            await page.goto('/ui/explore');
-
-            const cypherTab = page.getByRole('tab', {
-                name: 'Cypher',
-            });
-
-            await cypherTab.click();
-            await page.getByRole('textbox', { name: 'Cypher Editor' }).waitFor({ state: 'visible' });
-
-            const savedQueriesButton = page.getByRole('button', {
-                name: 'Saved Queries',
-                exact: true,
-            });
-
-            await savedQueriesButton.waitFor({ state: 'visible' });
-            await savedQueriesButton.click();
-
-            const searchTextbox = page.getByRole('textbox', {
-                name: 'Search',
-                exact: true,
-            });
-
-            await searchTextbox.waitFor({ state: 'visible' });
-            await searchTextbox.fill(queryName);
-
-            const savedQueryButton = page.getByRole('button', {
-                name: savedQueryAccessibleName,
-                exact: true,
-            });
-
-            await savedQueryButton.waitFor({ state: 'visible' });
-
-            const autoRunCheckbox = page.getByRole('checkbox', {
-                name: 'Auto-run selected query',
-                exact: true,
-            });
-
-            await autoRunCheckbox.waitFor({ state: 'visible' });
-
-            if (await autoRunCheckbox.isChecked()) {
-                await autoRunCheckbox.uncheck();
-            }
-            await savedQueryButton.click();
-
-            const actionMenuButton = page.getByRole('button', {
-                name: 'Show saved query actions',
-                exact: true,
-            });
-
-            await actionMenuButton.waitFor({ state: 'visible' });
-            await actionMenuButton.click();
-
-            const runButton = page.getByRole('button', {
-                name: 'Run',
-                exact: true,
-            });
-            const editShareButton = page.getByRole('button', {
-                name: 'Edit/Share',
-                exact: true,
-            });
-            const deleteButton = page.getByRole('button', {
-                name: 'Delete',
-                exact: true,
-            });
-
-            await runButton.waitFor({ state: 'visible' });
-            await editShareButton.waitFor({ state: 'visible' });
-            await deleteButton.waitFor({ state: 'visible' });
-
-            const results = await makeAxeBuilder()
-                .include('#content-wrapper')
-                .include('[data-testid="saved-query-action-menu"]')
-                .analyze();
-
-            await expectNoAccessibilityViolations(testInfo, results, { page });
-        } catch (error) {
-            testError = error;
-        } finally {
-            try {
-                await page.goto('/ui/explore');
-
-                const cypherTab = page.getByRole('tab', {
-                    name: 'Cypher',
-                });
-
-                await cypherTab.click();
-                await page.getByRole('textbox', { name: 'Cypher Editor' }).waitFor({ state: 'visible' });
-
-                const savedQueriesButton = page.getByRole('button', {
-                    name: 'Saved Queries',
-                    exact: true,
-                });
-
-                await savedQueriesButton.waitFor({ state: 'visible' });
-                await savedQueriesButton.click();
-
-                const searchTextbox = page.getByRole('textbox', {
-                    name: 'Search',
-                    exact: true,
-                });
-
-                await searchTextbox.waitFor({ state: 'visible' });
-                await searchTextbox.fill(queryName);
-
-                const savedQueryButton = page.getByRole('button', {
-                    name: savedQueryAccessibleName,
-                    exact: true,
-                });
-                const noResultsHeading = page.getByRole('heading', {
-                    name: 'No Results',
-                    exact: true,
-                });
-
-                await savedQueryButton.or(noResultsHeading).waitFor({ state: 'visible' });
-
-                if (await savedQueryButton.isVisible()) {
-                    const actionMenuButton = page.getByRole('button', {
-                        name: 'Show saved query actions',
-                        exact: true,
-                    });
-
-                    await actionMenuButton.waitFor({ state: 'visible' });
-                    await actionMenuButton.click();
-
-                    const deleteButton = page.getByRole('button', {
-                        name: 'Delete',
-                        exact: true,
-                    });
-
-                    await deleteButton.waitFor({ state: 'visible' });
-                    await deleteButton.click();
-
-                    const deleteDialog = page.getByRole('dialog', {
-                        name: 'Delete Query',
-                        exact: true,
-                    });
-                    const confirmButton = deleteDialog.getByRole('button', {
-                        name: 'Confirm',
-                        exact: true,
-                    });
-
-                    await deleteDialog.waitFor({ state: 'visible' });
-                    await confirmButton.click();
-
-                    await deleteDialog.waitFor({ state: 'hidden' });
-                    await savedQueryButton.waitFor({ state: 'detached' });
-                }
-            } catch (error) {
-                cleanupError = error;
-            }
-        }
-
-        if (testError !== undefined) {
-            throw testError;
-        }
-
-        if (cleanupError !== undefined) {
-            throw cleanupError;
-        }
-    });
-
-    test('Edit Saved Query dialog', async ({ page, makeAxeBuilder }, testInfo) => {
-        const query = 'MATCH (n) RETURN n LIMIT 1';
-        const queryName = `a11y-edit-dialog-${testInfo.project.name}-${Date.now()}`;
-        const savedQueryAccessibleName = `Run pre-built search query: ${queryName}`;
-        let testError: unknown;
-        let cleanupError: unknown;
-
-        try {
-            const cypherEditor = page.getByRole('textbox', {
-                name: 'Cypher Editor',
-            });
-
-            await cypherEditor.waitFor({ state: 'visible' });
-
-            await cypherEditor.fill(query);
-
-            const saveQueryButton = page.getByRole('button', {
-                name: 'Save query',
-                exact: true,
-            });
-
-            await saveQueryButton.waitFor({ state: 'visible' });
-            await saveQueryButton.click();
-
-            const saveQueryDialog = page.getByTestId('save-query-dialog');
-            const queryNameTextbox = saveQueryDialog.getByRole('textbox', {
-                name: 'Query Name',
-                exact: true,
-            });
-            const saveButton = saveQueryDialog.getByRole('button', {
-                name: 'Save',
-                exact: true,
-            });
-
-            await saveQueryDialog.waitFor({ state: 'visible' });
-            await queryNameTextbox.fill(queryName);
-            await saveButton.click();
-            await saveQueryDialog.waitFor({ state: 'hidden' });
-            await page.goto('/ui/explore');
-
-            const cypherTab = page.getByRole('tab', {
-                name: 'Cypher',
-            });
-
-            await cypherTab.click();
-            await page.getByRole('textbox', { name: 'Cypher Editor' }).waitFor({ state: 'visible' });
-
-            const savedQueriesButton = page.getByRole('button', {
-                name: 'Saved Queries',
-                exact: true,
-            });
-
-            await savedQueriesButton.waitFor({ state: 'visible' });
-            await savedQueriesButton.click();
-
-            const searchTextbox = page.getByRole('textbox', {
-                name: 'Search',
-                exact: true,
-            });
-
-            await searchTextbox.waitFor({ state: 'visible' });
-            await searchTextbox.fill(queryName);
-
-            const savedQueryButton = page.getByRole('button', {
-                name: savedQueryAccessibleName,
-                exact: true,
-            });
-
-            await savedQueryButton.waitFor({ state: 'visible' });
-
-            const autoRunCheckbox = page.getByRole('checkbox', {
-                name: 'Auto-run selected query',
-                exact: true,
-            });
-
-            await autoRunCheckbox.waitFor({ state: 'visible' });
-
-            if (await autoRunCheckbox.isChecked()) {
-                await autoRunCheckbox.uncheck();
-            }
-            await savedQueryButton.click();
-
-            const actionMenuButton = page.getByRole('button', {
-                name: 'Show saved query actions',
-                exact: true,
-            });
-
-            await actionMenuButton.waitFor({ state: 'visible' });
-            await actionMenuButton.click();
-
-            const actionMenu = page.getByTestId('saved-query-action-menu');
-            await actionMenu.waitFor({ state: 'visible' });
-
-            const editShareButton = page.getByRole('button', {
-                name: 'Edit/Share',
-                exact: true,
-            });
-
-            await editShareButton.waitFor({ state: 'visible' });
-            await editShareButton.click();
-
-            const editSavedQueryDialog = page.getByRole('dialog', {
-                name: 'Edit Saved Query',
-                exact: true,
-            });
-
-            await editSavedQueryDialog.waitFor({ state: 'visible' });
-
-            const editQueryNameTextbox = editSavedQueryDialog.getByRole('textbox', {
-                name: 'Query Name',
-                exact: true,
-            });
-            const editQueryDescriptionTextbox = editSavedQueryDialog.getByRole('textbox', {
-                name: 'Query Description',
-                exact: true,
-            });
-            const cypherQueryEditor = editSavedQueryDialog.getByRole('textbox', {
-                name: 'Cypher Query',
-                exact: true,
-            });
-            const cancelButton = editSavedQueryDialog.getByRole('button', {
-                name: 'Cancel',
-                exact: true,
-            });
-            const editSaveButton = editSavedQueryDialog.getByRole('button', {
-                name: 'Save',
-                exact: true,
-            });
-
-            await editQueryNameTextbox.waitFor({ state: 'visible' });
-            await editQueryDescriptionTextbox.waitFor({ state: 'visible' });
-            await cypherQueryEditor.waitFor({ state: 'visible' });
-            await cancelButton.waitFor({ state: 'visible' });
-            await editSaveButton.waitFor({ state: 'visible' });
-
-            const results = await makeAxeBuilder().include('#content-wrapper').include('[role="dialog"]').analyze();
-
-            await expectNoAccessibilityViolations(testInfo, results, { page });
-        } catch (error) {
-            testError = error;
-        } finally {
-            try {
-                await page.goto('/ui/explore');
-
-                const cypherTab = page.getByRole('tab', {
-                    name: 'Cypher',
-                });
-
-                await cypherTab.click();
-                await page.getByRole('textbox', { name: 'Cypher Editor' }).waitFor({ state: 'visible' });
-
-                const savedQueriesButton = page.getByRole('button', {
-                    name: 'Saved Queries',
-                    exact: true,
-                });
-
-                await savedQueriesButton.waitFor({ state: 'visible' });
-                await savedQueriesButton.click();
-
-                const searchTextbox = page.getByRole('textbox', {
-                    name: 'Search',
-                    exact: true,
-                });
-
-                await searchTextbox.waitFor({ state: 'visible' });
-                await searchTextbox.fill(queryName);
-
-                const savedQueryButton = page.getByRole('button', {
-                    name: savedQueryAccessibleName,
-                    exact: true,
-                });
-                const noResultsHeading = page.getByRole('heading', {
-                    name: 'No Results',
-                    exact: true,
-                });
-
-                await savedQueryButton.or(noResultsHeading).waitFor({ state: 'visible' });
-
-                if (await savedQueryButton.isVisible()) {
-                    const actionMenuButton = page.getByRole('button', {
-                        name: 'Show saved query actions',
-                        exact: true,
-                    });
-
-                    await actionMenuButton.waitFor({ state: 'visible' });
-                    await actionMenuButton.click();
-
-                    const deleteButton = page.getByRole('button', {
-                        name: 'Delete',
-                        exact: true,
-                    });
-
-                    await deleteButton.waitFor({ state: 'visible' });
-                    await deleteButton.click();
-
-                    const deleteDialog = page.getByRole('dialog', {
-                        name: 'Delete Query',
-                        exact: true,
-                    });
-                    const confirmButton = deleteDialog.getByRole('button', {
-                        name: 'Confirm',
-                        exact: true,
-                    });
-
-                    await deleteDialog.waitFor({ state: 'visible' });
-                    await confirmButton.click();
-
-                    await deleteDialog.waitFor({ state: 'hidden' });
-                    await savedQueryButton.waitFor({ state: 'detached' });
-                }
-            } catch (error) {
-                cleanupError = error;
-            }
-        }
-
-        if (testError !== undefined) {
-            throw testError;
-        }
-
-        if (cleanupError !== undefined) {
-            throw cleanupError;
-        }
-    });
-
-    test('Delete Query dialog', async ({ page, makeAxeBuilder }, testInfo) => {
-        const query = 'MATCH (n) RETURN n LIMIT 1';
-        const queryName = `a11y-delete-dialog-${testInfo.project.name}-${Date.now()}`;
-        const savedQueryAccessibleName = `Run pre-built search query: ${queryName}`;
-        let testError: unknown;
-        let cleanupError: unknown;
-
-        try {
-            const cypherEditor = page.getByRole('textbox', {
-                name: 'Cypher Editor',
-            });
-
-            await cypherEditor.waitFor({ state: 'visible' });
-
-            await cypherEditor.fill(query);
-
-            const saveQueryButton = page.getByRole('button', {
-                name: 'Save query',
-                exact: true,
-            });
-
-            await saveQueryButton.waitFor({ state: 'visible' });
-            await saveQueryButton.click();
-
-            const saveQueryDialog = page.getByTestId('save-query-dialog');
-            const queryNameTextbox = saveQueryDialog.getByRole('textbox', {
-                name: 'Query Name',
-                exact: true,
-            });
-            const saveButton = saveQueryDialog.getByRole('button', {
-                name: 'Save',
-                exact: true,
-            });
-
-            await saveQueryDialog.waitFor({ state: 'visible' });
-            await queryNameTextbox.fill(queryName);
-            await saveButton.click();
-            await saveQueryDialog.waitFor({ state: 'hidden' });
-            await page.goto('/ui/explore');
-
-            const cypherTab = page.getByRole('tab', {
-                name: 'Cypher',
-            });
-
-            await cypherTab.click();
-            await page.getByRole('textbox', { name: 'Cypher Editor' }).waitFor({ state: 'visible' });
-
-            const savedQueriesButton = page.getByRole('button', {
-                name: 'Saved Queries',
-                exact: true,
-            });
-
-            await savedQueriesButton.waitFor({ state: 'visible' });
-            await savedQueriesButton.click();
-
-            const searchTextbox = page.getByRole('textbox', {
-                name: 'Search',
-                exact: true,
-            });
-
-            await searchTextbox.waitFor({ state: 'visible' });
-            await searchTextbox.fill(queryName);
-
-            const savedQueryButton = page.getByRole('button', {
-                name: savedQueryAccessibleName,
-                exact: true,
-            });
-
-            await savedQueryButton.waitFor({ state: 'visible' });
-
-            const autoRunCheckbox = page.getByRole('checkbox', {
-                name: 'Auto-run selected query',
-                exact: true,
-            });
-
-            await autoRunCheckbox.waitFor({ state: 'visible' });
-
-            if (await autoRunCheckbox.isChecked()) {
-                await autoRunCheckbox.uncheck();
-            }
-            await savedQueryButton.click();
-
-            const actionMenuButton = page.getByRole('button', {
-                name: 'Show saved query actions',
-                exact: true,
-            });
-
-            await actionMenuButton.waitFor({ state: 'visible' });
-            await actionMenuButton.click();
-
-            const actionMenu = page.getByTestId('saved-query-action-menu');
-            await actionMenu.waitFor({ state: 'visible' });
-
-            const deleteButton = page.getByRole('button', {
-                name: 'Delete',
-                exact: true,
-            });
-
-            await deleteButton.waitFor({ state: 'visible' });
-            await deleteButton.click();
-
-            const deleteDialog = page.getByRole('dialog', {
-                name: 'Delete Query',
-                exact: true,
-            });
-
-            await deleteDialog.waitFor({ state: 'visible' });
-
-            const deleteQueryHeading = deleteDialog.getByRole('heading', {
-                name: 'Delete Query',
-                exact: true,
-            });
-            const confirmationText = deleteDialog.getByText('Are you sure you want to delete this query?', {
-                exact: true,
-            });
-            const cancelButton = deleteDialog.getByRole('button', {
-                name: 'Cancel',
-                exact: true,
-            });
-            const confirmButton = deleteDialog.getByRole('button', {
-                name: 'Confirm',
-                exact: true,
-            });
-
-            await deleteQueryHeading.waitFor({ state: 'visible' });
-            await confirmationText.waitFor({ state: 'visible' });
-            await cancelButton.waitFor({ state: 'visible' });
-            await confirmButton.waitFor({ state: 'visible' });
-
-            const results = await makeAxeBuilder().include('#content-wrapper').include('[role="dialog"]').analyze();
-
-            await expectNoAccessibilityViolations(testInfo, results, { page });
-        } catch (error) {
-            testError = error;
-        } finally {
-            try {
-                await page.goto('/ui/explore');
-
-                const cypherTab = page.getByRole('tab', {
-                    name: 'Cypher',
-                });
-
-                await cypherTab.click();
-                await page.getByRole('textbox', { name: 'Cypher Editor' }).waitFor({ state: 'visible' });
-
-                const savedQueriesButton = page.getByRole('button', {
-                    name: 'Saved Queries',
-                    exact: true,
-                });
-
-                await savedQueriesButton.waitFor({ state: 'visible' });
-                await savedQueriesButton.click();
-
-                const searchTextbox = page.getByRole('textbox', {
-                    name: 'Search',
-                    exact: true,
-                });
-
-                await searchTextbox.waitFor({ state: 'visible' });
-                await searchTextbox.fill(queryName);
-
-                const savedQueryButton = page.getByRole('button', {
-                    name: savedQueryAccessibleName,
-                    exact: true,
-                });
-                const noResultsHeading = page.getByRole('heading', {
-                    name: 'No Results',
-                    exact: true,
-                });
-
-                await savedQueryButton.or(noResultsHeading).waitFor({ state: 'visible' });
-
-                if (await savedQueryButton.isVisible()) {
-                    const actionMenuButton = page.getByRole('button', {
-                        name: 'Show saved query actions',
-                        exact: true,
-                    });
-
-                    await actionMenuButton.waitFor({ state: 'visible' });
-                    await actionMenuButton.click();
-
-                    const deleteButton = page.getByRole('button', {
-                        name: 'Delete',
-                        exact: true,
-                    });
-
-                    await deleteButton.waitFor({ state: 'visible' });
-                    await deleteButton.click();
-
-                    const deleteDialog = page.getByRole('dialog', {
-                        name: 'Delete Query',
-                        exact: true,
-                    });
-                    const confirmButton = deleteDialog.getByRole('button', {
-                        name: 'Confirm',
-                        exact: true,
-                    });
-
-                    await deleteDialog.waitFor({ state: 'visible' });
-                    await confirmButton.click();
-
-                    await deleteDialog.waitFor({ state: 'hidden' });
-                    await savedQueryButton.waitFor({ state: 'detached' });
-                }
-            } catch (error) {
-                cleanupError = error;
-            }
-        }
-
-        if (testError !== undefined) {
-            throw testError;
-        }
-
-        if (cleanupError !== undefined) {
-            throw cleanupError;
-        }
+        await checkA11y();
     });
 });

--- a/cmd/ui/tests/a11y/Explore/cypher.a11y.spec.ts
+++ b/cmd/ui/tests/a11y/Explore/cypher.a11y.spec.ts
@@ -374,6 +374,7 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab - Saved Queries', () 
         // Select the dots action from the saved query
         await page.getByTestId('saved-query-action-menu-trigger').click();
         await page.getByRole('button', { name: 'Edit/Share' }).click();
+        await page.getByText('MATCH (n) RETURN n LIMIT').waitFor();
 
         await hideBySelector(page, 'nav');
         await hideBySelector(page, '#content-wrapper');

--- a/cmd/ui/tests/a11y/Explore/cypher.a11y.spec.ts
+++ b/cmd/ui/tests/a11y/Explore/cypher.a11y.spec.ts
@@ -19,6 +19,9 @@ import { hideBySelector, test } from 'bh-playwright-testing';
 
 const installSaveQueryStub = async (page: Page, testInfo: TestInfo) => {
     const queryName = `a11y-export-${testInfo.project.name}-${Date.now()}`;
+    const testRunTime = Date.now();
+    const authSecretExpiresAt = new Date(testRunTime + 7 * 24 * 60 * 60 * 1000).toISOString();
+    const lastLogin = new Date(testRunTime - 8 * 60 * 60 * 1000).toISOString();
 
     const savedQuery = {
         id: 1,
@@ -34,14 +37,14 @@ const installSaveQueryStub = async (page: Page, testInfo: TestInfo) => {
             sso_provider_id: null,
             AuthSecret: {
                 digest_method: 'argon2',
-                expires_at: '2026-11-15T14:32:05.868773Z',
+                expires_at: authSecretExpiresAt,
                 id: 1,
             },
             first_name: 'BloodHound',
             last_name: 'Dev',
             email_address: 'spam@example.com',
             principal_name: 'admin',
-            last_login: '2026-08-24T17:12:33.222043Z',
+            last_login: lastLogin,
             is_disabled: false,
             all_environments: true,
             environment_targeted_access_control: [],
@@ -374,7 +377,7 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab - Saved Queries', () 
         // Select the dots action from the saved query
         await page.getByTestId('saved-query-action-menu-trigger').click();
         await page.getByRole('button', { name: 'Edit/Share' }).click();
-        await page.getByText('MATCH (n) RETURN n LIMIT').waitFor();
+        await page.getByRole('dialog', { name: 'Edit Saved Query' }).waitFor();
 
         await hideBySelector(page, 'nav');
         await hideBySelector(page, '#content-wrapper');
@@ -393,10 +396,11 @@ test.describe('WCAG A/AA Violations - Explore - Cypher Tab - Saved Queries', () 
 
         // Additional specifier as there are multiple Delete buttons in scope
         await page.getByTestId('saved-query-action-menu').getByRole('button', { name: 'Delete' }).click();
+        await page.getByRole('dialog', { name: 'Delete Query' }).waitFor();
 
         await hideBySelector(page, 'nav');
         await hideBySelector(page, '#content-wrapper');
 
-        await checkA11y();
+        await checkA11y({ include: '[role="presentation"][tabindex="-1"]' });
     });
 });

--- a/cmd/ui/tests/a11y/Explore/entity-info-panel.a11y.spec.ts
+++ b/cmd/ui/tests/a11y/Explore/entity-info-panel.a11y.spec.ts
@@ -15,7 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { Page } from '@playwright/test';
-import { expectNoAccessibilityViolations, test } from '../../fixtures';
+import { hideBySelector, test } from 'bh-playwright-testing';
 
 const SEARCH_TERM = 'test';
 const OBJECT_ID = 'playwright-gpo-1';
@@ -139,7 +139,7 @@ const selectMockedGPO = async (page: Page) => {
 };
 
 test.describe('WCAG A/AA Violations - Explore - Entity Information Panel', () => {
-    test('With a relationship section expanded', async ({ page, makeAxeBuilder }, testInfo) => {
+    test('With a relationship section expanded', async ({ page, checkA11y }) => {
         await mockCommonRoutes(page);
 
         await page.route(`**/api/v2/gpos/${OBJECT_ID}/*`, async (route) => {
@@ -172,11 +172,14 @@ test.describe('WCAG A/AA Violations - Explore - Entity Information Panel', () =>
 
         await infoPanel.getByText('RELATED_USER_0@PLAYWRIGHT.LOCAL').waitFor({ state: 'visible' });
 
-        const results = await makeAxeBuilder().include('#content-wrapper').analyze();
-        await expectNoAccessibilityViolations(testInfo, results, { page });
+        await hideBySelector(page, '[data-testid="explore_search-container"]');
+        await hideBySelector(page, '[data-testid="sigma-container-wrapper"]');
+        await hideBySelector(page, '.ReactQueryDevtools');
+
+        await checkA11y();
     });
 
-    test('With disabled sections', async ({ page, makeAxeBuilder }, testInfo) => {
+    test('With disabled sections', async ({ page, checkA11y }) => {
         await mockCommonRoutes(page);
 
         await page.route(`**/api/v2/gpos/${OBJECT_ID}/*`, async (route) => {
@@ -207,14 +210,16 @@ test.describe('WCAG A/AA Violations - Explore - Entity Information Panel', () =>
         const infoPanel = page.getByTestId('explore_entity-information-panel');
         await infoPanel.waitFor({ state: 'visible' });
         await infoPanel.getByTestId('entity-object-information-skeleton').waitFor({ state: 'detached' });
-
         await infoPanel.getByRole('button', { name: /Inbound Object Control/ }).waitFor({ state: 'visible' });
 
-        const results = await makeAxeBuilder().include('#content-wrapper').analyze();
-        await expectNoAccessibilityViolations(testInfo, results, { page });
+        await hideBySelector(page, '[data-testid="explore_search-container"]');
+        await hideBySelector(page, '[data-testid="sigma-container-wrapper"]');
+        await hideBySelector(page, '.ReactQueryDevtools');
+
+        await checkA11y();
     });
 
-    test('With selectable items section', async ({ page, makeAxeBuilder }, testInfo) => {
+    test('With selectable items section', async ({ page, checkA11y }) => {
         await mockCommonRoutes(page);
 
         await page.route(`**/api/v2/gpos/${OBJECT_ID}/*`, async (route) => {
@@ -296,7 +301,10 @@ test.describe('WCAG A/AA Violations - Explore - Entity Information Panel', () =>
 
         await infoPanel.getByText(SELECTABLE_OU_NAME).waitFor({ state: 'visible' });
 
-        const results = await makeAxeBuilder().include('#content-wrapper').analyze();
-        await expectNoAccessibilityViolations(testInfo, results, { page });
+        await hideBySelector(page, '[data-testid="explore_search-container"]');
+        await hideBySelector(page, '[data-testid="sigma-container-wrapper"]');
+        await hideBySelector(page, '.ReactQueryDevtools');
+
+        await checkA11y();
     });
 });

--- a/cmd/ui/tests/a11y/Explore/explore-graph-controls.a11y.spec.ts
+++ b/cmd/ui/tests/a11y/Explore/explore-graph-controls.a11y.spec.ts
@@ -15,8 +15,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { Page } from '@playwright/test';
+import { hideBySelector, test } from 'bh-playwright-testing';
 import type { StyledGraphEdge, StyledGraphNode } from 'js-client-library';
-import { expectNoAccessibilityViolations, test } from '../../fixtures';
 
 const CYPHER_QUERY = 'MATCH (n) RETURN n LIMIT 2';
 const EXPLORE_URL =
@@ -28,6 +28,8 @@ const FIRST_NODE_OBJECT_ID = 'playwright-object-1';
 const SECOND_NODE_OBJECT_ID = 'playwright-object-2';
 const FIRST_NODE_LABEL = 'PLAYWRIGHT GRAPH USER';
 const SECOND_NODE_LABEL = 'PLAYWRIGHT GRAPH GROUP';
+const HIDE_CLASSES =
+    '[data-testid="explore_search-container"], [data-testid="explore_graph-controls"], [data-testid="sigma-container-wrapper"], .ReactQueryDevtools';
 
 const createStyledNode = (objectId: string, label: string, nodeType: string): StyledGraphNode => ({
     color: '#5c6bc0',
@@ -98,33 +100,26 @@ const installExploreGraphRoute = async (page: Page) => {
     });
 };
 
-const loadExploreGraph = async (page: Page) => {
-    await installExploreGraphRoute(page);
-    await page.goto(EXPLORE_URL);
-    await page.getByTestId('sigma-container-wrapper').waitFor({ state: 'attached' });
-    await page.getByTestId('explore_graph-controls').waitFor({ state: 'visible' });
-};
-
 const expandGraphSearch = async (page: Page) => {
-    const searchButton = page.getByRole('button', {
-        name: 'Search node in results',
-        exact: true,
-    });
-
-    await searchButton.click();
+    await page.getByTestId('explore_graph-controls_search-current-results').click();
 
     const searchInput = page.getByPlaceholder('Search node in results');
-    await searchInput.waitFor({ state: 'visible' });
+    await searchInput.waitFor();
 
     return searchInput;
 };
 
 test.describe('WCAG A/AA Violations - Explore - Graph Controls', () => {
-    test.beforeEach(async ({ page }) => {
-        await loadExploreGraph(page);
+    test.beforeEach(async ({ goAndWaitFor, page }) => {
+        await installExploreGraphRoute(page);
+        await goAndWaitFor(EXPLORE_URL, page.getByTestId('explore_graph-controls'));
     });
 
-    test('With Hide Labels expanded', async ({ page, makeAxeBuilder }, testInfo) => {
+    test('Graph control buttons', async ({ checkA11y }) => {
+        await checkA11y({ include: '[data-testid="explore_graph-controls"]' });
+    });
+
+    test('With hide labels expanded', async ({ page, checkA11y }) => {
         const hideLabelsButton = page.getByRole('button', { name: 'Hide Labels', exact: true });
         await hideLabelsButton.click();
 
@@ -132,60 +127,64 @@ test.describe('WCAG A/AA Violations - Explore - Graph Controls', () => {
             name: 'Hide All Labels Toggle',
             exact: true,
         });
-        await hideAllLabelsMenuItem.waitFor({ state: 'visible' });
+        await hideAllLabelsMenuItem.waitFor();
 
-        const results = await makeAxeBuilder().include('#content-wrapper').include('[role="menu"]').analyze();
-        await expectNoAccessibilityViolations(testInfo, results, { page });
+        await hideBySelector(page, HIDE_CLASSES);
+
+        await checkA11y({ include: '[data-radix-popper-content-wrapper]' });
     });
 
-    test('With Layout expanded', async ({ page, makeAxeBuilder }, testInfo) => {
+    test('With layout expanded', async ({ page, checkA11y }) => {
         const layoutButton = page.getByRole('button', { name: 'Layout', exact: true });
         await layoutButton.click();
 
         const sequentialMenuItem = page.getByRole('menuitem', { name: 'Sequential', exact: true });
-        await sequentialMenuItem.waitFor({ state: 'visible' });
+        await sequentialMenuItem.waitFor();
 
-        const results = await makeAxeBuilder().include('#content-wrapper').include('[role="menu"]').analyze();
-        await expectNoAccessibilityViolations(testInfo, results, { page });
+        await hideBySelector(page, HIDE_CLASSES);
+
+        await checkA11y({ include: '[data-radix-popper-content-wrapper]' });
     });
 
-    test('With Export expanded', async ({ page, makeAxeBuilder }, testInfo) => {
+    test('With Export expanded', async ({ page, checkA11y }) => {
         const exportButton = page.getByRole('button', { name: 'Export', exact: true });
         await exportButton.click();
 
         const jsonMenuItem = page.getByRole('menuitem', { name: 'JSON', exact: true });
-        await jsonMenuItem.waitFor({ state: 'visible' });
+        await jsonMenuItem.waitFor();
 
-        const results = await makeAxeBuilder().include('#content-wrapper').include('[role="menu"]').analyze();
-        await expectNoAccessibilityViolations(testInfo, results, { page });
+        await hideBySelector(page, HIDE_CLASSES);
+
+        await checkA11y({ include: '[data-radix-popper-content-wrapper]' });
     });
 
-    test('With Search expanded', async ({ page, makeAxeBuilder }, testInfo) => {
+    test('With Search expanded', async ({ page, checkA11y }) => {
         await expandGraphSearch(page);
-
-        const results = await makeAxeBuilder().include('#content-wrapper').analyze();
-        await expectNoAccessibilityViolations(testInfo, results, { page });
+        await hideBySelector(page, HIDE_CLASSES);
+        await checkA11y({ include: '[aria-label="Search Current Nodes"]' });
     });
 
-    test('With search showing results', async ({ page, makeAxeBuilder }, testInfo) => {
+    test('With search showing results', async ({ page, checkA11y }) => {
         const searchInput = await expandGraphSearch(page);
         await searchInput.fill(FIRST_NODE_LABEL);
 
         const matchingResult = page.getByRole('option').filter({ hasText: FIRST_NODE_LABEL });
-        await matchingResult.waitFor({ state: 'visible' });
+        await matchingResult.waitFor();
 
-        const results = await makeAxeBuilder().include('#content-wrapper').analyze();
-        await expectNoAccessibilityViolations(testInfo, results, { page });
+        await hideBySelector(page, HIDE_CLASSES);
+
+        await checkA11y({ include: '[aria-label="Search Current Nodes"]' });
     });
 
-    test('With search showing no results', async ({ page, makeAxeBuilder }, testInfo) => {
+    test('With search showing no results', async ({ page, checkA11y }) => {
         const searchInput = await expandGraphSearch(page);
         await searchInput.fill('no-matching-playwright-node');
 
         const noResultsMessage = page.getByText('No result found in current results', { exact: true });
-        await noResultsMessage.waitFor({ state: 'visible' });
+        await noResultsMessage.waitFor();
 
-        const results = await makeAxeBuilder().include('#content-wrapper').analyze();
-        await expectNoAccessibilityViolations(testInfo, results, { page });
+        await hideBySelector(page, HIDE_CLASSES);
+
+        await checkA11y({ include: '[aria-label="Search Current Nodes"]' });
     });
 });

--- a/cmd/ui/tests/a11y/Explore/pathfinding.a11y.spec.ts
+++ b/cmd/ui/tests/a11y/Explore/pathfinding.a11y.spec.ts
@@ -13,22 +13,40 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
-import { expect, expectNoAccessibilityViolations, test } from '../../fixtures';
+import { Page } from '@playwright/test';
+import { expect, test } from 'bh-playwright-testing';
+
+const installPathfindingStub = async (page: Page) => {
+    await page.route('**/api/v2/graphs/shortest-path**', async (route) => {
+        if (route.request().method() !== 'GET') {
+            return route.fallback();
+        }
+
+        await route.fulfill({
+            json: {
+                data: {
+                    nodes: {},
+                    edges: [],
+                },
+            },
+        });
+    });
+};
 
 test.describe('WCAG A/AA Violations - Explore - Pathfinding Tab', () => {
-    test.beforeEach(async ({ page }) => {
-        await page.goto('/ui/explore?exploreSearchTab=pathfinding');
-        await page.getByRole('textbox', { name: 'Start Node' }).waitFor({ state: 'visible' });
+    test.beforeEach(async ({ page, goAndWaitFor }) => {
+        await goAndWaitFor(
+            '/ui/explore?exploreSearchTab=pathfinding',
+            page.getByRole('textbox', { name: 'Start node' })
+        );
     });
 
-    test('Pathfinding tab', async ({ page, makeAxeBuilder }, testInfo) => {
-        await page.getByText('Begin typing to search.').first().waitFor({ state: 'visible' });
-
-        const results = await makeAxeBuilder().include('#content-wrapper').analyze();
-        await expectNoAccessibilityViolations(testInfo, results, { page });
+    test('Pathfinding tab', async ({ page, checkA11y }) => {
+        await page.getByText('Begin typing to search.').first().waitFor();
+        await checkA11y();
     });
 
-    test('Start Node with results', async ({ page, makeAxeBuilder }, testInfo) => {
+    test('Start node with results', async ({ page, checkA11y }) => {
         const searchTerm = 'test';
         const searchResultName = 'TEST RESULT';
 
@@ -50,14 +68,13 @@ test.describe('WCAG A/AA Violations - Explore - Pathfinding Tab', () => {
             });
         });
 
-        await page.getByLabel('Start Node').fill(searchTerm);
-        await page.getByRole('option', { name: 'No results found for "' }).waitFor({ state: 'visible' });
+        await page.getByRole('textbox', { name: 'Start Node' }).fill(searchTerm);
+        await page.getByText('TEST RESULT').waitFor();
 
-        const results = await makeAxeBuilder().include('#content-wrapper').analyze();
-        await expectNoAccessibilityViolations(testInfo, results, { page });
+        await checkA11y();
     });
 
-    test('Start Node with no results', async ({ page, makeAxeBuilder }, testInfo) => {
+    test('Start node with no results', async ({ page, checkA11y }) => {
         const searchTerm = 'zzzznonexistentnode9999';
 
         await page.route('**/api/v2/search**', async (route) => {
@@ -68,28 +85,24 @@ test.describe('WCAG A/AA Violations - Explore - Pathfinding Tab', () => {
             await route.fulfill({ json: { data: [] } });
         });
 
-        const startNodeField = page.getByLabel('Start Node');
+        const startNodeField = page.getByRole('textbox', { name: 'Start Node' });
         await startNodeField.fill(searchTerm);
 
         const noResultsMessage = `No results found for "${searchTerm}"`;
         await expect(page.getByText(noResultsMessage)).toBeVisible();
 
-        const results = await makeAxeBuilder().include('#content-wrapper').analyze();
-        await expectNoAccessibilityViolations(testInfo, results, { page });
+        await checkA11y();
     });
 
-    test('Destination Node', async ({ page, makeAxeBuilder }, testInfo) => {
-        // Pathfinding autofocus opens the Start Node popup over the Destination Node field.
-        await page.getByLabel('Start Node').press('Escape');
+    test('Destination node', async ({ page, checkA11y }) => {
+        // Pathfinding autofocus opens the Start node popup over the Destination Node field.
+        await page.getByRole('textbox', { name: 'Start Node' }).press('Escape');
+        await page.getByRole('textbox', { name: 'Destination Node' }).click();
 
-        const destinationNodeField = page.getByLabel('Destination Node');
-        await destinationNodeField.click();
-
-        const results = await makeAxeBuilder().include('#content-wrapper').analyze();
-        await expectNoAccessibilityViolations(testInfo, results, { page });
+        await checkA11y();
     });
 
-    test('Destination Node with results', async ({ page, makeAxeBuilder }, testInfo) => {
+    test('Destination node with results', async ({ page, checkA11y }) => {
         const searchTerm = 'test';
         const searchResultName = 'DESTINATION TEST RESULT';
 
@@ -111,21 +124,15 @@ test.describe('WCAG A/AA Violations - Explore - Pathfinding Tab', () => {
             });
         });
 
-        // Pathfinding autofocus opens the Start Node popup over the Destination Node field.
-        await page.getByLabel('Start Node').press('Escape');
+        // Pathfinding autofocus opens the Start node popup over the Destination Node field.
+        await page.getByRole('textbox', { name: 'Start Node' }).press('Escape');
+        await page.getByRole('textbox', { name: 'Destination Node' }).fill(searchTerm);
+        await page.getByText('DESTINATION TEST RESULT').waitFor();
 
-        const destinationNodeField = page.getByLabel('Destination Node');
-        await destinationNodeField.click();
-        await destinationNodeField.fill(searchTerm);
-
-        const searchResult = page.getByRole('option').filter({ hasText: searchResultName });
-        await expect(searchResult).toBeVisible();
-
-        const results = await makeAxeBuilder().include('#content-wrapper').analyze();
-        await expectNoAccessibilityViolations(testInfo, results, { page });
+        await checkA11y();
     });
 
-    test('Destination Node with no results', async ({ page, makeAxeBuilder }, testInfo) => {
+    test('Destination node with no results', async ({ page, checkA11y }) => {
         const searchTerm = 'zzzznonexistentdestination9999';
 
         await page.route('**/api/v2/search**', async (route) => {
@@ -136,21 +143,15 @@ test.describe('WCAG A/AA Violations - Explore - Pathfinding Tab', () => {
             await route.fulfill({ json: { data: [] } });
         });
 
-        // Pathfinding autofocus opens the Start Node popup over the Destination Node field.
-        await page.getByLabel('Start Node').press('Escape');
+        // Pathfinding autofocus opens the Start node popup over the Destination Node field.
+        await page.getByRole('textbox', { name: 'Start Node' }).press('Escape');
+        await page.getByRole('textbox', { name: 'Destination Node' }).fill(searchTerm);
+        await page.getByText('No results found for "').waitFor();
 
-        const destinationNodeField = page.getByLabel('Destination Node');
-        await destinationNodeField.click();
-        await destinationNodeField.fill(searchTerm);
-
-        const noResultsMessage = `No results found for "${searchTerm}"`;
-        await expect(page.getByText(noResultsMessage)).toBeVisible();
-
-        const results = await makeAxeBuilder().include('#content-wrapper').analyze();
-        await expectNoAccessibilityViolations(testInfo, results, { page });
+        await checkA11y();
     });
 
-    test('Enabled pathfinding controls', async ({ page, makeAxeBuilder }, testInfo) => {
+    test('Enabled pathfinding controls', async ({ page, checkA11y }) => {
         const startResultName = 'START TEST RESULT';
         const destinationResultName = 'DESTINATION TEST RESULT';
 
@@ -177,34 +178,21 @@ test.describe('WCAG A/AA Violations - Explore - Pathfinding Tab', () => {
             });
         });
 
-        const startNodeField = page.getByLabel('Start Node');
-        await startNodeField.fill(startResultName);
+        await installPathfindingStub(page);
 
-        const startResult = page.getByRole('option').filter({ hasText: startResultName });
-        await expect(startResult).toBeVisible();
-        await startResult.click();
+        await page.getByRole('textbox', { name: 'Start Node' }).fill(startResultName);
+        await page.getByRole('option').filter({ hasText: startResultName }).click();
 
-        const destinationNodeField = page.getByLabel('Destination Node');
-        await destinationNodeField.click();
-        await destinationNodeField.fill(destinationResultName);
+        await page.getByRole('textbox', { name: 'Destination Node' }).fill(destinationResultName);
+        await page.getByRole('option').filter({ hasText: destinationResultName }).click();
 
-        const destinationResult = page.getByRole('option').filter({ hasText: destinationResultName });
-        await expect(destinationResult).toBeVisible();
-        await destinationResult.click();
+        await page.getByRole('button', { name: 'Swap start and destination' }).waitFor();
+        await page.getByRole('button', { name: 'Show pathfinding filter options' }).waitFor();
 
-        const swapButton = page.getByRole('button', { name: 'Swap start and destination' });
-        const filterButton = page.getByRole('button', {
-            name: 'Show pathfinding filter options',
-        });
-
-        await expect(swapButton).toBeEnabled();
-        await expect(filterButton).toBeEnabled();
-
-        const results = await makeAxeBuilder().include('#content-wrapper').analyze();
-        await expectNoAccessibilityViolations(testInfo, results, { page });
+        await checkA11y();
     });
 
-    test('Path Edge Filtering dialog', async ({ page, makeAxeBuilder }, testInfo) => {
+    test('Path edge filtering dialog', async ({ page, checkA11y }) => {
         const startResultName = 'START TEST RESULT';
         const destinationResultName = 'DESTINATION TEST RESULT';
 
@@ -231,112 +219,67 @@ test.describe('WCAG A/AA Violations - Explore - Pathfinding Tab', () => {
             });
         });
 
-        const startNodeField = page.getByLabel('Start Node');
-        await startNodeField.fill(startResultName);
+        await installPathfindingStub(page);
 
-        const startResult = page.getByRole('option').filter({ hasText: startResultName });
-        await expect(startResult).toBeVisible();
-        await startResult.click();
+        await page.getByRole('textbox', { name: 'Start Node' }).fill(startResultName);
+        await page.getByRole('option').filter({ hasText: startResultName }).click();
+        await page.getByRole('textbox', { name: 'Destination Node' }).fill(destinationResultName);
 
-        const destinationNodeField = page.getByLabel('Destination Node');
-        await destinationNodeField.click();
-        await destinationNodeField.fill(destinationResultName);
+        await page.getByRole('option').filter({ hasText: destinationResultName }).click();
+        await page.getByRole('button', { name: 'Show pathfinding filter options' }).click();
+        await page.getByRole('dialog', { name: 'Path Edge Filtering' }).waitFor();
 
-        const destinationResult = page.getByRole('option').filter({ hasText: destinationResultName });
-        await expect(destinationResult).toBeVisible();
-        await destinationResult.click();
+        await checkA11y({ include: '[role=dialog]' });
+    });
 
-        const filterButton = page.getByRole('button', {
-            name: 'Show pathfinding filter options',
+    test('Path edge filtering dialog with no selections', async ({ page, checkA11y }) => {
+        const startResultName = 'START TEST RESULT';
+        const destinationResultName = 'DESTINATION TEST RESULT';
+
+        await page.route('**/api/v2/search**', async (route) => {
+            if (route.request().method() !== 'GET') {
+                return route.fallback();
+            }
+
+            await route.fulfill({
+                json: {
+                    data: [
+                        {
+                            name: startResultName,
+                            objectid: 'playwright-pathfinding-start-result',
+                            type: 'User',
+                        },
+                        {
+                            name: destinationResultName,
+                            objectid: 'playwright-pathfinding-destination-result',
+                            type: 'Computer',
+                        },
+                    ],
+                },
+            });
         });
-        await expect(filterButton).toBeEnabled();
-        await filterButton.click();
+
+        await installPathfindingStub(page);
+
+        await page.getByRole('textbox', { name: 'Start Node' }).fill(startResultName);
+        await page.getByRole('option').filter({ hasText: startResultName }).click();
+
+        await page.getByRole('textbox', { name: 'Destination Node' }).fill(destinationResultName);
+        await page.getByRole('option').filter({ hasText: destinationResultName }).click();
+        await page.getByRole('button', { name: 'Show pathfinding filter options' }).click();
 
         const dialog = page.getByRole('dialog', { name: 'Path Edge Filtering' });
-        await expect(dialog).toBeVisible();
-        await expect(dialog.getByRole('checkbox', { name: 'Active Directory', exact: true })).toBeChecked();
-        await expect(dialog.getByRole('checkbox', { name: 'Azure', exact: true })).toBeChecked();
+        await dialog.waitFor();
 
-        const results = await makeAxeBuilder().include('[role=dialog]').analyze();
-        await expectNoAccessibilityViolations(testInfo, results, { page });
-    });
+        await dialog.getByRole('checkbox', { name: 'Active Directory', exact: true }).click();
+        await dialog.getByRole('checkbox', { name: 'Azure', exact: true }).click();
 
-    test('Path Edge Filtering dialog with no selections', async ({ page, makeAxeBuilder }, testInfo) => {
-        const startResultName = 'START TEST RESULT';
-        const destinationResultName = 'DESTINATION TEST RESULT';
-
-        await page.route('**/api/v2/search**', async (route) => {
-            if (route.request().method() !== 'GET') {
-                return route.fallback();
-            }
-
-            await route.fulfill({
-                json: {
-                    data: [
-                        {
-                            name: startResultName,
-                            objectid: 'playwright-pathfinding-start-result',
-                            type: 'User',
-                        },
-                        {
-                            name: destinationResultName,
-                            objectid: 'playwright-pathfinding-destination-result',
-                            type: 'Computer',
-                        },
-                    ],
-                },
-            });
-        });
-
-        const startNodeField = page.getByLabel('Start Node');
-        await startNodeField.fill(startResultName);
-
-        const startResult = page.getByRole('option').filter({ hasText: startResultName });
-        await expect(startResult).toBeVisible();
-        await startResult.click();
-
-        const destinationNodeField = page.getByLabel('Destination Node');
-        await destinationNodeField.fill(destinationResultName);
-
-        const destinationResult = page.getByRole('option').filter({ hasText: destinationResultName });
-        await expect(destinationResult).toBeVisible();
-        await destinationResult.click();
-
-        const filterButton = page.getByRole('button', {
-            name: 'Show pathfinding filter options',
-        });
-        await expect(filterButton).toBeEnabled();
-        await filterButton.click();
-
-        const dialog = page.getByRole('dialog', {
-            name: 'Path Edge Filtering',
-        });
-        await expect(dialog).toBeVisible();
-
-        const activeDirectoryFilter = dialog.getByRole('checkbox', {
-            name: 'Active Directory',
-            exact: true,
-        });
-        const azureFilter = dialog.getByRole('checkbox', {
-            name: 'Azure',
-            exact: true,
-        });
-
-        await expect(activeDirectoryFilter).toBeChecked();
-        await expect(azureFilter).toBeChecked();
-
-        await activeDirectoryFilter.click();
-        await azureFilter.click();
-
-        await expect(activeDirectoryFilter).not.toBeChecked();
-        await expect(azureFilter).not.toBeChecked();
         await expect(dialog.getByRole('checkbox', { checked: true })).toHaveCount(0);
 
-        const results = await makeAxeBuilder().include('[role=dialog]').analyze();
-        await expectNoAccessibilityViolations(testInfo, results, { page });
+        await checkA11y({ include: '[role=dialog]' });
     });
 
-    test('Path Edge Filtering dialog with search results', async ({ page, makeAxeBuilder }, testInfo) => {
+    test('Path edge filtering dialog with search results', async ({ page, checkA11y }) => {
         const startResultName = 'START TEST RESULT';
         const destinationResultName = 'DESTINATION TEST RESULT';
 
@@ -363,44 +306,26 @@ test.describe('WCAG A/AA Violations - Explore - Pathfinding Tab', () => {
             });
         });
 
-        const startNodeField = page.getByLabel('Start Node');
-        await startNodeField.fill(startResultName);
+        await installPathfindingStub(page);
 
-        const startResult = page.getByRole('option').filter({ hasText: startResultName });
-        await expect(startResult).toBeVisible();
-        await startResult.click();
+        await page.getByRole('textbox', { name: 'Start Node' }).fill(startResultName);
+        await page.getByRole('option').filter({ hasText: startResultName }).click();
+        await page.getByRole('textbox', { name: 'Destination Node' }).fill(destinationResultName);
 
-        const destinationNodeField = page.getByLabel('Destination Node');
-        await destinationNodeField.fill(destinationResultName);
+        await page.getByRole('option').filter({ hasText: destinationResultName }).click();
+        await page.getByRole('button', { name: 'Show pathfinding filter options' }).click();
 
-        const destinationResult = page.getByRole('option').filter({ hasText: destinationResultName });
-        await expect(destinationResult).toBeVisible();
-        await destinationResult.click();
-
-        const filterButton = page.getByRole('button', {
-            name: 'Show pathfinding filter options',
-        });
-        await expect(filterButton).toBeEnabled();
-        await filterButton.click();
-
-        const dialog = page.getByRole('dialog', {
-            name: 'Path Edge Filtering',
-        });
-        await expect(dialog).toBeVisible();
+        const dialog = page.getByRole('dialog', { name: 'Path Edge Filtering' });
+        await dialog.waitFor();
 
         const searchTextbox = dialog.getByRole('textbox', { name: 'Search edges...' });
         await searchTextbox.fill('write');
         await expect(searchTextbox).toHaveValue('write');
 
-        await expect(dialog.getByRole('checkbox', { name: 'GenericWrite', exact: true })).toBeVisible();
-        await expect(dialog.getByRole('checkbox', { name: 'WriteOwner', exact: true })).toBeVisible();
-        await expect(dialog.getByRole('checkbox', { name: 'Credential Access', exact: true })).toHaveCount(0);
-
-        const results = await makeAxeBuilder().include('[role=dialog]').analyze();
-        await expectNoAccessibilityViolations(testInfo, results, { page });
+        await checkA11y({ include: '[role=dialog]' });
     });
 
-    test('Path Edge Filtering dialog with no search results', async ({ page, makeAxeBuilder }, testInfo) => {
+    test('Path edge filtering dialog with no search results', async ({ page, checkA11y }) => {
         const startResultName = 'START TEST RESULT';
         const destinationResultName = 'DESTINATION TEST RESULT';
         const searchTerm = 'no-match-test-value';
@@ -428,40 +353,21 @@ test.describe('WCAG A/AA Violations - Explore - Pathfinding Tab', () => {
             });
         });
 
-        const startNodeField = page.getByLabel('Start Node');
-        await startNodeField.fill(startResultName);
+        await installPathfindingStub(page);
 
-        const startResult = page.getByRole('option').filter({ hasText: startResultName });
-        await expect(startResult).toBeVisible();
-        await startResult.click();
+        await page.getByRole('textbox', { name: 'Start Node' }).fill(startResultName);
+        await page.getByRole('option').filter({ hasText: startResultName }).click();
+        await page.getByRole('textbox', { name: 'Destination Node' }).fill(destinationResultName);
 
-        const destinationNodeField = page.getByLabel('Destination Node');
-        await destinationNodeField.fill(destinationResultName);
+        await page.getByRole('option').filter({ hasText: destinationResultName }).click();
+        await page.getByRole('button', { name: 'Show pathfinding filter options' }).click();
 
-        const destinationResult = page.getByRole('option').filter({ hasText: destinationResultName });
-        await expect(destinationResult).toBeVisible();
-        await destinationResult.click();
+        const dialog = page.getByRole('dialog', { name: 'Path Edge Filtering' });
+        await dialog.waitFor();
 
-        const filterButton = page.getByRole('button', {
-            name: 'Show pathfinding filter options',
-        });
-        await expect(filterButton).toBeEnabled();
-        await filterButton.click();
-
-        const dialog = page.getByRole('dialog', {
-            name: 'Path Edge Filtering',
-        });
-        await expect(dialog).toBeVisible();
-
-        const searchTextbox = dialog.getByRole('textbox', { name: 'Search edges...' });
-        await searchTextbox.fill(searchTerm);
-        await expect(searchTextbox).toHaveValue(searchTerm);
-
-        await expect(dialog.getByRole('checkbox', { name: 'GenericWrite', exact: true })).toHaveCount(0);
-        await expect(dialog.getByRole('checkbox', { name: 'Active Directory', exact: true })).toHaveCount(0);
+        await dialog.getByRole('textbox', { name: 'Search edges...' }).fill(searchTerm);
         await expect(dialog.getByRole('checkbox')).toHaveCount(0);
 
-        const results = await makeAxeBuilder().include('[role=dialog]').analyze();
-        await expectNoAccessibilityViolations(testInfo, results, { page });
+        await checkA11y({ include: '[role=dialog]' });
     });
 });

--- a/cmd/ui/tests/a11y/Explore/pathfinding.a11y.spec.ts
+++ b/cmd/ui/tests/a11y/Explore/pathfinding.a11y.spec.ts
@@ -16,6 +16,9 @@
 import { Page } from '@playwright/test';
 import { expect, test } from 'bh-playwright-testing';
 
+const startResultName = 'START TEST RESULT';
+const destinationResultName = 'DESTINATION TEST RESULT';
+
 const installPathfindingStub = async (page: Page) => {
     await page.route('**/api/v2/graphs/shortest-path**', async (route) => {
         if (route.request().method() !== 'GET') {
@@ -31,14 +34,36 @@ const installPathfindingStub = async (page: Page) => {
             },
         });
     });
+
+    await page.route('**/api/v2/search**', async (route) => {
+        if (route.request().method() !== 'GET') {
+            return route.fallback();
+        }
+
+        await route.fulfill({
+            json: {
+                data: [
+                    {
+                        name: startResultName,
+                        objectid: 'playwright-pathfinding-start-result',
+                        type: 'User',
+                    },
+                    {
+                        name: destinationResultName,
+                        objectid: 'playwright-pathfinding-destination-result',
+                        type: 'Computer',
+                    },
+                ],
+            },
+        });
+    });
 };
 
 test.describe('WCAG A/AA Violations - Explore - Pathfinding Tab', () => {
     test.beforeEach(async ({ page, goAndWaitFor }) => {
-        await goAndWaitFor(
-            '/ui/explore?exploreSearchTab=pathfinding',
-            page.getByRole('textbox', { name: 'Start node' })
-        );
+        const startNode = page.getByRole('textbox', { name: 'Start Node' });
+        await goAndWaitFor('/ui/explore?exploreSearchTab=pathfinding', startNode);
+        await startNode.focus();
     });
 
     test('Pathfinding tab', async ({ page, checkA11y }) => {
@@ -94,90 +119,7 @@ test.describe('WCAG A/AA Violations - Explore - Pathfinding Tab', () => {
         await checkA11y();
     });
 
-    test('Destination node', async ({ page, checkA11y }) => {
-        // Pathfinding autofocus opens the Start node popup over the Destination Node field.
-        await page.getByRole('textbox', { name: 'Start Node' }).press('Escape');
-        await page.getByRole('textbox', { name: 'Destination Node' }).click();
-
-        await checkA11y();
-    });
-
-    test('Destination node with results', async ({ page, checkA11y }) => {
-        const searchTerm = 'test';
-        const searchResultName = 'DESTINATION TEST RESULT';
-
-        await page.route('**/api/v2/search**', async (route) => {
-            if (route.request().method() !== 'GET') {
-                return route.fallback();
-            }
-
-            await route.fulfill({
-                json: {
-                    data: [
-                        {
-                            name: searchResultName,
-                            objectid: 'playwright-pathfinding-destination-result',
-                            type: 'User',
-                        },
-                    ],
-                },
-            });
-        });
-
-        // Pathfinding autofocus opens the Start node popup over the Destination Node field.
-        await page.getByRole('textbox', { name: 'Start Node' }).press('Escape');
-        await page.getByRole('textbox', { name: 'Destination Node' }).fill(searchTerm);
-        await page.getByText('DESTINATION TEST RESULT').waitFor();
-
-        await checkA11y();
-    });
-
-    test('Destination node with no results', async ({ page, checkA11y }) => {
-        const searchTerm = 'zzzznonexistentdestination9999';
-
-        await page.route('**/api/v2/search**', async (route) => {
-            if (route.request().method() !== 'GET') {
-                return route.fallback();
-            }
-
-            await route.fulfill({ json: { data: [] } });
-        });
-
-        // Pathfinding autofocus opens the Start node popup over the Destination Node field.
-        await page.getByRole('textbox', { name: 'Start Node' }).press('Escape');
-        await page.getByRole('textbox', { name: 'Destination Node' }).fill(searchTerm);
-        await page.getByText('No results found for "').waitFor();
-
-        await checkA11y();
-    });
-
     test('Enabled pathfinding controls', async ({ page, checkA11y }) => {
-        const startResultName = 'START TEST RESULT';
-        const destinationResultName = 'DESTINATION TEST RESULT';
-
-        await page.route('**/api/v2/search**', async (route) => {
-            if (route.request().method() !== 'GET') {
-                return route.fallback();
-            }
-
-            await route.fulfill({
-                json: {
-                    data: [
-                        {
-                            name: startResultName,
-                            objectid: 'playwright-pathfinding-start-result',
-                            type: 'User',
-                        },
-                        {
-                            name: destinationResultName,
-                            objectid: 'playwright-pathfinding-destination-result',
-                            type: 'Computer',
-                        },
-                    ],
-                },
-            });
-        });
-
         await installPathfindingStub(page);
 
         await page.getByRole('textbox', { name: 'Start Node' }).fill(startResultName);
@@ -186,39 +128,27 @@ test.describe('WCAG A/AA Violations - Explore - Pathfinding Tab', () => {
         await page.getByRole('textbox', { name: 'Destination Node' }).fill(destinationResultName);
         await page.getByRole('option').filter({ hasText: destinationResultName }).click();
 
-        await page.getByRole('button', { name: 'Swap start and destination' }).waitFor();
-        await page.getByRole('button', { name: 'Show pathfinding filter options' }).waitFor();
+        // Assertions set to ensure enabled state before
+        await expect(page.getByRole('button', { name: 'Swap start and destination' })).toBeEnabled();
+        await expect(page.getByRole('button', { name: 'Show pathfinding filter options' })).toBeEnabled();
+
+        await checkA11y();
+    });
+
+    test('Disabled swap controls', async ({ page, checkA11y }) => {
+        await installPathfindingStub(page);
+
+        await page.getByRole('textbox', { name: 'Start Node' }).fill(startResultName);
+        await page.getByRole('option').filter({ hasText: startResultName }).click();
+
+        // Assertions set to ensure enabled state before
+        await expect(page.getByRole('button', { name: 'Swap start and destination' })).toBeDisabled();
+        await expect(page.getByRole('button', { name: 'Show pathfinding filter options' })).toBeEnabled();
 
         await checkA11y();
     });
 
     test('Path edge filtering dialog', async ({ page, checkA11y }) => {
-        const startResultName = 'START TEST RESULT';
-        const destinationResultName = 'DESTINATION TEST RESULT';
-
-        await page.route('**/api/v2/search**', async (route) => {
-            if (route.request().method() !== 'GET') {
-                return route.fallback();
-            }
-
-            await route.fulfill({
-                json: {
-                    data: [
-                        {
-                            name: startResultName,
-                            objectid: 'playwright-pathfinding-start-result',
-                            type: 'User',
-                        },
-                        {
-                            name: destinationResultName,
-                            objectid: 'playwright-pathfinding-destination-result',
-                            type: 'Computer',
-                        },
-                    ],
-                },
-            });
-        });
-
         await installPathfindingStub(page);
 
         await page.getByRole('textbox', { name: 'Start Node' }).fill(startResultName);
@@ -233,32 +163,6 @@ test.describe('WCAG A/AA Violations - Explore - Pathfinding Tab', () => {
     });
 
     test('Path edge filtering dialog with no selections', async ({ page, checkA11y }) => {
-        const startResultName = 'START TEST RESULT';
-        const destinationResultName = 'DESTINATION TEST RESULT';
-
-        await page.route('**/api/v2/search**', async (route) => {
-            if (route.request().method() !== 'GET') {
-                return route.fallback();
-            }
-
-            await route.fulfill({
-                json: {
-                    data: [
-                        {
-                            name: startResultName,
-                            objectid: 'playwright-pathfinding-start-result',
-                            type: 'User',
-                        },
-                        {
-                            name: destinationResultName,
-                            objectid: 'playwright-pathfinding-destination-result',
-                            type: 'Computer',
-                        },
-                    ],
-                },
-            });
-        });
-
         await installPathfindingStub(page);
 
         await page.getByRole('textbox', { name: 'Start Node' }).fill(startResultName);
@@ -280,32 +184,6 @@ test.describe('WCAG A/AA Violations - Explore - Pathfinding Tab', () => {
     });
 
     test('Path edge filtering dialog with search results', async ({ page, checkA11y }) => {
-        const startResultName = 'START TEST RESULT';
-        const destinationResultName = 'DESTINATION TEST RESULT';
-
-        await page.route('**/api/v2/search**', async (route) => {
-            if (route.request().method() !== 'GET') {
-                return route.fallback();
-            }
-
-            await route.fulfill({
-                json: {
-                    data: [
-                        {
-                            name: startResultName,
-                            objectid: 'playwright-pathfinding-start-result',
-                            type: 'User',
-                        },
-                        {
-                            name: destinationResultName,
-                            objectid: 'playwright-pathfinding-destination-result',
-                            type: 'Computer',
-                        },
-                    ],
-                },
-            });
-        });
-
         await installPathfindingStub(page);
 
         await page.getByRole('textbox', { name: 'Start Node' }).fill(startResultName);
@@ -326,32 +204,7 @@ test.describe('WCAG A/AA Violations - Explore - Pathfinding Tab', () => {
     });
 
     test('Path edge filtering dialog with no search results', async ({ page, checkA11y }) => {
-        const startResultName = 'START TEST RESULT';
-        const destinationResultName = 'DESTINATION TEST RESULT';
         const searchTerm = 'no-match-test-value';
-
-        await page.route('**/api/v2/search**', async (route) => {
-            if (route.request().method() !== 'GET') {
-                return route.fallback();
-            }
-
-            await route.fulfill({
-                json: {
-                    data: [
-                        {
-                            name: startResultName,
-                            objectid: 'playwright-pathfinding-start-result',
-                            type: 'User',
-                        },
-                        {
-                            name: destinationResultName,
-                            objectid: 'playwright-pathfinding-destination-result',
-                            type: 'Computer',
-                        },
-                    ],
-                },
-            });
-        });
 
         await installPathfindingStub(page);
 

--- a/cmd/ui/tests/a11y/Explore/search.a11y.spec.ts
+++ b/cmd/ui/tests/a11y/Explore/search.a11y.spec.ts
@@ -13,21 +13,20 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
-import { expect, expectNoAccessibilityViolations, test } from '../../fixtures';
+import { expect, test } from 'bh-playwright-testing';
 
 test.describe('WCAG A/AA Violations - Explore - Search Tab', () => {
     test.beforeEach(async ({ page }) => {
         await page.goto('/ui/explore');
     });
 
-    test('Search tab', async ({ page, makeAxeBuilder }, testInfo) => {
+    test('Search tab', async ({ page, checkA11y }) => {
         await page.getByText('Begin typing to search').waitFor({ state: 'visible' });
 
-        const results = await makeAxeBuilder().include('#content-wrapper').analyze();
-        await expectNoAccessibilityViolations(testInfo, results, { page });
+        await checkA11y();
     });
 
-    test('Search with results', async ({ page, makeAxeBuilder }, testInfo) => {
+    test('Search with results', async ({ page, checkA11y }) => {
         const searchTerm = 'test';
         const searchResultName = 'TEST RESULT';
 
@@ -49,11 +48,10 @@ test.describe('WCAG A/AA Violations - Explore - Search Tab', () => {
         const searchResult = page.getByRole('option').filter({ hasText: searchResultName });
         await expect(searchResult).toBeVisible();
 
-        const results = await makeAxeBuilder().include('#content-wrapper').analyze();
-        await expectNoAccessibilityViolations(testInfo, results, { page });
+        await checkA11y();
     });
 
-    test('Search with no results', async ({ page, makeAxeBuilder }, testInfo) => {
+    test('Search with no results', async ({ page, checkA11y }) => {
         const searchTerm = 'zzzznonexistentnode9999';
 
         await page.route('**/api/v2/search**', async (route) => {
@@ -71,7 +69,6 @@ test.describe('WCAG A/AA Violations - Explore - Search Tab', () => {
         const noResultsMessage = `No results found for "${searchTerm}"`;
         await expect(page.getByText(noResultsMessage)).toBeVisible();
 
-        const results = await makeAxeBuilder().include('#content-wrapper').analyze();
-        await expectNoAccessibilityViolations(testInfo, results, { page });
+        await checkA11y();
     });
 });

--- a/cmd/ui/tests/a11y/Shared/date-range.a11y.spec.ts
+++ b/cmd/ui/tests/a11y/Shared/date-range.a11y.spec.ts
@@ -14,11 +14,10 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { hideBySelector } from 'bh-playwright-testing/axe';
-import { expectNoAccessibilityViolations, test } from '../../fixtures';
+import { hideBySelector, test } from 'bh-playwright-testing';
 
 test.describe('Date Range', () => {
-    test.beforeEach(async ({ page }) => {
+    test.beforeEach(async ({ goAndWaitFor, page }) => {
         await page.route('**/api/v2/features', async (route) => {
             if (route.request().method() !== 'GET') {
                 return route.fallback();
@@ -61,38 +60,38 @@ test.describe('Date Range', () => {
             });
         });
 
-        await page.goto('/ui/administration/file-ingest');
-
-        await page
-            .getByRole('columnheader', {
+        await goAndWaitFor(
+            '/ui/administration/file-ingest',
+            page.getByRole('columnheader', {
                 name: 'ID / User / Status',
                 exact: true,
             })
-            .waitFor({ state: 'visible' });
-        await page.getByText('0\u20130 of 0', { exact: true }).waitFor({ state: 'visible' });
+        );
+
+        await page.getByText('0\u20130 of 0', { exact: true }).waitFor();
 
         const filterButton = page.getByRole('button', {
             name: 'Open file ingest filters',
             exact: true,
         });
 
-        await filterButton.waitFor({ state: 'visible' });
+        await filterButton.waitFor();
         await filterButton.click();
 
         await hideBySelector(page, '#content-wrapper');
 
         const filterDialog = page.getByRole('dialog');
 
-        await filterDialog.waitFor({ state: 'visible' });
+        await filterDialog.waitFor();
         await filterDialog
             .getByRole('heading', {
                 name: 'Filter Clear All',
                 exact: true,
             })
-            .waitFor({ state: 'visible' });
+            .waitFor();
     });
 
-    test('default state', async ({ page, makeAxeBuilder }, testInfo) => {
+    test('default state', async ({ page, checkA11y }) => {
         const filterDialog = page.getByRole('dialog');
         const startDate = filterDialog.getByRole('textbox', {
             name: 'Start Date',
@@ -103,16 +102,14 @@ test.describe('Date Range', () => {
             exact: true,
         });
 
-        await filterDialog.getByText('Date Range', { exact: true }).waitFor({ state: 'visible' });
-        await startDate.waitFor({ state: 'visible' });
-        await endDate.waitFor({ state: 'visible' });
+        await filterDialog.getByText('Date Range', { exact: true }).waitFor();
+        await startDate.waitFor();
+        await endDate.waitFor();
 
-        const results = await makeAxeBuilder().include('[role="dialog"]').analyze();
-
-        await expectNoAccessibilityViolations(testInfo, results, { page });
+        await checkA11y({ include: '[role="dialog"]' });
     });
 
-    test('with focus', async ({ page, makeAxeBuilder }, testInfo) => {
+    test('with focus', async ({ page, checkA11y }) => {
         const filterDialog = page.getByRole('dialog');
         const statusSelect = filterDialog.getByRole('combobox', {
             name: 'Status Select',
@@ -126,15 +123,13 @@ test.describe('Date Range', () => {
         await statusSelect.focus();
         await page.keyboard.press('Tab');
 
-        await startDate.and(page.locator(':focus')).waitFor({ state: 'visible' });
-        await filterDialog.getByPlaceholder('yyyy-mm-dd', { exact: true }).waitFor({ state: 'visible' });
+        await startDate.and(page.locator(':focus')).waitFor();
+        await filterDialog.getByPlaceholder('yyyy-mm-dd', { exact: true }).waitFor();
 
-        const results = await makeAxeBuilder().include('[role="dialog"]').analyze();
-
-        await expectNoAccessibilityViolations(testInfo, results, { page });
+        await checkA11y({ include: '[role="dialog"]' });
     });
 
-    test('calendar visible', async ({ page, makeAxeBuilder }, testInfo) => {
+    test('calendar visible', async ({ page, checkA11y }) => {
         const filterDialog = page.getByRole('dialog');
         const startDateCalendarButton = filterDialog
             .getByRole('button', {
@@ -154,13 +149,11 @@ test.describe('Date Range', () => {
             year: 'numeric',
         }).format(new Date());
 
-        await calendarDialog.waitFor({ state: 'visible' });
-        await calendarGrid.waitFor({ state: 'visible' });
-        await calendarGrid.getByRole('gridcell').first().waitFor({ state: 'visible' });
-        await calendarDialog.getByText(visibleMonth, { exact: true }).waitFor({ state: 'visible' });
+        await calendarDialog.waitFor();
+        await calendarGrid.waitFor();
+        await calendarGrid.getByRole('gridcell').first().waitFor();
+        await calendarDialog.getByText(visibleMonth, { exact: true }).waitFor();
 
-        const results = await makeAxeBuilder().include('[role="dialog"]').analyze();
-
-        await expectNoAccessibilityViolations(testInfo, results, { page });
+        await checkA11y({ include: '[role="dialog"]' });
     });
 });

--- a/cmd/ui/tests/a11y/Shared/nav.a11y.spec.ts
+++ b/cmd/ui/tests/a11y/Shared/nav.a11y.spec.ts
@@ -14,8 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { hideBySelector } from 'bh-playwright-testing/axe';
-import { expectNoAccessibilityViolations, test } from '../../fixtures';
+import { hideBySelector, test } from 'bh-playwright-testing';
 
 const MAIN_NAV_SCOPE = '#app-root > nav';
 
@@ -28,28 +27,25 @@ test.describe('Shared navigation - has no detectable WCAG A/AA violations', () =
         await hideBySelector(page, '#content-wrapper');
     });
 
-    test('nav menu', async ({ page, makeAxeBuilder }, testInfo) => {
+    test('nav menu', async ({ page, checkA11y }) => {
         await page.getByRole('button', { name: 'Toggle Navigation', expanded: true }).waitFor({ state: 'visible' });
 
-        const results = await makeAxeBuilder().include(MAIN_NAV_SCOPE).analyze();
-        await expectNoAccessibilityViolations(testInfo, results, { page });
+        await checkA11y({ include: MAIN_NAV_SCOPE });
     });
 
-    test('collapsed nav menu', async ({ page, makeAxeBuilder }, testInfo) => {
+    test('collapsed nav menu', async ({ page, checkA11y }) => {
         await page.getByRole('button', { name: 'Toggle Navigation', expanded: true }).click();
         await page.getByRole('button', { name: 'Toggle Navigation', expanded: false }).waitFor({ state: 'visible' });
 
-        const results = await makeAxeBuilder().include(MAIN_NAV_SCOPE).analyze();
-        await expectNoAccessibilityViolations(testInfo, results, { page });
+        await checkA11y({ include: MAIN_NAV_SCOPE });
     });
 
-    test('administration subnav menu visible', async ({ page, makeAxeBuilder }, testInfo) => {
+    test('administration subnav menu visible', async ({ page, checkA11y }) => {
         await page.getByRole('button', { name: 'Administration', exact: true }).click();
         const subNav = page.getByTestId('sub-nav');
         await subNav.waitFor({ state: 'visible' });
         await subNav.getByText('File Ingest', { exact: true }).waitFor({ state: 'visible' });
 
-        const results = await makeAxeBuilder().include(MAIN_NAV_SCOPE).analyze();
-        await expectNoAccessibilityViolations(testInfo, results, { page });
+        await checkA11y({ include: MAIN_NAV_SCOPE });
     });
 });

--- a/cmd/ui/tests/a11y/Shared/no-data-dialog.a11y.spec.ts
+++ b/cmd/ui/tests/a11y/Shared/no-data-dialog.a11y.spec.ts
@@ -1,0 +1,36 @@
+// Copyright 2026 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { hideBySelector, test } from 'bh-playwright-testing';
+import { installGraphHasNoDataStub } from 'bh-playwright-testing/stubs';
+
+test.describe('No Data Available dialog accessibility', () => {
+    test('upload dialog has no detectable WCAG A/AA violations', async ({ page, goAndWaitFor, checkA11y }) => {
+        await installGraphHasNoDataStub(page);
+
+        // Wait for the dialog to render before proceeding.
+        await goAndWaitFor(
+            '/ui/explore',
+            page.getByRole('heading', { name: 'Upload Data to Start Mapping Your Environment' })
+        );
+
+        await hideBySelector(page, '#content-wrapper');
+
+        // Scope the scan to the dialog (rendered as `role="dialog"` by MUI) so violations from
+        // the rest of the Explore page don't bleed into this test's signal.
+        await checkA11y({ include: '[role="dialog"]' });
+    });
+});

--- a/cmd/ui/tests/a11y/Shared/quick-upload.a11y.spec.ts
+++ b/cmd/ui/tests/a11y/Shared/quick-upload.a11y.spec.ts
@@ -14,8 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { hideBySelector } from 'bh-playwright-testing/axe';
-import { expectNoAccessibilityViolations, test } from '../../fixtures';
+import { hideBySelector, test } from 'bh-playwright-testing';
 
 test.describe('Quick Upload dialog', () => {
     const UPLOAD_FILE = 'tests/a11y/Shared/fixtures/playwright-upload.json';
@@ -49,7 +48,7 @@ test.describe('Quick Upload dialog', () => {
         await hideBySelector(page, '#content-wrapper');
     });
 
-    test('default state', async ({ page, makeAxeBuilder }, testInfo) => {
+    test('default state', async ({ page, checkA11y }) => {
         const dialog = page.getByRole('dialog');
 
         await dialog
@@ -59,12 +58,10 @@ test.describe('Quick Upload dialog', () => {
             .waitFor({ state: 'visible' });
         await dialog.getByText('View File Ingest History', { exact: true }).waitFor({ state: 'visible' });
 
-        const results = await makeAxeBuilder().include('[role="dialog"]').analyze();
-
-        await expectNoAccessibilityViolations(testInfo, results, { page });
+        await checkA11y({ include: '[role="dialog"]' });
     });
 
-    test('with files added', async ({ page, makeAxeBuilder }, testInfo) => {
+    test('with files added', async ({ page, checkA11y }) => {
         const dialog = page.getByRole('dialog');
 
         const fileChooserPromise = page.waitForEvent('filechooser');
@@ -78,12 +75,10 @@ test.describe('Quick Upload dialog', () => {
         await dialog.getByText('playwright-upload.json', { exact: true }).waitFor({ state: 'visible' });
         await dialog.getByRole('button', { name: 'Remove item', exact: true }).waitFor({ state: 'visible' });
 
-        const results = await makeAxeBuilder().include('[role="dialog"]').analyze();
-
-        await expectNoAccessibilityViolations(testInfo, results, { page });
+        await checkA11y({ include: '[role="dialog"]' });
     });
 
-    test('with completed uploads', async ({ page, makeAxeBuilder }, testInfo) => {
+    test('with completed uploads', async ({ page, checkA11y }) => {
         await page.route('**/api/v2/file-upload/start', async (route) => {
             if (route.request().method() !== 'POST') {
                 return route.fallback();
@@ -142,12 +137,10 @@ test.describe('Quick Upload dialog', () => {
         await dialog.getByText('100%', { exact: true }).waitFor({ state: 'visible' });
         await dialog.getByText('Upload in progress.', { exact: true }).waitFor({ state: 'hidden' });
 
-        const results = await makeAxeBuilder().include('[role="dialog"]').analyze();
-
-        await expectNoAccessibilityViolations(testInfo, results, { page });
+        await checkA11y({ include: '[role="dialog"]' });
     });
 
-    test('with failed uploads', async ({ page, makeAxeBuilder }, testInfo) => {
+    test('with failed uploads', async ({ page, checkA11y }) => {
         await page.route('**/api/v2/file-upload/start', async (route) => {
             if (route.request().method() !== 'POST') {
                 return route.fallback();
@@ -213,8 +206,6 @@ test.describe('Quick Upload dialog', () => {
         await dialog.getByRole('button', { name: 'Retry upload', exact: true }).waitFor({ state: 'visible' });
         await dialog.getByText('Upload in progress.', { exact: true }).waitFor({ state: 'hidden' });
 
-        const results = await makeAxeBuilder().include('[role="dialog"]').analyze();
-
-        await expectNoAccessibilityViolations(testInfo, results, { page });
+        await checkA11y({ include: '[role="dialog"]' });
     });
 });

--- a/cmd/ui/tests/a11y/Shared/simple-environment-selector.a11y.spec.ts
+++ b/cmd/ui/tests/a11y/Shared/simple-environment-selector.a11y.spec.ts
@@ -14,7 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { expectNoAccessibilityViolations, test } from '../../fixtures';
+import { test } from 'bh-playwright-testing';
 
 test.describe('Simple Environment Selector - has no detectable WCAG A/AA violations', () => {
     test.beforeEach(async ({ page }) => {
@@ -45,7 +45,7 @@ test.describe('Simple Environment Selector - has no detectable WCAG A/AA violati
         await page.getByRole('button', { name: 'EXAMPLE.COM', exact: true }).waitFor({ state: 'visible' });
     });
 
-    test('no query', async ({ page, makeAxeBuilder }, testInfo) => {
+    test('no query', async ({ page, checkA11y }) => {
         await page.getByRole('button', { name: 'EXAMPLE.COM', exact: true }).click();
 
         const popover = page.getByTestId('data-quality_context-selector-popover');
@@ -53,14 +53,10 @@ test.describe('Simple Environment Selector - has no detectable WCAG A/AA violati
         await popover.getByRole('textbox', { name: 'Search' }).waitFor({ state: 'visible' });
         await popover.getByRole('button', { name: 'EXAMPLE.COM', exact: true }).waitFor({ state: 'visible' });
 
-        const results = await makeAxeBuilder()
-            .include('[data-testid="data-quality_context-selector-popover"]')
-            .analyze();
-
-        await expectNoAccessibilityViolations(testInfo, results, { page });
+        await checkA11y({ include: '[data-testid="data-quality_context-selector-popover"]' });
     });
 
-    test('with query', async ({ page, makeAxeBuilder }, testInfo) => {
+    test('with query', async ({ page, checkA11y }) => {
         await page.getByRole('button', { name: 'EXAMPLE.COM', exact: true }).click();
 
         const popover = page.getByTestId('data-quality_context-selector-popover');
@@ -73,14 +69,10 @@ test.describe('Simple Environment Selector - has no detectable WCAG A/AA violati
         await searchInput.and(page.locator('[value="EXAMPLE"]')).waitFor({ state: 'visible' });
         await popover.getByRole('button', { name: 'EXAMPLE.COM', exact: true }).waitFor({ state: 'visible' });
 
-        const results = await makeAxeBuilder()
-            .include('[data-testid="data-quality_context-selector-popover"]')
-            .analyze();
-
-        await expectNoAccessibilityViolations(testInfo, results, { page });
+        await checkA11y({ include: '[data-testid="data-quality_context-selector-popover"]' });
     });
 
-    test('no results query', async ({ page, makeAxeBuilder }, testInfo) => {
+    test('no results query', async ({ page, checkA11y }) => {
         const query = 'zzzznonexistentenvironment9999';
 
         await page.getByRole('button', { name: 'EXAMPLE.COM', exact: true }).click();
@@ -95,10 +87,6 @@ test.describe('Simple Environment Selector - has no detectable WCAG A/AA violati
         await searchInput.and(page.locator(`[value="${query}"]`)).waitFor({ state: 'visible' });
         await popover.getByRole('button', { name: 'EXAMPLE.COM', exact: true }).waitFor({ state: 'hidden' });
 
-        const results = await makeAxeBuilder()
-            .include('[data-testid="data-quality_context-selector-popover"]')
-            .analyze();
-
-        await expectNoAccessibilityViolations(testInfo, results, { page });
+        await checkA11y({ include: '[data-testid="data-quality_context-selector-popover"]' });
     });
 });


### PR DESCRIPTION
## Description

* **Tests**
  * Expanded accessibility coverage across Explore navigation, search, graph controls, pathfinding, saved queries, uploads, date ranges, selectors, and entity panels.
  * Added accessibility validation for no-data upload dialogs and saved-query actions, including edit, sharing, and deletion dialogs.
  * Improved test reliability with consistent waits, targeted checks for dialogs and menus, and deterministic test scenarios.
  * Added coverage for empty states, filtering, search results, calendar interactions, and pathfinding workflows.

## Motivation and Context

Resolves BED-9440

## How Has This Been Tested?

Manually tested running Playwright locally

## Types of changes

- Chore (a change that does not modify the application functionality)

## Checklist:

- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Tests

* Standardized accessibility testing across Explore and shared UI workflows.
* Improved test reliability with consistent navigation waits, deterministic test data, and focused checks for dialogs, menus, controls, and popovers.
* Added coverage for the no-data upload dialog and saved-query actions, including editing, sharing, and deletion.
* Updated accessibility coverage for search, pathfinding, graph controls, uploads, date ranges, selectors, navigation, and entity panels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->