### PR TITLE
chore: Test Fix for ADCS - BED-9336

### DIFF
--- a/packages/go/lab/generic/graph.go
+++ b/packages/go/lab/generic/graph.go
@@ -29,6 +29,7 @@ import (
 )
 
 var excludedProperties = map[string]struct{}{
+	"firstseen":     {},
 	"lastseen":      {},
 	"lastcollected": {},
 }


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Post-Processing changed, therefore the fixtures files for ADCS needed to be re-generated.

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves [BED-8336](https://specterops.atlassian.net/browse/BED-8336)

Pipeline is failing due to ADCS post-processing changes.

This fix regenerates the Version6 ADCS ingest and analysis fixtures to reflect the new post-processing behavior.

## How Has This Been Tested?

Integration Tests passing

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [ ] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [ ] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [ ] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated database graph assertions to ignore the `firstseen` property when comparing expected nodes and edges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[BED-8336]: https://specterops.atlassian.net/browse/BED-8336?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