### PR TITLE
chore: update graphschema_integration_test callsites - BED-9566

### DIFF
--- a/cmd/api/src/database/graphschema_integration_test.go
+++ b/cmd/api/src/database/graphschema_integration_test.go
@@ -3672,7 +3672,7 @@ func TestDatabase_Findings_CRUD(t *testing.T) {
 					SchemaExtensionId: extension.ID,
 					KindId:            1,
 					Type:              model.SchemaFindingTypeRelationship,
-					EnvironmentId:     environment.ID,
+					EnvironmentId:     environment.EnvironmentKindId,
 					Name:              "finding",
 					DisplayName:       "display name",
 				}
@@ -3696,7 +3696,7 @@ func TestDatabase_Findings_CRUD(t *testing.T) {
 				finding := model.SchemaFinding{
 					SchemaExtensionId: extension.ID,
 					KindId:            1,
-					EnvironmentId:     environment.ID,
+					EnvironmentId:     environment.EnvironmentKindId,
 					Name:              "finding",
 					DisplayName:       "display name",
 					PZDisplayName:     null.StringFrom("zone display name"),
@@ -3719,7 +3719,7 @@ func TestDatabase_Findings_CRUD(t *testing.T) {
 					SchemaExtensionId: extension.ID,
 					Type:              model.SchemaFindingTypeRelationship,
 					KindId:            1,
-					EnvironmentId:     environment.ID,
+					EnvironmentId:     environment.EnvironmentKindId,
 					Name:              "finding",
 					DisplayName:       "display name",
 				}
@@ -3751,7 +3751,7 @@ func TestDatabase_Findings_CRUD(t *testing.T) {
 					SchemaExtensionId: extension.ID,
 					Type:              model.SchemaFindingTypeRelationship,
 					KindId:            1,
-					EnvironmentId:     environment.ID,
+					EnvironmentId:     environment.EnvironmentKindId,
 					Name:              "finding",
 					DisplayName:       "display name",
 				}
@@ -3782,7 +3782,7 @@ func TestDatabase_Findings_CRUD(t *testing.T) {
 					SchemaExtensionId: extension.ID,
 					Type:              model.SchemaFindingTypeRelationship,
 					KindId:            1,
-					EnvironmentId:     environment.ID,
+					EnvironmentId:     environment.EnvironmentKindId,
 					Name:              "finding",
 					DisplayName:       "display name",
 				}
@@ -3835,7 +3835,7 @@ func TestDatabase_Findings_CRUD(t *testing.T) {
 				finding1 := model.SchemaFinding{
 					SchemaExtensionId: createdExtension.ID,
 					KindId:            edgeKind.ID,
-					EnvironmentId:     createdEnvironment.ID,
+					EnvironmentId:     createdEnvironment.EnvironmentKindId,
 					Name:              "Finding_1",
 					DisplayName:       "Finding 1",
 				}
@@ -3844,7 +3844,7 @@ func TestDatabase_Findings_CRUD(t *testing.T) {
 				finding2 := model.SchemaFinding{
 					SchemaExtensionId: createdExtension.ID,
 					KindId:            edgeKind.ID,
-					EnvironmentId:     createdEnvironment.ID,
+					EnvironmentId:     createdEnvironment.EnvironmentKindId,
 					Name:              "Finding_2",
 					DisplayName:       "Finding 2",
 				}
@@ -3911,7 +3911,7 @@ func TestDatabase_Remediations_CRUD(t *testing.T) {
 			SchemaExtensionId: extension.ID,
 			KindId:            nodeKind.ID,
 			Type:              model.SchemaFindingTypeRelationship,
-			EnvironmentId:     environment.ID,
+			EnvironmentId:     environment.EnvironmentKindId,
 			Name:              "finding",
 			DisplayName:       "display name",
 		})
@@ -4310,7 +4310,7 @@ func TestDeleteSchemaExtension_CascadeDeletesAllDependents(t *testing.T) {
 		SchemaExtensionId: extension.ID,
 		Type:              model.SchemaFindingTypeRelationship,
 		KindId:            edgeKind.ID,
-		EnvironmentId:     environment.ID,
+		EnvironmentId:     environment.EnvironmentKindId,
 		Name:              "CascadeTestFinding",
 		DisplayName:       "Cascade Test Finding",
 	})
@@ -4385,12 +4385,12 @@ func TestDatabase_GetSchemaFindings(t *testing.T) {
 		require.NoError(t, err)
 
 		extensionId := ext.ID
-		environmentId := env.ID
+		environmentKindId := env.EnvironmentKindId
 		if i%3 == 0 {
 			extensionId = ext2.ID
-			environmentId = env2.ID
+			environmentKindId = env2.EnvironmentKindId
 		}
-		finding, err := testSuite.BHDatabase.CreateSchemaFinding(testCtx, model.SchemaFindingTypeRelationship, extensionId, kind.KindId, environmentId, "F_"+strconv.Itoa(i), "", "")
+		finding, err := testSuite.BHDatabase.CreateSchemaFinding(testCtx, model.SchemaFindingTypeRelationship, extensionId, kind.KindId, environmentKindId, "F_"+strconv.Itoa(i), "", "")
 		require.NoError(t, err)
 		finding.Kind = graph.StringKind(kindName)
 
@@ -4848,7 +4848,7 @@ func TestUpdateSchemaFinding(t *testing.T) {
 			Type:              model.SchemaFindingTypeRelationship,
 			SchemaExtensionId: ext.ID,
 			KindId:            int32(relKind.ID),
-			EnvironmentId:     env.ID,
+			EnvironmentId:     env.EnvironmentKindId,
 			Name:              "TestFinding",
 			DisplayName:       "Original Display Name",
 		})


### PR DESCRIPTION
## Description
Align the `graphschema_integration_test.go` harness with the new meaning of the `model.SchemaFinding.EnvironmentId` column.

## Motivation and Context
Resolves BED-9566
This PR is needed because an earlier PR https://github.com/SpecterOps/BloodHound/pull/3282 changed the meaning of the `EnvironmentID` field on the  `model.SchemaFinding` struct. Several integration test cases needed to be updated to reflect the new meaning of this column. 

The earlier PR did not catch these test cases because these tests don't directly assert anything about the `model.SchemaFinding` contract, it just so happens that the `SchemaFinding` type is instantiated by these tests during setup due to the huge amount of "setup" required by these tests. Put another way, the test corpus we have for the extension upsert endpoint typically wires up many things for each test case which don't get asserted on directly in the test.

## How Has This Been Tested?

## Screenshots (optional):

## Types of changes

<!-- Please remove any items that do not apply. -->

- Chore (a change that does not modify the application functionality)
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)
- Database Migrations

## Checklist:

<!-- Please make sure you have completed all following checks. -->
- [ ] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [ ] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments (GoDocs / JSDocs)
- [ ] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated integration-test fixtures to validate schema findings against the environment kind identifier.
  * Expanded consistency across finding creation, updates, remediation, bulk operations, and cascade-delete test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->