### PR TITLE
fix(auth): remove unsafe SAMLResponse WARN logging - BED-9639

### DIFF
--- a/cmd/api/src/api/v2/auth/saml.go
+++ b/cmd/api/src/api/v2/auth/saml.go
@@ -498,7 +498,6 @@ func (s ManagementResource) SAMLCallbackHandler(response http.ResponseWriter, re
 				"[SAML] Failed to parse ACS response for provider",
 				slog.String("issuer_uri", ssoProvider.SAMLProvider.IssuerURI),
 				attr.Error(typedErr.PrivateErr),
-				slog.String("response", typedErr.Response),
 			)
 		default:
 			slog.WarnContext(


### PR DESCRIPTION
fixes: BED-9639

<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Remove sensitive logging. For more info, see https://specterops.atlassian.net/browse/BED-9639

## Motivation and Context

Fixes: 
https://specterops.atlassian.net/browse/BED-9639

*Why is this change required? What problem does it solve?*

## How Has This Been Tested?

- all tests pass 
## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Improved authentication privacy by no longer logging raw SAML responses when parsing fails.
  * Issuer information and private error details continue to be logged for troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->