### PR TITLE
feat(Nav): auto-expand/contract when resizing at breakpoint - BED-9547

### DIFF
--- a/packages/javascript/bh-shared-ui/src/components/Navigation/MainNav.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/Navigation/MainNav.test.tsx
@@ -188,28 +188,39 @@ describe('MainNav responsive expansion', () => {
         });
     });
 
-    it('contracts an expanded nav on initial load below the xl breakpoint', async () => {
+    it('preserves an expanded nav on initial load below the xl breakpoint', () => {
         createMatchMediaController(false);
         window.localStorage.setItem(NAV_EXPANDED_STORAGE_KEY, JSON.stringify(true));
 
         render(<MainNav mainNavData={mainNavData} />);
 
-        await waitFor(() => {
-            expect(screen.getByRole('button', { name: 'Toggle Navigation' })).toHaveAttribute('aria-expanded', 'false');
-            expect(window.localStorage.getItem(NAV_EXPANDED_STORAGE_KEY)).toBe(JSON.stringify(false));
-        });
+        expect(screen.getByRole('button', { name: 'Toggle Navigation' })).toHaveAttribute('aria-expanded', 'true');
+        expect(window.localStorage.getItem(NAV_EXPANDED_STORAGE_KEY)).toBe(JSON.stringify(true));
     });
 
-    it('expands a contracted nav on initial load at the xl breakpoint', async () => {
+    it('preserves a contracted nav on initial load at the xl breakpoint', () => {
         createMatchMediaController(true);
         window.localStorage.setItem(NAV_EXPANDED_STORAGE_KEY, JSON.stringify(false));
 
         render(<MainNav mainNavData={mainNavData} />);
 
-        await waitFor(() => {
-            expect(screen.getByRole('button', { name: 'Toggle Navigation' })).toHaveAttribute('aria-expanded', 'true');
-            expect(window.localStorage.getItem(NAV_EXPANDED_STORAGE_KEY)).toBe(JSON.stringify(true));
-        });
+        expect(screen.getByRole('button', { name: 'Toggle Navigation' })).toHaveAttribute('aria-expanded', 'false');
+        expect(window.localStorage.getItem(NAV_EXPANDED_STORAGE_KEY)).toBe(JSON.stringify(false));
+    });
+
+    it('preserves the user-selected state after a refresh without a breakpoint crossing', async () => {
+        const user = userEvent.setup();
+        createMatchMediaController(false);
+        const { unmount } = render(<MainNav mainNavData={mainNavData} />);
+
+        await user.click(screen.getByRole('button', { name: 'Toggle Navigation' }));
+
+        expect(window.localStorage.getItem(NAV_EXPANDED_STORAGE_KEY)).toBe(JSON.stringify(false));
+
+        unmount();
+        render(<MainNav mainNavData={mainNavData} />);
+
+        expect(screen.getByRole('button', { name: 'Toggle Navigation' })).toHaveAttribute('aria-expanded', 'false');
     });
 });
 

--- a/packages/javascript/bh-shared-ui/src/components/Navigation/MainNav.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/Navigation/MainNav.test.tsx
@@ -17,7 +17,9 @@
 import userEvent from '@testing-library/user-event';
 import { rest } from 'msw';
 import { setupServer } from 'msw/node';
-import { render, screen, within } from '../../test-utils';
+import { NAV_EXPANDED_STORAGE_KEY } from '../../hooks';
+import { act, render, screen, waitFor, within } from '../../test-utils';
+import { createMatchMediaController } from '../../testing';
 import { AppIcon } from '../AppIcon';
 import MainNav from './MainNav';
 import { MainNavData, MainNavDataListItem, MainNavLogoDataObject } from './types';
@@ -145,6 +147,69 @@ describe('MainNav', () => {
     it('should have a .z-nav class', () => {
         const navbarElement = screen.getByRole('navigation');
         expect(navbarElement).toHaveClass('z-nav');
+    });
+});
+
+describe('MainNav responsive expansion', () => {
+    afterEach(() => {
+        window.localStorage.clear();
+        vi.unstubAllGlobals();
+    });
+
+    it('contracts an expanded nav when the viewport shrinks below the xl breakpoint', async () => {
+        const matchMediaController = createMatchMediaController(true);
+        window.localStorage.setItem(NAV_EXPANDED_STORAGE_KEY, JSON.stringify(true));
+
+        render(<MainNav mainNavData={mainNavData} />);
+
+        expect(screen.getByRole('button', { name: 'Toggle Navigation' })).toHaveAttribute('aria-expanded', 'true');
+
+        act(() => matchMediaController.setMatches(false));
+
+        await waitFor(() => {
+            expect(screen.getByRole('button', { name: 'Toggle Navigation' })).toHaveAttribute('aria-expanded', 'false');
+            expect(window.localStorage.getItem(NAV_EXPANDED_STORAGE_KEY)).toBe(JSON.stringify(false));
+        });
+    });
+
+    it('expands a contracted nav when the viewport grows to the xl breakpoint', async () => {
+        const matchMediaController = createMatchMediaController(false);
+        window.localStorage.setItem(NAV_EXPANDED_STORAGE_KEY, JSON.stringify(false));
+
+        render(<MainNav mainNavData={mainNavData} />);
+
+        expect(screen.getByRole('button', { name: 'Toggle Navigation' })).toHaveAttribute('aria-expanded', 'false');
+
+        act(() => matchMediaController.setMatches(true));
+
+        await waitFor(() => {
+            expect(screen.getByRole('button', { name: 'Toggle Navigation' })).toHaveAttribute('aria-expanded', 'true');
+            expect(window.localStorage.getItem(NAV_EXPANDED_STORAGE_KEY)).toBe(JSON.stringify(true));
+        });
+    });
+
+    it('contracts an expanded nav on initial load below the xl breakpoint', async () => {
+        createMatchMediaController(false);
+        window.localStorage.setItem(NAV_EXPANDED_STORAGE_KEY, JSON.stringify(true));
+
+        render(<MainNav mainNavData={mainNavData} />);
+
+        await waitFor(() => {
+            expect(screen.getByRole('button', { name: 'Toggle Navigation' })).toHaveAttribute('aria-expanded', 'false');
+            expect(window.localStorage.getItem(NAV_EXPANDED_STORAGE_KEY)).toBe(JSON.stringify(false));
+        });
+    });
+
+    it('expands a contracted nav on initial load at the xl breakpoint', async () => {
+        createMatchMediaController(true);
+        window.localStorage.setItem(NAV_EXPANDED_STORAGE_KEY, JSON.stringify(false));
+
+        render(<MainNav mainNavData={mainNavData} />);
+
+        await waitFor(() => {
+            expect(screen.getByRole('button', { name: 'Toggle Navigation' })).toHaveAttribute('aria-expanded', 'true');
+            expect(window.localStorage.getItem(NAV_EXPANDED_STORAGE_KEY)).toBe(JSON.stringify(true));
+        });
     });
 });
 

--- a/packages/javascript/bh-shared-ui/src/components/Navigation/MainNav.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/Navigation/MainNav.tsx
@@ -17,10 +17,10 @@
 import { faCaretRight, faExternalLink } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { IconButton } from 'doodle-ui';
-import { FC, useMemo, useRef, useState } from 'react';
+import { FC, useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { useLocation } from 'react-router-dom';
-import { useApiVersion, useKeybindings, useNavExpanded } from '../../hooks';
+import { BREAKPOINTS, useApiVersion, useKeybindings, useMediaQuery, useNavExpanded } from '../../hooks';
 import { privilegeZonesPath } from '../../routes';
 import { cn, useAppNavigate } from '../../utils';
 import { adaptClickHandlerToKeyDown } from '../../utils/adaptClickHandlerToKeyDown';
@@ -160,6 +160,7 @@ const MainNavFooter: FC<{
 
 const MainNav: FC<{ mainNavData: MainNavData }> = ({ mainNavData }) => {
     const [isExpanded, setIsExpanded] = useNavExpanded();
+    const isExtraLargeViewport = useMediaQuery(`(min-width: ${BREAKPOINTS.xl})`);
     const navigate = useAppNavigate();
 
     const keybindings = useMemo(
@@ -181,6 +182,10 @@ const MainNav: FC<{ mainNavData: MainNavData }> = ({ mainNavData }) => {
     );
 
     useKeybindings(keybindings);
+
+    useEffect(() => {
+        setIsExpanded(isExtraLargeViewport);
+    }, [isExtraLargeViewport, setIsExpanded]);
 
     const handleToggleNav = () => setIsExpanded(!isExpanded);
 

--- a/packages/javascript/bh-shared-ui/src/components/Navigation/MainNav.tsx
+++ b/packages/javascript/bh-shared-ui/src/components/Navigation/MainNav.tsx
@@ -161,6 +161,7 @@ const MainNavFooter: FC<{
 const MainNav: FC<{ mainNavData: MainNavData }> = ({ mainNavData }) => {
     const [isExpanded, setIsExpanded] = useNavExpanded();
     const isExtraLargeViewport = useMediaQuery(`(min-width: ${BREAKPOINTS.xl})`);
+    const previousIsExtraLargeViewport = useRef(isExtraLargeViewport);
     const navigate = useAppNavigate();
 
     const keybindings = useMemo(
@@ -184,6 +185,9 @@ const MainNav: FC<{ mainNavData: MainNavData }> = ({ mainNavData }) => {
     useKeybindings(keybindings);
 
     useEffect(() => {
+        if (previousIsExtraLargeViewport.current === isExtraLargeViewport) return;
+
+        previousIsExtraLargeViewport.current = isExtraLargeViewport;
         setIsExpanded(isExtraLargeViewport);
     }, [isExtraLargeViewport, setIsExpanded]);
 

--- a/packages/javascript/bh-shared-ui/src/hooks/useMediaQuery/useMediaQuery.test.tsx
+++ b/packages/javascript/bh-shared-ui/src/hooks/useMediaQuery/useMediaQuery.test.tsx
@@ -1,0 +1,67 @@
+// Copyright 2026 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { act, renderHook } from '../../test-utils';
+import { createMatchMediaController } from '../../testing';
+import { useMediaQuery } from './useMediaQuery';
+
+const query = '(min-width: 1280px)';
+const alternateQuery = '(prefers-color-scheme: dark)';
+
+describe('useMediaQuery', () => {
+    afterEach(() => vi.unstubAllGlobals());
+
+    it('returns the current media-query match on initial render', () => {
+        createMatchMediaController(true);
+
+        const { result } = renderHook(() => useMediaQuery(query));
+
+        expect(result.current).toBe(true);
+    });
+
+    it('updates when the media-query match changes', () => {
+        const matchMediaController = createMatchMediaController(false);
+        const { result } = renderHook(() => useMediaQuery(query));
+
+        act(() => matchMediaController.setMatches(true));
+
+        expect(result.current).toBe(true);
+    });
+
+    it('keeps multiple media queries independent', () => {
+        const matchMediaController = createMatchMediaController({
+            [query]: false,
+            [alternateQuery]: true,
+        });
+        const { result } = renderHook(() => [useMediaQuery(query), useMediaQuery(alternateQuery)]);
+
+        act(() => matchMediaController.setMatches(true, query));
+
+        expect(result.current).toEqual([true, true]);
+    });
+
+    it('removes its change listener when unmounted', () => {
+        const matchMediaController = createMatchMediaController(false);
+        const { unmount } = renderHook(() => useMediaQuery(query));
+
+        unmount();
+
+        expect(matchMediaController.getMediaQueryList(query).removeEventListener).toHaveBeenCalledWith(
+            'change',
+            expect.any(Function)
+        );
+    });
+});

--- a/packages/javascript/bh-shared-ui/src/hooks/useMediaQuery/useMediaQuery.tsx
+++ b/packages/javascript/bh-shared-ui/src/hooks/useMediaQuery/useMediaQuery.tsx
@@ -26,8 +26,10 @@ export const BREAKPOINTS = {
     '3xl': '1920px',
 };
 
+const isMatchMediaAvailable = (): boolean => typeof window !== 'undefined' && typeof window.matchMedia === 'function';
+
 const getMediaQueryMatches = (query: string): boolean => {
-    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return false;
+    if (!isMatchMediaAvailable()) return false;
 
     return window.matchMedia(query).matches;
 };
@@ -36,7 +38,7 @@ export const useMediaQuery = (query: string): boolean => {
     const [matches, setMatches] = useState(() => getMediaQueryMatches(query));
 
     useEffect(() => {
-        if (typeof window.matchMedia !== 'function') return;
+        if (!isMatchMediaAvailable()) return;
 
         const mediaQueryList = window.matchMedia(query);
 

--- a/packages/javascript/bh-shared-ui/src/hooks/useMediaQuery/useMediaQuery.tsx
+++ b/packages/javascript/bh-shared-ui/src/hooks/useMediaQuery/useMediaQuery.tsx
@@ -26,13 +26,21 @@ export const BREAKPOINTS = {
     '3xl': '1920px',
 };
 
+const getMediaQueryMatches = (query: string): boolean => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return false;
+
+    return window.matchMedia(query).matches;
+};
+
 export const useMediaQuery = (query: string): boolean => {
-    const [matches, setMatches] = useState(false);
+    const [matches, setMatches] = useState(() => getMediaQueryMatches(query));
 
     useEffect(() => {
+        if (typeof window.matchMedia !== 'function') return;
+
         const mediaQueryList = window.matchMedia(query);
 
-        // Set initial value
+        // Reconcile the value if the query changed after the initial render.
         setMatches(mediaQueryList.matches);
 
         // Create a listener function

--- a/packages/javascript/bh-shared-ui/src/testing/testHelpers.ts
+++ b/packages/javascript/bh-shared-ui/src/testing/testHelpers.ts
@@ -16,6 +16,69 @@
 
 import { QueryClient, QueryKey } from 'react-query';
 
+type MediaQueryChangeListener = (event: MediaQueryListEvent) => void;
+type MockMediaQueryList = {
+    matches: boolean;
+    listeners: Set<MediaQueryChangeListener>;
+    addEventListener: ReturnType<typeof vi.fn>;
+    removeEventListener: ReturnType<typeof vi.fn>;
+};
+
+/**
+ * Installs a controllable `window.matchMedia` mock for tests that use media-query APIs.
+ * Each query receives an independent media-query list. Call `setMatches` to simulate
+ * crossing a breakpoint, then call `vi.unstubAllGlobals()` in test cleanup to restore
+ * the browser global.
+ */
+export const createMatchMediaController = (initialMatches: boolean | Record<string, boolean> = false) => {
+    const mediaQueryLists = new Map<string, MockMediaQueryList>();
+
+    const getInitialMatches = (query: string) =>
+        typeof initialMatches === 'boolean' ? initialMatches : initialMatches[query] ?? false;
+
+    const getMediaQueryList = (query: string): MockMediaQueryList => {
+        const existingMediaQueryList = mediaQueryLists.get(query);
+        if (existingMediaQueryList) return existingMediaQueryList;
+
+        const listeners = new Set<MediaQueryChangeListener>();
+        const mediaQueryList = {
+            matches: getInitialMatches(query),
+            listeners,
+            addEventListener: vi.fn((eventType: string, listener: EventListenerOrEventListenerObject) => {
+                if (eventType === 'change' && typeof listener === 'function') {
+                    listeners.add(listener as MediaQueryChangeListener);
+                }
+            }),
+            removeEventListener: vi.fn((eventType: string, listener: EventListenerOrEventListenerObject) => {
+                if (eventType === 'change' && typeof listener === 'function') {
+                    listeners.delete(listener as MediaQueryChangeListener);
+                }
+            }),
+        };
+
+        mediaQueryLists.set(query, mediaQueryList);
+
+        return mediaQueryList;
+    };
+
+    vi.stubGlobal(
+        'matchMedia',
+        vi.fn((query: string) => getMediaQueryList(query))
+    );
+
+    return {
+        getMediaQueryList,
+        setMatches: (matches: boolean, query?: string) => {
+            const selectedMediaQueryLists = query ? [getMediaQueryList(query)] : Array.from(mediaQueryLists.values());
+
+            selectedMediaQueryLists.forEach((mediaQueryList) => {
+                mediaQueryList.matches = matches;
+                mediaQueryList.listeners.forEach((listener) => listener({ matches } as MediaQueryListEvent));
+            });
+        },
+    };
+};
+
 /**
  * Tests interacting with a codemirror editor can output unwanted errors relating to missing DOM methods; running this
  * function in your test file will prevent those errors.


### PR DESCRIPTION
## Description

* Add automatic expand and collapse when resizing through large width breakpoint
    * When the user resizes the browser width to from less than 1280px to greater than, the nav menu will automatically expand
    * When the user resizes the browser width to from greater than 1280px to less than, the nav menu will automatically contract
    * If the nav is manually expanded/contracted after that, the setting will keep on refresh.

## Motivation and Context

Resolves BED-9547

*Why is this change required? What problem does it solve?*

## How Has This Been Tested?

Manual test and unit tests

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Navigation now automatically expands on extra-large screens and collapses on smaller screens.
  - Navigation responds when the browser crosses the extra-large breakpoint while preserving user-selected state when the breakpoint does not change.
  - Responsive navigation state is preserved during initial page loads and browser refreshes.

- **Bug Fixes**
  - Improved navigation behavior during window resizing.
  - Improved media-query handling when browser media-query APIs are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->