### PR TITLE
fix(azure): AZAddSecret must not target managed identities (#943)

### DIFF
--- a/cmd/api/src/test/integration/harnesses.go
+++ b/cmd/api/src/test/integration/harnesses.go
@@ -6996,11 +6996,13 @@ func (s *ESC13HarnessECA) Setup(graphTestContext *GraphTestContext) {
 }
 
 type AZAddSecretHarness struct {
-	AZApp              *graph.Node
-	AZServicePrincipal *graph.Node
-	AZTenant           *graph.Node
-	AppAdminRole       *graph.Node
-	CloudAppAdminRole  *graph.Node
+	AZApp                   *graph.Node
+	AZServicePrincipal      *graph.Node
+	AZManagedIdentitySP     *graph.Node
+	AZVMWithManagedIdentity *graph.Node
+	AZTenant                *graph.Node
+	AppAdminRole            *graph.Node
+	CloudAppAdminRole       *graph.Node
 }
 
 func (s *AZAddSecretHarness) Setup(graphTestContext *GraphTestContext) {
@@ -7013,8 +7015,19 @@ func (s *AZAddSecretHarness) Setup(graphTestContext *GraphTestContext) {
 	s.AppAdminRole = graphTestContext.NewAzureRole("AppAdminRole", RandomObjectID(graphTestContext.testCtx), azure.ApplicationAdministratorRole, tenantID)
 	s.CloudAppAdminRole = graphTestContext.NewAzureRole("CloudAppAdminRole", RandomObjectID(graphTestContext.testCtx), azure.CloudApplicationAdministratorRole, tenantID)
 
+	// A managed identity is ingested as a plain service principal, distinguished only by an
+	// inbound AZManagedIdentity edge from the resource that owns it. Its credentials are
+	// Azure-managed, so an AddSecret-capable role must NOT receive an AZAddSecret edge to it
+	// (regression guard for #943). Without the fix this SP is treated like any other and the
+	// AddSecret count rises from 4 to 6.
+	s.AZVMWithManagedIdentity = graphTestContext.NewAzureVM("AZVMWithManagedIdentity", RandomObjectID(graphTestContext.testCtx), tenantID)
+	s.AZManagedIdentitySP = graphTestContext.NewAzureServicePrincipal("AZManagedIdentitySP", RandomObjectID(graphTestContext.testCtx), tenantID)
+
 	graphTestContext.NewRelationship(s.AZTenant, s.AZApp, azure.Contains)
 	graphTestContext.NewRelationship(s.AZTenant, s.AZServicePrincipal, azure.Contains)
+	graphTestContext.NewRelationship(s.AZTenant, s.AZManagedIdentitySP, azure.Contains)
+	graphTestContext.NewRelationship(s.AZTenant, s.AZVMWithManagedIdentity, azure.Contains)
+	graphTestContext.NewRelationship(s.AZVMWithManagedIdentity, s.AZManagedIdentitySP, azure.ManagedIdentity)
 	graphTestContext.NewRelationship(s.AZTenant, s.AppAdminRole, azure.Contains)
 	graphTestContext.NewRelationship(s.AZTenant, s.CloudAppAdminRole, azure.Contains)
 }

--- a/packages/go/analysis/azure/azure_integration_test.go
+++ b/packages/go/analysis/azure/azure_integration_test.go
@@ -791,6 +791,9 @@ func TestEntityDetails(t *testing.T) {
 				assert.Equal(t, graphAzure.AddSecret, edge.Kind)
 				assert.True(t, slices.Contains([]graph.ID{harness.AZAddSecretHarness.AppAdminRole.ID, harness.AZAddSecretHarness.CloudAppAdminRole.ID}, edge.StartID))
 				assert.True(t, slices.Contains([]graph.ID{harness.AZAddSecretHarness.AZApp.ID, harness.AZAddSecretHarness.AZServicePrincipal.ID}, edge.EndID))
+				// Regression for #943: the managed-identity service principal, whose credentials
+				// are Azure-managed, must never be the target of an AZAddSecret edge.
+				assert.NotEqual(t, harness.AZAddSecretHarness.AZManagedIdentitySP.ID, edge.EndID)
 			}
 		})
 	})

