### PR TITLE
chore: Apply outlined canvas surfaces BED-9683

### DIFF
--- a/cmd/ui/src/components/LoginPage.tsx
+++ b/cmd/ui/src/components/LoginPage.tsx
@@ -15,6 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Container } from '@mui/material';
+import { OUTLINED_CANVAS_SURFACE_CLASS } from 'bh-shared-ui';
 import { useEffect } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { addSnackbar } from 'src/ducks/global/actions';
@@ -41,7 +42,7 @@ const LoginPage: React.FC<LoginPageProps> = ({ children }) => {
     return (
         <div className='flex justify-center items-center h-full'>
             <Container maxWidth='sm'>
-                <div className='bg-neutral-2 shadow-outer-1 px-16 pb-16 pt-8'>
+                <div className={`${OUTLINED_CANVAS_SURFACE_CLASS} px-16 pb-16 pt-8`}>
                     <div className='h-full w-auto text-center box-border p-16'>
                         <img
                             src={`${import.meta.env.BASE_URL}${imageUrl}`}

--- a/cmd/ui/src/styles/swagger-overrides.scss
+++ b/cmd/ui/src/styles/swagger-overrides.scss
@@ -92,6 +92,10 @@
     }
 
     .models {
+        background-color: var(--neutral-1);
+        border-color: var(--neutral-light-4);
+        box-shadow: none;
+
         h4 {
             border-bottom-color: var(--input-border-default);
         }
@@ -139,6 +143,13 @@
     }
 
     .opblock {
+        border-color: var(--neutral-light-4);
+        box-shadow: none;
+
+        .opblock-body {
+            background-color: var(--neutral-1);
+        }
+
         .opblock-section-header {
             color: var(--text-main);
             background-color: var(--neutral-100);
@@ -150,6 +161,13 @@
         }
         .opblock-section .parameters tr .col_header {
             border-color: var(--neutral-700);
+        }
+    }
+
+    .dark & {
+        .models,
+        .opblock {
+            border-color: var(--neutral-900);
         }
     }
 }

--- a/cmd/ui/src/views/DownloadCollectors/DownloadCollectors.tsx
+++ b/cmd/ui/src/views/DownloadCollectors/DownloadCollectors.tsx
@@ -15,7 +15,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Alert, Box, Link, Paper, Skeleton } from '@mui/material';
-import { CollectorCardList, DocumentationLinks, PageWithTitle, apiClient, useFeatureFlag } from 'bh-shared-ui';
+import {
+    CollectorCardList,
+    DocumentationLinks,
+    OUTLINED_CANVAS_SURFACE_CLASS,
+    PageWithTitle,
+    apiClient,
+    useFeatureFlag,
+} from 'bh-shared-ui';
 import { Typography } from 'doodle-ui';
 import { CommunityCollectorType } from 'js-client-library';
 import fileDownload from 'js-file-download';
