### PR TITLE
fix: Failure to create cypher query audit log: context canceled BED-8525

### DIFF
--- a/cmd/api/src/api/v2/cypherquery.go
+++ b/cmd/api/src/api/v2/cypherquery.go
@@ -36,7 +36,7 @@ import (
 	"github.com/specterops/dawgs/util"
 )
 
-const auditLogOutcomeTimeout = time.Second
+const auditLogOutcomeTimeout = time.Second * 30
 
 var errUnauthorizedGraphMutation = errors.New("unauthorized graph mutation")
 

--- a/cmd/api/src/api/v2/cypherquery.go
+++ b/cmd/api/src/api/v2/cypherquery.go
@@ -17,11 +17,13 @@
 package v2
 
 import (
+	"context"
 	"errors"
 	"log/slog"
 	"maps"
 	"net/http"
 	"slices"
+	"time"
 
 	"github.com/specterops/bloodhound/cmd/api/src/api"
 	"github.com/specterops/bloodhound/cmd/api/src/auth"
@@ -33,6 +35,8 @@ import (
 	"github.com/specterops/dawgs/ops"
 	"github.com/specterops/dawgs/util"
 )
+
+const auditLogOutcomeTimeout = time.Second
 
 var errUnauthorizedGraphMutation = errors.New("unauthorized graph mutation")
 
@@ -148,7 +152,10 @@ func (s Resources) CypherQuery(response http.ResponseWriter, request *http.Reque
 	auditLogEntry.Status = model.AuditLogStatusFailure
 
 	defer func() {
-		if err = s.DB.AppendAuditLog(request.Context(), auditLogEntry); err != nil {
+		auditContext, cancelAudit := context.WithTimeout(context.WithoutCancel(request.Context()), auditLogOutcomeTimeout)
+		defer cancelAudit()
+
+		if err = s.DB.AppendAuditLog(auditContext, auditLogEntry); err != nil {
 			slog.ErrorContext(request.Context(), "Failure to create run cypher query audit log", attr.Error(err))
 		}
 	}()
@@ -230,15 +237,19 @@ func (s Resources) cypherMutation(request *http.Request, primaryDisplayKinds gra
 		return model.UnifiedGraph{}, err
 	}
 
-	if graphResponse, err = s.GraphQuery.RawCypherQuery(request.Context(), primaryDisplayKinds, preparedQuery, includeProperties); err != nil {
-		auditLogEntry.Status = model.AuditLogStatusFailure
-	} else {
-		auditLogEntry.Status = model.AuditLogStatusSuccess
-	}
+	auditLogEntry.Status = model.AuditLogStatusFailure
+	defer func() {
+		auditContext, cancelAudit := context.WithTimeout(context.WithoutCancel(request.Context()), auditLogOutcomeTimeout)
+		defer cancelAudit()
 
-	if err := s.DB.AppendAuditLog(request.Context(), auditLogEntry); err != nil {
-		// We want to keep err scoped because having info on the mutation graph response trumps this error
-		slog.ErrorContext(request.Context(), "Failure to create mutation audit log", attr.Error(err))
+		if auditErr := s.DB.AppendAuditLog(auditContext, auditLogEntry); auditErr != nil {
+			// We want to keep the graph response error because it is more useful to the caller than an audit log error.
+			slog.ErrorContext(request.Context(), "Failure to create mutation audit log", attr.Error(auditErr))
+		}
+	}()
+
+	if graphResponse, err = s.GraphQuery.RawCypherQuery(request.Context(), primaryDisplayKinds, preparedQuery, includeProperties); err == nil {
+		auditLogEntry.Status = model.AuditLogStatusSuccess
 	}
 
 	return graphResponse, err

--- a/cmd/api/src/api/v2/cypherquery_test.go
+++ b/cmd/api/src/api/v2/cypherquery_test.go
@@ -38,6 +38,7 @@ import (
 
 	v2 "github.com/specterops/bloodhound/cmd/api/src/api/v2"
 	"github.com/specterops/bloodhound/cmd/api/src/auth"
+	"github.com/specterops/bloodhound/cmd/api/src/bhctx"
 	dbmocks "github.com/specterops/bloodhound/cmd/api/src/database/mocks"
 	"github.com/specterops/bloodhound/cmd/api/src/model"
 	"github.com/specterops/bloodhound/cmd/api/src/queries"
@@ -735,42 +736,89 @@ func TestResources_CypherQuery(t *testing.T) {
 }
 
 func TestResources_CypherQuery_CanceledRequestKeepsAuditOutcomeContextActive(t *testing.T) {
-	var (
-		mockController                = gomock.NewController(t)
-		mockDatabase                  = dbmocks.NewMockDatabase(mockController)
-		mockGraphQuery                = mocks.NewMockGraph(mockController)
-		requestContext, ctxCancelFunc = context.WithCancel(setupUserCtx(model.User{AllEnvironments: true}))
-		request                       = httptest.NewRequest(http.MethodPost, "/api/v2/graphs/cypher", bytes.NewBufferString(`{"query":"query","include_properties":true}`)).WithContext(requestContext)
-		auditOutcomeContextErr        error
-	)
-	defer ctxCancelFunc()
-
-	request.Header.Set(headers.ContentType.String(), "application/json")
-
-	mockGraphQuery.EXPECT().PrepareCypherQuery("query", int64(queries.DefaultQueryFitnessLowerBoundExplore)).Return(queries.PreparedQuery{
-		StrippedQuery: "query",
-	}, nil)
-	mockDatabase.EXPECT().AppendAuditLog(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, entry model.AuditEntry) error {
-		if entry.Action == model.AuditLogActionRunCypherQuery && entry.Status == model.AuditLogStatusFailure {
-			// cache the context error from the audit outcome write to assert that it is not canceled
-			auditOutcomeContextErr = ctx.Err()
-		}
-		return nil
-	}).Times(2)
-	mockDatabase.EXPECT().GetPrimaryDisplayKinds(gomock.Any()).Return(graphschema.PrimaryDisplayKinds{}, nil)
-	mockGraphQuery.EXPECT().RawCypherQuery(gomock.Any(), gomock.Any(), gomock.Any(), true).DoAndReturn(func(context.Context, graphschema.PrimaryDisplayKinds, queries.PreparedQuery, bool) (model.UnifiedGraph, error) {
-		// cancel the context within the cypher query execution
-		ctxCancelFunc()
-		return model.UnifiedGraph{}, context.Canceled
-	})
-
-	resources := v2.Resources{
-		GraphQuery: mockGraphQuery,
-		DB:         mockDatabase,
-		Authorizer: auth.NewAuthorizer(mockDatabase),
-		DogTags:    dogtags.NewTestService(dogtags.TestOverrides{}),
+	type mock struct {
+		database   *dbmocks.MockDatabase
+		graphQuery *mocks.MockGraph
 	}
-	resources.CypherQuery(httptest.NewRecorder(), request)
+	type auditOutcome struct {
+		contextErr error
+		recorded   bool
+	}
+	type testData struct {
+		name       string
+		setupMocks func(context.Context, context.CancelFunc, mock, *auditOutcome)
+	}
 
-	assert.NoError(t, auditOutcomeContextErr, "the audit outcome write must not inherit a canceled request context")
+	testCases := []testData{
+		{
+			name: "Query",
+			setupMocks: func(_ context.Context, ctxCancelFunc context.CancelFunc, mocks mock, auditOutcome *auditOutcome) {
+				mocks.graphQuery.EXPECT().PrepareCypherQuery("query", int64(queries.DefaultQueryFitnessLowerBoundExplore)).Return(queries.PreparedQuery{StrippedQuery: "query"}, nil)
+				mocks.database.EXPECT().AppendAuditLog(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, entry model.AuditEntry) error {
+					if entry.Action == model.AuditLogActionRunCypherQuery && entry.Status == model.AuditLogStatusFailure {
+						auditOutcome.contextErr = ctx.Err()
+						auditOutcome.recorded = true
+					}
+					return nil
+				}).Times(2)
+				mocks.database.EXPECT().GetPrimaryDisplayKinds(gomock.Any()).Return(graphschema.PrimaryDisplayKinds{}, nil)
+				mocks.graphQuery.EXPECT().RawCypherQuery(gomock.Any(), gomock.Any(), gomock.Any(), true).DoAndReturn(func(context.Context, graphschema.PrimaryDisplayKinds, queries.PreparedQuery, bool) (model.UnifiedGraph, error) {
+					ctxCancelFunc()
+					return model.UnifiedGraph{}, context.Canceled
+				})
+			},
+		},
+		{
+			name: "Mutation",
+			setupMocks: func(requestContext context.Context, ctxCancelFunc context.CancelFunc, mocks mock, auditOutcome *auditOutcome) {
+				bhctx.Get(requestContext).AuthCtx.PermissionOverrides = auth.PermissionOverrides{
+					Enabled:     true,
+					Permissions: model.Permissions{auth.Permissions().GraphDBMutate},
+				}
+				mocks.graphQuery.EXPECT().PrepareCypherQuery("query", int64(queries.DefaultQueryFitnessLowerBoundExplore)).Return(queries.PreparedQuery{
+					StrippedQuery: "query",
+					HasMutation:   true,
+				}, nil)
+				mocks.database.EXPECT().AppendAuditLog(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, entry model.AuditEntry) error {
+					if entry.Action == model.AuditLogActionMutateGraph && entry.Status == model.AuditLogStatusFailure {
+						auditOutcome.contextErr = ctx.Err()
+						auditOutcome.recorded = true
+					}
+					return nil
+				}).Times(4)
+				mocks.database.EXPECT().GetPrimaryDisplayKinds(gomock.Any()).Return(graphschema.PrimaryDisplayKinds{}, nil)
+				mocks.graphQuery.EXPECT().RawCypherQuery(gomock.Any(), gomock.Any(), gomock.Any(), true).DoAndReturn(func(context.Context, graphschema.PrimaryDisplayKinds, queries.PreparedQuery, bool) (model.UnifiedGraph, error) {
+					ctxCancelFunc()
+					return model.UnifiedGraph{}, context.Canceled
+				})
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			var (
+				mockController                = gomock.NewController(t)
+				mocks                         = mock{database: dbmocks.NewMockDatabase(mockController), graphQuery: mocks.NewMockGraph(mockController)}
+				requestContext, ctxCancelFunc = context.WithCancel(setupUserCtx(model.User{AllEnvironments: true}))
+				request                       = httptest.NewRequest(http.MethodPost, "/api/v2/graphs/cypher", bytes.NewBufferString(`{"query":"query","include_properties":true}`)).WithContext(requestContext)
+				auditOutcome                  auditOutcome
+			)
+			defer ctxCancelFunc()
+
+			request.Header.Set(headers.ContentType.String(), "application/json")
+			testCase.setupMocks(requestContext, ctxCancelFunc, mocks, &auditOutcome)
+
+			resources := v2.Resources{
+				GraphQuery: mocks.graphQuery,
+				DB:         mocks.database,
+				Authorizer: auth.NewAuthorizer(mocks.database),
+				DogTags:    dogtags.NewTestService(dogtags.TestOverrides{}),
+			}
+			resources.CypherQuery(httptest.NewRecorder(), request)
+
+			assert.True(t, auditOutcome.recorded, "the %s audit outcome must be recorded", testCase.name)
+			assert.NoError(t, auditOutcome.contextErr, "the %s audit outcome write must not inherit a canceled request context", testCase.name)
+		})
+	}
 }

--- a/cmd/api/src/api/v2/cypherquery_test.go
+++ b/cmd/api/src/api/v2/cypherquery_test.go
@@ -18,6 +18,7 @@ package v2_test
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"io"
@@ -731,4 +732,45 @@ func TestResources_CypherQuery(t *testing.T) {
 			assert.JSONEq(t, testCase.expected.responseBody, body)
 		})
 	}
+}
+
+func TestResources_CypherQuery_CanceledRequestKeepsAuditOutcomeContextActive(t *testing.T) {
+	var (
+		mockController                = gomock.NewController(t)
+		mockDatabase                  = dbmocks.NewMockDatabase(mockController)
+		mockGraphQuery                = mocks.NewMockGraph(mockController)
+		requestContext, ctxCancelFunc = context.WithCancel(setupUserCtx(model.User{AllEnvironments: true}))
+		request                       = httptest.NewRequest(http.MethodPost, "/api/v2/graphs/cypher", bytes.NewBufferString(`{"query":"query","include_properties":true}`)).WithContext(requestContext)
+		auditOutcomeContextErr        error
+	)
+	defer ctxCancelFunc()
+
+	request.Header.Set(headers.ContentType.String(), "application/json")
+
+	mockGraphQuery.EXPECT().PrepareCypherQuery("query", int64(queries.DefaultQueryFitnessLowerBoundExplore)).Return(queries.PreparedQuery{
+		StrippedQuery: "query",
+	}, nil)
+	mockDatabase.EXPECT().AppendAuditLog(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, entry model.AuditEntry) error {
+		if entry.Action == model.AuditLogActionRunCypherQuery && entry.Status == model.AuditLogStatusFailure {
+			// cache the context error from the audit outcome write to assert that it is not canceled
+			auditOutcomeContextErr = ctx.Err()
+		}
+		return nil
+	}).Times(2)
+	mockDatabase.EXPECT().GetPrimaryDisplayKinds(gomock.Any()).Return(graphschema.PrimaryDisplayKinds{}, nil)
+	mockGraphQuery.EXPECT().RawCypherQuery(gomock.Any(), gomock.Any(), gomock.Any(), true).DoAndReturn(func(context.Context, graphschema.PrimaryDisplayKinds, queries.PreparedQuery, bool) (model.UnifiedGraph, error) {
+		// cancel the context within the cypher query execution
+		ctxCancelFunc()
+		return model.UnifiedGraph{}, context.Canceled
+	})
+
+	resources := v2.Resources{
+		GraphQuery: mockGraphQuery,
+		DB:         mockDatabase,
+		Authorizer: auth.NewAuthorizer(mockDatabase),
+		DogTags:    dogtags.NewTestService(dogtags.TestOverrides{}),
+	}
+	resources.CypherQuery(httptest.NewRecorder(), request)
+
+	assert.NoError(t, auditOutcomeContextErr, "the audit outcome write must not inherit a canceled request context")
 }


### PR DESCRIPTION
## Description

If a request context is cancelled after the audit log intent is written, it's possible for the audit log result to not get written since it's running under the same context. 

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves https://specterops.atlassian.net/browse/BED-8525


## How Has This Been Tested?

Tests have been added to demonstrate the issue for the cypher endpoint is resolved. 

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved audit-log reliability for graph queries and mutations when requests are canceled or interrupted.
  - Audit records now capture failed outcomes by default and update to successful only after execution completes successfully.
  - Audit-log updates use a bounded timeout, preventing them from delaying requests indefinitely.
  - Original graph query errors are preserved even if recording the audit outcome encounters an error.
  - Ensured audit outcomes remain recorded even after the originating request is canceled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->