--- a/packages/go/analysis/azure/post.go
+++ b/packages/go/analysis/azure/post.go
@@ -229,8 +229,24 @@ func AppRoleAssignments(ctx context.Context, db graph.Database) (*post.AtomicPos
 		sink := post.NewFilteredRelationshipSink(ctx, "Azure App Role Assignments Post Processing", db, appRoleAssignmentTracker)
 		defer sink.Done()
 
+		// A managed identity's service principal is recognised by inbound
+		// AZManagedIdentity edges across the whole graph, independent of tenant, so
+		// resolve the set once here instead of re-running the same lookup for every
+		// tenant inside postAddSecret.
+		managedIdentityIDs := make(map[graph.ID]struct{})
+		if err := db.ReadTransaction(ctx, func(tx graph.Transaction) error {
+			ids, err := managedIdentityServicePrincipalIDs(tx)
+			if err != nil {
+				return err
+			}
+			managedIdentityIDs = ids
+			return nil
+		}); err != nil {
+			return &post.AtomicPostProcessingStats{}, err
+		}
+
 		for _, tenant := range tenants {
-			if err := postAppRoleAssignmentsForTenant(ctx, db, sink, tenant); err != nil {
+			if err := postAppRoleAssignmentsForTenant(ctx, db, sink, tenant, managedIdentityIDs); err != nil {
 				return &post.AtomicPostProcessingStats{}, err
 			}
 		}
@@ -239,7 +255,7 @@ func AppRoleAssignments(ctx context.Context, db graph.Database) (*post.AtomicPos
 	}
 }
 
-func postAppRoleAssignmentsForTenant(ctx context.Context, db graph.Database, sink *post.FilteredRelationshipSink, tenant *graph.Node) error {
+func postAppRoleAssignmentsForTenant(ctx context.Context, db graph.Database, sink *post.FilteredRelationshipSink, tenant *graph.Node, managedIdentityIDs map[graph.ID]struct{}) error {
 	return db.ReadTransaction(ctx, func(tx graph.Transaction) error {
 		if tenantContainsServicePrincipalRelationships, err := fetchTenantContainsRelationships(tx, tenant, azure.ServicePrincipal); err != nil {
 			return err
@@ -265,7 +281,7 @@ func postAppRoleAssignmentsForTenant(ctx context.Context, db graph.Database, sin
 			return err
 		} else if err := postAZMGServicePrincipalEndpointReadWriteAllEdges(ctx, db, sink, tenantContainsServicePrincipalRelationships); err != nil {
 			return err
-		} else if err := postAddSecret(ctx, db, sink, tenant); err != nil {
+		} else if err := postAddSecret(ctx, db, sink, tenant, managedIdentityIDs); err != nil {
 			return err
 		}
 
@@ -545,7 +561,7 @@ func postAZMGServicePrincipalEndpointReadWriteAllEdges(ctx context.Context, db g
 	})
 }
 
-func postAddSecret(ctx context.Context, db graph.Database, sink *post.FilteredRelationshipSink, tenant *graph.Node) error {
+func postAddSecret(ctx context.Context, db graph.Database, sink *post.FilteredRelationshipSink, tenant *graph.Node, managedIdentityIDs map[graph.ID]struct{}) error {
 	return db.ReadTransaction(ctx, func(tx graph.Transaction) error {
 		if addSecretRoles, err := TenantRoles(tx, tenant, AddSecretRoleIDs()...); err != nil {
 			return err
@@ -554,6 +570,14 @@ func postAddSecret(ctx context.Context, db graph.Database, sink *post.FilteredRe
 		} else {
 			for _, role := range addSecretRoles {
 				for _, target := range tenantAppsAndSPs {
+					// A managed identity's service principal has its credentials issued and
+					// rotated by Azure; there is no addPassword/addKey path on it, so an
+					// AddSecret-capable role cannot mint one. Emitting AZAddSecret to it draws
+					// a privilege-escalation edge that cannot be walked, so skip it.
+					if _, isManagedIdentity := managedIdentityIDs[target.ID]; isManagedIdentity {
+						continue
+					}
+
 					slog.DebugContext(
 						ctx,
 						"Adding AZAddSecret edge from role to target",
@@ -573,6 +597,25 @@ func postAddSecret(ctx context.Context, db graph.Database, sink *post.FilteredRe
 
 		return nil
 	})
+}
+
+// managedIdentityServicePrincipalIDs returns the set of service principal node IDs that back
+// a managed identity — the end nodes of AZManagedIdentity edges. A managed identity is
+// ingested as a plain ServicePrincipal distinguished only by that inbound edge, so this is
+// the only way to recognise one. Its credentials are Azure-managed and cannot be added to,
+// which is why AZAddSecret must not target it.
+func managedIdentityServicePrincipalIDs(tx graph.Transaction) (map[graph.ID]struct{}, error) {
+	if managedIdentitySPs, err := ops.FetchEndNodes(tx.Relationships().Filterf(func() graph.Criteria {
+		return query.Kind(query.Relationship(), azure.ManagedIdentity)
+	})); err != nil {
+		return nil, err
+	} else {
+		ids := make(map[graph.ID]struct{}, len(managedIdentitySPs))
+		for _, id := range managedIdentitySPs.IDs() {
+			ids[id] = struct{}{}
+		}
+		return ids, nil
+	}
 }
 
 var addOwnerPostProcessedEdges = graph.Kinds{


### PR DESCRIPTION
Fixes #943.

### The problem
`postAddSecret` (`packages/go/analysis/azure/post.go`) paired every AddSecret-capable role with every application and service principal in the tenant, with no discrimination. A managed identity is ingested as a plain `AZServicePrincipal`, so it was swept in and given an inbound `AZAddSecret` edge. That edge is bogus: a managed identity's credentials are issued and rotated by Azure — there is no `addPassword`/`addKey` on it — so an Application Administrator cannot mint one. The path renders as a privilege-escalation route that cannot be walked.

### The fix
There is no managed-identity node kind. `AZManagedIdentity` is a relationship (`resource --AZManagedIdentity--> ServicePrincipal`), so the only way to recognise a managed identity is an inbound `AZManagedIdentity` edge — a fix written as a node-kind or property check silently matches nothing. `managedIdentityServicePrincipalIDs` collects the end nodes of `AZManagedIdentity` edges, and `postAddSecret` skips those targets. The exclusion is applied in `postAddSecret`, not in the shared `TenantApplicationsAndServicePrincipals` query; `AddOwner` is left untouched (a separate question).

The managed-identity set is resolved once in `AppRoleAssignments` and threaded through, rather than re-queried per tenant inside `postAddSecret` (addresses the reviewer's earlier performance note).

### Test
`AZAddSecretHarness` gains a VM-backed managed identity (a VM, a managed-identity SP, and the `AZManagedIdentity` edge). `RoleAddSecret` asserts exactly 4 edges and additionally that no `AZAddSecret` edge targets the managed-identity SP. `go build` and `go vet` pass; the integration test binary compiles with the harness changes.

3 files, +68/-9.

---
*Note: this supersedes #3240, which GitHub auto-locked after a bad force-push corrupted its diff view. This branch is now clean.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented incorrect `AZAddSecret` relationships from being assigned to service principals backed by Azure-managed identities.
  * Ensured Azure-managed credentials are not treated as user-mintable secrets.
* **Tests**
  * Added regression coverage verifying managed-identity service principals are excluded from `AZAddSecret` relationships.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->