### PR TITLE
fix: Support DORA collection date ranges BED-9054

### DIFF
--- a/packages/go/stbernard/README.md
+++ b/packages/go/stbernard/README.md
@@ -58,9 +58,9 @@ St Bernard includes automated DORA (DevOps Research and Assessment) metrics coll
 
 The repository includes a GitHub Actions workflow that automatically generates quarterly DORA metrics reports:
 
-- **Schedule**: Runs on the 5th of February, May, August, and November
+- **Schedule**: Runs on the 20th of February, May, August, and November
 - **Reports**: Most recent complete fiscal quarter (Feb/May/Aug/Nov start)
-- **Artifacts**: Text and JSON reports retained for 90 days
+- **Artifacts**: Text and JSON reports retained for 400 days
 - **Summary**: Metrics displayed in GitHub Actions summary view
 
 **Manual Trigger:**
@@ -77,6 +77,9 @@ The repository includes a GitHub Actions workflow that automatically generates q
 ```bash
 # Collect data for a time period
 stbernard dora collect -start 2026-02-01 -end 2026-04-30
+
+# Collect the last complete fiscal quarter
+stbernard dora collect -last-quarter
 
 # Generate report
 stbernard dora report -start 2026-02-01 -end 2026-04-30

--- a/packages/go/stbernard/command/dora/collect.go
+++ b/packages/go/stbernard/command/dora/collect.go
@@ -45,13 +45,21 @@ func (s *command) runCollect() error {
 	defaultDays := parseDefaultPeriod(config.Metrics.DefaultPeriod)
 
 	var (
-		cmd        = flag.NewFlagSet("dora collect", flag.ExitOnError)
-		daysFlag   int
-		deployFlag bool
-		commitFlag bool
+		cmd             = flag.NewFlagSet("dora collect", flag.ExitOnError)
+		daysFlag        int
+		startFlag       string
+		endFlag         string
+		lastQuarterFlag bool
+		fiscalStartFlag int
+		deployFlag      bool
+		commitFlag      bool
 	)
 
 	cmd.IntVar(&daysFlag, "days", defaultDays, fmt.Sprintf("Number of days to collect data for (default: %s from config)", config.Metrics.DefaultPeriod))
+	cmd.StringVar(&startFlag, "start", "", "Start date (YYYY-MM-DD) - overrides -days")
+	cmd.StringVar(&endFlag, "end", "", "End date (YYYY-MM-DD) - defaults to now")
+	cmd.BoolVar(&lastQuarterFlag, "last-quarter", false, "Collect the last complete fiscal quarter")
+	cmd.IntVar(&fiscalStartFlag, "fiscal-start", 2, "Fiscal year start month (1=Jan, 2=Feb, etc.) - used with -last-quarter")
 	cmd.BoolVar(&deployFlag, "deployments", false, "Collect deployment data only")
 	cmd.BoolVar(&commitFlag, "commits", false, "Collect commit data only")
 
@@ -69,6 +77,10 @@ func (s *command) runCollect() error {
 		fmt.Fprintf(w, "  %s dora collect\n\n", filepath.Base(os.Args[0]))
 		fmt.Fprintf(w, "  # Collect last 365 days\n")
 		fmt.Fprintf(w, "  %s dora collect -days 365\n\n", filepath.Base(os.Args[0]))
+		fmt.Fprintf(w, "  # Collect the last complete fiscal quarter\n")
+		fmt.Fprintf(w, "  %s dora collect -last-quarter\n\n", filepath.Base(os.Args[0]))
+		fmt.Fprintf(w, "  # Collect a specific date range\n")
+		fmt.Fprintf(w, "  %s dora collect -start 2026-02-01 -end 2026-04-30\n\n", filepath.Base(os.Args[0]))
 		fmt.Fprintf(w, "  # Collect only deployments\n")
 		fmt.Fprintf(w, "  %s dora collect -deployments\n\n", filepath.Base(os.Args[0]))
 		fmt.Fprintf(w, "  # Collect commits only\n")
@@ -102,9 +114,17 @@ func (s *command) runCollect() error {
 	// Create collector
 	collector := dora.NewGitHubCollector(&config, s.env)
 
-	// Calculate time range
-	endTime := time.Now()
-	startTime := endTime.AddDate(0, 0, -daysFlag)
+	startTime, endTime, err := resolveTimeRange(
+		daysFlag,
+		startFlag,
+		endFlag,
+		lastQuarterFlag,
+		fiscalStartFlag,
+		time.Now(),
+	)
+	if err != nil {
+		return err
+	}
 
 	ctx := context.Background()
 

--- a/packages/go/stbernard/command/dora/report.go
+++ b/packages/go/stbernard/command/dora/report.go
@@ -30,67 +30,6 @@ import (
 	"github.com/specterops/bloodhound/packages/go/stbernard/workspace"
 )
 
-// calculateLastFiscalQuarter returns the start and end dates of the most recent complete fiscal quarter
-// based on the fiscal year start month (1=Jan, 2=Feb, etc.)
-func calculateLastFiscalQuarter(fiscalStartMonth int) (time.Time, time.Time) {
-	return calculateLastFiscalQuarterAt(fiscalStartMonth, time.Now())
-}
-
-func calculateLastFiscalQuarterAt(fiscalStartMonth int, referenceTime time.Time) (time.Time, time.Time) {
-	currentYear := referenceTime.Year()
-
-	// Use absolute month arithmetic (months since year 0)
-	// This eliminates wraparound branches and simplifies year calculations
-	currentMonthAbs := currentYear*12 + int(referenceTime.Month())
-	fiscalStartMonthAbs := currentYear*12 + fiscalStartMonth
-
-	// If we haven't reached this year's fiscal start, use last year's
-	if currentMonthAbs < fiscalStartMonthAbs {
-		fiscalStartMonthAbs -= 12
-	}
-
-	// Calculate months into current fiscal year
-	monthsIntoFY := currentMonthAbs - fiscalStartMonthAbs
-
-	// Determine last completed quarter (0-3)
-	// Subtract 1 because we want the *completed* quarter
-	completedQuarterInFY := (monthsIntoFY - 1) / 3
-	if completedQuarterInFY < 0 {
-		// We're in Q1, so last complete quarter is Q4 of previous FY
-		completedQuarterInFY = 3
-		fiscalStartMonthAbs -= 12
-	}
-
-	// Calculate absolute month for quarter start
-	quarterStartAbs := fiscalStartMonthAbs + (completedQuarterInFY * 3)
-
-	// Convert back to year/month
-	startYear := quarterStartAbs / 12
-	quarterStartMonth := quarterStartAbs % 12
-	if quarterStartMonth == 0 {
-		quarterStartMonth = 12
-		startYear--
-	}
-
-	// Start of quarter (first day, 00:00:00 UTC)
-	start := time.Date(startYear, time.Month(quarterStartMonth), 1, 0, 0, 0, 0, time.UTC)
-
-	// End of quarter (last second of third month)
-	quarterEndAbs := quarterStartAbs + 2
-	endYear := quarterEndAbs / 12
-	endMonth := quarterEndAbs % 12
-	if endMonth == 0 {
-		endMonth = 12
-		endYear--
-	}
-
-	// Last second of the last day of the month
-	endMonthStart := time.Date(endYear, time.Month(endMonth)+1, 1, 0, 0, 0, 0, time.UTC)
-	end := endMonthStart.Add(-time.Second)
-
-	return start, end
-}
-
 // parseDefaultPeriod converts a period string to number of days
 // Supports:
 //   - Days: "30d", "90d", "30", "90days"
@@ -217,41 +156,16 @@ func (s *command) runReport() error {
 		return fmt.Errorf("unsupported format: %s (supported: terminal, json)", formatFlag)
 	}
 
-	// Calculate time range based on flags
-	var startTime, endTime time.Time
-
-	if lastQuarterFlag {
-		// Calculate the last complete fiscal quarter
-		startTime, endTime = calculateLastFiscalQuarter(fiscalStartFlag)
-	} else if startFlag != "" {
-		// Parse start date
-		parsedStart, err := time.Parse("2006-01-02", startFlag)
-		if err != nil {
-			return fmt.Errorf("invalid start date format (use YYYY-MM-DD): %w", err)
-		}
-		startTime = parsedStart
-
-		// Parse end date or default to now
-		if endFlag != "" {
-			parsedEnd, err := time.Parse("2006-01-02", endFlag)
-			if err != nil {
-				return fmt.Errorf("invalid end date format (use YYYY-MM-DD): %w", err)
-			}
-			// Set to end of day (23:59:59)
-			endTime = parsedEnd.Add(24*time.Hour - time.Second)
-		} else {
-			endTime = time.Now()
-		}
-	} else {
-		// Use days-based calculation (default)
-		endTime = time.Now()
-		startTime = endTime.AddDate(0, 0, -daysFlag)
-	}
-
-	// Validate time range
-	if startTime.After(endTime) {
-		return fmt.Errorf("start date (%s) cannot be after end date (%s)",
-			startTime.Format("2006-01-02"), endTime.Format("2006-01-02"))
+	startTime, endTime, err := resolveTimeRange(
+		daysFlag,
+		startFlag,
+		endFlag,
+		lastQuarterFlag,
+		fiscalStartFlag,
+		time.Now(),
+	)
+	if err != nil {
+		return err
 	}
 
 	// Create storage

--- a/packages/go/stbernard/command/dora/report_test.go
+++ b/packages/go/stbernard/command/dora/report_test.go
@@ -283,6 +283,23 @@ func TestResolveTimeRange(t *testing.T) {
 			fiscalStartMonth: 2,
 			expectedError:    "start date (2026-05-01) cannot be after end date (2026-04-30)",
 		},
+		{
+			name:             "end date requires start date",
+			endDate:          "2026-04-30",
+			fiscalStartMonth: 2,
+			expectedError:    "end date requires start date",
+		},
+		{
+			name:             "zero days is invalid",
+			fiscalStartMonth: 2,
+			expectedError:    "days must be greater than zero",
+		},
+		{
+			name:             "negative days is invalid",
+			days:             -1,
+			fiscalStartMonth: 2,
+			expectedError:    "days must be greater than zero",
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/packages/go/stbernard/command/dora/report_test.go
+++ b/packages/go/stbernard/command/dora/report_test.go
@@ -123,42 +123,46 @@ func TestCalculateLastFiscalQuarter(t *testing.T) {
 			expectedEnd:      "2026-03-31 23:59:59",
 		},
 		{
-			name:             "January FY, reference at end of Q3 (September 30)",
-			fiscalStartMonth: 1, // January FY: Q1=Jan-Mar, Q2=Apr-Jun, Q3=Jul-Sep, Q4=Oct-Dec
+			name:             "January FY, reference in Q3 (September)",
+			fiscalStartMonth: 1,
 			referenceTime:    "2026-09-30",
-			expectedStart:    "2026-07-01 00:00:00", // monthsIntoFY=8, (8-1)/3=2 (Q3), return Q3
-			expectedEnd:      "2026-09-30 23:59:59",
+			expectedStart:    "2026-04-01 00:00:00",
+			expectedEnd:      "2026-06-30 23:59:59",
 		},
 		{
-			name:             "February FY, reference at end of Q2 (July 31)",
-			fiscalStartMonth: 2, // February FY: Q1=Feb-Apr, Q2=May-Jul, Q3=Aug-Oct, Q4=Nov-Jan
+			name:             "February FY, reference in Q2 (July)",
+			fiscalStartMonth: 2,
 			referenceTime:    "2026-07-31",
-			expectedStart:    "2026-05-01 00:00:00", // monthsIntoFY=5, (5-1)/3=1 (Q2), return Q2
-			expectedEnd:      "2026-07-31 23:59:59",
+			expectedStart:    "2026-02-01 00:00:00",
+			expectedEnd:      "2026-04-30 23:59:59",
 		},
 		{
 			name:             "October FY, reference in Q1 (November)",
-			fiscalStartMonth: 10, // October FY: Q1=Oct-Dec, Q2=Jan-Mar, Q3=Apr-Jun, Q4=Jul-Sep
+			fiscalStartMonth: 10,
 			referenceTime:    "2025-11-15",
-			expectedStart:    "2025-10-01 00:00:00", // monthsIntoFY=1, (1-1)/3=0 (Q1), return Q1
-			expectedEnd:      "2025-12-31 23:59:59",
+			expectedStart:    "2025-07-01 00:00:00",
+			expectedEnd:      "2025-09-30 23:59:59",
 		},
 		{
 			name:             "October FY, reference in Q2 (February)",
-			fiscalStartMonth: 10, // October
+			fiscalStartMonth: 10,
 			referenceTime:    "2026-02-28",
-			expectedStart:    "2026-01-01 00:00:00", // monthsIntoFY=4, (4-1)/3=1 (Q2), return Q2
-			expectedEnd:      "2026-03-31 23:59:59",
+			expectedStart:    "2025-10-01 00:00:00",
+			expectedEnd:      "2025-12-31 23:59:59",
 		},
 		{
-			name:             "January FY, reference early in Q1 (January 15)",
-			fiscalStartMonth: 1, // January
+			name:             "January FY, reference in Q1 (January)",
+			fiscalStartMonth: 1,
 			referenceTime:    "2026-01-15",
-			// Note: monthsIntoFY=0, (0-1)/3=-1 should return Q4 of prev FY (Oct-Dec 2025)
-			// but current implementation returns Q1. This may be intentional to avoid
-			// returning incomplete quarter data at the start of the fiscal year.
-			expectedStart: "2026-01-01 00:00:00",
-			expectedEnd:   "2026-03-31 23:59:59",
+			expectedStart:    "2025-10-01 00:00:00",
+			expectedEnd:      "2025-12-31 23:59:59",
+		},
+		{
+			name:             "February FY, reference in Q1 (February)",
+			fiscalStartMonth: 2,
+			referenceTime:    "2026-02-20",
+			expectedStart:    "2025-11-01 00:00:00",
+			expectedEnd:      "2026-01-31 23:59:59",
 		},
 	}
 
@@ -214,6 +218,100 @@ func TestCalculateLastFiscalQuarter(t *testing.T) {
 			t.Logf("✓ Fiscal start=%s, ref=%s: Q = %v to %v",
 				time.Month(tt.fiscalStartMonth), tt.referenceTime,
 				start.Format("2006-01-02"), end.Format("2006-01-02"))
+		})
+	}
+}
+
+func TestResolveTimeRange(t *testing.T) {
+	referenceTime, err := time.Parse(time.RFC3339, "2026-08-20T10:15:30Z")
+	if err != nil {
+		t.Fatalf("parsing reference time: %v", err)
+	}
+
+	testCases := []struct {
+		name             string
+		days             int
+		startDate        string
+		endDate          string
+		lastQuarter      bool
+		fiscalStartMonth int
+		expectedStart    string
+		expectedEnd      string
+		expectedError    string
+	}{
+		{
+			name:             "days range",
+			days:             90,
+			fiscalStartMonth: 2,
+			expectedStart:    "2026-05-22T10:15:30Z",
+			expectedEnd:      "2026-08-20T10:15:30Z",
+		},
+		{
+			name:             "custom range includes the end date",
+			startDate:        "2026-02-01",
+			endDate:          "2026-04-30",
+			fiscalStartMonth: 2,
+			expectedStart:    "2026-02-01T00:00:00Z",
+			expectedEnd:      "2026-04-30T23:59:59Z",
+		},
+		{
+			name:             "last complete fiscal quarter",
+			lastQuarter:      true,
+			fiscalStartMonth: 2,
+			expectedStart:    "2026-05-01T00:00:00Z",
+			expectedEnd:      "2026-07-31T23:59:59Z",
+		},
+		{
+			name:             "last quarter takes precedence over explicit dates",
+			startDate:        "2026-01-01",
+			endDate:          "2026-01-31",
+			lastQuarter:      true,
+			fiscalStartMonth: 2,
+			expectedStart:    "2026-05-01T00:00:00Z",
+			expectedEnd:      "2026-07-31T23:59:59Z",
+		},
+		{
+			name:             "invalid fiscal start month",
+			lastQuarter:      true,
+			fiscalStartMonth: 13,
+			expectedError:    "fiscal start month must be between 1 and 12",
+		},
+		{
+			name:             "invalid custom range",
+			startDate:        "2026-05-01",
+			endDate:          "2026-04-30",
+			fiscalStartMonth: 2,
+			expectedError:    "start date (2026-05-01) cannot be after end date (2026-04-30)",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			actualStart, actualEnd, err := resolveTimeRange(
+				testCase.days,
+				testCase.startDate,
+				testCase.endDate,
+				testCase.lastQuarter,
+				testCase.fiscalStartMonth,
+				referenceTime,
+			)
+			if testCase.expectedError != "" {
+				if err == nil || err.Error() != testCase.expectedError {
+					t.Fatalf("resolveTimeRange() error = %v, want %q", err, testCase.expectedError)
+				}
+
+				return
+			}
+			if err != nil {
+				t.Fatalf("resolveTimeRange() error = %v", err)
+			}
+
+			if actualStart.Format(time.RFC3339) != testCase.expectedStart {
+				t.Errorf("start = %s, want %s", actualStart.Format(time.RFC3339), testCase.expectedStart)
+			}
+			if actualEnd.Format(time.RFC3339) != testCase.expectedEnd {
+				t.Errorf("end = %s, want %s", actualEnd.Format(time.RFC3339), testCase.expectedEnd)
+			}
 		})
 	}
 }

--- a/packages/go/stbernard/command/dora/time_range.go
+++ b/packages/go/stbernard/command/dora/time_range.go
@@ -62,6 +62,10 @@ func resolveTimeRange(
 		return startTime, endTime, nil
 	}
 
+	if endDate != "" && startDate == "" {
+		return time.Time{}, time.Time{}, fmt.Errorf("end date requires start date")
+	}
+
 	if startDate != "" {
 		startTime, err := time.Parse(time.DateOnly, startDate)
 		if err != nil {
@@ -86,6 +90,10 @@ func resolveTimeRange(
 		}
 
 		return startTime, endTime, nil
+	}
+
+	if days <= 0 {
+		return time.Time{}, time.Time{}, fmt.Errorf("days must be greater than zero")
 	}
 
 	startTime := referenceTime.AddDate(0, 0, -days)

--- a/packages/go/stbernard/command/dora/time_range.go
+++ b/packages/go/stbernard/command/dora/time_range.go
@@ -1,0 +1,93 @@
+// Copyright 2026 Specter Ops, Inc.
+//
+// Licensed under the Apache License, Version 2.0
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package dora
+
+import (
+	"fmt"
+	"time"
+)
+
+func calculateLastFiscalQuarterAt(fiscalStartMonth int, referenceTime time.Time) (time.Time, time.Time) {
+	var (
+		fiscalStartYear = referenceTime.Year()
+		currentMonth    = int(referenceTime.Month())
+	)
+
+	if currentMonth < fiscalStartMonth {
+		fiscalStartYear--
+	}
+
+	monthsIntoFiscalYear := (referenceTime.Year()-fiscalStartYear)*12 + currentMonth - fiscalStartMonth
+	completedQuarterInFiscalYear := monthsIntoFiscalYear/3 - 1
+	if completedQuarterInFiscalYear < 0 {
+		completedQuarterInFiscalYear = 3
+		fiscalStartYear--
+	}
+
+	quarterStart := time.Date(fiscalStartYear, time.Month(fiscalStartMonth), 1, 0, 0, 0, 0, time.UTC).
+		AddDate(0, completedQuarterInFiscalYear*3, 0)
+	quarterEnd := quarterStart.AddDate(0, 3, 0).Add(-time.Second)
+
+	return quarterStart, quarterEnd
+}
+
+func resolveTimeRange(
+	days int,
+	startDate string,
+	endDate string,
+	lastQuarter bool,
+	fiscalStartMonth int,
+	referenceTime time.Time,
+) (time.Time, time.Time, error) {
+	if lastQuarter {
+		if fiscalStartMonth < 1 || fiscalStartMonth > 12 {
+			return time.Time{}, time.Time{}, fmt.Errorf("fiscal start month must be between 1 and 12")
+		}
+
+		startTime, endTime := calculateLastFiscalQuarterAt(fiscalStartMonth, referenceTime)
+		return startTime, endTime, nil
+	}
+
+	if startDate != "" {
+		startTime, err := time.Parse(time.DateOnly, startDate)
+		if err != nil {
+			return time.Time{}, time.Time{}, fmt.Errorf("invalid start date format (use YYYY-MM-DD): %w", err)
+		}
+
+		endTime := referenceTime
+		if endDate != "" {
+			endTime, err = time.Parse(time.DateOnly, endDate)
+			if err != nil {
+				return time.Time{}, time.Time{}, fmt.Errorf("invalid end date format (use YYYY-MM-DD): %w", err)
+			}
+			endTime = endTime.Add(24*time.Hour - time.Second)
+		}
+
+		if startTime.After(endTime) {
+			return time.Time{}, time.Time{}, fmt.Errorf(
+				"start date (%s) cannot be after end date (%s)",
+				startTime.Format(time.DateOnly),
+				endTime.Format(time.DateOnly),
+			)
+		}
+
+		return startTime, endTime, nil
+	}
+
+	startTime := referenceTime.AddDate(0, 0, -days)
+	return startTime, referenceTime, nil
+}


### PR DESCRIPTION
<!-- README: https://github.com/SpecterOps/BloodHound/issues/672 -->
<!-- All pull requests require either an associated -->
<!-- Jira ticket or GitHub issue. PRs opened without -->
<!-- an associated discussion item will be closed! -->

## Description

Previous PR had changed the command structure in a way that broke my `last-quarter` options. Decided to undo that change.

## Motivation and Context

<!-- Please replace "<TICKET_OR_ISSUE_NUMBER>" with the associated ticket or issue number -->
Resolves BED-9054

Fixes a problem with my script that uses this tool

## How Has This Been Tested?

Ran successfully with my scripts

## Types of changes

<!-- Please remove any items that do not apply. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for collecting and reporting DORA data for the previous fiscal quarter.
  * Added explicit start and end date options, fiscal-year start month configuration, and rolling day-based ranges.
  * Added validation for date formats, date ordering, required date combinations, fiscal month values, and positive day counts.
  * Updated help output with examples for supported collection modes.

* **Documentation**
  * Updated quarterly report scheduling to run on the 20th of February, May, August, and November.
  * Extended report artifact retention from 90 to 400 days.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->