### PR TITLE
feat(ui): Add collector job secret client APIs BED-9727

### DIFF
--- a/packages/javascript/js-client-library/src/client.ts
+++ b/packages/javascript/js-client-library/src/client.ts
@@ -23,6 +23,7 @@ import {
     CreateAssetGroupTagRequest,
     CreateAzureHoundClientRequest,
     CreateAzureHoundEventRequest,
+    CreateCollectorJobSecretRequest,
     CreateOIDCProviderRequest,
     CreateOpenHoundClientRequest,
     CreateScheduledJobRequest,
@@ -76,6 +77,7 @@ import {
     BasicResponse,
     CreateAlertResponse,
     CreateAuthTokenResponse,
+    CreateCollectorJobSecretResponse,
     CreateWebhookResponse,
     DatapipeStatusResponse,
     EndFileIngestResponse,
@@ -90,6 +92,7 @@ import {
     GetClientResponse,
     GetCollectorJobProfilesResponse,
     GetCollectorJobScheduleResponse,
+    GetCollectorJobSecretResponse,
     GetCollectorsResponse,
     GetCommunityCollectorsResponse,
     GetConfigurationResponse,
@@ -832,6 +835,12 @@ class BHEAPIClient {
             { job_profile_id: profileId },
             options
         );
+
+    getCollectorJobSecret = (secretId: string, options?: RequestOptions) =>
+        this.baseClient.get<GetCollectorJobSecretResponse>(`/api/v2/collector-job-secrets/${secretId}`, options);
+
+    createCollectorJobSecret = (request: CreateCollectorJobSecretRequest, options?: RequestOptions) =>
+        this.baseClient.post<CreateCollectorJobSecretResponse>('/api/v2/collector-job-secrets', request, options);
 
     /* clients */
 

--- a/packages/javascript/js-client-library/src/requests.ts
+++ b/packages/javascript/js-client-library/src/requests.ts
@@ -24,6 +24,7 @@ import {
     AuthenticationMethod,
     CertificationManual,
     CertificationRevoked,
+    CollectorJobSecret,
     SeedExpansionMethod,
     SSOProviderConfiguration,
     WebhookType,
@@ -382,3 +383,10 @@ export interface AlertRetryRequest {
     channel_id: string;
     event_id: string;
 }
+
+// ---------------------------------------------------------------------------
+//  Collectors - Managed Collections
+// ---------------------------------------------------------------------------
+export type CreateCollectorJobSecretRequest = Pick<CollectorJobSecret, 'type' | 'key_id' | 'display_key_id'> & {
+    value: string;
+};

--- a/packages/javascript/js-client-library/src/responses.ts
+++ b/packages/javascript/js-client-library/src/responses.ts
@@ -30,6 +30,7 @@ import {
     CollectorJobHistory,
     CollectorJobProfile,
     CollectorJobSchedule,
+    CollectorJobSecret,
     CollectorManifest,
     CommunityCollectorType,
     CustomNodeKindType,
@@ -369,8 +370,14 @@ export type GetScheduledJobDisplayResponse = PaginatedResponse<ScheduledJobDispl
 
 export type GetExportQueryResponse = AxiosResponse<Blob>;
 
+// ---------------------------------------------------------------------------
+//  Collectors - Clients
+// ---------------------------------------------------------------------------
 export type GetClientResponse = PaginatedResponse<Client[]>;
 
+// ---------------------------------------------------------------------------
+//  Collectors - Managed Collections
+// ---------------------------------------------------------------------------
 export type GetCollectorJobProfilesResponse = PaginatedResponse<{ profiles: CollectorJobProfile[] }>;
 
 export type GetCollectorJobScheduleResponse = BasicResponse<{ schedule: CollectorJobSchedule }>;
@@ -379,6 +386,13 @@ export type GetLatestCollectorJobHistoryResponse = PaginatedResponse<{ records: 
 
 export type RunCollectorJobProfileResponse = BasicResponse<{ job: CollectorJob }>;
 
+export type GetCollectorJobSecretResponse = BasicResponse<{ secret: CollectorJobSecret }>;
+
+export type CreateCollectorJobSecretResponse = BasicResponse<{ secret: CollectorJobSecret }>;
+
+// ---------------------------------------------------------------------------
+//  Collectors - Support Bundles (Management Operations)
+// ---------------------------------------------------------------------------
 export enum ManagementOperationStatus {
     QUEUED = 'queued',
     RUNNING = 'running',
@@ -419,6 +433,7 @@ export type SupportBundleDownloadURLResponse = BasicResponse<{
     file_name: string;
     size: number;
 }>;
+// ---------------------------------------------------------------------------
 
 export type EdgeType = {
     id: number;

--- a/packages/javascript/js-client-library/src/types.ts
+++ b/packages/javascript/js-client-library/src/types.ts
@@ -1005,9 +1005,14 @@ export type RelationshipDetailsWithInfo = RelationshipDetails & {
     info?: RelationshipKindInfo;
 };
 
+// While this only has one currently, there will be more in the future, so we're doing this now to make that easier.
+export enum CollectorJobSecretType {
+    AuthKey = 'auth_key',
+}
+
 export interface CollectorJobSecret {
     id: string;
-    type: 'auth_key';
+    type: CollectorJobSecretType;
     key_id: string;
     display_key_id: string;
     created_at: string;

--- a/packages/javascript/js-client-library/src/types.ts
+++ b/packages/javascript/js-client-library/src/types.ts
@@ -1005,6 +1005,14 @@ export type RelationshipDetailsWithInfo = RelationshipDetails & {
     info?: RelationshipKindInfo;
 };
 
+export interface CollectorJobSecret {
+    id: string;
+    type: 'auth_key';
+    key_id: string;
+    display_key_id: string;
+    created_at: string;
+}
+
 export interface CollectorJobProfileMinimal {
     id: number;
     name: string;


### PR DESCRIPTION
## Description

Adds typed collector job-secret models and client methods for retrieving and creating managed-collection job secrets.

## Motivation and Context

Resolves BED-9727

Provides the JavaScript client-library surface needed to manage collector job secrets.

## How Has This Been Tested?

Will be tested in associated BHE ticket

## Screenshots (optional):

Not applicable.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist:

- [ ] I have met the contributing prerequisites
  - [ ] Assigned myself to this PR
  - [ ] Added the appropriate labels
  - [x] Associated an issue: BED-9727
  - [x] Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - [x] Code comments (GoDocs / JSDocs)
- [ ] I have followed proper test practices
  - [ ] Added/updated tests to cover my changes
  - [ ] All new and existing tests passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added JavaScript client support for creating and retrieving collector job secrets.
  - Added request and response types for collector job secrets.
  - Added structured secret details, including identifier, key metadata, type, and creation timestamp.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->