### PR TITLE
feat: config for experiment storage

### DIFF
--- a/cmd/api/src/config/config.go
+++ b/cmd/api/src/config/config.go
@@ -228,9 +228,16 @@ type BucketConfiguration struct {
 	Region string `json:"region"`
 }
 
+type ExperimentStorage struct {
+	Name   string `json:"name"`
+	Region string `json:"region"`
+	Prefix string `json:"prefix"`
+}
+
 type StorageConfiguration struct {
-	InstanceBucket BucketConfiguration                 `json:"instance_bucket"`
-	FileServices   map[string]FileServiceConfiguration `json:"file_services"`
+	InstanceBucket    BucketConfiguration                 `json:"instance_bucket"`
+	FileServices      map[string]FileServiceConfiguration `json:"file_services"`
+	ExperimentStorage ExperimentStorage                   `json:"experiments"`
 }
 
 type Configuration struct {

--- a/cmd/api/src/config/config_test.go
+++ b/cmd/api/src/config/config_test.go
@@ -208,6 +208,11 @@ func TestParseConfiguration_Storage(t *testing.T) {
 					"provider": "local",
 					"prefix": ""
 				}
+			},
+			"experiments": {
+				"name": "experiment-bucket",
+				"region": "us-west-2",
+				"prefix": "experiments"
 			}
 		}
 	}`))
@@ -222,6 +227,11 @@ func TestParseConfiguration_Storage(t *testing.T) {
 	assert.Equal(t, config.FileServiceConfiguration{
 		Provider: "local",
 	}, configuration.Storage.FileServices["work"])
+	assert.Equal(t, config.ExperimentStorage{
+		Name:   "experiment-bucket",
+		Region: "us-west-2",
+		Prefix: "experiments",
+	}, configuration.Storage.ExperimentStorage)
 }
 
 func TestParseConfiguration_DefaultAdminEnabled(t *testing.T) {


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

*Describe your changes in detail*

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves <TICKET_OR_ISSUE_NUMBER>

*Why is this change required? What problem does it solve?*

## How Has This Been Tested?

*Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc.*

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)
- Database Migrations

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [ ] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [ ] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [ ] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration support for dedicated experiment storage, including storage name, region, and path prefix settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->