### PR TITLE
chore(tests): Fix TestIngestionCoordinator Test Flapping BED-9625

### DIFF
--- a/cmd/api/src/daemons/changelog/ingestion_integration_test.go
+++ b/cmd/api/src/daemons/changelog/ingestion_integration_test.go
@@ -213,7 +213,6 @@ func TestIngestionCoordinator(t *testing.T) {
 						}))
 					require.True(t, coordinator.submit(ctx, change))
 				}
-				time.Sleep(200 * time.Millisecond)
 			},
 			assert: func(t *testing.T, suite IntegrationTestSuite, objectIDs []string) {
 				t.Helper()
@@ -237,7 +236,6 @@ func TestIngestionCoordinator(t *testing.T) {
 						}))
 					require.True(t, coordinator.submit(ctx, change))
 				}
-				time.Sleep(200 * time.Millisecond)
 			},
 			assert: func(t *testing.T, suite IntegrationTestSuite, objectIDs []string) {
 				t.Helper()
@@ -259,7 +257,6 @@ func TestIngestionCoordinator(t *testing.T) {
 						"lastseen": time.Now().UTC(),
 					}))
 				require.True(t, coordinator.submit(ctx, change))
-				time.Sleep(150 * time.Millisecond)
 			},
 			assert: func(t *testing.T, suite IntegrationTestSuite, objectIDs []string) {
 				t.Helper()
@@ -312,22 +309,32 @@ func TestIngestionCoordinator(t *testing.T) {
 func assertNodesExist(t *testing.T, suite IntegrationTestSuite, objectIDs []string) {
 	t.Helper()
 
-	var nodeCount int
-	filters := make([]graph.Criteria, 0, len(objectIDs))
-	for _, objectID := range objectIDs {
-		filters = append(filters, query.Equals(query.NodeProperty("objectid"), objectID))
-	}
+	var (
+		nodeCount int
+		readErr   error
+	)
 
-	err := suite.GraphDB.ReadTransaction(suite.Context, func(tx graph.Transaction) error {
-		return tx.Nodes().
-			Filter(query.Or(filters...)).
-			Fetch(func(cursor graph.Cursor[*graph.Node]) error {
-				for range cursor.Chan() {
-					nodeCount++
-				}
-				return cursor.Error()
-			})
-	})
-	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		nodeCount = 0
+		filters := make([]graph.Criteria, 0, len(objectIDs))
+		for _, objectID := range objectIDs {
+			filters = append(filters, query.Equals(query.NodeProperty("objectid"), objectID))
+		}
+
+		readErr = suite.GraphDB.ReadTransaction(suite.Context, func(tx graph.Transaction) error {
+			return tx.Nodes().
+				Filter(query.Or(filters...)).
+				Fetch(func(cursor graph.Cursor[*graph.Node]) error {
+					for range cursor.Chan() {
+						nodeCount++
+					}
+					return cursor.Error()
+				})
+		})
+
+		return readErr == nil && nodeCount == len(objectIDs)
+	}, 5*time.Second, 10*time.Millisecond,
+		"timed out waiting for ingested nodes: %v (found %d of %d)", readErr, nodeCount, len(objectIDs))
+	require.NoError(t, readErr)
 	require.Equal(t, len(objectIDs), nodeCount)
 }


### PR DESCRIPTION

<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

This removes the `time.Sleep` from some of the ingestion tests and replaces them with `require.Eventually` with the hopes that this removes the flapping test results that we see in CI

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-9625

*Why is this change required? What problem does it solve?*

## How Has This Been Tested?

Ran the integration tests multiple times locally and received no errors

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved ingestion integration test reliability by waiting for expected data to become available instead of relying on fixed delays.
  * Added clearer timeout diagnostics, including read errors and the number of nodes found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->