### PR TITLE
feat: Add collection plan API client methods (BED-9664)

### DIFF
--- a/packages/javascript/bh-shared-ui/src/types.ts
+++ b/packages/javascript/bh-shared-ui/src/types.ts
@@ -38,6 +38,8 @@ export type MappedStringLiteral<T extends string | number, V = ''> = {
 export type SubNavItem = {
     label: string;
     path: string;
+    /** Optional route matcher when it differs from the navigation URL, such as a path with nested routes. */
+    routePath?: string;
     component: React.LazyExoticComponent<React.FC>;
     adminOnly: boolean;
     featureFlag?: string;

--- a/packages/javascript/js-client-library/src/client.ts
+++ b/packages/javascript/js-client-library/src/client.ts
@@ -14,6 +14,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+import type { CollectorJob, CollectorJobHistory, CollectorJobProfile, CollectorJobSchedule } from './types';
+
 import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios';
 import {
     ClearDatabaseRequest,
@@ -793,6 +795,42 @@ class BHEAPIClient {
     /* ingest */
 
     ingestData = (options?: RequestOptions) => this.baseClient.post('/api/v2/ingest', options);
+
+    /* collector job profiles */
+
+    getLatestCollectorJobHistory = (profileId: number, options?: RequestOptions) =>
+        this.baseClient.get<PaginatedResponse<{ records: CollectorJobHistory[] }>>('/api/v2/collector-job-history', {
+            ...options,
+            params: {
+                ...options?.params,
+                job_profile_id: `eq:${profileId}`,
+                sort_by: '-recorded_at',
+                skip: 0,
+                limit: 1,
+            },
+        });
+
+    getCollectorJobProfiles = (skip = 0, limit = 100, options?: RequestOptions) =>
+        this.baseClient.get<PaginatedResponse<{ profiles: CollectorJobProfile[] }>>('/api/v2/collector-job-profiles', {
+            ...options,
+            params: { ...options?.params, skip, limit },
+        });
+
+    getCollectorJobSchedule = (scheduleId: number, options?: RequestOptions) =>
+        this.baseClient.get<BasicResponse<{ schedule: CollectorJobSchedule }>>(
+            `/api/v2/collector-job-schedules/${scheduleId}`,
+            options
+        );
+
+    deleteCollectorJobProfile = (profileId: number, options?: RequestOptions) =>
+        this.baseClient.delete<void>(`/api/v2/collector-job-profiles/${profileId}`, options);
+
+    runCollectorJobProfile = (profileId: number, options?: RequestOptions) =>
+        this.baseClient.post<BasicResponse<{ job: CollectorJob }>>(
+            '/api/v2/collector-job-queue',
+            { job_profile_id: profileId },
+            options
+        );
 
     /* clients */
 

--- a/packages/javascript/js-client-library/src/client.ts
+++ b/packages/javascript/js-client-library/src/client.ts
@@ -14,8 +14,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import type { CollectorJob, CollectorJobHistory, CollectorJobProfile, CollectorJobSchedule } from './types';
-
 import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios';
 import {
     ClearDatabaseRequest,

--- a/packages/javascript/js-client-library/src/client.ts
+++ b/packages/javascript/js-client-library/src/client.ts
@@ -14,8 +14,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import type { CollectorJob, CollectorJobHistory, CollectorJobProfile, CollectorJobSchedule } from './types';
-
 import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios';
 import {
     ClearDatabaseRequest,
@@ -89,6 +87,8 @@ import {
     GetAlertResponse,
     GetAlertsResponse,
     GetClientResponse,
+    GetCollectorJobProfilesResponse,
+    GetCollectorJobScheduleResponse,
     GetCollectorsResponse,
     GetCommunityCollectorsResponse,
     GetConfigurationResponse,
@@ -97,6 +97,7 @@ import {
     GetEnterpriseCollectorsResponse,
     GetExportQueryResponse,
     GetExtensionsResponse,
+    GetLatestCollectorJobHistoryResponse,
     GetNodeKindResponse,
     GetNodeResponse,
     GetRelationshipKindResponse,
@@ -118,6 +119,7 @@ import {
     PostureResponse,
     PreviewSelectorsResponse,
     RotateWebhookSecretResponse,
+    RunCollectorJobProfileResponse,
     SavedQuery,
     SavedQueryPermissionsResponse,
     SourceKindsResponse,
@@ -799,7 +801,7 @@ class BHEAPIClient {
     /* collector job profiles */
 
     getLatestCollectorJobHistory = (profileId: number, options?: RequestOptions) =>
-        this.baseClient.get<PaginatedResponse<{ records: CollectorJobHistory[] }>>('/api/v2/collector-job-history', {
+        this.baseClient.get<GetLatestCollectorJobHistoryResponse>('/api/v2/collector-job-history', {
             ...options,
             params: {
                 ...options?.params,
@@ -811,22 +813,19 @@ class BHEAPIClient {
         });
 
     getCollectorJobProfiles = (skip = 0, limit = 100, options?: RequestOptions) =>
-        this.baseClient.get<PaginatedResponse<{ profiles: CollectorJobProfile[] }>>('/api/v2/collector-job-profiles', {
+        this.baseClient.get<GetCollectorJobProfilesResponse>('/api/v2/collector-job-profiles', {
             ...options,
             params: { ...options?.params, skip, limit },
         });
 
     getCollectorJobSchedule = (scheduleId: number, options?: RequestOptions) =>
-        this.baseClient.get<BasicResponse<{ schedule: CollectorJobSchedule }>>(
-            `/api/v2/collector-job-schedules/${scheduleId}`,
-            options
-        );
+        this.baseClient.get<GetCollectorJobScheduleResponse>(`/api/v2/collector-job-schedules/${scheduleId}`, options);
 
     deleteCollectorJobProfile = (profileId: number, options?: RequestOptions) =>
         this.baseClient.delete<void>(`/api/v2/collector-job-profiles/${profileId}`, options);
 
     runCollectorJobProfile = (profileId: number, options?: RequestOptions) =>
-        this.baseClient.post<BasicResponse<{ job: CollectorJob }>>(
+        this.baseClient.post<RunCollectorJobProfileResponse>(
             '/api/v2/collector-job-queue',
             { job_profile_id: profileId },
             options

--- a/packages/javascript/js-client-library/src/responses.ts
+++ b/packages/javascript/js-client-library/src/responses.ts
@@ -26,6 +26,10 @@ import {
     AssetGroupTagMember,
     AssetGroupTagSelector,
     Client,
+    CollectorJob,
+    CollectorJobHistory,
+    CollectorJobProfile,
+    CollectorJobSchedule,
     CollectorManifest,
     CommunityCollectorType,
     CustomNodeKindType,
@@ -366,6 +370,14 @@ export type GetScheduledJobDisplayResponse = PaginatedResponse<ScheduledJobDispl
 export type GetExportQueryResponse = AxiosResponse<Blob>;
 
 export type GetClientResponse = PaginatedResponse<Client[]>;
+
+export type GetCollectorJobProfilesResponse = PaginatedResponse<{ profiles: CollectorJobProfile[] }>;
+
+export type GetCollectorJobScheduleResponse = BasicResponse<{ schedule: CollectorJobSchedule }>;
+
+export type GetLatestCollectorJobHistoryResponse = PaginatedResponse<{ records: CollectorJobHistory[] }>;
+
+export type RunCollectorJobProfileResponse = BasicResponse<{ job: CollectorJob }>;
 
 export enum ManagementOperationStatus {
     QUEUED = 'queued',

--- a/packages/javascript/js-client-library/src/types.ts
+++ b/packages/javascript/js-client-library/src/types.ts
@@ -1036,6 +1036,12 @@ export interface CollectorJobSchedule extends CollectorJobScheduleMinimal {
     updated_at: string;
 }
 
+export enum CollectorJobStatus {
+    Ready = 'ready',
+    Claimed = 'claimed',
+    Running = 'running',
+}
+
 export interface CollectorJob {
     id: string;
     job_schedule_id: number | null;
@@ -1047,7 +1053,7 @@ export interface CollectorJob {
     scope_client_id: string | null;
     secret_key_id: string | null;
     priority: number;
-    status: 'ready' | 'claimed' | 'running';
+    status: CollectorJobStatus;
     run_at: string;
     unclaimed_deadline_at: string;
     attempts: number;
@@ -1058,6 +1064,12 @@ export interface CollectorJob {
     claim_expires_at: string | null;
     created_at: string;
     updated_at: string;
+}
+
+export enum CollectorJobOutcome {
+    Succeeded = 'succeeded',
+    Failed = 'failed',
+    Cancelled = 'cancelled',
 }
 
 export interface CollectorJobHistory {
@@ -1074,7 +1086,7 @@ export interface CollectorJobHistory {
     priority: number;
     params: Record<string, unknown>;
     attempts: number;
-    outcome: 'succeeded' | 'failed' | 'cancelled';
+    outcome: CollectorJobOutcome;
     outcome_metadata: Record<string, unknown> | null;
     failure_reason: string | null;
 }

--- a/packages/javascript/js-client-library/src/types.ts
+++ b/packages/javascript/js-client-library/src/types.ts
@@ -1004,3 +1004,77 @@ export interface RelationshipDetails {
 export type RelationshipDetailsWithInfo = RelationshipDetails & {
     info?: RelationshipKindInfo;
 };
+
+export interface CollectorJobProfileMinimal {
+    id: number;
+    name: string;
+    job_type_id: number;
+    params: Record<string, unknown>;
+    scope_client_id: string | null;
+    secret_id: string | null;
+}
+
+export interface CollectorJobScheduleMinimal {
+    id: number;
+    name: string;
+    rrule: string;
+    next_run_at: string;
+    priority: number;
+}
+
+export interface CollectorJobProfile extends CollectorJobProfileMinimal {
+    schedules: CollectorJobScheduleMinimal[];
+    created_at: string;
+    updated_at: string;
+}
+
+export interface CollectorJobSchedule extends CollectorJobScheduleMinimal {
+    disabled_at: string | null;
+    disabled_by: string | null;
+    profiles: CollectorJobProfileMinimal[];
+    created_at: string;
+    updated_at: string;
+}
+
+export interface CollectorJob {
+    id: string;
+    job_schedule_id: number | null;
+    job_profile_id: number | null;
+    job_type_id: number;
+    job_key: string;
+    params_version: string;
+    params: Record<string, unknown>;
+    scope_client_id: string | null;
+    secret_key_id: string | null;
+    priority: number;
+    status: 'ready' | 'claimed' | 'running';
+    run_at: string;
+    unclaimed_deadline_at: string;
+    attempts: number;
+    max_attempts: number;
+    last_failure: string | null;
+    claimed_by: string | null;
+    claimed_at: string | null;
+    claim_expires_at: string | null;
+    created_at: string;
+    updated_at: string;
+}
+
+export interface CollectorJobHistory {
+    id: string;
+    recorded_at: string;
+    job_created_at: string;
+    last_claimed_at: string | null;
+    last_claimed_by: string | null;
+    job_schedule_id: number | null;
+    job_profile_id: number | null;
+    job_type_id: number;
+    job_key: string;
+    params_version: string;
+    priority: number;
+    params: Record<string, unknown>;
+    attempts: number;
+    outcome: 'succeeded' | 'failed' | 'cancelled';
+    outcome_metadata: Record<string, unknown> | null;
+    failure_reason: string | null;
+}


### PR DESCRIPTION
## Description

Adds typed client methods for listing collector job profiles, fetching linked schedules, deleting profiles, queuing profile runs, and retrieving the latest terminal history record. Request paths, bodies, pagination envelopes, and nullable fields follow the API contract in https://github.com/SpecterOps/BloodHound/pull/3253.

Built on #3271 (`BED-9662-managed-coll-nav-routing`). The companion BHE PR https://github.com/SpecterOps/bloodhound-enterprise/pull/1911 provides Collection Plans tiles, React Query hooks, and MSW coverage.

## Motivation and Context

Supports BED-9664. The frontend presents profiles and schedules as collection plans for v1 while preserving their separate API resources.

## How Has This Been Tested?

- Client TypeScript check and ESLint passed.
- Client bundle generated successfully; the Rollup process remained open after emission and was stopped.
- Companion BHE tests exercise these methods through MSW: profile pagination, schedule IDs, queue request body, deletion, history filters, and error responses.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have met the contributing prerequisites
- [x] I have ensured that related documentation is up-to-date
- [x] I have followed proper test practices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added TypeScript types for collector job profiles, schedules, jobs, and execution history.
  - Added standardized enums for collector job statuses and execution outcomes.
  - Added dedicated response types for retrieving profiles, schedules, and job history, and for running collector job profiles.
  - Improved type safety for collector job management methods in the JavaScript client library.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->