### PR TITLE
chore: Improve cross extension findings - BED-9566

### DIFF
--- a/cmd/api/src/database/migration/migrations/20260908174043_v9_all_cross_extension_findings.sql
+++ b/cmd/api/src/database/migration/migrations/20260908174043_v9_all_cross_extension_findings.sql
@@ -1,0 +1,44 @@
+-- +goose Up
+-- schema_findings.environment_id now stores the environment kind ID from dawgs rather than
+-- the schema_environments ID. This permits findings to reference environment kinds defined by another extension.
+ALTER TABLE schema_findings
+    DROP CONSTRAINT IF EXISTS schema_findings_environment_id_fkey;
+
+UPDATE schema_findings sf
+SET environment_id = se.environment_kind_id
+FROM schema_environments se
+WHERE sf.environment_id = se.id;
+
+ALTER TABLE schema_findings
+    ADD CONSTRAINT schema_findings_environment_id_fkey
+    FOREIGN KEY (environment_id) REFERENCES kind(id) ON DELETE RESTRICT;
+
+-- +goose Down
+-- A rollback would only work while every referenced environment kind still has a
+-- schema_environments mapping to restore the original foreign key.
+-- +goose StatementBegin
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM schema_findings sf
+        LEFT JOIN schema_environments se ON se.environment_kind_id = sf.environment_id
+        WHERE se.id IS NULL
+    ) THEN
+        RAISE EXCEPTION 'cannot restore schema_findings.environment_id to schema_environments: referenced environment kinds have no schema environment mapping';
+    END IF;
+END
+$$;
+-- +goose StatementEnd
+
+ALTER TABLE schema_findings
+    DROP CONSTRAINT IF EXISTS schema_findings_environment_id_fkey;
+
+UPDATE schema_findings sf
+SET environment_id = se.id
+FROM schema_environments se
+WHERE sf.environment_id = se.environment_kind_id;
+
+ALTER TABLE schema_findings
+    ADD CONSTRAINT schema_findings_environment_id_fkey
+    FOREIGN KEY (environment_id) REFERENCES schema_environments(id) ON DELETE CASCADE;

--- a/cmd/api/src/database/migration/migrations/20260908174043_v9_all_cross_extension_findings.sql
+++ b/cmd/api/src/database/migration/migrations/20260908174043_v9_all_cross_extension_findings.sql
@@ -1,3 +1,18 @@
+-- Copyright 2026 Specter Ops, Inc.
+--
+-- Licensed under the Apache License, Version 2.0
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- SPDX-License-Identifier: Apache-2.0
 -- +goose Up
 -- schema_findings.environment_id now stores the environment kind ID from dawgs rather than
 -- the schema_environments ID. This permits findings to reference environment kinds defined by another extension.

--- a/cmd/api/src/database/migration/migrations/20260908174043_v9_all_cross_extension_findings.sql
+++ b/cmd/api/src/database/migration/migrations/20260908174043_v9_all_cross_extension_findings.sql
@@ -29,8 +29,18 @@ ALTER TABLE schema_findings
     FOREIGN KEY (environment_id) REFERENCES kind(id) ON DELETE RESTRICT;
 
 -- +goose Down
--- A rollback would only work while every referenced environment kind still has a
--- schema_environments mapping to restore the original foreign key.
+-- The Down migration can restore the schema_finding only while every environment
+-- kind referenced by schema_findings has a corresponding schema_environments mapping. A
+-- rollback will fail if a finding references an environment kind whose owning extension
+-- was never installed or was later removed, because there is no schema environment ID to
+-- restore.
+--
+-- Recovering from this condition requires manually removing findings that do not have a
+-- corresponding schema_environments mapping, then retrying the rollback. Built-in and
+-- embedded extensions are not expected to encounter this condition because their
+-- environment kinds have schema_environments mappings. The risk is therefore limited to
+-- extensions that create findings for environment kinds whose owning extensions are
+-- absent during rollback.
 -- +goose StatementBegin
 DO $$
 BEGIN