@@ -112,7 +119,7 @@ const DownloadCollectors = () => {
                 <Box>
                     <Typography variant='h2'>SharpHound</Typography>
                     {sharpHoundCollectorsQuery.isLoading ? (
-                        <Paper>
+                        <Paper className={OUTLINED_CANVAS_SURFACE_CLASS} elevation={0}>
                             <Box p={2}>
                                 <Typography variant='h6' component='div'>
                                     <Skeleton variant='text' />
@@ -146,7 +153,7 @@ const DownloadCollectors = () => {
                 <Box>
                     <Typography variant='h2'>AzureHound</Typography>
                     {azureHoundCollectorsQuery.isLoading ? (
-                        <Paper>
+                        <Paper className={OUTLINED_CANVAS_SURFACE_CLASS} elevation={0}>
                             <Box p={2}>
                                 <Typography variant='h6' component='div'>
                                     <Skeleton variant='text' />
@@ -180,7 +187,7 @@ const DownloadCollectors = () => {
                 {openHoundEnabled?.enabled && (
                     <Box>
                         <Typography variant='h2'>OpenHound</Typography>
-                        <Paper>
+                        <Paper className={OUTLINED_CANVAS_SURFACE_CLASS} elevation={0}>
                             <Box p={2}>
                                 <Typography variant='body1'>
                                     <Link href={openHoundHref} target='_blank'>

--- a/cmd/ui/src/views/EarlyAccessFeatures/EarlyAccessFeatures.tsx
+++ b/cmd/ui/src/views/EarlyAccessFeatures/EarlyAccessFeatures.tsx
@@ -29,6 +29,7 @@ import {
 import {
     cn,
     Flag,
+    OUTLINED_CANVAS_SURFACE_CLASS,
     PageWithTitle,
     Permission,
     useAppNavigate,
@@ -53,7 +54,7 @@ export const EarlyAccessFeatureToggle: React.FC<{
     };
 
     return (
-        <div className='bg-neutral-2 shadow-outer-1'>
+        <div className={OUTLINED_CANVAS_SURFACE_CLASS}>
             <div className='p-4 flex justify-between gap-4'>
                 <div className='overflow-hidden'>
                     <Typography variant='h6' component='h2'>
@@ -156,7 +157,7 @@ const EarlyAccessFeatures: FC = () => {
                 }>
                 {!showWarningDialog &&
                     (isLoading ? (
-                        <div className='bg-neutral-2'>
+                        <div className={OUTLINED_CANVAS_SURFACE_CLASS}>
                             <div className='p-4'>
                                 <Typography variant='h6' component='div'>
                                     <Skeleton />
@@ -172,7 +173,7 @@ const EarlyAccessFeatures: FC = () => {
                             An unexpected error occurred. Please refresh this page or try again later.
                         </Alert>
                     ) : data!.filter((flag) => flag.user_updatable).length === 0 ? (
-                        <div className='bg-neutral-2'>
+                        <div className={OUTLINED_CANVAS_SURFACE_CLASS}>
                             <div className='p-4'>
                                 <Typography variant='h2'>No Early Access Features Available</Typography>
                                 <Typography variant='body1'>

--- a/cmd/ui/src/views/GroupManagement/GroupManagement.tsx
+++ b/cmd/ui/src/views/GroupManagement/GroupManagement.tsx
@@ -23,6 +23,7 @@ import {
     ExploreQueryParams,
     GroupManagementContent,
     HIGH_VALUE_LABEL,
+    OUTLINED_CANVAS_SURFACE_CLASS,
     Permission,
     SelectedNode,
     TIER_ZERO_TAG,
@@ -94,7 +95,13 @@ const GroupManagement = () => {
             tierZeroLabel={HIGH_VALUE_LABEL}
             tierZeroTag={TIER_ZERO_TAG}
             // Both these components should eventually be moved into the shared UI library
-            entityPanelComponent={<EntityInfoPanel selectedNode={node} DataTable={EntityInfoDataTable} />}
+            entityPanelComponent={
+                <EntityInfoPanel
+                    selectedNode={node}
+                    DataTable={EntityInfoDataTable}
+                    surfaceClassName={OUTLINED_CANVAS_SURFACE_CLASS}
+                />
+            }
             domainSelectorErrorMessage={<>Domains unavailable. {dataCollectionMessage}</>}
             onShowNodeInExplore={handleShowNodeInExplore}
             onClickMember={handleClickMember}

--- a/packages/javascript/bh-shared-ui/src/components/AssetGroupEdit/AssetGroupEdit.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/AssetGroupEdit/AssetGroupEdit.tsx
@@ -23,8 +23,8 @@ import {
 } from 'js-client-library';
 import { FC, useEffect, useState } from 'react';
 import { useMutation, useQueryClient } from 'react-query';
-import { useTheme } from '../../hooks/useTheme';
 import { useNotifications } from '../../providers';
+import { OUTLINED_CANVAS_SURFACE_CLASS } from '../../styles';
 import { apiClient } from '../../utils';
 import { SubHeader } from '../../views/Explore/fragments';
 import AssetGroupAutocomplete from './AssetGroupAutocomplete';
@@ -41,7 +41,6 @@ const AssetGroupEdit: FC<{
     const addRows = changelog.filter((entry) => entry.action === ChangelogAction.ADD);
     const removeRows = changelog.filter((entry) => entry.action === ChangelogAction.REMOVE);
     const { addNotification } = useNotifications();
-    const theme = useTheme();
     const queryClient = useQueryClient();
 
     const handleUpdateAssetGroupChangelog = (_event: any, changelogEntry: AssetGroupChangelogEntry) => {
@@ -94,7 +93,7 @@ const AssetGroupEdit: FC<{
     };
 
     return (
-        <Box component={Paper} elevation={0} padding={1} bgcolor={theme.neutral.secondary}>
+        <Box component={Paper} className={OUTLINED_CANVAS_SURFACE_CLASS} elevation={0} padding={1}>
             <SubHeader label='Total Count' count={memberCounts?.total_count} />
             {isEditable && (
                 <>

--- a/packages/javascript/bh-shared-ui/src/components/AssetGroupFilters/AssetGroupFilters.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/AssetGroupFilters/AssetGroupFilters.tsx
@@ -31,7 +31,7 @@ import { Button, Typography } from 'doodle-ui';
 import { AssetGroupMemberCounts } from 'js-client-library';
 import { AssetGroupMemberParams } from 'js-client-library/dist/types';
 import { FC, useState } from 'react';
-import { useTheme } from '../../hooks/useTheme';
+import { OUTLINED_CANVAS_SURFACE_CLASS } from '../../styles';
 import { cn } from '../../utils';
 import NodeIcon from '../NodeIcon';
 
@@ -48,8 +48,6 @@ interface Props {
 
 const AssetGroupFilters: FC<Props> = ({ filterParams, handleFilterChange, memberCounts = { counts: {} } }) => {
     const [displayFilters, setDisplayFilters] = useState(false);
-    const theme = useTheme();
-
     const handleClearFilters = () => {
         for (const filter of FILTERABLE_PARAMS) {
             handleFilterChange(filter, '');
@@ -62,7 +60,7 @@ const AssetGroupFilters: FC<Props> = ({ filterParams, handleFilterChange, member
         <Box
             p={1}
             component={Paper}
-            bgcolor={theme.neutral.secondary}
+            className={OUTLINED_CANVAS_SURFACE_CLASS}
             elevation={0}
             marginBottom={1}
             data-testid='asset-group-filters-container'>

--- a/packages/javascript/bh-shared-ui/src/components/AssetGroupMemberList/AssetGroupMemberList.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/AssetGroupMemberList/AssetGroupMemberList.tsx
@@ -33,6 +33,7 @@ import { Typography } from 'doodle-ui';
 import { AssetGroup, AssetGroupMember, AssetGroupMemberParams } from 'js-client-library';
 import { FC, useEffect, useState } from 'react';
 import { useQuery } from 'react-query';
+import { CANVAS_MUI_TABLE_CLASS } from '../../styles';
 import { apiClient, cn } from '../../utils';
 import NodeIcon from '../NodeIcon';
 
@@ -90,7 +91,7 @@ const AssetGroupMemberList: FC<{
     };
 
     return (
-        <TableContainer className='max-h-full bg-neutral-2' component={Paper} elevation={0}>
+        <TableContainer className={`${CANVAS_MUI_TABLE_CLASS} max-h-full`} component={Paper} elevation={0}>
             <Table stickyHeader className='h-full relative'>
                 <colgroup>
                     <col width='80%' />
@@ -159,7 +160,8 @@ const AssetGroupMemberRow: FC<{
     return (
         <TableRow
             onClick={handleClick}
-            className={cn({ 'hover:bg-neutral-4 cursor-pointer': !disabled, 'opacity-50': disabled })}>
+            hover={!disabled}
+            className={cn({ 'cursor-pointer': !disabled, 'opacity-50': disabled })}>
             <TableCell>
                 <Box className='flex items-center w-full'>
                     <NodeIcon nodeType={member.primary_kind} />

--- a/packages/javascript/bh-shared-ui/src/components/CardWithSwitch.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/CardWithSwitch.tsx
@@ -16,6 +16,7 @@
 
 import { Switch } from 'doodle-ui';
 import { FC, ReactNode } from 'react';
+import { OUTLINED_CANVAS_SURFACE_CLASS } from '../styles';
 import { cn } from '../utils';
 
 type CardWithSwitchProps = {
@@ -37,9 +38,8 @@ const CardWithSwitch: FC<CardWithSwitchProps> = ({
 }) => {
     return (
         <div
-            className={cn('p-4 border rounded-lg', {
-                'bg-neutral-2 border-transparent shadow-outer-1': isEnabled,
-                'bg-neutral-2/30 border-neutral-3 shadow-none': !isEnabled,
+            className={cn(OUTLINED_CANVAS_SURFACE_CLASS, 'p-4 rounded-lg', {
+                'opacity-60': !isEnabled,
             })}>
             <div className='flex justify-between mb-4'>
                 <h4 className='font-bold text-lg'>{title}</h4>

--- a/packages/javascript/bh-shared-ui/src/components/CardWithSwitch.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/CardWithSwitch.tsx
@@ -37,10 +37,7 @@ const CardWithSwitch: FC<CardWithSwitchProps> = ({
     disableSwitch = false,
 }) => {
     return (
-        <div
-            className={cn(OUTLINED_CANVAS_SURFACE_CLASS, 'p-4 rounded-lg', {
-                'opacity-60': !isEnabled,
-            })}>
+        <div className={cn(OUTLINED_CANVAS_SURFACE_CLASS, 'p-4 rounded-lg')}>
             <div className='flex justify-between mb-4'>
                 <h4 className='font-bold text-lg'>{title}</h4>
                 <Switch

--- a/packages/javascript/bh-shared-ui/src/components/CollectorCard/CollectorCard.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/CollectorCard/CollectorCard.tsx
@@ -19,6 +19,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Box, Link, Paper } from '@mui/material';
 import { Button, Typography } from 'doodle-ui';
 import { CommunityCollectorType } from 'js-client-library';
+import { OUTLINED_CANVAS_SURFACE_CLASS } from '../../styles';
 
 interface CollectorCardProps {
     collectorType: CommunityCollectorType;
@@ -53,7 +54,7 @@ const CollectorCard: React.FC<CollectorCardProps> = ({
     };
 
     return (
-        <Paper>
+        <Paper className={OUTLINED_CANVAS_SURFACE_CLASS} elevation={0}>
             <Box p={2} display='flex' justifyContent='space-between' flexWrap='wrap' style={{ rowGap: '1rem' }}>
                 <Box overflow='hidden'>
                     <Typography variant='h3'>

--- a/packages/javascript/bh-shared-ui/src/components/DetailsAccordion/DetailsAccordion.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/DetailsAccordion/DetailsAccordion.test.tsx
@@ -115,6 +115,22 @@ describe('<DetailsAccordion />', () => {
         expect(header).toHaveClass('border-primary');
     });
 
+    it('replaces the default item surface styling when itemClassName is provided', () => {
+        render(
+            <DetailsAccordion<Item>
+                Header={Header}
+                Content={Content}
+                getKey={(item) => item.title}
+                itemClassName='custom-surface'
+                items={[{ title: 'Custom', description: 'Surface' }]}
+            />
+        );
+
+        const item = screen.getByTestId('Custom');
+        expect(item).toHaveClass('custom-surface');
+        expect(item).not.toHaveClass('bg-neutral-light-2');
+    });
+
     it('disables items via itemDisabled and hides the chevron icon visually', () => {
         render(
             <DetailsAccordion<Item>

--- a/packages/javascript/bh-shared-ui/src/components/DetailsAccordion/DetailsAccordion.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/DetailsAccordion/DetailsAccordion.tsx
@@ -37,6 +37,9 @@ export type DetailsAccordionProps<T extends Record<string, unknown>> = {
     /** Predicate to determine if an item is disabled (default: always `false`) */
     itemDisabled?: (item: T) => boolean;
 
+    /** Optional surface classes that replace the default item surface styling */
+    itemClassName?: string;
+
     /** Component to render the header of each item */
     Header: ComponentType<T>;
 
@@ -79,6 +82,7 @@ export const DetailsAccordion = <T extends Record<string, unknown>>({
     getKey,
     items,
     itemDisabled = () => false,
+    itemClassName,
     Header,
     openIndex,
 }: DetailsAccordionProps<T>) => {
@@ -103,7 +107,10 @@ export const DetailsAccordion = <T extends Record<string, unknown>>({
 
                 return (
                     <AccordionItem
-                        className='bg-neutral-light-2 dark:bg-neutral-dark-2 border-t dark:border-neutral-dark-4 first:border-none'
+                        className={
+                            itemClassName ??
+                            'bg-neutral-light-2 dark:bg-neutral-dark-2 border-t dark:border-neutral-dark-4 first:border-none'
+                        }
                         disabled={isDisabled}
                         key={key}
                         value={String(idx)}

--- a/packages/javascript/bh-shared-ui/src/components/EntityInfo/EntityInfoPanel.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/EntityInfo/EntityInfoPanel.test.tsx
@@ -93,4 +93,11 @@ describe('EntityInfoPanel', async () => {
         expect(entityHeaderTitle).toBeInTheDocument();
         expect(selectObjectMessage).toBeInTheDocument();
     });
+
+    it('should remove default shadows when a custom surface class is provided', () => {
+        const { container } = render(<EntityInfoPanel {...testProps} surfaceClassName='custom-surface' />);
+
+        expect(container.querySelectorAll('.custom-surface')).toHaveLength(2);
+        expect(container.querySelectorAll('.shadow-outer-1')).toHaveLength(0);
+    });
 });

--- a/packages/javascript/bh-shared-ui/src/components/EntityInfo/EntityInfoPanel.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/EntityInfo/EntityInfoPanel.tsx
@@ -57,12 +57,18 @@ const EntityInfoPanel: React.FC<EntityInfoPanelProps> = ({
             )}
             data-testid='explore_entity-information-panel'>
             <RoleBasedFilterBadge />
-            <div className={cn('bg-neutral-2 pointer-events-auto rounded-lg shadow-outer-1', surfaceClassName)}>
+            <div
+                className={cn(
+                    'bg-neutral-2 pointer-events-auto rounded-lg',
+                    !surfaceClassName && 'shadow-outer-1',
+                    surfaceClassName
+                )}>
                 <Header name={getEntityName(selectedNode)} nodeType={primaryKind} />
             </div>
             <div
                 className={cn(
-                    'bg-neutral-2 overflow-x-hidden overflow-y-auto py-1 px-4 pointer-events-auto rounded-lg shadow-outer-1',
+                    'bg-neutral-2 overflow-x-hidden overflow-y-auto py-1 px-4 pointer-events-auto rounded-lg',
+                    !surfaceClassName && 'shadow-outer-1',
                     surfaceClassName
                 )}>
                 {selectedNode ? (

--- a/packages/javascript/bh-shared-ui/src/components/EntityInfo/EntityInfoPanel.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/EntityInfo/EntityInfoPanel.tsx
@@ -33,6 +33,7 @@ export interface EntityInfoPanelProps {
     DataTable: EntityTable;
     selectedNode?: NodeDetails | NodeDetailsWithInfo;
     className?: HTMLProps<HTMLDivElement>['className'];
+    surfaceClassName?: HTMLProps<HTMLDivElement>['className'];
     additionalTables?: EntityTables;
     priorityTables?: EntityTables;
     showPlaceholderMessage?: boolean;
@@ -41,6 +42,7 @@ export interface EntityInfoPanelProps {
 const EntityInfoPanel: React.FC<EntityInfoPanelProps> = ({
     selectedNode,
     className,
+    surfaceClassName,
     additionalTables,
     priorityTables,
     DataTable,
@@ -55,10 +57,14 @@ const EntityInfoPanel: React.FC<EntityInfoPanelProps> = ({
             )}
             data-testid='explore_entity-information-panel'>
             <RoleBasedFilterBadge />
-            <div className='bg-neutral-2 pointer-events-auto rounded-lg shadow-outer-1'>
+            <div className={cn('bg-neutral-2 pointer-events-auto rounded-lg shadow-outer-1', surfaceClassName)}>
                 <Header name={getEntityName(selectedNode)} nodeType={primaryKind} />
             </div>
-            <div className='bg-neutral-2 overflow-x-hidden overflow-y-auto py-1 px-4 pointer-events-auto rounded-lg shadow-outer-1'>
+            <div
+                className={cn(
+                    'bg-neutral-2 overflow-x-hidden overflow-y-auto py-1 px-4 pointer-events-auto rounded-lg shadow-outer-1',
+                    surfaceClassName
+                )}>
                 {selectedNode ? (
                     <EntityInfoContent
                         DataTable={DataTable}

--- a/packages/javascript/bh-shared-ui/src/components/FileIngestTable/FileIngestDetailsPanel.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/FileIngestTable/FileIngestDetailsPanel.tsx
@@ -18,6 +18,7 @@ import { Alert, AlertTitle } from '@mui/material';
 import { Card, CardContent } from 'doodle-ui';
 import type { FileIngestCompletedTask, FileIngestJob } from 'js-client-library';
 import { useFileUploadQuery } from '../../hooks';
+import { OUTLINED_CANVAS_SURFACE_CLASS } from '../../styles';
 import { IndicatorType } from '../../types';
 import { DetailsAccordion } from '../DetailsAccordion';
 import { StatusIndicator } from '../StatusIndicator';
@@ -106,7 +107,7 @@ const IngestContent: React.FC<FileIngestJob> = (ingest) => {
 
 /** Displays a message to click an ingest ID */
 export const NoIngest = () => (
-    <Card>
+    <Card className={OUTLINED_CANVAS_SURFACE_CLASS}>
         <CardContent className='px-4'>Click on the Ingest ID to reveal further information.</CardContent>
     </Card>
 );

--- a/packages/javascript/bh-shared-ui/src/components/FileIngestTable/FileIngestDetailsPanel.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/FileIngestTable/FileIngestDetailsPanel.tsx
@@ -124,6 +124,7 @@ export const FileIngestDetailsPanel = ({ ingest }: Props) => {
             Content={IngestContent}
             Empty={NoIngest}
             Header={IngestHeader}
+            itemClassName={`${OUTLINED_CANVAS_SURFACE_CLASS} rounded-lg overflow-hidden`}
             items={ingest}
             openIndex={0}
         />

--- a/packages/javascript/bh-shared-ui/src/components/FileIngestTable/FileIngestTable.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/FileIngestTable/FileIngestTable.tsx
@@ -18,6 +18,7 @@ import { Card } from 'doodle-ui';
 import type { FileIngestJob } from 'js-client-library';
 import { FC, useState } from 'react';
 import { useGetFileUploadsQuery } from '../../hooks';
+import { CANVAS_MUI_TABLE_CLASS } from '../../styles';
 import { JOB_STATUS_INDICATORS, JOB_STATUS_MAP, getSimpleDuration, toFormatted } from '../../utils';
 import DataTable from '../DataTable';
 import { FileIngestUploadButton } from '../FileIngest/FileIngestUploadButton';
@@ -91,7 +92,7 @@ export const FileIngestTable: FC = () => {
             </div>
 
             <div className='col-[1] row-[2] min-h-0'>
-                <Card>
+                <Card className={CANVAS_MUI_TABLE_CLASS}>
                     <DataTable
                         data={fileUploadJobs.map(getRowWithSelect)}
                         headers={getHeaders(HEADERS)}

--- a/packages/javascript/bh-shared-ui/src/components/GroupManagementContent/GroupManagementContent.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/GroupManagementContent/GroupManagementContent.tsx
@@ -22,6 +22,7 @@ import { AssetGroup, AssetGroupMember, AssetGroupMemberParams } from 'js-client-
 import { FC, HTMLProps, ReactNode, useEffect, useState } from 'react';
 import { useQuery } from 'react-query';
 import useRoleBasedFiltering from '../../hooks/useRoleBasedFiltering';
+import { OUTLINED_CANVAS_SURFACE_CLASS } from '../../styles';
 import { apiClient } from '../../utils/api';
 import AssetGroupEdit from '../AssetGroupEdit/AssetGroupEdit';
 import AssetGroupFilters from '../AssetGroupFilters';
@@ -152,7 +153,7 @@ const GroupManagementContent: FC<GroupManagementContentProps> = ({
             <Grid container height={'100%'} spacing={2}>
                 <Grid item xs={3} md={3}>
                     <div className='mb-2'>
-                        <Grid container className='bg-neutral-2'>
+                        <Grid container className={OUTLINED_CANVAS_SURFACE_CLASS}>
                             <Grid item sm={4} className={selectorLabelStyles} alignItems={'center'} paddingLeft={3}>
                                 <Typography className='font-medium text-sm uppercase'>Group:</Typography>
                             </Grid>

--- a/packages/javascript/bh-shared-ui/src/components/LegacyFileIngestTable/LegacyFileIngestTable.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/LegacyFileIngestTable/LegacyFileIngestTable.tsx
@@ -19,6 +19,7 @@ import { DateTime } from 'luxon';
 import { useEffect, useState } from 'react';
 import { ZERO_VALUE_API_DATE } from '../../constants';
 import { useGetFileUploadsQuery } from '../../hooks';
+import { CANVAS_MUI_TABLE_CLASS } from '../../styles';
 import { LuxonFormat, getSimpleDuration } from '../../utils/datetime';
 import DataTable from '../DataTable';
 import { FileIngestUploadButton } from '../FileIngest/FileIngestUploadButton';
@@ -74,7 +75,7 @@ const LegacyFileIngestTable: React.FC = () => {
                 <FileIngestUploadButton />
             </div>
 
-            <Paper>
+            <Paper className={CANVAS_MUI_TABLE_CLASS} elevation={0}>
                 <DataTable
                     headers={ingestTableHeaders}
                     data={ingestRows}

--- a/packages/javascript/bh-shared-ui/src/components/SSOProviderInfoPanel/SSOProviderInfoPanel.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/SSOProviderInfoPanel/SSOProviderInfoPanel.tsx
@@ -19,6 +19,7 @@ import { OIDCProviderInfo, Role, SAMLProviderInfo, SSOProvider } from 'js-client
 import fileDownload from 'js-file-download';
 import { FC, useMemo } from 'react';
 import { useNotifications } from '../../providers';
+import { OUTLINED_CANVAS_SURFACE_CLASS } from '../../styles';
 import { apiClient } from '../../utils';
 import { Field, FieldsContainer } from '../../views/Explore/fragments';
 import LabelWithCopy from '../LabelWithCopy';
@@ -132,7 +133,8 @@ const SSOProviderInfoPanel: FC<{
                             {ssoProvider?.name}
                         </h5>
                     </div>
-                    <div className='bg-neutral-2 overflow-x-hidden overflow-y-auto px-4 py-2 shadow-outer-1 rounded'>
+                    <div
+                        className={`${OUTLINED_CANVAS_SURFACE_CLASS} overflow-x-hidden overflow-y-auto px-4 py-2 rounded`}>
                         <div className='font-bold ml-2 text-sm'>Provider Information:</div>
                         <FieldsContainer>
                             {innerInfoPanel}

--- a/packages/javascript/bh-shared-ui/src/index.ts
+++ b/packages/javascript/bh-shared-ui/src/index.ts
@@ -57,6 +57,7 @@ export * from './graphSchema';
 export * from './hooks';
 export * from './providers';
 export * from './routes';
+export * from './styles';
 export * from './types';
 export * from './utils';
 export * from './views';

--- a/packages/javascript/bh-shared-ui/src/styles/canvasSurfaces.ts
+++ b/packages/javascript/bh-shared-ui/src/styles/canvasSurfaces.ts
@@ -1,0 +1,28 @@
+// Copyright 2026 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/** Matches a page-level surface to the application canvas in both themes. */
+export const CANVAS_SURFACE_CLASS = '!bg-neutral-1 !shadow-none';
+
+/** Adds the standard neutral boundary used by page-level content surfaces. */
+export const OUTLINED_CANVAS_SURFACE_CLASS = `${CANVAS_SURFACE_CLASS} border border-solid border-neutral-light-4 dark:border-neutral-900`;
+
+/** Keeps table rows on the canvas while preserving stateful row styling. */
+export const CANVAS_TABLE_ROW_CLASS =
+    'bg-neutral-1 hover:bg-neutral-3 data-[state=selected]:bg-muted aria-selected:bg-muted';
+
+/** Applies the canvas treatment to legacy MUI table containers and their non-selected rows. */
+export const CANVAS_MUI_TABLE_CLASS = `${OUTLINED_CANVAS_SURFACE_CLASS} [&_.MuiTableBody-root]:!bg-neutral-1 [&_.MuiTableRow-root:not(.Mui-selected)]:!bg-neutral-1 [&_.MuiTableRow-hover:not(.Mui-selected):hover]:!bg-neutral-3`;

--- a/packages/javascript/bh-shared-ui/src/styles/index.ts
+++ b/packages/javascript/bh-shared-ui/src/styles/index.ts
@@ -1,0 +1,17 @@
+// Copyright 2026 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+export * from './canvasSurfaces';

--- a/packages/javascript/bh-shared-ui/src/views/DataQuality/DomainInfo.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/DataQuality/DomainInfo.tsx
@@ -17,24 +17,13 @@
 import { faChartPie, faSignInAlt, faStream, faUsers } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Box, Paper, Table, TableBody, TableContainer } from '@mui/material';
-import makeStyles from '@mui/styles/makeStyles';
 import { ActiveDirectoryQualityStat } from 'js-client-library';
 import React, { useEffect } from 'react';
 import { NodeIcon } from '../../components';
 import { ActiveDirectoryNodeKind } from '../../graphSchema';
 import { useActiveDirectoryDataQualityStatsQuery, useActiveDirectoryPlatformsDataQualityStatsQuery } from '../../hooks';
+import { CANVAS_MUI_TABLE_CLASS } from '../../styles';
 import LoadContainer from './LoadContainer';
-
-const useStyles = makeStyles((theme) => ({
-    print: {
-        '@media print': {
-            display: 'none',
-        },
-    },
-    container: {
-        backgroundColor: theme.palette.neutral.secondary,
-    },
-}));
 
 export const DomainMap = {
     users: { displayText: 'Users', kind: ActiveDirectoryNodeKind.User },
@@ -111,10 +100,9 @@ const Layout: React.FC<{
     stats: ActiveDirectoryQualityStat | null;
     isLoading: boolean;
 }> = ({ stats, isLoading }) => {
-    const classes = useStyles();
     return (
         <Box position='relative'>
-            <TableContainer component={Paper} className={classes.container}>
+            <TableContainer component={Paper} className={CANVAS_MUI_TABLE_CLASS} elevation={0}>
                 <Table>
                     <TableBody>
                         {Object.keys(DomainMap).map((key) => {
@@ -136,7 +124,11 @@ const Layout: React.FC<{
                     </TableBody>
                 </Table>
             </TableContainer>
-            <TableContainer style={{ marginTop: '16px' }} component={Paper} className={classes.container}>
+            <TableContainer
+                style={{ marginTop: '16px' }}
+                component={Paper}
+                className={CANVAS_MUI_TABLE_CLASS}
+                elevation={0}>
                 <Table>
                     <TableBody>
                         <LoadContainer
@@ -162,7 +154,11 @@ const Layout: React.FC<{
                     </TableBody>
                 </Table>
             </TableContainer>
-            <TableContainer style={{ marginTop: '16px' }} component={Paper} className={classes.container}>
+            <TableContainer
+                style={{ marginTop: '16px' }}
+                component={Paper}
+                className={CANVAS_MUI_TABLE_CLASS}
+                elevation={0}>
                 <Table>
                     <TableBody>
                         <LoadContainer

--- a/packages/javascript/bh-shared-ui/src/views/DataQuality/OpenGraphInfo.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/DataQuality/OpenGraphInfo.tsx
@@ -17,27 +17,16 @@
 import { faStream, faUsers } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Box, Paper, Table, TableBody, TableContainer } from '@mui/material';
-import makeStyles from '@mui/styles/makeStyles';
 import { Environment, OpenGraphDataQualityStat } from 'js-client-library';
 import React, { useEffect } from 'react';
 import { NodeIcon } from '../../components';
 import { useOpenGraphDataQualityStatsQuery, useOpenGraphPlatformsDataQualityStatsQuery } from '../../hooks';
+import { CANVAS_MUI_TABLE_CLASS, OUTLINED_CANVAS_SURFACE_CLASS } from '../../styles';
 import { cn } from '../../utils';
 import LoadContainer from './LoadContainer';
 
-const useStyles = makeStyles((theme) => ({
-    print: {
-        '@media print': {
-            display: 'none',
-        },
-    },
-    container: {
-        backgroundColor: theme.palette.neutral.secondary,
-    },
-}));
-
 const NoDataMessage: React.FC = () => (
-    <div className='flex items-center justify-center h-[400px] bg-neutral-2'>
+    <div className={`${OUTLINED_CANVAS_SURFACE_CLASS} flex items-center justify-center h-[400px]`}>
         <span className='font-bold text-sm text-contrast leading-normal'>No data to display</span>
     </div>
 );
@@ -142,11 +131,9 @@ const Layout: React.FC<{
     isLoading: boolean;
     headers?: boolean;
 }> = ({ nodeStats, relationshipTotalCount, isLoading }) => {
-    const classes = useStyles();
-
     return (
         <Box position='relative'>
-            <TableContainer className={classes.container}>
+            <TableContainer className={CANVAS_MUI_TABLE_CLASS}>
                 <Table>
                     <TableBody>
                         {nodeStats?.map((key: any) => {
@@ -163,7 +150,10 @@ const Layout: React.FC<{
                     </TableBody>
                 </Table>
             </TableContainer>
-            <TableContainer component={Paper} className={cn(classes.container, { 'mt-4': !isLoading })}>
+            <TableContainer
+                component={Paper}
+                className={cn(CANVAS_MUI_TABLE_CLASS, { 'mt-4': !isLoading })}
+                elevation={0}>
                 <Table>
                     <TableBody>
                         <LoadContainer

--- a/packages/javascript/bh-shared-ui/src/views/DataQuality/TenantInfo.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/DataQuality/TenantInfo.tsx
@@ -17,24 +17,13 @@
 import { faUsers } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Box, Paper, Table, TableBody, TableContainer } from '@mui/material';
-import makeStyles from '@mui/styles/makeStyles';
 import { AzureDataQualityStat } from 'js-client-library';
 import React, { useEffect } from 'react';
 import { NodeIcon } from '../../components';
 import { AzureNodeKind } from '../../graphSchema';
 import { useAzureDataQualityStatsQuery, useAzurePlatformsDataQualityStatsQuery } from '../../hooks';
+import { CANVAS_MUI_TABLE_CLASS } from '../../styles';
 import LoadContainer from './LoadContainer';
-
-const useStyles = makeStyles((theme) => ({
-    print: {
-        '@media print': {
-            display: 'none',
-        },
-    },
-    container: {
-        backgroundColor: theme.palette.neutral.secondary,
-    },
-}));
 
 export const TenantMap = {
     users: { displayText: 'Users', kind: AzureNodeKind.User },
@@ -116,10 +105,9 @@ const Layout: React.FC<{
     stats: AzureDataQualityStat | null;
     isLoading: boolean;
 }> = ({ stats, isLoading }) => {
-    const classes = useStyles();
     return (
         <Box position='relative'>
-            <TableContainer className={classes.container}>
+            <TableContainer className={CANVAS_MUI_TABLE_CLASS}>
                 <Table>
                     <TableBody>
                         {Object.keys(TenantMap).map((key) => {
@@ -141,7 +129,11 @@ const Layout: React.FC<{
                     </TableBody>
                 </Table>
             </TableContainer>
-            <TableContainer style={{ marginTop: '16px' }} component={Paper} className={classes.container}>
+            <TableContainer
+                style={{ marginTop: '16px' }}
+                component={Paper}
+                className={CANVAS_MUI_TABLE_CLASS}
+                elevation={0}>
                 <Table>
                     <TableBody>
                         <LoadContainer

--- a/packages/javascript/bh-shared-ui/src/views/OpenGraphManagement/ActiveExtensionsCard.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/OpenGraphManagement/ActiveExtensionsCard.tsx
@@ -23,6 +23,7 @@ import { useState } from 'react';
 import { SearchInput } from '../../components';
 import { useDeleteExtension, useExtensionsQuery, usePermissions } from '../../hooks';
 import { DEFAULT_NOTIFICATION, ERROR_NOTIFICATION, useNotifications } from '../../providers';
+import { CANVAS_TABLE_ROW_CLASS, OUTLINED_CANVAS_SURFACE_CLASS } from '../../styles';
 import { Permission } from '../../utils';
 import { ConfirmDeleteExtensionDialog, DeleteExtensionButton } from './DeleteExtensionButton';
 
@@ -174,7 +175,7 @@ export const ActiveExtensionsCard = () => {
     }
 
     return (
-        <Card className='flex flex-col gap-4 overflow-hidden'>
+        <Card className={`${OUTLINED_CANVAS_SURFACE_CLASS} flex flex-col gap-4 overflow-hidden`}>
             <header className='flex justify-between items-center pt-6 px-6 gap-3'>
                 <CardTitle className='text-base'>Active Extensions</CardTitle>
                 <SearchInput
@@ -196,6 +197,7 @@ export const ActiveExtensionsCard = () => {
                             : `${TABLE_HEADER_HEIGHT + TABLE_CELL_HEIGHT * filteredData.length}px`,
                 }}>
                 <DataTable
+                    TableBodyRowProps={{ className: CANVAS_TABLE_ROW_CLASS }}
                     className='h-full'
                     data={filteredData}
                     noResultsFallback={

--- a/packages/javascript/bh-shared-ui/src/views/OpenGraphManagement/SchemaUploadCard.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/OpenGraphManagement/SchemaUploadCard.tsx
@@ -15,10 +15,11 @@
 // SPDX-License-Identifier: Apache-2.0
 import { Card } from 'doodle-ui';
 import { SchemaUploadDialog } from '../../components/SchemaUploadDialog/SchemaUploadDialog';
+import { OUTLINED_CANVAS_SURFACE_CLASS } from '../../styles';
 
 export const SchemaUploadCard = () => {
     return (
-        <Card className='flex flex-col p-6 gap-4'>
+        <Card className={`${OUTLINED_CANVAS_SURFACE_CLASS} flex flex-col p-6 gap-4`}>
             <h2 className='text-xl font-bold'>Custom Schema Upload</h2>
             <p>
                 Upload custom schema JSON files to introduce new node and edge types. Then apply and validate schema

--- a/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/Details/Details.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/Details/Details.tsx
@@ -18,6 +18,7 @@ import { Alert, AlertTitle } from '@mui/material';
 import { AssetGroupTagMemberListItem } from 'js-client-library';
 import { FC } from 'react';
 import { useHighestPrivilegeTagId, useObjectCounts, usePZPathParams, useRuleInfo } from '../../../hooks';
+import { OUTLINED_CANVAS_SURFACE_CLASS } from '../../../styles';
 import { useAppNavigate } from '../../../utils';
 import { usePZContext } from '../PrivilegeZonesContext';
 import { PageDescription } from '../fragments';
@@ -63,7 +64,7 @@ const Details: FC = () => {
                 <InfoHeader />
             </div>
             <div className='flex gap-6 mt-4 h-full'>
-                <div className='flex flex-col bg-neutral-2 pt-4 rounded-lg shadow-outer-1 basis-2/3'>
+                <div className={`${OUTLINED_CANVAS_SURFACE_CLASS} flex flex-col pt-4 rounded-lg basis-2/3`}>
                     <h2 className='font-bold text-xl pl-4 mb-2'>{tagTypeDisplay} Details</h2>
                     <div className='flex flex-wrap justify-between w-full pb-6 border-b border-neutral-3 pl-4'>
                         <div className='flex gap-4 items-center'>

--- a/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/Details/DynamicDetails.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/Details/DynamicDetails.tsx
@@ -27,6 +27,7 @@ import { DateTime } from 'luxon';
 import { FC, useContext } from 'react';
 import { UseQueryResult } from 'react-query';
 import { useHighestPrivilegeTagId, useOwnedTagId, usePZPathParams, usePrivilegeZoneAnalysis } from '../../../hooks';
+import { OUTLINED_CANVAS_SURFACE_CLASS } from '../../../styles';
 import { LuxonFormat } from '../../../utils';
 import { PrivilegeZonesContext } from '../PrivilegeZonesContext';
 import PrivilegeZonesCypherEditor from '../PrivilegeZonesCypherEditor';
@@ -80,7 +81,7 @@ const TagDetails: FC<{ tagData: AssetGroupTag; hasObjectCountPanel: boolean }> =
         <div
             className='mb-8 flex max-h-full min-w-0 max-w-full flex-col gap-6'
             data-testid='privilege-zones_tag-details-card'>
-            <Card className='min-w-0 max-w-full overflow-hidden p-6'>
+            <Card className={`${OUTLINED_CANVAS_SURFACE_CLASS} min-w-0 max-w-full overflow-hidden p-6`}>
                 <div className='flex items-center min-w-0' title={name}>
                     {glyph && <ZoneIcon zone={tagData} persistGlyph size={20} wrapperClasses='shrink-0' />}
                     <span className='min-w-0 flex-1 truncate text-xl font-bold'>{name}</span>
@@ -131,7 +132,7 @@ const RuleDetails: FC<{ ruleData: AssetGroupTagSelector }> = ({ ruleData }) => {
 
     return (
         <div className='flex flex-col gap-6' data-testid='privilege-zones_selector-details-card'>
-            <Card className='p-6'>
+            <Card className={`${OUTLINED_CANVAS_SURFACE_CLASS} p-6`}>
                 <div className='text-xl font-bold break-all line-clamp-2' title={name}>
                     {name}
                 </div>
@@ -177,7 +178,7 @@ const DynamicDetails: FC<DynamicDetailsProps> = ({
         return <Skeleton className='p-6 h-52' />;
     } else if (isError) {
         return (
-            <Card className='p-6'>
+            <Card className={`${OUTLINED_CANVAS_SURFACE_CLASS} p-6`}>
                 <span className='text-base'>There was an error fetching this data</span>
             </Card>
         );

--- a/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/Details/ObjectCountPanel.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/Details/ObjectCountPanel.tsx
@@ -18,13 +18,17 @@ import { Badge, Card, Skeleton } from 'doodle-ui';
 import { FC } from 'react';
 import { NodeIcon } from '../../../components';
 import { useObjectCounts } from '../../../hooks/useAssetGroupTags/useObjectCounts';
+import { OUTLINED_CANVAS_SURFACE_CLASS } from '../../../styles';
 
 const ObjectCountPanel: FC = () => {
     const objectsCountQuery = useObjectCounts();
 
     if (objectsCountQuery.isLoading) {
         return (
-            <Card tabIndex={0} className='flex flex-col p-6 select-none' data-testid='privilege-zones_object-counts'>
+            <Card
+                tabIndex={0}
+                className={`${OUTLINED_CANVAS_SURFACE_CLASS} flex flex-col p-6 select-none`}
+                data-testid='privilege-zones_object-counts'>
                 <div className='flex justify-between items-center'>
                     <p>Total Count</p>
                     <Skeleton className='h-8 w-16' />
@@ -39,7 +43,10 @@ const ObjectCountPanel: FC = () => {
         );
     } else if (objectsCountQuery.isError) {
         return (
-            <Card tabIndex={0} className='flex flex-col p-6 select-none' data-testid='privilege-zones_object-counts'>
+            <Card
+                tabIndex={0}
+                className={`${OUTLINED_CANVAS_SURFACE_CLASS} flex flex-col p-6 select-none`}
+                data-testid='privilege-zones_object-counts'>
                 <div className='flex justify-between items-center'>
                     <p>Total Count</p>
                     <Badge label={'0'} />
@@ -54,7 +61,7 @@ const ObjectCountPanel: FC = () => {
         return (
             <Card
                 tabIndex={0}
-                className='flex flex-col p-6 select-none overflow-y-auto '
+                className={`${OUTLINED_CANVAS_SURFACE_CLASS} flex flex-col p-6 select-none overflow-y-auto`}
                 data-testid='privilege-zones_object-counts'>
                 <div className='flex justify-between items-center'>
                     <p>Total Count</p>

--- a/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/Details/SelectedDetails.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/Details/SelectedDetails.tsx
@@ -17,6 +17,7 @@
 import { FC } from 'react';
 import { EntityInfoDataTable, EntityInfoPanel } from '../../../components';
 import { useAssetGroupTagInfo, useGetNodeById, useMemberInfo, usePZPathParams, useRuleInfo } from '../../../hooks';
+import { OUTLINED_CANVAS_SURFACE_CLASS } from '../../../styles';
 import DynamicDetails from './DynamicDetails';
 import EntityRulesInformation from './EntityRulesInformation';
 
@@ -35,6 +36,7 @@ export const SelectedDetails: FC = () => {
             <div className='h-full'>
                 <EntityInfoPanel
                     selectedNode={selectedNode}
+                    surfaceClassName={OUTLINED_CANVAS_SURFACE_CLASS}
                     showPlaceholderMessage={true}
                     DataTable={EntityInfoDataTable}
                     additionalTables={[

--- a/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/Details/SelectedDetailsTabs/SelectedDetailsTabContent.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/Details/SelectedDetailsTabs/SelectedDetailsTabContent.tsx
@@ -17,6 +17,7 @@
 import { FC } from 'react';
 import { EntityInfoDataTable, EntityInfoPanel } from '../../../../components';
 import { useAssetGroupTagInfo, useGetNodeById, useMemberInfo, useRuleInfo } from '../../../../hooks';
+import { OUTLINED_CANVAS_SURFACE_CLASS } from '../../../../styles';
 import { DetailsTabOption, ObjectTabValue, RuleTabValue, TagTabValue } from '../../utils';
 import DynamicDetails from '../DynamicDetails';
 import EntityRulesInformation from '../EntityRulesInformation';
@@ -46,6 +47,7 @@ export const SelectedDetailsTabContent: FC<SelectedDetailsTabContent> = ({
             <div className='h-full'>
                 <EntityInfoPanel
                     selectedNode={selectedNode}
+                    surfaceClassName={OUTLINED_CANVAS_SURFACE_CLASS}
                     showPlaceholderMessage={true}
                     DataTable={EntityInfoDataTable}
                     additionalTables={[

--- a/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/History/HistoryContent.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/History/HistoryContent.tsx
@@ -18,6 +18,7 @@ import { Card, CardHeader, DataTable, Typography } from 'doodle-ui';
 import { useState } from 'react';
 import { SearchInput } from '../../../components/SearchInput';
 import { useInfiniteScroll } from '../../../hooks';
+import { CANVAS_TABLE_ROW_CLASS, OUTLINED_CANVAS_SURFACE_CLASS } from '../../../styles';
 import { measureElement } from '../utils';
 import { FilterDialog } from './FilterDialog';
 import HistoryNote from './HistoryNote';
@@ -32,7 +33,7 @@ const tableProps: DataTableProps['TableProps'] = {
 };
 
 const tableHeaderProps: DataTableProps['TableHeaderProps'] = {
-    className: 'sticky top-0 z-10 shadow-sm text-base',
+    className: 'sticky top-0 z-10 bg-neutral-2 text-base',
 };
 
 const tableHeadProps: DataTableProps['TableHeadProps'] = {
@@ -79,7 +80,7 @@ const HistoryContent = () => {
                 cleared.
             </p>
             <div data-testid='history-wrapper' className='flex gap-6 mt-4 h-[calc(100%-5rem)]'>
-                <Card className='flex flex-col'>
+                <Card className={`${OUTLINED_CANVAS_SURFACE_CLASS} flex flex-col`}>
                     <CardHeader className='flex-row ml-3 justify-between items-center'>
                         <Typography variant='h2'>History Log</Typography>
                         <div className='flex items-center'>
@@ -97,6 +98,7 @@ const HistoryContent = () => {
                         <DataTable
                             aria-label='History Log Table'
                             data={records}
+                            TableBodyRowProps={{ className: CANVAS_TABLE_ROW_CLASS }}
                             TableHeaderProps={tableHeaderProps}
                             TableHeadProps={tableHeadProps}
                             TableProps={tableProps}

--- a/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/History/HistoryNote.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/History/HistoryNote.tsx
@@ -17,6 +17,7 @@ import { Card, CardContent, CardFooter, CardTitle } from 'doodle-ui';
 import { DateTime } from 'luxon';
 import { LuxonFormat } from '../../..';
 import { AppIcon } from '../../../components';
+import { OUTLINED_CANVAS_SURFACE_CLASS } from '../../../styles';
 import { useHistoryTableContext } from './HistoryTableContext';
 
 const HistoryNote = () => {
@@ -24,7 +25,7 @@ const HistoryNote = () => {
 
     return (
         <div>
-            <Card className='flex justify-center mb-4 p-4 h-14'>
+            <Card className={`${OUTLINED_CANVAS_SURFACE_CLASS} flex justify-center mb-4 p-4 h-14`}>
                 <CardTitle className='flex items-center gap-2'>
                     <AppIcon.LinedPaper size={24} className='-mb-[3px]' />
                     Note
@@ -32,7 +33,7 @@ const HistoryNote = () => {
             </Card>
 
             {selected && (
-                <Card className='p-4'>
+                <Card className={`${OUTLINED_CANVAS_SURFACE_CLASS} p-4`}>
                     <CardContent>
                         <p className='text-xl'>{selected.note}</p>
                     </CardContent>

--- a/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/PrivilegeZonesCypherEditor/PrivilegeZonesCypherEditor.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/PrivilegeZonesCypherEditor/PrivilegeZonesCypherEditor.tsx
@@ -22,6 +22,7 @@ import { useLocation } from 'react-router-dom';
 import { TagLabelPrefix } from '../../../constants';
 import { useCypherSchema } from '../../../hooks/useGraphKinds';
 import { usePZPathParams } from '../../../hooks/usePZParams';
+import { OUTLINED_CANVAS_SURFACE_CLASS } from '../../../styles';
 import { cn } from '../../../utils';
 import { adaptClickHandlerToKeyDown } from '../../../utils/adaptClickHandlerToKeyDown';
 import { useRuleFormContext } from '../Save/RuleForm/RuleFormContext';
@@ -92,7 +93,7 @@ export const PrivilegeZonesCypherEditor: FC<{
     }, [cypherQuery, onChange]);
 
     return (
-        <Card className='mb-8'>
+        <Card className={`${OUTLINED_CANVAS_SURFACE_CLASS} mb-8`}>
             <CardHeader>
                 <div className='flex justify-between items-center px-6 pt-3'>
                     <CardTitle>{preview ? 'Cypher Preview' : 'Cypher Rule'}</CardTitle>

--- a/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/Save/RuleForm/BasicInfo.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/Save/RuleForm/BasicInfo.tsx
@@ -40,6 +40,7 @@ import { FC, useContext, useEffect } from 'react';
 import { Control } from 'react-hook-form';
 import { useLocation } from 'react-router-dom';
 import { useAssetGroupTagInfo, usePZPathParams } from '../../../../hooks';
+import { OUTLINED_CANVAS_SURFACE_CLASS } from '../../../../styles';
 import { queriesAreLoadingOrErrored } from '../../../../utils';
 import { PrivilegeZonesContext } from '../../PrivilegeZonesContext';
 import { useRuleFormContext } from './RuleFormContext';
@@ -69,7 +70,7 @@ const BasicInfo: FC<{ control: Control<RuleFormInputs, any, RuleFormInputs> }> =
 
     return (
         <div className={'max-lg:w-full w-96 h-[36rem]'}>
-            <Card className='p-3'>
+            <Card className={`${OUTLINED_CANVAS_SURFACE_CLASS} p-3`}>
                 <CardHeader className='text-xl font-bold'>Defining Rule</CardHeader>
                 <CardContent>
                     {ruleId !== '' && (

--- a/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/Save/RuleForm/ObjectSelect.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/Save/RuleForm/ObjectSelect.tsx
@@ -31,6 +31,7 @@ import {
 import { useState } from 'react';
 import ExploreSearchCombobox from '../../../../components/ExploreSearchCombobox';
 import NodeIcon from '../../../../components/NodeIcon';
+import { CANVAS_SURFACE_CLASS, CANVAS_TABLE_ROW_CLASS, OUTLINED_CANVAS_SURFACE_CLASS } from '../../../../styles';
 import { SearchValue } from '../../../Explore';
 import { useRuleFormContext } from './RuleFormContext';
 
@@ -48,7 +49,7 @@ const ObjectSelect = ({ errorMessage }: { errorMessage?: string }) => {
     };
 
     return (
-        <Card className='min-h-[33rem] h-[33rem]'>
+        <Card className={`${OUTLINED_CANVAS_SURFACE_CLASS} min-h-[33rem] h-[33rem]`}>
             <CardHeader className='px-6 first:pt-6 text-xl font-bold'>
                 <div className='flex justify-between'>
                     <span>Object Rule</span>
@@ -73,9 +74,12 @@ const ObjectSelect = ({ errorMessage }: { errorMessage?: string }) => {
                 </div>
                 <div className='h-[350px] overflow-auto'>
                     <Table className='w-full table-fixed' role='table' aria-label='Selected Objects'>
-                        <TableBody className='first:border-t-[1px] last:border-b-[1px] border-neutral-light-5 dark:border-netural-dark-5'>
+                        <TableBody
+                            className={`${CANVAS_SURFACE_CLASS} first:border-t-[1px] last:border-b-[1px] border-neutral-light-5 dark:border-neutral-900`}>
                             {selectedObjects.map((node, index) => (
-                                <TableRow key={node.objectid + index} className='p-0 *:p-0 *:h-12'>
+                                <TableRow
+                                    key={node.objectid + index}
+                                    className={`${CANVAS_TABLE_ROW_CLASS} p-0 *:p-0 *:h-12`}>
                                     <TableCell className='*:p-0 text-center w-[30px]'>
                                         <TextButton
                                             onClick={() => handleDeleteNode(node)}

--- a/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/Save/RuleForm/SeedSelection.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/Save/RuleForm/SeedSelection.tsx
@@ -38,6 +38,7 @@ import { Control } from 'react-hook-form';
 import { DeleteConfirmationDialog } from '../../../../components';
 import { encodeCypherQuery, useDeleteRule, usePZPathParams } from '../../../../hooks';
 import { useNotifications } from '../../../../providers';
+import { OUTLINED_CANVAS_SURFACE_CLASS } from '../../../../styles';
 import { cn, useAppNavigate } from '../../../../utils';
 import PrivilegeZonesCypherEditor from '../../PrivilegeZonesCypherEditor';
 import { handleError } from '../utils';
@@ -112,7 +113,7 @@ const SeedSelection: FC<{
                         </FormItem>
                     )}
                 />
-                <Card className='mb-5 pl-4 px-4 py-2'>
+                <Card className={`${OUTLINED_CANVAS_SURFACE_CLASS} mb-5 pl-4 px-4 py-2`}>
                     <CardHeader className='text-xl font-bold'>
                         <Label className='text-base font-bold' htmlFor='rule-seed-type-select'>
                             Rule Type

--- a/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/Save/RuleForm/SeedSelectionPreview.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/Save/RuleForm/SeedSelectionPreview.tsx
@@ -30,6 +30,7 @@ import { FC, useEffect } from 'react';
 import { useQuery } from 'react-query';
 import VirtualizedNodeList from '../../../../components/VirtualizedNodeList';
 import { useOwnedTagId, usePZPathParams } from '../../../../hooks';
+import { OUTLINED_CANVAS_SURFACE_CLASS } from '../../../../styles';
 import { apiClient, cn } from '../../../../utils';
 import { useRuleFormContext } from './RuleFormContext';
 
@@ -90,7 +91,8 @@ export const SeedSelectionPreview: FC<{ seeds: SelectorSeedRequest[]; ruleType: 
     }, [directObjects, expandedObjects, cypherQueryYieldsNoResults, dispatch, sampleResultsFetched]);
 
     return (
-        <Card className='xl:max-w-[26rem] sm:w-96 md:w-96 lg:w-lg grow max-lg:mb-10 2xl:max-w-full min-h-[36rem]'>
+        <Card
+            className={`${OUTLINED_CANVAS_SURFACE_CLASS} xl:max-w-[26rem] sm:w-96 md:w-96 lg:w-lg grow max-lg:mb-10 2xl:max-w-full min-h-[36rem]`}>
             <CardHeader className='pl-6 pr-6 first:py-6 text-xl font-bold'>
                 <div className='flex justify-between items-center min-h-10'>
                     <span>Sample Results</span>

--- a/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/Save/TagForm/TagForm.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/PrivilegeZones/Save/TagForm/TagForm.tsx
@@ -60,6 +60,7 @@ import {
     useTagsQuery,
 } from '../../../../hooks/useAssetGroupTags';
 import { useNotifications } from '../../../../providers';
+import { OUTLINED_CANVAS_SURFACE_CLASS } from '../../../../styles';
 import { useAppNavigate } from '../../../../utils';
 import { PrivilegeZonesContext } from '../../PrivilegeZonesContext';
 import { LabelsLink, ZonesLink } from '../../fragments';
@@ -281,7 +282,7 @@ export const TagForm: FC = () => {
         return (
             <form className='flex gap-x-6 mt-6'>
                 <div className='flex flex-col justify-between min-w-96 w-[672px]'>
-                    <Card className='p-3 mb-4'>
+                    <Card className={`${OUTLINED_CANVAS_SURFACE_CLASS} p-3 mb-4`}>
                         <CardHeader>
                             <CardTitle>{formTitle}</CardTitle>
                         </CardHeader>
@@ -406,7 +407,7 @@ export const TagForm: FC = () => {
             <Form {...form}>
                 <form className='flex gap-x-6 mt-6'>
                     <div className='flex flex-col justify-between min-w-96 w-[672px]'>
-                        <Card className='p-3 mb-4'>
+                        <Card className={`${OUTLINED_CANVAS_SURFACE_CLASS} p-3 mb-4`}>
                             <div className='flex flex-wrap justify-between items-center'>
                                 <CardHeader>
                                     <CardTitle>{formTitle}</CardTitle>

--- a/packages/javascript/bh-shared-ui/src/views/SSOConfiguration/SSOConfiguration.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/SSOConfiguration/SSOConfiguration.tsx
@@ -32,6 +32,7 @@ import {
 import { UpsertOIDCProviderDialog, UpsertSAMLProviderDialog } from '../../components/UpsertSSOProviders';
 import { useFeatureFlag, useMountEffect, usePermissions, useTheme } from '../../hooks';
 import { useNotifications } from '../../providers';
+import { CANVAS_MUI_TABLE_CLASS } from '../../styles';
 import { SortOrder } from '../../types';
 import { Permission, apiClient } from '../../utils';
 
@@ -283,7 +284,7 @@ const SSOConfiguration: FC = () => {
                         />
                     </Grid>
                     <Grid item xs={6}>
-                        <div className='bg-neutral-2 rounded-lg shadow-outer-1 pt-2'>
+                        <div className={`${CANVAS_MUI_TABLE_CLASS} rounded-lg pt-2`}>
                             <Box display='flex' justifyContent='space-between'>
                                 <Box className='flex items-center ml-6'>
                                     <Typography variant='h5'>Providers</Typography>

--- a/packages/javascript/bh-shared-ui/src/views/Users/Users.tsx
+++ b/packages/javascript/bh-shared-ui/src/views/Users/Users.tsx
@@ -33,6 +33,7 @@ import {
 import { useMountEffect, usePermissions, useToggle } from '../../hooks';
 import { useBloodHoundUsers, useSelf } from '../../hooks/useBloodHoundUsers';
 import { useNotifications } from '../../providers';
+import { CANVAS_MUI_TABLE_CLASS } from '../../styles';
 import { Permission, apiClient } from '../../utils';
 import UsersTable from './UsersTable';
 import { mapUserResponseToRequest } from './utils';
@@ -180,7 +181,7 @@ const Users: FC<{ showEnvironmentAccessControls?: boolean }> = ({ showEnvironmen
                         showEnvironmentAccessControls={showEnvironmentAccessControls}
                     />
                 </Box>
-                <Paper data-testid='manage-users_table'>
+                <Paper className={CANVAS_MUI_TABLE_CLASS} data-testid='manage-users_table' elevation={0}>
                     <UsersTable
                         onDeleteUser={toggleDeleteUserDialog}
                         onDisabledUser={toggleDisableUserDialog}


### PR DESCRIPTION
## Description

**Paired BHE PR:** https://github.com/SpecterOps/bloodhound-enterprise/pull/1919

This removes inconsistent elevated page containers and establishes one reusable visual contract across CE and Enterprise.

## How Has This Been Tested?

- Fresh independent enterprise review: **PASS with zero findings** at BHCE `d507c6c5dcf0d6214d9880c2e7db59f29e7893c7` on base `8d6d98eed34cc6b021a2b4641e32c54799f83edc` and paired BHE `a30becffe99270bec24f556e3952da351e4b6fc4` on base `94fb72e50750e3a8bdd22b7735d1a70184b7a91a`.
- Reviewer verified all six candidate commits are signed by `jkohler@specterops.io`, both repository ranges pass `git diff --check` and `git fsck --connectivity-only`, and the BHE gitlink exactly matches this reviewed BHCE head.
- Shared UI focused tests passed 16/16 and the shared no-emit TypeScript check passed.
- The paired BHE header test passed 1/1; focused changed-file lint and formatting passed.
- Broad sample-backed Playwright passed 20 routes in light and dark at 1440×900 plus five representative routes at 720×900, verifying canvas fills, outlines, zero page-surface shadows, focus, disabled semantics, table hover, populated data, and overflow.
- Browser diagnostics from the broad run found no actionable page errors, console errors, failed requests, or 5xx responses.

The full paired `just prepare-for-codereview` repeat was attempted after the latest refinement but stalled in unchanged BHCE dependency installation and was interrupted. During the independent review, full app-level no-emit TypeScript checks were stopped after extended silent execution with no diagnostics. GitHub CI remains authoritative.

## Screenshots

### Data Quality — dark desktop
<img width="1253" alt="Data Quality dark desktop" src="https://github.com/user-attachments/assets/6b4f017b-4b43-40d5-9647-b8c01d909741" />

### Group Management — dark desktop
<img width="1253" alt="Group Management dark desktop" src="https://github.com/user-attachments/assets/a2e70d9d-e6f0-41fd-be68-976041255306" />

### Privilege Zones — dark narrow
<img width="1253" alt="Privilege Zones dark narrow" src="https://github.com/user-attachments/assets/b65af199-e29d-4018-8c7b-f3e3228266af" />

## Types of changes

- Chore (a change that does not modify application functionality)

## Checklist

- [x] Associated Jira story: BED-9683
- [x] Documentation impact assessed; no OpenAPI changes required
- [x] Focused tests and broad browser validation completed
- [ ] Terminal GitHub CI passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Standardized cards, panels, forms, and empty states with consistent outlined canvas surfaces across the application.
  - Improved table styling with unified backgrounds, borders, row states, and reduced visual elevation, including dark-theme support.
  - Refined Swagger UI model and operation block presentation.

- **New Features**
  - Added reusable surface and table styling options for shared UI components.
  - Added customization support for accordion item and entity information panel surfaces.

- **Tests**
  - Added coverage for custom accordion and entity information panel surface styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


