### PR TITLE
chore(types): Add route matcher to subnav items BED-9662

### DIFF
--- a/packages/javascript/bh-shared-ui/src/types.ts
+++ b/packages/javascript/bh-shared-ui/src/types.ts
@@ -38,6 +38,8 @@ export type MappedStringLiteral<T extends string | number, V = ''> = {
 export type SubNavItem = {
     label: string;
     path: string;
+    /** Optional route matcher when it differs from the navigation URL, such as a path with nested routes. */
+    routePath?: string;
     component: React.LazyExoticComponent<React.FC>;
     adminOnly: boolean;
     featureFlag?: string;


### PR DESCRIPTION
## Description

Adds an optional `routePath` property to `SubNavItem`. This allows a navigation item to keep a clean link URL while using a different React Router match pattern, such as a trailing splat for nested routes.

Companion BHE PR: https://github.com/SpecterOps/bloodhound-enterprise/pull/1908

## Motivation and Context

Resolves BED-9662

The Managed Collection navigation entry links to `/administration/collection-plans`, while its route wrapper must match `/administration/collection-plans/*`. Separating the navigation URL from the route matcher keeps the shared navigation model extensible for nested feature routes.

## How Has This Been Tested?

- Built the `bh-shared-ui` workspace package.
- Ran the `bh-shared-ui` TypeScript check.
- Ran ESLint against `src/types.ts`.

## Screenshots (optional):

Not applicable; this PR changes a shared TypeScript route definition.

## Types of changes

- Chore (a change that does not modify the application functionality)

## Checklist:

- [ ] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [ ] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Navigation items can now match routes separately from their displayed navigation URLs, including nested routes.
  * This provides more accurate navigation highlighting and route handling when the URL shown in navigation differs from the route currently being viewed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->