--- a/cmd/api/src/database/upsert_schema_extension_integration_test.go
+++ b/cmd/api/src/database/upsert_schema_extension_integration_test.go
@@ -279,7 +279,7 @@ func TestBloodhoundDB_UpsertOpenGraphExtension(t *testing.T) {
 			},
 		},
 		{
-			name: "error_-_finding_has_invalid_environment_kind",
+			name: "success_-_finding_auto_registers_environment_kind",
 			setup: func(t *testing.T, testSuite IntegrationTestSuite) testSetupData {
 				t.Helper()
 				return testSetupData{
@@ -292,13 +292,49 @@ func TestBloodhoundDB_UpsertOpenGraphExtension(t *testing.T) {
 							{Name: "BadFEK_Finding1", DisplayName: "Finding 1", RelationshipKindName: "BadFEK_RK1", EnvironmentKindName: "NonExistentEnvKind", RemediationInput: model.RemediationInput{ShortDescription: "sd", LongDescription: "ld", ShortRemediation: "sr", LongRemediation: "lr"}},
 						},
 					},
-					wantErrContains: "error retrieving environment kind 'NonExistentEnvKind'",
 				}
 			},
 			assert: func(t *testing.T, testSuite IntegrationTestSuite, setupData testSetupData, updated bool, err error) {
 				t.Helper()
-				assert.ErrorContains(t, err, setupData.wantErrContains)
-				assertExtensionDoesNotExist(t, testSuite, setupData.input.ExtensionInput.Name)
+				require.NoError(t, err)
+				assert.False(t, updated)
+				assertGraphExtension(t, testSuite, setupData.input)
+			},
+		},
+		{
+			name: "success_-_finding_references_environment_kind_from_another_extension",
+			setup: func(t *testing.T, testSuite IntegrationTestSuite) testSetupData {
+				t.Helper()
+
+				providerInput := model.GraphExtensionInput{
+					ExtensionInput: model.ExtensionInput{Name: "EnvironmentProviderExt", DisplayName: "Environment Provider", Version: "1.0.0", Namespace: "ENV_PROVIDER"},
+					NodeKindsInput: model.NodesInput{
+						{Name: "ENV_PROVIDER_Principal", DisplayName: "Principal", IsDisplayKind: true, Icon: "user", IconColor: "#2779F5"},
+						{Name: "ENV_PROVIDER_Environment", DisplayName: "Environment", IsDisplayKind: false},
+					},
+					EnvironmentsInput: model.EnvironmentsInput{{
+						EnvironmentKindName: "ENV_PROVIDER_Environment",
+						SourceKindName:      "ENV_PROVIDER_Source",
+						PrincipalKinds:      []string{"ENV_PROVIDER_Principal"},
+					}},
+				}
+				_, err := testSuite.BHDatabase.UpsertOpenGraphExtension(testSuite.Context, providerInput)
+				require.NoError(t, err)
+
+				return testSetupData{
+					input: model.GraphExtensionInput{
+						ExtensionInput:            model.ExtensionInput{Name: "FindingConsumerExt", DisplayName: "Finding Consumer", Version: "1.0.0", Namespace: "FINDING_CONSUMER"},
+						NodeKindsInput:            model.NodesInput{{Name: "FINDING_CONSUMER_Principal", DisplayName: "Principal", IsDisplayKind: true, Icon: "user", IconColor: "#2779F5"}},
+						RelationshipKindsInput:    model.RelationshipsInput{{Name: "FINDING_CONSUMER_Relationship", Description: "relationship", IsTraversable: true}},
+						RelationshipFindingsInput: model.RelationshipFindingsInput{{Name: "FINDING_CONSUMER_Finding", DisplayName: "Cross-extension finding", RelationshipKindName: "FINDING_CONSUMER_Relationship", EnvironmentKindName: "ENV_PROVIDER_Environment", RemediationInput: model.RemediationInput{ShortDescription: "sd", LongDescription: "ld", ShortRemediation: "sr", LongRemediation: "lr"}}},
+					},
+				}
+			},
+			assert: func(t *testing.T, testSuite IntegrationTestSuite, setupData testSetupData, updated bool, err error) {
+				t.Helper()
+				require.NoError(t, err)
+				assert.False(t, updated)
+				assertGraphExtension(t, testSuite, setupData.input)
 			},
 		},
 		{
@@ -1014,9 +1050,7 @@ func assertFindings(t *testing.T, testSuite IntegrationTestSuite, extensionId in
 		require.Len(t, relKinds, 1)
 		assert.Equalf(t, wantFinding.RelationshipKindName, relKinds[0].Name, "Finding(%v) - relationship kind mismatch", gotFinding.Name)
 
-		findingEnv, err := testSuite.BHDatabase.GetEnvironmentById(testSuite.Context, gotFinding.EnvironmentId)
-		require.NoError(t, err)
-		envKinds, err := testSuite.BHDatabase.GetKindsByIDs(testSuite.Context, findingEnv.EnvironmentKindId)
+		envKinds, err := testSuite.BHDatabase.GetKindsByIDs(testSuite.Context, gotFinding.EnvironmentId)
 		require.NoError(t, err)
 		require.Len(t, envKinds, 1)
 		assert.Equalf(t, wantFinding.EnvironmentKindName, envKinds[0].Name, "Finding(%v) - environment kind mismatch", gotFinding.Name)

--- a/cmd/api/src/database/upsert_schema_finding.go
+++ b/cmd/api/src/database/upsert_schema_finding.go
@@ -25,33 +25,34 @@ import (
 )
 
 // resolveFindingFKs translates the FK names in a RelationshipFindingInput to their corresponding IDs.
+// To allow cross-extension findings, we upsert environment kinds if they have not been installed yet.
 func (s *BloodhoundDB) resolveFindingFKs(ctx context.Context, input model.RelationshipFindingInput) (int32, int32, error) {
 	if relKind, err := s.GetKindsByNames(ctx, input.RelationshipKindName); err != nil {
 		return 0, 0, fmt.Errorf("error retrieving relationship kind '%s': %w", input.RelationshipKindName, err)
-	} else if environment, err := s.GetEnvironmentKindName(ctx, input.EnvironmentKindName); err != nil {
-		return 0, 0, fmt.Errorf("error retrieving environment kind '%s': %w", input.EnvironmentKindName, err)
+	} else if environmentKind, err := s.UpsertKind(ctx, input.EnvironmentKindName); err != nil {
+		return 0, 0, fmt.Errorf("error registering environment kind '%s': %w", input.EnvironmentKindName, err)
 	} else {
-		return relKind[0].ID, environment.ID, nil
+		return relKind[0].ID, environmentKind.ID, nil
 	}
 }
 
 // applyFindingInput applies resolved FK IDs and mutable fields from input onto an existing finding,
 // returning the updated struct.
-func applyFindingInput(existing model.SchemaFinding, relKindId, environmentId int32, input model.RelationshipFindingInput) model.SchemaFinding {
+func applyFindingInput(existing model.SchemaFinding, relKindId, environmentKindId int32, input model.RelationshipFindingInput) model.SchemaFinding {
 	existing.Type = model.SchemaFindingTypeRelationship
 	existing.DisplayName = input.DisplayName
 	existing.PZDisplayName = null.NewString(input.PZDisplayName, input.PZDisplayName != "")
 	existing.KindId = relKindId
-	existing.EnvironmentId = environmentId
+	existing.EnvironmentId = environmentKindId
 	return existing
 }
 
 // CreateFindingWithRemediation translates FK names, creates the finding, and creates its 1:1 remediation.
 func (s *BloodhoundDB) CreateFindingWithRemediation(ctx context.Context, extensionId int32, input model.RelationshipFindingInput) (model.SchemaFinding, error) {
-	if relKindId, environmentId, err := s.resolveFindingFKs(ctx, input); err != nil {
+	if relKindId, environmentKindId, err := s.resolveFindingFKs(ctx, input); err != nil {
 		return model.SchemaFinding{}, err
 	} else if finding, err := s.CreateSchemaFinding(ctx, model.SchemaFindingTypeRelationship,
-		extensionId, relKindId, environmentId, input.Name, input.DisplayName, input.PZDisplayName); err != nil {
+		extensionId, relKindId, environmentKindId, input.Name, input.DisplayName, input.PZDisplayName); err != nil {
 		return model.SchemaFinding{}, fmt.Errorf("error creating finding: %w", err)
 	} else if _, err := s.CreateRemediation(ctx, finding.ID,
 		input.RemediationInput.ShortDescription, input.RemediationInput.LongDescription,
@@ -64,9 +65,9 @@ func (s *BloodhoundDB) CreateFindingWithRemediation(ctx context.Context, extensi
 
 // UpdateFindingWithRemediation translates FK names, updates the finding, and updates its 1:1 remediation.
 func (s *BloodhoundDB) UpdateFindingWithRemediation(ctx context.Context, existing model.SchemaFinding, input model.RelationshipFindingInput) (model.SchemaFinding, error) {
-	if relKindId, environmentId, err := s.resolveFindingFKs(ctx, input); err != nil {
+	if relKindId, environmentKindId, err := s.resolveFindingFKs(ctx, input); err != nil {
 		return model.SchemaFinding{}, err
-	} else if updated, err := s.UpdateSchemaFinding(ctx, applyFindingInput(existing, relKindId, environmentId, input)); err != nil {
+	} else if updated, err := s.UpdateSchemaFinding(ctx, applyFindingInput(existing, relKindId, environmentKindId, input)); err != nil {
 		return model.SchemaFinding{}, fmt.Errorf("error updating finding: %w", err)
 	} else if _, err := s.UpdateRemediation(ctx, updated.ID,
 		input.RemediationInput.ShortDescription, input.RemediationInput.LongDescription,

--- a/cmd/api/src/database/upsert_schema_finding_integration_test.go
+++ b/cmd/api/src/database/upsert_schema_finding_integration_test.go
@@ -111,10 +111,10 @@ func TestCreateFindingWithRemediation(t *testing.T) {
 			},
 		},
 		{
-			name: "error_-_invalid_environment_kind",
+			name: "success_-_auto_registers_environment_kind",
 			args: args{
-				name:                 "BadEnvKindFinding",
-				displayName:          "Bad Env Kind Finding",
+				name:                 "EnvKindFinding",
+				displayName:          "Env Kind Finding",
 				relationshipKindName: "TestRelationshipKind",
 				environmentKindName:  "KindThatDoesNotExist",
 			},
@@ -128,8 +128,11 @@ func TestCreateFindingWithRemediation(t *testing.T) {
 			},
 			assert: func(t *testing.T, db *database.BloodhoundDB, finding model.SchemaFinding, err error, args args) {
 				t.Helper()
-				require.ErrorContains(t, err, "error retrieving environment kind 'KindThatDoesNotExist'")
-				assert.Zero(t, finding.ID)
+				require.NoError(t, err)
+				environmentKinds, err := db.GetKindsByIDs(context.Background(), finding.EnvironmentId)
+				require.NoError(t, err)
+				require.Len(t, environmentKinds, 1)
+				assert.Equal(t, args.environmentKindName, environmentKinds[0].Name)
 			},
 		},
 	}
@@ -276,7 +279,7 @@ func TestUpdateFindingWithRemediation(t *testing.T) {
 			},
 		},
 		{
-			name: "error_-_invalid_environment_kind",
+			name: "success_-_auto_registers_environment_kind",
 			args: args{
 				newDisplayName:       "Updated Display",
 				relationshipKindName: "TestRelationshipKind",
@@ -315,8 +318,11 @@ func TestUpdateFindingWithRemediation(t *testing.T) {
 			},
 			assert: func(t *testing.T, db *database.BloodhoundDB, existing model.SchemaFinding, updated model.SchemaFinding, err error, args args) {
 				t.Helper()
-				require.ErrorContains(t, err, "error retrieving environment kind 'NonExistentEnvKind'")
-				assert.Zero(t, updated.ID)
+				require.NoError(t, err)
+				environmentKinds, err := db.GetKindsByIDs(context.Background(), updated.EnvironmentId)
+				require.NoError(t, err)
+				require.Len(t, environmentKinds, 1)
+				assert.Equal(t, args.environmentKindName, environmentKinds[0].Name)
 			},
 		},
 	}

--- a/cmd/api/src/model/graphschema.go
+++ b/cmd/api/src/model/graphschema.go
@@ -976,10 +976,7 @@ func (s GraphExtensionPayload) ToGraphExtensionInput() (GraphExtensionInput, err
 
 			var seeds = make([]SelectorSeedInput, 0, len(rulePayload.Seeds))
 			for _, seedPayload := range rulePayload.Seeds {
-				seeds = append(seeds, SelectorSeedInput{
-					Type:  seedPayload.Type,
-					Value: seedPayload.Value,
-				})
+				seeds = append(seeds, SelectorSeedInput(seedPayload))
 			}
 
 			graphExtension.PZRulesInput = append(graphExtension.PZRulesInput, PZRuleInput{
@@ -994,12 +991,7 @@ func (s GraphExtensionPayload) ToGraphExtensionInput() (GraphExtensionInput, err
 	if s.SavedQueries != nil {
 		graphExtension.SavedQueriesInput = make(SavedQueriesInput, 0, len(s.SavedQueries.Queries))
 		for _, queryPayload := range s.SavedQueries.Queries {
-			graphExtension.SavedQueriesInput = append(graphExtension.SavedQueriesInput, SavedQueryInput{
-				QueryKey:    queryPayload.QueryKey,
-				Name:        queryPayload.Name,
-				Query:       queryPayload.Query,
-				Description: queryPayload.Description,
-			})
+			graphExtension.SavedQueriesInput = append(graphExtension.SavedQueriesInput, SavedQueryInput(queryPayload))
 		}
 	}
 	return graphExtension, nil

--- a/cmd/api/src/model/graphschema.go
+++ b/cmd/api/src/model/graphschema.go
@@ -323,10 +323,11 @@ type SchemaFinding struct {
 	ID                int32
 	Type              SchemaFindingType
 	SchemaExtensionId int32
-	EnvironmentId     int32
-	KindId            int32
-	Name              string
-	DisplayName       string
+	// EnvironmentId stores the environment kind ID (DAWGs `kind` table)
+	EnvironmentId int32
+	KindId        int32
+	Name          string
+	DisplayName   string
 	// PZ Variant Display Title
 	PZDisplayName null.String
 	CreatedAt     time.Time


### PR DESCRIPTION
## Description
This migration changes the meaning of `schema_findings.environment_id`.
Before this change, it referenced `schema_environments.id`. After this change, it references the global DAWGS `kind.id` for the environment kind. This is required so a relationship finding can reference an environment declared by another extension, including when the "dependent" extension is loaded later.

**migration risk**
(imo low risk, with a known recovery path)
A rollback will fail if a schema_finding names an environment_kind whose owning extension is never installed, or is later removed. In either case, there is no "schema_environment" mapping to rollback to.

As currently written, the migration's Down path rejects rollback in that case. If the feature must be removed after deployment, the recovering from this exception would need manual remediation on any tenant that violates the condition above. Manual remediation would involve removing any schema_finding created that wouldn't have a corresponding schema_environment mapping.

Builtin extensions aren't victims of this problem, and embedded extensions aren't either (because all of these extensions have schema_environment mappings). So at the end of the day it really is an edge case, but due to the manual remediation required for a true rollback I want to call it out.

## Motivation and Context
Resolves BED-9566
It is hard to load extensions which contain hybrid findings. This work decouples extensions such that the upload order no longer matters.  It achieves this decoupling by removing the dependency that a relationship finding definition had on another extensions environment definitions. This coupling was fragile and unneccessary.

## How Has This Been Tested?
- the extension schema upsert unit and integration tests have been brought in to line with the new data model.

## Screenshots (optional):

## Types of changes

- Chore (a change that does not modify the application functionality)
- Database Migrations

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [ ] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [ ] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [ ] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Relationship findings can automatically register previously unknown environment kinds.
  * Findings can reference environment kinds supplied by other extensions.
  * Creating and updating findings no longer requires environment kinds to be configured in advance.

* **Bug Fixes**
  * Improved environment-kind resolution for relationship findings.
  * Finding references are preserved more safely when environments are removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->