### PR TITLE
fix: git log level for s3 diagnostics - BED-9700

### DIFF
--- a/cmd/api/src/services/storage/s3_ingest_diagnostics.go
+++ b/cmd/api/src/services/storage/s3_ingest_diagnostics.go
@@ -170,7 +170,7 @@ func (s awsS3OperationDiagnostic) finish(err error) {
 func logAWSConfigurationLoading(ctx context.Context, bucketConfiguration config.BucketConfiguration) {
 	slog.LogAttrs(
 		ctx,
-		slog.LevelInfo,
+		slog.LevelDebug,
 		"S3 ingest diagnostic: loading AWS configuration",
 		s3IngestDiagnosticAttributes(
 			slog.String("bucket", strings.TrimSpace(bucketConfiguration.Name)),
@@ -182,7 +182,7 @@ func logAWSConfigurationLoading(ctx context.Context, bucketConfiguration config.
 func logS3ClientInitialized(ctx context.Context, bucketConfiguration config.BucketConfiguration) {
 	slog.LogAttrs(
 		ctx,
-		slog.LevelInfo,
+		slog.LevelDebug,
 		"S3 ingest diagnostic: S3 client initialized",
 		s3IngestDiagnosticAttributes(
 			slog.String("bucket", strings.TrimSpace(bucketConfiguration.Name)),
@@ -211,7 +211,7 @@ func logFileServiceInitialized(ctx context.Context, bucketConfiguration config.B
 
 	slog.LogAttrs(
 		ctx,
-		slog.LevelInfo,
+		slog.LevelDebug,
 		"S3 ingest diagnostic: file service initialized",
 		s3IngestDiagnosticAttributes(attributes...)...,
 	)

--- a/cmd/api/src/services/upload/s3_ingest_diagnostics.go
+++ b/cmd/api/src/services/upload/s3_ingest_diagnostics.go
@@ -56,7 +56,7 @@ func startIngestUploadDiagnostic(ctx context.Context, jobID int64, fileType mode
 
 	slog.LogAttrs(
 		ctx,
-		slog.LevelInfo,
+		slog.LevelDebug,
 		"S3 ingest diagnostic: ingest upload started",
 		slog.String("diagnostic", s3IngestDiagnostic),
 		slog.String("request_id", requestID),
@@ -89,7 +89,7 @@ func (s ingestUploadDiagnostic) finish(tempFileName string, err error) {
 		return
 	}
 
-	slog.LogAttrs(s.ctx, slog.LevelInfo, "S3 ingest diagnostic: ingest upload stored and validated", attributes...)
+	slog.LogAttrs(s.ctx, slog.LevelDebug, "S3 ingest diagnostic: ingest upload stored and validated", attributes...)
 }
 
 func startIngestStorageWriteDiagnostic(ctx context.Context, prefix string) ingestStorageWriteDiagnostic {
@@ -110,7 +110,7 @@ func startIngestStorageWriteDiagnostic(ctx context.Context, prefix string) inges
 		attributes = append(attributes, slog.Time("context_deadline", deadline))
 	}
 
-	slog.LogAttrs(ctx, slog.LevelInfo, "S3 ingest diagnostic: ingest storage write started", attributes...)
+	slog.LogAttrs(ctx, slog.LevelDebug, "S3 ingest diagnostic: ingest storage write started", attributes...)
 
 	return ingestStorageWriteDiagnostic{
 		ctx:       ctx,
@@ -135,13 +135,13 @@ func (s ingestStorageWriteDiagnostic) finish(tempFileName string, err error) {
 		return
 	}
 
-	slog.LogAttrs(s.ctx, slog.LevelInfo, "S3 ingest diagnostic: ingest storage write returned", attributes...)
+	slog.LogAttrs(s.ctx, slog.LevelDebug, "S3 ingest diagnostic: ingest storage write returned", attributes...)
 }
 
 func startIngestTaskCreationDiagnostic(ctx context.Context, parameters IngestTaskParams) ingestTaskCreationDiagnostic {
 	slog.LogAttrs(
 		ctx,
-		slog.LevelInfo,
+		slog.LevelDebug,
 		"S3 ingest diagnostic: creating ingest task",
 		slog.String("diagnostic", s3IngestDiagnostic),
 		slog.String("request_id", parameters.RequestID),
@@ -173,5 +173,5 @@ func (s ingestTaskCreationDiagnostic) finish(err error) {
 		return
 	}
 
-	slog.LogAttrs(s.ctx, slog.LevelInfo, "S3 ingest diagnostic: ingest task created", attributes...)
+	slog.LogAttrs(s.ctx, slog.LevelDebug, "S3 ingest diagnostic: ingest task created", attributes...)
 }


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description
Lower the log level of S3 diagnostics to debug. 

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-9700

*Why is this change required? What problem does it solve?*

## How Has This Been Tested?

*Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc.*

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)
- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reduced the visibility of routine S3 ingest diagnostic messages by moving them from informational logs to debug logs.
  * Error messages remain unchanged and continue to be logged normally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->