### PR TITLE
feat: Gate managed OpenHound collection BED-9450

### DIFF
--- a/cmd/api/src/database/migration/migrations/20260903171935_v9_add_managed_openhound_collection_feature_flag.sql
+++ b/cmd/api/src/database/migration/migrations/20260903171935_v9_add_managed_openhound_collection_feature_flag.sql
@@ -1,0 +1,29 @@
+-- Copyright 2026 Specter Ops, Inc.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- SPDX-License-Identifier: Apache-2.0
+
+-- +goose Up
+INSERT INTO feature_flags (created_at, updated_at, key, name, description, enabled, user_updatable)
+VALUES (current_timestamp,
+        current_timestamp,
+        'managed_openhound_collection',
+        'Managed OpenHound Collection',
+        'Enables managed OpenHound collection provided by BloodHound Enterprise.',
+        false,
+        false)
+ON CONFLICT DO NOTHING;
+
+-- +goose Down
+DELETE FROM feature_flags WHERE key = 'managed_openhound_collection';

--- a/cmd/api/src/model/appcfg/flag.go
+++ b/cmd/api/src/model/appcfg/flag.go
@@ -46,6 +46,7 @@ const (
 	FeatureClientBearerAuth             = "client_bearer_auth"
 	FeatureOpenGraphExtensionManagement = "opengraph_extension_management"
 	FeatureOpenHoundSupport             = "openhound_support"
+	FeatureManagedOpenHoundCollection   = "managed_openhound_collection"
 	FeatureAPIKeyExpirationSupport      = "api_key_expiration_support"
 	FeatureCollectorSupportBundle       = "collector_support_bundle"
 	FeatureArtifactExpirationCleanup    = "artifact_expiration_cleanup"
@@ -130,6 +131,11 @@ func GetTieringEnabled(ctx context.Context, service GetFlagByKeyer) bool {
 // GetOpenHoundEnabled returns true if the OpenHound Support feature flag is enabled.
 func GetOpenHoundEnabled(ctx context.Context, service GetFlagByKeyer) bool {
 	return GetFlagEnabled(ctx, service, FeatureOpenHoundSupport)
+}
+
+// GetManagedOpenHoundCollectionEnabled returns true if managed OpenHound collection is enabled.
+func GetManagedOpenHoundCollectionEnabled(ctx context.Context, service GetFlagByKeyer) bool {
+	return GetFlagEnabled(ctx, service, FeatureManagedOpenHoundCollection)
 }
 
 // GetUseRawObjectIDsEnabled returns true if the use raw object id feature flag is enabled.

--- a/cmd/api/src/model/appcfg/flag.go
+++ b/cmd/api/src/model/appcfg/flag.go
@@ -133,11 +133,6 @@ func GetOpenHoundEnabled(ctx context.Context, service GetFlagByKeyer) bool {
 	return GetFlagEnabled(ctx, service, FeatureOpenHoundSupport)
 }
 
-// GetManagedOpenHoundCollectionEnabled returns true if managed OpenHound collection is enabled.
-func GetManagedOpenHoundCollectionEnabled(ctx context.Context, service GetFlagByKeyer) bool {
-	return GetFlagEnabled(ctx, service, FeatureManagedOpenHoundCollection)
-}
-
 // GetUseRawObjectIDsEnabled returns true if the use raw object id feature flag is enabled.
 func GetUseRawObjectIDsEnabled(ctx context.Context, service GetFlagByKeyer) bool {
 	return GetFlagEnabled(ctx, service, FeatureUseRawObjectID)

--- a/server/featureflags/featureflags.go
+++ b/server/featureflags/featureflags.go
@@ -33,9 +33,10 @@ import (
 )
 
 const (
-	FeatureOpenHoundSupport          = services.FeatureOpenHoundSupport
-	FeatureAlerts                    = services.FeatureAlerts
-	FeatureArtifactExpirationCleanup = services.FeatureArtifactExpirationCleanup
+	FeatureOpenHoundSupport           = services.FeatureOpenHoundSupport
+	FeatureManagedOpenHoundCollection = services.FeatureManagedOpenHoundCollection
+	FeatureAlerts                     = services.FeatureAlerts
+	FeatureArtifactExpirationCleanup  = services.FeatureArtifactExpirationCleanup
 )
 
 type FeatureFlagRequestAdapter interface {

--- a/server/featureflags/internal/services/services.go
+++ b/server/featureflags/internal/services/services.go
@@ -31,10 +31,11 @@ import (
 // defined in cmd/api/src/model/appcfg but are redeclared here so consumers do
 // not need to import the appcfg package.
 const (
-	FeatureOpenHoundSupport          = "openhound_support"
-	FeatureAlerts                    = "alerts"
-	FeatureFindingsPrioritizationV0  = appcfg.FeatureFindingsPrioritizationV0
-	FeatureArtifactExpirationCleanup = "artifact_expiration_cleanup"
+	FeatureOpenHoundSupport           = "openhound_support"
+	FeatureManagedOpenHoundCollection = "managed_openhound_collection"
+	FeatureAlerts                     = "alerts"
+	FeatureFindingsPrioritizationV0   = appcfg.FeatureFindingsPrioritizationV0
+	FeatureArtifactExpirationCleanup  = "artifact_expiration_cleanup"
 )
 
 // Request source values used by the feature flags slice.


### PR DESCRIPTION
## Description

Adds the independent `managed_openhound_collection` feature flag for the managed OpenHound collection project. The flag is disabled by default, cannot be changed by users, and is exposed through the shared feature-flag APIs for future managed collection UI and routes.

## Motivation and Context

Resolves BED-9450

The existing `openhound_support` flag governs customer-deployed OpenHound. Managed OpenHound collection needs its own independent rollout control.

## How Has This Been Tested?

- `just prepare-for-codereview`
- `go test ./cmd/api/src/model/appcfg ./server/featureflags/...`
  - The appcfg package and feature-flag service tests passed.

## Screenshots (optional):

Not applicable.

## Types of changes

- New feature (non-breaking change which adds functionality)
- Database Migrations

## Checklist:

- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [ ] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Existing relevant tests passed
  - `just prepare-for-codereview` completed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a centrally managed feature flag for managed OpenHound collections.
  - The capability is currently disabled and cannot be changed by users.
  - The flag is now consistently recognized across the application’s feature-flag systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->